### PR TITLE
Style guide Phase 5: sidebar data wiring

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,9 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../auth/AuthContext'
+import { getMyTasks, type CharacterTaskOut } from '../../api/tasks'
+import { listSubmissions, type SubmissionOut } from '../../api/submissions'
+import { relativeTime } from '../../utils/dates'
 
 /** Faction display names keyed by slug */
 const FACTION_NAMES: Record<string, string> = {
@@ -9,10 +13,10 @@ const FACTION_NAMES: Record<string, string> = {
   snide: 'S.N.I.D.E.',
   journeymen: 'Journeymen',
   singularity: 'Singularity',
-  'ua-masters': 'UA Masters',
+  ua_masters: 'UA Masters',
 }
 
-/** Faction color for the avatar orb gradient */
+/** Faction color for the avatar orb gradient and accents */
 const FACTION_COLORS: Record<string, string> = {
   ua: '#6b6a7a',
   analog: '#15803d',
@@ -20,18 +24,30 @@ const FACTION_COLORS: Record<string, string> = {
   snide: '#8a6a20',
   journeymen: '#c49a3a',
   singularity: '#7c3aed',
-  'ua-masters': '#555555',
+  ua_masters: '#555555',
 }
+
+const MAX_TASK_SLOTS = 20
 
 /**
  * Always-on right sidebar (Style Guide §4.2).
- *
- * Phase 1: Character card + placeholder active tasks + propose-a-task button.
- * Phase 2 will wire up active tasks data and recent activity panel.
+ * Character card + active tasks (live data) + recent activity (live data) + propose-a-task button.
  */
 export default function Sidebar() {
   const { user } = useAuth()
   const character = user?.character
+
+  const [activeTasks, setActiveTasks] = useState<CharacterTaskOut[]>([])
+  const [recentActivity, setRecentActivity] = useState<SubmissionOut[]>([])
+
+  useEffect(() => {
+    if (!user) return
+    getMyTasks('active').then(setActiveTasks).catch(() => {})
+    listSubmissions().then((submissions) => setRecentActivity(submissions.slice(0, 3))).catch(() => {})
+  }, [user])
+
+  const slotCount = activeTasks.length
+  const slotPercent = Math.min((slotCount / MAX_TASK_SLOTS) * 100, 100)
 
   return (
     <aside className="flex flex-col gap-3" style={{ width: 256 }}>
@@ -39,7 +55,6 @@ export default function Sidebar() {
       {character ? (
         <div className="sidebar-card">
           <div className="flex items-center gap-3 mb-3">
-            {/* Avatar orb */}
             <div
               className="shrink-0 rounded-full"
               style={{
@@ -69,7 +84,6 @@ export default function Sidebar() {
             </div>
           </div>
 
-          {/* 3-column stat grid */}
           <div className="grid grid-cols-3 gap-1">
             {[
               { label: 'Score', value: character.score },
@@ -97,12 +111,113 @@ export default function Sidebar() {
         </div>
       )}
 
-      {/* ── Active Tasks Panel (placeholder) ── */}
+      {/* ── Active Tasks Panel ── */}
       <div className="sidebar-card">
         <p className="eyebrow mb-2">Your active tasks</p>
-        <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-          No active tasks
-        </p>
+
+        {activeTasks.length === 0 ? (
+          <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+            No active tasks
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {activeTasks.map((characterTask) => {
+              const factionColor = FACTION_COLORS[characterTask.task.primary_faction_slug ?? ''] ?? '#6b6a7a'
+              const factionName = FACTION_NAMES[characterTask.task.primary_faction_slug ?? ''] ?? 'UA'
+              return (
+                <div
+                  key={characterTask.id}
+                  style={{
+                    borderLeft: `3px solid ${factionColor}`,
+                    paddingLeft: 8,
+                  }}
+                >
+                  <Link
+                    to={`/tasks/${characterTask.task.id}`}
+                    className="font-body"
+                    style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', display: 'block', lineHeight: 1.3 }}
+                  >
+                    {characterTask.task.title}
+                  </Link>
+                  <span className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
+                    {factionName} · lvl {characterTask.task.level_required} · {relativeTime(characterTask.signed_up_at)}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Progress bar */}
+        <div style={{ marginTop: 8 }}>
+          <div
+            style={{
+              height: 4,
+              borderRadius: 2,
+              background: 'var(--color-bg-surface-alt)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${slotPercent}%`,
+                background: '#4f46e5',
+                borderRadius: 2,
+                transition: 'width 300ms',
+              }}
+            />
+          </div>
+          <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)', marginTop: 3 }}>
+            {slotCount} / {MAX_TASK_SLOTS} slots
+          </p>
+        </div>
+      </div>
+
+      {/* ── Recent Activity Panel ── */}
+      <div className="sidebar-card">
+        <p className="eyebrow mb-2">Recent activity</p>
+
+        {recentActivity.length === 0 ? (
+          <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+            No activity yet
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {recentActivity.map((submission, index) => (
+              <div
+                key={submission.id}
+                style={{
+                  padding: '5px 0',
+                  borderTop: index > 0 ? '1px dashed var(--color-border)' : undefined,
+                }}
+              >
+                <div className="font-body" style={{ fontSize: 9, lineHeight: 1.4 }}>
+                  <Link
+                    to={`/characters/${submission.character_id}`}
+                    style={{
+                      fontWeight: 700,
+                      color: 'var(--color-text-primary)',
+                      textDecoration: 'none',
+                    }}
+                  >
+                    {submission.character_display_name}
+                  </Link>
+                  {' completed '}
+                  <Link
+                    to={`/submissions/${submission.id}`}
+                    style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}
+                  >
+                    {submission.task_title}
+                  </Link>
+                </div>
+                <span className="font-body" style={{ fontSize: 7, color: 'var(--color-text-tertiary)' }}>
+                  {relativeTime(submission.created_at)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* ── Propose a Task Button ── */}

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -4,3 +4,17 @@ export function formatTimestamp(iso: string): string {
     timeStyle: 'short',
   })
 }
+
+/** Returns a human-friendly relative time string (e.g. "2h ago", "3d ago"). */
+export function relativeTime(iso: string): string {
+  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}


### PR DESCRIPTION
## Summary
- Active tasks panel fetches signed-up tasks, shows faction-color borders, task names, meta, indigo progress bar (X/20 slots)
- Recent activity panel shows 3 most recent submissions with player names, task titles, relative timestamps
- Added relativeTime() utility to dates.ts

## Test plan
- [ ] Log in and verify active tasks panel shows your signed-up tasks
- [ ] Verify faction-color left borders on each task item
- [ ] Verify progress bar fills proportionally to task count
- [ ] Verify recent activity panel shows 3 latest submissions
- [ ] Verify relative timestamps (just now, 2h ago, 3d ago)
- [ ] Verify empty states when no tasks/activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)