### PR TITLE
Add faction system with granular modifiers, defection, and invitations

### DIFF
--- a/backend/alembic/versions/0002_add_faction_defection_invitation_doubler.py
+++ b/backend/alembic/versions/0002_add_faction_defection_invitation_doubler.py
@@ -1,0 +1,80 @@
+"""Add faction defection history, invitation letter, and analog double dipper tables.
+
+Revision ID: 0002_faction_models
+Revises: 0001_squashed
+Create Date: 2026-04-14 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002_faction_models"
+down_revision: Union[str, None] = "0001_squashed"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "faction_defection_history",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("character_id", sa.Integer(), nullable=False),
+        sa.Column("faction_slug", sa.String(), nullable=False),
+        sa.Column("era_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "defected_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["character_id"], ["character.id"]),
+        sa.ForeignKeyConstraint(["faction_slug"], ["faction.slug"]),
+        sa.ForeignKeyConstraint(["era_id"], ["era.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("character_id", "faction_slug", "era_id"),
+    )
+
+    op.create_table(
+        "invitation_letter",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("character_id", sa.Integer(), nullable=False),
+        sa.Column("faction_slug", sa.String(), nullable=False),
+        sa.Column("era_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "delivered_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["character_id"], ["character.id"]),
+        sa.ForeignKeyConstraint(["faction_slug"], ["faction.slug"]),
+        sa.ForeignKeyConstraint(["era_id"], ["era.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("character_id", "faction_slug", "era_id"),
+    )
+
+    op.create_table(
+        "analog_double_dipper",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("character_id", sa.Integer(), nullable=False),
+        sa.Column("level_tier", sa.Integer(), nullable=False),
+        sa.Column("task_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["character_id"], ["character.id"]),
+        sa.ForeignKeyConstraint(["task_id"], ["task.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("character_id", "level_tier"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("analog_double_dipper")
+    op.drop_table("invitation_letter")
+    op.drop_table("faction_defection_history")

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -15,11 +15,14 @@ class FactionConfig:
     name: str
     description: str
     color: str                       # hex color for UI display (e.g. "#6b6a7a")
-    point_multiplier: float          # applied to all task earnings
-    duel_bonus_multiplier: float     # extra % on duel wins (0.0 if not applicable)
     is_selectable: bool              # can players choose this faction at level 3?
-    own_faction_multiplier: float    # some factions get a bonus on in-faction tasks
-    other_faction_multiplier: float  # and a penalty on out-of-faction tasks
+    can_always_rejoin: bool          # True for UA Masters and Albescent
+    own_task_modifier: float         # solo own-faction task multiplier
+    other_task_modifier: float       # solo other-faction task multiplier
+    collab_own_modifier: float       # collaborative own-faction task multiplier
+    collab_other_modifier: float     # collaborative other-faction task multiplier
+    duel_win_modifier: float         # duel win multiplier (applied to base points)
+    duel_loss_modifier: float        # duel loss multiplier (applied to base points)
 
 
 @dataclass(frozen=True)
@@ -59,110 +62,140 @@ ERA_1_FACTIONS = {
         name="UA",
         description="The default starting faction. Full points on all tasks. Must leave at level 3.",
         color="#6b6a7a",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=False,          # assigned automatically; not a choosable destination
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
     "ua_masters": FactionConfig(
         slug="ua_masters",
         name="UA Masters",
         description="Veterans who aged out of UA. Can sign up for any task at reduced points.",
         color="#555555",
-        point_multiplier=0.8,
-        duel_bonus_multiplier=0.0,
         is_selectable=True,
-        own_faction_multiplier=0.8,
-        other_faction_multiplier=0.8,
+        can_always_rejoin=True,       # can always be rejoined after defecting
+        own_task_modifier=0.8,
+        other_task_modifier=0.8,
+        collab_own_modifier=0.8,
+        collab_other_modifier=0.8,
+        duel_win_modifier=0.8,
+        duel_loss_modifier=0.8,
     ),
     "snide": FactionConfig(
         slug="snide",
         name="S.N.I.D.E.",
         description="Specialists in one-on-one competition. Bonus points for winning duels.",
         color="#8a6a20",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.1,    # +10% on duel wins
         is_selectable=True,
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=0.7,
+        collab_own_modifier=1.0,
+        collab_other_modifier=0.7,
+        duel_win_modifier=1.5,        # duel win: 150% of base
+        duel_loss_modifier=0.5,       # duel loss: 50% of base
     ),
     "gestalt": FactionConfig(
         slug="gestalt",
         name="Gestalt",
         description="Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
         color="#14532d",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=True,
-        own_faction_multiplier=1.1,   # +10% on own-faction tasks
-        other_faction_multiplier=0.7, # -30% on other-faction tasks
+        can_always_rejoin=False,
+        own_task_modifier=1.1,        # +10% on solo own-faction
+        other_task_modifier=0.7,      # -30% on solo other-faction
+        collab_own_modifier=1.1,      # +10% on collab own-faction
+        collab_other_modifier=0.9,    # -10% on collab other-faction (less penalty)
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
     "journeymen": FactionConfig(
         slug="journeymen",
         name="Journeymen",
         description="Explorers with access to select retired tasks (Task Vision ability).",
         color="#c49a3a",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=True,
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=0.7,
+        collab_own_modifier=1.0,
+        collab_other_modifier=0.7,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
     "analog": FactionConfig(
         slug="analog",
         name="Analog",
         description="Depth over breadth. Can repeat one task per level for points (Double Dipper).",
         color="#15803d",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=True,
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=0.7,
+        collab_own_modifier=1.0,
+        collab_other_modifier=0.7,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
     "singularity": FactionConfig(
         slug="singularity",
         name="Singularity",
         description="TBD",
         color="#7c3aed",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=True,
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
     "albescent": FactionConfig(
         slug="albescent",
         name="/Albescent",
         description="Full points and any meta tasks from any group. Unlock-only.",
         color="#6b6a7a",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=False,          # only available as additional character unlock
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=True,       # can always be rejoined after defecting
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
     "aged_out": FactionConfig(
         slug="aged_out",
         name="AgedOutOfUA",
         description="Placeholder faction for characters who hit level 3 while offline.",
         color="#6b6a7a",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=False,
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
     "na": FactionConfig(
         slug="na",
         name="None",
         description="Sentinel value for tasks with no specific faction affiliation.",
         color="#a9a9a9",
-        point_multiplier=1.0,
-        duel_bonus_multiplier=0.0,
         is_selectable=False,
-        own_faction_multiplier=1.0,
-        other_faction_multiplier=1.0,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
     ),
 }
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -14,6 +14,9 @@ from models.message import Message
 from models.meta_task import MetaTask, SubmissionMetaTask
 from models.contact import ContactMessage
 from models.taunt_message import TauntMessage
+from models.faction_defection_history import FactionDefectionHistory
+from models.invitation_letter import InvitationLetter
+from models.analog_double_dipper import AnalogDoubleDipper
 
 __all__ = [
     "Faction",
@@ -37,4 +40,7 @@ __all__ = [
     "SubmissionMetaTask",
     "ContactMessage",
     "TauntMessage",
+    "FactionDefectionHistory",
+    "InvitationLetter",
+    "AnalogDoubleDipper",
 ]

--- a/backend/models/analog_double_dipper.py
+++ b/backend/models/analog_double_dipper.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+
+class AnalogDoubleDipper(Base):
+    """One row per level tier for Analog faction players.
+
+    The Double Dipper ability lets an Analog player designate one task per level
+    tier as their repeatable task. They may complete it a second time for full
+    points with a brand new praxis. The designation is locked once chosen and
+    cannot be changed.
+    """
+
+    __tablename__ = "analog_double_dipper"
+    __table_args__ = (
+        UniqueConstraint("character_id", "level_tier"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    character_id: Mapped[int] = mapped_column(
+        ForeignKey("character.id"), nullable=False
+    )
+    level_tier: Mapped[int] = mapped_column(Integer, nullable=False)
+    task_id: Mapped[int] = mapped_column(
+        ForeignKey("task.id"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/models/faction_defection_history.py
+++ b/backend/models/faction_defection_history.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+
+class FactionDefectionHistory(Base):
+    """Records each faction a character has left, scoped to an era.
+
+    Used to enforce the rule that players cannot rejoin factions they have
+    defected from (with exceptions for factions where can_always_rejoin is True).
+    All rows for an era are deleted on era reset.
+    """
+
+    __tablename__ = "faction_defection_history"
+    __table_args__ = (
+        UniqueConstraint("character_id", "faction_slug", "era_id"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    character_id: Mapped[int] = mapped_column(
+        ForeignKey("character.id"), nullable=False
+    )
+    faction_slug: Mapped[str] = mapped_column(
+        ForeignKey("faction.slug"), nullable=False
+    )
+    era_id: Mapped[int] = mapped_column(
+        ForeignKey("era.id"), nullable=False
+    )
+    defected_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/models/invitation_letter.py
+++ b/backend/models/invitation_letter.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+
+class InvitationLetter(Base):
+    """Tracks which faction invitation letters have been delivered to a character.
+
+    A letter is delivered when a qualifying character (level >= 3, score >= 20)
+    completes a task from a given faction. UA Masters sends invitations to all
+    qualifying characters regardless of task faction. Letters are era-scoped and
+    appear in the player's update feed.
+    """
+
+    __tablename__ = "invitation_letter"
+    __table_args__ = (
+        UniqueConstraint("character_id", "faction_slug", "era_id"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    character_id: Mapped[int] = mapped_column(
+        ForeignKey("character.id"), nullable=False
+    )
+    faction_slug: Mapped[str] = mapped_column(
+        ForeignKey("faction.slug"), nullable=False
+    )
+    era_id: Mapped[int] = mapped_column(
+        ForeignKey("era.id"), nullable=False
+    )
+    delivered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -457,6 +457,38 @@ async def retire_task(
     )
 
 
+class TaskVisionToggle(BaseModel):
+    is_task_vision_eligible: bool
+
+
+@router.patch("/tasks/{task_id}/task-vision", response_model=TaskOut)
+async def admin_toggle_task_vision(
+    task_id: int,
+    data: TaskVisionToggle,
+    _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+):
+    """Admin-only: toggle whether Journeymen/Albescent can access a retired task."""
+    task = await session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found.")
+    task.is_task_vision_eligible = data.is_task_vision_eligible
+    await session.commit()
+    await session.refresh(task)
+    return TaskOut(
+        id=task.id,
+        title=task.title,
+        description=task.description,
+        point_value=task.point_value,
+        level_required=task.level_required,
+        status=task.status.value,
+        created_by=task.created_by,
+        primary_faction_slug=task.primary_faction_slug,
+        is_task_vision_eligible=task.is_task_vision_eligible,
+        created_at=task.created_at,
+    )
+
+
 @router.delete("/submissions/{submission_id}", status_code=204)
 async def delete_submission(
     submission_id: int,

--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -3,10 +3,27 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import require_admin
+from dependencies import get_current_character, require_admin
+from game_config import CURRENT_ERA
 from models.account import Account
+from models.character import Character
 from models.faction import Faction, FactionStatus
-from schemas.faction import FactionOut, FactionUpdate
+from schemas.faction import (
+    DefectionHistoryOut,
+    FactionChoiceRequest,
+    FactionOut,
+    FactionPageOut,
+    FactionStatusOut,
+    FactionUpdate,
+    InvitationLetterOut,
+)
+from services.era import get_current_era_row
+from services.faction_service import (
+    defect_to_faction,
+    get_defection_history,
+    get_invitation_status,
+)
+from models.invitation_letter import InvitationLetter
 
 router = APIRouter()
 
@@ -36,3 +53,90 @@ async def update_faction(
     await session.commit()
     await session.refresh(faction)
     return FactionOut.model_validate(faction)
+
+
+@router.post("/choose", response_model=FactionOut)
+async def choose_faction(
+    data: FactionChoiceRequest,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Choose or defect to a new faction.
+
+    Works for initial faction selection (from aged_out) and later defections.
+    Players cannot rejoin factions they have left, except UA Masters and Albescent.
+    """
+    updated_character = await defect_to_faction(
+        character, data.faction_slug, session
+    )
+    faction = await session.get(Faction, updated_character.faction_slug)
+    return FactionOut.model_validate(faction)
+
+
+@router.get("/status", response_model=FactionPageOut)
+async def get_faction_status(
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Return faction page data: current faction and status of all factions."""
+    era_row = await get_current_era_row(session)
+    status_map = await get_invitation_status(
+        character.id, era_row.id, session
+    )
+    all_factions = [
+        FactionStatusOut(
+            slug=slug,
+            name=CURRENT_ERA.factions[slug].name if slug in CURRENT_ERA.factions else slug,
+            status=status,
+        )
+        for slug, status in status_map.items()
+    ]
+    return FactionPageOut(
+        current_faction_slug=character.faction_slug,
+        all_factions=all_factions,
+    )
+
+
+@router.get("/invitations", response_model=list[InvitationLetterOut])
+async def list_invitations(
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Return all invitation letters delivered to the current character."""
+    era_row = await get_current_era_row(session)
+    result = await session.execute(
+        select(InvitationLetter).where(
+            InvitationLetter.character_id == character.id,
+            InvitationLetter.era_id == era_row.id,
+        )
+    )
+    letters = result.scalars().all()
+    return [
+        InvitationLetterOut(
+            faction_slug=letter.faction_slug,
+            faction_name=(
+                CURRENT_ERA.factions[letter.faction_slug].name
+                if letter.faction_slug in CURRENT_ERA.factions
+                else letter.faction_slug
+            ),
+            delivered_at=letter.delivered_at,
+        )
+        for letter in letters
+    ]
+
+
+@router.get("/defection-history", response_model=list[DefectionHistoryOut])
+async def list_defection_history(
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Return defection history for the current character in the current era."""
+    era_row = await get_current_era_row(session)
+    records = await get_defection_history(character.id, era_row.id, session)
+    return [
+        DefectionHistoryOut(
+            faction_slug=record.faction_slug,
+            defected_at=record.defected_at,
+        )
+        for record in records
+    ]

--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -16,10 +16,13 @@ async def get_game_config() -> GameConfigOut:
             description=faction.description,
             color=faction.color,
             is_selectable=faction.is_selectable,
-            point_multiplier=faction.point_multiplier,
-            own_faction_multiplier=faction.own_faction_multiplier,
-            other_faction_multiplier=faction.other_faction_multiplier,
-            duel_bonus_multiplier=faction.duel_bonus_multiplier,
+            can_always_rejoin=faction.can_always_rejoin,
+            own_task_modifier=faction.own_task_modifier,
+            other_task_modifier=faction.other_task_modifier,
+            collab_own_modifier=faction.collab_own_modifier,
+            collab_other_modifier=faction.collab_other_modifier,
+            duel_win_modifier=faction.duel_win_modifier,
+            duel_loss_modifier=faction.duel_loss_modifier,
         )
         for faction in CURRENT_ERA.factions.values()
     ]

--- a/backend/schemas/faction.py
+++ b/backend/schemas/faction.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 
@@ -13,3 +15,33 @@ class FactionOut(BaseModel):
 class FactionUpdate(BaseModel):
     name: str = Field(min_length=1, max_length=100)
     description: str = Field(default="", max_length=2000)
+
+
+class FactionChoiceRequest(BaseModel):
+    faction_slug: str = Field(min_length=1, max_length=50)
+
+
+class FactionStatusOut(BaseModel):
+    slug: str
+    name: str
+    status: str  # member, invited, not_invited, defected, can_return
+
+
+class FactionPageOut(BaseModel):
+    current_faction_slug: str
+    all_factions: list[FactionStatusOut]
+
+
+class InvitationLetterOut(BaseModel):
+    faction_slug: str
+    faction_name: str
+    delivered_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class DefectionHistoryOut(BaseModel):
+    faction_slug: str
+    defected_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/schemas/game_config.py
+++ b/backend/schemas/game_config.py
@@ -7,10 +7,13 @@ class FactionConfigOut(BaseModel):
     description: str
     color: str
     is_selectable: bool
-    point_multiplier: float
-    own_faction_multiplier: float
-    other_faction_multiplier: float
-    duel_bonus_multiplier: float
+    can_always_rejoin: bool
+    own_task_modifier: float
+    other_task_modifier: float
+    collab_own_modifier: float
+    collab_other_modifier: float
+    duel_win_modifier: float
+    duel_loss_modifier: float
 
 
 class GameConfigOut(BaseModel):

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -43,7 +43,12 @@ async def recalculate_character_stats(
         if task is None:
             continue
         task_faction_slug = task.primary_faction_slug or "na"
-        faction_multiplier = compute_faction_multiplier(character_faction_slug, task_faction_slug, era)
+        faction_multiplier = compute_faction_multiplier(
+            character_faction_slug,
+            task_faction_slug,
+            era,
+            collaboration_mode=submission.collaboration_mode.value,
+        )
         sum_result = await session.execute(
             select(func.sum(Vote.stars)).where(Vote.submission_id == submission.id)
         )

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -6,6 +6,8 @@ from game_config import CURRENT_ERA, EraConfig
 from models.character_stats import CharacterStats
 from models.era import Era
 
+ERA_RESET_DEFAULT_FACTION: str = "na"
+
 
 async def get_current_era_row(session: AsyncSession) -> Era:
     """Return the Era DB row for CURRENT_ERA.
@@ -87,6 +89,11 @@ async def apply_era_reset(
         session.add(new_stats)
 
         if era.reset_faction:
-            character.faction_slug = "aged_out"
+            character.faction_slug = ERA_RESET_DEFAULT_FACTION
+
+    # Clear defection history so players can join any faction fresh
+    if era.reset_faction:
+        from services.faction_service import clear_defection_history_for_era
+        await clear_defection_history_for_era(new_era_row.id, session)
 
     await session.commit()

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -1,0 +1,310 @@
+"""Faction lifecycle: defection, invitation letters, and Analog Double Dipper."""
+
+from fastapi import HTTPException
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA, EraConfig
+from models.analog_double_dipper import AnalogDoubleDipper
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.faction_defection_history import FactionDefectionHistory
+from models.invitation_letter import InvitationLetter
+from models.task import Task
+from services.era import get_current_era_row, get_or_create_stats
+
+FACTION_GRADUATION_LEVEL: int = 3
+INVITATION_POINT_THRESHOLD: int = 20
+ANALOG_FACTION_SLUG: str = "analog"
+UA_MASTERS_FACTION_SLUG: str = "ua_masters"
+UA_FACTION_SLUG: str = "ua"
+UNAFFILIATED_FACTION_SLUG: str = "na"
+
+
+# ---------------------------------------------------------------------------
+# Defection
+# ---------------------------------------------------------------------------
+
+
+async def can_join_faction(
+    character_id: int,
+    target_slug: str,
+    era_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """Check whether a character is allowed to join the target faction.
+
+    Returns False if the character has previously defected from this faction
+    in the current era and the faction does not allow rejoining.
+    """
+    faction_config = era.factions.get(target_slug)
+    if faction_config is None:
+        return False
+    if faction_config.can_always_rejoin:
+        return True
+    result = await session.execute(
+        select(FactionDefectionHistory).where(
+            FactionDefectionHistory.character_id == character_id,
+            FactionDefectionHistory.faction_slug == target_slug,
+            FactionDefectionHistory.era_id == era_id,
+        )
+    )
+    return result.scalar_one_or_none() is None
+
+
+async def defect_to_faction(
+    character: Character,
+    target_slug: str,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Character:
+    """Move a character to a new faction, recording the defection.
+
+    Works for both initial faction choice (from aged_out) and later defections.
+    Raises 422 if the target is the current faction, 404 if the target doesn't
+    exist or isn't selectable, and 403 if the player previously left this faction
+    and it doesn't allow rejoining.
+    """
+    if character.faction_slug == target_slug:
+        raise HTTPException(
+            status_code=422,
+            detail="Already a member of this faction.",
+        )
+
+    faction_config = era.factions.get(target_slug)
+    if faction_config is None:
+        raise HTTPException(status_code=404, detail="Faction not found.")
+    if not faction_config.is_selectable and not faction_config.can_always_rejoin:
+        raise HTTPException(
+            status_code=422,
+            detail="This faction cannot be chosen directly.",
+        )
+
+    era_row = await get_current_era_row(session)
+
+    if not await can_join_faction(
+        character.id, target_slug, era_row.id, session, era
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Cannot rejoin a faction you have left.",
+        )
+
+    # Record defection from current faction (if it's a real faction, not na)
+    old_slug = character.faction_slug
+    if old_slug and old_slug != UNAFFILIATED_FACTION_SLUG:
+        defection = FactionDefectionHistory(
+            character_id=character.id,
+            faction_slug=old_slug,
+            era_id=era_row.id,
+        )
+        session.add(defection)
+
+    character.faction_slug = target_slug
+    await session.commit()
+    await session.refresh(character)
+    return character
+
+
+async def get_defection_history(
+    character_id: int,
+    era_id: int,
+    session: AsyncSession,
+) -> list[FactionDefectionHistory]:
+    """Return all defection records for a character in the given era."""
+    result = await session.execute(
+        select(FactionDefectionHistory).where(
+            FactionDefectionHistory.character_id == character_id,
+            FactionDefectionHistory.era_id == era_id,
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def clear_defection_history_for_era(
+    era_id: int,
+    session: AsyncSession,
+) -> None:
+    """Delete all defection records for a given era. Called during era reset."""
+    await session.execute(
+        delete(FactionDefectionHistory).where(
+            FactionDefectionHistory.era_id == era_id,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invitation Letters
+# ---------------------------------------------------------------------------
+
+
+async def check_and_deliver_invitations(
+    character: Character,
+    task: Task,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> list[InvitationLetter]:
+    """Deliver invitation letters if the character qualifies.
+
+    Trigger conditions (all must be true):
+    - Character level >= FACTION_GRADUATION_LEVEL (3)
+    - Character score >= INVITATION_POINT_THRESHOLD (20)
+
+    When conditions are met, delivers a letter for the task's faction. UA Masters
+    always sends an invitation to every qualifying player.
+    """
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, character.id, era_row.id)
+
+    if stats.level < FACTION_GRADUATION_LEVEL:
+        return []
+    if stats.score < INVITATION_POINT_THRESHOLD:
+        return []
+
+    task_faction_slug = task.primary_faction_slug or UNAFFILIATED_FACTION_SLUG
+    factions_to_invite: set[str] = set()
+
+    # Always invite to UA Masters if qualifying
+    if UA_MASTERS_FACTION_SLUG in era.factions:
+        factions_to_invite.add(UA_MASTERS_FACTION_SLUG)
+
+    # Invite to the task's faction if it's a real selectable faction
+    if task_faction_slug != UNAFFILIATED_FACTION_SLUG:
+        faction_config = era.factions.get(task_faction_slug)
+        if faction_config is not None and faction_config.is_selectable:
+            factions_to_invite.add(task_faction_slug)
+
+    delivered: list[InvitationLetter] = []
+    for slug in factions_to_invite:
+        existing = await session.execute(
+            select(InvitationLetter).where(
+                InvitationLetter.character_id == character.id,
+                InvitationLetter.faction_slug == slug,
+                InvitationLetter.era_id == era_row.id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            continue
+
+        letter = InvitationLetter(
+            character_id=character.id,
+            faction_slug=slug,
+            era_id=era_row.id,
+        )
+        session.add(letter)
+        delivered.append(letter)
+
+    if delivered:
+        await session.flush()
+
+    return delivered
+
+
+async def get_invitation_status(
+    character_id: int,
+    era_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> dict[str, str]:
+    """Return a dict mapping faction slug to relationship status.
+
+    Possible values: "member", "invited", "not_invited", "defected", "can_return".
+    """
+    character = await session.get(Character, character_id)
+    if character is None:
+        return {}
+
+    current_faction = character.faction_slug
+
+    defections = await get_defection_history(character_id, era_id, session)
+    defected_slugs = {defection.faction_slug for defection in defections}
+
+    invitation_result = await session.execute(
+        select(InvitationLetter).where(
+            InvitationLetter.character_id == character_id,
+            InvitationLetter.era_id == era_id,
+        )
+    )
+    invited_slugs = {
+        letter.faction_slug for letter in invitation_result.scalars().all()
+    }
+
+    status_map: dict[str, str] = {}
+    for slug, faction_config in era.factions.items():
+        if slug == current_faction:
+            status_map[slug] = "member"
+        elif slug in defected_slugs and faction_config.can_always_rejoin:
+            status_map[slug] = "can_return"
+        elif slug in defected_slugs:
+            status_map[slug] = "defected"
+        elif slug in invited_slugs:
+            status_map[slug] = "invited"
+        else:
+            status_map[slug] = "not_invited"
+
+    return status_map
+
+
+# ---------------------------------------------------------------------------
+# Analog Double Dipper
+# ---------------------------------------------------------------------------
+
+
+async def designate_double_dipper(
+    character: Character,
+    task: Task,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> AnalogDoubleDipper:
+    """Designate a task as the character's repeatable task for their current level.
+
+    Only available to Analog faction members. One designation per level tier,
+    locked on insert (cannot be changed).
+    """
+    if character.faction_slug != ANALOG_FACTION_SLUG:
+        raise HTTPException(
+            status_code=403,
+            detail="Only Analog faction members can use Double Dipper.",
+        )
+
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, character.id, era_row.id)
+    current_level = stats.level
+
+    existing = await session.execute(
+        select(AnalogDoubleDipper).where(
+            AnalogDoubleDipper.character_id == character.id,
+            AnalogDoubleDipper.level_tier == current_level,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="Already designated a repeated task for this level.",
+        )
+
+    designation = AnalogDoubleDipper(
+        character_id=character.id,
+        level_tier=current_level,
+        task_id=task.id,
+    )
+    session.add(designation)
+    await session.commit()
+    await session.refresh(designation)
+    return designation
+
+
+async def get_double_dipper_for_level(
+    character_id: int,
+    level_tier: int,
+    session: AsyncSession,
+) -> AnalogDoubleDipper | None:
+    """Return the Double Dipper designation for a character at a given level, or None."""
+    result = await session.execute(
+        select(AnalogDoubleDipper).where(
+            AnalogDoubleDipper.character_id == character_id,
+            AnalogDoubleDipper.level_tier == level_tier,
+        )
+    )
+    return result.scalar_one_or_none()

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -14,25 +14,53 @@ def compute_level(score: int, era: EraConfig = CURRENT_ERA) -> int:
     return 0
 
 
+COLLABORATION_MODE_SOLO = "solo"
+COLLABORATION_MODE_COLLAB = "collab"
+COLLABORATION_MODE_DUEL = "duel"
+UNAFFILIATED_FACTION_SLUG = "na"
+
+
 def compute_faction_multiplier(
     character_faction_slug: str,
     task_faction_slug: str,
     era: EraConfig,
+    collaboration_mode: str = COLLABORATION_MODE_SOLO,
+    is_duel_winner: bool = False,
 ) -> float:
     """Return the point multiplier for a character doing a given task.
 
-    Uses own_faction_multiplier when the task belongs to the character's faction,
-    other_faction_multiplier when it belongs to a different faction, and
-    point_multiplier for unaffiliated ("na") tasks.
+    Selects the appropriate modifier based on:
+    - Whether the task belongs to the character's own faction or another
+    - The collaboration mode (solo, collab, or duel)
+    - For duels, whether the character won or lost
+
+    Unaffiliated ("na") tasks are treated as own-faction (no penalty).
+    Votes are always added flat after the modifier is applied.
     """
     faction_config = era.factions.get(character_faction_slug)
     if faction_config is None:
         return 1.0
-    if task_faction_slug == "na" or not task_faction_slug:
-        return faction_config.point_multiplier
-    if task_faction_slug == character_faction_slug:
-        return faction_config.own_faction_multiplier
-    return faction_config.other_faction_multiplier
+
+    if collaboration_mode == COLLABORATION_MODE_DUEL:
+        if is_duel_winner:
+            return faction_config.duel_win_modifier
+        return faction_config.duel_loss_modifier
+
+    is_own_faction = (
+        task_faction_slug == character_faction_slug
+        or task_faction_slug == UNAFFILIATED_FACTION_SLUG
+        or not task_faction_slug
+    )
+
+    if collaboration_mode == COLLABORATION_MODE_COLLAB:
+        if is_own_faction:
+            return faction_config.collab_own_modifier
+        return faction_config.collab_other_modifier
+
+    # Solo (default)
+    if is_own_faction:
+        return faction_config.own_task_modifier
+    return faction_config.other_task_modifier
 
 
 def compute_submission_score(

--- a/backend/services/submission.py
+++ b/backend/services/submission.py
@@ -13,6 +13,7 @@ from models.vote import Vote
 from schemas.submission import MediaItemOut, SubmissionCreate, SubmissionOut
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
+from services.faction_service import check_and_deliver_invitations
 from services.scoring import compute_faction_multiplier, compute_submission_score
 
 
@@ -58,6 +59,7 @@ async def create_submission(
     await session.commit()
     await session.refresh(submission)
     await recalculate_character_stats(character.id, session)
+    await check_and_deliver_invitations(character, task, session)
     await session.commit()
     return submission
 
@@ -188,7 +190,12 @@ async def compute_submission_score_from_db(
     author = await session.get(Character, submission.character_id)
     character_faction_slug = author.faction_slug if author else "na"
     task_faction_slug = task.primary_faction_slug or "na"
-    faction_multiplier = compute_faction_multiplier(character_faction_slug, task_faction_slug, era)
+    faction_multiplier = compute_faction_multiplier(
+        character_faction_slug,
+        task_faction_slug,
+        era,
+        collaboration_mode=submission.collaboration_mode.value,
+    )
     sum_result = await session.execute(
         select(func.sum(Vote.stars)).where(Vote.submission_id == submission.id)
     )

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -9,6 +9,9 @@ from models.task import CharacterTask, CharacterTaskStatus, Task, TaskStatus
 from schemas.task import TaskCreate
 from services.era import get_current_era_row, get_or_create_stats
 
+JOURNEYMEN_FACTION_SLUG: str = "journeymen"
+ALBESCENT_FACTION_SLUG: str = "albescent"
+
 
 async def signup_for_task(
     character: Character,
@@ -24,6 +27,18 @@ async def signup_for_task(
             status_code=403,
             detail=f"Task requires level {task.level_required}; your character is level {stats.level}.",
         )
+
+    # Retired tasks are only accessible to Journeymen/Albescent with Task Vision
+    if task.status == TaskStatus.retired:
+        has_task_vision = character.faction_slug in (
+            JOURNEYMEN_FACTION_SLUG,
+            ALBESCENT_FACTION_SLUG,
+        )
+        if not (task.is_task_vision_eligible and has_task_vision):
+            raise HTTPException(
+                status_code=403,
+                detail="This task is retired and not available to your faction.",
+            )
 
     result = await session.execute(
         select(func.count()).select_from(CharacterTask).where(

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -32,18 +32,37 @@ def test_faction_slugs_match_keys():
         assert faction.slug == slug, f"Faction key '{slug}' doesn't match slug '{faction.slug}'"
 
 
-def test_all_factions_have_valid_point_multipliers():
+def test_all_factions_have_valid_task_modifiers():
     for slug, faction in ERA_1.factions.items():
-        assert 0 < faction.point_multiplier <= 2.0, (
-            f"Faction '{slug}' has out-of-range point_multiplier: {faction.point_multiplier}"
+        assert 0 < faction.own_task_modifier <= 2.0, (
+            f"Faction '{slug}' has out-of-range own_task_modifier: {faction.own_task_modifier}"
+        )
+        assert 0 < faction.other_task_modifier <= 2.0, (
+            f"Faction '{slug}' has out-of-range other_task_modifier: {faction.other_task_modifier}"
+        )
+        assert 0 < faction.collab_own_modifier <= 2.0, (
+            f"Faction '{slug}' has out-of-range collab_own_modifier: {faction.collab_own_modifier}"
+        )
+        assert 0 < faction.collab_other_modifier <= 2.0, (
+            f"Faction '{slug}' has out-of-range collab_other_modifier: {faction.collab_other_modifier}"
         )
 
 
-def test_all_factions_have_valid_duel_bonus():
+def test_all_factions_have_valid_duel_modifiers():
     for slug, faction in ERA_1.factions.items():
-        assert 0.0 <= faction.duel_bonus_multiplier <= 1.0, (
-            f"Faction '{slug}' has out-of-range duel_bonus_multiplier: {faction.duel_bonus_multiplier}"
+        assert 0.0 <= faction.duel_win_modifier <= 2.0, (
+            f"Faction '{slug}' has out-of-range duel_win_modifier: {faction.duel_win_modifier}"
         )
+        assert 0.0 <= faction.duel_loss_modifier <= 2.0, (
+            f"Faction '{slug}' has out-of-range duel_loss_modifier: {faction.duel_loss_modifier}"
+        )
+
+
+def test_can_always_rejoin_factions():
+    assert ERA_1.factions["ua_masters"].can_always_rejoin is True
+    assert ERA_1.factions["albescent"].can_always_rejoin is True
+    assert ERA_1.factions["snide"].can_always_rejoin is False
+    assert ERA_1.factions["gestalt"].can_always_rejoin is False
 
 
 def test_ua_faction_exists_and_not_selectable():

--- a/backend/tests/unit/test_era_reset.py
+++ b/backend/tests/unit/test_era_reset.py
@@ -23,7 +23,7 @@ def apply_era_reset(character: dict, new_era: EraConfig) -> dict:
     if new_era.reset_level:
         result["level"] = 0
     if new_era.reset_faction:
-        result["faction_slug"] = "aged_out"
+        result["faction_slug"] = "na"
     if new_era.reset_vote_budget:
         result["votes_available"] = new_era.vote_budget_base
     if new_era.reset_all_time_score:
@@ -78,7 +78,7 @@ def test_full_reset_zeroes_level(sample_character, full_reset_era):
 
 def test_full_reset_sets_faction_to_aged_out(sample_character, full_reset_era):
     result = apply_era_reset(sample_character, full_reset_era)
-    assert result["faction_slug"] == "aged_out"
+    assert result["faction_slug"] == "na"
 
 
 def test_full_reset_resets_vote_budget_to_base(sample_character, full_reset_era):
@@ -118,7 +118,7 @@ def test_era1_reset_clears_level(sample_character):
 def test_era1_reset_clears_faction(sample_character):
     assert ERA_1.reset_faction is True
     result = apply_era_reset(sample_character, ERA_1)
-    assert result["faction_slug"] == "aged_out"
+    assert result["faction_slug"] == "na"
 
 
 def test_era1_reset_resets_vote_budget(sample_character):

--- a/backend/tests/unit/test_faction_config.py
+++ b/backend/tests/unit/test_faction_config.py
@@ -1,0 +1,96 @@
+"""Unit tests for faction configuration values and modifier semantics."""
+
+from game_config import ERA_1
+
+
+def test_gestalt_solo_modifiers():
+    config = ERA_1.factions["gestalt"]
+    assert config.own_task_modifier == 1.1
+    assert config.other_task_modifier == 0.7
+
+
+def test_gestalt_collab_modifiers():
+    config = ERA_1.factions["gestalt"]
+    assert config.collab_own_modifier == 1.1
+    assert config.collab_other_modifier == 0.9
+
+
+def test_snide_duel_modifiers():
+    config = ERA_1.factions["snide"]
+    assert config.duel_win_modifier == 1.5
+    assert config.duel_loss_modifier == 0.5
+
+
+def test_snide_other_faction_penalty():
+    config = ERA_1.factions["snide"]
+    assert config.other_task_modifier == 0.7
+
+
+def test_ua_masters_uniform_reduced():
+    config = ERA_1.factions["ua_masters"]
+    assert config.own_task_modifier == 0.8
+    assert config.other_task_modifier == 0.8
+    assert config.collab_own_modifier == 0.8
+    assert config.collab_other_modifier == 0.8
+    assert config.duel_win_modifier == 0.8
+    assert config.duel_loss_modifier == 0.8
+
+
+def test_albescent_full_access():
+    config = ERA_1.factions["albescent"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 1.0
+    assert config.collab_own_modifier == 1.0
+    assert config.collab_other_modifier == 1.0
+    assert config.can_always_rejoin is True
+
+
+def test_ua_baseline():
+    config = ERA_1.factions["ua"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 1.0
+    assert config.is_selectable is False
+
+
+def test_journeymen_penalties():
+    config = ERA_1.factions["journeymen"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 0.7
+    assert config.collab_other_modifier == 0.7
+
+
+def test_analog_penalties():
+    config = ERA_1.factions["analog"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 0.7
+    assert config.collab_other_modifier == 0.7
+
+
+def test_singularity_defaults():
+    config = ERA_1.factions["singularity"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 1.0
+    assert config.is_selectable is True
+
+
+def test_na_sentinel():
+    config = ERA_1.factions["na"]
+    assert config.is_selectable is False
+    assert config.can_always_rejoin is False
+
+
+def test_selectable_factions_count():
+    selectable = [
+        slug for slug, config in ERA_1.factions.items()
+        if config.is_selectable
+    ]
+    # ua_masters, snide, gestalt, journeymen, analog, singularity = 6
+    assert len(selectable) == 6
+
+
+def test_can_always_rejoin_only_two():
+    rejoinable = [
+        slug for slug, config in ERA_1.factions.items()
+        if config.can_always_rejoin
+    ]
+    assert set(rejoinable) == {"ua_masters", "albescent"}

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -1,5 +1,13 @@
 from game_config import ERA_1
-from services.scoring import compute_faction_multiplier, compute_level, compute_submission_score, compute_vote_budget
+from services.scoring import (
+    COLLABORATION_MODE_COLLAB,
+    COLLABORATION_MODE_DUEL,
+    COLLABORATION_MODE_SOLO,
+    compute_faction_multiplier,
+    compute_level,
+    compute_submission_score,
+    compute_vote_budget,
+)
 
 
 def test_vote_budget_base():
@@ -51,17 +59,14 @@ def test_level_max():
 
 
 def test_submission_score_no_votes():
-    # Base points awarded on submission even with zero votes
     assert compute_submission_score(task_point_value=10, faction_multiplier=1.0, total_stars=0) == 10.0
 
 
 def test_submission_score_with_votes():
-    # 10 base + 3 stars from one vote
     assert compute_submission_score(task_point_value=10, faction_multiplier=1.0, total_stars=3) == 13.0
 
 
 def test_submission_score_multiple_votes():
-    # 20 base + 5+4 = 9 total stars from two votes
     assert compute_submission_score(task_point_value=20, faction_multiplier=1.0, total_stars=9) == 29.0
 
 
@@ -70,21 +75,169 @@ def test_submission_score_with_multiplier():
     assert compute_submission_score(task_point_value=10, faction_multiplier=0.8, total_stars=5) == 13.0
 
 
+# ---------------------------------------------------------------------------
+# Solo mode faction multiplier tests
+# ---------------------------------------------------------------------------
+
+
 def test_faction_multiplier_unaffiliated_task():
-    # "na" tasks use point_multiplier
-    assert compute_faction_multiplier("ua_masters", "na", ERA_1) == ERA_1.factions["ua_masters"].point_multiplier
+    # "na" tasks use own_task_modifier (treated as own-faction, no penalty)
+    result = compute_faction_multiplier("ua_masters", "na", ERA_1)
+    assert result == ERA_1.factions["ua_masters"].own_task_modifier
 
 
 def test_faction_multiplier_own_faction():
-    # gestalt doing a gestalt task gets own_faction_multiplier
-    assert compute_faction_multiplier("gestalt", "gestalt", ERA_1) == ERA_1.factions["gestalt"].own_faction_multiplier
+    result = compute_faction_multiplier("gestalt", "gestalt", ERA_1)
+    assert result == ERA_1.factions["gestalt"].own_task_modifier
+    assert result == 1.1
 
 
 def test_faction_multiplier_other_faction():
-    # gestalt doing a ua task gets other_faction_multiplier
-    assert compute_faction_multiplier("gestalt", "ua", ERA_1) == ERA_1.factions["gestalt"].other_faction_multiplier
+    result = compute_faction_multiplier("gestalt", "ua", ERA_1)
+    assert result == ERA_1.factions["gestalt"].other_task_modifier
+    assert result == 0.7
 
 
 def test_faction_multiplier_unknown_faction():
-    # Unknown faction slug falls back to 1.0
     assert compute_faction_multiplier("nonexistent", "ua", ERA_1) == 1.0
+
+
+def test_faction_multiplier_empty_task_faction():
+    result = compute_faction_multiplier("ua_masters", "", ERA_1)
+    assert result == ERA_1.factions["ua_masters"].own_task_modifier
+
+
+# ---------------------------------------------------------------------------
+# Collab mode faction multiplier tests
+# ---------------------------------------------------------------------------
+
+
+def test_collab_own_faction():
+    result = compute_faction_multiplier(
+        "gestalt", "gestalt", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_COLLAB,
+    )
+    assert result == ERA_1.factions["gestalt"].collab_own_modifier
+    assert result == 1.1
+
+
+def test_collab_other_faction():
+    result = compute_faction_multiplier(
+        "gestalt", "snide", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_COLLAB,
+    )
+    assert result == ERA_1.factions["gestalt"].collab_other_modifier
+    assert result == 0.9
+
+
+def test_collab_unaffiliated_task():
+    result = compute_faction_multiplier(
+        "gestalt", "na", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_COLLAB,
+    )
+    assert result == ERA_1.factions["gestalt"].collab_own_modifier
+
+
+# ---------------------------------------------------------------------------
+# Duel mode faction multiplier tests
+# ---------------------------------------------------------------------------
+
+
+def test_duel_win():
+    result = compute_faction_multiplier(
+        "snide", "ua", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_DUEL,
+        is_duel_winner=True,
+    )
+    assert result == ERA_1.factions["snide"].duel_win_modifier
+    assert result == 1.5
+
+
+def test_duel_loss():
+    result = compute_faction_multiplier(
+        "snide", "ua", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_DUEL,
+        is_duel_winner=False,
+    )
+    assert result == ERA_1.factions["snide"].duel_loss_modifier
+    assert result == 0.5
+
+
+def test_duel_non_snide_faction():
+    # Non-duel-specialist factions get 1.0 on both win and loss
+    result_win = compute_faction_multiplier(
+        "gestalt", "ua", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_DUEL,
+        is_duel_winner=True,
+    )
+    result_loss = compute_faction_multiplier(
+        "gestalt", "ua", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_DUEL,
+        is_duel_winner=False,
+    )
+    assert result_win == 1.0
+    assert result_loss == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Cross-faction collaboration examples from spec
+# ---------------------------------------------------------------------------
+
+
+def test_cross_faction_collab_example():
+    """Spec example: Gestalt + Journeymen collaborate on a Snide task."""
+    gestalt_mult = compute_faction_multiplier(
+        "gestalt", "snide", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_COLLAB,
+    )
+    journeymen_mult = compute_faction_multiplier(
+        "journeymen", "snide", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_COLLAB,
+    )
+    assert gestalt_mult == 0.9   # collab_other_modifier for gestalt
+    assert journeymen_mult == 0.7  # collab_other_modifier for journeymen
+
+
+def test_ua_masters_uniform_modifier():
+    """UA Masters gets 0.8 on everything."""
+    config = ERA_1.factions["ua_masters"]
+    assert config.own_task_modifier == 0.8
+    assert config.other_task_modifier == 0.8
+    assert config.collab_own_modifier == 0.8
+    assert config.collab_other_modifier == 0.8
+    assert config.duel_win_modifier == 0.8
+    assert config.duel_loss_modifier == 0.8
+
+
+def test_ua_full_points():
+    """UA gets 1.0 on everything."""
+    config = ERA_1.factions["ua"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 1.0
+    assert config.collab_own_modifier == 1.0
+    assert config.collab_other_modifier == 1.0
+
+
+def test_albescent_no_penalties():
+    """Albescent gets 1.0 on everything — no penalties."""
+    config = ERA_1.factions["albescent"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 1.0
+    assert config.collab_own_modifier == 1.0
+    assert config.collab_other_modifier == 1.0
+
+
+def test_journeymen_other_faction_penalty():
+    """Journeymen get 0.7 on other-faction tasks."""
+    config = ERA_1.factions["journeymen"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 0.7
+    assert config.collab_own_modifier == 1.0
+    assert config.collab_other_modifier == 0.7
+
+
+def test_analog_other_faction_penalty():
+    """Analog get 0.7 on other-faction tasks."""
+    config = ERA_1.factions["analog"]
+    assert config.own_task_modifier == 1.0
+    assert config.other_task_modifier == 0.7


### PR DESCRIPTION
## Summary
- Expand FactionConfig with 6 context-aware modifiers (solo/collab/duel x own/other faction), `can_always_rejoin` flag, and spec-accurate values for all 10 factions
- New models: FactionDefectionHistory, InvitationLetter, AnalogDoubleDipper + Alembic migration
- Faction service layer: defection rules, invitation delivery (hooked into submission creation), Double Dipper designation
- API routes: `POST /factions/choose`, `GET /factions/status`, `GET /factions/invitations`, `GET /factions/defection-history`, `PATCH /admin/tasks/{id}/task-vision`
- Retired task access gated to Journeymen/Albescent via `is_task_vision_eligible`
- Era reset fix: faction resets to `na` (not `aged_out`), defection history cleared

## Test plan
- [x] 91 unit tests passing (scoring modifiers, faction config, era reset, cross-faction collaboration examples)
- [ ] Integration tests with DB (requires running PostgreSQL)
- [ ] Run `alembic upgrade head` to verify migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)