### PR TITLE
Fix: create_type=False in migration sa.Enum + full-stack audit

### DIFF
--- a/backend/alembic/versions/e5f6a7b8c9d0_star_schema_modernization.py
+++ b/backend/alembic/versions/e5f6a7b8c9d0_star_schema_modernization.py
@@ -82,7 +82,7 @@ def upgrade() -> None:
         ))
 
     if not _column_exists('faction', 'status'):
-        op.add_column('faction', sa.Column('status', sa.Enum('visible', 'hidden', 'deprecated', name='factionstatus'), nullable=True))
+        op.add_column('faction', sa.Column('status', sa.Enum('visible', 'hidden', 'deprecated', name='factionstatus', create_type=False), nullable=True))
         if _column_exists('faction', 'is_hidden'):
             conn.execute(sa.text(
                 "UPDATE faction SET status = CASE WHEN is_hidden = true THEN 'hidden'::factionstatus ELSE 'visible'::factionstatus END"
@@ -106,7 +106,7 @@ def upgrade() -> None:
     # 3. Account table: replace is_active with status enum + updated_at
     # ------------------------------------------------------------------
     if not _column_exists('account', 'status'):
-        op.add_column('account', sa.Column('status', sa.Enum('active', 'suspended', 'deleted', name='accountstatus'), nullable=True))
+        op.add_column('account', sa.Column('status', sa.Enum('active', 'suspended', 'deleted', name='accountstatus', create_type=False), nullable=True))
         if _column_exists('account', 'is_active'):
             conn.execute(sa.text(
                 "UPDATE account SET status = CASE WHEN is_active = true THEN 'active'::accountstatus ELSE 'suspended'::accountstatus END"
@@ -131,7 +131,7 @@ def upgrade() -> None:
     # 5. Character table: major restructure
     # ------------------------------------------------------------------
     if not _column_exists('character', 'status'):
-        op.add_column('character', sa.Column('status', sa.Enum('active', 'paused', 'banned', name='characterstatus'), nullable=True))
+        op.add_column('character', sa.Column('status', sa.Enum('active', 'paused', 'banned', name='characterstatus', create_type=False), nullable=True))
         if _column_exists('character', 'is_active'):
             conn.execute(sa.text(
                 "UPDATE character SET status = CASE WHEN is_active = true THEN 'active'::characterstatus ELSE 'banned'::characterstatus END"

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -32,6 +32,7 @@ from schemas.admin import (
 )
 from schemas.task import TaskCreate, TaskOut
 from schemas.submission import SubmissionOut
+from services.submission import build_submission_out
 from services.admin_service import (
     admin_create_character,
     archive_message,
@@ -323,26 +324,7 @@ async def admin_list_flagged_submissions(
         .order_by(Submission.created_at.desc())
     )
     submissions = result.scalars().all()
-    out: list[SubmissionOut] = []
-    for sub in submissions:
-        character = await session.get(Character, sub.character_id)
-        character_display_name = character.display_name if character else ""
-        out.append(
-            SubmissionOut(
-                id=sub.id,
-                task_id=sub.task_id,
-                character_id=sub.character_id,
-                character_display_name=character_display_name,
-                title=sub.title,
-                body_text=sub.body_text,
-                moderation_status=sub.moderation_status.value,
-                is_withdrawn=sub.is_withdrawn,
-                admin_note=sub.admin_note,
-                created_at=sub.created_at,
-                updated_at=sub.updated_at,
-            )
-        )
-    return out
+    return [await build_submission_out(sub, session) for sub in submissions]
 
 
 @router.patch("/submissions/{submission_id}/moderate", response_model=SubmissionOut)
@@ -354,19 +336,7 @@ async def admin_moderate_submission(
 ):
     new_status = ModerationStatus(data.status)
     submission = await moderate_submission(submission_id, new_status, data.admin_note, session)
-    # Build a minimal SubmissionOut — admin doesn't need full score computation
-    return SubmissionOut(
-        id=submission.id,
-        task_id=submission.task_id,
-        character_id=submission.character_id,
-        title=submission.title,
-        body_text=submission.body_text,
-        moderation_status=submission.moderation_status.value,
-        is_withdrawn=submission.is_withdrawn,
-        admin_note=submission.admin_note,
-        created_at=submission.created_at,
-        updated_at=submission.updated_at,
-    )
+    return await build_submission_out(submission, session)
 
 
 @router.put("/tasks/{task_id}/status", response_model=TaskOut)

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -17,7 +17,7 @@ from models.submission import MediaItem, MediaType, ModerationStatus, Submission
 from models.task import CharacterTask, Task
 from schemas.submission import MediaItemOut, SubmissionCreate, SubmissionOut
 from services.submission import (
-    compute_submission_score_from_db,
+    build_submission_out,
     create_submission,
     edit_submission,
     flag_submission,
@@ -26,49 +26,6 @@ from services.submission import (
 )
 
 router = APIRouter()
-
-
-async def _build_submission_out(sub: Submission, session: AsyncSession) -> SubmissionOut:
-    score = await compute_submission_score_from_db(sub, session)
-    media_result = await session.execute(
-        select(MediaItem)
-        .where(MediaItem.submission_id == sub.id)
-        .order_by(MediaItem.display_order)
-    )
-    media = [MediaItemOut.model_validate(media_item) for media_item in media_result.scalars().all()]
-
-    character = await session.get(Character, sub.character_id)
-    character_display_name = character.display_name if character else ""
-
-    task = await session.get(Task, sub.task_id)
-    task_title = task.title if task else ""
-    task_point_value = task.point_value if task else 0
-
-    partner_display_name = None
-    if sub.partner_character_id:
-        partner = await session.get(Character, sub.partner_character_id)
-        partner_display_name = partner.display_name if partner else None
-
-    return SubmissionOut(
-        id=sub.id,
-        task_id=sub.task_id,
-        character_id=sub.character_id,
-        character_display_name=character_display_name,
-        task_title=task_title,
-        task_point_value=task_point_value,
-        title=sub.title,
-        body_text=sub.body_text,
-        moderation_status=sub.moderation_status.value,
-        is_withdrawn=sub.is_withdrawn,
-        admin_note=sub.admin_note,
-        collaboration_mode=sub.collaboration_mode.value,
-        partner_character_id=sub.partner_character_id,
-        partner_display_name=partner_display_name,
-        created_at=sub.created_at,
-        updated_at=sub.updated_at,
-        media=media,
-        score=score,
-    )
 
 
 @router.get("", response_model=list[SubmissionOut])
@@ -101,7 +58,7 @@ async def list_submissions(
     query = query.limit(limit).offset(offset)
     result = await session.execute(query)
     submissions = result.scalars().all()
-    return [await _build_submission_out(sub, session) for sub in submissions]
+    return [await build_submission_out(sub, session) for sub in submissions]
 
 
 @router.get("/{submission_id}", response_model=SubmissionOut)
@@ -109,7 +66,7 @@ async def get_submission(submission_id: int, session: AsyncSession = Depends(get
     sub = await session.get(Submission, submission_id)
     if sub is None or sub.moderation_status == ModerationStatus.hidden:
         raise HTTPException(status_code=404, detail="Submission not found.")
-    return await _build_submission_out(sub, session)
+    return await build_submission_out(sub, session)
 
 
 @router.post("", response_model=SubmissionOut, status_code=201)
@@ -122,7 +79,7 @@ async def create_submission_route(
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found.")
     sub = await create_submission(character, task, data, session)
-    return await _build_submission_out(sub, session)
+    return await build_submission_out(sub, session)
 
 
 @router.put("/{submission_id}", response_model=SubmissionOut)
@@ -138,7 +95,7 @@ async def edit_submission_route(
     if sub.character_id != character.id:
         raise HTTPException(status_code=403, detail="Cannot edit another character's submission.")
     sub = await edit_submission(sub, data, session)
-    return await _build_submission_out(sub, session)
+    return await build_submission_out(sub, session)
 
 
 @router.post("/{submission_id}/withdraw", response_model=SubmissionOut)
@@ -151,7 +108,7 @@ async def withdraw_submission_route(
     if sub is None or sub.moderation_status == ModerationStatus.hidden:
         raise HTTPException(status_code=404, detail="Submission not found.")
     sub = await withdraw_submission(sub, character, session)
-    return await _build_submission_out(sub, session)
+    return await build_submission_out(sub, session)
 
 
 @router.post("/{submission_id}/resubmit", response_model=SubmissionOut)
@@ -164,7 +121,7 @@ async def resubmit_submission_route(
     if sub is None or sub.moderation_status == ModerationStatus.hidden:
         raise HTTPException(status_code=404, detail="Submission not found.")
     sub = await resubmit_submission(sub, character, session)
-    return await _build_submission_out(sub, session)
+    return await build_submission_out(sub, session)
 
 
 @router.post("/{submission_id}/media", response_model=MediaItemOut, status_code=201)
@@ -266,4 +223,4 @@ async def flag_submission_route(
     if sub is None:
         raise HTTPException(status_code=404, detail="Submission not found.")
     sub = await flag_submission(sub, character, reason, session)
-    return await _build_submission_out(sub, session)
+    return await build_submission_out(sub, session)

--- a/backend/services/submission.py
+++ b/backend/services/submission.py
@@ -7,10 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.flag import Flag
-from models.submission import CollaborationMode, ModerationStatus, Submission
+from models.submission import CollaborationMode, MediaItem, ModerationStatus, Submission
 from models.task import CharacterTask, CharacterTaskStatus, Task
 from models.vote import Vote
-from schemas.submission import SubmissionCreate
+from schemas.submission import MediaItemOut, SubmissionCreate, SubmissionOut
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
 from services.scoring import compute_faction_multiplier, compute_submission_score
@@ -194,3 +194,49 @@ async def compute_submission_score_from_db(
     )
     total_stars = int(sum_result.scalar_one_or_none() or 0)
     return compute_submission_score(task.point_value, faction_multiplier, total_stars)
+
+
+async def build_submission_out(
+    submission: Submission, session: AsyncSession
+) -> SubmissionOut:
+    """Build a complete SubmissionOut with all joined fields (task, character, media, score)."""
+    score = await compute_submission_score_from_db(submission, session)
+    media_result = await session.execute(
+        select(MediaItem)
+        .where(MediaItem.submission_id == submission.id)
+        .order_by(MediaItem.display_order)
+    )
+    media = [MediaItemOut.model_validate(item) for item in media_result.scalars().all()]
+
+    character = await session.get(Character, submission.character_id)
+    character_display_name = character.display_name if character else ""
+
+    task = await session.get(Task, submission.task_id)
+    task_title = task.title if task else ""
+    task_point_value = task.point_value if task else 0
+
+    partner_display_name = None
+    if submission.partner_character_id:
+        partner = await session.get(Character, submission.partner_character_id)
+        partner_display_name = partner.display_name if partner else None
+
+    return SubmissionOut(
+        id=submission.id,
+        task_id=submission.task_id,
+        character_id=submission.character_id,
+        character_display_name=character_display_name,
+        task_title=task_title,
+        task_point_value=task_point_value,
+        title=submission.title,
+        body_text=submission.body_text,
+        moderation_status=submission.moderation_status.value,
+        is_withdrawn=submission.is_withdrawn,
+        admin_note=submission.admin_note,
+        collaboration_mode=submission.collaboration_mode.value,
+        partner_character_id=submission.partner_character_id,
+        partner_display_name=partner_display_name,
+        created_at=submission.created_at,
+        updated_at=submission.updated_at,
+        media=media,
+        score=score,
+    )

--- a/docs/BUILD_STATE.md
+++ b/docs/BUILD_STATE.md
@@ -62,11 +62,13 @@ This file is the source of truth for what has been built, what is in progress, a
 - `services/auth.py` — create_jwt, decode_jwt, get_current_account, create_or_get_account ✅ 2026-04-01
 - `services/character.py` — create_character (level gate), update_character, soft_delete_character, check_faction_graduation ✅ 2026-04-01
 - `services/task.py` — signup_for_task (cap + level gate), drop_task, propose_task ✅ 2026-04-01
-- `services/submission.py` — create_submission, edit_submission, flag_submission, compute_submission_score_from_db ✅ 2026-04-01
+- `services/submission.py` — create_submission, edit_submission, flag_submission, withdraw/resubmit, compute_submission_score_from_db, build_submission_out (shared helper) ✅ 2026-04-13
 - `services/vote.py` — cast_or_update_vote (budget deduction, anti-self-vote, update-is-free logic) ✅ 2026-04-01
-- `services/era.py` — apply_era_reset (driven by EraConfig flags) — reset logic unit-tested via test_era_reset.py; DB service deferred to Session 2
+- `services/era.py` — apply_era_reset (driven by EraConfig flags), get_current_era_row, get_or_create_stats ✅
 - `services/relationship_service.py` — create, block, list relationships with display_status computation ✅ 2026-04-13
 - `services/taunt_service.py` — generate_taunt, get_taunts_for_character ✅ 2026-04-13
+- `services/admin_service.py` — game_overview, list_accounts, get_account_detail, list_characters, moderate_submission, suspend_account, assign_or_revoke_role, create_faction, admin_create_character, set_character_stats, reactivate_task, update_task_status ✅ 2026-04-13
+- `services/character_stats.py` — recalculate_character_stats (era-aware scoring engine) ✅ 2026-04-13
 
 ### Backend — Layer 4: Routers ✅ 2026-04-02
 `backend/routers/` created. All 40 routes registered and importing cleanly.
@@ -81,7 +83,9 @@ This file is the source of truth for what has been built, what is in progress, a
 - `routers/game_config.py` — GET /game-config (era config, faction colors, level thresholds) ✅ 2026-04-13
 - `routers/meta_tasks.py` — GET /meta-tasks?task_id=X (applicable meta tasks per task) ✅ 2026-04-13
 - `routers/messages.py` — GET /messages, POST /messages, GET /messages/{id} ✅
-- `routers/admin.py` — task approval/retire, submission delete, character ban, admin task create ✅
+- `routers/admin.py` — full admin panel: overview stats, accounts/characters management, task approval/retire/reactivate, submission moderation (flagged list + moderate action), contact messages, CLI token, faction creation ✅ 2026-04-13
+- `routers/contact.py` — POST /contact (public contact form) ✅ 2026-04-13
+- `routers/factions.py` — GET /factions, PUT /factions/{slug} ✅ 2026-04-13
 - `routers/leaderboard.py` — GET /leaderboard ✅
 - `backend/dependencies.py` — shared get_current_character + require_admin deps ✅
 
@@ -89,8 +93,18 @@ This file is the source of truth for what has been built, what is in progress, a
 - `backend/main.py` — FastAPI app, CORS config, SessionMiddleware, router registration, static file mount for media ✅
 - Added `itsdangerous` and `python-multipart` to requirements.txt (required by SessionMiddleware and file upload) ✅
 
-### Backend — Database Migrations ✅ 2026-04-02
-- `backend/alembic/versions/a1b2c3d4e5f6_initial_schema.py` — Initial migration (all 17 tables + enums). Applied and verified drift-free via `alembic check`. ✅
+### Backend — Database Migrations ✅ 2026-04-13
+- `a1b2c3d4e5f6` — Initial schema (17 tables + 6 enums) ✅
+- `b2c3d4e5f6a7` — Add contact_messages table ✅
+- `c3d4e5f6a7b8` — Seed factions ✅
+- `d4e5f6a7b8c9` — Add is_hidden to faction ✅
+- `e5f6a7b8c9d0` — Star schema modernization (CharacterStats, status enums, non-nullable columns) ✅ idempotent
+- `f6a7b8c9d0e1` — Submission soft delete (is_deleted) ✅
+- `g7h8i9j0k1l2` — Backend gaps (relationship status redesign, collaboration_mode, taunt_message) ✅ idempotent
+- `h8i9j0k1l2m3` — Submission withdraw (is_withdrawn) ✅
+- `i9j0k1l2m3n4` — Admin moderation (ModerationStatus enum replaces is_flagged/is_deleted, admin_note, contact is_archived) ✅ checkfirst
+
+All migrations use `create_type=False` on `sa.Enum()` in `add_column`/`create_table` calls. Enum types created via explicit `op.execute("CREATE TYPE ...")` with idempotency guards.
 
 ### Backend — Tests ✅ (unit + integration scaffold) 2026-04-02
 `backend/tests/` created.

--- a/docs/spec/SPEC-api.md
+++ b/docs/spec/SPEC-api.md
@@ -1,86 +1,201 @@
 # World Zero — API Endpoints
 
+> Last synced with code: 2026-04-13
+
 ## 9. API Endpoints
 
-### Auth
+All routes return JSON. Auth routes set/clear httpOnly JWT cookies.
+Snake_case field names throughout. ISO 8601 timestamps.
+
+---
+
+### Auth (`/auth`)
 ```
 GET  /auth/google              → redirect to Google OAuth
-GET  /auth/google/callback     → exchange code, create/login account, return JWT
-GET  /auth/me                  → return current account + active character
-POST /auth/logout
+GET  /auth/google/callback     → exchange code, create/login account, set JWT cookie
+GET  /auth/me                  → CurrentUser { account_id, character?, is_admin }
+POST /auth/logout              → clear JWT cookie
+POST /auth/dev-login           → dev-only test login (disabled in production)
 ```
 
-### Characters
+### Characters (`/characters`)
 ```
-GET    /characters             → list/search all characters (public)
-GET    /characters/{id}        → public character profile
-POST   /characters             → create character (level-gated beyond first)
-PUT    /characters/{id}        → edit own character
-DELETE /characters/{id}        → soft-delete own character
-GET    /characters/{id}/submissions
-GET    /characters/{id}/relationships
-```
-
-### Tasks
-```
-GET    /tasks                  → paginated list (filter: status, level, faction, points, date)
-GET    /tasks/{id}             → task detail + submissions
-POST   /tasks                  → propose task (level 3+) or create active task (admin)
-PUT    /tasks/{id}             → edit (admin for active; proposer for pending)
-POST   /tasks/{id}/signup      → sign up for task
-DELETE /tasks/{id}/signup      → drop task
+GET    /characters                       → list/search (query: search, faction, limit, offset)
+GET    /characters/{id}                  → CharacterOut (public profile)
+POST   /characters                       → CharacterCreate → CharacterOut (level-gated beyond first)
+PUT    /characters/{id}                  → CharacterUpdate → CharacterOut (owner only)
+DELETE /characters/{id}                  → soft-delete (owner only)
+GET    /characters/{id}/submissions      → list[SubmissionOut] (query: limit, offset)
+GET    /characters/{id}/relationships    → list[RelationshipOut]
+POST   /characters/{id}/avatar           → multipart file upload → CharacterOut
 ```
 
-### Submissions (Praxis)
+### Tasks (`/tasks`)
 ```
-GET    /submissions            → feed (paginated; recent | top-rated)
-GET    /submissions/{id}       → submission detail
-POST   /submissions            → create submission
-PUT    /submissions/{id}       → edit own submission
-POST   /submissions/{id}/media → upload media file(s)
-POST   /submissions/{id}/flag  → flag (level 4+)
-GET    /submissions/{id}/collaborators
-POST   /submissions/{id}/collaborators → add collaborator
-```
-
-### Votes
-```
-POST /submissions/{id}/vote    → cast or update vote
-GET  /submissions/{id}/votes   → vote summary
+GET    /tasks                  → list (query: status, level, faction, min_points, max_points, exclude_character_id, limit, offset)
+GET    /tasks/my-tasks         → list[CharacterTaskOut] (query: status) — auth required
+GET    /tasks/{id}             → TaskOut
+GET    /tasks/{id}/signups     → list[TaskSignupOut]
+POST   /tasks                  → TaskCreate → TaskOut (level 3+ or admin)
+PUT    /tasks/{id}             → TaskCreate → TaskOut (proposer or admin)
+POST   /tasks/{id}/signup      → CharacterTaskOut — auth required
+DELETE /tasks/{id}/signup      → drop task — auth required
 ```
 
-### Relationships
+### Submissions (`/submissions`)
 ```
-POST   /relationships          → send friend or foe request
-PUT    /relationships/{id}     → accept / decline
-DELETE /relationships/{id}     → remove
-```
-
-### Messages
-```
-GET  /messages                 → inbox
-POST /messages                 → send DM
-GET  /messages/{id}            → read message (marks read)
-```
-
-### Admin
-```
-GET    /admin/tasks/pending         → pending task queue
-PUT    /admin/tasks/{id}/approve    → approve → active
-PUT    /admin/tasks/{id}/retire     → retire active task
-DELETE /admin/submissions/{id}      → delete flagged submission
-POST   /admin/characters/{id}/ban   → ban/unban character
-POST   /admin/meta-tasks            → create meta task
-POST   /admin/eras                  → start Era reset (requires confirmation payload)
+GET    /submissions                        → list (query: sort, task_id, character_id, moderation_status, limit, offset)
+GET    /submissions/{id}                   → SubmissionOut
+POST   /submissions                        → SubmissionCreate → SubmissionOut — auth required
+PUT    /submissions/{id}                   → SubmissionCreate → SubmissionOut (owner only)
+POST   /submissions/{id}/withdraw          → SubmissionOut (owner only)
+POST   /submissions/{id}/resubmit          → SubmissionOut (owner only)
+POST   /submissions/{id}/media             → multipart file + display_order → MediaItemOut (owner only)
+DELETE /submissions/{id}/media/{media_id}  → delete media file (owner only)
+POST   /submissions/{id}/flag              → SubmissionOut (query: reason) — level 4+ required
 ```
 
-### Account (private)
+### Votes (no prefix — paths embed in `/submissions`)
 ```
-GET    /account                → current account info
-DELETE /account                → delete account + all characters
+POST /submissions/{id}/vote    → VoteIn { stars: 1-5 } → VoteOut — auth required
+GET  /submissions/{id}/votes   → VoteSummary { total_votes, average_stars, total_score }
+GET  /submissions/{id}/voters  → list[VoterDetail]
 ```
 
-### Leaderboard
+### Relationships (`/relationships`)
 ```
-GET /leaderboard               → top characters by score, paginated
+GET    /relationships          → list[RelationshipListItem] (query: type, status) — auth required
+POST   /relationships          → { to_character_id, type } → RelationshipOut — auth required
+PUT    /relationships/{id}     → block relationship → RelationshipOut
+DELETE /relationships/{id}     → remove relationship (declaring party only)
+```
+*Relationships are instant declarations (no pending state). Status: active | blocked.*
+
+### Messages (`/messages`)
+```
+GET  /messages       → list[MessageOut] — auth required
+POST /messages       → MessageCreate { to_character_id, body } → MessageOut
+GET  /messages/{id}  → MessageOut (marks as read if recipient)
+```
+
+### Leaderboard (`/leaderboard`)
+```
+GET /leaderboard     → list[CharacterOut] (query: faction, limit, offset) — sorted by score DESC
+```
+
+### Factions (`/factions`)
+```
+GET /factions        → list[FactionOut] (visible factions only)
+PUT /factions/{slug} → FactionUpdate → FactionOut — admin only
+```
+
+### Game Config (`/game-config`)
+```
+GET /game-config     → GameConfigOut (era config, faction colors, level thresholds — static from game_config.py)
+```
+
+### Meta Tasks (`/meta-tasks`)
+```
+GET /meta-tasks      → list[MetaTaskOut] (query: task_id — required, filters by task's faction or generic)
+```
+
+### Contact (`/contact`)
+```
+POST /contact        → ContactMessageIn { name, email, message } → ContactMessageOut
+```
+
+### Health (`/health`)
+```
+GET /health          → { "status": "ok" }
+```
+
+---
+
+### Admin (`/admin`) — requires admin role
+
+#### Dashboard
+```
+GET /admin/overview                   → OverviewStats { accounts, characters, active_tasks, submissions, votes, flagged_submissions, suspended_accounts }
+```
+
+#### Accounts & Characters
+```
+GET    /admin/accounts                → list[AccountSummary] (query: email filter)
+GET    /admin/accounts/{id}           → AccountDetail (with characters list)
+POST   /admin/accounts/{id}/suspend   → SuspendAction { suspended: bool }
+POST   /admin/accounts/{id}/role      → RoleAction { role, action: grant|revoke }
+GET    /admin/characters              → list[CharacterSummary] (query: faction, status)
+POST   /admin/characters              → AdminCharacterCreate → new character for any account
+POST   /admin/characters/{id}/ban     → BanAction { banned: bool }
+PATCH  /admin/characters/{id}/stats   → CharacterStatsPatch → CharacterStatsOut
+POST   /admin/characters/backfill-stats → recalculate all character stats → { recalculated: int }
+```
+
+#### Tasks
+```
+GET  /admin/tasks/pending          → list[PendingTaskOut] (with created_by_name)
+PUT  /admin/tasks/{id}/approve     → TaskOut (pending → active)
+PUT  /admin/tasks/{id}/retire      → TaskOut (active → retired)
+PUT  /admin/tasks/{id}/status      → TaskStatusAction → TaskOut
+POST /admin/tasks                  → TaskCreate → TaskOut (admin can create active tasks directly)
+POST /admin/tasks/{id}/reactivate  → TaskOut (retired → active)
+```
+
+#### Submissions & Moderation
+```
+GET    /admin/submissions/flagged        → list[SubmissionOut] (full data with media, score, task info)
+PATCH  /admin/submissions/{id}/moderate  → ModerationAction { status, admin_note } → SubmissionOut
+DELETE /admin/submissions/{id}           → hard delete submission
+```
+
+#### Contact Messages
+```
+GET   /admin/messages               → list[ContactMessageOut] (query: archived)
+PATCH /admin/messages/{id}/archive  → ContactMessageOut
+```
+
+#### Factions
+```
+POST /admin/factions               → FactionCreate → FactionOut
+```
+
+#### CLI Token
+```
+POST /admin/cli-token              → CliTokenResponse (header: X-Admin-Cli-Secret)
+```
+
+---
+
+## Key Response Schemas
+
+### CharacterOut
+```
+id, username, display_name, bio, avatar_url, location,
+level, score, all_time_score,  ← from CharacterStats join
+faction_slug, status, created_at
+```
+
+### SubmissionOut
+```
+id, task_id, character_id, character_display_name, task_title, task_point_value,
+title, body_text, moderation_status, is_withdrawn, admin_note,
+collaboration_mode, partner_character_id, partner_display_name,
+created_at, updated_at, media: list[MediaItemOut], score
+```
+
+### TaskOut
+```
+id, title, description, point_value, level_required, status,
+created_by, primary_faction_slug, is_task_vision_eligible, created_at
+```
+
+### VoteSummary
+```
+submission_id, total_votes, average_stars, total_score
+```
+
+### RelationshipListItem (GET /relationships response)
+```
+id, from_character_id, to_character_id, type, status, created_at,
+to_display_name, to_avatar_url, to_faction_slug, reverse_type, display_status
 ```

--- a/docs/spec/SPEC-frontend.md
+++ b/docs/spec/SPEC-frontend.md
@@ -1,5 +1,7 @@
 # World Zero — Frontend Pages
 
+> Last synced with code: 2026-04-13
+
 ## 10. Frontend Pages
 
 ### Navigation — Top
@@ -7,33 +9,74 @@
 2. Updates (`/updates`) — Recent activity, friend/foe feed, votes on your submissions
 3. Tasks (`/tasks`) — Browse, filter, sign up
 4. Groups (`/groups`) — Faction pages
-5. Players (`/players`) — Character directory
+5. Players (`/leaderboard`) — Leaderboard
 6. Praxis (`/submissions`) — Global submission feed
 7. Login / Profile (state-dependent)
 
 ### Navigation — Bottom
 About, Contact, Disclaimer, Attributions, Donate
 
-### Pages (MVP)
+---
+
+### Pages
 
 **Home (`/`)** — Activity feed when logged in. About content when logged out.
 
-**Task Feed (`/tasks`)** — Card grid. Filters: status, date, faction, level, points, completions, rating.
+**Tasks (`/tasks`)** — Card grid with faction-specific card archetypes (sticky note, field journal, collage, etc.). Filters: status, faction, level, points. Each faction slug maps to a unique card component (TaskCardUA, TaskCardAnalog, TaskCardGestalt, TaskCardSNIDE, TaskCardJourneymen, TaskCardSingularity, TaskCardUAMasters). Uses `flex-wrap` layout, not CSS grid.
 
-**Task Detail (`/tasks/:id`)** — Full description, praxis sorted by score, "Submit Proof" CTA.
+**Task Detail (`/tasks/:id`)** — Full description, submissions sorted by score, "Submit Proof" CTA, signup/drop controls.
 
-**Task Edit/Add** — Rich text editor with preview.
+**Submit Proof (`/tasks/:id/submit`)** — Auth-gated. Title, rich body, media upload, collaboration mode selector, partner picker for collab/duel.
 
-**Submission Detail (`/submissions/:id`)** — Full proof post, media gallery, star rating widget, collaborators, flag button (level 4+).
+**Edit Submission (`/submissions/:id/edit`)** — Edit existing submission. Media management (upload/delete/reorder).
 
-**Submit Proof (`/tasks/:id/submit`)** — Auth-gated. Title, rich body, media upload, preview.
+**Submissions (`/submissions`)** — Grid of all visible submissions. Cards show title, author, score, media preview.
 
-**Character Profile (`/characters/:id`)** — Avatar, display name, bio, level, faction, score, all-time score, submission grid, relationship controls.
+**Submission Detail (`/submissions/:id`)** — Full proof post, media gallery, star rating widget (1-5 stars), vote summary (total votes, average, total score), withdraw/resubmit controls (owner), flag button (level 4+). Moderation status badges for flagged/hidden/failed.
 
-**Leaderboard (`/leaderboard`)** — Ranked by score, paginated.
+**Character Profile (`/characters/:id`)** — Avatar, display name, bio, level (with progress bar), faction, score, all-time score, submission grid, relationship controls (friend/foe/block). Level progress bar uses hardcoded thresholds: `[0, 10, 70, 170, 330, 610, 1090, 1840, 3040]`.
 
-**Groups (`/groups`)** — Faction list before joining; own faction featured after.
+**Create Character (`/characters/create`)** — Auth-gated. Username, display name, bio, avatar, location fields.
 
-**Updates (`/updates`)** — Reverse chronological activity. Foe-specific taunts included (catch up / watch your back).
+**Edit Character (`/characters/:id/edit`)** — Edit existing character (owner only).
 
-**Admin (`/admin`)** — Task approval queue, flagged submissions, character management, meta task creation, Era reset with confirmation dialog.
+**Propose Task (`/tasks/propose`)** — Level 3+ can propose tasks. Title, description, point value, level requirement, faction selector.
+
+**Leaderboard (`/leaderboard`)** — Ranked by era score or all-time score, with faction filter. Shows avatar, display name, level, score, faction badge.
+
+**Groups / Factions (`/groups`, `/factions`)** — Faction list. Own faction featured after joining.
+
+**Updates (`/updates`)** — Reverse chronological activity feed. Includes foe taunts.
+
+**About (`/about`)** — Static about page.
+
+**Contact (`/contact`)** — Public contact form (name, email, message). No auth required.
+
+**Disclaimer (`/disclaimer`)** — Static legal content.
+
+**Attributions (`/attributions`)** — Credits and attributions.
+
+**Donate (`/donate`)** — Donation info.
+
+---
+
+### Admin (`/admin`) — tabbed interface, requires admin role
+
+**Overview Tab** — Dashboard counters: accounts, characters, active tasks, submissions, votes, flagged count, suspended count.
+
+**Tasks Tab** — Pending task approval queue + all tasks with inline status controls (approve, retire, reactivate). Admin can create tasks directly as active.
+
+**Moderation Tab** — Flagged submissions with full details (media, score, task info). Inline moderation actions (approve → visible, hide, fail with admin note). Contact messages with archive toggle.
+
+**Accounts Tab** — Account list with email filter. Expand to see characters. Suspend/unsuspend accounts, ban/unban characters, grant/revoke roles.
+
+---
+
+### Key Frontend Assumptions
+
+- **Level thresholds** hardcoded in CharacterProfile.tsx — must match `game_config.py`
+- **Faction slugs** map to specific card components and colors — unknown slugs fall back to UA
+- **Enum values** checked by exact string match (case-sensitive): status, type, moderation_status
+- **Media paths** resolved through `mediaUrl()` utility before display
+- **No pagination** currently — all list endpoints return full results
+- **Dark mode** via `data-theme="dark"` on root element with per-component variants


### PR DESCRIPTION
## Summary
- **Deploy fix**: Added `create_type=False` to 3 `sa.Enum()` calls inside `op.add_column()` in migration `e5f6a7b8c9d0`. This was the actual root cause — SQLAlchemy's `visit_enum` was issuing `CREATE TYPE` for enums already created by `op.execute()` earlier in the same migration.
- **Bug fix**: Admin `/submissions/flagged` and `/submissions/{id}/moderate` now return complete `SubmissionOut` with media, score, and task details (was returning incomplete data)
- **Docs**: Rewrote `SPEC-api.md` (48+ routes across 13 routers), `SPEC-frontend.md` (21 pages), and `BUILD_STATE.md` to match actual codebase

## Root cause analysis
Three layers of the same bug:
1. PR #55: Model `Enum()` without `create_type=False` — fixed
2. PR #56: Migration `DO $$` blocks not working with asyncpg — fixed with idempotency guards
3. **This PR**: Migration `op.add_column()` with `sa.Enum()` defaulting to `create_type=True` — the actual trigger for `visit_enum` → `CREATE TYPE`

## Test plan
- [x] All models, services, and migrations compile
- [x] All `sa.Enum()` in migration `add_column` calls have `create_type=False`
- [ ] Render deployment succeeds
- [ ] Admin flagged submissions returns full data

🤖 Generated with [Claude Code](https://claude.com/claude-code)