### PR TITLE
Fix: force create_type=False on all metadata enums in env.py

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -17,6 +17,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from models.base import Base
 import models  # noqa: F401 - registers all mapped classes with Base.metadata
 
+# Belt-and-suspenders: force every enum in metadata to create_type=False.
+# Migrations own all CREATE TYPE statements; the metadata must never emit them.
+# This prevents SQLAlchemy's visit_enum from issuing CREATE TYPE during
+# migration runs, even if a model Enum() somehow defaults to create_type=True.
+for _table in Base.metadata.tables.values():
+    for _col in _table.columns:
+        if hasattr(_col.type, "create_type"):
+            _col.type.create_type = False
+
 config = context.config
 
 if config.config_file_name is not None:


### PR DESCRIPTION
## Summary
Defense-in-depth fix for the persistent `taunttriggertype already exists` deploy error.

After importing models in `alembic/env.py`, this iterates all enum columns in `Base.metadata` and forces `create_type=False`. This ensures SQLAlchemy's `visit_enum` can **never** issue `CREATE TYPE` during migration runs, regardless of any edge case in how metadata processes enum types.

All model `Enum()` calls already have `create_type=False`, but SQLAlchemy's internal DDL visitor (`visit_enum` in `named_types.py`) may still fire from metadata registration. This catches that.

## Test plan
- [x] Safety net verified: all metadata enums confirmed `create_type=False` after processing
- [ ] Render deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)