### PR TITLE
Fix 13 bugs: admin, tasks, media, and UI

### DIFF
--- a/backend/alembic/versions/f6a7b8c9d0e1_submission_soft_delete.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_submission_soft_delete.py
@@ -1,0 +1,27 @@
+"""add is_deleted to submission for soft-delete
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-12 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "submission",
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("submission", "is_deleted")

--- a/backend/models/submission.py
+++ b/backend/models/submission.py
@@ -22,6 +22,7 @@ class Submission(Base):
     character_id: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
     title: Mapped[str] = mapped_column(String, nullable=False)
     body_text: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, server_default="false")
     is_flagged: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # flagged_at is nullable: NULL means "not yet flagged" — semantic NULL, not missing data
     flagged_at: Mapped[Optional[datetime]] = mapped_column(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ python-jose[cryptography]
 authlib
 itsdangerous
 python-multipart
+Pillow
 httpx
 pytest
 pytest-asyncio

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,5 +1,7 @@
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, Header, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,6 +10,7 @@ from db import get_db
 from dependencies import require_admin
 from models.account import Account
 from models.character import Character, CharacterStatus
+from models.contact import ContactMessage
 from models.roles import AccountRole, Role
 from models.submission import Submission
 from models.task import Task, TaskStatus
@@ -48,6 +51,16 @@ class BanAction(BaseModel):
     banned: bool
 
 
+class ContactMessageOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    email: str
+    message: str
+    created_at: datetime
+
+
 # ---------------------------------------------------------------------------
 # Read / Inspect
 # ---------------------------------------------------------------------------
@@ -59,6 +72,17 @@ async def admin_overview(
     session: AsyncSession = Depends(get_db),
 ) -> OverviewStats:
     return await game_overview(session)
+
+
+@router.get("/messages", response_model=list[ContactMessageOut])
+async def admin_list_messages(
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> list[ContactMessageOut]:
+    result = await session.execute(
+        select(ContactMessage).order_by(ContactMessage.created_at.desc())
+    )
+    return [ContactMessageOut.model_validate(m) for m in result.scalars().all()]
 
 
 @router.get("/accounts", response_model=list[AccountSummary])
@@ -268,17 +292,24 @@ async def admin_cli_token(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/tasks/pending", response_model=list[TaskOut])
+class PendingTaskOut(TaskOut):
+    created_by_name: str = ""
+
+
+@router.get("/tasks/pending", response_model=list[PendingTaskOut])
 async def list_pending_tasks(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ):
     result = await session.execute(
-        select(Task).where(Task.status == TaskStatus.pending).order_by(Task.created_at)
+        select(Task, Character.display_name)
+        .outerjoin(Character, Character.id == Task.created_by)
+        .where(Task.status == TaskStatus.pending)
+        .order_by(Task.created_at)
     )
-    tasks = result.scalars().all()
+    rows = result.all()
     return [
-        TaskOut(
+        PendingTaskOut(
             id=task.id,
             title=task.title,
             description=task.description,
@@ -289,8 +320,9 @@ async def list_pending_tasks(
             primary_faction_slug=task.primary_faction_slug,
             is_task_vision_eligible=task.is_task_vision_eligible,
             created_at=task.created_at,
+            created_by_name=display_name or "",
         )
-        for task in tasks
+        for task, display_name in rows
     ]
 
 
@@ -359,7 +391,7 @@ async def delete_submission(
     sub = await session.get(Submission, submission_id)
     if sub is None:
         raise HTTPException(status_code=404, detail="Submission not found.")
-    await session.delete(sub)
+    sub.is_deleted = True
     await session.commit()
 
 

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -1,7 +1,10 @@
+import io
 import logging
 import os
 import re
 from typing import Optional
+
+from PIL import Image
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
@@ -230,21 +233,29 @@ async def upload_avatar(
 
     rel_dir = os.path.join(str(character_id), "avatar")
     abs_dir = os.path.join(settings.MEDIA_ROOT, rel_dir)
-    raw_name = os.path.basename(file.filename or "avatar")
-    filename = re.sub(r"[^\w.\-]", "_", raw_name)[:100] or "avatar"
+    filename = "avatar.jpg"
     abs_path = os.path.join(abs_dir, filename)
     rel_path = os.path.join(rel_dir, filename)
+
+    AVATAR_MAX_SIZE = 512
+    AVATAR_JPEG_QUALITY = 85
 
     try:
         os.makedirs(abs_dir, exist_ok=True)
         contents = await file.read()
         if len(contents) > 10 * 1024 * 1024:
             raise HTTPException(status_code=413, detail="Avatar too large (max 10 MB).")
+
+        img = Image.open(io.BytesIO(contents))
+        img = img.convert("RGB")
+        img.thumbnail((AVATAR_MAX_SIZE, AVATAR_MAX_SIZE), Image.LANCZOS)
+        buffer = io.BytesIO()
+        img.save(buffer, format="JPEG", quality=AVATAR_JPEG_QUALITY, optimize=True)
         with open(abs_path, "wb") as f:
-            f.write(contents)
+            f.write(buffer.getvalue())
     except HTTPException:
         raise
-    except OSError:
+    except Exception:
         logger.exception("Failed to save avatar for character %s", character_id)
         raise HTTPException(
             status_code=500,

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -68,7 +68,7 @@ async def list_submissions(
     offset: int = 0,
     session: AsyncSession = Depends(get_db),
 ):
-    query = select(Submission)
+    query = select(Submission).where(Submission.is_deleted == False)
     if task_id:
         query = query.where(Submission.task_id == task_id)
     if character_id:
@@ -83,7 +83,7 @@ async def list_submissions(
 @router.get("/{submission_id}", response_model=SubmissionOut)
 async def get_submission(submission_id: int, session: AsyncSession = Depends(get_db)):
     sub = await session.get(Submission, submission_id)
-    if sub is None:
+    if sub is None or sub.is_deleted:
         raise HTTPException(status_code=404, detail="Submission not found.")
     return await _build_submission_out(sub, session)
 
@@ -153,8 +153,8 @@ async def upload_media(
     try:
         os.makedirs(abs_dir, exist_ok=True)
         contents = await file.read()
-        if len(contents) > 50 * 1024 * 1024:
-            raise HTTPException(status_code=413, detail="File too large (max 50 MB).")
+        if len(contents) > 100 * 1024 * 1024:
+            raise HTTPException(status_code=413, detail="File too large (max 100 MB).")
         with open(abs_path, "wb") as f:
             f.write(contents)
     except HTTPException:

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -63,7 +63,7 @@ async def list_tasks(
     else:
         query = query.where(Task.status == TaskStatus.active)
     if level is not None:
-        query = query.where(Task.level_required <= level)
+        query = query.where(Task.level_required >= level)
     if faction:
         query = query.where(Task.primary_faction_slug == faction)
     if min_points is not None:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import CreateCharacter from './pages/CreateCharacter'
 import EditCharacter from './pages/EditCharacter'
 import About from './pages/About'
 import Contact from './pages/Contact'
+import ProposeTask from './pages/ProposeTask'
 import Disclaimer from './pages/Disclaimer'
 import Attributions from './pages/Attributions'
 import Donate from './pages/Donate'
@@ -83,6 +84,14 @@ export default function App() {
         />
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />
+        <Route
+          path="/propose-task"
+          element={
+            <ProtectedRoute>
+              <ProposeTask />
+            </ProtectedRoute>
+          }
+        />
         <Route path="/disclaimer" element={<Disclaimer />} />
         <Route path="/attributions" element={<Attributions />} />
         <Route path="/donate" element={<Donate />} />

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -2,8 +2,25 @@ import api from './axios'
 import type { TaskOut } from './tasks'
 import type { SubmissionOut } from './submissions'
 
-export async function getPendingTasks(): Promise<TaskOut[]> {
-  const { data } = await api.get<TaskOut[]>('/admin/tasks/pending')
+export interface PendingTaskOut extends TaskOut {
+  created_by_name: string
+}
+
+export interface ContactMessageOut {
+  id: number
+  name: string
+  email: string
+  message: string
+  created_at: string
+}
+
+export async function getPendingTasks(): Promise<PendingTaskOut[]> {
+  const { data } = await api.get<PendingTaskOut[]>('/admin/tasks/pending')
+  return data
+}
+
+export async function getMessages(): Promise<ContactMessageOut[]> {
+  const { data } = await api.get<ContactMessageOut[]>('/admin/messages')
   return data
 }
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -107,7 +107,7 @@ export default function Sidebar() {
 
       {/* ── Propose a Task Button ── */}
       <Link
-        to="/contact"
+        to="/propose-task"
         className="btn-primary text-center w-full block"
       >
         Propose a Task

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react'
-import { getPendingTasks, approveTask, retireTask, getFlaggedSubmissions, deleteSubmission } from '../api/admin'
+import { getPendingTasks, approveTask, retireTask, getFlaggedSubmissions, deleteSubmission, getMessages } from '../api/admin'
+import type { PendingTaskOut, ContactMessageOut } from '../api/admin'
 import { getFactions, updateFaction } from '../api/factions'
 import type { FactionOut } from '../api/factions'
-import type { TaskOut } from '../api/tasks'
 import type { SubmissionOut } from '../api/submissions'
+import { formatTimestamp } from '../utils/dates'
 import { extractError } from '../utils/errors'
 
 export default function Admin() {
-  const [pending, setPending] = useState<TaskOut[]>([])
+  const [pending, setPending] = useState<PendingTaskOut[]>([])
   const [flagged, setFlagged] = useState<SubmissionOut[]>([])
   const [factions, setFactions] = useState<FactionOut[]>([])
+  const [messages, setMessages] = useState<ContactMessageOut[]>([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
@@ -22,8 +24,8 @@ export default function Admin() {
 
   const refresh = () => {
     setFetchError(null)
-    Promise.all([getPendingTasks(), getFlaggedSubmissions(), getFactions()])
-      .then(([p, f, fa]) => { setPending(p); setFlagged(f); setFactions(fa) })
+    Promise.all([getPendingTasks(), getFlaggedSubmissions(), getFactions(), getMessages()])
+      .then(([p, f, fa, m]) => { setPending(p); setFlagged(f); setFactions(fa); setMessages(m) })
       .catch((err) => setFetchError(extractError(err, "Couldn't load admin data.")))
       .finally(() => setLoading(false))
   }
@@ -127,6 +129,7 @@ export default function Admin() {
                   <p className="font-display text-lg font-bold">{t.title}</p>
                   <p className="font-body text-xs text-muted">
                     {t.point_value} pts · lvl {t.level_required}+ · {t.primary_faction_slug ?? 'unaffiliated'}
+                    {t.created_by_name && ` · by ${t.created_by_name}`}
                   </p>
                 </div>
                 <button onClick={() => void handleApprove(t.id)} className="btn-primary text-xs">approve</button>
@@ -196,7 +199,7 @@ export default function Admin() {
       </section>
 
       {/* Flagged submissions */}
-      <section>
+      <section className="mb-10">
         <h2 className="font-display text-2xl font-bold mb-3 border-b-2 border-border pb-1">
           Flagged Submissions <span className="text-muted text-lg">({flagged.length})</span>
         </h2>
@@ -208,7 +211,7 @@ export default function Admin() {
               <div key={s.id} className="card px-4 py-3 flex items-center gap-4">
                 <div className="flex-1">
                   <p className="font-display text-lg font-bold">{s.title}</p>
-                  <p className="font-body text-xs text-muted">by #{s.character_id}</p>
+                  <p className="font-body text-xs text-muted">by {s.character_display_name || `#${s.character_id}`}</p>
                 </div>
                 {deleteTarget === s.id ? (
                   <div className="flex items-center gap-2 font-body text-xs">
@@ -221,6 +224,30 @@ export default function Admin() {
                     delete
                   </button>
                 )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Contact Messages */}
+      <section>
+        <h2 className="font-display text-2xl font-bold mb-3 border-b-2 border-border pb-1">
+          Messages <span className="text-muted text-lg">({messages.length})</span>
+        </h2>
+        {messages.length === 0 ? (
+          <p className="font-body text-sm text-muted">No messages.</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {messages.map((m) => (
+              <div key={m.id} className="card px-4 py-3">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <p className="font-display text-lg font-bold">{m.name}</p>
+                    <p className="font-body text-xs text-muted">{m.email} · {formatTimestamp(m.created_at)}</p>
+                  </div>
+                </div>
+                <p className="font-body text-sm text-ink mt-2 whitespace-pre-wrap">{m.message}</p>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { proposeTask } from '../api/tasks'
+import { getFactions, type FactionOut } from '../api/factions'
+import { useAuth } from '../auth/AuthContext'
+import { extractError } from '../utils/errors'
+
+const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5]
+
+export default function ProposeTask() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const [factions, setFactions] = useState<FactionOut[]>([])
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [pointValue, setPointValue] = useState(10)
+  const [levelRequired, setLevelRequired] = useState(0)
+  const [factionSlug, setFactionSlug] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    getFactions().then(setFactions).catch(() => {})
+  }, [])
+
+  const characterLevel = user?.character?.level ?? 0
+
+  if (!user) {
+    return (
+      <div className="py-8 max-w-2xl">
+        <h1 className="page-heading">Propose a Task</h1>
+        <p className="font-body text-muted">You need to be logged in to propose a task.</p>
+      </div>
+    )
+  }
+
+  if (characterLevel < 3) {
+    return (
+      <div className="py-8 max-w-2xl">
+        <h1 className="page-heading">Propose a Task</h1>
+        <p className="font-body text-muted">
+          You must be level 3 or higher to propose tasks. You are currently level {characterLevel}.
+        </p>
+      </div>
+    )
+  }
+
+  if (success) {
+    return (
+      <div className="py-8 max-w-2xl">
+        <h1 className="page-heading">Propose a Task</h1>
+        <div className="card p-6 text-center">
+          <p className="font-display text-2xl font-bold mb-2">Task proposed!</p>
+          <p className="font-body text-muted">An admin will review it soon.</p>
+        </div>
+      </div>
+    )
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      await proposeTask({
+        title,
+        description: description || undefined,
+        point_value: pointValue,
+        level_required: levelRequired,
+        primary_faction_slug: factionSlug || undefined,
+      })
+      setSuccess(true)
+    } catch (err) {
+      setError(extractError(err, 'Could not propose task.'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const inputClass = 'w-full border-2 border-border bg-card font-body text-sm px-3 py-2 focus:outline-none focus:shadow-sketch-sm disabled:opacity-50'
+
+  return (
+    <div className="py-8 max-w-2xl">
+      <h1 className="page-heading">Propose a Task</h1>
+      <p className="font-body text-muted mb-6">
+        Suggest a new task for the community. An admin will review and approve it.
+      </p>
+
+      <form onSubmit={handleSubmit} className="card p-6 space-y-4">
+        <div>
+          <label className="font-body text-sm block mb-1" htmlFor="title">Title</label>
+          <input
+            id="title"
+            type="text"
+            required
+            maxLength={200}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            disabled={submitting}
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className="font-body text-sm block mb-1" htmlFor="description">Description</label>
+          <textarea
+            id="description"
+            rows={4}
+            maxLength={5000}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={submitting}
+            className={`${inputClass} resize-y`}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="font-body text-sm block mb-1" htmlFor="pointValue">Suggested Points</label>
+            <input
+              id="pointValue"
+              type="number"
+              min={1}
+              max={1000}
+              required
+              value={pointValue}
+              onChange={(e) => setPointValue(Number(e.target.value))}
+              disabled={submitting}
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className="font-body text-sm block mb-1" htmlFor="levelRequired">Level Required</label>
+            <select
+              id="levelRequired"
+              value={levelRequired}
+              onChange={(e) => setLevelRequired(Number(e.target.value))}
+              disabled={submitting}
+              className={inputClass}
+            >
+              {LEVEL_OPTIONS.map((l) => (
+                <option key={l} value={l}>Level {l}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label className="font-body text-sm block mb-1" htmlFor="faction">Faction (optional)</label>
+          <select
+            id="faction"
+            value={factionSlug}
+            onChange={(e) => setFactionSlug(e.target.value)}
+            disabled={submitting}
+            className={inputClass}
+          >
+            <option value="">Any faction</option>
+            {factions.map((f) => (
+              <option key={f.slug} value={f.slug}>{f.name}</option>
+            ))}
+          </select>
+        </div>
+
+        {error && (
+          <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">{error}</p>
+        )}
+
+        <button type="submit" disabled={submitting} className="btn-primary disabled:opacity-50">
+          {submitting ? 'Submitting…' : 'Propose Task'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/SubmissionDetail.tsx
+++ b/frontend/src/pages/SubmissionDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
 import { getSubmission, flagSubmission, type SubmissionOut } from '../api/submissions'
 import { getVotes, type VoteSummary } from '../api/votes'
 import MediaGallery from '../components/MediaGallery'
@@ -81,9 +82,9 @@ export default function SubmissionDetail() {
         </div>
 
         {submission.body_text && (
-          <p className="font-body text-base text-ink mt-4 leading-relaxed whitespace-pre-wrap">
-            {submission.body_text}
-          </p>
+          <div className="font-body text-base text-ink mt-4 leading-relaxed prose prose-sm max-w-none">
+            <ReactMarkdown>{submission.body_text}</ReactMarkdown>
+          </div>
         )}
 
         {submission.media.length > 0 && (

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import { useParams, Link, useNavigate } from 'react-router-dom'
-import { getTask, getMyTasks, signupTask, type TaskOut } from '../api/tasks'
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom'
+import { getTask, getMyTasks, signupTask, dropTask, type TaskOut } from '../api/tasks'
 import { listSubmissions, type SubmissionOut } from '../api/submissions'
 import SubmissionCard from '../components/SubmissionCard'
 import { useAuth } from '../auth/AuthContext'
@@ -9,6 +9,7 @@ import { extractError } from '../utils/errors'
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const location = useLocation()
   const { user } = useAuth()
   const [task, setTask] = useState<TaskOut | null>(null)
   const [submissions, setSubmissions] = useState<SubmissionOut[]>([])
@@ -19,6 +20,8 @@ export default function TaskDetail() {
 
   useEffect(() => {
     if (!id) return
+    setLoading(true)
+    setIsInProgress(false)
     const taskId = parseInt(id, 10)
     const fetches: Promise<unknown>[] = [getTask(taskId), listSubmissions({ task_id: taskId })]
     if (user) fetches.push(getMyTasks('in_progress'))
@@ -32,7 +35,7 @@ export default function TaskDetail() {
       })
       .catch((err) => setFetchError(extractError(err, "Couldn't load this task.")))
       .finally(() => setLoading(false))
-  }, [id, user])
+  }, [id, location.key])
 
   const mySubmission = user?.character
     ? submissions.find((s) => s.character_id === user.character!.id)
@@ -46,6 +49,17 @@ export default function TaskDetail() {
       navigate(`/tasks/${task.id}/submit`)
     } catch (err) {
       setSignupError(extractError(err, 'Could not sign up for this task.'))
+    }
+  }
+
+  const handleDrop = async () => {
+    if (!task || !window.confirm('Drop this task? You can sign up again later.')) return
+    setSignupError(null)
+    try {
+      await dropTask(task.id)
+      setIsInProgress(false)
+    } catch (err) {
+      setSignupError(extractError(err, 'Could not drop this task.'))
     }
   }
 
@@ -78,11 +92,16 @@ export default function TaskDetail() {
             </Link>
           )}
           {user && !mySubmission && isInProgress && (
-            <Link to={`/tasks/${task.id}/submit`} className="btn-primary shrink-0">
-              in progress → submit
-            </Link>
+            <div className="flex gap-2 shrink-0">
+              <Link to={`/tasks/${task.id}/submit`} className="btn-primary">
+                in progress → submit
+              </Link>
+              <button onClick={handleDrop} className="font-body text-xs text-muted hover:underline">
+                drop
+              </button>
+            </div>
           )}
-          {user && !mySubmission && !isInProgress && (
+          {user && !mySubmission && !isInProgress && (user.character?.level ?? 0) >= task.level_required && (
             <button onClick={handleSignup} className="btn-primary shrink-0">sign up</button>
           )}
         </div>

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { listTasks, signupTask, type TaskOut } from '../api/tasks'
 import { getFactions, type FactionOut } from '../api/factions'
 import TaskCard from '../components/TaskCard'
@@ -13,6 +14,7 @@ const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
 
 export default function Tasks() {
   const { user } = useAuth()
+  const navigate = useNavigate()
   const characterLevel = user?.character?.level ?? 0
   const characterId = user?.character?.id
 
@@ -48,8 +50,7 @@ export default function Tasks() {
     setSignupMsg(null)
     try {
       await signupTask(id)
-      setSignupMsg({ id, msg: "You're signed up!", ok: true })
-      setTasks((prev) => prev.filter((t) => t.id !== id))
+      navigate(`/tasks/${id}/submit`)
     } catch (err) {
       setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
     }
@@ -90,7 +91,7 @@ export default function Tasks() {
         /* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
           {tasks.map((t) => (
-            <TaskCard key={t.id} task={t} onSignup={handleSignup} />
+            <TaskCard key={t.id} task={t} onSignup={user && characterLevel >= t.level_required ? handleSignup : undefined} />
           ))}
         </div>
       )}

--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,10 @@ services:
     dockerfilePath: ./backend/Dockerfile
     branch: main
     autoDeploy: true
+    disk:
+      name: media-storage
+      mountPath: /app/media
+      sizeGB: 1
     envVars:
       - key: DATABASE_URL
         fromDatabase:
@@ -18,6 +22,8 @@ services:
         sync: false
       - key: GOOGLE_REDIRECT_URI
         value: https://api.worldzero.org/auth/google/callback
+      - key: MEDIA_ROOT
+        value: /app/media
       - key: MEDIA_BASE_URL
         value: https://api.worldzero.org/media
       - key: FRONTEND_URL


### PR DESCRIPTION
## Summary
- **Admin**: Add messages section, show character names instead of IDs, soft-delete submissions (fixes FK violation)
- **Tasks**: Fix level filter direction, hide sign-up for ineligible tasks, redirect to submit after sign-up, add drop task button, create Propose a Task page
- **Media**: Compress avatars with Pillow (512x512 JPEG), increase upload limit to 100MB, add Render Disk for persistent storage
- **UI**: Render markdown in submission proof, fix stale state on task detail navigation

## Test plan
- [ ] Verify level filter shows tasks at or above selected level
- [ ] Confirm sign-up button hidden for tasks above player level
- [ ] Test sign-up redirects to submit praxis page
- [ ] Test drop task button with confirmation dialog
- [ ] Verify Propose a Task page at /propose-task with form
- [ ] Check admin Messages section shows contact form submissions
- [ ] Confirm admin shows character names, not numeric IDs
- [ ] Test admin delete submission (should soft-delete, no FK error)
- [ ] Verify markdown renders in submission detail view
- [ ] Test avatar upload compresses to JPEG
- [ ] Run `alembic upgrade head` for is_deleted migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)