### PR TITLE
Style guide Phase 1: foundation redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,20 @@ complete real-world tasks, post proof ("praxis"), and earn points through commun
 - Expose account_id or email in public API responses
 - Put business logic in route handlers
 
+## Frontend conventions
+- `WORLD_ZERO_STYLE.md` is the single source of truth for all visual decisions — read it before any UI work
+- All colors must use CSS custom properties defined in `:root` / `[data-theme="dark"]` — never hardcode hex values in components
+- Base UI font is `Courier Prime`; display/titles use `Lora` italic; factions have specific fonts (see style guide Section 3)
+- Each faction has a unique card archetype (sticky note, field journal, collage, etc.) — do not unify card designs
+- Task cards use `flex-wrap`, not CSS grid — varied heights and slight rotations are intentional
+- Filter controls have specific visual treatments (rubber stamps, diagonal pennants, connected nodes) — do not use standard `<select>` or checkbox elements
+- Dark mode uses `data-theme="dark"` on the root element with per-component dark variants — do not auto-invert colors
+- See style guide Section 10 ("What NOT To Do") for a full list of anti-patterns
+- See `docs/STYLE_MIGRATION_NOTES.md` for Phase 2+ remaining work
+
 ## Key documents (read before starting any session)
+- `WORLD_ZERO_STYLE.md` — Visual style guide. Source of truth for colors, typography, layout, card archetypes, and dark mode. Read before any frontend/UI work.
+- `docs/STYLE_MIGRATION_NOTES.md` — Remaining style migration tasks (Phase 2+). Read before doing UI work.
 - `docs/BUILD_STATE.md` — What has been built vs. what's missing. Read to understand current state.
 - `docs/TASKS.md` — Structured task queue. Read to find what to work on in this session.
 

--- a/docs/STYLE_MIGRATION_NOTES.md
+++ b/docs/STYLE_MIGRATION_NOTES.md
@@ -1,0 +1,62 @@
+# Style Migration Notes — Phase 2+
+
+Reference: `WORLD_ZERO_STYLE.md` (root of repo)
+
+## What Phase 1 completed
+- CSS custom properties for all colors (`:root` + `[data-theme="dark"]`)
+- New fonts: Lora, Courier Prime, Special Elite, Share Tech Mono, Bebas Neue
+- Tailwind config updated with CSS-variable-backed colors and faction palette
+- Nav: frosted glass background, rainbow gradient wordmark underline, Courier Prime uppercase links
+- PageTitle component: Lora italic 34px with per-letter colored underline bars
+- Layout: grid with 1fr + 256px sidebar column
+- WatercolorBackground: SVG blurred ellipses in four corners
+- Sidebar shell: character card, active tasks placeholder, propose-a-task button
+- Removed: graph-paper background, Caveat/Kalam fonts, sketch box-shadows
+
+## Phase 2: Faction Card Archetypes
+
+Each faction needs a completely different card component. See style guide Section 6 for full specs.
+
+- [ ] **TaskCardUA** — Sticky note: push pin, clipped corner, pastel yellow/pink, slight rotation. Width ~122–130px. Font: Courier Prime. (§6.1)
+- [ ] **TaskCardAnalog** — Field journal page: yellowed paper, red margin rule on left, horizontal ruled lines, torn bottom edge via clip-path. Width ~132–140px. Font: Special Elite. (§6.2)
+- [ ] **TaskCardGestalt** — Collage / layered scraps: three stacked paper scraps at different rotations + scotch tape strip across top. Width ~138px. Font: Courier Prime. (§6.3)
+- [ ] **TaskCardSNIDE** — Newspaper clipping: aged newsprint, torn top/bottom edges via ::before/::after, masthead banner, two-column body, cutout ransom letters for faction name. Width ~148px. Font: Special Elite for card, Courier Prime for cutout letters. (§6.4)
+- [ ] **TaskCardJourneymen** — Luggage tag: dashed string + eyelet hole, hazard stripe at top, bordered tag body. Width ~118px. Font: Courier Prime. (§6.5)
+- [ ] **TaskCardSingularity** — Terminal printout: always dark background, green terminal text, corner bracket decorations, sprocket hole rows, scanline overlay, blinking cursor. Width ~140px. Font: Share Tech Mono. (§6.6)
+- [ ] **TaskCardUAMasters** — Gazette article: deckled corner-snipped edges, proper masthead, headline + dateline, two-column layout. Width ~148px. Font: Special Elite. (§6.7)
+- [ ] **TaskCard router** — `TaskCard.tsx` should select the correct card component based on `task.primary_faction_slug`
+- [ ] **Flex-wrap container** — Replace CSS grid on Tasks page with `display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start`. Cards are NOT on a strict grid — varying heights and slight rotations are intentional.
+- [ ] **LevelPill component** — Dark pill shared by all cards: `background: #1a1209; color: white; font-size: 7px; padding: 1px 6px; border-radius: 6px; text-transform: uppercase`. Dark mode: `background: var(--faction-color); color: dark-bg`.
+
+## Phase 3: Custom Filter Controls
+
+Replace current chip-based filters with three distinct visual types. See style guide Section 5.3.
+
+- [ ] **FilterStamps** (status filter) — Rectangular rubber stamps, no border-radius. 2px solid border, inner dashed border inset. Active: `bg: #1a1209; color: #F7F4EE`. Font: Courier Prime 10px bold uppercase. (§5.3)
+- [ ] **FilterFactionTabs** (faction filter) — Diagonal banner/pennant shape via `clip-path: polygon(0 0, 100% 0, 95% 100%, 5% 100%)`. Background: faction color. Inactive: `opacity: 0.42; filter: saturate(0.3)`. White text with text-shadow. Font: Courier Prime 9px bold uppercase. (§5.3)
+- [ ] **FilterLevelNodes** (level filter) — Connected circles (30px diameter) with horizontal connector bars. Active: scale(1.15), dark fill. Represents minimum level filter. (§5.3)
+
+## Phase 4: Dark Mode
+
+- [ ] **Theme toggle** — Add toggle in nav or settings. Store preference in `localStorage` key `wz-theme`. Default to system preference via `prefers-color-scheme`.
+- [ ] **useTheme hook** — Returns `'light' | 'dark'`, manages `data-theme` attribute on `<html>`.
+- [ ] **WatercolorBackground dark variant** — Lower opacity (0.11–0.18) and deep color variants per style guide §2.3.
+- [ ] **Nav dark mode** — `background: rgba(19, 18, 26, 0.92); backdrop-filter: blur(8px)`.
+- [ ] **Card dark variants** — Each faction card has a specifically designed dark variant. See §6.1–6.7 dark mode sections. Singularity card is always dark in both modes.
+- [ ] **Button dark variants** — Propose a task: `background: #f0e6d0; color: #13121a`. Stamps/chips: `bg: #f0e6d0; color: #13121a`.
+- [ ] **Body transition** — 150ms `transition: background-color, color` on body (already in index.css).
+
+## Phase 5: Sidebar Data Wiring
+
+- [ ] **Active tasks panel** — Fetch user's signed-up tasks, show with faction color left-border, task name, meta (faction · level · date), badge pill (Solo/Collab/Duel). Progress bar: `X / 20 slots` with indigo fill.
+- [ ] **Recent activity panel** — Fetch 3 most recent events. Player names in faction color + bold. Timestamps in tertiary color. Separated by 1px dashed border.
+
+## Phase 6: Per-Page Polish
+
+- [ ] Apply PageTitle to remaining secondary pages (About, Contact, Disclaimer, Attributions, Donate, Admin, EditCharacter, EditSubmission, SubmitProof, TaskDetail, SubmissionDetail, CharacterProfile, Updates, Groups)
+- [ ] Update SubmissionCard component to match new card aesthetic
+- [ ] Update CharacterProfile page layout
+- [ ] Update Leaderboard entry cards
+- [ ] Update Factions page cards to use faction-specific styling
+- [ ] Remove remaining `hover:-translate` sketch effects from all components
+- [ ] Audit all hardcoded hex values in components and replace with CSS custom properties

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;600;700&family=Kalam:wght@300;400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,500;0,600;1,400;1,500&family=Courier+Prime:wght@400;700&family=Special+Elite&family=Share+Tech+Mono&family=Bebas+Neue&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,8 @@ import { useEffect, type ReactNode } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
 import NavBar from './NavBar'
+import WatercolorBackground from './layout/WatercolorBackground'
+import Sidebar from './layout/Sidebar'
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { user, loading } = useAuth()
@@ -15,10 +17,32 @@ export default function Layout({ children }: { children: ReactNode }) {
   }, [user, loading, pathname, navigate])
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col relative">
+      <WatercolorBackground />
+
       <NavBar />
-      <main className="flex-1">{children}</main>
-      <footer className="border-t-2 border-border mt-12 px-6 py-4 font-body text-xs text-muted flex gap-6 flex-wrap">
+
+      {/* Page body: main content + sidebar (Style Guide §4.1) */}
+      <div
+        className="flex-1 relative max-w-5xl mx-auto w-full px-4 sm:px-6 py-5"
+        style={{ zIndex: 5 }}
+      >
+        <div
+          className="gap-4 items-start"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: user ? '1fr 256px' : '1fr',
+          }}
+        >
+          <main className="min-w-0">{children}</main>
+          {user && <Sidebar />}
+        </div>
+      </div>
+
+      <footer
+        className="relative font-body text-xs flex gap-6 flex-wrap max-w-5xl mx-auto w-full px-4 sm:px-6 py-4 mt-8"
+        style={{ color: 'var(--color-text-tertiary)', zIndex: 5 }}
+      >
         <Link to="/about" className="hover:underline">About</Link>
         <Link to="/contact" className="hover:underline">Contact</Link>
         <Link to="/disclaimer" className="hover:underline">Disclaimer</Link>

--- a/frontend/src/components/MediaGallery.tsx
+++ b/frontend/src/components/MediaGallery.tsx
@@ -21,7 +21,7 @@ export default function MediaGallery({ media }: Props) {
               key={item.id}
               src={src}
               alt=""
-              className="w-full border-2 border-border shadow-sketch-sm object-cover max-h-96"
+              className="w-full border-2 border-border object-cover max-h-96"
             />
           )
         }
@@ -31,7 +31,7 @@ export default function MediaGallery({ media }: Props) {
               key={item.id}
               src={src}
               controls
-              className="w-full border-2 border-border shadow-sketch-sm"
+              className="w-full border-2 border-border"
             />
           )
         }

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -11,6 +11,15 @@ const links = [
   { to: '/updates', label: 'Updates' },
 ]
 
+/** Nav link style — Courier Prime 10px uppercase (Style Guide §5.1) */
+const NAV_LINK_BASE = {
+  fontFamily: "'Courier Prime', monospace",
+  fontSize: 10,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.12em',
+  paddingBottom: 2,
+}
+
 export default function NavBar() {
   const { user, refetch } = useAuth()
 
@@ -20,23 +29,49 @@ export default function NavBar() {
   }
 
   return (
-    <nav className="bg-card border-b-2 border-border shadow-[0_3px_0_#3d3734] sticky top-0 z-10">
+    <nav
+      className="sticky top-0"
+      style={{
+        zIndex: 10,
+        background: 'rgba(247, 244, 238, 0.88)',
+        backdropFilter: 'blur(6px)',
+        borderBottom: '1px solid var(--color-border)',
+      }}
+    >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 h-14 flex items-center gap-6">
-        <NavLink to="/" className="font-display text-2xl font-bold shrink-0 leading-none">
-          World Zero
+        {/* Wordmark — Lora italic with rainbow gradient underline */}
+        <NavLink to="/" className="shrink-0 leading-none" style={{ textDecoration: 'none' }}>
+          <span
+            className="font-display italic"
+            style={{
+              fontSize: 19,
+              color: 'var(--color-text-primary)',
+              display: 'inline-block',
+              borderBottom: '2px solid transparent',
+              backgroundImage: 'linear-gradient(var(--color-bg-page), var(--color-bg-page)), linear-gradient(90deg, #4f46e5, #be185d, #f97316, #16a34a)',
+              backgroundSize: '100% calc(100% - 2px), 100% 2px',
+              backgroundPosition: 'top, bottom',
+              backgroundRepeat: 'no-repeat',
+              paddingBottom: 2,
+            }}
+          >
+            World Zero
+          </span>
         </NavLink>
 
+        {/* Nav links */}
         <ul className="flex gap-5 flex-1 list-none">
           {links.map(({ to, label, end }) => (
             <li key={to}>
               <NavLink
                 to={to}
                 end={end}
-                className={({ isActive }) =>
-                  `font-body text-sm pb-0.5 border-b-2 transition-colors ${
-                    isActive ? 'border-ink' : 'border-transparent hover:border-ink'
-                  }`
-                }
+                className="transition-colors"
+                style={({ isActive }) => ({
+                  ...NAV_LINK_BASE,
+                  color: isActive ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
+                  borderBottom: isActive ? '1.5px solid var(--color-text-primary)' : '1.5px solid transparent',
+                })}
               >
                 {label}
               </NavLink>
@@ -46,11 +81,12 @@ export default function NavBar() {
             <li>
               <NavLink
                 to="/admin"
-                className={({ isActive }) =>
-                  `font-body text-sm pb-0.5 border-b-2 transition-colors ${
-                    isActive ? 'border-ink' : 'border-transparent hover:border-ink'
-                  }`
-                }
+                className="transition-colors"
+                style={({ isActive }) => ({
+                  ...NAV_LINK_BASE,
+                  color: isActive ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
+                  borderBottom: isActive ? '1.5px solid var(--color-text-primary)' : '1.5px solid transparent',
+                })}
               >
                 Admin
               </NavLink>
@@ -58,25 +94,36 @@ export default function NavBar() {
           )}
         </ul>
 
+        {/* User area */}
         <div className="flex items-center gap-3 shrink-0">
           {user ? (
             <>
               {user.character ? (
                 <NavLink
                   to={`/characters/${user.character.id}/edit`}
-                  className="font-body text-sm text-muted hover:text-ink transition-colors"
+                  className="font-body transition-colors"
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--color-text-secondary)',
+                    letterSpacing: '0.08em',
+                  }}
                 >
                   {user.character.display_name}
                 </NavLink>
               ) : (
                 <NavLink
                   to="/characters/create"
-                  className="font-body text-sm text-muted hover:text-ink transition-colors"
+                  className="font-body transition-colors"
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--color-text-secondary)',
+                    letterSpacing: '0.08em',
+                  }}
                 >
-                  create character →
+                  create character
                 </NavLink>
               )}
-              <button onClick={handleLogout} className="btn-outline text-xs py-1 px-3">
+              <button onClick={handleLogout} className="btn-outline" style={{ padding: '0.25rem 0.75rem' }}>
                 logout
               </button>
             </>

--- a/frontend/src/components/SubmissionCard.tsx
+++ b/frontend/src/components/SubmissionCard.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function SubmissionCard({ submission }: Props) {
   return (
-    <div className="card p-4 flex flex-col gap-2 transition-all duration-150 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch-lg">
+    <div className="card p-4 flex flex-col gap-2 transition-all duration-150 hover:-translate-x-0.5 hover:-translate-y-0.5">
       <Link to={`/submissions/${submission.id}`}>
         <h3 className="font-display text-xl font-semibold leading-tight hover:underline">
           {submission.title}

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -21,7 +21,7 @@ export default function TaskCard({ task, onSignup }: Props) {
   const faction = FACTION_STYLES[task.primary_faction_slug ?? ''] ?? DEFAULT_STYLE
 
   return (
-    <div className="card relative overflow-hidden flex flex-col transition-all duration-150 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch-lg">
+    <div className="card relative overflow-hidden flex flex-col transition-all duration-150 hover:-translate-x-0.5 hover:-translate-y-0.5">
       {/* Faction color stripe */}
       <div className={`absolute left-0 top-0 bottom-0 w-1.5 ${faction.stripe}`} />
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,117 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../auth/AuthContext'
+
+/** Faction display names keyed by slug */
+const FACTION_NAMES: Record<string, string> = {
+  ua: 'UA',
+  analog: 'Analog',
+  gestalt: 'Gestalt',
+  snide: 'S.N.I.D.E.',
+  journeymen: 'Journeymen',
+  singularity: 'Singularity',
+  'ua-masters': 'UA Masters',
+}
+
+/** Faction color for the avatar orb gradient */
+const FACTION_COLORS: Record<string, string> = {
+  ua: '#6b6a7a',
+  analog: '#15803d',
+  gestalt: '#14532d',
+  snide: '#8a6a20',
+  journeymen: '#c49a3a',
+  singularity: '#7c3aed',
+  'ua-masters': '#555555',
+}
+
+/**
+ * Always-on right sidebar (Style Guide §4.2).
+ *
+ * Phase 1: Character card + placeholder active tasks + propose-a-task button.
+ * Phase 2 will wire up active tasks data and recent activity panel.
+ */
+export default function Sidebar() {
+  const { user } = useAuth()
+  const character = user?.character
+
+  return (
+    <aside className="flex flex-col gap-3" style={{ width: 256 }}>
+      {/* ── Character Card ── */}
+      {character ? (
+        <div className="sidebar-card">
+          <div className="flex items-center gap-3 mb-3">
+            {/* Avatar orb */}
+            <div
+              className="shrink-0 rounded-full"
+              style={{
+                width: 40,
+                height: 40,
+                background: `linear-gradient(135deg, ${FACTION_COLORS[character.faction_slug ?? ''] ?? '#6b6a7a'}, ${FACTION_COLORS[character.faction_slug ?? ''] ?? '#6b6a7a'}88)`,
+              }}
+            />
+            <div className="min-w-0">
+              <Link
+                to={`/characters/${character.id}`}
+                className="font-display italic text-sm block truncate"
+                style={{ color: 'var(--color-text-primary)' }}
+              >
+                {character.display_name}
+              </Link>
+              <span
+                className="font-body uppercase block truncate"
+                style={{
+                  fontSize: 9,
+                  letterSpacing: '0.12em',
+                  color: FACTION_COLORS[character.faction_slug ?? ''] ?? 'var(--color-text-tertiary)',
+                }}
+              >
+                {FACTION_NAMES[character.faction_slug ?? ''] ?? 'Unaffiliated'} · Level {character.level}
+              </span>
+            </div>
+          </div>
+
+          {/* 3-column stat grid */}
+          <div className="grid grid-cols-3 gap-1">
+            {[
+              { label: 'Score', value: character.score },
+              { label: 'Level', value: character.level },
+              { label: 'Era', value: 1 },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                className="text-center rounded-md py-1.5"
+                style={{ background: 'var(--color-bg-surface-alt)' }}
+              >
+                <div className="font-body font-bold text-sm" style={{ color: 'var(--color-text-primary)' }}>
+                  {stat.value}
+                </div>
+                <div className="eyebrow" style={{ fontSize: 7 }}>
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="sidebar-card">
+          <p className="eyebrow text-center">No character yet</p>
+        </div>
+      )}
+
+      {/* ── Active Tasks Panel (placeholder) ── */}
+      <div className="sidebar-card">
+        <p className="eyebrow mb-2">Your active tasks</p>
+        <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+          No active tasks
+        </p>
+      </div>
+
+      {/* ── Propose a Task Button ── */}
+      <Link
+        to="/contact"
+        className="btn-primary text-center w-full block"
+      >
+        Propose a Task
+      </Link>
+    </aside>
+  )
+}

--- a/frontend/src/components/layout/WatercolorBackground.tsx
+++ b/frontend/src/components/layout/WatercolorBackground.tsx
@@ -1,0 +1,60 @@
+/**
+ * Full-bleed watercolor splash background (Style Guide §7 / §2.3).
+ *
+ * Renders SVG blurred ellipses in four corners with paint-bleed distortion.
+ * Purely presentational — no data props, identical on every page.
+ */
+export default function WatercolorBackground() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 w-full h-full"
+      style={{ zIndex: 0 }}
+      preserveAspectRatio="none"
+    >
+      <defs>
+        {/* Main blob blur */}
+        <filter id="wc-blur" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="28" />
+        </filter>
+        {/* Paint-bleed distortion */}
+        <filter id="wc-distort" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="26" result="blur" />
+          <feTurbulence type="turbulence" baseFrequency="0.015" numOctaves="3" result="turb" />
+          <feDisplacementMap in="blur" in2="turb" scale="18" />
+        </filter>
+        {/* Small droplet blur */}
+        <filter id="wc-droplet" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="9" />
+        </filter>
+      </defs>
+
+      {/* ── Top-left: Blue / Indigo / Violet ── */}
+      <ellipse cx="8%" cy="10%" rx="14%" ry="18%" fill="#4f46e5" opacity="0.32" filter="url(#wc-distort)" />
+      <ellipse cx="14%" cy="6%" rx="10%" ry="12%" fill="#7c3aed" opacity="0.28" filter="url(#wc-blur)" />
+      <ellipse cx="4%" cy="18%" rx="6%" ry="8%" fill="#be185d" opacity="0.22" filter="url(#wc-blur)" />
+      {/* droplets */}
+      <circle cx="18%" cy="14%" r="1.5%" fill="#4f46e5" opacity="0.18" filter="url(#wc-droplet)" />
+      <circle cx="6%" cy="24%" r="1%" fill="#7c3aed" opacity="0.15" filter="url(#wc-droplet)" />
+
+      {/* ── Top-right: Orange / Amber / Lime ── */}
+      <ellipse cx="90%" cy="8%" rx="12%" ry="16%" fill="#b45309" opacity="0.30" filter="url(#wc-distort)" />
+      <ellipse cx="85%" cy="14%" rx="10%" ry="10%" fill="#d97706" opacity="0.28" filter="url(#wc-blur)" />
+      <ellipse cx="95%" cy="4%" rx="8%" ry="10%" fill="#16a34a" opacity="0.24" filter="url(#wc-blur)" />
+      {/* droplets */}
+      <circle cx="82%" cy="6%" r="1.2%" fill="#d97706" opacity="0.16" filter="url(#wc-droplet)" />
+
+      {/* ── Bottom-left: Rose / Pink / Orange ── */}
+      <ellipse cx="10%" cy="90%" rx="14%" ry="14%" fill="#9f1239" opacity="0.30" filter="url(#wc-distort)" />
+      <ellipse cx="6%" cy="85%" rx="8%" ry="12%" fill="#7c3aed" opacity="0.26" filter="url(#wc-blur)" />
+      {/* droplets */}
+      <circle cx="16%" cy="86%" r="1.3%" fill="#9f1239" opacity="0.16" filter="url(#wc-droplet)" />
+
+      {/* ── Bottom-right: Teal / Cyan / Sky ── */}
+      <ellipse cx="88%" cy="88%" rx="12%" ry="16%" fill="#0f766e" opacity="0.30" filter="url(#wc-distort)" />
+      <ellipse cx="94%" cy="92%" rx="10%" ry="10%" fill="#0e7490" opacity="0.26" filter="url(#wc-blur)" />
+      {/* droplets */}
+      <circle cx="84%" cy="94%" r="1%" fill="#0e7490" opacity="0.14" filter="url(#wc-droplet)" />
+    </svg>
+  )
+}

--- a/frontend/src/components/ui/PageTitle.tsx
+++ b/frontend/src/components/ui/PageTitle.tsx
@@ -1,0 +1,49 @@
+/**
+ * Page title with per-letter colored underline bars (Style Guide §5.2).
+ *
+ * Each letter gets a border-bottom cycling through the faction-inspired palette.
+ * Spaces render as gaps with no underline.
+ */
+
+const UNDERLINE_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '#f97316']
+
+interface Props {
+  title: string
+  /** Small eyebrow text above the title (e.g. era name, item count) */
+  eyebrow?: string
+}
+
+export default function PageTitle({ title, eyebrow }: Props) {
+  let colorIndex = 0
+
+  return (
+    <div className="mb-6">
+      {eyebrow && <p className="eyebrow mb-1">{eyebrow}</p>}
+      <h1
+        className="font-display italic font-medium leading-tight"
+        style={{ fontSize: 34, color: 'var(--color-text-primary)' }}
+      >
+        {title.split('').map((char, index) => {
+          if (char === ' ') {
+            return (
+              <span key={index} style={{ display: 'inline-block', width: '0.3em' }} />
+            )
+          }
+          const color = UNDERLINE_COLORS[colorIndex % UNDERLINE_COLORS.length]
+          colorIndex++
+          return (
+            <span
+              key={index}
+              style={{
+                borderBottom: `4px solid ${color}`,
+                paddingBottom: 2,
+              }}
+            >
+              {char}
+            </span>
+          )
+        })}
+      </h1>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,13 +2,60 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Color System (Style Guide §2.1) ── */
+:root {
+  /* Background layers */
+  --color-bg-page:        #F7F4EE;
+  --color-bg-surface:     rgba(255, 255, 255, 0.72);
+  --color-bg-surface-alt: #F0EDE6;
+
+  /* Text */
+  --color-text-primary:   #1a1209;
+  --color-text-secondary: #6b6050;
+  --color-text-tertiary:  #9b8e7d;
+
+  /* Borders */
+  --color-border:         rgba(0, 0, 0, 0.07);
+  --color-border-strong:  rgba(0, 0, 0, 0.15);
+
+  /* Accent */
+  --color-accent-primary: #be185d;
+}
+
+[data-theme="dark"] {
+  --color-bg-page:        #13121a;
+  --color-bg-surface:     rgba(255, 255, 255, 0.04);
+  --color-bg-surface-alt: rgba(255, 255, 255, 0.06);
+
+  --color-text-primary:   #f0e6d0;
+  --color-text-secondary: #7a7060;
+  --color-text-tertiary:  #4a4860;
+
+  --color-border:         rgba(255, 255, 255, 0.07);
+  --color-border-strong:  rgba(255, 255, 255, 0.15);
+
+  --color-accent-primary: #be185d;
+}
+
+/* ── Type Scale (Style Guide §3) ── */
+:root {
+  --text-xs:   8px;
+  --text-sm:   9px;
+  --text-base: 10px;
+  --text-md:   11px;
+  --text-lg:   12px;
+  --text-xl:   14px;
+  --text-2xl:  18px;
+  --text-3xl:  28px;
+  --text-4xl:  34px;
+}
+
 @layer base {
   body {
     @apply bg-paper font-body text-ink;
-    background-image: theme('backgroundImage.graph-paper');
-    background-size: theme('backgroundSize.graph-paper');
-    background-color: theme('colors.paper');
+    background-color: var(--color-bg-page);
     min-height: 100vh;
+    transition: background-color 150ms, color 150ms;
   }
 
   h1, h2, h3, h4 {
@@ -17,36 +64,85 @@
 }
 
 @layer components {
-  /* Hard-offset sketch card */
+  /* Frosted surface card (Style Guide §5.4) */
+  .sidebar-card {
+    background: var(--color-bg-surface);
+    border-radius: 14px;
+    padding: 0.9rem;
+    border: 1px solid var(--color-border);
+    backdrop-filter: blur(4px);
+  }
+
+  /* General card */
   .card {
-    @apply bg-card border-2 border-border shadow-sketch;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    backdrop-filter: blur(4px);
   }
 
-  /* Sketch button — dark fill */
+  /* Primary button (Style Guide §4.2 propose-a-task style) */
   .btn-primary {
-    @apply font-body bg-ink text-paper border-2 border-border shadow-sketch-sm
-           px-4 py-1.5 text-sm cursor-pointer
-           transition-all duration-100
-           hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch;
+    @apply font-body;
+    background: var(--color-text-primary);
+    color: var(--color-bg-page);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: opacity 150ms;
+  }
+  .btn-primary:hover {
+    opacity: 0.85;
   }
 
-  /* Sketch button — outline */
+  /* Outline button */
   .btn-outline {
-    @apply font-body bg-card text-ink border-2 border-border shadow-sketch-sm
-           px-4 py-1.5 text-sm cursor-pointer
-           transition-all duration-100
-           hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch;
+    @apply font-body;
+    background: var(--color-bg-surface);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-strong);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: opacity 150ms;
+  }
+  .btn-outline:hover {
+    opacity: 0.85;
   }
 
-  /* Filter chip */
+  /* Filter chip (temporary — Phase 2 replaces with rubber stamps / pennants / nodes) */
   .chip {
-    @apply font-body text-xs border-2 border-border bg-card shadow-sketch-sm
-           px-2.5 py-0.5 cursor-pointer
-           transition-all duration-100
-           hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch;
+    @apply font-body;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    background: var(--color-bg-surface);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-strong);
+    padding: 0.25rem 0.625rem;
+    cursor: pointer;
+    transition: all 150ms;
+  }
+  .chip:hover {
+    background: var(--color-bg-surface-alt);
   }
   .chip-active {
-    @apply bg-ink text-paper;
+    background: var(--color-text-primary);
+    color: var(--color-bg-page);
+    border-color: var(--color-text-primary);
+  }
+
+  /* Eyebrow / label text (Style Guide §3) */
+  .eyebrow {
+    @apply font-body;
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--color-text-tertiary);
   }
 
   /* Page wrapper */
@@ -54,9 +150,11 @@
     @apply max-w-5xl mx-auto px-4 sm:px-6 py-8;
   }
 
-  /* Section heading with underline */
+  /* Section heading (legacy — prefer PageTitle component) */
   .page-heading {
-    @apply font-display text-4xl font-bold border-b-2 border-border pb-2 mb-6;
+    @apply font-display text-4xl font-bold mb-6;
+    font-style: italic;
+    color: var(--color-text-primary);
   }
 
   /* Markdown preview pane */
@@ -68,8 +166,26 @@
   .markdown-preview em { @apply italic; }
   .markdown-preview ul { @apply list-disc pl-5 mb-3 space-y-1; }
   .markdown-preview ol { @apply list-decimal pl-5 mb-3 space-y-1; }
-  .markdown-preview code { @apply bg-paper px-1 border border-border text-xs; }
-  .markdown-preview pre { @apply bg-paper border-2 border-border p-3 mb-3 overflow-x-auto text-xs; }
-  .markdown-preview blockquote { @apply border-l-4 border-border pl-3 italic text-muted mb-3; }
-  .markdown-preview a { @apply underline text-muted hover:text-ink; }
+  .markdown-preview code {
+    background: var(--color-bg-surface-alt);
+    @apply px-1 text-xs;
+    border: 1px solid var(--color-border);
+  }
+  .markdown-preview pre {
+    background: var(--color-bg-surface-alt);
+    border: 1px solid var(--color-border);
+    @apply p-3 mb-3 overflow-x-auto text-xs;
+  }
+  .markdown-preview blockquote {
+    border-left: 4px solid var(--color-border-strong);
+    @apply pl-3 italic mb-3;
+    color: var(--color-text-secondary);
+  }
+  .markdown-preview a {
+    @apply underline;
+    color: var(--color-text-secondary);
+  }
+  .markdown-preview a:hover {
+    color: var(--color-text-primary);
+  }
 }

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,6 +1,6 @@
 export default function About() {
   return (
-    <div className="page max-w-2xl">
+    <div className="py-8 max-w-2xl">
       <h1 className="page-heading">About World Zero</h1>
 
       <div className="card p-6 mb-6">

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -93,10 +93,10 @@ export default function Admin() {
     }
   }
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
 
   return (
-    <div className="page">
+    <div className="py-8">
       <h1 className="page-heading">Admin</h1>
 
       {fetchError && (
@@ -154,13 +154,13 @@ export default function Admin() {
                 {edit ? (
                   <div className="flex flex-col gap-2">
                     <input
-                      className="border-2 border-border bg-card px-3 py-1 font-body text-sm shadow-sketch-sm focus:outline-none focus:border-ink"
+                      className="border-2 border-border bg-card px-3 py-1 font-body text-sm focus:outline-none focus:border-ink"
                       value={edit.name}
                       onChange={(e) => setFactionEdits((prev) => ({ ...prev, [f.slug]: { ...edit, name: e.target.value } }))}
                       placeholder="Name"
                     />
                     <textarea
-                      className="border-2 border-border bg-card px-3 py-1 font-body text-sm shadow-sketch-sm focus:outline-none focus:border-ink resize-none"
+                      className="border-2 border-border bg-card px-3 py-1 font-body text-sm focus:outline-none focus:border-ink resize-none"
                       rows={3}
                       value={edit.description}
                       onChange={(e) => setFactionEdits((prev) => ({ ...prev, [f.slug]: { ...edit, description: e.target.value } }))}

--- a/frontend/src/pages/Attributions.tsx
+++ b/frontend/src/pages/Attributions.tsx
@@ -44,7 +44,7 @@ const attributions = [
 
 export default function Attributions() {
   return (
-    <div className="page max-w-2xl">
+    <div className="py-8 max-w-2xl">
       <h1 className="page-heading">Attributions</h1>
       <p className="font-body text-muted mb-6">
         World Zero is built on the shoulders of great open source projects and creative

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -22,28 +22,28 @@ export default function CharacterProfile() {
       .finally(() => setLoading(false))
   }, [id])
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
   if (fetchError) return (
-    <div className="page">
+    <div className="py-8">
       <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
         {fetchError}{' '}
         <button onClick={() => window.location.reload()} className="underline">Try refreshing.</button>
       </p>
     </div>
   )
-  if (!character) return <div className="page font-body text-muted">Character not found.</div>
+  if (!character) return <div className="py-8 font-body text-muted">Character not found.</div>
 
   return (
-    <div className="page">
+    <div className="py-8">
       <div className="card p-6 mb-6 flex gap-5 items-start">
         {character.avatar_url ? (
           <img
             src={mediaUrl(character.avatar_url)}
             alt={character.username}
-            className="w-20 h-20 rounded-full border-2 border-border shadow-sketch-sm object-cover shrink-0"
+            className="w-20 h-20 rounded-full border-2 border-border object-cover shrink-0"
           />
         ) : (
-          <div className="w-20 h-20 rounded-full border-2 border-border shadow-sketch-sm bg-paper flex items-center justify-center font-display text-3xl font-bold shrink-0">
+          <div className="w-20 h-20 rounded-full border-2 border-border bg-paper flex items-center justify-center font-display text-3xl font-bold shrink-0">
             {character.username[0]?.toUpperCase()}
           </div>
         )}

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -29,7 +29,7 @@ export default function Contact() {
 
   if (success) {
     return (
-      <div className="page max-w-2xl">
+      <div className="py-8 max-w-2xl">
         <h1 className="page-heading">Contact</h1>
         <div className="card p-6 text-center">
           <p className="font-display text-2xl font-bold mb-2">Message sent!</p>
@@ -40,7 +40,7 @@ export default function Contact() {
   }
 
   return (
-    <div className="page max-w-2xl">
+    <div className="py-8 max-w-2xl">
       <h1 className="page-heading">Contact</h1>
       <p className="font-body text-muted mb-6">
         Have a question, bug report, or just want to say hi? Send us a message.
@@ -99,7 +99,7 @@ export default function Contact() {
         </div>
 
         {error && (
-          <p className="font-body text-sm border-2 border-border px-3 py-2 shadow-sketch-sm">
+          <p className="font-body text-sm border-2 border-border px-3 py-2">
             {error}
           </p>
         )}

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -83,9 +83,9 @@ export default function CreateCharacter() {
   }
 
   return (
-    <div className="page max-w-xl mx-auto py-10">
+    <div className="py-8 max-w-xl mx-auto py-10">
       {/* Flavor text */}
-      <div className="mb-8 border-2 border-border p-4 shadow-sketch bg-card font-body text-sm leading-relaxed">
+      <div className="mb-8 border-2 border-border p-4 bg-card font-body text-sm leading-relaxed">
         <p className="text-muted">
           The first task reads: <span className="line-through">"Take a picture of yourself."</span>
         </p>
@@ -106,14 +106,14 @@ export default function CreateCharacter() {
               <img
                 src={avatarPreview}
                 alt="Avatar preview"
-                className="w-16 h-16 object-cover border-2 border-border shadow-sketch-sm"
+                className="w-16 h-16 object-cover border-2 border-border"
               />
             )}
             {!avatarPreview && avatarUrl && (
               <img
                 src={avatarUrl}
                 alt="Avatar preview"
-                className="w-16 h-16 object-cover border-2 border-border shadow-sketch-sm"
+                className="w-16 h-16 object-cover border-2 border-border"
                 onError={(e) => (e.currentTarget.style.display = 'none')}
               />
             )}
@@ -132,7 +132,7 @@ export default function CreateCharacter() {
                   value={avatarUrl}
                   onChange={handleUrlChange}
                   placeholder="https://..."
-                  className="flex-1 border-2 border-border bg-card px-2 py-1 font-body text-xs shadow-sketch-sm focus:outline-none focus:border-ink"
+                  className="flex-1 border-2 border-border bg-card px-2 py-1 font-body text-xs focus:outline-none focus:border-ink"
                 />
               </div>
             </div>
@@ -153,7 +153,7 @@ export default function CreateCharacter() {
             minLength={3}
             maxLength={30}
             required
-            className="border-2 border-border bg-card px-3 py-2 font-body text-sm shadow-sketch-sm focus:outline-none focus:border-ink"
+            className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink"
           />
           {fieldErrors.username && (
             <p className="font-body text-xs text-red-600">{fieldErrors.username}</p>
@@ -172,7 +172,7 @@ export default function CreateCharacter() {
             placeholder="The name others will see"
             maxLength={50}
             required
-            className="border-2 border-border bg-card px-3 py-2 font-body text-sm shadow-sketch-sm focus:outline-none focus:border-ink"
+            className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink"
           />
           {fieldErrors.displayName && (
             <p className="font-body text-xs text-red-600">{fieldErrors.displayName}</p>
@@ -190,7 +190,7 @@ export default function CreateCharacter() {
             placeholder="Who is your character?"
             maxLength={500}
             rows={3}
-            className="border-2 border-border bg-card px-3 py-2 font-body text-sm shadow-sketch-sm focus:outline-none focus:border-ink resize-none"
+            className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink resize-none"
           />
           <span className="font-body text-xs text-muted self-end">{bio.length}/500</span>
           {fieldErrors.bio && (
@@ -209,7 +209,7 @@ export default function CreateCharacter() {
             onChange={(e) => setLocation(e.target.value)}
             placeholder="Where in the world?"
             maxLength={100}
-            className="border-2 border-border bg-card px-3 py-2 font-body text-sm shadow-sketch-sm focus:outline-none focus:border-ink"
+            className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink"
           />
           {fieldErrors.location && (
             <p className="font-body text-xs text-red-600">{fieldErrors.location}</p>

--- a/frontend/src/pages/Disclaimer.tsx
+++ b/frontend/src/pages/Disclaimer.tsx
@@ -1,6 +1,6 @@
 export default function Disclaimer() {
   return (
-    <div className="page max-w-2xl">
+    <div className="py-8 max-w-2xl">
       <h1 className="page-heading">Disclaimer</h1>
 
       <div className="card p-6 space-y-5 font-body text-base leading-relaxed">

--- a/frontend/src/pages/Donate.tsx
+++ b/frontend/src/pages/Donate.tsx
@@ -1,6 +1,6 @@
 export default function Donate() {
   return (
-    <div className="page max-w-2xl text-center">
+    <div className="py-8 max-w-2xl text-center">
       <h1 className="page-heading text-center">Support World Zero</h1>
 
       <div className="card p-8 mb-6">

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -60,12 +60,12 @@ export default function EditCharacter() {
     }
   }
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
-  if (!character) return <div className="page font-body text-muted">Character not found.</div>
-  if (!isOwner) return <div className="page font-body text-muted">You can only edit your own character.</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
+  if (!character) return <div className="py-8 font-body text-muted">Character not found.</div>
+  if (!isOwner) return <div className="py-8 font-body text-muted">You can only edit your own character.</div>
 
   return (
-    <div className="page max-w-xl">
+    <div className="py-8 max-w-xl">
       <h1 className="page-heading">Edit Character</h1>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-5">
@@ -75,10 +75,10 @@ export default function EditCharacter() {
             <img
               src={mediaUrl(character.avatar_url)}
               alt={character.username}
-              className="w-16 h-16 rounded-full border-2 border-border shadow-sketch-sm object-cover"
+              className="w-16 h-16 rounded-full border-2 border-border object-cover"
             />
           ) : (
-            <div className="w-16 h-16 rounded-full border-2 border-border shadow-sketch-sm bg-paper flex items-center justify-center font-display text-2xl font-bold">
+            <div className="w-16 h-16 rounded-full border-2 border-border bg-paper flex items-center justify-center font-display text-2xl font-bold">
               {character.username[0]?.toUpperCase()}
             </div>
           )}
@@ -100,7 +100,7 @@ export default function EditCharacter() {
             type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
-            className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none"
+            className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none"
             maxLength={50}
           />
         </div>
@@ -111,7 +111,7 @@ export default function EditCharacter() {
             value={bio}
             onChange={(e) => setBio(e.target.value)}
             rows={4}
-            className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none resize-none"
+            className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none resize-none"
             maxLength={500}
             placeholder="Tell people about your character..."
           />
@@ -123,7 +123,7 @@ export default function EditCharacter() {
             type="text"
             value={location}
             onChange={(e) => setLocation(e.target.value)}
-            className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none"
+            className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none"
             maxLength={100}
             placeholder="Where are you based?"
           />

--- a/frontend/src/pages/EditSubmission.tsx
+++ b/frontend/src/pages/EditSubmission.tsx
@@ -77,10 +77,10 @@ export default function EditSubmission() {
     }
   }
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
 
   return (
-    <div className="page max-w-6xl">
+    <div className="py-8 max-w-6xl">
       <h1 className="page-heading">Edit Praxis</h1>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-5">
@@ -91,7 +91,7 @@ export default function EditSubmission() {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none"
+            className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none"
           />
         </div>
 
@@ -103,13 +103,13 @@ export default function EditSubmission() {
               value={body}
               onChange={(e) => setBody(e.target.value)}
               rows={16}
-              className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none resize-none h-full min-h-64"
+              className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none resize-none h-full min-h-64"
               placeholder="Describe what you did... (supports **markdown**)"
             />
           </div>
           <div className="flex flex-col gap-1 flex-1">
             <label className="font-body text-sm font-bold text-muted">Preview</label>
-            <div className="border-2 border-border px-4 py-3 bg-card shadow-sketch-sm min-h-64 overflow-auto font-body text-sm markdown-preview">
+            <div className="border-2 border-border px-4 py-3 bg-card min-h-64 overflow-auto font-body text-sm markdown-preview">
               {body.trim() ? (
                 <ReactMarkdown>{body}</ReactMarkdown>
               ) : (
@@ -128,7 +128,7 @@ export default function EditSubmission() {
                 const src = `${BASE_URL}/media/${item.file_path}`
                 const filename = item.file_path.split('/').pop() ?? item.file_path
                 return (
-                  <div key={item.id} className="flex items-center gap-3 border-2 border-border p-2 bg-card shadow-sketch-sm">
+                  <div key={item.id} className="flex items-center gap-3 border-2 border-border p-2 bg-card">
                     {item.type === 'image' && (
                       <img src={src} alt="" className="h-16 w-16 object-cover border border-border shrink-0" />
                     )}

--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { getFactions } from '../api/factions'
 import type { FactionOut } from '../api/factions'
+import PageTitle from '../components/ui/PageTitle'
 import { extractError } from '../utils/errors'
 
 export default function Factions() {
@@ -15,11 +16,11 @@ export default function Factions() {
       .finally(() => setLoading(false))
   }, [])
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
 
   return (
-    <div className="page">
-      <h1 className="page-heading">Factions</h1>
+    <div className="py-8">
+      <PageTitle title="Factions" />
       <p className="font-body text-sm text-muted mb-6">
         Factions are chosen at level 3. Until then, you start in UA.
       </p>
@@ -32,7 +33,7 @@ export default function Factions() {
         {factions.map((f) => (
           <div
             key={f.slug}
-            className="card p-5 flex flex-col gap-2 relative overflow-hidden transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch-lg"
+            className="card p-5 flex flex-col gap-2 relative overflow-hidden transition-all hover:-translate-x-0.5 hover:-translate-y-0.5"
           >
             <div className={`absolute left-0 top-0 bottom-0 w-1.5 bg-faction-${f.slug}`} />
             <div className="pl-2">

--- a/frontend/src/pages/Groups.tsx
+++ b/frontend/src/pages/Groups.tsx
@@ -53,13 +53,13 @@ const FACTIONS = [
 
 export default function Groups() {
   return (
-    <div className="page">
+    <div className="py-8">
       <h1 className="page-heading">Groups</h1>
       <p className="font-body text-sm text-muted mb-6">Factions are chosen at level 3. Until then, you start in the University of Aesthematics.</p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
         {FACTIONS.map((f) => (
-          <div key={f.slug} className="card p-5 flex flex-col gap-2 relative overflow-hidden transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch-lg">
+          <div key={f.slug} className="card p-5 flex flex-col gap-2 relative overflow-hidden transition-all hover:-translate-x-0.5 hover:-translate-y-0.5">
             <div className={`absolute left-0 top-0 bottom-0 w-1.5 ${f.dotClass}`} />
             <div className="pl-2">
               <div className="flex items-center gap-2 mb-1">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth/AuthContext'
 import { listSubmissions, type SubmissionOut } from '../api/submissions'
 import { loginWithGoogle, devLogin } from '../api/auth'
 import SubmissionCard from '../components/SubmissionCard'
+import PageTitle from '../components/ui/PageTitle'
 
 export default function Home() {
   const { user, refetch } = useAuth()
@@ -19,9 +20,9 @@ export default function Home() {
 
   if (!user) {
     return (
-      <div className="page max-w-2xl mx-auto text-center py-20">
+      <div className="max-w-2xl mx-auto text-center py-20">
         {loginRequired && (
-          <p className="font-body text-sm text-muted mb-6 border-2 border-border px-4 py-2 shadow-sketch-sm inline-block">
+          <p className="font-body text-sm text-muted mb-6 border-2 border-border px-4 py-2 inline-block">
             You need to log in to access that page.
           </p>
         )}
@@ -46,11 +47,8 @@ export default function Home() {
   }
 
   return (
-    <div className="page">
-      <div className="flex items-baseline gap-3 mb-6 border-b-2 border-border pb-2">
-        <h1 className="font-display text-4xl font-bold">Recent Praxis</h1>
-        <span className="font-body text-sm text-muted">{feed.length} submissions</span>
-      </div>
+    <div className="py-8">
+      <PageTitle title="Recent Praxis" eyebrow={`${feed.length} submissions`} />
       {feed.length === 0 ? (
         <p className="font-body text-muted">No submissions yet. Be the first!</p>
       ) : (

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { getLeaderboard } from '../api/leaderboard'
 import type { CharacterOut } from '../api/auth'
+import PageTitle from '../components/ui/PageTitle'
 import { extractError } from '../utils/errors'
 
 export default function Leaderboard() {
@@ -17,8 +18,8 @@ export default function Leaderboard() {
   }, [])
 
   return (
-    <div className="page max-w-2xl">
-      <h1 className="page-heading">Leaderboard</h1>
+    <div className="py-8 max-w-2xl">
+      <PageTitle title="Leaderboard" />
 
       {loading ? (
         <p className="font-body text-muted">Loading...</p>
@@ -32,7 +33,7 @@ export default function Leaderboard() {
       ) : (
         <div className="flex flex-col gap-2">
           {characters.map((c, i) => (
-            <div key={c.id} className="card px-4 py-3 flex items-center gap-4 transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sketch-lg">
+            <div key={c.id} className="card px-4 py-3 flex items-center gap-4 transition-all hover:-translate-x-0.5 hover:-translate-y-0.5">
               <span className="font-display text-2xl font-bold text-muted w-8 shrink-0 text-right">
                 {i + 1}
               </span>

--- a/frontend/src/pages/SubmissionDetail.tsx
+++ b/frontend/src/pages/SubmissionDetail.tsx
@@ -43,21 +43,21 @@ export default function SubmissionDetail() {
     }
   }
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
   if (fetchError) return (
-    <div className="page">
+    <div className="py-8">
       <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
         {fetchError}{' '}
         <button onClick={() => window.location.reload()} className="underline">Try refreshing.</button>
       </p>
     </div>
   )
-  if (!submission) return <div className="page font-body text-muted">Not found.</div>
+  if (!submission) return <div className="py-8 font-body text-muted">Not found.</div>
 
   const canFlag = (user?.character?.level ?? 0) >= 4 && user?.character?.id !== submission.character_id
 
   return (
-    <div className="page max-w-2xl">
+    <div className="py-8 max-w-2xl">
       <Link to={`/tasks/${submission.task_id}`} className="font-body text-xs text-muted hover:underline">
         ← {submission.task_title || 'back to task'}
       </Link>

--- a/frontend/src/pages/Submissions.tsx
+++ b/frontend/src/pages/Submissions.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { listSubmissions } from '../api/submissions'
 import type { SubmissionOut } from '../api/submissions'
 import SubmissionCard from '../components/SubmissionCard'
+import PageTitle from '../components/ui/PageTitle'
 import { extractError } from '../utils/errors'
 
 export default function Submissions() {
@@ -17,8 +18,8 @@ export default function Submissions() {
   }, [])
 
   return (
-    <div className="page">
-      <h1 className="page-heading">Praxis</h1>
+    <div className="py-8">
+      <PageTitle title="Praxis" />
       <p className="font-body text-sm text-muted mb-6">
         Proof of action. All submissions from across World Zero.
       </p>

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -42,7 +42,7 @@ export default function SubmitProof() {
   }
 
   return (
-    <div className="page max-w-6xl">
+    <div className="py-8 max-w-6xl">
       <h1 className="page-heading">Submit Proof</h1>
 
       {task && (
@@ -67,7 +67,7 @@ export default function SubmitProof() {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none"
+            className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none"
             placeholder="Give your proof a title"
           />
         </div>
@@ -81,7 +81,7 @@ export default function SubmitProof() {
               value={body}
               onChange={(e) => setBody(e.target.value)}
               rows={16}
-              className="border-2 border-border px-3 py-2 font-body text-sm bg-card shadow-sketch-sm focus:outline-none resize-none h-full min-h-64"
+              className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none resize-none h-full min-h-64"
               placeholder="Describe what you did... (supports **markdown**)"
             />
           </div>
@@ -89,7 +89,7 @@ export default function SubmitProof() {
           {/* Right: preview */}
           <div className="flex flex-col gap-1 flex-1">
             <label className="font-body text-sm font-bold text-muted">Preview</label>
-            <div className="border-2 border-border px-4 py-3 bg-card shadow-sketch-sm min-h-64 overflow-auto font-body text-sm markdown-preview">
+            <div className="border-2 border-border px-4 py-3 bg-card min-h-64 overflow-auto font-body text-sm markdown-preview">
               {body.trim() ? (
                 <ReactMarkdown>{body}</ReactMarkdown>
               ) : (

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -49,19 +49,19 @@ export default function TaskDetail() {
     }
   }
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
   if (fetchError) return (
-    <div className="page">
+    <div className="py-8">
       <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
         {fetchError}{' '}
         <button onClick={() => window.location.reload()} className="underline">Try refreshing.</button>
       </p>
     </div>
   )
-  if (!task) return <div className="page font-body text-muted">Task not found.</div>
+  if (!task) return <div className="py-8 font-body text-muted">Task not found.</div>
 
   return (
-    <div className="page">
+    <div className="py-8">
       <Link to="/tasks" className="font-body text-xs text-muted hover:underline">← back to tasks</Link>
 
       <div className="card p-5 my-4">

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { listTasks, signupTask, type TaskOut } from '../api/tasks'
 import { getFactions, type FactionOut } from '../api/factions'
 import TaskCard from '../components/TaskCard'
+import PageTitle from '../components/ui/PageTitle'
 import { extractError } from '../utils/errors'
 import { useAuth } from '../auth/AuthContext'
 
@@ -58,11 +59,8 @@ export default function Tasks() {
   if (characterLevel >= 3) statusFilters.push('pending')
 
   return (
-    <div className="page">
-      <div className="flex items-baseline gap-3 mb-5 border-b-2 border-border pb-2">
-        <h1 className="font-display text-4xl font-bold">Tasks</h1>
-        <span className="font-body text-sm text-muted">{tasks.length} shown</span>
-      </div>
+    <div className="py-8">
+      <PageTitle title="Tasks" eyebrow={`${tasks.length} shown`} />
 
       {/* Filters */}
       <div className="flex flex-wrap gap-2 items-center mb-6">

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -27,10 +27,10 @@ export default function Updates() {
       .finally(() => setLoading(false))
   }, [user])
 
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
 
   if (fetchError) return (
-    <div className="page">
+    <div className="py-8">
       <h1 className="page-heading">Updates</h1>
       <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
         {fetchError}{' '}
@@ -40,7 +40,7 @@ export default function Updates() {
   )
 
   return (
-    <div className="page">
+    <div className="py-8">
       <h1 className="page-heading">Updates</h1>
 
       {messages.length > 0 && (

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -2,41 +2,45 @@ import type { Config } from 'tailwindcss'
 
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['selector', '[data-theme="dark"]'],
   theme: {
     extend: {
       fontFamily: {
-        display: ['Caveat', 'cursive'],
-        body: ['Kalam', 'cursive'],
+        display: ['Lora', 'serif'],
+        body: ['Courier Prime', 'monospace'],
+        'faction-analog': ['Special Elite', 'serif'],
+        'faction-singularity': ['Share Tech Mono', 'monospace'],
+        accent: ['Bebas Neue', 'sans-serif'],
       },
       colors: {
-        paper: '#faf9f6',
-        ink: '#1c1917',
-        muted: '#78716c',
-        border: '#3d3734',
-        card: '#fffef9',
-        // Faction palette
-        ua: { DEFAULT: '#6d28d9', accent: '#fbbf24' },
-        journeymen: { DEFAULT: '#1d4ed8', accent: '#d97706' },
-        gestalt: { DEFAULT: '#7c3aed', accent: '#c4b5fd' },
-        geo: { DEFAULT: '#92400e', accent: '#d97706' },
-        snide: { DEFAULT: '#166534', accent: '#4ade80' },
-        cm: { DEFAULT: '#b45309', accent: '#fde68a' },
+        paper: 'var(--color-bg-page)',
+        ink: 'var(--color-text-primary)',
+        muted: 'var(--color-text-secondary)',
+        tertiary: 'var(--color-text-tertiary)',
+        border: 'var(--color-border)',
+        'border-strong': 'var(--color-border-strong)',
+        surface: 'var(--color-bg-surface)',
+        'surface-alt': 'var(--color-bg-surface-alt)',
+        accent: 'var(--color-accent-primary)',
+        // Faction palette (light mode values — dark mode handled via CSS vars in Phase 2)
+        ua: { DEFAULT: '#6b6a7a', accent: '#a78bfa' },
+        analog: { DEFAULT: '#15803d', accent: '#15803d' },
+        gestalt: { DEFAULT: '#14532d', accent: '#4ade80' },
+        snide: { DEFAULT: '#8a6a20', accent: '#c49a3a' },
+        journeymen: { DEFAULT: '#c49a3a', accent: '#c49a3a' },
+        singularity: { DEFAULT: '#7c3aed', accent: '#4ade80' },
+        'ua-masters': { DEFAULT: '#555555', accent: '#c49a3a' },
       },
-      boxShadow: {
-        sketch: '3px 3px 0 #3d3734',
-        'sketch-sm': '2px 2px 0 #3d3734',
-        'sketch-lg': '5px 5px 0 #3d3734',
-      },
-      backgroundImage: {
-        'graph-paper': `
-          linear-gradient(rgba(99, 102, 241, 0.08) 1px, transparent 1px),
-          linear-gradient(90deg, rgba(99, 102, 241, 0.08) 1px, transparent 1px),
-          linear-gradient(rgba(99, 102, 241, 0.04) 1px, transparent 1px),
-          linear-gradient(90deg, rgba(99, 102, 241, 0.04) 1px, transparent 1px)
-        `,
-      },
-      backgroundSize: {
-        'graph-paper': '80px 80px, 80px 80px, 16px 16px, 16px 16px',
+      fontSize: {
+        'wz-xs': '8px',
+        'wz-sm': '9px',
+        'wz-base': '10px',
+        'wz-md': '11px',
+        'wz-lg': '12px',
+        'wz-xl': '14px',
+        'wz-2xl': '18px',
+        'wz-3xl': '28px',
+        'wz-4xl': '34px',
       },
     },
   },


### PR DESCRIPTION
## Summary
- Replace sketch aesthetic (Caveat/Kalam fonts, graph-paper, hard shadows) with style guide foundation
- CSS custom properties for all colors with dark mode variables ready
- New typography: Lora (display), Courier Prime (body), Special Elite, Share Tech Mono, Bebas Neue
- Frosted glass nav with rainbow gradient wordmark underline
- PageTitle component with per-letter colored underline bars
- WatercolorBackground SVG with blurred ellipses in four corners
- Grid layout with 256px sidebar (character card, active tasks placeholder, propose-a-task button)
- Updated CLAUDE.md with frontend conventions and style guide reference
- Added `docs/STYLE_MIGRATION_NOTES.md` with detailed Phase 2–6 task list

## Test plan
- [ ] Verify warm paper background (#F7F4EE) replaces graph paper
- [ ] Verify Courier Prime body text and Lora italic headings
- [ ] Verify frosted glass nav with rainbow wordmark underline
- [ ] Verify PageTitle colored underline bars on Tasks, Praxis, Leaderboard, Factions pages
- [ ] Verify watercolor splashes visible in corners
- [ ] Verify sidebar appears for logged-in users, hidden for logged-out
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)