### PR TITLE
Add admin management API for ad-hoc DB operations

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     MEDIA_ROOT: str = "/media"
     FRONTEND_URL: str = "http://localhost:3000"
     COOKIE_DOMAIN: str | None = None
+    ADMIN_CLI_SECRET: str = ""
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,21 +1,250 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from config import settings
 from db import get_db
 from dependencies import require_admin
 from models.account import Account
 from models.character import Character, CharacterStatus
+from models.roles import AccountRole, Role
 from models.submission import Submission
 from models.task import Task, TaskStatus
+from schemas.admin import (
+    AccountDetail,
+    AccountSummary,
+    AdminCharacterCreate,
+    CharacterStatsPatch,
+    CharacterStatsOut,
+    CharacterSummary,
+    CliTokenResponse,
+    FactionCreate,
+    FactionOut,
+    OverviewStats,
+    RoleAction,
+    SuspendAction,
+)
 from schemas.task import TaskCreate, TaskOut
+from services.admin_service import (
+    admin_create_character,
+    assign_or_revoke_role,
+    create_faction,
+    game_overview,
+    get_account_detail,
+    list_accounts,
+    list_characters,
+    reactivate_task,
+    set_character_stats,
+    suspend_account,
+)
+from services.auth import create_jwt
 
 router = APIRouter()
 
 
 class BanAction(BaseModel):
     banned: bool
+
+
+# ---------------------------------------------------------------------------
+# Read / Inspect
+# ---------------------------------------------------------------------------
+
+
+@router.get("/overview", response_model=OverviewStats)
+async def admin_overview(
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> OverviewStats:
+    return await game_overview(session)
+
+
+@router.get("/accounts", response_model=list[AccountSummary])
+async def admin_list_accounts(
+    email: str | None = None,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> list[AccountSummary]:
+    return await list_accounts(session, email_filter=email)
+
+
+@router.get("/accounts/{account_id}", response_model=AccountDetail)
+async def admin_get_account(
+    account_id: int,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> AccountDetail:
+    return await get_account_detail(account_id, session)
+
+
+@router.get("/characters", response_model=list[CharacterSummary])
+async def admin_list_characters(
+    faction: str | None = None,
+    status: str | None = None,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> list[CharacterSummary]:
+    return await list_characters(session, faction=faction, status=status)
+
+
+# ---------------------------------------------------------------------------
+# Seed / Insert
+# ---------------------------------------------------------------------------
+
+
+@router.post("/factions", response_model=FactionOut, status_code=201)
+async def admin_create_faction(
+    data: FactionCreate,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> FactionOut:
+    faction = await create_faction(data, session)
+    return FactionOut(
+        slug=faction.slug,
+        name=faction.name,
+        description=faction.description,
+        status=faction.status.value,
+        created_at=faction.created_at,
+    )
+
+
+@router.post("/characters", status_code=201)
+async def admin_create_character_endpoint(
+    data: AdminCharacterCreate,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    character = await admin_create_character(data, session)
+    return {
+        "id": character.id,
+        "account_id": character.account_id,
+        "username": character.username,
+        "display_name": character.display_name,
+        "faction_slug": character.faction_slug,
+        "status": character.status.value,
+        "created_at": character.created_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Adjust Game State
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/characters/{character_id}/stats", response_model=CharacterStatsOut)
+async def admin_patch_character_stats(
+    character_id: int,
+    patch: CharacterStatsPatch,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> CharacterStatsOut:
+    stats = await set_character_stats(character_id, patch, session)
+    return CharacterStatsOut(
+        id=stats.id,
+        character_id=stats.character_id,
+        era_id=stats.era_id,
+        score=stats.score,
+        all_time_score=stats.all_time_score,
+        level=stats.level,
+        votes_available=stats.votes_available,
+    )
+
+
+@router.post("/tasks/{task_id}/reactivate", response_model=TaskOut)
+async def admin_reactivate_task(
+    task_id: int,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> TaskOut:
+    task = await reactivate_task(task_id, session)
+    return TaskOut(
+        id=task.id,
+        title=task.title,
+        description=task.description,
+        point_value=task.point_value,
+        level_required=task.level_required,
+        status=task.status.value,
+        created_by=task.created_by,
+        primary_faction_slug=task.primary_faction_slug,
+        is_task_vision_eligible=task.is_task_vision_eligible,
+        created_at=task.created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Role & Account Management
+# ---------------------------------------------------------------------------
+
+
+@router.post("/accounts/{account_id}/role", status_code=200)
+async def admin_manage_role(
+    account_id: int,
+    data: RoleAction,
+    admin: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    await assign_or_revoke_role(
+        account_id=account_id,
+        role_name=data.role,
+        action=data.action,
+        admin_account_id=admin.id,
+        session=session,
+    )
+    return {"account_id": account_id, "role": data.role, "action": data.action}
+
+
+@router.post("/accounts/{account_id}/suspend", status_code=200)
+async def admin_suspend_account(
+    account_id: int,
+    data: SuspendAction,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    account = await suspend_account(account_id, data.suspended, session)
+    return {"account_id": account.id, "status": account.status.value}
+
+
+# ---------------------------------------------------------------------------
+# CLI Auth (for skill/programmatic access)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/cli-token", response_model=CliTokenResponse)
+async def admin_cli_token(
+    x_admin_cli_secret: str = Header(..., alias="X-Admin-Cli-Secret"),
+    session: AsyncSession = Depends(get_db),
+) -> CliTokenResponse:
+    """Return a JWT for the admin account using a static secret.
+
+    Requires ADMIN_CLI_SECRET to be set in the environment. Returns 403 if
+    the secret is blank (disabled) or does not match.
+    """
+    if not settings.ADMIN_CLI_SECRET:
+        raise HTTPException(status_code=403, detail="CLI token endpoint is disabled.")
+    if x_admin_cli_secret != settings.ADMIN_CLI_SECRET:
+        raise HTTPException(status_code=403, detail="Invalid CLI secret.")
+
+    # Find the admin account (first account with the admin role)
+    result = await session.execute(
+        select(Account)
+        .join(AccountRole, AccountRole.account_id == Account.id)
+        .join(Role, Role.id == AccountRole.role_id)
+        .where(Role.name == "admin")
+        .limit(1)
+    )
+    admin_account = result.scalar_one_or_none()
+
+    if admin_account is None:
+        raise HTTPException(status_code=500, detail="No admin account found. Run seed first.")
+
+    token = create_jwt(admin_account.id)
+    return CliTokenResponse(access_token=token)
+
+
+# ---------------------------------------------------------------------------
+# Existing endpoints (unchanged)
+# ---------------------------------------------------------------------------
 
 
 @router.get("/tasks/pending", response_model=list[TaskOut])

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -1,0 +1,142 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------------------------------------------------------------------------
+# Read / Inspect
+# ---------------------------------------------------------------------------
+
+
+class AccountSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    email: str
+    status: str
+    created_at: datetime
+
+
+class CharacterBrief(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    username: str
+    display_name: str
+    faction_slug: str
+    status: str
+
+
+class AccountDetail(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    email: str
+    status: str
+    created_at: datetime
+    characters: list[CharacterBrief]
+
+
+class CharacterSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    account_id: int
+    username: str
+    display_name: str
+    faction_slug: str
+    status: str
+    score: int
+    level: int
+    votes_available: int
+    created_at: datetime
+
+
+class OverviewStats(BaseModel):
+    accounts: int
+    characters: int
+    active_tasks: int
+    submissions: int
+    votes: int
+
+
+# ---------------------------------------------------------------------------
+# Seed / Insert
+# ---------------------------------------------------------------------------
+
+
+class FactionCreate(BaseModel):
+    slug: str = Field(..., min_length=2, max_length=30, pattern=r"^[a-z0-9_-]+$")
+    name: str = Field(..., min_length=1, max_length=100)
+    description: str = Field(default="", max_length=500)
+    hidden: bool = False
+
+
+class FactionOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    slug: str
+    name: str
+    description: str
+    status: str
+    created_at: datetime
+
+
+class AdminCharacterCreate(BaseModel):
+    account_id: int
+    username: str = Field(..., min_length=3, max_length=30)
+    display_name: str = Field(..., max_length=50)
+    bio: str = Field(default="", max_length=500)
+    avatar_url: str = Field(default="", max_length=500)
+    location: str = Field(default="", max_length=100)
+    faction_slug: str = Field(default="ua")
+
+
+# ---------------------------------------------------------------------------
+# Adjust Game State
+# ---------------------------------------------------------------------------
+
+
+class CharacterStatsPatch(BaseModel):
+    """All fields optional — only supplied fields are updated."""
+
+    level: int | None = Field(None, ge=0)
+    score: int | None = Field(None, ge=0)
+    all_time_score: int | None = Field(None, ge=0)
+    votes_available: int | None = Field(None, ge=0)
+
+
+class CharacterStatsOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    character_id: int
+    era_id: int
+    score: int
+    all_time_score: int
+    level: int
+    votes_available: int
+
+
+# ---------------------------------------------------------------------------
+# Role & Account Management
+# ---------------------------------------------------------------------------
+
+
+class RoleAction(BaseModel):
+    role: str = Field(..., min_length=1, max_length=50)
+    action: Literal["grant", "revoke"]
+
+
+class SuspendAction(BaseModel):
+    suspended: bool
+
+
+# ---------------------------------------------------------------------------
+# CLI Auth
+# ---------------------------------------------------------------------------
+
+
+class CliTokenResponse(BaseModel):
+    access_token: str

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -1,0 +1,327 @@
+"""Admin-only service functions for ad-hoc database management."""
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA, EraConfig
+from models.account import Account, AccountStatus
+from models.character import Character, CharacterStatus
+from models.character_stats import CharacterStats
+from models.faction import Faction, FactionStatus
+from models.roles import AccountRole, Role
+from models.submission import Submission
+from models.task import Task, TaskStatus
+from models.vote import Vote
+from schemas.admin import (
+    AccountDetail,
+    AccountSummary,
+    AdminCharacterCreate,
+    CharacterBrief,
+    CharacterStatsPatch,
+    CharacterSummary,
+    FactionCreate,
+    OverviewStats,
+)
+from services.era import get_current_era_row, get_or_create_stats
+
+
+# ---------------------------------------------------------------------------
+# Read / Inspect
+# ---------------------------------------------------------------------------
+
+
+async def list_accounts(
+    session: AsyncSession,
+    email_filter: str | None = None,
+) -> list[AccountSummary]:
+    query = select(Account).order_by(Account.created_at.desc())
+    if email_filter:
+        query = query.where(Account.email.ilike(f"%{email_filter}%"))
+    result = await session.execute(query)
+    accounts = result.scalars().all()
+    return [
+        AccountSummary(
+            id=account.id,
+            email=account.email,
+            status=account.status.value,
+            created_at=account.created_at,
+        )
+        for account in accounts
+    ]
+
+
+async def get_account_detail(account_id: int, session: AsyncSession) -> AccountDetail:
+    account = await session.get(Account, account_id)
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found.")
+
+    result = await session.execute(
+        select(Character).where(Character.account_id == account_id).order_by(Character.created_at)
+    )
+    characters = result.scalars().all()
+
+    return AccountDetail(
+        id=account.id,
+        email=account.email,
+        status=account.status.value,
+        created_at=account.created_at,
+        characters=[
+            CharacterBrief(
+                id=character.id,
+                username=character.username,
+                display_name=character.display_name,
+                faction_slug=character.faction_slug,
+                status=character.status.value,
+            )
+            for character in characters
+        ],
+    )
+
+
+async def list_characters(
+    session: AsyncSession,
+    faction: str | None = None,
+    status: str | None = None,
+) -> list[CharacterSummary]:
+    era_row = await get_current_era_row(session)
+
+    query = (
+        select(Character, CharacterStats)
+        .outerjoin(
+            CharacterStats,
+            (CharacterStats.character_id == Character.id)
+            & (CharacterStats.era_id == era_row.id),
+        )
+        .order_by(Character.created_at.desc())
+    )
+    if faction:
+        query = query.where(Character.faction_slug == faction)
+    if status:
+        try:
+            status_enum = CharacterStatus(status)
+        except ValueError:
+            raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
+        query = query.where(Character.status == status_enum)
+
+    result = await session.execute(query)
+    rows = result.all()
+
+    return [
+        CharacterSummary(
+            id=character.id,
+            account_id=character.account_id,
+            username=character.username,
+            display_name=character.display_name,
+            faction_slug=character.faction_slug,
+            status=character.status.value,
+            score=stats.score if stats else 0,
+            level=stats.level if stats else 0,
+            votes_available=stats.votes_available if stats else 0,
+            created_at=character.created_at,
+        )
+        for character, stats in rows
+    ]
+
+
+async def game_overview(session: AsyncSession) -> OverviewStats:
+    account_count_result = await session.execute(select(func.count()).select_from(Account))
+    character_count_result = await session.execute(select(func.count()).select_from(Character))
+    active_task_count_result = await session.execute(
+        select(func.count()).select_from(Task).where(Task.status == TaskStatus.active)
+    )
+    submission_count_result = await session.execute(select(func.count()).select_from(Submission))
+    vote_count_result = await session.execute(select(func.count()).select_from(Vote))
+
+    return OverviewStats(
+        accounts=account_count_result.scalar_one(),
+        characters=character_count_result.scalar_one(),
+        active_tasks=active_task_count_result.scalar_one(),
+        submissions=submission_count_result.scalar_one(),
+        votes=vote_count_result.scalar_one(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seed / Insert
+# ---------------------------------------------------------------------------
+
+
+async def create_faction(data: FactionCreate, session: AsyncSession) -> Faction:
+    existing = await session.get(Faction, data.slug)
+    if existing is not None:
+        raise HTTPException(status_code=409, detail=f"Faction with slug '{data.slug}' already exists.")
+
+    faction = Faction(
+        slug=data.slug,
+        name=data.name,
+        description=data.description,
+        status=FactionStatus.hidden if data.hidden else FactionStatus.visible,
+    )
+    session.add(faction)
+    await session.commit()
+    await session.refresh(faction)
+    return faction
+
+
+async def admin_create_character(
+    data: AdminCharacterCreate,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Character:
+    """Create a character on any account, bypassing the level-3 gate."""
+    account = await session.get(Account, data.account_id)
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found.")
+
+    # Verify username is unique
+    existing = await session.execute(
+        select(Character).where(Character.username == data.username)
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail=f"Username '{data.username}' is already taken.")
+
+    era_row = await get_current_era_row(session)
+
+    character = Character(
+        account_id=data.account_id,
+        username=data.username,
+        display_name=data.display_name,
+        bio=data.bio,
+        avatar_url=data.avatar_url,
+        location=data.location,
+        faction_slug=data.faction_slug,
+    )
+    session.add(character)
+    await session.flush()
+
+    await get_or_create_stats(
+        session,
+        character_id=character.id,
+        era_id=era_row.id,
+        initial_votes=era.vote_budget_base,
+    )
+
+    await session.commit()
+    await session.refresh(character)
+    return character
+
+
+# ---------------------------------------------------------------------------
+# Adjust Game State
+# ---------------------------------------------------------------------------
+
+
+async def set_character_stats(
+    character_id: int,
+    patch: CharacterStatsPatch,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> CharacterStats:
+    era_row = await get_current_era_row(session)
+
+    stats = await get_or_create_stats(
+        session,
+        character_id=character_id,
+        era_id=era_row.id,
+        initial_votes=era.vote_budget_base,
+    )
+
+    if patch.level is not None:
+        stats.level = patch.level
+    if patch.score is not None:
+        stats.score = patch.score
+    if patch.all_time_score is not None:
+        stats.all_time_score = patch.all_time_score
+    if patch.votes_available is not None:
+        stats.votes_available = patch.votes_available
+
+    await session.commit()
+    await session.refresh(stats)
+    return stats
+
+
+async def reactivate_task(task_id: int, session: AsyncSession) -> Task:
+    task = await session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found.")
+    if task.status != TaskStatus.retired:
+        raise HTTPException(status_code=422, detail="Only retired tasks can be reactivated.")
+    task.status = TaskStatus.active
+    await session.commit()
+    await session.refresh(task)
+    return task
+
+
+# ---------------------------------------------------------------------------
+# Role & Account Management
+# ---------------------------------------------------------------------------
+
+
+async def assign_or_revoke_role(
+    account_id: int,
+    role_name: str,
+    action: str,
+    admin_account_id: int,
+    session: AsyncSession,
+) -> None:
+    account = await session.get(Account, account_id)
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found.")
+
+    role_result = await session.execute(select(Role).where(Role.name == role_name))
+    role = role_result.scalar_one_or_none()
+
+    if action == "grant":
+        if role is None:
+            role = Role(name=role_name, description="")
+            session.add(role)
+            await session.flush()
+
+        existing_result = await session.execute(
+            select(AccountRole).where(
+                AccountRole.account_id == account_id,
+                AccountRole.role_id == role.id,
+            )
+        )
+        if existing_result.scalar_one_or_none() is not None:
+            return  # Already has the role — idempotent
+
+        account_role = AccountRole(
+            account_id=account_id,
+            role_id=role.id,
+            granted_by=admin_account_id,
+        )
+        session.add(account_role)
+        await session.commit()
+
+    elif action == "revoke":
+        if role is None:
+            raise HTTPException(status_code=404, detail=f"Role '{role_name}' does not exist.")
+
+        existing_result = await session.execute(
+            select(AccountRole).where(
+                AccountRole.account_id == account_id,
+                AccountRole.role_id == role.id,
+            )
+        )
+        account_role = existing_result.scalar_one_or_none()
+        if account_role is None:
+            return  # Doesn't have the role — idempotent
+
+        await session.delete(account_role)
+        await session.commit()
+
+
+async def suspend_account(
+    account_id: int,
+    suspended: bool,
+    session: AsyncSession,
+) -> Account:
+    account = await session.get(Account, account_id)
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found.")
+    account.status = AccountStatus.suspended if suspended else AccountStatus.active
+    await session.commit()
+    await session.refresh(account)
+    return account


### PR DESCRIPTION
## Summary
- 10 new admin endpoints covering read/inspect, seed/insert, game state adjustment, and role/account management
- New `POST /admin/cli-token` endpoint for programmatic access (skill enablement) via `X-Admin-Cli-Secret` header
- `ADMIN_CLI_SECRET` config field added (optional, defaults to empty/disabled)

## New endpoints
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/admin/overview` | Game-wide counts |
| GET | `/admin/accounts` | List/search accounts by email |
| GET | `/admin/accounts/{id}` | Account detail + linked characters |
| GET | `/admin/characters` | All characters with current stats |
| POST | `/admin/factions` | Create a new faction |
| POST | `/admin/characters` | Admin-create character (bypasses level gate) |
| PATCH | `/admin/characters/{id}/stats` | Set level/score/votes directly |
| POST | `/admin/tasks/{id}/reactivate` | Retired → active |
| POST | `/admin/accounts/{id}/role` | Grant/revoke a named role |
| POST | `/admin/accounts/{id}/suspend` | Suspend/unsuspend account |
| POST | `/admin/cli-token` | Get JWT via secret header |

## Test plan
- [x] 60 unit tests pass
- [ ] Deploy to Render and smoke-test `GET /admin/overview` and `POST /admin/cli-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)