### PR TITLE
Fix: add PATCH to CORS allowed methods

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -67,7 +67,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[o.strip() for o in _cors_origins],
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## Summary
- Add `PATCH` to the CORS `allow_methods` list in `main.py`
- Without this, the browser's preflight OPTIONS request for the new admin PATCH endpoints (moderate submission, archive message) was being rejected silently

## Test plan
- [ ] Verify admin moderation actions (approve/hide/fail) now work
- [ ] Verify message archive toggle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)