### PR TITLE
Fix: prevent duplicate enum type errors on deploy

### DIFF
--- a/backend/models/account.py
+++ b/backend/models/account.py
@@ -19,7 +19,7 @@ class Account(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     email: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     status: Mapped[AccountStatus] = mapped_column(
-        Enum(AccountStatus), nullable=False, default=AccountStatus.active
+        Enum(AccountStatus, create_type=False), nullable=False, default=AccountStatus.active
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/backend/models/character.py
+++ b/backend/models/character.py
@@ -28,7 +28,7 @@ class Character(Base):
         ForeignKey("faction.slug"), nullable=False, server_default="ua"
     )
     status: Mapped[CharacterStatus] = mapped_column(
-        Enum(CharacterStatus), nullable=False, default=CharacterStatus.active
+        Enum(CharacterStatus, create_type=False), nullable=False, default=CharacterStatus.active
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/backend/models/faction.py
+++ b/backend/models/faction.py
@@ -20,7 +20,7 @@ class Faction(Base):
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     status: Mapped[FactionStatus] = mapped_column(
-        Enum(FactionStatus), nullable=False, default=FactionStatus.visible
+        Enum(FactionStatus, create_type=False), nullable=False, default=FactionStatus.visible
     )
     # No multiplier columns: faction rules live in game_config.py, not the DB.
     # This table exists for FK references and UI display only.

--- a/backend/models/meta_task.py
+++ b/backend/models/meta_task.py
@@ -19,7 +19,7 @@ class MetaTask(Base):
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     faction_slug: Mapped[str] = mapped_column(ForeignKey("faction.slug"), nullable=False)
-    bonus_type: Mapped[BonusType] = mapped_column(Enum(BonusType), nullable=False)
+    bonus_type: Mapped[BonusType] = mapped_column(Enum(BonusType, create_type=False), nullable=False)
     bonus_value: Mapped[float] = mapped_column(Float, nullable=False)
     level_required: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/models/relationship.py
+++ b/backend/models/relationship.py
@@ -29,10 +29,10 @@ class Relationship(Base):
         ForeignKey("character.id"), nullable=False
     )
     type: Mapped[RelationshipType] = mapped_column(
-        Enum(RelationshipType), nullable=False
+        Enum(RelationshipType, create_type=False), nullable=False
     )
     status: Mapped[RelationshipStatus] = mapped_column(
-        Enum(RelationshipStatus), nullable=False
+        Enum(RelationshipStatus, create_type=False), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/backend/models/submission.py
+++ b/backend/models/submission.py
@@ -36,7 +36,7 @@ class Submission(Base):
     title: Mapped[str] = mapped_column(String, nullable=False)
     body_text: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     moderation_status: Mapped[ModerationStatus] = mapped_column(
-        Enum(ModerationStatus), nullable=False, server_default="visible"
+        Enum(ModerationStatus, create_type=False), nullable=False, server_default="visible"
     )
     is_withdrawn: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, server_default="false")
     admin_note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -48,7 +48,7 @@ class Submission(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
     collaboration_mode: Mapped[CollaborationMode] = mapped_column(
-        Enum(CollaborationMode), nullable=False, server_default="solo"
+        Enum(CollaborationMode, create_type=False), nullable=False, server_default="solo"
     )
     partner_character_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("character.id"), nullable=True
@@ -65,7 +65,7 @@ class MediaItem(Base):
     submission_id: Mapped[int] = mapped_column(
         ForeignKey("submission.id"), nullable=False
     )
-    type: Mapped[MediaType] = mapped_column(Enum(MediaType), nullable=False)
+    type: Mapped[MediaType] = mapped_column(Enum(MediaType, create_type=False), nullable=False)
     file_path: Mapped[str] = mapped_column(String, nullable=False)
     display_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/models/task.py
+++ b/backend/models/task.py
@@ -28,7 +28,7 @@ class Task(Base):
     point_value: Mapped[int] = mapped_column(Integer, nullable=False)
     level_required: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     status: Mapped[TaskStatus] = mapped_column(
-        Enum(TaskStatus), default=TaskStatus.pending, nullable=False
+        Enum(TaskStatus, create_type=False), default=TaskStatus.pending, nullable=False
     )
     created_by: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
     # "na" is the sentinel for generic cross-faction tasks
@@ -68,7 +68,7 @@ class CharacterTask(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
     status: Mapped[CharacterTaskStatus] = mapped_column(
-        Enum(CharacterTaskStatus),
+        Enum(CharacterTaskStatus, create_type=False),
         default=CharacterTaskStatus.in_progress,
         nullable=False,
     )

--- a/backend/models/taunt_message.py
+++ b/backend/models/taunt_message.py
@@ -25,7 +25,7 @@ class TauntMessage(Base):
     )
     message: Mapped[str] = mapped_column(Text, nullable=False)
     trigger_type: Mapped[TauntTriggerType] = mapped_column(
-        Enum(TauntTriggerType), nullable=False
+        Enum(TauntTriggerType, create_type=False), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/docs/BUILD_STATE.md
+++ b/docs/BUILD_STATE.md
@@ -11,12 +11,14 @@ This file is the source of truth for what has been built, what is in progress, a
 
 ### Foundation
 - `backend/models/` — All SQLAlchemy models defined and reviewed
-  - `account.py` — Account (private login identity)
-  - `character.py` — Character (public game persona), with level, score, faction, votes_available
+  - `account.py` — Account (private login identity) with AccountStatus enum (active/suspended/deleted)
+  - `character.py` — Character (public game persona) with CharacterStatus enum; stats moved to CharacterStats
+  - `character_stats.py` — CharacterStats (per-era volatile stats: score, level, votes_available, all_time_score) ✅ star schema split
   - `era.py` — Era DB record (stores config_key, not rules)
-  - `faction.py` — Faction (FK reference table; rules live in game_config.py)
+  - `faction.py` — Faction with FactionStatus enum (visible/hidden/deprecated; rules live in game_config.py)
   - `task.py` — Task, TaskFaction (join), CharacterTask (signup tracking)
-  - `submission.py` — Submission (praxis) + MediaItem + CollaborationMode (solo/collab/duel)
+  - `submission.py` — Submission (praxis) + MediaItem + CollaborationMode + ModerationStatus (visible/flagged/hidden/failed)
+  - `contact.py` — ContactMessage (public contact form submissions) ✅
   - `vote.py` — Vote with voter_account_id for anti-self-vote
   - `relationship.py` — friend/foe relationships (instant declarations, active/blocked status) ✅ redesigned 2026-04-13
   - `message.py` — direct messages between characters

--- a/docs/spec/SPEC-data-models.md
+++ b/docs/spec/SPEC-data-models.md
@@ -1,109 +1,139 @@
 # World Zero — Data Models
 
+> Last synced with code: 2026-04-13
+
 ## 5. Data Models
 
 ### Account
 ```
 id
 email                -- from OAuth provider, never public
+status               -- enum: active | suspended | deleted (AccountStatus)
 created_at
-is_active            -- for soft bans
+updated_at
 ```
 
 ### OAuthProvider
 ```
 id
-account_id           -- FK → Account
+account_id           -- FK -> Account
 provider             -- e.g. "google", "github" (future)
 provider_user_id     -- the ID from the OAuth provider
 access_token         -- encrypted at rest
 created_at
+updated_at
 ```
 *This table is what makes adding new OAuth providers a config change, not a schema change.*
 
 ### Role
 ```
 id
-name                 -- e.g. "admin", "moderator", "trusted_user"
+name                 -- e.g. "admin", "moderator", "trusted_user"; unique
 description
+created_at
+updated_at
 ```
 
 ### AccountRole
 ```
 id
-account_id           -- FK → Account
-role_id              -- FK → Role
+account_id           -- FK -> Account
+role_id              -- FK -> Role
 granted_at
-granted_by           -- FK → Account (who granted it)
+granted_by           -- FK -> Account (who granted it)
 ```
 
 ### Character
 ```
 id
-account_id           -- FK → Account (private, never exposed in public API responses)
+account_id           -- FK -> Account (private, never exposed in public API responses)
 username             -- permanent, unique, public handle
 display_name         -- editable
-bio                  -- editable, rich text / markdown
-avatar_url           -- editable
-location             -- optional, editable
-level                -- integer 0–8; derived from score, stored for query performance
-score                -- sum of non-flagged submission scores for current era
-all_time_score       -- cumulative, never resets
-votes_available      -- spendable budget; formula and reset behaviour from EraConfig
-faction_slug         -- FK → Faction.slug (nullable until level 3)
+bio                  -- editable, rich text / markdown (default "")
+avatar_url           -- editable (default "")
+location             -- editable (default "")
+faction_slug         -- FK -> Faction.slug, NOT NULL, default "ua" (starting faction)
+status               -- enum: active | paused | banned (CharacterStatus)
 created_at
-is_active            -- soft delete / ban flag
+updated_at
 ```
+*Score, level, votes_available, and all_time_score live in CharacterStats (star schema split).*
+*Faction graduation (level >= 3 to pick a real faction) is enforced at API layer, not DB.*
+
+### CharacterStats
+```
+id
+character_id         -- FK -> Character
+era_id               -- FK -> Era
+score                -- sum of non-flagged submission scores for this era (default 0)
+all_time_score       -- cumulative, never resets (default 0)
+level                -- integer 0-8; derived from score (default 0)
+votes_available      -- spendable budget; formula from EraConfig (default 0)
+updated_at
+CONSTRAINT: unique(character_id, era_id)
+```
+*One row per (character, era) pair. Era resets insert new rows; old rows are preserved
+for historical queries. Character is a pure dimension table; all volatile game state
+lives here.*
 
 ### Faction
 ```
 slug                 -- PK, matches FactionConfig.slug in game_config.py
 name
-description
--- No multiplier columns: faction rules live in game_config.py, not the DB
--- This table exists for FK references and UI display only
+description          -- default ""
+status               -- enum: visible | hidden | deprecated (FactionStatus)
+created_at
+updated_at
 ```
+*No multiplier columns: faction rules live in game_config.py, not the DB.
+This table exists for FK references and UI display only.*
 
 ### Task
 ```
 id
 title
-description          -- rich text / markdown, can embed images and video
+description          -- rich text / markdown (default "")
 point_value          -- base point value
-level_required       -- players must be >= this level to sign up
-status               -- enum: pending | active | retired
-created_by           -- FK → Character (admin character)
-primary_faction_slug -- FK → Faction.slug
+level_required       -- players must be >= this level to sign up (default 0)
+status               -- enum: pending | active | retired (TaskStatus)
+created_by           -- FK -> Character (admin character)
+primary_faction_slug -- FK -> Faction.slug, default "na" (cross-faction sentinel)
 is_task_vision_eligible -- bool; Journeymen can sign up for these when pretired/retired
 created_at
+updated_at
 ```
 
-### TaskFaction (join table — future multi-faction support)
+### TaskFaction (join table -- future multi-faction support)
 ```
-task_id
-faction_slug
+task_id              -- PK, FK -> Task
+faction_slug         -- PK, FK -> Faction.slug
 is_primary
 ```
 
 ### CharacterTask
 ```
 id
-character_id         -- FK → Character
-task_id              -- FK → Task
+character_id         -- FK -> Character
+task_id              -- FK -> Task
 signed_up_at
-status               -- enum: in_progress | submitted | abandoned
+status               -- enum: in_progress | submitted | abandoned (CharacterTaskStatus)
+updated_at
 ```
 *Active rows capped at `EraConfig.max_task_signups` per character, enforced at API layer.*
 
 ### Submission (aka "Praxis")
 ```
 id
-task_id              -- FK → Task
-character_id         -- FK → Character
+task_id              -- FK -> Task
+character_id         -- FK -> Character
 title
-body_text            -- rich text / markdown
-is_flagged           -- bool, default false
-flagged_at
+body_text            -- rich text / markdown (default "")
+moderation_status    -- enum: visible | flagged | hidden | failed (ModerationStatus)
+is_withdrawn         -- bool, default false
+admin_note           -- text, nullable (for failed/hidden submissions)
+flagged_at           -- nullable; NULL means "not yet flagged"
+collaboration_mode   -- enum: solo | collab | duel (CollaborationMode), default solo
+partner_character_id -- FK -> Character, nullable (for collab/duel)
 created_at
 updated_at
 ```
@@ -112,21 +142,21 @@ updated_at
 ### MediaItem
 ```
 id
-submission_id        -- FK → Submission
-type                 -- enum: image | video | audio
+submission_id        -- FK -> Submission
+type                 -- enum: image | video | audio (MediaType)
 file_path            -- relative path (structured for S3 swap in v2)
-display_order
+display_order        -- default 0
 created_at
 ```
 
 ### Vote
 ```
 id
-submission_id        -- FK → Submission
-voter_character_id   -- FK → Character
-voter_account_id     -- FK → Account (denormalized for anti-self-vote check)
-stars                -- integer 1–5
-duel_vote_for        -- FK → Character (nullable; Duels only)
+submission_id        -- FK -> Submission
+voter_character_id   -- FK -> Character
+voter_account_id     -- FK -> Account (denormalized for anti-self-vote check)
+stars                -- integer 1-5
+duel_vote_for        -- FK -> Character (nullable; Duels only)
 created_at
 updated_at           -- votes can be updated; update costs 0 additional budget
 CONSTRAINT: unique(submission_id, voter_character_id)
@@ -135,33 +165,46 @@ CONSTRAINT: unique(submission_id, voter_character_id)
 ### Flag
 ```
 id
-submission_id        -- FK → Submission
-flagged_by           -- FK → Character
-reason               -- optional text
+submission_id        -- FK -> Submission
+flagged_by           -- FK -> Character
+reason               -- text (default "")
 created_at
 ```
 
 ### Relationship
 ```
 id
-from_character_id    -- FK → Character
-to_character_id      -- FK → Character
-type                 -- enum: friend | foe
-status               -- enum: pending | accepted | blocked
+from_character_id    -- FK -> Character
+to_character_id      -- FK -> Character
+type                 -- enum: friend | foe (RelationshipType)
+status               -- enum: active | blocked (RelationshipStatus)
 created_at
+updated_at
 CONSTRAINT: unique(from_character_id, to_character_id)
 ```
-*Mutual friend + mutual foe = Rival (one per character). Foe is opt-in by both parties.*
+*Relationships are instant declarations -- no pending state. Mutual friend + mutual foe = Rival
+(one per character). Foe is opt-in by both parties.*
 
 ### Message
 ```
 id
-from_character_id    -- FK → Character
-to_character_id      -- FK → Character
+from_character_id    -- FK -> Character
+to_character_id      -- FK -> Character
 body
-read_at
+read_at              -- nullable; NULL = unread
 created_at
 ```
+
+### TauntMessage
+```
+id
+from_character_id    -- FK -> Character
+to_character_id      -- FK -> Character
+message              -- text
+trigger_type         -- enum: score_overtake | level_up | submission_complete (TauntTriggerType)
+created_at
+```
+*Auto-generated messages between foes triggered by game events. Templates live in game_config.py.*
 
 ### Era
 ```
@@ -169,8 +212,9 @@ id
 name                 -- human label for the era
 config_key           -- references EraConfig.config_key in game_config.py
 started_at
-started_by           -- FK → Account
-notes
+started_by           -- FK -> Account
+notes                -- default ""
+updated_at
 ```
 
 ### MetaTask
@@ -178,16 +222,47 @@ notes
 id
 name
 description
-faction_slug         -- FK → Faction (group-specific)
-bonus_type           -- enum: flat | percentage
-bonus_value
-level_required
+faction_slug         -- FK -> Faction (group-specific)
+bonus_type           -- enum: flat | percentage (BonusType)
+bonus_value          -- float
+level_required       -- default 0
 created_at
+updated_at
 ```
 
 ### SubmissionMetaTask
 ```
-submission_id
-meta_task_id
+submission_id        -- PK, FK -> Submission
+meta_task_id         -- PK, FK -> MetaTask
 applied_at
 ```
+
+### ContactMessage
+```
+id
+name                 -- String(100)
+email                -- String(254)
+message              -- text
+is_archived          -- bool, default false
+created_at
+```
+*Public contact form capture. Not part of the game system.*
+
+---
+
+## Enum Summary
+
+| Enum | Values | Used By |
+|------|--------|---------|
+| AccountStatus | active, suspended, deleted | Account.status |
+| CharacterStatus | active, paused, banned | Character.status |
+| FactionStatus | visible, hidden, deprecated | Faction.status |
+| TaskStatus | pending, active, retired | Task.status |
+| CharacterTaskStatus | in_progress, submitted, abandoned | CharacterTask.status |
+| MediaType | image, video, audio | MediaItem.type |
+| CollaborationMode | solo, collab, duel | Submission.collaboration_mode |
+| ModerationStatus | visible, flagged, hidden, failed | Submission.moderation_status |
+| RelationshipType | friend, foe | Relationship.type |
+| RelationshipStatus | active, blocked | Relationship.status |
+| BonusType | flat, percentage | MetaTask.bonus_type |
+| TauntTriggerType | score_overtake, level_up, submission_complete | TauntMessage.trigger_type |


### PR DESCRIPTION
## Summary
- Added `create_type=False` to all 12 `Enum()` calls across 8 model files — fixes `type "taunttriggertype" already exists` error that was blocking Render deployment
- Rewrote `docs/spec/SPEC-data-models.md` to match actual schema (was missing CharacterStats, TauntMessage, ContactMessage models; had stale Submission/Relationship/Account/Character definitions)
- Updated `docs/BUILD_STATE.md` with missing model entries

## Test plan
- [x] All models import successfully (`python -c "import models"`)
- [x] Verified all 12 Enum() calls now have `create_type=False`
- [x] No bare `Enum(ClassName)` calls remain in any model file
- [ ] Render deployment succeeds (no more duplicate type error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)