### PR TITLE
Fix /tasks/my-tasks route shadowed by /{task_id}

### DIFF
--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -3,7 +3,7 @@ import os
 import re
 from typing import Optional
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
 
 logger = logging.getLogger(__name__)
 from sqlalchemy import select
@@ -167,6 +167,33 @@ async def upload_media(
     await session.commit()
     await session.refresh(media_item)
     return MediaItemOut.model_validate(media_item)
+
+
+@router.delete("/{submission_id}/media/{media_id}", status_code=204)
+async def delete_media(
+    submission_id: int,
+    media_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    sub = await session.get(Submission, submission_id)
+    if sub is None:
+        raise HTTPException(status_code=404, detail="Submission not found.")
+    if sub.character_id != character.id:
+        raise HTTPException(status_code=403, detail="Cannot delete media from another character's submission.")
+    media_item = await session.get(MediaItem, media_id)
+    if media_item is None or media_item.submission_id != submission_id:
+        raise HTTPException(status_code=404, detail="Media item not found.")
+
+    abs_path = os.path.join(settings.MEDIA_ROOT, media_item.file_path)
+    try:
+        os.remove(abs_path)
+    except OSError:
+        pass  # File already gone — proceed with DB cleanup
+
+    await session.delete(media_item)
+    await session.commit()
+    return Response(status_code=204)
 
 
 @router.post("/{submission_id}/flag", response_model=SubmissionOut)

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -191,3 +191,24 @@ async def drop_task_route(
     if ct is None:
         raise HTTPException(status_code=404, detail="Signup not found.")
     await drop_task(ct, session)
+
+
+@router.get("/my-tasks", response_model=list[CharacterTaskOut])
+async def list_my_tasks(
+    status: Optional[str] = None,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """List the authenticated character's task signups, optionally filtered by status."""
+    query = select(CharacterTask).where(CharacterTask.character_id == character.id)
+    if status:
+        try:
+            query = query.where(CharacterTask.status == CharacterTaskStatus[status])
+        except KeyError:
+            raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
+    else:
+        query = query.where(CharacterTask.status == CharacterTaskStatus.in_progress)
+    query = query.order_by(CharacterTask.signed_up_at.desc())
+    result = await session.execute(query)
+    character_tasks = result.scalars().all()
+    return [await _build_character_task_out(ct, session) for ct in character_tasks]

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -82,6 +82,27 @@ async def list_tasks(
     ]
 
 
+@router.get("/my-tasks", response_model=list[CharacterTaskOut])
+async def list_my_tasks(
+    status: Optional[str] = None,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """List the authenticated character's task signups, optionally filtered by status."""
+    query = select(CharacterTask).where(CharacterTask.character_id == character.id)
+    if status:
+        try:
+            query = query.where(CharacterTask.status == CharacterTaskStatus[status])
+        except KeyError:
+            raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
+    else:
+        query = query.where(CharacterTask.status == CharacterTaskStatus.in_progress)
+    query = query.order_by(CharacterTask.signed_up_at.desc())
+    result = await session.execute(query)
+    character_tasks = result.scalars().all()
+    return [await _build_character_task_out(ct, session) for ct in character_tasks]
+
+
 @router.get("/{task_id}", response_model=TaskOut)
 async def get_task(task_id: int, session: AsyncSession = Depends(get_db)):
     task = await session.get(Task, task_id)
@@ -191,24 +212,3 @@ async def drop_task_route(
     if ct is None:
         raise HTTPException(status_code=404, detail="Signup not found.")
     await drop_task(ct, session)
-
-
-@router.get("/my-tasks", response_model=list[CharacterTaskOut])
-async def list_my_tasks(
-    status: Optional[str] = None,
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    """List the authenticated character's task signups, optionally filtered by status."""
-    query = select(CharacterTask).where(CharacterTask.character_id == character.id)
-    if status:
-        try:
-            query = query.where(CharacterTask.status == CharacterTaskStatus[status])
-        except KeyError:
-            raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
-    else:
-        query = query.where(CharacterTask.status == CharacterTaskStatus.in_progress)
-    query = query.order_by(CharacterTask.signed_up_at.desc())
-    result = await session.execute(query)
-    character_tasks = result.scalars().all()
-    return [await _build_character_task_out(ct, session) for ct in character_tasks]

--- a/backend/services/submission.py
+++ b/backend/services/submission.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from models.character import Character
 from models.flag import Flag
 from models.submission import Submission
-from models.task import Task
+from models.task import CharacterTask, CharacterTaskStatus, Task
 from models.vote import Vote
 from schemas.submission import SubmissionCreate
 from services.era import get_current_era_row, get_or_create_stats
@@ -20,6 +20,17 @@ async def create_submission(
     data: SubmissionCreate,
     session: AsyncSession,
 ) -> Submission:
+    character_task_result = await session.execute(
+        select(CharacterTask).where(
+            CharacterTask.character_id == character.id,
+            CharacterTask.task_id == task.id,
+            CharacterTask.status != CharacterTaskStatus.abandoned,
+        )
+    )
+    character_task = character_task_result.scalar_one_or_none()
+    if character_task is None:
+        raise HTTPException(status_code=403, detail="Must be signed up for this task to submit proof.")
+
     submission = Submission(
         task_id=task.id,
         character_id=character.id,
@@ -27,6 +38,7 @@ async def create_submission(
         body_text=data.body_text or "",
     )
     session.add(submission)
+    character_task.status = CharacterTaskStatus.submitted
     await session.commit()
     await session.refresh(submission)
     return submission

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Tasks from './pages/Tasks'
 import TaskDetail from './pages/TaskDetail'
 import SubmitProof from './pages/SubmitProof'
 import SubmissionDetail from './pages/SubmissionDetail'
+import EditSubmission from './pages/EditSubmission'
 import CharacterProfile from './pages/CharacterProfile'
 import Leaderboard from './pages/Leaderboard'
 import Factions from './pages/Factions'
@@ -36,6 +37,14 @@ export default function App() {
         />
         <Route path="/submissions" element={<Submissions />} />
         <Route path="/submissions/:id" element={<SubmissionDetail />} />
+        <Route
+          path="/submissions/:id/edit"
+          element={
+            <ProtectedRoute>
+              <EditSubmission />
+            </ProtectedRoute>
+          }
+        />
         <Route path="/characters/:id" element={<CharacterProfile />} />
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/factions" element={<Factions />} />

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -57,3 +57,7 @@ export async function flagSubmission(submissionId: number, reason: string): Prom
   const { data } = await api.post<SubmissionOut>(`/submissions/${submissionId}/flag`, { reason })
   return data
 }
+
+export async function deleteMedia(submissionId: number, mediaId: number): Promise<void> {
+  await api.delete(`/submissions/${submissionId}/media/${mediaId}`)
+}

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -57,3 +57,8 @@ export async function proposeTask(body: TaskCreate): Promise<TaskOut> {
   const { data } = await api.post<TaskOut>('/tasks', body)
   return data
 }
+
+export async function getMyTasks(status?: string): Promise<CharacterTaskOut[]> {
+  const { data } = await api.get<CharacterTaskOut[]>('/tasks/my-tasks', { params: status ? { status } : undefined })
+  return data
+}

--- a/frontend/src/pages/EditSubmission.tsx
+++ b/frontend/src/pages/EditSubmission.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useRef, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import {
+  getSubmission,
+  editSubmission,
+  uploadMedia,
+  deleteMedia,
+  type MediaItemOut,
+} from '../api/submissions'
+import { useAuth } from '../auth/AuthContext'
+import { extractError } from '../utils/errors'
+
+const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
+
+export default function EditSubmission() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+
+  const [taskId, setTaskId] = useState<number | null>(null)
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [media, setMedia] = useState<MediaItemOut[]>([])
+  const [newFiles, setNewFiles] = useState<FileList | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!id) return
+    getSubmission(parseInt(id, 10))
+      .then((submission) => {
+        if (user?.character?.id !== submission.character_id) {
+          navigate(`/submissions/${id}`, { replace: true })
+          return
+        }
+        setTaskId(submission.task_id)
+        setTitle(submission.title)
+        setBody(submission.body_text ?? '')
+        setMedia(submission.media)
+      })
+      .catch(() => setError("Couldn't load this submission."))
+      .finally(() => setLoading(false))
+  }, [id, user])
+
+  const handleRemoveMedia = async (mediaItem: MediaItemOut) => {
+    if (!id) return
+    try {
+      await deleteMedia(parseInt(id, 10), mediaItem.id)
+      setMedia((previous) => previous.filter((item) => item.id !== mediaItem.id))
+    } catch (err) {
+      setError(extractError(err, 'Could not remove media item.'))
+    }
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!id || !title.trim()) { setError('Title is required.'); return }
+    setSaving(true)
+    setError('')
+    try {
+      const submissionId = parseInt(id, 10)
+      await editSubmission(submissionId, { task_id: taskId!, title, body_text: body || undefined })
+      if (newFiles) {
+        for (const file of Array.from(newFiles)) {
+          const uploaded = await uploadMedia(submissionId, file)
+          setMedia((previous) => [...previous, uploaded])
+        }
+      }
+      navigate(`/submissions/${id}`)
+    } catch (err) {
+      setError(extractError(err, 'Could not save changes.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return <div className="page font-body text-muted">Loading...</div>
+
+  return (
+    <div className="page max-w-6xl">
+      <h1 className="page-heading">Edit Praxis</h1>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+        {/* Title */}
+        <div className="flex flex-col gap-1">
+          <label className="font-body text-sm font-bold">Title *</label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none"
+          />
+        </div>
+
+        {/* Split pane: editor + preview */}
+        <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex flex-col gap-1 flex-1">
+            <label className="font-body text-sm font-bold">Body</label>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={16}
+              className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none resize-none h-full min-h-64"
+              placeholder="Describe what you did... (supports **markdown**)"
+            />
+          </div>
+          <div className="flex flex-col gap-1 flex-1">
+            <label className="font-body text-sm font-bold text-muted">Preview</label>
+            <div className="border-2 border-border px-4 py-3 bg-card shadow-sketch-sm min-h-64 overflow-auto font-body text-sm markdown-preview">
+              {body.trim() ? (
+                <ReactMarkdown>{body}</ReactMarkdown>
+              ) : (
+                <p className="text-muted italic">Preview will appear here...</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Existing media */}
+        {media.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <label className="font-body text-sm font-bold">Attached Media</label>
+            <div className="flex flex-col gap-3">
+              {media.map((item) => {
+                const src = `${BASE_URL}/media/${item.file_path}`
+                const filename = item.file_path.split('/').pop() ?? item.file_path
+                return (
+                  <div key={item.id} className="flex items-center gap-3 border-2 border-border p-2 bg-card shadow-sketch-sm">
+                    {item.type === 'image' && (
+                      <img src={src} alt="" className="h-16 w-16 object-cover border border-border shrink-0" />
+                    )}
+                    {item.type === 'video' && (
+                      <video src={src} className="h-16 w-16 object-cover border border-border shrink-0" />
+                    )}
+                    {item.type === 'audio' && (
+                      <div className="h-16 w-16 flex items-center justify-center border border-border shrink-0 bg-muted/10 font-body text-xs text-muted">
+                        audio
+                      </div>
+                    )}
+                    <span className="font-body text-xs text-ink flex-1 truncate">{filename}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveMedia(item)}
+                      className="font-body text-xs text-red-600 hover:underline shrink-0"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Add new media */}
+        <div className="flex flex-col gap-1">
+          <label className="font-body text-sm font-bold">Add Media</label>
+          <input
+            ref={fileRef}
+            type="file"
+            multiple
+            accept="image/*,video/*,audio/*"
+            onChange={(e) => setNewFiles(e.target.files)}
+            className="font-body text-sm"
+          />
+        </div>
+
+        {error && <p className="font-body text-sm text-red-600">{error}</p>}
+
+        <div className="flex gap-3">
+          <button type="submit" disabled={saving} className="btn-primary">
+            {saving ? 'Saving...' : 'Save Changes'}
+          </button>
+          <button type="button" onClick={() => navigate(`/submissions/${id}`)} className="btn-outline">
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/SubmissionDetail.tsx
+++ b/frontend/src/pages/SubmissionDetail.tsx
@@ -65,9 +65,16 @@ export default function SubmissionDetail() {
       <div className="card p-5 my-4">
         <div className="flex items-start justify-between gap-4">
           <h1 className="font-display text-3xl font-bold leading-tight">{submission.title}</h1>
-          <Link to={`/characters/${submission.character_id}`} className="font-body text-xs text-muted shrink-0 hover:underline">
-            by #{submission.character_id}
-          </Link>
+          <div className="flex items-center gap-3 shrink-0">
+            <Link to={`/characters/${submission.character_id}`} className="font-body text-xs text-muted hover:underline">
+              by #{submission.character_id}
+            </Link>
+            {user?.character?.id === submission.character_id && (
+              <Link to={`/submissions/${submission.id}/edit`} className="font-body text-xs hover:underline">
+                edit
+              </Link>
+            )}
+          </div>
         </div>
 
         {submission.body_text && (

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { listSubmissions, type SubmissionOut } from '../api/submissions'
 import { getMessages, type MessageOut } from '../api/messages'
+import { getMyTasks, type CharacterTaskOut } from '../api/tasks'
 import SubmissionCard from '../components/SubmissionCard'
 import { useAuth } from '../auth/AuthContext'
 import { formatTimestamp } from '../utils/dates'
@@ -10,6 +12,7 @@ export default function Updates() {
   const { user } = useAuth()
   const [submissions, setSubmissions] = useState<SubmissionOut[]>([])
   const [messages, setMessages] = useState<MessageOut[]>([])
+  const [inProgressTasks, setInProgressTasks] = useState<CharacterTaskOut[]>([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
 
@@ -17,8 +20,9 @@ export default function Updates() {
     Promise.all([
       listSubmissions(user?.character ? { character_id: user.character.id } : {}),
       getMessages(),
+      getMyTasks('in_progress'),
     ])
-      .then(([s, m]) => { setSubmissions(s); setMessages(m) })
+      .then(([s, m, t]) => { setSubmissions(s); setMessages(m); setInProgressTasks(t) })
       .catch((err) => setFetchError(extractError(err, "Couldn't load your updates.")))
       .finally(() => setLoading(false))
   }, [user])
@@ -57,6 +61,30 @@ export default function Updates() {
           </div>
         </section>
       )}
+
+      <section className="mb-8">
+        <h2 className="font-display text-2xl font-bold mb-3">Tasks in Progress</h2>
+        {inProgressTasks.length === 0 ? (
+          <p className="font-body text-muted">No tasks in progress. <Link to="/tasks" className="underline">Browse tasks</Link> to sign up.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {inProgressTasks.map((ct) => (
+              <div key={ct.id} className="card px-4 py-3 flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-body font-semibold">{ct.task.title}</p>
+                  <p className="font-body text-xs text-muted">{ct.task.point_value} pts · signed up {formatTimestamp(ct.signed_up_at)}</p>
+                </div>
+                <Link
+                  to={`/tasks/${ct.task.id}/submit`}
+                  className="font-body text-sm border-2 border-current px-3 py-1 hover:bg-ua hover:text-white hover:border-ua transition-colors whitespace-nowrap"
+                >
+                  Submit Proof
+                </Link>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
 
       <section>
         <h2 className="font-display text-2xl font-bold mb-3">Your Praxis</h2>


### PR DESCRIPTION
## Summary
- Moves `GET /tasks/my-tasks` before `GET /tasks/{task_id}` in the router
- FastAPI matches routes in registration order; the `/{task_id}` pattern was capturing `my-tasks` as a path segment and then failing to parse it as an integer (422)

## Root cause
The endpoint was appended at the end of the file in the previous PR, after the `/{task_id}` route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)