### PR TITLE
Fix: dedicated admin endpoint for flagged submissions

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -311,6 +311,40 @@ async def admin_cli_token(
 # ---------------------------------------------------------------------------
 
 
+@router.get("/submissions/flagged", response_model=list[SubmissionOut])
+async def admin_list_flagged_submissions(
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+):
+    """Return submissions with moderation_status == flagged."""
+    result = await session.execute(
+        select(Submission)
+        .where(Submission.moderation_status == ModerationStatus.flagged)
+        .order_by(Submission.created_at.desc())
+    )
+    submissions = result.scalars().all()
+    out: list[SubmissionOut] = []
+    for sub in submissions:
+        character = await session.get(Character, sub.character_id)
+        character_display_name = character.display_name if character else ""
+        out.append(
+            SubmissionOut(
+                id=sub.id,
+                task_id=sub.task_id,
+                character_id=sub.character_id,
+                character_display_name=character_display_name,
+                title=sub.title,
+                body_text=sub.body_text,
+                moderation_status=sub.moderation_status.value,
+                is_withdrawn=sub.is_withdrawn,
+                admin_note=sub.admin_note,
+                created_at=sub.created_at,
+                updated_at=sub.updated_at,
+            )
+        )
+    return out
+
+
 @router.patch("/submissions/{submission_id}/moderate", response_model=SubmissionOut)
 async def admin_moderate_submission(
     submission_id: int,

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -64,7 +64,7 @@ export async function getMessages(archived = false): Promise<ContactMessageOut[]
 }
 
 export async function getFlaggedSubmissions(): Promise<SubmissionOut[]> {
-  const { data } = await api.get<SubmissionOut[]>('/submissions', { params: { moderation_status: 'flagged' } })
+  const { data } = await api.get<SubmissionOut[]>('/admin/submissions/flagged')
   return data
 }
 


### PR DESCRIPTION
## Summary
- Add `GET /admin/submissions/flagged` endpoint that queries `moderation_status == flagged` directly
- Frontend moderation tab now uses this admin endpoint instead of the public `/submissions?moderation_status=flagged`
- Fixes mismatch where overview showed 0 flagged but moderation tab showed 13

## Root cause
The public `/submissions` endpoint was returning all non-hidden submissions when the `moderation_status` query param wasn't being applied correctly, causing the moderation tab to show unrelated submissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)