### PR TITLE
Fix /factions 500 error: filter by status enum instead of missing is_hidden

### DIFF
--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db import get_db
 from dependencies import require_admin
 from models.account import Account
-from models.faction import Faction
+from models.faction import Faction, FactionStatus
 from schemas.faction import FactionOut, FactionUpdate
 
 router = APIRouter()
@@ -15,7 +15,7 @@ router = APIRouter()
 async def list_factions(session: AsyncSession = Depends(get_db)):
     """Return all non-hidden factions."""
     result = await session.execute(
-        select(Faction).where(Faction.is_hidden == False).order_by(Faction.slug)
+        select(Faction).where(Faction.status == FactionStatus.visible).order_by(Faction.slug)
     )
     return [FactionOut.model_validate(faction) for faction in result.scalars().all()]
 


### PR DESCRIPTION
## Summary
- `GET /factions` was crashing with `AttributeError: type object 'Faction' has no attribute 'is_hidden'` on every request
- The `Faction` model uses a `status` enum (`visible`/`hidden`/`deprecated`), not a boolean `is_hidden` column
- Fixed the filter in `list_factions` to use `Faction.status == FactionStatus.visible`

## Test plan
- [ ] `GET https://api.worldzero.org/factions` returns 200 with faction list
- [ ] Factions page renders without error
- [ ] Login flow still works (was already working — this crash was masking it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)