### PR TITLE
Bug bash: sidebar refresh, avatars, admin messages, unsubmit, friends

### DIFF
--- a/backend/alembic/versions/h8i9j0k1l2m3_submission_withdraw.py
+++ b/backend/alembic/versions/h8i9j0k1l2m3_submission_withdraw.py
@@ -1,0 +1,27 @@
+"""add is_withdrawn to submission for unsubmit/resubmit
+
+Revision ID: h8i9j0k1l2m3
+Revises: g7h8i9j0k1l2
+Create Date: 2026-04-13 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "h8i9j0k1l2m3"
+down_revision: Union[str, None] = "g7h8i9j0k1l2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "submission",
+        sa.Column("is_withdrawn", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("submission", "is_withdrawn")

--- a/backend/models/submission.py
+++ b/backend/models/submission.py
@@ -29,6 +29,7 @@ class Submission(Base):
     title: Mapped[str] = mapped_column(String, nullable=False)
     body_text: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, server_default="false")
+    is_withdrawn: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, server_default="false")
     is_flagged: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # flagged_at is nullable: NULL means "not yet flagged" — semantic NULL, not missing data
     flagged_at: Mapped[Optional[datetime]] = mapped_column(

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -85,6 +85,19 @@ async def admin_list_messages(
     return [ContactMessageOut.model_validate(m) for m in result.scalars().all()]
 
 
+@router.delete("/messages/{message_id}", status_code=204)
+async def admin_delete_message(
+    message_id: int,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> None:
+    message = await session.get(ContactMessage, message_id)
+    if message is None:
+        raise HTTPException(status_code=404, detail="Message not found.")
+    await session.delete(message)
+    await session.commit()
+
+
 @router.get("/accounts", response_model=list[AccountSummary])
 async def admin_list_accounts(
     email: str | None = None,

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -21,6 +21,8 @@ from services.submission import (
     create_submission,
     edit_submission,
     flag_submission,
+    resubmit_submission,
+    withdraw_submission,
 )
 
 router = APIRouter()
@@ -57,6 +59,7 @@ async def _build_submission_out(sub: Submission, session: AsyncSession) -> Submi
         title=sub.title,
         body_text=sub.body_text,
         is_flagged=sub.is_flagged,
+        is_withdrawn=sub.is_withdrawn,
         collaboration_mode=sub.collaboration_mode.value,
         partner_character_id=sub.partner_character_id,
         partner_display_name=partner_display_name,
@@ -122,6 +125,32 @@ async def edit_submission_route(
     if sub.character_id != character.id:
         raise HTTPException(status_code=403, detail="Cannot edit another character's submission.")
     sub = await edit_submission(sub, data, session)
+    return await _build_submission_out(sub, session)
+
+
+@router.post("/{submission_id}/withdraw", response_model=SubmissionOut)
+async def withdraw_submission_route(
+    submission_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    sub = await session.get(Submission, submission_id)
+    if sub is None or sub.is_deleted:
+        raise HTTPException(status_code=404, detail="Submission not found.")
+    sub = await withdraw_submission(sub, character, session)
+    return await _build_submission_out(sub, session)
+
+
+@router.post("/{submission_id}/resubmit", response_model=SubmissionOut)
+async def resubmit_submission_route(
+    submission_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    sub = await session.get(Submission, submission_id)
+    if sub is None or sub.is_deleted:
+        raise HTTPException(status_code=404, detail="Submission not found.")
+    sub = await resubmit_submission(sub, character, session)
     return await _build_submission_out(sub, session)
 
 

--- a/backend/schemas/submission.py
+++ b/backend/schemas/submission.py
@@ -25,6 +25,7 @@ class SubmissionOut(BaseModel):
     title: str
     body_text: Optional[str]
     is_flagged: bool
+    is_withdrawn: bool = False
     collaboration_mode: str = "solo"
     partner_character_id: Optional[int] = None
     partner_display_name: Optional[str] = None

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -29,7 +29,11 @@ async def recalculate_character_stats(
     character_faction_slug = author.faction_slug if author else "na"
 
     submissions_result = await session.execute(
-        select(Submission).where(Submission.character_id == character_id)
+        select(Submission).where(
+            Submission.character_id == character_id,
+            Submission.is_deleted == False,
+            Submission.is_withdrawn == False,
+        )
     )
     submissions = submissions_result.scalars().all()
 

--- a/backend/services/submission.py
+++ b/backend/services/submission.py
@@ -62,6 +62,76 @@ async def create_submission(
     return submission
 
 
+async def withdraw_submission(
+    submission: Submission,
+    character: Character,
+    session: AsyncSession,
+) -> Submission:
+    """Withdraw a submitted praxis back to editing state.
+
+    Sets is_withdrawn=True, reverts CharacterTask status to in_progress,
+    and recalculates stats so points/votes no longer count.
+    """
+    if submission.character_id != character.id:
+        raise HTTPException(status_code=403, detail="Cannot withdraw another character's submission.")
+    if submission.is_withdrawn:
+        raise HTTPException(status_code=422, detail="Submission is already withdrawn.")
+
+    submission.is_withdrawn = True
+
+    character_task_result = await session.execute(
+        select(CharacterTask).where(
+            CharacterTask.character_id == character.id,
+            CharacterTask.task_id == submission.task_id,
+            CharacterTask.status == CharacterTaskStatus.submitted,
+        )
+    )
+    character_task = character_task_result.scalar_one_or_none()
+    if character_task is not None:
+        character_task.status = CharacterTaskStatus.in_progress
+
+    await session.commit()
+    await recalculate_character_stats(character.id, session)
+    await session.commit()
+    await session.refresh(submission)
+    return submission
+
+
+async def resubmit_submission(
+    submission: Submission,
+    character: Character,
+    session: AsyncSession,
+) -> Submission:
+    """Resubmit a previously withdrawn praxis.
+
+    Clears is_withdrawn, sets CharacterTask status back to submitted,
+    and recalculates stats so points/votes count again.
+    """
+    if submission.character_id != character.id:
+        raise HTTPException(status_code=403, detail="Cannot resubmit another character's submission.")
+    if not submission.is_withdrawn:
+        raise HTTPException(status_code=422, detail="Submission is not withdrawn.")
+
+    submission.is_withdrawn = False
+
+    character_task_result = await session.execute(
+        select(CharacterTask).where(
+            CharacterTask.character_id == character.id,
+            CharacterTask.task_id == submission.task_id,
+            CharacterTask.status == CharacterTaskStatus.in_progress,
+        )
+    )
+    character_task = character_task_result.scalar_one_or_none()
+    if character_task is not None:
+        character_task.status = CharacterTaskStatus.submitted
+
+    await session.commit()
+    await recalculate_character_stats(character.id, session)
+    await session.commit()
+    await session.refresh(submission)
+    return submission
+
+
 async def edit_submission(
     submission: Submission,
     data: SubmissionCreate,

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -38,6 +38,10 @@ export async function deleteSubmission(id: number): Promise<void> {
   await api.delete(`/admin/submissions/${id}`)
 }
 
+export async function deleteMessage(id: number): Promise<void> {
+  await api.delete(`/admin/messages/${id}`)
+}
+
 export async function banCharacter(id: number): Promise<void> {
   await api.post(`/admin/characters/${id}/ban`)
 }

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -17,6 +17,7 @@ export interface SubmissionOut {
   title: string
   body_text: string | null
   is_flagged: boolean
+  is_withdrawn: boolean
   created_at: string
   updated_at: string
   media: MediaItemOut[]
@@ -63,4 +64,14 @@ export async function flagSubmission(submissionId: number, reason: string): Prom
 
 export async function deleteMedia(submissionId: number, mediaId: number): Promise<void> {
   await api.delete(`/submissions/${submissionId}/media/${mediaId}`)
+}
+
+export async function withdrawSubmission(submissionId: number): Promise<SubmissionOut> {
+  const { data } = await api.post<SubmissionOut>(`/submissions/${submissionId}/withdraw`)
+  return data
+}
+
+export async function resubmitSubmission(submissionId: number): Promise<SubmissionOut> {
+  const { data } = await api.post<SubmissionOut>(`/submissions/${submissionId}/resubmit`)
+  return data
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { getMyTasks, type CharacterTaskOut } from '../../api/tasks'
 import { listSubmissions, type SubmissionOut } from '../../api/submissions'
 import { relativeTime } from '../../utils/dates'
 import { factionColor, factionName } from '../../utils/factions'
+import { mediaUrl } from '../../utils/media'
 
 const MAX_TASK_SLOTS = 20
 
@@ -34,14 +35,23 @@ export default function Sidebar() {
       {character ? (
         <div className="sidebar-card">
           <div className="flex items-center gap-3 mb-3">
-            <div
-              className="shrink-0 rounded-full"
-              style={{
-                width: 40,
-                height: 40,
-                background: `linear-gradient(135deg, ${factionColor(character.faction_slug)}, ${factionColor(character.faction_slug)}88)`,
-              }}
-            />
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="shrink-0 rounded-full"
+                style={{ width: 40, height: 40, objectFit: 'cover' }}
+              />
+            ) : (
+              <div
+                className="shrink-0 rounded-full"
+                style={{
+                  width: 40,
+                  height: 40,
+                  background: `linear-gradient(135deg, ${factionColor(character.faction_slug)}, ${factionColor(character.faction_slug)}88)`,
+                }}
+              />
+            )}
             <div className="min-w-0">
               <Link
                 to={`/characters/${character.id}`}

--- a/frontend/src/components/ui/VoteStamps.tsx
+++ b/frontend/src/components/ui/VoteStamps.tsx
@@ -31,7 +31,7 @@ interface Props {
 }
 
 export default function VoteStamps({ submissionId, currentStars, averageStars, totalVotes }: Props) {
-  const { user } = useAuth()
+  const { user, refetch } = useAuth()
   const { theme } = useTheme()
   const dark = theme === 'dark'
   const [hovered, setHovered] = useState(0)
@@ -45,6 +45,8 @@ export default function VoteStamps({ submissionId, currentStars, averageStars, t
     try {
       await castVote(submissionId, stars)
       setSelected(stars)
+      // Refresh sidebar character stats (score/level may have changed)
+      void refetch()
     } catch (err) {
       setError(extractError(err, 'Could not save your vote. Please try again.'))
     } finally {

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { getPendingTasks, approveTask, retireTask, getFlaggedSubmissions, deleteSubmission, getMessages } from '../api/admin'
+import { getPendingTasks, approveTask, retireTask, getFlaggedSubmissions, deleteSubmission, deleteMessage, getMessages } from '../api/admin'
 import type { PendingTaskOut, ContactMessageOut } from '../api/admin'
 import { getFactions, updateFaction } from '../api/factions'
 import type { FactionOut } from '../api/factions'
@@ -17,6 +17,7 @@ export default function Admin() {
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<number | null>(null)
+  const [deleteMessageTarget, setDeleteMessageTarget] = useState<number | null>(null)
 
   // Faction inline edit state: slug → { name, description } | null (null = not editing)
   const [factionEdits, setFactionEdits] = useState<Record<string, { name: string; description: string } | null>>({})
@@ -62,6 +63,18 @@ export default function Admin() {
     } catch (err) {
       setDeleteTarget(null)
       setActionError(extractError(err, 'Could not delete this submission.'))
+    }
+  }
+
+  const handleDeleteMessage = async (id: number) => {
+    setActionError(null)
+    try {
+      await deleteMessage(id)
+      setDeleteMessageTarget(null)
+      refresh()
+    } catch (err) {
+      setDeleteMessageTarget(null)
+      setActionError(extractError(err, 'Could not delete this message.'))
     }
   }
 
@@ -247,6 +260,17 @@ export default function Admin() {
                     <p className="font-display text-lg font-bold">{m.name}</p>
                     <p className="font-body text-xs text-muted">{m.email} · {formatTimestamp(m.created_at)}</p>
                   </div>
+                  {deleteMessageTarget === m.id ? (
+                    <div className="flex items-center gap-2 font-body text-xs shrink-0">
+                      <span className="text-muted">Sure?</span>
+                      <button onClick={() => void handleDeleteMessage(m.id)} className="btn-primary text-xs bg-red-700 border-red-900">yes, delete</button>
+                      <button onClick={() => setDeleteMessageTarget(null)} className="btn-outline text-xs">cancel</button>
+                    </div>
+                  ) : (
+                    <button onClick={() => setDeleteMessageTarget(m.id)} className="btn-primary text-xs bg-red-700 border-red-900 shrink-0">
+                      delete
+                    </button>
+                  )}
                 </div>
                 <p className="font-body text-sm text-ink mt-2 whitespace-pre-wrap">{m.message}</p>
               </div>

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -51,24 +51,53 @@ export default function CharacterProfile() {
       .catch(() => {})
   }, [id, user])
 
+  const [relationshipError, setRelationshipError] = useState<string | null>(null)
+
   const handleAddRelationship = async (type: 'friend' | 'foe') => {
     if (!character) return
     setRelationshipLoading(true)
+    setRelationshipError(null)
     try {
-      const rel = await createRelationship(character.id, type)
-      setRelationship(rel)
-    } catch { /* ignore — may already exist */ }
-    finally { setRelationshipLoading(false) }
+      await createRelationship(character.id, type)
+      // Re-fetch to get the properly typed RelationshipListItem with display data
+      const rels = await listRelationships()
+      const match = rels.find(
+        (r) => r.to_character_id === character.id && r.status !== 'blocked'
+      )
+      setRelationship(match ?? null)
+    } catch (err: unknown) {
+      // Handle 409 (already exists) gracefully — re-fetch existing relationship
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosErr = err as { response?: { status?: number } }
+        if (axiosErr.response?.status === 409) {
+          const rels = await listRelationships()
+          const match = rels.find(
+            (r) => r.to_character_id === character.id && r.status !== 'blocked'
+          )
+          setRelationship(match ?? null)
+        } else {
+          setRelationshipError('Could not add relationship.')
+        }
+      } else {
+        setRelationshipError('Could not add relationship.')
+      }
+    } finally {
+      setRelationshipLoading(false)
+    }
   }
 
   const handleRemoveRelationship = async () => {
     if (!relationship) return
     setRelationshipLoading(true)
+    setRelationshipError(null)
     try {
       await deleteRelationship(relationship.id)
       setRelationship(null)
-    } catch { /* ignore */ }
-    finally { setRelationshipLoading(false) }
+    } catch {
+      setRelationshipError('Could not remove relationship.')
+    } finally {
+      setRelationshipLoading(false)
+    }
   }
 
   if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
@@ -203,6 +232,9 @@ export default function CharacterProfile() {
                 )}
               </div>
             ) : null}
+            {relationshipError && (
+              <p className="font-body" style={{ fontSize: 8, color: '#dc2626', marginTop: 4, textAlign: 'center' }}>{relationshipError}</p>
+            )}
           </div>
 
           {/* Info */}

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '../auth/AuthContext'
 import { useTheme } from '../hooks/useTheme'
 import { factionColor, factionName } from '../utils/factions'
 import { extractError } from '../utils/errors'
+import { mediaUrl } from '../utils/media'
 
 const RANK_COLORS = ['#f59e0b', '#c49a3a', '#888'] // gold, silver, bronze
 
@@ -109,14 +110,26 @@ export default function Leaderboard() {
                       </span>
 
                       {/* Avatar orb */}
-                      <div
-                        style={{
-                          width: avatarSize, height: avatarSize, borderRadius: '50%',
-                          background: `linear-gradient(135deg, ${color}, ${color}88)`,
-                          margin: '0 auto 6px',
-                          border: `2px solid ${color}`,
-                        }}
-                      />
+                      {player.avatar_url ? (
+                        <img
+                          src={mediaUrl(player.avatar_url)}
+                          alt={player.display_name}
+                          style={{
+                            width: avatarSize, height: avatarSize, borderRadius: '50%',
+                            objectFit: 'cover', margin: '0 auto 6px',
+                            border: `2px solid ${color}`,
+                          }}
+                        />
+                      ) : (
+                        <div
+                          style={{
+                            width: avatarSize, height: avatarSize, borderRadius: '50%',
+                            background: `linear-gradient(135deg, ${color}, ${color}88)`,
+                            margin: '0 auto 6px',
+                            border: `2px solid ${color}`,
+                          }}
+                        />
+                      )}
 
                       {/* Name */}
                       <Link
@@ -172,12 +185,20 @@ export default function Leaderboard() {
               <span className="font-display italic" style={{ fontSize: 20, fontWeight: 700, color: '#4f46e5', minWidth: 32, textAlign: 'right' }}>
                 {myRank + 1}
               </span>
-              <div
-                style={{
-                  width: 28, height: 28, borderRadius: '50%',
-                  background: `linear-gradient(135deg, ${factionColor(user?.character?.faction_slug)}, ${factionColor(user?.character?.faction_slug)}88)`,
-                }}
-              />
+              {user?.character?.avatar_url ? (
+                <img
+                  src={mediaUrl(user.character.avatar_url)}
+                  alt={user.character.display_name}
+                  style={{ width: 28, height: 28, borderRadius: '50%', objectFit: 'cover' }}
+                />
+              ) : (
+                <div
+                  style={{
+                    width: 28, height: 28, borderRadius: '50%',
+                    background: `linear-gradient(135deg, ${factionColor(user?.character?.faction_slug)}, ${factionColor(user?.character?.faction_slug)}88)`,
+                  }}
+                />
+              )}
               <div className="flex-1">
                 <span className="font-display italic" style={{ fontSize: 12, color: '#4f46e5' }}>
                   {user?.character?.display_name}
@@ -221,6 +242,7 @@ export default function Leaderboard() {
           </div>
 
           {/* ── Main Table (§16.6) ── */}
+          {rest.length > 0 && (
           <div
             className="sidebar-card"
             style={{ padding: 0, overflow: 'hidden' }}
@@ -271,7 +293,11 @@ export default function Leaderboard() {
 
                   {/* Player */}
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-                    <div style={{ width: 32, height: 32, borderRadius: '50%', background: `linear-gradient(135deg, ${color}, ${color}88)`, shrink: 0 }} />
+                    {c.avatar_url ? (
+                      <img src={mediaUrl(c.avatar_url)} alt={c.display_name} style={{ width: 32, height: 32, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }} />
+                    ) : (
+                      <div style={{ width: 32, height: 32, borderRadius: '50%', background: `linear-gradient(135deg, ${color}, ${color}88)`, flexShrink: 0 }} />
+                    )}
                     <div className="min-w-0">
                       <Link to={`/characters/${c.id}`} className="font-display italic block truncate" style={{ fontSize: 12, color: isMe ? color : 'var(--color-text-primary)', textDecoration: 'none' }}>
                         {c.display_name}
@@ -298,6 +324,7 @@ export default function Leaderboard() {
               )
             })}
           </div>
+          )}
         </>
       )}
     </div>

--- a/frontend/src/pages/SubmissionDetail.tsx
+++ b/frontend/src/pages/SubmissionDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
-import { getSubmission, flagSubmission, type SubmissionOut } from '../api/submissions'
+import { getSubmission, flagSubmission, withdrawSubmission, resubmitSubmission, type SubmissionOut } from '../api/submissions'
 import { getVotes, type VoteSummary } from '../api/votes'
 import MediaGallery from '../components/MediaGallery'
 import { formatTimestamp } from '../utils/dates'
@@ -25,6 +25,9 @@ export default function SubmissionDetail() {
   const [flagging, setFlagging] = useState(false)
   const [flagError, setFlagError] = useState<string | null>(null)
   const [showFlagConfirm, setShowFlagConfirm] = useState(false)
+  const [withdrawing, setWithdrawing] = useState(false)
+  const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false)
+  const [withdrawError, setWithdrawError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!id) return
@@ -47,6 +50,39 @@ export default function SubmissionDetail() {
       setFlagError(extractError(err, 'Could not flag this submission.'))
     } finally {
       setFlagging(false)
+    }
+  }
+
+  const { refetch } = useAuth()
+
+  const handleWithdraw = async () => {
+    if (!submission) return
+    setWithdrawing(true)
+    setWithdrawError(null)
+    try {
+      const updated = await withdrawSubmission(submission.id)
+      setSubmission(updated)
+      setShowWithdrawConfirm(false)
+      void refetch()
+    } catch (err) {
+      setWithdrawError(extractError(err, 'Could not withdraw this submission.'))
+    } finally {
+      setWithdrawing(false)
+    }
+  }
+
+  const handleResubmit = async () => {
+    if (!submission) return
+    setWithdrawing(true)
+    setWithdrawError(null)
+    try {
+      const updated = await resubmitSubmission(submission.id)
+      setSubmission(updated)
+      void refetch()
+    } catch (err) {
+      setWithdrawError(extractError(err, 'Could not resubmit.'))
+    } finally {
+      setWithdrawing(false)
     }
   }
 
@@ -75,6 +111,22 @@ export default function SubmissionDetail() {
         {' › '}
         <span style={{ color: 'var(--color-text-primary)' }}>Praxis</span>
       </nav>
+
+      {/* Withdrawn banner */}
+      {submission.is_withdrawn && (
+        <div
+          style={{
+            background: 'rgba(245,158,11,0.1)', border: '2px solid rgba(245,158,11,0.3)',
+            borderRadius: 8, padding: '8px 14px', marginBottom: 12,
+            display: 'flex', alignItems: 'center', gap: 8,
+          }}
+        >
+          <span style={{ fontSize: 16 }}>⏸</span>
+          <span className="font-body" style={{ fontSize: 11, color: '#92400e', fontWeight: 700 }}>
+            This praxis has been withdrawn. Points and votes are paused until resubmitted.
+          </span>
+        </div>
+      )}
 
       {/* ── Byline Block (§12.2) ── */}
       <div
@@ -126,15 +178,64 @@ export default function SubmissionDetail() {
         ))}
       </div>
 
-      {/* Edit link for author */}
+      {/* Author actions */}
       {user?.character?.id === submission.character_id && (
-        <Link
-          to={`/submissions/${submission.id}/edit`}
-          className="font-body eyebrow hover:underline mb-4 inline-block"
-          style={{ color: 'var(--color-text-tertiary)' }}
-        >
-          edit this praxis
-        </Link>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+          <Link
+            to={`/submissions/${submission.id}/edit`}
+            className="font-body eyebrow hover:underline"
+            style={{ color: 'var(--color-text-tertiary)' }}
+          >
+            edit this praxis
+          </Link>
+          {submission.is_withdrawn ? (
+            <button
+              onClick={handleResubmit}
+              disabled={withdrawing}
+              style={{
+                background: '#14532d', color: 'white',
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.08em',
+                padding: '4px 12px', border: 'none', cursor: 'pointer', borderRadius: 0,
+                opacity: withdrawing ? 0.5 : 1,
+              }}
+            >
+              {withdrawing ? '...' : 'Resubmit'}
+            </button>
+          ) : !showWithdrawConfirm ? (
+            <button
+              onClick={() => setShowWithdrawConfirm(true)}
+              className="font-body eyebrow"
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}
+            >
+              unsubmit
+            </button>
+          ) : (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Sure? Points & votes will pause.</span>
+              <button
+                onClick={handleWithdraw}
+                disabled={withdrawing}
+                style={{
+                  background: 'rgba(220,38,38,0.1)', border: '1.5px solid #dc2626', color: '#dc2626',
+                  fontFamily: "'Courier Prime', monospace", fontSize: 9, textTransform: 'uppercase',
+                  padding: '3px 10px', cursor: 'pointer', borderRadius: 0,
+                }}
+              >
+                {withdrawing ? '...' : 'Yes, unsubmit'}
+              </button>
+              <button
+                onClick={() => setShowWithdrawConfirm(false)}
+                className="btn-outline" style={{ fontSize: 9, padding: '3px 10px' }}
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {withdrawError && (
+        <p className="font-body text-xs mb-3" style={{ color: '#dc2626' }}>{withdrawError}</p>
       )}
 
       {/* ── Task Context Strip (§12.4) ── */}

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import { createSubmission, uploadMedia } from '../api/submissions'
 import { getTask, type TaskOut } from '../api/tasks'
 import LevelPill from '../components/ui/LevelPill'
+import { useAuth } from '../auth/AuthContext'
 import { useTheme } from '../hooks/useTheme'
 import { factionColor, factionName } from '../utils/factions'
 
@@ -12,6 +13,7 @@ const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '
 export default function SubmitProof() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const { refetch } = useAuth()
   const { theme } = useTheme()
   const dark = theme === 'dark'
   const [task, setTask] = useState<TaskOut | null>(null)
@@ -36,6 +38,8 @@ export default function SubmitProof() {
       for (const file of files) {
         await uploadMedia(submission.id, file)
       }
+      // Refresh sidebar character stats (score/level changed)
+      void refetch()
       navigate(`/submissions/${submission.id}`)
     } catch {
       setError('Could not submit. Check you are signed up for this task.')

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -34,6 +34,7 @@ export default function Updates() {
   const [inProgressTasks, setInProgressTasks] = useState<CharacterTaskOut[]>([])
   const [friends, setFriends] = useState<RelationshipListItem[]>([])
   const [foes, setFoes] = useState<RelationshipListItem[]>([])
+  const [friendSubmissions, setFriendSubmissions] = useState<SubmissionOut[]>([])
   const [filter, setFilter] = useState<FeedFilter>('All')
   const [loading, setLoading] = useState(true)
 
@@ -47,7 +48,19 @@ export default function Updates() {
       getMyTasks('in_progress')
         .then(setInProgressTasks).catch(() => {}),
       listRelationships({ type: 'friend' })
-        .then((fr) => setFriends(fr.filter((r) => r.status === 'active'))).catch(() => {}),
+        .then((fr) => {
+          const activeFriends = fr.filter((r) => r.status === 'active')
+          setFriends(activeFriends)
+          // Fetch recent submissions from friends
+          const friendFetches = activeFriends.slice(0, 10).map((rel) =>
+            listSubmissions({ character_id: rel.to_character_id }).catch(() => [] as SubmissionOut[])
+          )
+          return Promise.all(friendFetches).then((results) => {
+            setFriendSubmissions(results.flat().sort((a, b) =>
+              new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+            ).slice(0, 20))
+          })
+        }).catch(() => {}),
       listRelationships({ type: 'foe' })
         .then((fo) => setFoes(fo.filter((r) => r.status === 'active'))).catch(() => {}),
     ]
@@ -141,6 +154,15 @@ export default function Updates() {
               )
             })}
           </div>
+          {/* Friends' recent praxis */}
+          {friendSubmissions.length > 0 && (
+            <div style={{ marginTop: 12 }}>
+              <span className="eyebrow" style={{ marginBottom: 8, display: 'block' }}>Friends' recent praxis</span>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {friendSubmissions.map((s) => <SubmissionCard key={s.id} submission={s} />)}
+              </div>
+            </div>
+          )}
         </section>
       )}
 


### PR DESCRIPTION
## Summary
- **Sidebar refresh**: Score/level updates live after voting or submitting proof (calls `refetch()` from AuthContext)
- **Avatar images**: Sidebar, leaderboard podium, table rows, and rank strip now show real avatar when uploaded (gradient circle fallback)
- **Admin delete messages**: New `DELETE /admin/messages/{id}` endpoint + UI with confirmation dialog
- **Empty leaderboard table**: Hidden when ≤3 players so it doesn't show a blank header-only table
- **Unsubmit/resubmit praxis**: New `POST /submissions/{id}/withdraw` and `/resubmit` endpoints. Withdrawn submissions pause their points and votes. Resubmitting restores them. Includes Alembic migration for `is_withdrawn` column. Also fixes `recalculate_character_stats` which was counting deleted submissions in score.
- **Friends/foes persistence**: Fixed type mismatch after creating relationship (re-fetches list for proper type), handles 409 "already exists" gracefully, shows error messages instead of silent catch. Updates page now fetches and displays friends' recent submissions.

## Test plan
- [ ] Vote on a submission → sidebar score updates without refresh
- [ ] Upload avatar → verify it shows on sidebar, leaderboard podium, and table
- [ ] Admin page → delete a message → verify it disappears
- [ ] With ≤3 players, verify no empty table below podium
- [ ] Submit praxis → Unsubmit → score decreases → Resubmit → score restores with votes
- [ ] Add friend on profile → navigate away → return → friend badge persists
- [ ] Check Updates page Friends filter shows friends' submissions
- [ ] Run `alembic upgrade head` for the new migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)