### PR TITLE
Fix Render deployment: DB readiness wait + URL normalization

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import sys
 from logging.config import fileConfig
 from pathlib import Path
@@ -23,10 +24,9 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
-# Read DATABASE_URL from environment; normalise to asyncpg scheme
+# Read DATABASE_URL from environment; normalise postgres:// or postgresql:// to asyncpg scheme
 _db_url = os.environ.get("DATABASE_URL", "")
-if _db_url.startswith("postgresql://"):
-    _db_url = _db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+_db_url = re.sub(r"^postgres(?:ql)?://", "postgresql+asyncpg://", _db_url)
 if _db_url:
     config.set_main_option("sqlalchemy.url", _db_url)
 

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,8 +1,36 @@
 #!/bin/sh
 set -e
-# Render provides DATABASE_URL as postgres:// or postgresql:// — normalize to asyncpg driver
+
+# Normalize Render's postgres:// or postgresql:// to asyncpg driver scheme
 DATABASE_URL=$(echo "$DATABASE_URL" | sed 's|^postgres://|postgresql+asyncpg://|; s|^postgresql://|postgresql+asyncpg://|')
 export DATABASE_URL
+
+# Wait for the database to be reachable (up to 60 s, 2 s between retries)
+echo "Waiting for database..."
+i=0
+until python - <<'PYEOF'
+import asyncio, asyncpg, os
+
+url = os.environ["DATABASE_URL"]
+dsn = url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+async def check():
+    conn = await asyncpg.connect(dsn=dsn, timeout=5)
+    await conn.close()
+
+asyncio.run(check())
+PYEOF
+do
+    i=$((i + 1))
+    if [ "$i" -ge 30 ]; then
+        echo "Database did not become ready within 60 seconds. Aborting."
+        exit 1
+    fi
+    echo "  ...not ready yet (attempt $i/30). Retrying in 2 s."
+    sleep 2
+done
+echo "Database is ready."
+
 alembic upgrade head
-python seed.py --yes
+python seed.py --env prod --yes
 exec uvicorn main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary

- **start.sh**: adds a 60-second DB readiness loop using `asyncpg.connect()` before running `alembic upgrade head`, fixing a race condition on Render's free tier where the PostgreSQL instance isn't ready when the container starts; also corrects the seed call to `--env prod --yes`
- **alembic/env.py**: normalizes both `postgres://` and `postgresql://` to the asyncpg scheme using a regex, not just `postgresql://`

## Root cause

Render's free-tier PostgreSQL isn't guaranteed to be accepting connections when the web service container boots. `alembic upgrade head` would fail (crashing start.sh via `set -e`), leaving the schema empty. When the container eventually started the app, the `account` table didn't exist.

## Test plan

- [ ] Deploy to Render with a fresh database (wipe and recreate `worldzero-db`)
- [ ] Confirm deploy logs show: `Waiting for database... → Database is ready. → alembic migrations → Seed complete!`
- [ ] Log in with Google OAuth and confirm the pixie admin account works

🤖 Generated with [Claude Code](https://claude.com/claude-code)