### PR TITLE
Fix JWT expiry, task faction filters, and stale vote self-check

### DIFF
--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -12,7 +12,7 @@ from db import get_db
 from models.account import Account, AccountStatus, OAuthProvider
 
 _ALGORITHM = "HS256"
-_TOKEN_EXPIRE_DAYS = 1
+_TOKEN_EXPIRE_DAYS = 7
 
 _BEARER = HTTPBearer(auto_error=False)
 

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -19,9 +19,6 @@ async def cast_or_update_vote(
     if not 1 <= stars <= 5:
         raise HTTPException(status_code=422, detail="Stars must be between 1 and 5.")
 
-    if voter.account_id == submission.character_id:
-        raise HTTPException(status_code=403, detail="Cannot vote on your own submission.")
-
     result = await session.execute(
         select(Vote).where(
             Vote.submission_id == submission.id,

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -6,11 +6,12 @@ import { extractError } from '../utils/errors'
 const STATUS_FILTERS = ['All', 'active', 'pending', 'retired']
 const FACTION_FILTERS = [
   { slug: 'ua', label: 'UA' },
+  { slug: 'ua_masters', label: 'UA Masters' },
   { slug: 'journeymen', label: 'Journeymen' },
   { slug: 'gestalt', label: 'Gestalt' },
-  { slug: 'geo', label: 'Analog' },
+  { slug: 'analog', label: 'Analog' },
   { slug: 'snide', label: 'S.N.I.D.E.' },
-  { slug: 'cm', label: 'Creative Masters' },
+  { slug: 'singularity', label: 'Singularity' },
 ]
 const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
 


### PR DESCRIPTION
## Summary
- **JWT was expiring after 1 day** while the cookie lasted 7 days — users got silently logged out every night. `_TOKEN_EXPIRE_DAYS` bumped to 7.
- **Tasks faction filters had wrong slugs**: `'geo'` (no such faction, should be `'analog'`) and `'cm'` (doesn't exist). Replaced with the actual slugs from the DB: `analog`, `ua_masters`, `singularity`.
- **Vote service had a bogus self-vote guard** comparing `voter.account_id == submission.character_id` (account ID vs character ID — different namespaces, always wrong). Removed it; the router already does the correct check before calling the service.

## Test plan
- [ ] Log in → come back next day → still logged in
- [ ] Tasks page: Analog, UA Masters, Singularity filters return correct results
- [ ] Voting on your own submission still returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)