### PR TITLE
Style guide Phase 4: dark mode

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -641,3 +641,671 @@ frontend/src/
 | Journeymen  | Luggage tag        | Hanging string, eyelet, hazard stripe    | Courier Prime  |
 | Singularity | Terminal printout  | Dark always, green text, sprocket holes  | Share Tech Mono|
 | UA Masters  | Gazette article    | Corner-snipped edges, proper masthead    | Special Elite  |
+
+---
+
+## 12. Praxis Submission Page
+
+### 12.1 Page Layout
+
+Same shell as all logged-in pages (nav + watercolor bg + main/sidebar grid). The sidebar is identical to the tasks page — character card, active tasks, recent activity, propose button — with one addition: an "Other praxis for this task" panel sits between active tasks and recent activity, showing up to 3 other submissions for the same task with player avatar orbs and their score.
+
+Breadcrumb above the title: `Tasks › [faction dot] [Task Name] › Praxis` — task name links back to task detail, faction dot is a 7px circle in faction color.
+
+### 12.2 Byline Block
+
+The byline block uses the **author's faction card aesthetic** as its visual framing. This is load-bearing — the submission is signed with the author's visual identity before you read their name.
+
+- Gestalt author → collage scrap background with tape strip
+- Analog author → notebook paper texture
+- SNIDE author → aged newsprint with masthead strip
+- etc. — mirror the card archetypes from Section 6
+
+Contents: avatar orb (faction gradient, 42px), display name (Lora italic, faction color), faction + level + era meta (9px uppercase), collaboration tags if applicable. Right side: average vote score (large, Lora), vote count (9px muted).
+
+### 12.3 Praxis Title
+
+Lora italic, 30px. Followed immediately by a full-width rainbow underline bar — NOT per-letter (user-generated titles are unpredictable length). The bar is a flex row of equal-width segments in the cycling color order: `#fbbf24 → #be185d → #4f46e5 → #0e7490 → #16a34a → #f97316` repeating. 8 segments total, 4px height.
+
+### 12.4 Task Context Strip
+
+A slim horizontal bar below the title linking the submission back to its task:
+- Left border: 4px solid in faction color
+- Border-radius: 0 8px 8px 0 (sharp left, rounded right)
+- Background: `rgba(255,255,255,0.6)` with blur
+- Contents: "Completing task" label (8px muted) + task name (12px bold) + points + level pill
+
+### 12.5 Media Gallery
+
+- Main image/video: full width, 16:9 aspect ratio, rounded 8px
+- Image counter badge: bottom-right, `rgba(0,0,0,0.5)` pill
+- Filename label: bottom-left, monospace 8px, muted
+- Thumbnail strip below: flex row of equal-width thumbs, 4:3 aspect ratio, 5px rounded
+- Active thumb: 2px solid faction-color border
+- Overflow thumb: shows "+N more" in muted style
+- Video thumbs: distinguish with a play icon overlay
+
+### 12.6 Body Text
+
+- Font: Lora (not Courier Prime — this is prose, not UI)
+- Size: 15px, line-height: 1.75
+- Color: `#2a1e10` (slightly warmer than pure black)
+- **Drop cap on first letter:** float left, 58px, faction color, Lora bold
+- Paragraphs separated by 0.9rem
+- Italic emphasis (`<em>`) renders in faction color
+
+### 12.7 Collaboration Strip
+
+Shown only when the praxis has collaborators or is a duel result.
+
+- Background: `rgba(255,255,255,0.6)` with blur, rounded 10px
+- Left: "Completed with" label + overlapping avatar orbs (each 26px, -8px margin-left for overlap) + player names
+- Right: badge pill — "Collab · Both earn pts" or "Duel · Winner takes pts"
+
+---
+
+## 13. Voting System (Praxis Page)
+
+### 13.1 Vote Input — Stamp Buttons
+
+Replaces star rating. Five rectangular stamp-style buttons numbered 1–5 with a word label below each. NO star iconography anywhere.
+
+**Labels:**
+| Value | Word |
+|-------|------|
+| 1 | a start |
+| 2 | solid |
+| 3 | good |
+| 4 | excellent |
+| 5 | legendary |
+
+**Button appearance:**
+- 44×44px square
+- Border: 2.5px solid in value color (see below)
+- Font: Courier Prime, 18px, 900 weight
+- Background: `rgba(255,255,255,0.8)`
+- Inner dashed border inset on selected state
+- Word label: 7px uppercase, max-width 44px
+
+**Value colors (border + selected background):**
+| Value | Color |
+|-------|-------|
+| 1 | `#9b8e7d` (muted — intentionally low energy) |
+| 2 | `#0e7490` (teal) |
+| 3 | `#4f46e5` (indigo) |
+| 4 | `#be185d` (rose) |
+| 5 | `#14532d` (deep green — reserved for legendary) |
+
+**Selected state:** background becomes the value color, text white, inner dashed border `rgba(255,255,255,0.25)`.
+
+**Below the stamps:**
+- "Submit vote" button: rectangular stamp style (matches status filters), `background: #1a1209`
+- Inline text: "Voting X pts · costs X of your votes" — makes the vote economy visible at decision time
+- Player's remaining vote count shown in the sublabel above stamps
+
+**Vote economy reminder:** players have 100 + 2× their total score in votes. This depletes as they vote. Surface it here without making it anxious — matter of fact.
+
+### 13.2 Vote Results — Voter Tile Grid
+
+Replaces star average display. Shows every voter as a tile with their avatar and their vote value.
+
+**Tile structure (per voter):**
+- Avatar: 48×48px, border-radius 4px (slightly square — distinguishes from orbs elsewhere), faction gradient background
+- Points badge: 18px circle, top-right corner, faction color background, white text, 1.5px white border
+- Name: 8px, muted, max-width 52px, truncated with ellipsis
+
+**Grid:** `flex-wrap: wrap; gap: 0.5rem` — not a strict grid, tiles flow naturally.
+
+**Overflow:** if more than ~12 voters, show a "+N more" tile in the same size with dashed border and muted text. Clicking expands (or links to a full voter list page).
+
+**Header row above grid:**
+- Left: "Points earned from votes" (9px label) + total in Lora italic 26px + "points from votes" suffix
+- Right: voter count (9px muted uppercase)
+
+### 13.3 Flag Block
+
+Flagging is a first-class UI element, not a footer link. Placed below the voter grid.
+
+**Structure:**
+- Background: `rgba(255,255,255,0.6)`, border `1.5px solid rgba(0,0,0,0.08)`, rounded 10px
+- Left: circular icon (32px, red-tinted border, ⚑ character at 50% red opacity)
+- Middle: "Flag this praxis" title (10px bold, muted) + explanation text (8px): "If this content is inappropriate, harmful, or violates the rules, flag it for admin review. Flagged praxis loses its points until reviewed."
+- Right: "⚑ Flag" button — outline style, red-tinted border and text at low opacity, intensifies on hover
+
+**Confirmation:** clicking Flag opens a confirmation modal (not inline) before submitting. The modal should restate the consequence: the author loses base task points AND vote points until an admin reviews. This prevents frivolous flagging.
+
+**Flag button colors:**
+- Default: `color: rgba(220,38,38,0.6); border-color: rgba(220,38,38,0.25)`
+- Hover: `color: #dc2626; border-color: rgba(220,38,38,0.5); background: rgba(220,38,38,0.05)`
+
+---
+
+---
+
+## 14. Player Profile Page
+
+### 14.1 Page Layout
+
+Same shell as all logged-in pages. Sidebar is identical to all other pages. Main column has four sections stacked vertically: profile header, level track, praxis grid, friends/foes row.
+
+### 14.2 Profile Header — Faction-Framed
+
+The profile header uses the **subject player's faction card aesthetic** as its visual container. This is the same principle as the praxis byline block — the faction identity follows the player everywhere they appear.
+
+- Gestalt player → collage scrap layers with tape strip
+- Analog player → notebook paper with margin rule, torn bottom edge
+- S.N.I.D.E. player → manila folder with dossier header
+- Journeymen player → large luggage tag framing
+- Singularity player → terminal black with green text and corner brackets
+- UA Masters player → aged newsprint with masthead
+- UA player → oversized sticky note
+
+Implementation: the profile header is a wrapper component that accepts `faction` as a prop and renders the appropriate background treatment behind a consistent content layout.
+
+**Header content (always):**
+- Avatar orb: 80px circle, faction gradient, 3px white border, 3px faction-color outer ring
+- Level badge: pill below avatar, `background: faction-color; color: white; 8px uppercase`
+- Action buttons (other player's profile only): Friend, Foe, DM — stacked below level badge, full width of avatar column
+  - Friend: `background: faction-color; color: white`
+  - Foe: outline style, `border: 1.5px solid #dc2626; color: #dc2626`
+  - DM: outline style, `border: 1.5px solid faction-color; color: faction-color`
+- Own profile: "Edit Profile" button replaces action buttons
+- Display name: Lora italic, 26px, faction color
+- Username: `@handle · joined Era X`, 10px muted
+- Faction banner: diagonal pennant clip-path (same as filter tabs), faction color
+- Member since: 8px muted
+- Bio: Special Elite 11px, 1.6 line-height, left border 3px in faction color at 30% opacity
+- Stat strip: Era score, All-time score, Praxis count, Votes remaining, Friends count, Foes count — each in a small rounded card `rgba(255,255,255,0.6)`
+
+### 14.3 Level Track
+
+Full-width horizontal track showing all 9 levels (0–8).
+
+**Node states:**
+- Completed: `background: faction-color; border-color: faction-color; color: white`
+- Current: `background: light-faction-tint; border: 3px solid faction-color; color: faction-color; box-shadow: 0 0 0 3px rgba(faction, 0.2)` — shows current point total inside
+- Locked: `background: rgba(255,255,255,0.5); border-color: rgba(0,0,0,0.12); color: #c8c0b0` — shows point threshold inside
+
+**Connectors:** 3px height, faction-color for completed segments, `rgba(0,0,0,0.1)` for locked.
+
+**Below track:** progress bar toward next level. `flex` row: "Lvl N → N+1" label, bar track, "X / Y pts" in faction color bold.
+
+**Top right of section:** "Next unlock at Level N: [unlock description]" in 9px italic faction color.
+
+**Section background:** `rgba(255,255,255,0.65)` frosted card, rounded 12px.
+
+### 14.4 Praxis Grid
+
+3-column grid of praxis cards. Each card:
+- Thumbnail: 4:3 aspect ratio, placeholder or actual image, dark gradient bg
+- Points badge: bottom-right of thumbnail, `rgba(0,0,0,0.55)` pill, white text, 7px
+- Card body: task name (9px bold), task it belongs to (8px muted), average vote score (7px faction color bold)
+- Voter mini-tiles: row of 14×14px square avatars (faction gradient), "+N" overflow tile
+
+Last card in grid is a "+N more praxis" overflow card — dashed border, centered count, links to full praxis list.
+
+Header: "Praxis — N total" left, "View all →" right in `#4f46e5` with dashed underline.
+
+### 14.5 Friends / Foes
+
+Two-column row below the praxis grid.
+
+Each column: label ("Friends · N" or "Foes · N"), list of relation items, "See all →" link or explanatory note.
+
+**Relation item:**
+- 24px avatar orb (faction gradient)
+- Display name (10px) + faction · level (7px muted)
+- Score delta right-aligned: "+N pts ahead" in `#14532d` (green) or "−N pts behind" in `#dc2626` (red)
+
+**Foes panel note:** "Mutual foes see each other's score delta after every completed task." — 8px italic muted. This surfaces the mechanic without requiring a tooltip.
+
+**Score delta** only shows if the relationship is mutual (both have added each other). One-sided friend/foe requests show "pending" instead.
+
+### 14.6 Own Profile vs. Other Profile
+
+| Element | Own profile | Other player's profile |
+|---------|-------------|----------------------|
+| Action buttons | "Edit Profile" | Friend / Foe / DM |
+| Bio | Editable inline (click to edit) | Read-only |
+| Display name | Editable inline | Read-only |
+| Active tasks sidebar | Your tasks | Your tasks (unchanged — sidebar is always yours) |
+| Level track | Shows your unlocks | Shows their unlocks |
+| Praxis grid | Your praxis | Their praxis |
+
+---
+
+---
+
+## 15. Task Detail Page
+
+### 15.1 Page Layout
+
+Same shell as all logged-in pages. Two-column grid: main content left, 256px sidebar right.
+
+Sidebar panels (top to bottom): character card, "who else is on this task" panel, active tasks panel, recent activity, propose button.
+
+### 15.2 Breadcrumb
+
+`Tasks › [Task Name]` — "Tasks" links back to task list. Task name is plain text (current page).
+
+### 15.3 Task Hero Block — Faction Expanded Card
+
+The task description block IS the faction card archetype expanded to full width. The same visual logic that governs a small task card governs the full task hero — just larger.
+
+- Analog task → full journal page with spiral binding holes (left edge), red margin rule, horizontal lines, torn bottom edge
+- Gestalt task → large collage with multiple paper layers and tape
+- S.N.I.D.E. task → full newspaper clipping with masthead, column rule, torn edges
+- Journeymen task → oversized luggage tag
+- Singularity task → full terminal window, dark bg, green text, corner brackets
+- UA task → large sticky note
+- UA Masters task → full gazette article
+
+**Contents (always present regardless of faction):**
+- Faction tab (diagonal pennant) + status pill ("Active") + level pill
+- Task title: faction-appropriate font, ~28px
+- Stats strip: Base pts · Completed count. **No "in progress" count. No average vote score.**
+- Task description: faction-appropriate font, 13px, 1.7 line-height
+- Task description is hypertext — can embed images and video inline
+
+### 15.4 Sign-Up Block
+
+The most important action on the page. Gets the most visual weight.
+
+**Step 1 — Mode selector:** Three stamp-style buttons side by side (same rectangular stamp aesthetic as status filters):
+
+| Option | Icon | Description |
+|--------|------|-------------|
+| Solo | ◎ | Just you. All points are yours. |
+| Collaboration | ⬡ | Invite others. Everyone earns full points. |
+| Duel | ⚔ | Challenge one player. Winner takes the points. |
+
+Selected state: `background: #1a1209; color: #F7F4EE` with inner dashed border. Unselected: `background: rgba(255,255,255,0.7); border: 2.5px solid #1a1209`.
+
+**Step 2 — Conditional fields:**
+- Solo: no additional fields
+- Collaboration: inline player invite field appears below selector. Input + "+ Add" button. Shows invited players as dismissible pills. If invited player's task list is full, show inline error.
+- Duel: same as collab but limited to one player. Label changes to "Challenge".
+
+**Step 3 — Sign up button:**
+- Full width, faction color background (not generic black — this is the faction's action)
+- Font: Courier Prime, 13px, bold, uppercase, tracking 0.15em
+- Inner dashed border (same stamp pattern)
+- Subtitle text inside button: "· earn up to N pts + votes" in lighter weight
+
+**Below button:** two lines of context — slot count remaining ("You have N of 20 task slots open") and level eligibility ("Level N required ✓" or "Level N required — you are level N ✗").
+
+**Already signed up state:** button replaced by a confirmation badge: `background: rgba(faction, 0.1); border: 1.5px solid rgba(faction, 0.25)` with checkmark and "You're on this task" text. Collab/duel partners shown as small orbs.
+
+### 15.5 Meta Tasks
+
+Shown below the sign-up block. Always visible even if not yet in the backend — treat as display-only until implemented.
+
+**Section container:** frosted card, `rgba(255,255,255,0.65)`, rounded 10px.
+
+**Each meta task item:**
+- Faction color dot (8px circle) — meta tasks belong to specific factions
+- Name (10px bold)
+- Description (8px muted, flex: 2)
+- Bonus: "+N%" or "+N flat" in faction color, bold
+
+**Locked meta tasks** (level too low): `opacity: 0.45` on the entire row + locked level pill appended.
+
+**Implementation note:** meta tasks are modifiers applied at praxis submission time, not at sign-up. The UI here is informational — it shows what bonuses are available for this task before you commit. The submission form will have a separate step for attaching applicable meta tasks.
+
+### 15.6 Praxis Gallery
+
+Grid of completed praxis submissions for this task. Two-column layout (not three — more room for excerpts, which are important for inspiring sign-ups).
+
+**Sort options:** "Top rated" (default) · "Recent" — displayed as small stamp-style toggles top-right.
+
+**Each praxis card:**
+- Thumbnail: 16:9 or 4:3 depending on content, dark gradient bg with emoji placeholder, points badge top-right, media type label bottom-left
+- Author row: 18px orb + display name + average vote score right-aligned
+- Title: Lora italic, 11px
+- Excerpt: 9px muted, ~2 lines, encourages click-through
+- Footer: voter mini-tiles (14px square, faction gradient) + "N pts earned" right
+
+**Below grid:** "View all N praxis →" centered link in `#4f46e5`.
+
+### 15.7 "Who Else Is On This Task" Sidebar Panel
+
+Replaces the "other praxis for this task" panel from the praxis detail page. Shows players currently signed up.
+
+- Header: "N players in progress" (N = total signed up count)
+- List: up to 4 players shown — friends and foes prioritized over strangers
+- Each item: 22px avatar orb + display name + relationship badge ("Friend" in green, "Foe" in red, "—" for neutral)
+- "+ N more →" overflow link
+
+This panel creates social pressure and collaboration opportunities simultaneously. A foe on the same task is competitive motivation. A friend is a potential collab invite.
+
+---
+
+---
+
+## 16. Leaderboard / Players Page
+
+### 16.1 Naming
+
+This page is called **"Players"** everywhere — nav link, page title, breadcrumbs. Never "Leaderboard" in the UI.
+
+### 16.2 Page Title
+
+"Player" with per-letter underline bars in cycling faction colors. Eyebrow: "Era III · [Era Name]".
+
+### 16.3 Podium — Top 3
+
+The top 3 players get a podium treatment above the main table. Three columns arranged: 2nd | 1st | 3rd, with 1st place visually largest.
+
+**Each podium slot:**
+- Card using the player's faction card archetype (tape strip, collage layers, etc.) — same visual logic as task cards and profile headers
+- Faction diagonal pennant tab inside card
+- Avatar orb with faction gradient + faction-color outer ring
+- Rank badge: circle top-right, faction-color for 1st/2nd/3rd specific colors: `#f59e0b` (gold), `#c49a3a` (silver), `#888` (bronze)
+- Display name in Lora italic, faction color
+- Era score: large, bold, Lora, faction color
+- "era pts" label beneath, 7px muted
+- Praxis count: 8px muted
+
+**Platform blocks** below each card (no border-top):
+- Heights: 1st = 52px, 2nd = 36px, 3rd = 24px
+- Background: very light tint of rank color
+- Large faded rank numeral as background texture
+
+**1st place** is additionally larger: card width 160px vs 140px for 2nd/3rd, avatar 64px vs 52px, score font 28px vs 22px, border 3px vs 2px, border-color `#fbbf24`.
+
+### 16.4 Your Rank Strip
+
+Shown between podium and the main table. Always present regardless of your actual rank — pulls your row out and displays it in a highlighted strip so you immediately know where you stand.
+
+- Background: `rgba(79,70,229,0.08)` (your faction color ideally, but indigo as default)
+- Border: `2px solid rgba(79,70,229,0.25)`
+- Left: rank number (large, Lora, faction color) + your avatar orb + name + faction/level
+- Right: score value + "era pts" label + rank delta ("↑ N places this week")
+
+### 16.5 Score Toggle + Faction Filter
+
+Two controls in a flex row:
+
+**Score toggle** (left): Era III | All-time — rectangular stamp buttons, same as status filters. Switches the score column and re-sorts the table.
+
+**Faction filter** (right): diagonal pennant tabs, same as task page. "All" is active by default. Filters table to show only that faction's players.
+
+### 16.6 Main Table
+
+Contained in a frosted card (`rgba(255,255,255,0.65)`, rounded 12px, backdrop blur).
+
+**Columns:** `#` · Player · Faction · Level · Praxis · Score
+
+**Header row:** 8px uppercase, muted, `letter-spacing: 0.15em`. Separated from body by `2px solid #1a1209`.
+
+**Each row:**
+- Left edge accent: 3px vertical bar in the player's faction color (absolute positioned, `top: 20%; bottom: 20%`)
+- Rank: Lora serif, 13px bold. Ranks 4+ are muted color; your rank is faction color
+- Player cell: 32px orb + display name (Lora italic 12px) + "Joined Era X · N days" (7px muted)
+- Faction: 8px faction color dot + faction name (8px uppercase muted)
+- Level: dark pill (`background: #1a1209`)
+- Praxis: centered, 11px bold
+- Score: right-aligned. Era score 15px bold. Below it: all-time score in 8px muted (or rank delta for your row)
+- Row separator: `1px dashed rgba(0,0,0,0.07)`
+- Hover: `background: rgba(255,255,255,0.55)`
+- Your row: `background: rgba(faction,0.06)`, all text in faction color, "You · Level N" as subtitle
+
+**Gap indicator:** When your row is surfaced out of natural order, a separator row spans all columns showing `· · · N players · · ·` with flanking horizontal rules. This communicates the contextual jump without confusion.
+
+**Pagination:** "Load more players →" link at bottom of card, centered, indigo with dashed underline.
+
+### 16.7 Sidebar — Faction Standings Panel
+
+Unique to the Players page. Replaces the "other praxis" or "who's on this task" panel.
+
+Shows collective score per faction for the current era — each faction as a row with:
+- Faction color pip (10px circle)
+- Faction name (9px bold uppercase)
+- Horizontal bar (proportional to highest faction score = 100% width)
+- Total faction score (9px bold right-aligned)
+
+Bar colors match faction colors. This panel gives the leaderboard a second axis: individual competition AND faction competition. Useful for players deciding which faction to join at Level 3.
+
+Standard active tasks panel and recent activity panel below it. Propose button at bottom.
+
+---
+
+---
+
+## 17. Updates Feed Page
+
+### 17.1 Page Layout
+
+Same shell as all logged-in pages. Two-column grid: feed stream left, 256px sidebar right.
+
+Sidebar panels (top to bottom): character card, pending requests panel (unique to this page), active tasks panel, recent global activity panel, propose button.
+
+### 17.2 Feed Filters
+
+Stamp-style rectangular pills (same aesthetic as status filters) in a horizontal row above the feed.
+
+| Filter | Description |
+|--------|-------------|
+| All | Everything, reverse chronological |
+| Friends | Activity from players you've friended |
+| Foes | Foe taunts only |
+| Your stuff | Votes/comments on your praxis, collab invites, duel challenges |
+| Global | Site-wide events, new tasks, era announcements |
+| Requests | Pending friend/foe requests |
+
+The **Requests pill** gets a colored badge count (red background, white text) when there are pending requests — the only pill with a colored count, because requests genuinely need action.
+
+### 17.3 Feed Item Types
+
+All items share a base card: `rgba(255,255,255,0.68)` frosted, `border-radius: 10px`, `backdrop-filter: blur(3px)`. Each type has a **4px left-edge accent bar** and a **type label pill** top-right.
+
+| Type | Left bar color | Label color | Notes |
+|------|---------------|-------------|-------|
+| Friend activity | `#14532d` green | `#14532d` | Warm |
+| Global | `#4f46e5` indigo | `#4f46e5` | System/admin |
+| Your stuff | `#be185d` rose | `#be185d` | Ego feed |
+| Duel challenge | `rgba(220,38,38,0.2)` border tint | `#dc2626` with ⚔ | Card bg: `rgba(255,248,248,0.7)` |
+| Foe taunt | No base card — see below | — | Special treatment |
+| Era announcement | No left bar — see below | — | Special treatment |
+
+**Date separators** between temporal groups: flex row with flanking `1px rgba(0,0,0,0.08)` lines and "Today" / "Yesterday" / date label in 8px muted uppercase.
+
+### 17.4 Feed Item Content Patterns
+
+**Player action items** (completed task, signed up, voted):
+- Player orb (28px) + bold player name in faction color + action text + time
+- Preview strip below: faction dot + task/praxis name + metadata + "→" arrow
+- Clicking preview strip navigates to the task or praxis
+
+**Praxis completion items** (friend completed, global completion):
+- Same header
+- Praxis card below: thumbnail (52×40px) + italic Lora title + task name + voter mini-tiles + pts earned so far
+
+**Vote notification** (someone voted on your praxis):
+- Header as above
+- Vote row: stamp-style number badge + "on [praxis title]" + "+N pts" right-aligned
+
+**Collab invite** (actionable):
+- Header
+- Task preview strip
+- Accept / Decline buttons inline below. Show remaining task slots as inline hint text.
+
+**Duel challenge** (actionable):
+- Same pattern as collab invite
+- Red "Accept duel" button, neutral "Decline" button
+- Preview strip has ⚔ instead of →, red tint
+
+### 17.5 Foe Taunt — Special Treatment
+
+Foe taunts do NOT use the base card. They are rendered as **physical notes** — aged paper, tape at top, torn bottom edge.
+
+**"Watch your back"** (foe passed you in score):
+- Paper: `background: #fef9ee; border: 1.5px solid #c49a3a`
+- Tape strip: `rgba(250,230,130,0.7)` centered at top, `width: 48px; height: 13px`
+- Torn bottom edge: `::after` pseudo-element with jagged clip-path in page background color
+- Font: Special Elite throughout
+- Header: small foe orb + "From your foe · [Name]" in `#8a6a20` + timestamp in `#c49a3a`
+- Message: italic, 12px — auto-generated: `"You might want to watch your back, [player]. Things just got interesting."`
+- Footer: task completed left + score delta right in `#dc2626` ("Foe now leads by N pts")
+
+**"Catch up"** (you're still ahead):
+- Paper: `background: #fff8f8; border: 1.5px solid #dc2626`
+- Same structure but red-tinted
+- Message: `"Still trailing. I'll catch up eventually, [player]. Eventually."`
+- Footer: score delta in `#14532d` ("You lead by N pts")
+
+The taunt messages are game-generated strings. Admins should be able to define a pool of taunt templates per faction — S.N.I.D.E. taunts should feel different from Journeymen taunts.
+
+### 17.6 Era Announcement — Special Treatment
+
+Full-width dark card. Only item type with `background: #1a1209`.
+
+- 4px left bar in `#fbbf24`
+- Gold circular icon (36px, `background: #fbbf24`) with ◎ symbol
+- "ERA ANNOUNCEMENT · ADMIN" label in `#fbbf24`, 8px uppercase
+- Title: Lora italic, 18px, `#F7F4EE`
+- Body: 10px, `rgba(255,255,255,0.65)`, 1.55 line-height
+- Action buttons below: primary (`background: #fbbf24; color: #1a1209`) + secondary (outline, muted)
+
+Era announcements are always pinned to the top of the feed on the day they're posted, regardless of other activity.
+
+### 17.7 Pending Requests Sidebar Panel
+
+Unique to the Updates page. Sits between the character card and the active tasks panel.
+
+Each request item:
+- 24px player orb
+- Display name + relationship type ("Friend request" in green, "Foe request" in red)
+- Accept button (`background: #14532d`) + Decline button (✕, outline)
+
+If no pending requests: panel is hidden entirely (don't show an empty state).
+
+### 17.8 Recent Global Activity Sidebar Panel
+
+On the Updates page, the "recent activity" sidebar panel shows **global** activity (not personal) — it's a compact running ticker of what's happening site-wide while you read your personal feed.
+
+Same format as on other pages: player name in faction color + action + timestamp. Up to 3 items.
+
+---
+
+---
+
+## 18. Submit Proof Form
+
+### 18.1 Layout — No Sidebar
+
+This is the **only logged-in page without the right-hand sidebar panels**. The user is writing. Give them the full width.
+
+Layout: single centered column, max-width ~720px, with generous padding. The watercolor background is still present. Nav is still present. No sidebar, no active tasks panel, no character card, no activity feed.
+
+The breadcrumb reads: `Tasks › [Task Name] › Submit Proof`
+
+### 18.2 Task Context Header
+
+The form opens with a faction-framed task context block — same collage/journal/dossier aesthetic as the faction card for the task's faction. This anchors the writer to what they're proving before they start.
+
+**Contents:**
+- "Proving completion of" eyebrow (8px uppercase muted)
+- Task name (Special Elite or faction-appropriate font, 18px, faction color)
+- Faction + base pts + level pills
+- If collaboration: right side shows collaborator orbs + names
+- If duel: right side shows opponent orb + "Duel — winner takes all"
+
+### 18.3 Form Sections
+
+Each section is a frosted card (`rgba(255,255,255,0.7)`, `border-radius: 12px`, `backdrop-filter: blur(3px)`). Sections stack vertically with `gap: 1.1rem`.
+
+**Section header pattern:** 9px uppercase label left + 8px italic hint text right (muted, non-uppercase).
+
+#### Section 1 — Proof Title
+
+- Input: Lora italic, 24px, transparent background, no border except bottom (2px, `rgba(0,0,0,0.12)`)
+- Focus state: bottom border transitions to faction color
+- Placeholder: "What did you do?" in `#c8c0b0` italic
+- Below input: full-width rainbow underline bars (same 8-segment system as page titles, `opacity: 0.6`, `height: 3px`) — appear as soon as text is present
+
+#### Section 2 — The Proof (Rich Text)
+
+- Minimal toolbar: Bold, Italic, Underline | H1, Quote | Bullet, Link | Insert Image, Insert Video
+- Toolbar buttons: 28×28px, `border: 1.5px solid rgba(0,0,0,0.12)`, `border-radius: 3px`
+- Active/pressed: `background: #1a1209; color: white`
+- Separator bars: `1px rgba(0,0,0,0.1)`, 28px height
+- Text area: Lora, 14px, `color: #2a1e10`, `line-height: 1.75`, `min-height: 180px`, no border, full width
+- Placeholder: italic, `#c8c0b0`
+- Word count: 8px muted, right-aligned, below textarea. Label: "N words · no limit"
+- **No character limit. No word limit.** The culture of long-form proof posts should be encouraged.
+
+#### Section 3 — Media
+
+Three media type tabs above the grid (Photos / Video / Audio) using stamp-style buttons — same rectangular stamp aesthetic, no border-radius.
+
+**Media grid:** 3 columns, `gap: 0.6rem`
+
+**Uploaded tile:**
+- 4:3 aspect ratio, `border-radius: 6px`, `border: 1.5px solid rgba(0,0,0,0.1)`
+- "Main" badge: top-left, `background: faction-color; color: white; 7px uppercase` — first uploaded image gets this by default
+- File type + size badge: bottom-left, `rgba(0,0,0,0.5)` pill, 7px, white
+- Hover overlay: `rgba(0,0,0,0.35)` with "Remove" and "Set main" action pills
+- Action pills: `background: rgba(255,255,255,0.9); color: #1a1209; 7px uppercase; border-radius: 3px`
+
+**Upload zone (always last):**
+- Same 4:3 grid cell
+- `border: 2px dashed rgba(0,0,0,0.15)`, `border-radius: 6px`
+- ⊕ icon + "Drop files here / or click to upload"
+- Hover: `border-color: faction-color; background: rgba(faction, 0.04)`
+
+Accepted formats note below grid: 8px muted. Max 50mb per file.
+
+Multiple upload zones are NOT shown — just one. As files are uploaded, they fill the grid left-to-right and the upload zone stays at the end.
+
+#### Section 4 — Meta Tasks
+
+Only shown if the player has applicable meta tasks available for this task.
+
+**Each meta task row:**
+- Checkbox (18px, `border-radius: 3px`) — checked state: `background: faction-color; color: white; ✓`
+- Meta task name (10px bold) + description (8px muted)
+- Bonus right-aligned: `+N%` or `+N pts` in faction color bold
+
+Below the list: if any meta tasks are checked, show a caveat: "You're claiming [Meta Task Name]. Your proof must demonstrate this — voters can dispute it." — 8px italic muted.
+
+#### Section 5 — Collaboration Note (conditional)
+
+Shown only for collab or duel submissions.
+
+- `background: rgba(faction, 0.07); border: 1px solid rgba(faction, 0.15); border-radius: 8px`
+- ⬡ icon + explanatory text
+- For collab: "Both of you will earn points from votes. [Partner] will be notified when you submit — they can add their own proof post for the same task, or endorse this one."
+- For duel: "Only the player with the higher vote total earns points. Voting on a duel also requires voters to indicate who they believe won."
+
+### 18.4 Submit Row
+
+Below all sections, full width:
+
+- **"Publish proof"** button (primary): faction color background, white text, Courier Prime 12px bold uppercase, rectangular stamp style with inner dashed border. NOT "Submit" — "Publish" implies pride of authorship.
+- **"Save draft"** button: outline style, `border: 2px solid rgba(0,0,0,0.15)`, muted text. Saves without publishing.
+- Submit note (right of buttons, 8px muted): "Once published, others can vote on your proof. You can edit it after publishing."
+
+### 18.5 Sidebar Replacement — Contextual Panels
+
+Since there is no right sidebar, two pieces of information that would normally live in a sidebar are instead placed as the **right column of the main content area** on wider screens, or as collapsed accordions on mobile:
+
+**"What makes a good proof post"** — always visible on desktop, collapsed on mobile.
+Content (bulleted list, 9px, `color: #4a3f30`):
+- Write in first person. We want to feel like we were there.
+- Specificity beats spectacle. A real moment with one pigeon beats a zoo photo.
+- Photos and video help, but they don't replace the writing.
+- Tell us what changed. Did something unexpected happen?
+- Voters reward weirdness, honesty, and genuine effort over polish.
+
+**"Other proofs for this task"** — peek at up to 3 existing praxis submissions.
+- Small thumbnail (36×28px) + Lora italic title + points earned
+- Note below: "Reading other proofs is allowed and encouraged — see what approaches others took."
+
+These panels are editorial, not functional. They should feel like a soft nudge from the community, not a rules box.
+
+### 18.6 Active Task Highlight
+
+In the active tasks panel (if shown anywhere on this page — on mobile it may appear collapsed in a bottom drawer), the task currently being submitted is highlighted with faction-color background tint and "Submitting now" as the meta text.
+
+---

--- a/docs/STYLE_MIGRATION_NOTES.md
+++ b/docs/STYLE_MIGRATION_NOTES.md
@@ -58,12 +58,69 @@ Replace current chip-based filters with three distinct visual types. See style g
 - [ ] **Active tasks panel** — Fetch user's signed-up tasks, show with faction color left-border, task name, meta (faction · level · date), badge pill (Solo/Collab/Duel). Progress bar: `X / 20 slots` with indigo fill.
 - [ ] **Recent activity panel** — Fetch 3 most recent events. Player names in faction color + bold. Timestamps in tertiary color. Separated by 1px dashed border.
 
-## Phase 6: Per-Page Polish
+## Phase 6: Per-Page Polish (secondary pages)
 
-- [ ] Apply PageTitle to remaining secondary pages (About, Contact, Disclaimer, Attributions, Donate, Admin, EditCharacter, EditSubmission, SubmitProof, TaskDetail, SubmissionDetail, CharacterProfile, Updates, Groups)
-- [ ] Update SubmissionCard component to match new card aesthetic
-- [ ] Update CharacterProfile page layout
-- [ ] Update Leaderboard entry cards
+- [ ] Apply PageTitle to remaining secondary pages (About, Contact, Disclaimer, Attributions, Donate, Admin, EditCharacter, EditSubmission, Groups)
 - [ ] Update Factions page cards to use faction-specific styling
 - [ ] Remove remaining `hover:-translate` sketch effects from all components
 - [ ] Audit all hardcoded hex values in components and replace with CSS custom properties
+
+## Phase 7: Praxis Submission Page (§12)
+
+- [ ] **Breadcrumb** — `Tasks › [faction dot] [Task Name] › Praxis`
+- [ ] **Byline block** — Author's faction card aesthetic as framing (collage, notebook, newsprint, etc.). Avatar orb + name + faction meta + vote score.
+- [ ] **Praxis title** — Lora italic 30px + full-width rainbow underline bar (8 segments, NOT per-letter)
+- [ ] **Task context strip** — Faction-color left border, frosted bg, task name + points + level pill
+- [ ] **Media gallery** — Main image 16:9, thumbnail strip, active thumb faction-color border, "+N more" overflow
+- [ ] **Body text** — Lora 15px, line-height 1.75, drop cap first letter in faction color 58px, italic emphasis in faction color
+- [ ] **Collaboration strip** — Overlapping avatar orbs, badge pill (Collab/Duel)
+
+## Phase 8: Voting System (§13)
+
+- [ ] **Vote stamps** — Replace star rating with 5 rectangular stamp buttons (1–5) with word labels (a start / solid / good / excellent / legendary). Value-specific border colors.
+- [ ] **Voter tile grid** — Show every voter as a tile: 48×48 avatar, points badge, name. Flex-wrap layout. "+N more" overflow.
+- [ ] **Vote results header** — Total points earned, voter count
+- [ ] **Flag block** — First-class UI element below voter grid. Circular flag icon + explanation + confirmation modal.
+
+## Phase 9: Player Profile Page (§14)
+
+- [ ] **Faction-framed profile header** — Player's faction card aesthetic as container (same principle as praxis byline). Avatar orb 80px + level badge + action buttons (Friend/Foe/DM or Edit Profile).
+- [ ] **Level track** — Full-width horizontal track of 9 levels (0–8). Completed/current/locked node states. Faction-color connectors. Progress bar to next level.
+- [ ] **Praxis grid** — 3-column grid of praxis cards with thumbnails, voter mini-tiles, "+N more" overflow card
+- [ ] **Friends/Foes panels** — Two-column row. Relation items with avatar orb + score delta. Mutual vs pending states.
+
+## Phase 10: Task Detail Page (§15)
+
+- [ ] **Task hero block** — Faction card archetype expanded to full width (journal page, collage, newspaper, etc.)
+- [ ] **Sign-up block** — Mode selector (Solo/Collab/Duel) as stamp buttons. Conditional fields for collab/duel invites. Faction-color sign-up button with inner dashed border.
+- [ ] **Meta tasks section** — Frosted card, faction-color dots, bonus amounts. Locked tasks at opacity 0.45.
+- [ ] **Praxis gallery** — Two-column grid of completed submissions. Sort toggles (Top rated / Recent).
+- [ ] **"Who else is on this task" sidebar panel** — Signed-up players with relationship badges.
+
+## Phase 11: Leaderboard / Players Page (§16)
+
+- [ ] **Podium** — Top 3 players in faction-framed cards. Platform blocks with rank-specific heights/colors.
+- [ ] **Your rank strip** — Highlighted row between podium and table. Rank delta indicator.
+- [ ] **Score toggle** — Era/All-time stamp buttons + faction pennant filter
+- [ ] **Main table** — Frosted card, faction-color left edge accents, Lora serif ranks, avatar orbs, level pills. Your row highlighted. Gap indicator for contextual jump.
+- [ ] **Faction standings sidebar panel** — Horizontal bars per faction proportional to total score.
+
+## Phase 12: Updates Feed Page (§17)
+
+- [ ] **Feed filters** — Stamp-style pills: All, Friends, Foes, Your stuff, Global, Requests (with badge count)
+- [ ] **Feed item types** — Base frosted card with 4px left-edge accent + type label pill. Player action, praxis completion, vote notification, collab invite, duel challenge.
+- [ ] **Foe taunts** — Special treatment: aged paper notes with tape strip, torn bottom edge, Special Elite font, auto-generated messages. Red/gold tints.
+- [ ] **Era announcements** — Full-width dark card with gold accent. Pinned on day posted.
+- [ ] **Pending requests sidebar panel** — Avatar orbs + Accept/Decline buttons
+- [ ] **Date separators** — Flanking horizontal rules with day labels
+
+## Phase 13: Submit Proof Form (§18)
+
+- [ ] **No sidebar layout** — Single centered column, max-width ~720px
+- [ ] **Task context header** — Faction-framed block with task name, faction, points, collaborator orbs
+- [ ] **Proof title input** — Lora italic 24px, bottom border focus state, rainbow underline bars on input
+- [ ] **Rich text editor** — Minimal toolbar (Bold/Italic/Underline, H1/Quote, Bullet/Link, Insert Image/Video). Lora 14px body. No character/word limit.
+- [ ] **Media upload** — 3-column grid, "Main" badge on first upload, drag-drop zone, file type badges
+- [ ] **Meta tasks section** — Checkboxes with faction-color checked state + bonus amounts
+- [ ] **Submit row** — "Publish proof" faction-color stamp button + "Save draft" outline button
+- [ ] **Contextual panels** — "What makes a good proof post" tips + "Other proofs for this task" peek

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,6 +1,7 @@
 import { NavLink } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
 import { loginWithGoogle, logout } from '../api/auth'
+import { useTheme } from '../hooks/useTheme'
 
 const links = [
   { to: '/', label: 'Home', end: true },
@@ -20,8 +21,13 @@ const NAV_LINK_BASE = {
   paddingBottom: 2,
 }
 
+const NAV_BG_LIGHT = 'rgba(247, 244, 238, 0.88)'
+const NAV_BG_DARK = 'rgba(19, 18, 26, 0.92)'
+
 export default function NavBar() {
   const { user, refetch } = useAuth()
+  const { theme, toggle } = useTheme()
+  const dark = theme === 'dark'
 
   const handleLogout = async () => {
     await logout()
@@ -33,9 +39,10 @@ export default function NavBar() {
       className="sticky top-0"
       style={{
         zIndex: 10,
-        background: 'rgba(247, 244, 238, 0.88)',
-        backdropFilter: 'blur(6px)',
+        background: dark ? NAV_BG_DARK : NAV_BG_LIGHT,
+        backdropFilter: dark ? 'blur(8px)' : 'blur(6px)',
         borderBottom: '1px solid var(--color-border)',
+        transition: 'background 150ms',
       }}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 h-14 flex items-center gap-6">
@@ -93,6 +100,22 @@ export default function NavBar() {
             </li>
           )}
         </ul>
+
+        {/* Theme toggle */}
+        <button
+          onClick={toggle}
+          className="eyebrow"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '2px 6px',
+            color: 'var(--color-text-tertiary)',
+            transition: 'color 150ms',
+          }}
+        >
+          {dark ? 'light' : 'dark'}
+        </button>
 
         {/* User area */}
         <div className="flex items-center gap-3 shrink-0">

--- a/frontend/src/components/cards/TaskCardAnalog.tsx
+++ b/frontend/src/components/cards/TaskCardAnalog.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { TaskOut } from '../../api/tasks'
 import LevelPill from '../ui/LevelPill'
+import { useTheme } from '../../hooks/useTheme'
 
 /**
  * Analog — Torn Field Journal Page (Style Guide §6.2).
@@ -13,61 +14,46 @@ interface Props {
 }
 
 export default function TaskCardAnalog({ task, onSignup }: Props) {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
+
   return (
     <div
       style={{
         width: 136,
-        background: '#fffef5',
-        border: '1px solid rgba(0,0,0,0.08)',
+        background: dark ? '#1e1a10' : '#fffef5',
+        border: `1px solid ${dark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)'}`,
         clipPath: 'polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)',
         position: 'relative',
         padding: '12px 12px 18px 24px',
         fontFamily: "'Special Elite', serif",
-        color: '#1a1209',
-        backgroundImage: 'repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.1) 17px, rgba(100,140,200,0.1) 18px)',
+        color: dark ? '#e8dcc8' : '#1a1209',
+        backgroundImage: `repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,${dark ? '0.05' : '0.1'}) 17px, rgba(100,140,200,${dark ? '0.05' : '0.1'}) 18px)`,
+        transition: 'background 150ms, color 150ms',
       }}
     >
-      {/* Red margin rule */}
-      <div
-        style={{
-          position: 'absolute',
-          left: 20,
-          top: 0,
-          bottom: 0,
-          width: 1,
-          background: 'rgba(220,80,80,0.25)',
-        }}
-      />
+      <div style={{ position: 'absolute', left: 20, top: 0, bottom: 0, width: 1, background: `rgba(220,80,80,${dark ? '0.16' : '0.25'})` }} />
 
-      {/* Faction + points */}
       <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#15803d', marginBottom: 6, fontFamily: "'Courier Prime', monospace" }}>
         Analog · {task.point_value} pts
       </div>
 
-      {/* Title */}
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-        <div style={{ fontSize: 12, fontWeight: 400, lineHeight: 1.3, marginBottom: 6 }}>
-          {task.title}
-        </div>
+        <div style={{ fontSize: 12, fontWeight: 400, lineHeight: 1.3, marginBottom: 6 }}>{task.title}</div>
       </Link>
 
-      {/* Description */}
       {task.description && (
-        <div style={{ fontSize: 9, color: '#555', lineHeight: 1.5, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+        <div style={{ fontSize: 9, color: dark ? '#a89878' : '#555', lineHeight: 1.5, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
           {task.description}
         </div>
       )}
 
-      {/* Sign up */}
       {onSignup && (
-        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
-          sign up
-        </button>
+        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>sign up</button>
       )}
 
-      {/* Footer */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.12)', paddingTop: 6 }}>
-        <LevelPill level={task.level_required} />
+        <LevelPill level={task.level_required} factionColor={dark ? '#e8dcc8' : undefined} />
         <span style={{ fontSize: 10, fontWeight: 700, fontFamily: "'Courier Prime', monospace" }}>{task.point_value}</span>
       </div>
     </div>

--- a/frontend/src/components/cards/TaskCardGestalt.tsx
+++ b/frontend/src/components/cards/TaskCardGestalt.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { TaskOut } from '../../api/tasks'
 import LevelPill from '../ui/LevelPill'
+import { useTheme } from '../../hooks/useTheme'
 
 /**
  * Gestalt — Collage / Layered Scraps (Style Guide §6.3).
@@ -13,94 +14,53 @@ interface Props {
 }
 
 export default function TaskCardGestalt({ task, onSignup }: Props) {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
+
   return (
     <div style={{ position: 'relative', width: 138, height: 'auto', minHeight: 128 }}>
       {/* Back scrap 2 (deepest) */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 10,
-          left: -4,
-          right: -4,
-          height: 20,
-          background: '#bbf7d0',
-          border: '1.5px solid rgba(0,0,0,0.12)',
-          transform: 'rotate(-4deg)',
-          borderRadius: 1,
-        }}
-      />
-
+      <div style={{ position: 'absolute', top: 10, left: -4, right: -4, height: 20, background: dark ? '#091209' : '#bbf7d0', border: '1.5px solid rgba(0,0,0,0.12)', transform: 'rotate(-4deg)', borderRadius: 1 }} />
       {/* Back scrap 1 */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 4,
-          left: -2,
-          right: -2,
-          height: 30,
-          background: '#dcfce7',
-          border: '1.5px solid rgba(0,0,0,0.12)',
-          transform: 'rotate(3deg)',
-          borderRadius: 1,
-        }}
-      />
+      <div style={{ position: 'absolute', top: 4, left: -2, right: -2, height: 30, background: dark ? '#0d1a10' : '#dcfce7', border: '1.5px solid rgba(0,0,0,0.12)', transform: 'rotate(3deg)', borderRadius: 1 }} />
 
       {/* Front scrap (main content) */}
       <div
         style={{
           position: 'relative',
-          background: '#f0fdf4',
+          background: dark ? '#132318' : '#f0fdf4',
           border: '1.5px solid rgba(0,0,0,0.12)',
           transform: 'rotate(-2deg)',
           padding: '18px 10px 12px',
           fontFamily: "'Courier Prime', monospace",
-          color: '#14532d',
+          color: dark ? '#4ade80' : '#14532d',
           zIndex: 2,
+          transition: 'background 150ms, color 150ms',
         }}
       >
         {/* Scotch tape strip */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 4,
-            left: '50%',
-            transform: 'translateX(-50%) rotate(-1deg)',
-            width: 40,
-            height: 12,
-            background: 'rgba(250,230,130,0.7)',
-            borderRadius: 1,
-          }}
-        />
+        <div style={{ position: 'absolute', top: 4, left: '50%', transform: 'translateX(-50%) rotate(-1deg)', width: 40, height: 12, background: dark ? 'rgba(250,230,130,0.12)' : 'rgba(250,230,130,0.7)', borderRadius: 1 }} />
 
-        {/* Faction + points */}
-        <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#15803d', marginBottom: 6 }}>
+        <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: dark ? '#4ade80' : '#15803d', marginBottom: 6 }}>
           Gestalt · {task.point_value} pts
         </div>
 
-        {/* Title */}
         <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-          <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 6 }}>
-            {task.title}
-          </div>
+          <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 6 }}>{task.title}</div>
         </Link>
 
-        {/* Description */}
         {task.description && (
-          <div style={{ fontSize: 8, color: '#2d6a4f', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+          <div style={{ fontSize: 8, color: dark ? '#2d8a50' : '#2d6a4f', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
             {task.description}
           </div>
         )}
 
-        {/* Sign up */}
         {onSignup && (
-          <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
-            sign up
-          </button>
+          <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>sign up</button>
         )}
 
-        {/* Footer */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.12)', paddingTop: 6 }}>
-          <LevelPill level={task.level_required} />
+          <LevelPill level={task.level_required} factionColor={dark ? '#4ade80' : undefined} />
           <span style={{ fontSize: 10, fontWeight: 700 }}>{task.point_value}</span>
         </div>
       </div>

--- a/frontend/src/components/cards/TaskCardJourneymen.tsx
+++ b/frontend/src/components/cards/TaskCardJourneymen.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { TaskOut } from '../../api/tasks'
 import LevelPill from '../ui/LevelPill'
+import { useTheme } from '../../hooks/useTheme'
 
 /**
  * Journeymen — Luggage Tag (Style Guide §6.5).
@@ -13,81 +14,52 @@ interface Props {
 }
 
 export default function TaskCardJourneymen({ task, onSignup }: Props) {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
+  const borderColor = dark ? '#c49a3a' : '#8a6a20'
+
   return (
     <div style={{ paddingTop: 26, position: 'relative', width: 118 }}>
       {/* Hanging string */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
-        {/* Dashed string */}
-        <div style={{ width: 0, height: 14, borderLeft: '2px dashed #8a6a20' }} />
-        {/* Eyelet hole */}
-        <div
-          style={{
-            width: 10,
-            height: 10,
-            borderRadius: '50%',
-            border: '2px solid #8a6a20',
-            background: 'var(--color-bg-page)',
-          }}
-        />
+      <div style={{ position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <div style={{ width: 0, height: 14, borderLeft: `2px dashed ${borderColor}` }} />
+        <div style={{ width: 10, height: 10, borderRadius: '50%', border: `2px solid ${borderColor}`, background: 'var(--color-bg-page)' }} />
       </div>
 
       {/* Tag body */}
       <div
         style={{
-          border: '2px solid #8a6a20',
-          background: '#fef9ee',
+          border: `2px solid ${borderColor}`,
+          background: dark ? '#1c1610' : '#fef9ee',
           fontFamily: "'Courier Prime', monospace",
-          color: '#1a1209',
+          color: dark ? '#f5e6c8' : '#1a1209',
+          transition: 'background 150ms, color 150ms',
         }}
       >
         {/* Hazard stripe */}
-        <div
-          style={{
-            height: 3,
-            backgroundImage: 'repeating-linear-gradient(90deg, #c2410c 0, #c2410c 8px, #1a1209 8px, #1a1209 16px, #f59e0b 16px, #f59e0b 24px, #1a1209 24px, #1a1209 32px)',
-          }}
-        />
+        <div style={{ height: 3, backgroundImage: `repeating-linear-gradient(90deg, #c2410c 0, #c2410c 8px, ${dark ? '#1c1610' : '#1a1209'} 8px, ${dark ? '#1c1610' : '#1a1209'} 16px, #f59e0b 16px, #f59e0b 24px, ${dark ? '#1c1610' : '#1a1209'} 24px, ${dark ? '#1c1610' : '#1a1209'} 32px)` }} />
 
         <div style={{ padding: '8px 10px 10px' }}>
-          {/* Faction + points */}
-          <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#8a6a20', marginBottom: 5 }}>
+          <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: dark ? '#c49a3a' : '#8a6a20', marginBottom: 5 }}>
             Journeymen · {task.point_value} pts
           </div>
 
-          {/* Title */}
           <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-            <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 5 }}>
-              {task.title}
-            </div>
+            <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 5 }}>{task.title}</div>
           </Link>
 
-          {/* Description */}
           {task.description && (
-            <div style={{ fontSize: 8, color: '#555', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+            <div style={{ fontSize: 8, color: dark ? '#a89878' : '#555', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
               {task.description}
             </div>
           )}
 
-          {/* Sign up */}
           {onSignup && (
-            <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
-              sign up
-            </button>
+            <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>sign up</button>
           )}
 
-          {/* Footer */}
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.15)', paddingTop: 5 }}>
-            <LevelPill level={task.level_required} />
+            <LevelPill level={task.level_required} factionColor={dark ? '#c49a3a' : undefined} />
             <span style={{ fontSize: 10, fontWeight: 700 }}>{task.point_value}</span>
           </div>
         </div>

--- a/frontend/src/components/cards/TaskCardSNIDE.tsx
+++ b/frontend/src/components/cards/TaskCardSNIDE.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { TaskOut } from '../../api/tasks'
 import LevelPill from '../ui/LevelPill'
+import { useTheme } from '../../hooks/useTheme'
 
 /**
  * S.N.I.D.E. — Newspaper Clipping (Style Guide §6.4).
@@ -14,120 +15,74 @@ interface Props {
   onSignup?: (id: number) => void
 }
 
-/** Render faction name as cutout ransom-style letters */
-function CutoutLetters({ text }: { text: string }) {
+function CutoutLetters({ text, dark }: { text: string; dark: boolean }) {
   return (
     <span style={{ display: 'inline-flex', gap: 1 }}>
-      {text.split('').map((char, index) => (
+      {text.split('').map((char, index) =>
         char === '.' ? (
-          <span key={index} style={{ fontSize: 9, fontFamily: "'Courier Prime', monospace", color: '#8a6a20' }}>.</span>
+          <span key={index} style={{ fontSize: 9, fontFamily: "'Courier Prime', monospace", color: dark ? '#c49a3a' : '#8a6a20' }}>.</span>
         ) : (
-          <span
-            key={index}
-            style={{
-              background: '#1a1209',
-              color: 'white',
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 9,
-              padding: '0 2px',
-              lineHeight: 1.4,
-            }}
-          >
+          <span key={index} style={{ background: dark ? '#c49a3a' : '#1a1209', color: dark ? '#1a1710' : 'white', fontFamily: "'Courier Prime', monospace", fontSize: 9, padding: '0 2px', lineHeight: 1.4 }}>
             {char}
           </span>
         )
-      ))}
+      )}
     </span>
   )
 }
 
 export default function TaskCardSNIDE({ task, onSignup }: Props) {
-  // Split description into two halves for columns
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
   const words = (task.description ?? '').split(' ')
   const mid = Math.ceil(words.length / 2)
   const col1 = words.slice(0, mid).join(' ')
   const col2 = words.slice(mid).join(' ')
+  const pageBg = dark ? '#13121a' : 'var(--color-bg-page)'
 
   return (
     <div
       style={{
         width: 148,
-        background: '#f0e8d0',
+        background: dark ? '#1a1710' : '#f0e8d0',
         position: 'relative',
         padding: '10px 10px 12px',
         fontFamily: "'Special Elite', serif",
-        color: '#1a1209',
+        color: dark ? '#f0e6d0' : '#1a1209',
+        transition: 'background 150ms, color 150ms',
       }}
     >
-      {/* Torn top edge */}
-      <div
-        style={{
-          content: "''",
-          position: 'absolute',
-          top: -1,
-          left: 0,
-          right: 0,
-          height: 6,
-          background: 'var(--color-bg-page)',
-          clipPath: TORN_CLIP,
-        }}
-      />
-      {/* Torn bottom edge */}
-      <div
-        style={{
-          content: "''",
-          position: 'absolute',
-          bottom: -1,
-          left: 0,
-          right: 0,
-          height: 6,
-          background: 'var(--color-bg-page)',
-          clipPath: TORN_CLIP,
-        }}
-      />
+      <div style={{ position: 'absolute', top: -1, left: 0, right: 0, height: 6, background: pageBg, clipPath: TORN_CLIP }} />
+      <div style={{ position: 'absolute', bottom: -1, left: 0, right: 0, height: 6, background: pageBg, clipPath: TORN_CLIP }} />
 
-      {/* Masthead */}
-      <div style={{ fontSize: 6, textTransform: 'uppercase', letterSpacing: '0.25em', color: '#666', borderBottom: '1.5px solid #1a1209', paddingBottom: 3, marginBottom: 5 }}>
+      <div style={{ fontSize: 6, textTransform: 'uppercase', letterSpacing: '0.25em', color: dark ? '#7a6a50' : '#666', borderBottom: `1.5px solid ${dark ? '#c49a3a' : '#1a1209'}`, paddingBottom: 3, marginBottom: 5 }}>
         The Daily Snide Gazette
       </div>
 
-      {/* Headline */}
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-        <div style={{ fontSize: 12, lineHeight: 1.2, marginBottom: 4 }}>
-          {task.title}
-        </div>
+        <div style={{ fontSize: 12, lineHeight: 1.2, marginBottom: 4 }}>{task.title}</div>
       </Link>
 
-      {/* Faction cutout letters */}
       <div style={{ marginBottom: 6 }}>
-        <CutoutLetters text="S.N.I.D.E." />
-        <span style={{ fontSize: 8, color: '#8a6a20', marginLeft: 4 }}>{task.point_value} pts</span>
+        <CutoutLetters text="S.N.I.D.E." dark={dark} />
+        <span style={{ fontSize: 8, color: dark ? '#c49a3a' : '#8a6a20', marginLeft: 4 }}>{task.point_value} pts</span>
       </div>
 
-      {/* Two-column body */}
       {task.description && (
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr', gap: 4, marginBottom: 8 }}>
-          <div style={{ fontSize: 7.5, color: '#444', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
-            {col1}
-          </div>
-          <div style={{ background: 'rgba(0,0,0,0.12)' }} />
-          <div style={{ fontSize: 7.5, color: '#444', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
-            {col2}
-          </div>
+          <div style={{ fontSize: 7.5, color: dark ? '#7a6a50' : '#444', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>{col1}</div>
+          <div style={{ background: dark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.12)' }} />
+          <div style={{ fontSize: 7.5, color: dark ? '#7a6a50' : '#444', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>{col2}</div>
         </div>
       )}
 
-      {/* Sign up */}
       {onSignup && (
-        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
-          sign up
-        </button>
+        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>sign up</button>
       )}
 
-      {/* Footer */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px solid rgba(0,0,0,0.15)', paddingTop: 5 }}>
-        <span style={{ fontSize: 8, color: '#8a6a20', fontFamily: "'Courier Prime', monospace" }}>{task.point_value} pts</span>
-        <LevelPill level={task.level_required} />
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: `1px solid ${dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.15)'}`, paddingTop: 5 }}>
+        <span style={{ fontSize: 8, color: dark ? '#c49a3a' : '#8a6a20', fontFamily: "'Courier Prime', monospace" }}>{task.point_value} pts</span>
+        <LevelPill level={task.level_required} factionColor={dark ? '#c49a3a' : undefined} />
       </div>
     </div>
   )

--- a/frontend/src/components/cards/TaskCardUA.tsx
+++ b/frontend/src/components/cards/TaskCardUA.tsx
@@ -1,14 +1,17 @@
 import { Link } from 'react-router-dom'
 import type { TaskOut } from '../../api/tasks'
 import LevelPill from '../ui/LevelPill'
+import { useTheme } from '../../hooks/useTheme'
 
 /**
  * UA — Sticky Note card (Style Guide §6.1).
  * Pastel yellow/pink, push pin at top, clipped corner, slight rotation.
  */
 
-const COLORS = ['#fef9c3', '#fce7f3'] // yellow, pink
-const PIN_COLORS = ['#fbbf24', '#f472b6']
+const LIGHT_COLORS = ['#fef9c3', '#fce7f3']
+const DARK_COLORS = ['#211d35', '#211d35']
+const LIGHT_PINS = ['#fbbf24', '#f472b6']
+const DARK_PIN = '#a78bfa'
 const ROTATIONS = [-2, 1.5, -1, 2.5]
 
 interface Props {
@@ -17,6 +20,8 @@ interface Props {
 }
 
 export default function TaskCardUA({ task, onSignup }: Props) {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
   const variant = task.id % 2
   const rotation = ROTATIONS[task.id % ROTATIONS.length]
 
@@ -24,13 +29,14 @@ export default function TaskCardUA({ task, onSignup }: Props) {
     <div
       style={{
         width: 125,
-        background: COLORS[variant],
+        background: dark ? DARK_COLORS[variant] : LIGHT_COLORS[variant],
         clipPath: 'polygon(0 0, 100% 0, 100% 88%, 88% 100%, 0 100%)',
         transform: `rotate(${rotation}deg)`,
         position: 'relative',
         padding: '24px 12px 14px',
         fontFamily: "'Courier Prime', monospace",
-        color: '#1a1209',
+        color: dark ? '#ddd6fe' : '#1a1209',
+        transition: 'background 150ms, color 150ms',
       }}
     >
       {/* Push pin */}
@@ -43,40 +49,35 @@ export default function TaskCardUA({ task, onSignup }: Props) {
           width: 10,
           height: 10,
           borderRadius: '50%',
-          background: PIN_COLORS[variant],
+          background: dark ? DARK_PIN : LIGHT_PINS[variant],
           border: '2px solid rgba(0,0,0,0.25)',
         }}
       />
 
-      {/* Faction + points */}
-      <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#6b6a7a', marginBottom: 6 }}>
+      <div style={{ fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em', color: dark ? '#a78bfa' : '#6b6a7a', marginBottom: 6 }}>
         UA · {task.point_value} pts
       </div>
 
-      {/* Title */}
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
         <div style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.3, marginBottom: 6 }}>
           {task.title}
         </div>
       </Link>
 
-      {/* Description */}
       {task.description && (
-        <div style={{ fontSize: 8, color: '#444', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
+        <div style={{ fontSize: 8, color: dark ? '#a8a0c0' : '#444', lineHeight: 1.4, marginBottom: 8, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
           {task.description}
         </div>
       )}
 
-      {/* Sign up */}
       {onSignup && (
         <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
           sign up
         </button>
       )}
 
-      {/* Footer */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px dashed rgba(0,0,0,0.15)', paddingTop: 6, marginTop: 'auto' }}>
-        <LevelPill level={task.level_required} />
+        <LevelPill level={task.level_required} factionColor={dark ? '#a78bfa' : undefined} />
         <span style={{ fontSize: 10, fontWeight: 700 }}>{task.point_value}</span>
       </div>
     </div>

--- a/frontend/src/components/cards/TaskCardUAMasters.tsx
+++ b/frontend/src/components/cards/TaskCardUAMasters.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { TaskOut } from '../../api/tasks'
 import LevelPill from '../ui/LevelPill'
+import { useTheme } from '../../hooks/useTheme'
 
 /**
  * UA Masters — Newspaper / Gazette (Style Guide §6.7).
@@ -13,6 +14,8 @@ interface Props {
 }
 
 export default function TaskCardUAMasters({ task, onSignup }: Props) {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
   const words = (task.description ?? '').split(' ')
   const mid = Math.ceil(words.length / 2)
   const col1 = words.slice(0, mid).join(' ')
@@ -22,55 +25,42 @@ export default function TaskCardUAMasters({ task, onSignup }: Props) {
     <div
       style={{
         width: 148,
-        background: '#f0ead8',
-        border: '1px solid rgba(0,0,0,0.12)',
+        background: dark ? '#1a1710' : '#f0ead8',
+        border: `1px solid ${dark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.12)'}`,
         clipPath: 'polygon(0 0, 98% 0, 100% 2%, 100% 98%, 98% 100%, 2% 100%, 0 98%, 0 2%)',
         padding: '10px 10px 12px',
         fontFamily: "'Special Elite', serif",
-        color: '#1a1209',
+        color: dark ? '#f0e6d0' : '#1a1209',
+        transition: 'background 150ms, color 150ms',
       }}
     >
-      {/* Masthead */}
-      <div style={{ fontSize: 6, textTransform: 'uppercase', letterSpacing: '0.2em', color: '#555', borderBottom: '2px solid #1a1209', paddingBottom: 3, marginBottom: 5 }}>
+      <div style={{ fontSize: 6, textTransform: 'uppercase', letterSpacing: '0.2em', color: dark ? '#5a5030' : '#555', borderBottom: `2px solid ${dark ? '#c49a3a' : '#1a1209'}`, paddingBottom: 3, marginBottom: 5 }}>
         The UA Masters Gazette
       </div>
 
-      {/* Headline */}
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-        <div style={{ fontSize: 13, lineHeight: 1.2, marginBottom: 3 }}>
-          {task.title}
-        </div>
+        <div style={{ fontSize: 13, lineHeight: 1.2, marginBottom: 3 }}>{task.title}</div>
       </Link>
 
-      {/* Dateline */}
-      <div style={{ fontSize: 7, fontStyle: 'italic', color: '#777', marginBottom: 6 }}>
+      <div style={{ fontSize: 7, fontStyle: 'italic', color: dark ? '#5a5030' : '#777', marginBottom: 6 }}>
         UA Masters · {task.point_value} points
       </div>
 
-      {/* Two-column body */}
       {task.description && (
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr', gap: 4, marginBottom: 8 }}>
-          <div style={{ fontSize: 7.5, color: '#333', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
-            {col1}
-          </div>
-          <div style={{ background: 'rgba(0,0,0,0.12)' }} />
-          <div style={{ fontSize: 7.5, color: '#333', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>
-            {col2}
-          </div>
+          <div style={{ fontSize: 7.5, color: dark ? '#7a6a50' : '#333', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>{col1}</div>
+          <div style={{ background: dark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.12)' }} />
+          <div style={{ fontSize: 7.5, color: dark ? '#7a6a50' : '#333', lineHeight: 1.5, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical' }}>{col2}</div>
         </div>
       )}
 
-      {/* Sign up */}
       {onSignup && (
-        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>
-          sign up
-        </button>
+        <button onClick={() => onSignup(task.id)} className="btn-primary" style={{ fontSize: 7, padding: '2px 8px', marginBottom: 6 }}>sign up</button>
       )}
 
-      {/* Footer */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: '1px solid rgba(0,0,0,0.15)', paddingTop: 5 }}>
-        <span style={{ fontSize: 8, color: '#555', fontFamily: "'Courier Prime', monospace" }}>{task.point_value} pts</span>
-        <LevelPill level={task.level_required} />
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: `1px solid ${dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.15)'}`, paddingTop: 5 }}>
+        <span style={{ fontSize: 8, color: dark ? '#c49a3a' : '#555', fontFamily: "'Courier Prime', monospace" }}>{task.point_value} pts</span>
+        <LevelPill level={task.level_required} factionColor={dark ? '#c49a3a' : undefined} />
       </div>
     </div>
   )

--- a/frontend/src/components/layout/WatercolorBackground.tsx
+++ b/frontend/src/components/layout/WatercolorBackground.tsx
@@ -1,60 +1,61 @@
+import { useTheme } from '../../hooks/useTheme'
+
 /**
  * Full-bleed watercolor splash background (Style Guide §7 / §2.3).
  *
  * Renders SVG blurred ellipses in four corners with paint-bleed distortion.
- * Purely presentational — no data props, identical on every page.
+ * Dark mode: same colors, reduced opacity (0.11–0.18 vs 0.22–0.38).
  */
 export default function WatercolorBackground() {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
+
+  // Opacity multiplier: dark mode dims the splashes
+  const opacity = (light: number) => dark ? light * 0.45 : light
+
   return (
     <svg
       aria-hidden="true"
       className="pointer-events-none fixed inset-0 w-full h-full"
-      style={{ zIndex: 0 }}
+      style={{ zIndex: 0, transition: 'opacity 300ms' }}
       preserveAspectRatio="none"
     >
       <defs>
-        {/* Main blob blur */}
         <filter id="wc-blur" x="-50%" y="-50%" width="200%" height="200%">
           <feGaussianBlur stdDeviation="28" />
         </filter>
-        {/* Paint-bleed distortion */}
         <filter id="wc-distort" x="-50%" y="-50%" width="200%" height="200%">
           <feGaussianBlur stdDeviation="26" result="blur" />
           <feTurbulence type="turbulence" baseFrequency="0.015" numOctaves="3" result="turb" />
           <feDisplacementMap in="blur" in2="turb" scale="18" />
         </filter>
-        {/* Small droplet blur */}
         <filter id="wc-droplet" x="-50%" y="-50%" width="200%" height="200%">
           <feGaussianBlur stdDeviation="9" />
         </filter>
       </defs>
 
       {/* ── Top-left: Blue / Indigo / Violet ── */}
-      <ellipse cx="8%" cy="10%" rx="14%" ry="18%" fill="#4f46e5" opacity="0.32" filter="url(#wc-distort)" />
-      <ellipse cx="14%" cy="6%" rx="10%" ry="12%" fill="#7c3aed" opacity="0.28" filter="url(#wc-blur)" />
-      <ellipse cx="4%" cy="18%" rx="6%" ry="8%" fill="#be185d" opacity="0.22" filter="url(#wc-blur)" />
-      {/* droplets */}
-      <circle cx="18%" cy="14%" r="1.5%" fill="#4f46e5" opacity="0.18" filter="url(#wc-droplet)" />
-      <circle cx="6%" cy="24%" r="1%" fill="#7c3aed" opacity="0.15" filter="url(#wc-droplet)" />
+      <ellipse cx="8%" cy="10%" rx="14%" ry="18%" fill="#4f46e5" opacity={opacity(0.32)} filter="url(#wc-distort)" />
+      <ellipse cx="14%" cy="6%" rx="10%" ry="12%" fill="#7c3aed" opacity={opacity(0.28)} filter="url(#wc-blur)" />
+      <ellipse cx="4%" cy="18%" rx="6%" ry="8%" fill="#be185d" opacity={opacity(0.22)} filter="url(#wc-blur)" />
+      <circle cx="18%" cy="14%" r="1.5%" fill="#4f46e5" opacity={opacity(0.18)} filter="url(#wc-droplet)" />
+      <circle cx="6%" cy="24%" r="1%" fill="#7c3aed" opacity={opacity(0.15)} filter="url(#wc-droplet)" />
 
       {/* ── Top-right: Orange / Amber / Lime ── */}
-      <ellipse cx="90%" cy="8%" rx="12%" ry="16%" fill="#b45309" opacity="0.30" filter="url(#wc-distort)" />
-      <ellipse cx="85%" cy="14%" rx="10%" ry="10%" fill="#d97706" opacity="0.28" filter="url(#wc-blur)" />
-      <ellipse cx="95%" cy="4%" rx="8%" ry="10%" fill="#16a34a" opacity="0.24" filter="url(#wc-blur)" />
-      {/* droplets */}
-      <circle cx="82%" cy="6%" r="1.2%" fill="#d97706" opacity="0.16" filter="url(#wc-droplet)" />
+      <ellipse cx="90%" cy="8%" rx="12%" ry="16%" fill="#b45309" opacity={opacity(0.30)} filter="url(#wc-distort)" />
+      <ellipse cx="85%" cy="14%" rx="10%" ry="10%" fill="#d97706" opacity={opacity(0.28)} filter="url(#wc-blur)" />
+      <ellipse cx="95%" cy="4%" rx="8%" ry="10%" fill="#16a34a" opacity={opacity(0.24)} filter="url(#wc-blur)" />
+      <circle cx="82%" cy="6%" r="1.2%" fill="#d97706" opacity={opacity(0.16)} filter="url(#wc-droplet)" />
 
       {/* ── Bottom-left: Rose / Pink / Orange ── */}
-      <ellipse cx="10%" cy="90%" rx="14%" ry="14%" fill="#9f1239" opacity="0.30" filter="url(#wc-distort)" />
-      <ellipse cx="6%" cy="85%" rx="8%" ry="12%" fill="#7c3aed" opacity="0.26" filter="url(#wc-blur)" />
-      {/* droplets */}
-      <circle cx="16%" cy="86%" r="1.3%" fill="#9f1239" opacity="0.16" filter="url(#wc-droplet)" />
+      <ellipse cx="10%" cy="90%" rx="14%" ry="14%" fill="#9f1239" opacity={opacity(0.30)} filter="url(#wc-distort)" />
+      <ellipse cx="6%" cy="85%" rx="8%" ry="12%" fill="#7c3aed" opacity={opacity(0.26)} filter="url(#wc-blur)" />
+      <circle cx="16%" cy="86%" r="1.3%" fill="#9f1239" opacity={opacity(0.16)} filter="url(#wc-droplet)" />
 
       {/* ── Bottom-right: Teal / Cyan / Sky ── */}
-      <ellipse cx="88%" cy="88%" rx="12%" ry="16%" fill="#0f766e" opacity="0.30" filter="url(#wc-distort)" />
-      <ellipse cx="94%" cy="92%" rx="10%" ry="10%" fill="#0e7490" opacity="0.26" filter="url(#wc-blur)" />
-      {/* droplets */}
-      <circle cx="84%" cy="94%" r="1%" fill="#0e7490" opacity="0.14" filter="url(#wc-droplet)" />
+      <ellipse cx="88%" cy="88%" rx="12%" ry="16%" fill="#0f766e" opacity={opacity(0.30)} filter="url(#wc-distort)" />
+      <ellipse cx="94%" cy="92%" rx="10%" ry="10%" fill="#0e7490" opacity={opacity(0.26)} filter="url(#wc-blur)" />
+      <circle cx="84%" cy="94%" r="1%" fill="#0e7490" opacity={opacity(0.14)} filter="url(#wc-droplet)" />
     </svg>
   )
 }

--- a/frontend/src/components/ui/FilterLevelNodes.tsx
+++ b/frontend/src/components/ui/FilterLevelNodes.tsx
@@ -1,6 +1,9 @@
+import { useTheme } from '../../hooks/useTheme'
+
 /**
  * Level filter — Connected Nodes (Style Guide §5.3).
  * Row of circles connected by horizontal bars. Active: dark fill, scale(1.15).
+ * Dark active: inverted to cream on dark-bg.
  */
 
 interface Props {
@@ -10,6 +13,9 @@ interface Props {
 }
 
 export default function FilterLevelNodes({ levels, value, onChange }: Props) {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
+
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 0 }}>
       <span className="eyebrow" style={{ marginRight: 8 }}>level:</span>
@@ -17,26 +23,18 @@ export default function FilterLevelNodes({ levels, value, onChange }: Props) {
         const active = value === level
         return (
           <div key={level} style={{ display: 'flex', alignItems: 'center' }}>
-            {/* Connector bar (not before first node) */}
             {index > 0 && (
-              <div
-                style={{
-                  width: 12,
-                  height: 2,
-                  background: 'rgba(0,0,0,0.2)',
-                }}
-              />
+              <div style={{ width: 12, height: 2, background: dark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.2)' }} />
             )}
-            {/* Node circle */}
             <button
               onClick={() => onChange(value === level ? '' : level)}
               style={{
                 width: 30,
                 height: 30,
                 borderRadius: '50%',
-                border: `2px solid ${active ? '#1a1209' : 'rgba(0,0,0,0.2)'}`,
-                background: active ? '#1a1209' : 'rgba(255,255,255,0.6)',
-                color: active ? '#F7F4EE' : 'var(--color-text-tertiary)',
+                border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
+                background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
+                color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-tertiary)',
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 10,
                 fontWeight: 700,

--- a/frontend/src/components/ui/FilterStamps.tsx
+++ b/frontend/src/components/ui/FilterStamps.tsx
@@ -1,6 +1,9 @@
+import { useTheme } from '../../hooks/useTheme'
+
 /**
  * Status filter — Rubber Stamps (Style Guide §5.3).
  * Rectangular, no border-radius, inner dashed border, bold uppercase.
+ * Dark active: inverted to cream on dark-bg.
  */
 
 interface Props {
@@ -10,6 +13,9 @@ interface Props {
 }
 
 export default function FilterStamps({ options, value, onChange }: Props) {
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
+
   return (
     <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
       <span className="eyebrow">status:</span>
@@ -21,10 +27,10 @@ export default function FilterStamps({ options, value, onChange }: Props) {
             onClick={() => onChange(option)}
             style={{
               position: 'relative',
-              border: `2px solid ${active ? '#1a1209' : 'rgba(0,0,0,0.2)'}`,
+              border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
               borderRadius: 0,
-              background: active ? '#1a1209' : 'rgba(255,255,255,0.6)',
-              color: active ? '#F7F4EE' : 'var(--color-text-primary)',
+              background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
+              color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-primary)',
               fontFamily: "'Courier Prime', monospace",
               fontSize: 10,
               fontWeight: 700,
@@ -35,12 +41,11 @@ export default function FilterStamps({ options, value, onChange }: Props) {
               transition: 'all 120ms',
             }}
           >
-            {/* Inner dashed border */}
             <span
               style={{
                 position: 'absolute',
                 inset: 2,
-                border: `1px dashed ${active ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)'}`,
+                border: `1px dashed ${active ? (dark ? 'rgba(0,0,0,0.15)' : 'rgba(255,255,255,0.2)') : (dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.15)')}`,
                 pointerEvents: 'none',
               }}
             />

--- a/frontend/src/components/ui/LevelPill.tsx
+++ b/frontend/src/components/ui/LevelPill.tsx
@@ -1,10 +1,13 @@
-/** Dark pill showing level requirement, shared by all faction cards (Style Guide §6). */
-export default function LevelPill({ level }: { level: number }) {
+/**
+ * Dark pill showing level requirement, shared by all faction cards (Style Guide §6).
+ * In dark mode, accepts factionColor to use as background instead of default dark ink.
+ */
+export default function LevelPill({ level, factionColor }: { level: number; factionColor?: string }) {
   return (
     <span
       style={{
-        background: '#1a1209',
-        color: 'white',
+        background: factionColor ?? '#1a1209',
+        color: factionColor ? 'var(--color-bg-page)' : 'white',
         fontSize: 7,
         padding: '1px 6px',
         borderRadius: 6,

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'wz-theme'
+
+function getInitialTheme(): Theme {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark') return stored
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute('data-theme', theme)
+}
+
+/**
+ * Theme hook (Style Guide §8).
+ * Persists to localStorage key 'wz-theme', defaults to system preference.
+ */
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme)
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  const toggle = useCallback(() => {
+    setTheme((previous) => {
+      const next = previous === 'light' ? 'dark' : 'light'
+      localStorage.setItem(STORAGE_KEY, next)
+      return next
+    })
+  }, [])
+
+  return { theme, toggle } as const
+}


### PR DESCRIPTION
## Summary
- useTheme hook with localStorage persistence + system preference fallback
- Nav toggle button (light/dark text) + dark frosted glass background
- WatercolorBackground dims to 45% opacity in dark mode
- 6 faction cards with designed dark variants (UA purple, Analog aged, Gestalt terminal green, SNIDE gold, Journeymen leather, UA Masters aged newsprint)
- Filter stamps + level nodes invert to cream-on-dark active states
- LevelPill accepts factionColor prop for dark mode faction-colored pills
- Updated WORLD_ZERO_STYLE.md with expanded sections §12-18

## Test plan
- [ ] Click dark mode toggle in nav — background switches to deep dark (#13121a)
- [ ] Nav becomes dark frosted glass (rgba(19,18,26,0.92))
- [ ] Watercolor splashes visibly dimmer
- [ ] Toggle back to light — everything returns to warm paper
- [ ] Refresh page — theme persists via localStorage
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)