### PR TITLE
Fix: remove ::factionstatus cast incompatible with asyncpg

### DIFF
--- a/backend/alembic/versions/0001_squashed_initial.py
+++ b/backend/alembic/versions/0001_squashed_initial.py
@@ -306,7 +306,7 @@ def upgrade() -> None:
         conn.execute(
             sa.text(
                 "INSERT INTO faction (slug, name, description, status) "
-                "VALUES (:slug, :name, :description, :status::factionstatus) "
+                "VALUES (:slug, :name, :description, :status) "
                 "ON CONFLICT (slug) DO NOTHING"
             ),
             {"slug": slug, "name": name, "description": description, "status": status},


### PR DESCRIPTION
## Summary
- Remove `::factionstatus` explicit cast from faction seed INSERT
- asyncpg's `$1/$2` parameter style conflicts with `::` cast syntax
- PostgreSQL infers the enum type from the column definition, so the cast was unnecessary

## Test plan
- [ ] Wipe Render DB and redeploy
- [ ] Verify factions seeded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)