### PR TITLE
Fix: guard taunttriggertype enum creation against duplicate

### DIFF
--- a/backend/alembic/versions/g7h8i9j0k1l2_backend_gaps.py
+++ b/backend/alembic/versions/g7h8i9j0k1l2_backend_gaps.py
@@ -62,7 +62,7 @@ def upgrade() -> None:
     )
 
     # -- 3. Create taunt_message table --
-    op.execute("CREATE TYPE taunttriggertype AS ENUM ('score_overtake', 'level_up', 'submission_complete')")
+    op.execute("DO $$ BEGIN CREATE TYPE taunttriggertype AS ENUM ('score_overtake', 'level_up', 'submission_complete'); EXCEPTION WHEN duplicate_object THEN null; END $$")
     op.create_table(
         "taunt_message",
         sa.Column("id", sa.Integer(), primary_key=True),


### PR DESCRIPTION
## Summary
- Migration `g7h8i9j0k1l2` used raw `CREATE TYPE taunttriggertype` without a guard, causing deploy failure when the type already existed from a partial migration run
- Wrapped in `DO/EXCEPTION` block to silently skip if the type is already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)