### PR TITLE
Award base points on submission; add backfill endpoint

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -38,6 +38,7 @@ from services.admin_service import (
     set_character_stats,
     suspend_account,
 )
+from services.character_stats import recalculate_character_stats
 from services.auth import create_jwt
 
 router = APIRouter()
@@ -149,6 +150,26 @@ async def admin_patch_character_stats(
         level=stats.level,
         votes_available=stats.votes_available,
     )
+
+
+@router.post("/characters/backfill-stats", status_code=200)
+async def backfill_all_character_stats(
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    """Recompute CharacterStats for every character using current vote data.
+
+    Safe to call repeatedly. Use after a scoring formula change to bring all
+    persisted scores in sync.
+    """
+    result = await session.execute(
+        select(Character).where(Character.status != CharacterStatus.banned)
+    )
+    characters = result.scalars().all()
+    for character in characters:
+        await recalculate_character_stats(character.id, session)
+    await session.commit()
+    return {"recalculated": len(characters)}
 
 
 @router.post("/tasks/{task_id}/reactivate", response_model=TaskOut)

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -1,0 +1,61 @@
+"""Service for recomputing and persisting CharacterStats from current vote data."""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA, EraConfig
+from models.character import Character
+from models.submission import Submission
+from models.task import Task
+from models.vote import Vote
+from services.era import get_current_era_row, get_or_create_stats
+from services.scoring import compute_faction_multiplier, compute_level, compute_submission_score, compute_vote_budget
+
+
+async def recalculate_character_stats(
+    character_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> None:
+    """Recompute and persist score, level, and vote budget for a character.
+
+    Sums point_value * faction_multiplier + total_stars across all submissions.
+    Safe to call on submission creation (0 votes → base points only) or after
+    any vote change.
+    """
+    era_row = await get_current_era_row(session)
+
+    author = await session.get(Character, character_id)
+    character_faction_slug = author.faction_slug if author else "na"
+
+    submissions_result = await session.execute(
+        select(Submission).where(Submission.character_id == character_id)
+    )
+    submissions = submissions_result.scalars().all()
+
+    total_score = 0.0
+    for submission in submissions:
+        task = await session.get(Task, submission.task_id)
+        if task is None:
+            continue
+        task_faction_slug = task.primary_faction_slug or "na"
+        faction_multiplier = compute_faction_multiplier(character_faction_slug, task_faction_slug, era)
+        sum_result = await session.execute(
+            select(func.sum(Vote.stars)).where(Vote.submission_id == submission.id)
+        )
+        total_stars = int(sum_result.scalar_one_or_none() or 0)
+        total_score += compute_submission_score(task.point_value, faction_multiplier, total_stars)
+
+    new_score = int(total_score)
+    stats = await get_or_create_stats(session, character_id, era_row.id)
+    old_score = stats.score
+
+    old_budget_capacity = compute_vote_budget(old_score, era)
+    new_budget_capacity = compute_vote_budget(new_score, era)
+    budget_delta = new_budget_capacity - old_budget_capacity
+    if budget_delta > 0:
+        stats.votes_available += budget_delta
+
+    stats.score = new_score
+    stats.all_time_score = max(stats.all_time_score, new_score)
+    stats.level = compute_level(new_score, era)

--- a/backend/services/submission.py
+++ b/backend/services/submission.py
@@ -11,6 +11,7 @@ from models.submission import Submission
 from models.task import CharacterTask, CharacterTaskStatus, Task
 from models.vote import Vote
 from schemas.submission import SubmissionCreate
+from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
 from services.scoring import compute_faction_multiplier, compute_submission_score
 
@@ -42,6 +43,8 @@ async def create_submission(
     character_task.status = CharacterTaskStatus.submitted
     await session.commit()
     await session.refresh(submission)
+    await recalculate_character_stats(character.id, session)
+    await session.commit()
     return submission
 
 

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -1,59 +1,13 @@
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.submission import Submission
-from models.task import Task
 from models.vote import Vote
+from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
-from services.scoring import compute_faction_multiplier, compute_level, compute_submission_score, compute_vote_budget
-
-
-async def _recalculate_author_stats(
-    author_id: int,
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-) -> None:
-    """Recompute and persist score, level, and vote budget for a submission author."""
-    era_row = await get_current_era_row(session)
-
-    author = await session.get(Character, author_id)
-    character_faction_slug = author.faction_slug if author else "na"
-
-    submissions_result = await session.execute(
-        select(Submission).where(Submission.character_id == author_id)
-    )
-    submissions = submissions_result.scalars().all()
-
-    total_score = 0.0
-    for sub in submissions:
-        task = await session.get(Task, sub.task_id)
-        if task is None:
-            continue
-        task_faction_slug = task.primary_faction_slug or "na"
-        faction_multiplier = compute_faction_multiplier(character_faction_slug, task_faction_slug, era)
-        sum_result = await session.execute(
-            select(func.sum(Vote.stars)).where(Vote.submission_id == sub.id)
-        )
-        total_stars = int(sum_result.scalar_one_or_none() or 0)
-        total_score += compute_submission_score(task.point_value, faction_multiplier, total_stars)
-
-    new_score = int(total_score)
-    stats = await get_or_create_stats(session, author_id, era_row.id)
-    old_score = stats.score
-
-    # Increase vote budget by the delta earned from the score gain
-    old_budget_capacity = compute_vote_budget(old_score, era)
-    new_budget_capacity = compute_vote_budget(new_score, era)
-    budget_delta = new_budget_capacity - old_budget_capacity
-    if budget_delta > 0:
-        stats.votes_available += budget_delta
-
-    stats.score = new_score
-    stats.all_time_score = max(stats.all_time_score, new_score)
-    stats.level = compute_level(new_score, era)
 
 
 async def cast_or_update_vote(
@@ -78,7 +32,7 @@ async def cast_or_update_vote(
         # Update is free — no budget deduction
         existing.stars = stars
         await session.commit()
-        await _recalculate_author_stats(submission.character_id, session, era)
+        await recalculate_character_stats(submission.character_id, session, era)
         await session.commit()
         await session.refresh(existing)
         return existing
@@ -99,7 +53,7 @@ async def cast_or_update_vote(
     stats.votes_available -= 1
     session.add(vote)
     await session.flush()  # persist vote before recalculating so avg includes it
-    await _recalculate_author_stats(submission.character_id, session, era)
+    await recalculate_character_stats(submission.character_id, session, era)
     await session.commit()
     await session.refresh(vote)
     return vote


### PR DESCRIPTION
## Summary
- Stats are now recalculated on submission creation, so `point_value × faction_multiplier` is awarded immediately (no votes needed to see score/level update)
- Extracts `recalculate_character_stats` into `services/character_stats.py` shared by both submission and vote services
- Adds `POST /admin/characters/backfill-stats` to resync all persisted scores — called below to fix existing character 1 data

## Test plan
- [ ] Create a new submission → character's score and level should update immediately
- [ ] Run backfill endpoint to fix existing data in prod
- [ ] Cast a vote → score increases by star count

🤖 Generated with [Claude Code](https://claude.com/claude-code)