### PR TITLE
Style guide Phase 2: faction cards + custom filters

### DIFF
--- a/docs/STYLE_MIGRATION_NOTES.md
+++ b/docs/STYLE_MIGRATION_NOTES.md
@@ -13,28 +13,35 @@ Reference: `WORLD_ZERO_STYLE.md` (root of repo)
 - Sidebar shell: character card, active tasks placeholder, propose-a-task button
 - Removed: graph-paper background, Caveat/Kalam fonts, sketch box-shadows
 
-## Phase 2: Faction Card Archetypes
+## What Phase 2 completed
+- 7 unique faction card components in `frontend/src/components/cards/`
+- TaskCard router selects card archetype by `primary_faction_slug`
+- LevelPill shared component
+- Flex-wrap container on Tasks page (not CSS grid)
+- 3 custom filter components: FilterStamps, FilterFactionTabs, FilterLevelNodes
+
+## ~~Phase 2: Faction Card Archetypes~~ DONE
 
 Each faction needs a completely different card component. See style guide Section 6 for full specs.
 
-- [ ] **TaskCardUA** — Sticky note: push pin, clipped corner, pastel yellow/pink, slight rotation. Width ~122–130px. Font: Courier Prime. (§6.1)
-- [ ] **TaskCardAnalog** — Field journal page: yellowed paper, red margin rule on left, horizontal ruled lines, torn bottom edge via clip-path. Width ~132–140px. Font: Special Elite. (§6.2)
-- [ ] **TaskCardGestalt** — Collage / layered scraps: three stacked paper scraps at different rotations + scotch tape strip across top. Width ~138px. Font: Courier Prime. (§6.3)
-- [ ] **TaskCardSNIDE** — Newspaper clipping: aged newsprint, torn top/bottom edges via ::before/::after, masthead banner, two-column body, cutout ransom letters for faction name. Width ~148px. Font: Special Elite for card, Courier Prime for cutout letters. (§6.4)
-- [ ] **TaskCardJourneymen** — Luggage tag: dashed string + eyelet hole, hazard stripe at top, bordered tag body. Width ~118px. Font: Courier Prime. (§6.5)
-- [ ] **TaskCardSingularity** — Terminal printout: always dark background, green terminal text, corner bracket decorations, sprocket hole rows, scanline overlay, blinking cursor. Width ~140px. Font: Share Tech Mono. (§6.6)
-- [ ] **TaskCardUAMasters** — Gazette article: deckled corner-snipped edges, proper masthead, headline + dateline, two-column layout. Width ~148px. Font: Special Elite. (§6.7)
-- [ ] **TaskCard router** — `TaskCard.tsx` should select the correct card component based on `task.primary_faction_slug`
-- [ ] **Flex-wrap container** — Replace CSS grid on Tasks page with `display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start`. Cards are NOT on a strict grid — varying heights and slight rotations are intentional.
-- [ ] **LevelPill component** — Dark pill shared by all cards: `background: #1a1209; color: white; font-size: 7px; padding: 1px 6px; border-radius: 6px; text-transform: uppercase`. Dark mode: `background: var(--faction-color); color: dark-bg`.
+- [x] **TaskCardUA** — Sticky note: push pin, clipped corner, pastel yellow/pink, slight rotation. Width ~122–130px. Font: Courier Prime. (§6.1)
+- [x] **TaskCardAnalog** — Field journal page: yellowed paper, red margin rule on left, horizontal ruled lines, torn bottom edge via clip-path. Width ~132–140px. Font: Special Elite. (§6.2)
+- [x] **TaskCardGestalt** — Collage / layered scraps: three stacked paper scraps at different rotations + scotch tape strip across top. Width ~138px. Font: Courier Prime. (§6.3)
+- [x] **TaskCardSNIDE** — Newspaper clipping: aged newsprint, torn top/bottom edges via ::before/::after, masthead banner, two-column body, cutout ransom letters for faction name. Width ~148px. Font: Special Elite for card, Courier Prime for cutout letters. (§6.4)
+- [x] **TaskCardJourneymen** — Luggage tag: dashed string + eyelet hole, hazard stripe at top, bordered tag body. Width ~118px. Font: Courier Prime. (§6.5)
+- [x] **TaskCardSingularity** — Terminal printout: always dark background, green terminal text, corner bracket decorations, sprocket hole rows, scanline overlay, blinking cursor. Width ~140px. Font: Share Tech Mono. (§6.6)
+- [x] **TaskCardUAMasters** — Gazette article: deckled corner-snipped edges, proper masthead, headline + dateline, two-column layout. Width ~148px. Font: Special Elite. (§6.7)
+- [x] **TaskCard router** — `TaskCard.tsx` should select the correct card component based on `task.primary_faction_slug`
+- [x] **Flex-wrap container** — Replace CSS grid on Tasks page with `display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start`. Cards are NOT on a strict grid — varying heights and slight rotations are intentional.
+- [x] **LevelPill component** — Dark pill shared by all cards: `background: #1a1209; color: white; font-size: 7px; padding: 1px 6px; border-radius: 6px; text-transform: uppercase`. Dark mode: `background: var(--faction-color); color: dark-bg`.
 
-## Phase 3: Custom Filter Controls
+## ~~Phase 3: Custom Filter Controls~~ DONE
 
 Replace current chip-based filters with three distinct visual types. See style guide Section 5.3.
 
-- [ ] **FilterStamps** (status filter) — Rectangular rubber stamps, no border-radius. 2px solid border, inner dashed border inset. Active: `bg: #1a1209; color: #F7F4EE`. Font: Courier Prime 10px bold uppercase. (§5.3)
-- [ ] **FilterFactionTabs** (faction filter) — Diagonal banner/pennant shape via `clip-path: polygon(0 0, 100% 0, 95% 100%, 5% 100%)`. Background: faction color. Inactive: `opacity: 0.42; filter: saturate(0.3)`. White text with text-shadow. Font: Courier Prime 9px bold uppercase. (§5.3)
-- [ ] **FilterLevelNodes** (level filter) — Connected circles (30px diameter) with horizontal connector bars. Active: scale(1.15), dark fill. Represents minimum level filter. (§5.3)
+- [x] **FilterStamps** (status filter) — Rectangular rubber stamps, no border-radius. 2px solid border, inner dashed border inset. Active: `bg: #1a1209; color: #F7F4EE`. Font: Courier Prime 10px bold uppercase. (§5.3)
+- [x] **FilterFactionTabs** (faction filter) — Diagonal banner/pennant shape via `clip-path: polygon(0 0, 100% 0, 95% 100%, 5% 100%)`. Background: faction color. Inactive: `opacity: 0.42; filter: saturate(0.3)`. White text with text-shadow. Font: Courier Prime 9px bold uppercase. (§5.3)
+- [x] **FilterLevelNodes** (level filter) — Connected circles (30px diameter) with horizontal connector bars. Active: scale(1.15), dark fill. Represents minimum level filter. (§5.3)
 
 ## Phase 4: Dark Mode
 

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,69 +1,36 @@
-import { Link } from 'react-router-dom'
 import type { TaskOut } from '../api/tasks'
+import TaskCardUA from './cards/TaskCardUA'
+import TaskCardAnalog from './cards/TaskCardAnalog'
+import TaskCardGestalt from './cards/TaskCardGestalt'
+import TaskCardSNIDE from './cards/TaskCardSNIDE'
+import TaskCardJourneymen from './cards/TaskCardJourneymen'
+import TaskCardSingularity from './cards/TaskCardSingularity'
+import TaskCardUAMasters from './cards/TaskCardUAMasters'
+import type { ComponentType } from 'react'
 
-const FACTION_STYLES: Record<string, { stripe: string; dot: string; label: string }> = {
-  ua:          { stripe: 'bg-ua',          dot: 'bg-ua',          label: 'University of Aesthematics' },
-  journeymen:  { stripe: 'bg-journeymen',  dot: 'bg-journeymen',  label: 'Journeymen' },
-  gestalt:     { stripe: 'bg-gestalt',     dot: 'bg-gestalt',     label: 'Gestalt' },
-  geo:         { stripe: 'bg-geo',         dot: 'bg-geo',         label: 'Geoanalogue' },
-  snide:       { stripe: 'bg-snide',       dot: 'bg-snide',       label: 'S.N.I.D.E.' },
-  cm:          { stripe: 'bg-cm',          dot: 'bg-cm',          label: 'Creative Masters' },
-}
-
-const DEFAULT_STYLE = { stripe: 'bg-muted', dot: 'bg-muted', label: 'Unaffiliated' }
-
-interface Props {
+interface CardProps {
   task: TaskOut
   onSignup?: (id: number) => void
 }
 
-export default function TaskCard({ task, onSignup }: Props) {
-  const faction = FACTION_STYLES[task.primary_faction_slug ?? ''] ?? DEFAULT_STYLE
+/** Map faction slugs to their unique card archetype (Style Guide §6). */
+const CARD_COMPONENTS: Record<string, ComponentType<CardProps>> = {
+  ua: TaskCardUA,
+  analog: TaskCardAnalog,
+  gestalt: TaskCardGestalt,
+  snide: TaskCardSNIDE,
+  journeymen: TaskCardJourneymen,
+  singularity: TaskCardSingularity,
+  ua_masters: TaskCardUAMasters,
+}
 
-  return (
-    <div className="card relative overflow-hidden flex flex-col transition-all duration-150 hover:-translate-x-0.5 hover:-translate-y-0.5">
-      {/* Faction color stripe */}
-      <div className={`absolute left-0 top-0 bottom-0 w-1.5 ${faction.stripe}`} />
+/** Fallback to UA sticky note for unknown factions */
+const DEFAULT_CARD = TaskCardUA
 
-      <div className="pl-4 pr-4 pt-3 pb-3 flex flex-col gap-2 flex-1">
-        {/* Faction + points */}
-        <div className="flex items-center gap-1.5">
-          <span className={`inline-block w-2 h-2 rounded-full shrink-0 ${faction.dot}`} />
-          <span className="font-body text-[0.68rem] uppercase tracking-widest text-muted font-bold">
-            {faction.label} · {task.point_value} pts
-          </span>
-        </div>
-
-        {/* Title */}
-        <Link to={`/tasks/${task.id}`}>
-          <h3 className="font-display text-xl font-semibold leading-tight hover:underline">
-            {task.title}
-          </h3>
-        </Link>
-
-        {/* Description */}
-        {task.description && (
-          <p className="font-body text-sm text-muted leading-relaxed flex-1 line-clamp-3">
-            {task.description}
-          </p>
-        )}
-
-        {/* Sign up */}
-        {onSignup && (
-          <button
-            onClick={() => onSignup(task.id)}
-            className="btn-primary self-start mt-1"
-          >
-            sign up
-          </button>
-        )}
-
-        {/* Footer */}
-        <div className="flex justify-between items-center pt-2 mt-auto border-t border-dashed border-border/40 font-body text-xs text-muted">
-          <span>lvl {task.level_required}+</span>
-          <span className="font-display text-sm font-bold text-ink">{task.point_value} pts</span>
-        </div>
-      </div>
-    </div>
-  )
+/**
+ * Router component: picks the correct faction card archetype based on task.primary_faction_slug.
+ */
+export default function TaskCard({ task, onSignup }: CardProps) {
+  const Card = CARD_COMPONENTS[task.primary_faction_slug ?? ''] ?? DEFAULT_CARD
+  return <Card task={task} onSignup={onSignup} />
 }

--- a/frontend/src/components/cards/TaskCardAnalog.tsx
+++ b/frontend/src/components/cards/TaskCardAnalog.tsx
@@ -1,0 +1,75 @@
+import { Link } from 'react-router-dom'
+import type { TaskOut } from '../../api/tasks'
+import LevelPill from '../ui/LevelPill'
+
+/**
+ * Analog — Torn Field Journal Page (Style Guide §6.2).
+ * Yellowed paper, red margin rule on left, horizontal ruled lines, torn bottom edge.
+ */
+
+interface Props {
+  task: TaskOut
+  onSignup?: (id: number) => void
+}
+
+export default function TaskCardAnalog({ task, onSignup }: Props) {
+  return (
+    <div
+      style={{
+        width: 136,
+        background: '#fffef5',
+        border: '1px solid rgba(0,0,0,0.08)',
+        clipPath: 'polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)',
+        position: 'relative',
+        padding: '12px 12px 18px 24px',
+        fontFamily: "'Special Elite', serif",
+        color: '#1a1209',
+        backgroundImage: 'repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.1) 17px, rgba(100,140,200,0.1) 18px)',
+      }}
+    >
+      {/* Red margin rule */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 20,
+          top: 0,
+          bottom: 0,
+          width: 1,
+          background: 'rgba(220,80,80,0.25)',
+        }}
+      />
+
+      {/* Faction + points */}
+      <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#15803d', marginBottom: 6, fontFamily: "'Courier Prime', monospace" }}>
+        Analog · {task.point_value} pts
+      </div>
+
+      {/* Title */}
+      <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+        <div style={{ fontSize: 12, fontWeight: 400, lineHeight: 1.3, marginBottom: 6 }}>
+          {task.title}
+        </div>
+      </Link>
+
+      {/* Description */}
+      {task.description && (
+        <div style={{ fontSize: 9, color: '#555', lineHeight: 1.5, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+          {task.description}
+        </div>
+      )}
+
+      {/* Sign up */}
+      {onSignup && (
+        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
+          sign up
+        </button>
+      )}
+
+      {/* Footer */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.12)', paddingTop: 6 }}>
+        <LevelPill level={task.level_required} />
+        <span style={{ fontSize: 10, fontWeight: 700, fontFamily: "'Courier Prime', monospace" }}>{task.point_value}</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/cards/TaskCardGestalt.tsx
+++ b/frontend/src/components/cards/TaskCardGestalt.tsx
@@ -1,0 +1,109 @@
+import { Link } from 'react-router-dom'
+import type { TaskOut } from '../../api/tasks'
+import LevelPill from '../ui/LevelPill'
+
+/**
+ * Gestalt — Collage / Layered Scraps (Style Guide §6.3).
+ * Three stacked paper scraps at different rotations + scotch tape strip.
+ */
+
+interface Props {
+  task: TaskOut
+  onSignup?: (id: number) => void
+}
+
+export default function TaskCardGestalt({ task, onSignup }: Props) {
+  return (
+    <div style={{ position: 'relative', width: 138, height: 'auto', minHeight: 128 }}>
+      {/* Back scrap 2 (deepest) */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          left: -4,
+          right: -4,
+          height: 20,
+          background: '#bbf7d0',
+          border: '1.5px solid rgba(0,0,0,0.12)',
+          transform: 'rotate(-4deg)',
+          borderRadius: 1,
+        }}
+      />
+
+      {/* Back scrap 1 */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 4,
+          left: -2,
+          right: -2,
+          height: 30,
+          background: '#dcfce7',
+          border: '1.5px solid rgba(0,0,0,0.12)',
+          transform: 'rotate(3deg)',
+          borderRadius: 1,
+        }}
+      />
+
+      {/* Front scrap (main content) */}
+      <div
+        style={{
+          position: 'relative',
+          background: '#f0fdf4',
+          border: '1.5px solid rgba(0,0,0,0.12)',
+          transform: 'rotate(-2deg)',
+          padding: '18px 10px 12px',
+          fontFamily: "'Courier Prime', monospace",
+          color: '#14532d',
+          zIndex: 2,
+        }}
+      >
+        {/* Scotch tape strip */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 4,
+            left: '50%',
+            transform: 'translateX(-50%) rotate(-1deg)',
+            width: 40,
+            height: 12,
+            background: 'rgba(250,230,130,0.7)',
+            borderRadius: 1,
+          }}
+        />
+
+        {/* Faction + points */}
+        <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#15803d', marginBottom: 6 }}>
+          Gestalt · {task.point_value} pts
+        </div>
+
+        {/* Title */}
+        <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+          <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 6 }}>
+            {task.title}
+          </div>
+        </Link>
+
+        {/* Description */}
+        {task.description && (
+          <div style={{ fontSize: 8, color: '#2d6a4f', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+            {task.description}
+          </div>
+        )}
+
+        {/* Sign up */}
+        {onSignup && (
+          <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
+            sign up
+          </button>
+        )}
+
+        {/* Footer */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.12)', paddingTop: 6 }}>
+          <LevelPill level={task.level_required} />
+          <span style={{ fontSize: 10, fontWeight: 700 }}>{task.point_value}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/cards/TaskCardJourneymen.tsx
+++ b/frontend/src/components/cards/TaskCardJourneymen.tsx
@@ -1,0 +1,97 @@
+import { Link } from 'react-router-dom'
+import type { TaskOut } from '../../api/tasks'
+import LevelPill from '../ui/LevelPill'
+
+/**
+ * Journeymen — Luggage Tag (Style Guide §6.5).
+ * Hanging string + eyelet, hazard stripe at top, bordered tag body.
+ */
+
+interface Props {
+  task: TaskOut
+  onSignup?: (id: number) => void
+}
+
+export default function TaskCardJourneymen({ task, onSignup }: Props) {
+  return (
+    <div style={{ paddingTop: 26, position: 'relative', width: 118 }}>
+      {/* Hanging string */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        {/* Dashed string */}
+        <div style={{ width: 0, height: 14, borderLeft: '2px dashed #8a6a20' }} />
+        {/* Eyelet hole */}
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            border: '2px solid #8a6a20',
+            background: 'var(--color-bg-page)',
+          }}
+        />
+      </div>
+
+      {/* Tag body */}
+      <div
+        style={{
+          border: '2px solid #8a6a20',
+          background: '#fef9ee',
+          fontFamily: "'Courier Prime', monospace",
+          color: '#1a1209',
+        }}
+      >
+        {/* Hazard stripe */}
+        <div
+          style={{
+            height: 3,
+            backgroundImage: 'repeating-linear-gradient(90deg, #c2410c 0, #c2410c 8px, #1a1209 8px, #1a1209 16px, #f59e0b 16px, #f59e0b 24px, #1a1209 24px, #1a1209 32px)',
+          }}
+        />
+
+        <div style={{ padding: '8px 10px 10px' }}>
+          {/* Faction + points */}
+          <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#8a6a20', marginBottom: 5 }}>
+            Journeymen · {task.point_value} pts
+          </div>
+
+          {/* Title */}
+          <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+            <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 5 }}>
+              {task.title}
+            </div>
+          </Link>
+
+          {/* Description */}
+          {task.description && (
+            <div style={{ fontSize: 8, color: '#555', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+              {task.description}
+            </div>
+          )}
+
+          {/* Sign up */}
+          {onSignup && (
+            <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
+              sign up
+            </button>
+          )}
+
+          {/* Footer */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.15)', paddingTop: 5 }}>
+            <LevelPill level={task.level_required} />
+            <span style={{ fontSize: 10, fontWeight: 700 }}>{task.point_value}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/cards/TaskCardSNIDE.tsx
+++ b/frontend/src/components/cards/TaskCardSNIDE.tsx
@@ -1,0 +1,134 @@
+import { Link } from 'react-router-dom'
+import type { TaskOut } from '../../api/tasks'
+import LevelPill from '../ui/LevelPill'
+
+/**
+ * S.N.I.D.E. — Newspaper Clipping (Style Guide §6.4).
+ * Aged newsprint, torn top/bottom edges, masthead, two-column body, cutout ransom letters.
+ */
+
+const TORN_CLIP = 'polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)'
+
+interface Props {
+  task: TaskOut
+  onSignup?: (id: number) => void
+}
+
+/** Render faction name as cutout ransom-style letters */
+function CutoutLetters({ text }: { text: string }) {
+  return (
+    <span style={{ display: 'inline-flex', gap: 1 }}>
+      {text.split('').map((char, index) => (
+        char === '.' ? (
+          <span key={index} style={{ fontSize: 9, fontFamily: "'Courier Prime', monospace", color: '#8a6a20' }}>.</span>
+        ) : (
+          <span
+            key={index}
+            style={{
+              background: '#1a1209',
+              color: 'white',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
+              padding: '0 2px',
+              lineHeight: 1.4,
+            }}
+          >
+            {char}
+          </span>
+        )
+      ))}
+    </span>
+  )
+}
+
+export default function TaskCardSNIDE({ task, onSignup }: Props) {
+  // Split description into two halves for columns
+  const words = (task.description ?? '').split(' ')
+  const mid = Math.ceil(words.length / 2)
+  const col1 = words.slice(0, mid).join(' ')
+  const col2 = words.slice(mid).join(' ')
+
+  return (
+    <div
+      style={{
+        width: 148,
+        background: '#f0e8d0',
+        position: 'relative',
+        padding: '10px 10px 12px',
+        fontFamily: "'Special Elite', serif",
+        color: '#1a1209',
+      }}
+    >
+      {/* Torn top edge */}
+      <div
+        style={{
+          content: "''",
+          position: 'absolute',
+          top: -1,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: 'var(--color-bg-page)',
+          clipPath: TORN_CLIP,
+        }}
+      />
+      {/* Torn bottom edge */}
+      <div
+        style={{
+          content: "''",
+          position: 'absolute',
+          bottom: -1,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: 'var(--color-bg-page)',
+          clipPath: TORN_CLIP,
+        }}
+      />
+
+      {/* Masthead */}
+      <div style={{ fontSize: 6, textTransform: 'uppercase', letterSpacing: '0.25em', color: '#666', borderBottom: '1.5px solid #1a1209', paddingBottom: 3, marginBottom: 5 }}>
+        The Daily Snide Gazette
+      </div>
+
+      {/* Headline */}
+      <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+        <div style={{ fontSize: 12, lineHeight: 1.2, marginBottom: 4 }}>
+          {task.title}
+        </div>
+      </Link>
+
+      {/* Faction cutout letters */}
+      <div style={{ marginBottom: 6 }}>
+        <CutoutLetters text="S.N.I.D.E." />
+        <span style={{ fontSize: 8, color: '#8a6a20', marginLeft: 4 }}>{task.point_value} pts</span>
+      </div>
+
+      {/* Two-column body */}
+      {task.description && (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr', gap: 4, marginBottom: 8 }}>
+          <div style={{ fontSize: 7.5, color: '#444', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
+            {col1}
+          </div>
+          <div style={{ background: 'rgba(0,0,0,0.12)' }} />
+          <div style={{ fontSize: 7.5, color: '#444', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
+            {col2}
+          </div>
+        </div>
+      )}
+
+      {/* Sign up */}
+      {onSignup && (
+        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
+          sign up
+        </button>
+      )}
+
+      {/* Footer */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px solid rgba(0,0,0,0.15)', paddingTop: 5 }}>
+        <span style={{ fontSize: 8, color: '#8a6a20', fontFamily: "'Courier Prime', monospace" }}>{task.point_value} pts</span>
+        <LevelPill level={task.level_required} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/cards/TaskCardSingularity.tsx
+++ b/frontend/src/components/cards/TaskCardSingularity.tsx
@@ -1,0 +1,146 @@
+import { Link } from 'react-router-dom'
+import type { TaskOut } from '../../api/tasks'
+
+/**
+ * Singularity — Terminal Printout (Style Guide §6.6).
+ * Always dark background, green terminal text, corner brackets, sprocket holes,
+ * scanline overlay, blinking cursor. Same in light and dark mode.
+ */
+
+interface Props {
+  task: TaskOut
+  onSignup?: (id: number) => void
+}
+
+/** Row of sprocket holes */
+function SprocketHoles() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', gap: 6, padding: '4px 0' }}>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          style={{
+            width: 6,
+            height: 4,
+            background: 'rgba(10,26,14)',
+            border: '1px solid #1a3a22',
+            borderRadius: 1,
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default function TaskCardSingularity({ task, onSignup }: Props) {
+  return (
+    <div
+      style={{
+        width: 140,
+        background: '#050f08',
+        border: '1px solid #1a3a22',
+        position: 'relative',
+        fontFamily: "'Share Tech Mono', monospace",
+        color: '#4ade80',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Scanline overlay */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          backgroundImage: 'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)',
+          pointerEvents: 'none',
+          zIndex: 1,
+        }}
+      />
+
+      {/* Corner brackets */}
+      {/* Top-left */}
+      <div style={{ position: 'absolute', top: 3, left: 3, width: 10, height: 10, borderTop: '1px solid #4ade80', borderLeft: '1px solid #4ade80' }} />
+      {/* Top-right */}
+      <div style={{ position: 'absolute', top: 3, right: 3, width: 10, height: 10, borderTop: '1px solid #4ade80', borderRight: '1px solid #4ade80' }} />
+      {/* Bottom-left */}
+      <div style={{ position: 'absolute', bottom: 3, left: 3, width: 10, height: 10, borderBottom: '1px solid #4ade80', borderLeft: '1px solid #4ade80' }} />
+      {/* Bottom-right */}
+      <div style={{ position: 'absolute', bottom: 3, right: 3, width: 10, height: 10, borderBottom: '1px solid #4ade80', borderRight: '1px solid #4ade80' }} />
+
+      {/* Sprocket holes top */}
+      <SprocketHoles />
+
+      <div style={{ padding: '4px 12px 8px', position: 'relative', zIndex: 2 }}>
+        {/* Header */}
+        <div style={{ fontSize: 7, color: '#1f6b34', textTransform: 'uppercase', letterSpacing: '0.15em', marginBottom: 6 }}>
+          singularity protocol
+          {/* Blinking cursor */}
+          <span
+            style={{
+              display: 'inline-block',
+              width: 5,
+              height: 9,
+              background: '#4ade80',
+              marginLeft: 3,
+              verticalAlign: 'middle',
+              animation: 'blink 1s step-end infinite',
+            }}
+          />
+        </div>
+
+        {/* Task name with > prefix */}
+        <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+          <div style={{ fontSize: 9, marginBottom: 6, lineHeight: 1.3 }}>
+            {'> '}{task.title}
+          </div>
+        </Link>
+
+        {/* Data lines */}
+        <div style={{ fontSize: 8, color: '#1f6b34', lineHeight: 1.6, marginBottom: 6 }}>
+          <div>PTS: <span style={{ color: '#4ade80', fontSize: 11, fontWeight: 700 }}>{task.point_value}</span></div>
+          <div>LVL: {task.level_required}+</div>
+        </div>
+
+        {/* Description */}
+        {task.description && (
+          <div style={{ fontSize: 7, color: '#1f6b34', lineHeight: 1.4, marginBottom: 6, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+            {task.description}
+          </div>
+        )}
+
+        {/* Sign up */}
+        {onSignup && (
+          <button
+            onClick={() => onSignup(task.id)}
+            style={{
+              background: 'transparent',
+              color: '#4ade80',
+              border: '1px solid #4ade80',
+              fontFamily: "'Share Tech Mono', monospace",
+              fontSize: 7,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              padding: '2px 8px',
+              cursor: 'pointer',
+              marginBottom: 4,
+            }}
+          >
+            {'>'} sign up
+          </button>
+        )}
+
+        {/* Level pill — outline style for Singularity */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', borderTop: '1px solid #1a3a22', paddingTop: 5 }}>
+          <span style={{ border: '1px solid #4ade80', color: '#4ade80', fontSize: 7, padding: '1px 6px', borderRadius: 6, textTransform: 'uppercase' }}>
+            lvl {task.level_required}+
+          </span>
+        </div>
+      </div>
+
+      {/* Sprocket holes bottom */}
+      <SprocketHoles />
+
+      {/* Blink keyframe */}
+      <style>{`@keyframes blink { 50% { opacity: 0; } }`}</style>
+    </div>
+  )
+}

--- a/frontend/src/components/cards/TaskCardUA.tsx
+++ b/frontend/src/components/cards/TaskCardUA.tsx
@@ -1,0 +1,84 @@
+import { Link } from 'react-router-dom'
+import type { TaskOut } from '../../api/tasks'
+import LevelPill from '../ui/LevelPill'
+
+/**
+ * UA — Sticky Note card (Style Guide §6.1).
+ * Pastel yellow/pink, push pin at top, clipped corner, slight rotation.
+ */
+
+const COLORS = ['#fef9c3', '#fce7f3'] // yellow, pink
+const PIN_COLORS = ['#fbbf24', '#f472b6']
+const ROTATIONS = [-2, 1.5, -1, 2.5]
+
+interface Props {
+  task: TaskOut
+  onSignup?: (id: number) => void
+}
+
+export default function TaskCardUA({ task, onSignup }: Props) {
+  const variant = task.id % 2
+  const rotation = ROTATIONS[task.id % ROTATIONS.length]
+
+  return (
+    <div
+      style={{
+        width: 125,
+        background: COLORS[variant],
+        clipPath: 'polygon(0 0, 100% 0, 100% 88%, 88% 100%, 0 100%)',
+        transform: `rotate(${rotation}deg)`,
+        position: 'relative',
+        padding: '24px 12px 14px',
+        fontFamily: "'Courier Prime', monospace",
+        color: '#1a1209',
+      }}
+    >
+      {/* Push pin */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 6,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          background: PIN_COLORS[variant],
+          border: '2px solid rgba(0,0,0,0.25)',
+        }}
+      />
+
+      {/* Faction + points */}
+      <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#6b6a7a', marginBottom: 6 }}>
+        UA · {task.point_value} pts
+      </div>
+
+      {/* Title */}
+      <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+        <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 6 }}>
+          {task.title}
+        </div>
+      </Link>
+
+      {/* Description */}
+      {task.description && (
+        <div style={{ fontSize: 8, color: '#444', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+          {task.description}
+        </div>
+      )}
+
+      {/* Sign up */}
+      {onSignup && (
+        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
+          sign up
+        </button>
+      )}
+
+      {/* Footer */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.15)', paddingTop: 6, marginTop: 'auto' }}>
+        <LevelPill level={task.level_required} />
+        <span style={{ fontSize: 10, fontWeight: 700 }}>{task.point_value}</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/cards/TaskCardUAMasters.tsx
+++ b/frontend/src/components/cards/TaskCardUAMasters.tsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom'
+import type { TaskOut } from '../../api/tasks'
+import LevelPill from '../ui/LevelPill'
+
+/**
+ * UA Masters — Newspaper / Gazette (Style Guide §6.7).
+ * Full newspaper format, deckled corner-snipped edges, masthead, headline + dateline, two columns.
+ */
+
+interface Props {
+  task: TaskOut
+  onSignup?: (id: number) => void
+}
+
+export default function TaskCardUAMasters({ task, onSignup }: Props) {
+  const words = (task.description ?? '').split(' ')
+  const mid = Math.ceil(words.length / 2)
+  const col1 = words.slice(0, mid).join(' ')
+  const col2 = words.slice(mid).join(' ')
+
+  return (
+    <div
+      style={{
+        width: 148,
+        background: '#f0ead8',
+        border: '1px solid rgba(0,0,0,0.12)',
+        clipPath: 'polygon(0 0, 98% 0, 100% 2%, 100% 98%, 98% 100%, 2% 100%, 0 98%, 0 2%)',
+        padding: '10px 10px 12px',
+        fontFamily: "'Special Elite', serif",
+        color: '#1a1209',
+      }}
+    >
+      {/* Masthead */}
+      <div style={{ fontSize: 6, textTransform: 'uppercase', letterSpacing: '0.2em', color: '#555', borderBottom: '2px solid #1a1209', paddingBottom: 3, marginBottom: 5 }}>
+        The UA Masters Gazette
+      </div>
+
+      {/* Headline */}
+      <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+        <div style={{ fontSize: 13, lineHeight: 1.2, marginBottom: 3 }}>
+          {task.title}
+        </div>
+      </Link>
+
+      {/* Dateline */}
+      <div style={{ fontSize: 7, fontStyle: 'italic', color: '#777', marginBottom: 6 }}>
+        UA Masters · {task.point_value} points
+      </div>
+
+      {/* Two-column body */}
+      {task.description && (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr', gap: 4, marginBottom: 8 }}>
+          <div style={{ fontSize: 7.5, color: '#333', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
+            {col1}
+          </div>
+          <div style={{ background: 'rgba(0,0,0,0.12)' }} />
+          <div style={{ fontSize: 7.5, color: '#333', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
+            {col2}
+          </div>
+        </div>
+      )}
+
+      {/* Sign up */}
+      {onSignup && (
+        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
+          sign up
+        </button>
+      )}
+
+      {/* Footer */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px solid rgba(0,0,0,0.15)', paddingTop: 5 }}>
+        <span style={{ fontSize: 8, color: '#555', fontFamily: "'Courier Prime', monospace" }}>{task.point_value} pts</span>
+        <LevelPill level={task.level_required} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/FilterFactionTabs.tsx
+++ b/frontend/src/components/ui/FilterFactionTabs.tsx
@@ -1,0 +1,63 @@
+import type { FactionOut } from '../../api/factions'
+
+/**
+ * Faction filter — Diagonal Banner Tabs (Style Guide §5.3).
+ * Pennant shape via clip-path, faction-colored, inactive: desaturated + low opacity.
+ */
+
+/** Faction slug → color mapping */
+const FACTION_COLORS: Record<string, string> = {
+  ua: '#6b6a7a',
+  analog: '#15803d',
+  gestalt: '#14532d',
+  snide: '#8a6a20',
+  journeymen: '#c49a3a',
+  singularity: '#7c3aed',
+  ua_masters: '#555555',
+  albescent: '#6b6a7a',
+  aged_out: '#6b6a7a',
+}
+
+interface Props {
+  factions: FactionOut[]
+  value: string
+  onChange: (slug: string) => void
+}
+
+export default function FilterFactionTabs({ factions, value, onChange }: Props) {
+  return (
+    <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+      <span className="eyebrow">faction:</span>
+      {factions.map((faction) => {
+        const active = value === faction.slug
+        const color = FACTION_COLORS[faction.slug] ?? '#6b6a7a'
+        return (
+          <button
+            key={faction.slug}
+            onClick={() => onChange(value === faction.slug ? '' : faction.slug)}
+            style={{
+              clipPath: 'polygon(0 0, 100% 0, 95% 100%, 5% 100%)',
+              background: color,
+              color: 'white',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.07em',
+              padding: '4px 12px',
+              cursor: 'pointer',
+              border: 'none',
+              borderRadius: 0,
+              textShadow: '0 1px 2px rgba(0,0,0,0.3)',
+              opacity: active ? 1 : 0.42,
+              filter: active ? 'none' : 'saturate(0.3)',
+              transition: 'all 120ms',
+            }}
+          >
+            {faction.name}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/FilterLevelNodes.tsx
+++ b/frontend/src/components/ui/FilterLevelNodes.tsx
@@ -1,0 +1,59 @@
+/**
+ * Level filter — Connected Nodes (Style Guide §5.3).
+ * Row of circles connected by horizontal bars. Active: dark fill, scale(1.15).
+ */
+
+interface Props {
+  levels: number[]
+  value: number | ''
+  onChange: (level: number | '') => void
+}
+
+export default function FilterLevelNodes({ levels, value, onChange }: Props) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 0 }}>
+      <span className="eyebrow" style={{ marginRight: 8 }}>level:</span>
+      {levels.map((level, index) => {
+        const active = value === level
+        return (
+          <div key={level} style={{ display: 'flex', alignItems: 'center' }}>
+            {/* Connector bar (not before first node) */}
+            {index > 0 && (
+              <div
+                style={{
+                  width: 12,
+                  height: 2,
+                  background: 'rgba(0,0,0,0.2)',
+                }}
+              />
+            )}
+            {/* Node circle */}
+            <button
+              onClick={() => onChange(value === level ? '' : level)}
+              style={{
+                width: 30,
+                height: 30,
+                borderRadius: '50%',
+                border: `2px solid ${active ? '#1a1209' : 'rgba(0,0,0,0.2)'}`,
+                background: active ? '#1a1209' : 'rgba(255,255,255,0.6)',
+                color: active ? '#F7F4EE' : 'var(--color-text-tertiary)',
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 10,
+                fontWeight: 700,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                transform: active ? 'scale(1.15)' : 'scale(1)',
+                transition: 'all 120ms',
+                padding: 0,
+              }}
+            >
+              {level}+
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/FilterStamps.tsx
+++ b/frontend/src/components/ui/FilterStamps.tsx
@@ -1,0 +1,53 @@
+/**
+ * Status filter — Rubber Stamps (Style Guide §5.3).
+ * Rectangular, no border-radius, inner dashed border, bold uppercase.
+ */
+
+interface Props {
+  options: string[]
+  value: string
+  onChange: (value: string) => void
+}
+
+export default function FilterStamps({ options, value, onChange }: Props) {
+  return (
+    <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+      <span className="eyebrow">status:</span>
+      {options.map((option) => {
+        const active = value === option
+        return (
+          <button
+            key={option}
+            onClick={() => onChange(option)}
+            style={{
+              position: 'relative',
+              border: `2px solid ${active ? '#1a1209' : 'rgba(0,0,0,0.2)'}`,
+              borderRadius: 0,
+              background: active ? '#1a1209' : 'rgba(255,255,255,0.6)',
+              color: active ? '#F7F4EE' : 'var(--color-text-primary)',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              padding: '5px 10px',
+              cursor: 'pointer',
+              transition: 'all 120ms',
+            }}
+          >
+            {/* Inner dashed border */}
+            <span
+              style={{
+                position: 'absolute',
+                inset: 2,
+                border: `1px dashed ${active ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)'}`,
+                pointerEvents: 'none',
+              }}
+            />
+            {option}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/LevelPill.tsx
+++ b/frontend/src/components/ui/LevelPill.tsx
@@ -1,0 +1,19 @@
+/** Dark pill showing level requirement, shared by all faction cards (Style Guide §6). */
+export default function LevelPill({ level }: { level: number }) {
+  return (
+    <span
+      style={{
+        background: '#1a1209',
+        color: 'white',
+        fontSize: 7,
+        padding: '1px 6px',
+        borderRadius: 6,
+        textTransform: 'uppercase',
+        fontFamily: "'Courier Prime', monospace",
+        letterSpacing: '0.08em',
+      }}
+    >
+      lvl {level}+
+    </span>
+  )
+}

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -3,6 +3,9 @@ import { listTasks, signupTask, type TaskOut } from '../api/tasks'
 import { getFactions, type FactionOut } from '../api/factions'
 import TaskCard from '../components/TaskCard'
 import PageTitle from '../components/ui/PageTitle'
+import FilterStamps from '../components/ui/FilterStamps'
+import FilterFactionTabs from '../components/ui/FilterFactionTabs'
+import FilterLevelNodes from '../components/ui/FilterLevelNodes'
 import { extractError } from '../utils/errors'
 import { useAuth } from '../auth/AuthContext'
 
@@ -22,7 +25,7 @@ export default function Tasks() {
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [signupMsg, setSignupMsg] = useState<{ id: number; msg: string; ok: boolean } | null>(null)
 
-  // Fetch factions once for filter chips
+  // Fetch factions once for filter tabs
   useEffect(() => {
     getFactions().then(setFactions).catch(() => {})
   }, [])
@@ -46,7 +49,6 @@ export default function Tasks() {
     try {
       await signupTask(id)
       setSignupMsg({ id, msg: "You're signed up!", ok: true })
-      // Remove the task from the list since they just signed up
       setTasks((prev) => prev.filter((t) => t.id !== id))
     } catch (err) {
       setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
@@ -62,44 +64,11 @@ export default function Tasks() {
     <div className="py-8">
       <PageTitle title="Tasks" eyebrow={`${tasks.length} shown`} />
 
-      {/* Filters */}
-      <div className="flex flex-wrap gap-2 items-center mb-6">
-        <span className="font-body text-xs text-muted">status:</span>
-        {statusFilters.map((s) => (
-          <button
-            key={s}
-            onClick={() => setStatus(s)}
-            className={`chip ${status === s ? 'chip-active' : ''}`}
-          >
-            {s}
-          </button>
-        ))}
-
-        <div className="w-px h-5 bg-border/30 mx-1" />
-
-        <span className="font-body text-xs text-muted">faction:</span>
-        {factions.map((f) => (
-          <button
-            key={f.slug}
-            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
-            className={`chip ${faction === f.slug ? 'chip-active' : ''}`}
-          >
-            {f.name}
-          </button>
-        ))}
-
-        <div className="w-px h-5 bg-border/30 mx-1" />
-
-        <span className="font-body text-xs text-muted">level:</span>
-        {LEVEL_FILTERS.map((l) => (
-          <button
-            key={l}
-            onClick={() => setLevel(level === l ? '' : l)}
-            className={`chip ${level === l ? 'chip-active' : ''}`}
-          >
-            {l}+
-          </button>
-        ))}
+      {/* Filters — three distinct visual types (Style Guide §5.3) */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 24 }}>
+        <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
+        <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
+        <FilterLevelNodes levels={LEVEL_FILTERS} value={level} onChange={setLevel} />
       </div>
 
       {signupMsg && (
@@ -118,7 +87,8 @@ export default function Tasks() {
       ) : tasks.length === 0 ? (
         <p className="font-body text-muted">No tasks match your filters.</p>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        /* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
           {tasks.map((t) => (
             <TaskCard key={t.id} task={t} onSignup={handleSignup} />
           ))}


### PR DESCRIPTION
## Summary
- 7 unique faction card archetypes (sticky note, field journal, collage, newspaper clipping, luggage tag, terminal printout, gazette) replacing the uniform card design
- 3 custom filter controls (rubber stamps, diagonal pennants, connected nodes) replacing chip-based filters
- TaskCard router selects card by faction slug, flex-wrap layout for intentional visual variety
- LevelPill shared component for all cards

## Test plan
- [ ] Navigate to /tasks and verify cards render with faction-specific archetypes
- [ ] Verify flex-wrap layout shows varied card sizes and shapes
- [ ] Verify rubber stamp status filters (sharp corners, inner dashed border)
- [ ] Verify diagonal pennant faction tabs in faction colors
- [ ] Verify connected-node level filter circles
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)