### PR TITLE
Add unified activity feed and Updates page rebuild

### DIFF
--- a/backend/alembic/versions/0002_invite_status.py
+++ b/backend/alembic/versions/0002_invite_status.py
@@ -1,0 +1,48 @@
+"""Add invite_status to submission for collab/duel invite flow.
+
+Revision ID: 0002_invite_status
+Revises: 0001_squashed
+Create Date: 2026-04-14
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002_invite_status"
+down_revision: Union[str, None] = "0001_squashed"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create enum type with idempotency guard
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE invitestatus AS ENUM ('pending', 'accepted', 'declined');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+    """)
+
+    op.add_column(
+        "submission",
+        sa.Column(
+            "invite_status",
+            sa.Enum("pending", "accepted", "declined", name="invitestatus", create_type=False),
+            nullable=True,
+        ),
+    )
+
+    # Set existing collab/duel submissions to 'accepted' (grandfathered in)
+    op.execute("""
+        UPDATE submission
+        SET invite_status = 'accepted'
+        WHERE collaboration_mode IN ('collab', 'duel')
+          AND partner_character_id IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.drop_column("submission", "invite_status")
+    op.execute("DROP TYPE IF EXISTS invitestatus")

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from starlette.middleware.sessions import SessionMiddleware
 
 from config import settings
-from routers import admin, auth, characters, factions, game_config, leaderboard, messages, meta_tasks, relationships, submissions, tasks, votes
+from routers import activity_feed, admin, auth, characters, factions, game_config, leaderboard, messages, meta_tasks, relationships, submissions, tasks, taunts, votes
 from routers import contact
 
 logger = logging.getLogger(__name__)
@@ -88,6 +88,8 @@ app.include_router(factions.router, prefix="/factions", tags=["factions"])
 app.include_router(game_config.router, prefix="/game-config", tags=["game-config"])
 app.include_router(meta_tasks.router, prefix="/meta-tasks", tags=["meta-tasks"])
 app.include_router(contact.router, prefix="/contact", tags=["contact"])
+app.include_router(taunts.router, prefix="/taunts", tags=["taunts"])
+app.include_router(activity_feed.router, prefix="/activity-feed", tags=["activity-feed"])
 
 
 @app.get("/health")

--- a/backend/models/submission.py
+++ b/backend/models/submission.py
@@ -20,6 +20,12 @@ class CollaborationMode(enum.Enum):
     duel = "duel"
 
 
+class InviteStatus(enum.Enum):
+    pending = "pending"
+    accepted = "accepted"
+    declined = "declined"
+
+
 class ModerationStatus(enum.Enum):
     visible = "visible"
     flagged = "flagged"
@@ -52,6 +58,9 @@ class Submission(Base):
     )
     partner_character_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("character.id"), nullable=True
+    )
+    invite_status: Mapped[Optional[str]] = mapped_column(
+        Enum(InviteStatus, create_type=False), nullable=True
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()

--- a/backend/routers/activity_feed.py
+++ b/backend/routers/activity_feed.py
@@ -1,0 +1,40 @@
+"""Router for the unified activity feed."""
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db import get_db
+from dependencies import get_current_character
+from models.character import Character
+from schemas.activity_feed import ActivityFeedResponse
+from services.activity_feed import get_activity_feed
+
+VALID_FILTERS = {"all", "friends", "foes", "your_stuff", "global", "requests"}
+
+router = APIRouter()
+
+
+@router.get("", response_model=ActivityFeedResponse)
+async def activity_feed(
+    filter: Optional[str] = Query(None, alias="filter"),
+    before: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+) -> ActivityFeedResponse:
+    """Return a unified, paginated activity feed for the current character."""
+    feed_filter = filter if filter in VALID_FILTERS else "all"
+
+    before_cursor: Optional[datetime] = None
+    if before:
+        before_cursor = datetime.fromisoformat(before)
+
+    return await get_activity_feed(
+        character_id=character.id,
+        session=session,
+        feed_filter=feed_filter,
+        before_cursor=before_cursor,
+        limit=limit,
+    )

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -9,7 +9,7 @@ from PIL import Image
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 logger = logging.getLogger(__name__)
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
@@ -21,6 +21,7 @@ from models.character_stats import CharacterStats
 from models.relationship import Relationship
 from models.submission import MediaItem, Submission
 from models.task import Task
+from models.vote import Vote
 from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
 from schemas.relationship import RelationshipOut
 from schemas.submission import MediaItemOut, SubmissionOut
@@ -289,3 +290,19 @@ async def get_character_relationships(
     )
     relationships = result.scalars().all()
     return [RelationshipOut.model_validate(relationship) for relationship in relationships]
+
+
+@router.get("/{character_id}/stats/votes-received")
+async def get_votes_received_count(
+    character_id: int,
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, int]:
+    """Return the total number of votes received on all of a character's submissions."""
+    result = await session.execute(
+        select(func.count())
+        .select_from(Vote)
+        .join(Submission, Vote.submission_id == Submission.id)
+        .where(Submission.character_id == character_id)
+    )
+    count = result.scalar_one()
+    return {"character_id": character_id, "votes_received": count}

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -17,8 +17,10 @@ from models.submission import MediaItem, MediaType, ModerationStatus, Submission
 from models.task import CharacterTask, Task
 from schemas.submission import MediaItemOut, SubmissionCreate, SubmissionOut
 from services.submission import (
+    accept_invite,
     build_submission_out,
     create_submission,
+    decline_invite,
     edit_submission,
     flag_submission,
     resubmit_submission,
@@ -210,6 +212,26 @@ async def delete_media(
     await session.delete(media_item)
     await session.commit()
     return Response(status_code=204)
+
+
+@router.post("/{submission_id}/accept-invite", response_model=SubmissionOut)
+async def accept_invite_route(
+    submission_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    sub = await accept_invite(submission_id, character.id, session)
+    return await build_submission_out(sub, session)
+
+
+@router.post("/{submission_id}/decline-invite", response_model=SubmissionOut)
+async def decline_invite_route(
+    submission_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    sub = await decline_invite(submission_id, character.id, session)
+    return await build_submission_out(sub, session)
 
 
 @router.post("/{submission_id}/flag", response_model=SubmissionOut)

--- a/backend/routers/taunts.py
+++ b/backend/routers/taunts.py
@@ -1,0 +1,22 @@
+"""Router for foe taunt messages."""
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db import get_db
+from dependencies import get_current_character
+from models.character import Character
+from schemas.taunt_message import TauntMessageOut
+from services.taunt_service import get_taunts_for_character
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[TauntMessageOut])
+async def list_taunts(
+    limit: int = 20,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+) -> list[TauntMessageOut]:
+    """Return recent taunts received by the current character."""
+    taunts = await get_taunts_for_character(character.id, session, limit=limit)
+    return taunts

--- a/backend/schemas/activity_feed.py
+++ b/backend/schemas/activity_feed.py
@@ -1,0 +1,46 @@
+"""Schemas for the unified activity feed."""
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class ActivityFeedItem(BaseModel):
+    """A single item in the activity feed.
+
+    The ``type`` field discriminates the payload shape:
+    - vote_on_mine: someone voted on your submission
+    - friend_completion: a friend completed a task
+    - foe_taunt: a foe sent a taunt
+    - global_task: a new task was activated
+    - era_announcement: a new era started
+    - collab_invite: someone invited you to collaborate
+    - duel_challenge: someone challenged you to a duel
+    - friend_signup: a friend signed up for a task you're doing
+    """
+
+    type: str
+    timestamp: datetime
+    actor_display_name: Optional[str] = None
+    actor_faction_slug: Optional[str] = None
+    actor_avatar_url: Optional[str] = None
+    payload: dict[str, Any]
+
+
+class FeedCounts(BaseModel):
+    """Badge counts for each filter tab."""
+
+    all: int = 0
+    friends: int = 0
+    foes: int = 0
+    your_stuff: int = 0
+    global_count: int = 0
+    requests: int = 0
+
+
+class ActivityFeedResponse(BaseModel):
+    """Paginated activity feed with badge counts."""
+
+    items: list[ActivityFeedItem]
+    counts: FeedCounts
+    next_cursor: Optional[str] = None

--- a/backend/schemas/submission.py
+++ b/backend/schemas/submission.py
@@ -30,6 +30,7 @@ class SubmissionOut(BaseModel):
     collaboration_mode: str = "solo"
     partner_character_id: Optional[int] = None
     partner_display_name: Optional[str] = None
+    invite_status: Optional[str] = None
     created_at: datetime
     updated_at: datetime
     media: list[MediaItemOut] = []

--- a/backend/schemas/taunt_message.py
+++ b/backend/schemas/taunt_message.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -12,3 +13,7 @@ class TauntMessageOut(BaseModel):
     message: str
     trigger_type: str
     created_at: datetime
+    # Enriched display fields (joined from Character)
+    from_display_name: str = ""
+    from_faction_slug: str = ""
+    from_avatar_url: Optional[str] = None

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -1,0 +1,834 @@
+"""Service layer for the unified activity feed.
+
+Aggregates multiple activity sources into a single reverse-chronological
+timeline with cursor-based pagination.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.era import Era
+from models.faction_defection_history import FactionDefectionHistory
+from models.invitation_letter import InvitationLetter
+from models.relationship import Relationship, RelationshipStatus, RelationshipType
+from models.submission import CollaborationMode, InviteStatus, Submission
+from models.task import CharacterTask, CharacterTaskStatus, Task, TaskStatus
+from models.taunt_message import TauntMessage
+from models.vote import Vote
+from schemas.activity_feed import ActivityFeedItem, ActivityFeedResponse, FeedCounts
+from services.era import get_current_era_row
+
+FEED_ITEM_TYPE_VOTE_ON_MINE = "vote_on_mine"
+FEED_ITEM_TYPE_FRIEND_COMPLETION = "friend_completion"
+FEED_ITEM_TYPE_FOE_TAUNT = "foe_taunt"
+FEED_ITEM_TYPE_GLOBAL_TASK = "global_task"
+FEED_ITEM_TYPE_ERA_ANNOUNCEMENT = "era_announcement"
+FEED_ITEM_TYPE_COLLAB_INVITE = "collab_invite"
+FEED_ITEM_TYPE_DUEL_CHALLENGE = "duel_challenge"
+FEED_ITEM_TYPE_FRIEND_SIGNUP = "friend_signup"
+FEED_ITEM_TYPE_INVITATION_LETTER = "invitation_letter"
+FEED_ITEM_TYPE_FRIEND_DEFECTION = "friend_defection"
+
+# Which sub-queries each filter includes
+FILTER_QUERIES: dict[str, set[str]] = {
+    "all": {
+        FEED_ITEM_TYPE_VOTE_ON_MINE,
+        FEED_ITEM_TYPE_FRIEND_COMPLETION,
+        FEED_ITEM_TYPE_FOE_TAUNT,
+        FEED_ITEM_TYPE_GLOBAL_TASK,
+        FEED_ITEM_TYPE_ERA_ANNOUNCEMENT,
+        FEED_ITEM_TYPE_COLLAB_INVITE,
+        FEED_ITEM_TYPE_DUEL_CHALLENGE,
+        FEED_ITEM_TYPE_FRIEND_SIGNUP,
+        FEED_ITEM_TYPE_INVITATION_LETTER,
+        FEED_ITEM_TYPE_FRIEND_DEFECTION,
+    },
+    "friends": {
+        FEED_ITEM_TYPE_FRIEND_COMPLETION,
+        FEED_ITEM_TYPE_FRIEND_SIGNUP,
+        FEED_ITEM_TYPE_FRIEND_DEFECTION,
+    },
+    "foes": {FEED_ITEM_TYPE_FOE_TAUNT},
+    "your_stuff": {
+        FEED_ITEM_TYPE_VOTE_ON_MINE,
+        FEED_ITEM_TYPE_COLLAB_INVITE,
+        FEED_ITEM_TYPE_DUEL_CHALLENGE,
+        FEED_ITEM_TYPE_INVITATION_LETTER,
+    },
+    "global": {FEED_ITEM_TYPE_GLOBAL_TASK, FEED_ITEM_TYPE_ERA_ANNOUNCEMENT},
+    "requests": {FEED_ITEM_TYPE_COLLAB_INVITE, FEED_ITEM_TYPE_DUEL_CHALLENGE},
+}
+
+SUB_QUERY_LIMIT = 50
+
+
+async def _get_friend_ids(
+    character_id: int,
+    session: AsyncSession,
+) -> list[int]:
+    """Get IDs of characters the current character has declared as friends."""
+    result = await session.execute(
+        select(Relationship.to_character_id).where(
+            Relationship.from_character_id == character_id,
+            Relationship.type == RelationshipType.friend,
+            Relationship.status == RelationshipStatus.active,
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def _get_my_task_ids(
+    character_id: int,
+    session: AsyncSession,
+) -> list[int]:
+    """Get task IDs that the character is currently working on."""
+    result = await session.execute(
+        select(CharacterTask.task_id).where(
+            CharacterTask.character_id == character_id,
+            CharacterTask.status == CharacterTaskStatus.in_progress,
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def _fetch_votes_on_mine(
+    character_id: int,
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Votes cast on the current character's submissions."""
+    voter_char = Character.__table__.alias("voter_char")
+
+    query = (
+        select(
+            Vote.id,
+            Vote.stars,
+            Vote.created_at,
+            Vote.submission_id,
+            Submission.title.label("submission_title"),
+            Task.point_value.label("task_point_value"),
+            voter_char.c.display_name.label("voter_display_name"),
+            voter_char.c.faction_slug.label("voter_faction_slug"),
+            voter_char.c.avatar_url.label("voter_avatar_url"),
+        )
+        .join(Submission, Vote.submission_id == Submission.id)
+        .join(Task, Submission.task_id == Task.id)
+        .join(voter_char, Vote.voter_character_id == voter_char.c.id)
+        .where(Submission.character_id == character_id)
+    )
+    if before is not None:
+        query = query.where(Vote.created_at < before)
+    query = query.order_by(Vote.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_VOTE_ON_MINE,
+            timestamp=row.created_at,
+            actor_display_name=row.voter_display_name,
+            actor_faction_slug=row.voter_faction_slug,
+            actor_avatar_url=row.voter_avatar_url,
+            payload={
+                "vote_id": row.id,
+                "stars": row.stars,
+                "submission_id": row.submission_id,
+                "submission_title": row.submission_title,
+                "task_point_value": row.task_point_value,
+                "points_earned": row.stars * row.task_point_value,
+            },
+        ))
+    return items
+
+
+async def _fetch_friend_completions(
+    friend_ids: list[int],
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Recent submissions (completions) from friends."""
+    if not friend_ids:
+        return []
+
+    query = (
+        select(
+            Submission.id,
+            Submission.title,
+            Submission.created_at,
+            Submission.character_id,
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+            Character.display_name.label("author_display_name"),
+            Character.faction_slug.label("author_faction_slug"),
+            Character.avatar_url.label("author_avatar_url"),
+        )
+        .join(Task, Submission.task_id == Task.id)
+        .join(Character, Submission.character_id == Character.id)
+        .where(
+            Submission.character_id.in_(friend_ids),
+            Submission.is_withdrawn == False,  # noqa: E712
+        )
+    )
+    if before is not None:
+        query = query.where(Submission.created_at < before)
+    query = query.order_by(Submission.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_FRIEND_COMPLETION,
+            timestamp=row.created_at,
+            actor_display_name=row.author_display_name,
+            actor_faction_slug=row.author_faction_slug,
+            actor_avatar_url=row.author_avatar_url,
+            payload={
+                "submission_id": row.id,
+                "submission_title": row.title,
+                "task_title": row.task_title,
+                "task_point_value": row.task_point_value,
+                "task_faction_slug": row.task_faction_slug,
+                "character_id": row.character_id,
+            },
+        ))
+    return items
+
+
+async def _fetch_foe_taunts(
+    character_id: int,
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Taunts received from foes."""
+    query = (
+        select(
+            TauntMessage,
+            Character.display_name.label("from_display_name"),
+            Character.faction_slug.label("from_faction_slug"),
+            Character.avatar_url.label("from_avatar_url"),
+        )
+        .join(Character, TauntMessage.from_character_id == Character.id)
+        .where(TauntMessage.to_character_id == character_id)
+    )
+    if before is not None:
+        query = query.where(TauntMessage.created_at < before)
+    query = query.order_by(TauntMessage.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for taunt, display_name, faction_slug, avatar_url in result.all():
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_FOE_TAUNT,
+            timestamp=taunt.created_at,
+            actor_display_name=display_name,
+            actor_faction_slug=faction_slug,
+            actor_avatar_url=avatar_url,
+            payload={
+                "taunt_id": taunt.id,
+                "message": taunt.message,
+                "trigger_type": taunt.trigger_type.value,
+                "from_character_id": taunt.from_character_id,
+            },
+        ))
+    return items
+
+
+async def _fetch_global_tasks(
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Recently activated tasks (global events)."""
+    query = (
+        select(
+            Task.id,
+            Task.title,
+            Task.point_value,
+            Task.level_required,
+            Task.primary_faction_slug,
+            Task.created_at,
+        )
+        .where(Task.status == TaskStatus.active)
+    )
+    if before is not None:
+        query = query.where(Task.created_at < before)
+    query = query.order_by(Task.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_GLOBAL_TASK,
+            timestamp=row.created_at,
+            actor_display_name="Admin",
+            actor_faction_slug=None,
+            actor_avatar_url=None,
+            payload={
+                "task_id": row.id,
+                "task_title": row.title,
+                "task_point_value": row.point_value,
+                "task_level_required": row.level_required,
+                "task_faction_slug": row.primary_faction_slug,
+            },
+        ))
+    return items
+
+
+async def _fetch_era_announcements(
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Era start announcements."""
+    query = select(Era)
+    if before is not None:
+        query = query.where(Era.started_at < before)
+    query = query.order_by(Era.started_at.desc()).limit(5)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for era in result.scalars().all():
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_ERA_ANNOUNCEMENT,
+            timestamp=era.started_at,
+            actor_display_name="Admin",
+            actor_faction_slug=None,
+            actor_avatar_url=None,
+            payload={
+                "era_id": era.id,
+                "era_name": era.name,
+                "era_notes": era.notes,
+                "config_key": era.config_key,
+            },
+        ))
+    return items
+
+
+async def _fetch_collab_invites(
+    character_id: int,
+    session: AsyncSession,
+    before: Optional[datetime],
+    pending_only: bool = False,
+) -> list[ActivityFeedItem]:
+    """Collab invites sent to the current character."""
+    query = (
+        select(
+            Submission.id,
+            Submission.title,
+            Submission.created_at,
+            Submission.invite_status,
+            Submission.character_id,
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+            Task.level_required.label("task_level_required"),
+            Character.display_name.label("inviter_display_name"),
+            Character.faction_slug.label("inviter_faction_slug"),
+            Character.avatar_url.label("inviter_avatar_url"),
+        )
+        .join(Task, Submission.task_id == Task.id)
+        .join(Character, Submission.character_id == Character.id)
+        .where(
+            Submission.partner_character_id == character_id,
+            Submission.collaboration_mode == CollaborationMode.collab,
+        )
+    )
+    if pending_only:
+        query = query.where(Submission.invite_status == InviteStatus.pending)
+    if before is not None:
+        query = query.where(Submission.created_at < before)
+    query = query.order_by(Submission.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        invite_status = row.invite_status.value if row.invite_status else None
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_COLLAB_INVITE,
+            timestamp=row.created_at,
+            actor_display_name=row.inviter_display_name,
+            actor_faction_slug=row.inviter_faction_slug,
+            actor_avatar_url=row.inviter_avatar_url,
+            payload={
+                "submission_id": row.id,
+                "submission_title": row.title,
+                "task_title": row.task_title,
+                "task_point_value": row.task_point_value,
+                "task_faction_slug": row.task_faction_slug,
+                "task_level_required": row.task_level_required,
+                "invite_status": invite_status,
+                "inviter_character_id": row.character_id,
+            },
+        ))
+    return items
+
+
+async def _fetch_duel_challenges(
+    character_id: int,
+    session: AsyncSession,
+    before: Optional[datetime],
+    pending_only: bool = False,
+) -> list[ActivityFeedItem]:
+    """Duel challenges sent to the current character."""
+    query = (
+        select(
+            Submission.id,
+            Submission.title,
+            Submission.created_at,
+            Submission.invite_status,
+            Submission.character_id,
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+            Character.display_name.label("challenger_display_name"),
+            Character.faction_slug.label("challenger_faction_slug"),
+            Character.avatar_url.label("challenger_avatar_url"),
+        )
+        .join(Task, Submission.task_id == Task.id)
+        .join(Character, Submission.character_id == Character.id)
+        .where(
+            Submission.partner_character_id == character_id,
+            Submission.collaboration_mode == CollaborationMode.duel,
+        )
+    )
+    if pending_only:
+        query = query.where(Submission.invite_status == InviteStatus.pending)
+    if before is not None:
+        query = query.where(Submission.created_at < before)
+    query = query.order_by(Submission.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        invite_status = row.invite_status.value if row.invite_status else None
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_DUEL_CHALLENGE,
+            timestamp=row.created_at,
+            actor_display_name=row.challenger_display_name,
+            actor_faction_slug=row.challenger_faction_slug,
+            actor_avatar_url=row.challenger_avatar_url,
+            payload={
+                "submission_id": row.id,
+                "submission_title": row.title,
+                "task_title": row.task_title,
+                "task_point_value": row.task_point_value,
+                "task_faction_slug": row.task_faction_slug,
+                "invite_status": invite_status,
+                "challenger_character_id": row.character_id,
+            },
+        ))
+    return items
+
+
+async def _fetch_friend_signups(
+    friend_ids: list[int],
+    my_task_ids: list[int],
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Friends who signed up for tasks the current character is also doing."""
+    if not friend_ids or not my_task_ids:
+        return []
+
+    query = (
+        select(
+            CharacterTask.id,
+            CharacterTask.signed_up_at,
+            CharacterTask.task_id,
+            Character.id.label("character_id"),
+            Character.display_name,
+            Character.faction_slug,
+            Character.avatar_url,
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+        )
+        .join(Character, CharacterTask.character_id == Character.id)
+        .join(Task, CharacterTask.task_id == Task.id)
+        .where(
+            CharacterTask.character_id.in_(friend_ids),
+            CharacterTask.task_id.in_(my_task_ids),
+            CharacterTask.status != CharacterTaskStatus.abandoned,
+        )
+    )
+    if before is not None:
+        query = query.where(CharacterTask.signed_up_at < before)
+    query = query.order_by(CharacterTask.signed_up_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_FRIEND_SIGNUP,
+            timestamp=row.signed_up_at,
+            actor_display_name=row.display_name,
+            actor_faction_slug=row.faction_slug,
+            actor_avatar_url=row.avatar_url,
+            payload={
+                "character_task_id": row.id,
+                "character_id": row.character_id,
+                "task_id": row.task_id,
+                "task_title": row.task_title,
+                "task_point_value": row.task_point_value,
+                "task_faction_slug": row.task_faction_slug,
+            },
+        ))
+    return items
+
+
+async def _fetch_invitation_letters(
+    character_id: int,
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Faction invitation letters delivered to the current character."""
+    era_row = await get_current_era_row(session)
+
+    query = (
+        select(InvitationLetter)
+        .where(
+            InvitationLetter.character_id == character_id,
+            InvitationLetter.era_id == era_row.id,
+        )
+    )
+    if before is not None:
+        query = query.where(InvitationLetter.delivered_at < before)
+    query = query.order_by(InvitationLetter.delivered_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for letter in result.scalars().all():
+        faction_name = (
+            CURRENT_ERA.factions[letter.faction_slug].name
+            if letter.faction_slug in CURRENT_ERA.factions
+            else letter.faction_slug
+        )
+        faction_color = (
+            CURRENT_ERA.factions[letter.faction_slug].color
+            if letter.faction_slug in CURRENT_ERA.factions
+            else None
+        )
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_INVITATION_LETTER,
+            timestamp=letter.delivered_at,
+            actor_display_name=faction_name,
+            actor_faction_slug=letter.faction_slug,
+            actor_avatar_url=None,
+            payload={
+                "letter_id": letter.id,
+                "faction_slug": letter.faction_slug,
+                "faction_name": faction_name,
+                "faction_color": faction_color,
+            },
+        ))
+    return items
+
+
+async def _fetch_friend_defections(
+    friend_ids: list[int],
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Friends who recently changed factions (defected)."""
+    if not friend_ids:
+        return []
+
+    era_row = await get_current_era_row(session)
+
+    query = (
+        select(
+            FactionDefectionHistory.id,
+            FactionDefectionHistory.character_id,
+            FactionDefectionHistory.faction_slug,
+            FactionDefectionHistory.defected_at,
+            Character.display_name,
+            Character.faction_slug.label("current_faction_slug"),
+            Character.avatar_url,
+        )
+        .join(Character, FactionDefectionHistory.character_id == Character.id)
+        .where(
+            FactionDefectionHistory.character_id.in_(friend_ids),
+            FactionDefectionHistory.era_id == era_row.id,
+        )
+    )
+    if before is not None:
+        query = query.where(FactionDefectionHistory.defected_at < before)
+    query = query.order_by(FactionDefectionHistory.defected_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        old_faction_name = (
+            CURRENT_ERA.factions[row.faction_slug].name
+            if row.faction_slug in CURRENT_ERA.factions
+            else row.faction_slug
+        )
+        new_faction_name = (
+            CURRENT_ERA.factions[row.current_faction_slug].name
+            if row.current_faction_slug in CURRENT_ERA.factions
+            else row.current_faction_slug
+        )
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_FRIEND_DEFECTION,
+            timestamp=row.defected_at,
+            actor_display_name=row.display_name,
+            actor_faction_slug=row.current_faction_slug,
+            actor_avatar_url=row.avatar_url,
+            payload={
+                "character_id": row.character_id,
+                "old_faction_slug": row.faction_slug,
+                "old_faction_name": old_faction_name,
+                "new_faction_slug": row.current_faction_slug,
+                "new_faction_name": new_faction_name,
+            },
+        ))
+    return items
+
+
+async def _compute_counts(
+    character_id: int,
+    friend_ids: list[int],
+    my_task_ids: list[int],
+    session: AsyncSession,
+) -> FeedCounts:
+    """Compute badge counts for each filter tab using lightweight COUNT queries."""
+
+    async def count_votes_on_mine() -> int:
+        result = await session.execute(
+            select(func.count())
+            .select_from(Vote)
+            .join(Submission, Vote.submission_id == Submission.id)
+            .where(Submission.character_id == character_id)
+        )
+        return result.scalar_one()
+
+    async def count_friend_completions() -> int:
+        if not friend_ids:
+            return 0
+        result = await session.execute(
+            select(func.count())
+            .select_from(Submission)
+            .where(
+                Submission.character_id.in_(friend_ids),
+                Submission.is_withdrawn == False,  # noqa: E712
+            )
+        )
+        return result.scalar_one()
+
+    async def count_friend_signups() -> int:
+        if not friend_ids or not my_task_ids:
+            return 0
+        result = await session.execute(
+            select(func.count())
+            .select_from(CharacterTask)
+            .where(
+                CharacterTask.character_id.in_(friend_ids),
+                CharacterTask.task_id.in_(my_task_ids),
+                CharacterTask.status != CharacterTaskStatus.abandoned,
+            )
+        )
+        return result.scalar_one()
+
+    async def count_foe_taunts() -> int:
+        result = await session.execute(
+            select(func.count())
+            .select_from(TauntMessage)
+            .where(TauntMessage.to_character_id == character_id)
+        )
+        return result.scalar_one()
+
+    async def count_invitation_letters() -> int:
+        era_row = await get_current_era_row(session)
+        result = await session.execute(
+            select(func.count())
+            .select_from(InvitationLetter)
+            .where(
+                InvitationLetter.character_id == character_id,
+                InvitationLetter.era_id == era_row.id,
+            )
+        )
+        return result.scalar_one()
+
+    async def count_friend_defections() -> int:
+        if not friend_ids:
+            return 0
+        era_row = await get_current_era_row(session)
+        result = await session.execute(
+            select(func.count())
+            .select_from(FactionDefectionHistory)
+            .where(
+                FactionDefectionHistory.character_id.in_(friend_ids),
+                FactionDefectionHistory.era_id == era_row.id,
+            )
+        )
+        return result.scalar_one()
+
+    async def count_your_stuff() -> int:
+        """Votes on mine + collab invites + duel challenges + invitation letters."""
+        collab_result = await session.execute(
+            select(func.count())
+            .select_from(Submission)
+            .where(
+                Submission.partner_character_id == character_id,
+                Submission.collaboration_mode.in_([
+                    CollaborationMode.collab, CollaborationMode.duel,
+                ]),
+            )
+        )
+        collab_count = collab_result.scalar_one()
+        votes_count = await count_votes_on_mine()
+        letters_count = await count_invitation_letters()
+        return votes_count + collab_count + letters_count
+
+    async def count_global() -> int:
+        tasks_result = await session.execute(
+            select(func.count())
+            .select_from(Task)
+            .where(Task.status == TaskStatus.active)
+        )
+        era_result = await session.execute(
+            select(func.count()).select_from(Era)
+        )
+        return tasks_result.scalar_one() + era_result.scalar_one()
+
+    async def count_requests() -> int:
+        result = await session.execute(
+            select(func.count())
+            .select_from(Submission)
+            .where(
+                Submission.partner_character_id == character_id,
+                Submission.collaboration_mode.in_([
+                    CollaborationMode.collab, CollaborationMode.duel,
+                ]),
+                Submission.invite_status == InviteStatus.pending,
+            )
+        )
+        return result.scalar_one()
+
+    # Run counts sequentially (shared async session)
+    friend_completions_count = await count_friend_completions()
+    friend_signups_count = await count_friend_signups()
+    friend_defections_count = await count_friend_defections()
+    friends_count = friend_completions_count + friend_signups_count + friend_defections_count
+    foes_count = await count_foe_taunts()
+    your_stuff_count = await count_your_stuff()
+    global_count = await count_global()
+    requests_count = await count_requests()
+
+    all_count = friends_count + foes_count + your_stuff_count + global_count
+
+    return FeedCounts(
+        all=all_count,
+        friends=friends_count,
+        foes=foes_count,
+        your_stuff=your_stuff_count,
+        global_count=global_count,
+        requests=requests_count,
+    )
+
+
+async def get_activity_feed(
+    character_id: int,
+    session: AsyncSession,
+    feed_filter: Optional[str] = None,
+    before_cursor: Optional[datetime] = None,
+    limit: int = 20,
+) -> ActivityFeedResponse:
+    """Fetch a unified activity feed for the given character.
+
+    Args:
+        character_id: The character requesting the feed.
+        session: Database session.
+        feed_filter: One of "all", "friends", "foes", "your_stuff", "global", "requests".
+        before_cursor: ISO datetime cursor for pagination (items before this time).
+        limit: Max items to return.
+    """
+    active_filter = feed_filter or "all"
+    allowed_types = FILTER_QUERIES.get(active_filter, FILTER_QUERIES["all"])
+    is_requests_filter = active_filter == "requests"
+
+    # Pre-fetch relationship and task context needed by multiple sub-queries
+    friend_ids: list[int] = []
+    my_task_ids: list[int] = []
+
+    needs_friends = bool(allowed_types & {
+        FEED_ITEM_TYPE_FRIEND_COMPLETION, FEED_ITEM_TYPE_FRIEND_SIGNUP,
+        FEED_ITEM_TYPE_FRIEND_DEFECTION,
+    })
+    needs_my_tasks = FEED_ITEM_TYPE_FRIEND_SIGNUP in allowed_types
+
+    if needs_friends:
+        friend_ids = await _get_friend_ids(character_id, session)
+    if needs_my_tasks:
+        my_task_ids = await _get_my_task_ids(character_id, session)
+
+    # Build list of coroutines to run in parallel
+    fetch_tasks: list = []
+
+    if FEED_ITEM_TYPE_VOTE_ON_MINE in allowed_types:
+        fetch_tasks.append(_fetch_votes_on_mine(character_id, session, before_cursor))
+
+    if FEED_ITEM_TYPE_FRIEND_COMPLETION in allowed_types:
+        fetch_tasks.append(_fetch_friend_completions(friend_ids, session, before_cursor))
+
+    if FEED_ITEM_TYPE_FOE_TAUNT in allowed_types:
+        fetch_tasks.append(_fetch_foe_taunts(character_id, session, before_cursor))
+
+    if FEED_ITEM_TYPE_GLOBAL_TASK in allowed_types:
+        fetch_tasks.append(_fetch_global_tasks(session, before_cursor))
+
+    if FEED_ITEM_TYPE_ERA_ANNOUNCEMENT in allowed_types:
+        fetch_tasks.append(_fetch_era_announcements(session, before_cursor))
+
+    if FEED_ITEM_TYPE_COLLAB_INVITE in allowed_types:
+        fetch_tasks.append(_fetch_collab_invites(
+            character_id, session, before_cursor, pending_only=is_requests_filter,
+        ))
+
+    if FEED_ITEM_TYPE_DUEL_CHALLENGE in allowed_types:
+        fetch_tasks.append(_fetch_duel_challenges(
+            character_id, session, before_cursor, pending_only=is_requests_filter,
+        ))
+
+    if FEED_ITEM_TYPE_FRIEND_SIGNUP in allowed_types:
+        fetch_tasks.append(_fetch_friend_signups(
+            friend_ids, my_task_ids, session, before_cursor,
+        ))
+
+    if FEED_ITEM_TYPE_INVITATION_LETTER in allowed_types:
+        fetch_tasks.append(_fetch_invitation_letters(
+            character_id, session, before_cursor,
+        ))
+
+    if FEED_ITEM_TYPE_FRIEND_DEFECTION in allowed_types:
+        fetch_tasks.append(_fetch_friend_defections(
+            friend_ids, session, before_cursor,
+        ))
+
+    # Run all sub-queries (they share the same session, so sequential is safer
+    # with SQLAlchemy async — asyncio.gather can cause issues with shared session)
+    all_items: list[ActivityFeedItem] = []
+    for task in fetch_tasks:
+        items = await task
+        all_items.extend(items)
+
+    # Sort by timestamp descending, slice to limit
+    all_items.sort(key=lambda item: item.timestamp, reverse=True)
+    paginated = all_items[:limit]
+
+    # Compute next cursor
+    next_cursor = None
+    if len(all_items) > limit:
+        next_cursor = paginated[-1].timestamp.isoformat()
+
+    # Compute badge counts (separate from pagination)
+    counts = await _compute_counts(character_id, friend_ids, my_task_ids, session)
+
+    return ActivityFeedResponse(
+        items=paginated,
+        counts=counts,
+        next_cursor=next_cursor,
+    )

--- a/backend/services/submission.py
+++ b/backend/services/submission.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.flag import Flag
-from models.submission import CollaborationMode, MediaItem, ModerationStatus, Submission
+from models.submission import CollaborationMode, InviteStatus, MediaItem, ModerationStatus, Submission
 from models.task import CharacterTask, CharacterTaskStatus, Task
 from models.vote import Vote
 from schemas.submission import MediaItemOut, SubmissionCreate, SubmissionOut
@@ -46,6 +46,8 @@ async def create_submission(
         if partner is None:
             raise HTTPException(status_code=404, detail="Partner character not found.")
 
+    invite_status = InviteStatus.pending if collab_mode != CollaborationMode.solo else None
+
     submission = Submission(
         task_id=task.id,
         character_id=character.id,
@@ -53,6 +55,7 @@ async def create_submission(
         body_text=data.body_text or "",
         collaboration_mode=collab_mode,
         partner_character_id=partner_id,
+        invite_status=invite_status,
     )
     session.add(submission)
     character_task.status = CharacterTaskStatus.submitted
@@ -179,6 +182,46 @@ async def flag_submission(
     return submission
 
 
+async def accept_invite(
+    submission_id: int,
+    character_id: int,
+    session: AsyncSession,
+) -> Submission:
+    """Partner accepts a collab/duel invite."""
+    submission = await session.get(Submission, submission_id)
+    if submission is None:
+        raise HTTPException(status_code=404, detail="Submission not found.")
+    if submission.partner_character_id != character_id:
+        raise HTTPException(status_code=403, detail="Only the invited partner can accept.")
+    if submission.invite_status != InviteStatus.pending:
+        raise HTTPException(status_code=422, detail="Invite is no longer pending.")
+
+    submission.invite_status = InviteStatus.accepted
+    await session.commit()
+    await session.refresh(submission)
+    return submission
+
+
+async def decline_invite(
+    submission_id: int,
+    character_id: int,
+    session: AsyncSession,
+) -> Submission:
+    """Partner declines a collab/duel invite."""
+    submission = await session.get(Submission, submission_id)
+    if submission is None:
+        raise HTTPException(status_code=404, detail="Submission not found.")
+    if submission.partner_character_id != character_id:
+        raise HTTPException(status_code=403, detail="Only the invited partner can decline.")
+    if submission.invite_status != InviteStatus.pending:
+        raise HTTPException(status_code=422, detail="Invite is no longer pending.")
+
+    submission.invite_status = InviteStatus.declined
+    await session.commit()
+    await session.refresh(submission)
+    return submission
+
+
 async def compute_submission_score_from_db(
     submission: Submission,
     session: AsyncSession,
@@ -227,6 +270,14 @@ async def build_submission_out(
         partner = await session.get(Character, submission.partner_character_id)
         partner_display_name = partner.display_name if partner else None
 
+    invite_status_value = None
+    if submission.invite_status is not None:
+        invite_status_value = (
+            submission.invite_status.value
+            if hasattr(submission.invite_status, "value")
+            else str(submission.invite_status)
+        )
+
     return SubmissionOut(
         id=submission.id,
         task_id=submission.task_id,
@@ -242,6 +293,7 @@ async def build_submission_out(
         collaboration_mode=submission.collaboration_mode.value,
         partner_character_id=submission.partner_character_id,
         partner_display_name=partner_display_name,
+        invite_status=invite_status_value,
         created_at=submission.created_at,
         updated_at=submission.updated_at,
         media=media,

--- a/backend/services/taunt_service.py
+++ b/backend/services/taunt_service.py
@@ -69,12 +69,33 @@ async def get_taunts_for_character(
     character_id: int,
     session: AsyncSession,
     limit: int = 20,
-) -> list[TauntMessage]:
-    """Fetch recent taunts received by a character."""
+) -> list[dict]:
+    """Fetch recent taunts received by a character, enriched with sender display info."""
     result = await session.execute(
-        select(TauntMessage)
+        select(
+            TauntMessage,
+            Character.display_name.label("from_display_name"),
+            Character.faction_slug.label("from_faction_slug"),
+            Character.avatar_url.label("from_avatar_url"),
+        )
+        .join(Character, TauntMessage.from_character_id == Character.id)
         .where(TauntMessage.to_character_id == character_id)
         .order_by(TauntMessage.created_at.desc())
         .limit(limit)
     )
-    return list(result.scalars().all())
+    rows = result.all()
+    enriched: list[dict] = []
+    for taunt, display_name, faction_slug, avatar_url in rows:
+        data = {
+            "id": taunt.id,
+            "from_character_id": taunt.from_character_id,
+            "to_character_id": taunt.to_character_id,
+            "message": taunt.message,
+            "trigger_type": taunt.trigger_type.value,
+            "created_at": taunt.created_at,
+            "from_display_name": display_name,
+            "from_faction_slug": faction_slug,
+            "from_avatar_url": avatar_url,
+        }
+        enriched.append(data)
+    return enriched

--- a/docs/BUILD_STATE.md
+++ b/docs/BUILD_STATE.md
@@ -66,7 +66,8 @@ This file is the source of truth for what has been built, what is in progress, a
 - `services/vote.py` — cast_or_update_vote (budget deduction, anti-self-vote, update-is-free logic) ✅ 2026-04-01
 - `services/era.py` — apply_era_reset (driven by EraConfig flags), get_current_era_row, get_or_create_stats ✅
 - `services/relationship_service.py` — create, block, list relationships with display_status computation ✅ 2026-04-13
-- `services/taunt_service.py` — generate_taunt, get_taunts_for_character ✅ 2026-04-13
+- `services/taunt_service.py` — generate_taunt, get_taunts_for_character (enriched with display fields) ✅ 2026-04-14
+- `services/activity_feed.py` — unified activity feed aggregation (8 activity types, cursor pagination, badge counts) ✅ 2026-04-14
 - `services/admin_service.py` — game_overview, list_accounts, get_account_detail, list_characters, moderate_submission, suspend_account, assign_or_revoke_role, create_faction, admin_create_character, set_character_stats, reactivate_task, update_task_status ✅ 2026-04-13
 - `services/character_stats.py` — recalculate_character_stats (era-aware scoring engine) ✅ 2026-04-13
 
@@ -87,6 +88,10 @@ This file is the source of truth for what has been built, what is in progress, a
 - `routers/contact.py` — POST /contact (public contact form) ✅ 2026-04-13
 - `routers/factions.py` — GET /factions, PUT /factions/{slug} ✅ 2026-04-13
 - `routers/leaderboard.py` — GET /leaderboard ✅
+- `routers/taunts.py` — GET /taunts (enriched taunt messages) ✅ 2026-04-14
+- `routers/activity_feed.py` — GET /activity-feed (unified feed with filters + pagination) ✅ 2026-04-14
+- `routers/characters.py` — added GET /characters/{id}/stats/votes-received ✅ 2026-04-14
+- `routers/submissions.py` — added POST /submissions/{id}/accept-invite, POST /submissions/{id}/decline-invite ✅ 2026-04-14
 - `backend/dependencies.py` — shared get_current_character + require_admin deps ✅
 
 ### Backend — App Entry Point ✅ 2026-04-02
@@ -133,7 +138,12 @@ All migrations use `create_type=False` on `sa.Enum()` in `add_column`/`create_ta
 - `frontend/src/App.tsx` — all routes wired ✅
 - `frontend/src/vite-env.d.ts` — Vite client types for `import.meta.env` ✅
 - `frontend/tailwind.config.ts` — custom palette, shadows, fonts (Caveat + Kalam) ✅
-- `npm run build` — zero TypeScript errors ✅
+- `npm run build` — zero TypeScript errors (excluding pre-existing Groups.tsx) ✅
+- `frontend/src/pages/Updates.tsx` — Complete rewrite: unified activity feed with 6 filter tabs, mixed card types, date dividers, cursor pagination ✅ 2026-04-14
+- `frontend/src/components/feed/` — 11 feed card components (FeedCardRouter, EraAnnouncement, VoteNotification, FoeTaunt, FriendActivity, CollabInvite, DuelChallenge, GlobalTask, FriendSignup, DateDivider, Badge) ✅ 2026-04-14
+- `frontend/src/components/layout/Sidebar.tsx` — Updated: pending requests panel, votes stat, global activity ticker ✅ 2026-04-14
+- `frontend/src/api/activityFeed.ts` — Activity feed API client ✅ 2026-04-14
+- `frontend/src/api/taunts.ts` — Taunts API client ✅ 2026-04-14
 - NavBar links verified (Tasks, Praxis /submissions, Players /leaderboard, Groups, Updates) ✅
 - Dev server running on port 5173 (`npm run dev`) ✅
 

--- a/frontend/src/api/activityFeed.ts
+++ b/frontend/src/api/activityFeed.ts
@@ -1,0 +1,34 @@
+import api from './axios'
+
+export interface ActivityFeedItem {
+  type: string
+  timestamp: string
+  actor_display_name: string | null
+  actor_faction_slug: string | null
+  actor_avatar_url: string | null
+  payload: Record<string, any>
+}
+
+export interface FeedCounts {
+  all: number
+  friends: number
+  foes: number
+  your_stuff: number
+  global_count: number
+  requests: number
+}
+
+export interface ActivityFeedResponse {
+  items: ActivityFeedItem[]
+  counts: FeedCounts
+  next_cursor: string | null
+}
+
+export async function getActivityFeed(params?: {
+  filter?: string
+  before?: string
+  limit?: number
+}): Promise<ActivityFeedResponse> {
+  const { data } = await api.get<ActivityFeedResponse>('/activity-feed', { params })
+  return data
+}

--- a/frontend/src/api/characters.ts
+++ b/frontend/src/api/characters.ts
@@ -44,3 +44,8 @@ export async function uploadCharacterAvatar(id: number, file: File): Promise<Cha
   const { data } = await api.post<CharacterOut>(`/characters/${id}/avatar`, form)
   return data
 }
+
+export async function getVotesReceived(characterId: number): Promise<{ character_id: number; votes_received: number }> {
+  const { data } = await api.get<{ character_id: number; votes_received: number }>(`/characters/${characterId}/stats/votes-received`)
+  return data
+}

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -76,3 +76,13 @@ export async function resubmitSubmission(submissionId: number): Promise<Submissi
   const { data } = await api.post<SubmissionOut>(`/submissions/${submissionId}/resubmit`)
   return data
 }
+
+export async function acceptInvite(submissionId: number): Promise<SubmissionOut> {
+  const { data } = await api.post<SubmissionOut>(`/submissions/${submissionId}/accept-invite`)
+  return data
+}
+
+export async function declineInvite(submissionId: number): Promise<SubmissionOut> {
+  const { data } = await api.post<SubmissionOut>(`/submissions/${submissionId}/decline-invite`)
+  return data
+}

--- a/frontend/src/api/taunts.ts
+++ b/frontend/src/api/taunts.ts
@@ -1,0 +1,18 @@
+import api from './axios'
+
+export interface TauntMessageOut {
+  id: number
+  from_character_id: number
+  to_character_id: number
+  message: string
+  trigger_type: string
+  created_at: string
+  from_display_name: string
+  from_faction_slug: string
+  from_avatar_url: string | null
+}
+
+export async function getTaunts(limit?: number): Promise<TauntMessageOut[]> {
+  const { data } = await api.get<TauntMessageOut[]>('/taunts', { params: { limit } })
+  return data
+}

--- a/frontend/src/components/feed/FeedBadge.tsx
+++ b/frontend/src/components/feed/FeedBadge.tsx
@@ -1,0 +1,40 @@
+/** Reusable badge chip for feed items (FRIEND, YOUR STUFF, GLOBAL, DUEL, etc.) */
+
+const BADGE_STYLES: Record<string, { bg: string; color: string }> = {
+  friend:    { bg: '#14532d', color: '#fff' },
+  your_stuff: { bg: '#8a6a20', color: '#fff' },
+  global:    { bg: '#6b6a7a', color: '#fff' },
+  duel:      { bg: '#dc2626', color: '#fff' },
+  collab:    { bg: '#15803d', color: '#fff' },
+  admin:     { bg: '#1a1209', color: '#F7F4EE' },
+}
+
+interface FeedBadgeProps {
+  type: string
+  label?: string
+}
+
+export default function FeedBadge({ type, label }: FeedBadgeProps) {
+  const style = BADGE_STYLES[type] ?? BADGE_STYLES.global
+  const text = label ?? type.replace(/_/g, ' ')
+
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        background: style.bg,
+        color: style.color,
+        fontFamily: "'Courier Prime', monospace",
+        fontSize: 8,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '0.1em',
+        padding: '2px 8px',
+        borderRadius: 3,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {text}
+    </span>
+  )
+}

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { acceptInvite, declineInvite } from '../../api/submissions'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardCollabInvite({ item }: Props) {
+  const {
+    submission_id, task_title, task_point_value, task_faction_slug,
+    task_level_required, invite_status, inviter_character_id,
+  } = item.payload
+  const taskColor = factionColor(task_faction_slug)
+  const actorColor = factionColor(item.actor_faction_slug)
+
+  const [status, setStatus] = useState<string | null>(invite_status)
+  const [loading, setLoading] = useState(false)
+
+  const handleAccept = async () => {
+    setLoading(true)
+    try {
+      await acceptInvite(submission_id)
+      setStatus('accepted')
+    } catch { /* swallow */ }
+    setLoading(false)
+  }
+
+  const handleDecline = async () => {
+    setLoading(true)
+    try {
+      await declineInvite(submission_id)
+      setStatus('declined')
+    } catch { /* swallow */ }
+    setLoading(false)
+  }
+
+  const isPending = status === 'pending' || status === null
+
+  return (
+    <div className="sidebar-card" style={{ padding: '12px 16px' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <Link to={`/characters/${inviter_character_id}`}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          />
+        </Link>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <Link
+              to={`/characters/${inviter_character_id}`}
+              className="font-body"
+              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            >
+              {item.actor_display_name}
+            </Link>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              invited you to collaborate
+            </span>
+            <FeedBadge type="your_stuff" label="Your Stuff" />
+          </div>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </div>
+      </div>
+
+      {/* Task detail */}
+      <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
+        <Link
+          to={`/tasks/${submission_id}`}
+          className="font-body"
+          style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+        >
+          {task_title}
+        </Link>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {task_point_value} pts · lvl {task_level_required}+
+        </span>
+        <FeedBadge type="collab" label="Collab" />
+      </div>
+
+      {/* Accept/Decline buttons */}
+      {isPending && (
+        <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={handleAccept}
+            disabled={loading}
+            style={{
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              background: '#14532d',
+              color: '#fff',
+              border: 'none',
+              padding: '5px 14px',
+              cursor: loading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Accept
+          </button>
+          <button
+            onClick={handleDecline}
+            disabled={loading}
+            style={{
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              background: 'transparent',
+              color: 'var(--color-text-secondary)',
+              border: '1px solid var(--color-border)',
+              padding: '5px 14px',
+              cursor: loading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Decline
+          </button>
+        </div>
+      )}
+
+      {status === 'accepted' && (
+        <div style={{ marginTop: 8, marginLeft: 38 }}>
+          <span className="eyebrow" style={{ color: '#14532d' }}>Accepted</span>
+        </div>
+      )}
+      {status === 'declined' && (
+        <div style={{ marginTop: 8, marginLeft: 38 }}>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Declined</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { acceptInvite, declineInvite } from '../../api/submissions'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardDuelChallenge({ item }: Props) {
+  const {
+    submission_id, task_title, task_point_value, task_faction_slug,
+    invite_status, challenger_character_id,
+  } = item.payload
+  const taskColor = factionColor(task_faction_slug)
+  const actorColor = factionColor(item.actor_faction_slug)
+
+  const [status, setStatus] = useState<string | null>(invite_status)
+  const [loading, setLoading] = useState(false)
+
+  const handleAccept = async () => {
+    setLoading(true)
+    try {
+      await acceptInvite(submission_id)
+      setStatus('accepted')
+    } catch { /* swallow */ }
+    setLoading(false)
+  }
+
+  const handleDecline = async () => {
+    setLoading(true)
+    try {
+      await declineInvite(submission_id)
+      setStatus('declined')
+    } catch { /* swallow */ }
+    setLoading(false)
+  }
+
+  const isPending = status === 'pending' || status === null
+
+  return (
+    <div
+      className="sidebar-card"
+      style={{
+        padding: '12px 16px',
+        borderLeft: '4px solid #dc2626',
+        background: 'linear-gradient(135deg, rgba(220,38,38,0.06), transparent)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <Link to={`/characters/${challenger_character_id}`}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          />
+        </Link>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <Link
+              to={`/characters/${challenger_character_id}`}
+              className="font-body"
+              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            >
+              {item.actor_display_name}
+            </Link>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              has challenged you to a duel
+            </span>
+            <FeedBadge type="duel" label="Duel" />
+          </div>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </div>
+      </div>
+
+      {/* Task detail */}
+      <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
+        <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+          {task_title}
+        </span>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {task_point_value} pts · winner takes all
+        </span>
+        <span style={{ fontSize: 12 }}>&#x1F525;</span>
+      </div>
+
+      {/* Accept/Decline buttons */}
+      {isPending && (
+        <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={handleAccept}
+            disabled={loading}
+            style={{
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              background: '#dc2626',
+              color: '#fff',
+              border: 'none',
+              padding: '5px 14px',
+              cursor: loading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Accept Duel
+          </button>
+          <button
+            onClick={handleDecline}
+            disabled={loading}
+            style={{
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              background: 'transparent',
+              color: 'var(--color-text-secondary)',
+              border: '1px solid var(--color-border)',
+              padding: '5px 14px',
+              cursor: loading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Decline
+          </button>
+        </div>
+      )}
+
+      {status === 'accepted' && (
+        <div style={{ marginTop: 8, marginLeft: 38 }}>
+          <span className="eyebrow" style={{ color: '#dc2626' }}>Duel Accepted</span>
+        </div>
+      )}
+      {status === 'declined' && (
+        <div style={{ marginTop: 8, marginLeft: 38 }}>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Declined</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
+++ b/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
@@ -1,0 +1,81 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardEraAnnouncement({ item }: Props) {
+  const { era_name, era_notes } = item.payload
+
+  return (
+    <div
+      className="sidebar-card"
+      style={{
+        background: '#1a1209',
+        color: '#F7F4EE',
+        padding: '20px 24px',
+        position: 'relative',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+        <span style={{ fontSize: 20 }}>&#x1F310;</span>
+        <span className="eyebrow" style={{ color: '#c49a3a', fontSize: 8 }}>
+          Era Announcement
+        </span>
+        <span style={{ marginLeft: 'auto' }}>
+          <FeedBadge type="admin" label="Admin" />
+        </span>
+      </div>
+
+      <h3
+        className="font-display italic"
+        style={{ fontSize: 18, color: '#F7F4EE', marginBottom: 8, lineHeight: 1.3 }}
+      >
+        {era_name} is now active.
+      </h3>
+
+      {era_notes && (
+        <p className="font-body" style={{ fontSize: 11, color: 'rgba(247,244,238,0.75)', marginBottom: 16, lineHeight: 1.5 }}>
+          {era_notes}
+        </p>
+      )}
+
+      <div style={{ display: 'flex', gap: 10 }}>
+        <Link
+          to="/tasks"
+          style={{
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 10,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.1em',
+            background: '#F7F4EE',
+            color: '#1a1209',
+            padding: '8px 16px',
+            textDecoration: 'none',
+          }}
+        >
+          See New Tasks
+        </Link>
+        <Link
+          to="/submissions"
+          style={{
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 10,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.1em',
+            border: '1px solid rgba(247,244,238,0.4)',
+            color: '#F7F4EE',
+            padding: '8px 16px',
+            textDecoration: 'none',
+          }}
+        >
+          Era Archive
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardFoeTaunt.tsx
+++ b/frontend/src/components/feed/FeedCardFoeTaunt.tsx
@@ -1,0 +1,86 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardFoeTaunt({ item }: Props) {
+  const { message, trigger_type, from_character_id } = item.payload
+  const color = factionColor(item.actor_faction_slug)
+
+  const triggerLabel =
+    trigger_type === 'score_overtake' ? 'Score overtake'
+    : trigger_type === 'level_up' ? 'Level up'
+    : trigger_type === 'submission_complete' ? 'Completed a task'
+    : trigger_type
+
+  return (
+    <div
+      className="sidebar-card"
+      style={{
+        background: 'linear-gradient(135deg, rgba(196,154,58,0.12), rgba(196,154,58,0.06))',
+        borderLeft: '4px solid #c49a3a',
+        padding: '16px 20px',
+        position: 'relative',
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
+        <span style={{ fontSize: 14 }}>&#x1F43A;</span>
+        <span
+          className="eyebrow"
+          style={{ color: '#c49a3a', fontSize: 8 }}
+        >
+          From Your Foe
+        </span>
+        <span style={{ margin: '0 2px', color: 'var(--color-text-tertiary)', fontSize: 8 }}>·</span>
+        <Link
+          to={`/characters/${from_character_id}`}
+          className="eyebrow"
+          style={{ color, fontSize: 8, textDecoration: 'none' }}
+        >
+          {item.actor_display_name}
+        </Link>
+        <span
+          className="eyebrow"
+          style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)', fontSize: 8 }}
+        >
+          {relativeTime(item.timestamp)}
+        </span>
+      </div>
+
+      {/* Taunt quote */}
+      <p
+        className="font-display italic"
+        style={{
+          fontSize: 14,
+          color: 'var(--color-text-primary)',
+          lineHeight: 1.4,
+          marginBottom: 8,
+        }}
+      >
+        &ldquo;{message}&rdquo;
+      </p>
+
+      {/* Trigger context */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', fontSize: 8 }}>
+          {triggerLabel}
+        </span>
+        <span
+          style={{
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 9,
+            fontWeight: 700,
+            color: '#dc2626',
+          }}
+        >
+          {/* Score comparison would need additional data — placeholder */}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardFriendActivity.tsx
+++ b/frontend/src/components/feed/FeedCardFriendActivity.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardFriendActivity({ item }: Props) {
+  const { submission_id, task_title, task_point_value, task_faction_slug, character_id } = item.payload
+  const actorColor = factionColor(item.actor_faction_slug)
+  const taskColor = factionColor(task_faction_slug)
+
+  return (
+    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        {/* Avatar */}
+        <Link to={`/characters/${character_id}`}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          />
+        </Link>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <Link
+              to={`/characters/${character_id}`}
+              className="font-body"
+              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            >
+              {item.actor_display_name}
+            </Link>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              completed a task
+            </span>
+            <FeedBadge type="friend" label="Friend" />
+          </div>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </div>
+      </div>
+
+      {/* Task info */}
+      <div
+        style={{
+          marginTop: 10,
+          marginLeft: 38,
+          borderLeft: `3px solid ${taskColor}`,
+          paddingLeft: 10,
+        }}
+      >
+        <Link
+          to={`/submissions/${submission_id}`}
+          className="font-body"
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: 'var(--color-text-primary)',
+            textDecoration: 'none',
+            display: 'block',
+            lineHeight: 1.3,
+          }}
+        >
+          {task_title}
+        </Link>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {task_point_value} pts
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardFriendDefection.tsx
+++ b/frontend/src/components/feed/FeedCardFriendDefection.tsx
@@ -1,0 +1,56 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor, factionName } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardFriendDefection({ item }: Props) {
+  const { character_id, old_faction_slug, old_faction_name, new_faction_slug, new_faction_name } = item.payload
+  const newColor = factionColor(new_faction_slug)
+  const oldColor = factionColor(old_faction_slug)
+
+  return (
+    <div className="sidebar-card" style={{ padding: '12px 16px' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <Link to={`/characters/${character_id}`}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${newColor}, ${newColor}88)`,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          />
+        </Link>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <Link
+              to={`/characters/${character_id}`}
+              className="font-body"
+              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            >
+              {item.actor_display_name}
+            </Link>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              defected from{' '}
+              <span style={{ color: oldColor, fontWeight: 600 }}>{old_faction_name}</span>
+              {' to '}
+              <span style={{ color: newColor, fontWeight: 600 }}>{new_faction_name}</span>
+            </span>
+            <FeedBadge type="friend" label="Friend" />
+          </div>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardFriendSignup.tsx
+++ b/frontend/src/components/feed/FeedCardFriendSignup.tsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardFriendSignup({ item }: Props) {
+  const { character_id, task_id, task_title, task_point_value, task_faction_slug } = item.payload
+  const actorColor = factionColor(item.actor_faction_slug)
+  const taskColor = factionColor(task_faction_slug)
+
+  return (
+    <div className="sidebar-card" style={{ padding: '12px 16px' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <Link to={`/characters/${character_id}`}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          />
+        </Link>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <Link
+              to={`/characters/${character_id}`}
+              className="font-body"
+              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            >
+              {item.actor_display_name}
+            </Link>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              signed up for a task you're doing
+            </span>
+            <FeedBadge type="friend" label="Friend" />
+          </div>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 8, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
+        <Link
+          to={`/tasks/${task_id}`}
+          className="font-body"
+          style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+        >
+          {task_title}
+        </Link>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {task_point_value} pts
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardGlobalTask.tsx
+++ b/frontend/src/components/feed/FeedCardGlobalTask.tsx
@@ -1,0 +1,51 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardGlobalTask({ item }: Props) {
+  const { task_id, task_title, task_point_value, task_level_required, task_faction_slug } = item.payload
+  const taskColor = factionColor(task_faction_slug)
+
+  return (
+    <div
+      className="sidebar-card"
+      style={{
+        padding: '12px 16px',
+        borderLeft: '3px solid var(--color-border-strong)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+        <span style={{ fontSize: 12 }}>&#x23F0;</span>
+        <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+          A new task has been activated
+        </span>
+        <FeedBadge type="global" label="Global" />
+        <span style={{ marginLeft: 'auto' }}>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginLeft: 22 }}>
+        <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
+        <Link
+          to={`/tasks/${task_id}`}
+          className="font-body"
+          style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+        >
+          {task_title}
+        </Link>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {task_point_value} pts · lvl {task_level_required}+
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -1,0 +1,61 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor, factionName } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardInvitationLetter({ item }: Props) {
+  const { faction_slug, faction_name } = item.payload
+  const color = factionColor(faction_slug)
+
+  return (
+    <div
+      className="sidebar-card"
+      style={{
+        padding: '16px 20px',
+        borderLeft: `4px solid ${color}`,
+        background: `linear-gradient(135deg, ${color}10, transparent)`,
+        position: 'relative',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+        <span style={{ fontSize: 16 }}>&#x2709;&#xFE0F;</span>
+        <span className="eyebrow" style={{ color, fontSize: 8 }}>
+          Faction Invitation
+        </span>
+        <FeedBadge type="your_stuff" label="Your Stuff" />
+        <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)', fontSize: 8 }}>
+          {relativeTime(item.timestamp)}
+        </span>
+      </div>
+
+      <p className="font-display italic" style={{ fontSize: 14, color: 'var(--color-text-primary)', lineHeight: 1.4, marginBottom: 8 }}>
+        You've received an invitation to join{' '}
+        <span style={{ color, fontWeight: 700 }}>{faction_name}</span>.
+      </p>
+
+      <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+        Complete faction tasks to prove your dedication, or visit the factions page to make your choice.
+      </p>
+
+      <Link
+        to="/factions"
+        style={{
+          fontFamily: "'Courier Prime', monospace",
+          fontSize: 9,
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+          color,
+          textDecoration: 'none',
+        }}
+      >
+        View Factions &rarr;
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardRouter.tsx
+++ b/frontend/src/components/feed/FeedCardRouter.tsx
@@ -1,0 +1,34 @@
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import FeedCardEraAnnouncement from './FeedCardEraAnnouncement'
+import FeedCardVoteNotification from './FeedCardVoteNotification'
+import FeedCardFoeTaunt from './FeedCardFoeTaunt'
+import FeedCardFriendActivity from './FeedCardFriendActivity'
+import FeedCardCollabInvite from './FeedCardCollabInvite'
+import FeedCardDuelChallenge from './FeedCardDuelChallenge'
+import FeedCardGlobalTask from './FeedCardGlobalTask'
+import FeedCardFriendSignup from './FeedCardFriendSignup'
+import FeedCardInvitationLetter from './FeedCardInvitationLetter'
+import FeedCardFriendDefection from './FeedCardFriendDefection'
+
+const CARD_MAP: Record<string, React.ComponentType<{ item: ActivityFeedItem }>> = {
+  era_announcement: FeedCardEraAnnouncement,
+  vote_on_mine: FeedCardVoteNotification,
+  foe_taunt: FeedCardFoeTaunt,
+  friend_completion: FeedCardFriendActivity,
+  collab_invite: FeedCardCollabInvite,
+  duel_challenge: FeedCardDuelChallenge,
+  global_task: FeedCardGlobalTask,
+  friend_signup: FeedCardFriendSignup,
+  invitation_letter: FeedCardInvitationLetter,
+  friend_defection: FeedCardFriendDefection,
+}
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardRouter({ item }: Props) {
+  const Card = CARD_MAP[item.type]
+  if (!Card) return null
+  return <Card item={item} />
+}

--- a/frontend/src/components/feed/FeedCardVoteNotification.tsx
+++ b/frontend/src/components/feed/FeedCardVoteNotification.tsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardVoteNotification({ item }: Props) {
+  const { stars, submission_id, submission_title, points_earned } = item.payload
+  const color = factionColor(item.actor_faction_slug)
+
+  return (
+    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        {/* Avatar */}
+        <div
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: '50%',
+            background: `linear-gradient(135deg, ${color}, ${color}88)`,
+            flexShrink: 0,
+            marginTop: 2,
+          }}
+        />
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+              {item.actor_display_name}
+            </span>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              voted on your praxis
+            </span>
+            <FeedBadge type="your_stuff" label="Your Stuff" />
+          </div>
+
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </div>
+      </div>
+
+      {/* Vote detail row */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 8, paddingLeft: 38 }}>
+        {/* Star badge */}
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 28,
+            height: 28,
+            borderRadius: 4,
+            background: '#14532d',
+            color: '#fff',
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 14,
+            fontWeight: 700,
+          }}
+        >
+          {stars}
+        </span>
+
+        <span className="font-body" style={{ fontSize: 10, color: 'var(--color-text-secondary)', flex: 1 }}>
+          on{' '}
+          <Link
+            to={`/submissions/${submission_id}`}
+            style={{ color: 'var(--color-text-primary)', fontWeight: 600, textDecoration: 'none' }}
+          >
+            {submission_title}
+          </Link>
+        </span>
+
+        <span
+          style={{
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 10,
+            fontWeight: 700,
+            color: '#14532d',
+          }}
+        >
+          +{points_earned} pts
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedDateDivider.tsx
+++ b/frontend/src/components/feed/FeedDateDivider.tsx
@@ -1,0 +1,38 @@
+/** Date divider for the activity feed (TODAY, YESTERDAY, or formatted date). */
+
+export function getDateLabel(iso: string): string {
+  const date = new Date(iso)
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const yesterday = new Date(today.getTime() - 86400000)
+  const itemDate = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+
+  if (itemDate.getTime() === today.getTime()) return 'Today'
+  if (itemDate.getTime() === yesterday.getTime()) return 'Yesterday'
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+interface FeedDateDividerProps {
+  label: string
+}
+
+export default function FeedDateDivider({ label }: FeedDateDividerProps) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, margin: '16px 0' }}>
+      <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
+      <span
+        style={{
+          fontFamily: "'Courier Prime', monospace",
+          fontSize: 9,
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.15em',
+          color: 'var(--color-text-tertiary)',
+        }}
+      >
+        {label}
+      </span>
+      <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,28 +3,42 @@ import { Link } from 'react-router-dom'
 import { useAuth } from '../../auth/AuthContext'
 import { getMyTasks, type CharacterTaskOut } from '../../api/tasks'
 import { listSubmissions, type SubmissionOut } from '../../api/submissions'
+import { getActivityFeed, type ActivityFeedItem } from '../../api/activityFeed'
+import { getVotesReceived } from '../../api/characters'
 import { relativeTime } from '../../utils/dates'
 import { factionColor, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
+import FeedBadge from '../feed/FeedBadge'
 
 const MAX_TASK_SLOTS = 20
 
 /**
  * Always-on right sidebar (Style Guide §4.2).
- * Character card + active tasks (live data) + recent activity (live data) + propose-a-task button.
+ * Character card + pending requests + active tasks + recent global activity + propose button.
  */
 export default function Sidebar() {
   const { user } = useAuth()
   const character = user?.character
 
   const [activeTasks, setActiveTasks] = useState<CharacterTaskOut[]>([])
-  const [recentActivity, setRecentActivity] = useState<SubmissionOut[]>([])
+  const [globalActivity, setGlobalActivity] = useState<SubmissionOut[]>([])
+  const [pendingRequests, setPendingRequests] = useState<ActivityFeedItem[]>([])
+  const [votesReceived, setVotesReceived] = useState<number>(0)
 
   useEffect(() => {
     if (!user) return
     getMyTasks('in_progress').then(setActiveTasks).catch(() => {})
-    listSubmissions().then((submissions) => setRecentActivity(submissions.slice(0, 3))).catch(() => {})
-  }, [user])
+    // Global activity: recent completions from anyone
+    listSubmissions({ limit: 5 } as any).then((submissions) => setGlobalActivity(submissions.slice(0, 5))).catch(() => {})
+    // Pending requests (collab invites + duel challenges)
+    getActivityFeed({ filter: 'requests', limit: 5 })
+      .then((response) => setPendingRequests(response.items))
+      .catch(() => {})
+    // Votes received count
+    if (character) {
+      getVotesReceived(character.id).then((data) => setVotesReceived(data.votes_received)).catch(() => {})
+    }
+  }, [user, character])
 
   const slotCount = activeTasks.length
   const slotPercent = Math.min((slotCount / MAX_TASK_SLOTS) * 100, 100)
@@ -34,6 +48,9 @@ export default function Sidebar() {
       {/* ── Character Card ── */}
       {character ? (
         <div className="sidebar-card">
+          <div className="eyebrow" style={{ fontSize: 8, marginBottom: 8, color: 'var(--color-text-tertiary)' }}>
+            Your Character
+          </div>
           <div className="flex items-center gap-3 mb-3">
             {character.avatar_url ? (
               <img
@@ -75,9 +92,9 @@ export default function Sidebar() {
 
           <div className="grid grid-cols-3 gap-1">
             {[
-              { label: 'Score', value: character.score },
-              { label: 'Level', value: character.level },
-              { label: 'Era', value: 1 },
+              { label: 'Score', value: character.score?.toLocaleString() ?? '0' },
+              { label: 'Votes', value: votesReceived.toLocaleString() },
+              { label: 'Current', value: `Era 3`, sublabel: true },
             ].map((stat) => (
               <div
                 key={stat.label}
@@ -100,6 +117,51 @@ export default function Sidebar() {
         </div>
       )}
 
+      {/* ── Pending Requests Panel ── */}
+      {pendingRequests.length > 0 && (
+        <div className="sidebar-card">
+          <p className="eyebrow mb-2">
+            Pending Requests · {pendingRequests.length}
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {pendingRequests.map((item, index) => {
+              const actorColor = factionColor(item.actor_faction_slug)
+              const isCollab = item.type === 'collab_invite'
+              return (
+                <div
+                  key={`${item.type}-${index}`}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '6px 0',
+                    borderTop: index > 0 ? '1px dashed var(--color-border)' : undefined,
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 24,
+                      height: 24,
+                      borderRadius: '50%',
+                      background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <span className="font-body" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', display: 'block' }}>
+                      {item.actor_display_name}
+                    </span>
+                    <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+                      {isCollab ? 'Collab Invite' : 'Duel Challenge'}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
       {/* ── Active Tasks Panel ── */}
       <div className="sidebar-card">
         <p className="eyebrow mb-2">Your active tasks</p>
@@ -119,18 +181,24 @@ export default function Sidebar() {
                   style={{
                     borderLeft: `3px solid ${taskFactionColor}`,
                     paddingLeft: 8,
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    justifyContent: 'space-between',
                   }}
                 >
-                  <Link
-                    to={`/tasks/${characterTask.task.id}`}
-                    className="font-body"
-                    style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', display: 'block', lineHeight: 1.3 }}
-                  >
-                    {characterTask.task.title}
-                  </Link>
-                  <span className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-                    {taskFactionName} · lvl {characterTask.task.level_required} · {relativeTime(characterTask.signed_up_at)}
-                  </span>
+                  <div style={{ minWidth: 0 }}>
+                    <Link
+                      to={`/tasks/${characterTask.task.id}`}
+                      className="font-body"
+                      style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', display: 'block', lineHeight: 1.3 }}
+                    >
+                      {characterTask.task.title}
+                    </Link>
+                    <span className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
+                      {taskFactionName} · lvl {characterTask.task.level_required}
+                    </span>
+                  </div>
+                  <FeedBadge type="global" label="Solo" />
                 </div>
               )
             })}
@@ -163,17 +231,17 @@ export default function Sidebar() {
         </div>
       </div>
 
-      {/* ── Recent Activity Panel ── */}
+      {/* ── Recent Global Activity Panel ── */}
       <div className="sidebar-card">
-        <p className="eyebrow mb-2">Recent activity</p>
+        <p className="eyebrow mb-2">Recent global activity</p>
 
-        {recentActivity.length === 0 ? (
+        {globalActivity.length === 0 ? (
           <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
             No activity yet
           </p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            {recentActivity.map((submission, index) => (
+            {globalActivity.map((submission, index) => (
               <div
                 key={submission.id}
                 style={{

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -1,298 +1,195 @@
-import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { listSubmissions, type SubmissionOut } from '../api/submissions'
-import { getMessages, type MessageOut } from '../api/messages'
-import { getMyTasks, type CharacterTaskOut } from '../api/tasks'
-import { listRelationships, type RelationshipListItem } from '../api/relationships'
-import SubmissionCard from '../components/SubmissionCard'
+import { useEffect, useState, useCallback } from 'react'
+import { getActivityFeed, type ActivityFeedItem, type FeedCounts } from '../api/activityFeed'
 import PageTitle from '../components/ui/PageTitle'
-import { useAuth } from '../auth/AuthContext'
+import FeedCardRouter from '../components/feed/FeedCardRouter'
+import FeedDateDivider, { getDateLabel } from '../components/feed/FeedDateDivider'
 import { useTheme } from '../hooks/useTheme'
-import { factionColor } from '../utils/factions'
-import { relativeTime } from '../utils/dates'
-// Individual fetches fail silently — no global error state needed
 
-type FeedFilter = 'All' | 'Friends' | 'Foes' | 'Your stuff' | 'Global'
+type FeedFilter = 'All' | 'Friends' | 'Foes' | 'Your Stuff' | 'Global' | 'Requests'
 
-const FILTER_OPTIONS: FeedFilter[] = ['All', 'Friends', 'Foes', 'Your stuff', 'Global']
+const ROW_1_FILTERS: FeedFilter[] = ['All', 'Friends', 'Foes', 'Your Stuff']
+const ROW_2_FILTERS: FeedFilter[] = ['Global', 'Requests']
 
-/** Feed item accent colors by type (§17.3) */
-const TYPE_COLORS: Record<string, string> = {
-  message: '#be185d',
-  task: '#4f46e5',
-  praxis: '#14532d',
-  friend: '#14532d',
-  foe: '#dc2626',
+/** Map UI filter name to API filter param. */
+const FILTER_API_MAP: Record<FeedFilter, string> = {
+  'All': 'all',
+  'Friends': 'friends',
+  'Foes': 'foes',
+  'Your Stuff': 'your_stuff',
+  'Global': 'global',
+  'Requests': 'requests',
+}
+
+/** Map filter name to the key in FeedCounts. */
+function getCount(filter: FeedFilter, counts: FeedCounts): number {
+  switch (filter) {
+    case 'All': return counts.all
+    case 'Friends': return counts.friends
+    case 'Foes': return counts.foes
+    case 'Your Stuff': return counts.your_stuff
+    case 'Global': return counts.global_count
+    case 'Requests': return counts.requests
+  }
 }
 
 export default function Updates() {
-  const { user } = useAuth()
   const { theme } = useTheme()
   const dark = theme === 'dark'
-  const [submissions, setSubmissions] = useState<SubmissionOut[]>([])
-  const [messages, setMessages] = useState<MessageOut[]>([])
-  const [inProgressTasks, setInProgressTasks] = useState<CharacterTaskOut[]>([])
-  const [friends, setFriends] = useState<RelationshipListItem[]>([])
-  const [foes, setFoes] = useState<RelationshipListItem[]>([])
-  const [friendSubmissions, setFriendSubmissions] = useState<SubmissionOut[]>([])
+
+  const [items, setItems] = useState<ActivityFeedItem[]>([])
+  const [counts, setCounts] = useState<FeedCounts>({ all: 0, friends: 0, foes: 0, your_stuff: 0, global_count: 0, requests: 0 })
   const [filter, setFilter] = useState<FeedFilter>('All')
   const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
 
+  const fetchFeed = useCallback(async (feedFilter: FeedFilter, cursor?: string) => {
+    const response = await getActivityFeed({
+      filter: FILTER_API_MAP[feedFilter],
+      before: cursor,
+      limit: 20,
+    })
+    return response
+  }, [])
+
+  // Initial load + filter changes
   useEffect(() => {
-    // Fetch each data source independently so one failure doesn't break the page
-    const fetches = [
-      listSubmissions(user?.character ? { character_id: user.character.id } : {})
-        .then(setSubmissions).catch(() => {}),
-      getMessages()
-        .then(setMessages).catch(() => {}),
-      getMyTasks('in_progress')
-        .then(setInProgressTasks).catch(() => {}),
-      listRelationships({ type: 'friend' })
-        .then((fr) => {
-          const activeFriends = fr.filter((r) => r.status === 'active')
-          setFriends(activeFriends)
-          // Fetch recent submissions from friends
-          const friendFetches = activeFriends.slice(0, 10).map((rel) =>
-            listSubmissions({ character_id: rel.to_character_id }).catch(() => [] as SubmissionOut[])
-          )
-          return Promise.all(friendFetches).then((results) => {
-            setFriendSubmissions(results.flat().sort((a, b) =>
-              new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-            ).slice(0, 20))
-          })
-        }).catch(() => {}),
-      listRelationships({ type: 'foe' })
-        .then((fo) => setFoes(fo.filter((r) => r.status === 'active'))).catch(() => {}),
-    ]
-    Promise.all(fetches).finally(() => setLoading(false))
-  }, [user])
+    let cancelled = false
+    setLoading(true)
+    fetchFeed(filter).then((response) => {
+      if (cancelled) return
+      setItems(response.items)
+      setCounts(response.counts)
+      setNextCursor(response.next_cursor)
+      setLoading(false)
+    }).catch(() => {
+      if (!cancelled) setLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [filter, fetchFeed])
 
-  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
+  const loadMore = async () => {
+    if (!nextCursor || loadingMore) return
+    setLoadingMore(true)
+    try {
+      const response = await fetchFeed(filter, nextCursor)
+      setItems((prev) => [...prev, ...response.items])
+      setNextCursor(response.next_cursor)
+    } catch { /* swallow */ }
+    setLoadingMore(false)
+  }
 
-  const showMessages = filter === 'All' || filter === 'Your stuff'
-  const showTasks = filter === 'All' || filter === 'Your stuff'
-  const showPraxis = filter === 'All' || filter === 'Your stuff'
-  const showFriends = filter === 'All' || filter === 'Friends'
-  const showFoes = filter === 'All' || filter === 'Foes'
-  const showGlobal = filter === 'Global'
+  /** Insert date dividers between items when the date changes. */
+  const renderFeedWithDividers = () => {
+    const elements: React.ReactNode[] = []
+    let lastDateLabel = ''
+
+    for (let index = 0; index < items.length; index++) {
+      const item = items[index]
+      const dateLabel = getDateLabel(item.timestamp)
+
+      if (dateLabel !== lastDateLabel) {
+        elements.push(<FeedDateDivider key={`divider-${dateLabel}-${index}`} label={dateLabel} />)
+        lastDateLabel = dateLabel
+      }
+
+      elements.push(<FeedCardRouter key={`${item.type}-${item.timestamp}-${index}`} item={item} />)
+    }
+
+    return elements
+  }
+
+  const renderFilterButton = (option: FeedFilter) => {
+    const active = filter === option
+    const count = getCount(option, counts)
+    const isRequests = option === 'Requests'
+    const hasRedBadge = isRequests && count > 0
+
+    return (
+      <button
+        key={option}
+        onClick={() => setFilter(option)}
+        style={{
+          position: 'relative',
+          border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
+          borderRadius: 0,
+          background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
+          color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-primary)',
+          fontFamily: "'Courier Prime', monospace",
+          fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
+          letterSpacing: '0.1em', padding: '5px 10px',
+          cursor: 'pointer', transition: 'all 120ms',
+          display: 'flex', alignItems: 'center', gap: 5,
+        }}
+      >
+        {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed rgba(255,255,255,0.2)', pointerEvents: 'none' }} />}
+        {option}
+        {count > 0 && (
+          <span style={{
+            background: hasRedBadge ? '#dc2626' : (active ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.1)'),
+            color: hasRedBadge ? 'white' : 'inherit',
+            fontSize: 8, padding: '0 5px', borderRadius: 8, minWidth: 16, textAlign: 'center',
+          }}>
+            {count}
+          </span>
+        )}
+      </button>
+    )
+  }
 
   return (
     <div className="py-8">
-      <PageTitle title="Updates" eyebrow="Era I" />
+      <PageTitle title="Updates" eyebrow="Activity Feed" />
 
-      {/* ── Feed Filters (§17.2) — full set with badge count ── */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 20, alignItems: 'center' }}>
-        <span className="eyebrow">show</span>
-        {FILTER_OPTIONS.map((option) => {
-          const active = filter === option
-          const count = option === 'All' ? null
-            : option === 'Friends' ? friends.length || null
-            : option === 'Foes' ? foes.length || null
-            : null
-          const hasRedBadge = false
-
-          return (
-            <button
-              key={option}
-              onClick={() => setFilter(option)}
-              style={{
-                position: 'relative',
-                border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
-                borderRadius: 0,
-                background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
-                color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-primary)',
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
-                letterSpacing: '0.1em', padding: '5px 10px',
-                cursor: 'pointer', transition: 'all 120ms',
-                display: 'flex', alignItems: 'center', gap: 5,
-              }}
-            >
-              {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed rgba(255,255,255,0.2)', pointerEvents: 'none' }} />}
-              {option}
-              {count !== null && (
-                <span style={{
-                  background: hasRedBadge ? '#dc2626' : (active ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.1)'),
-                  color: hasRedBadge ? 'white' : 'inherit',
-                  fontSize: 8, padding: '0 5px', borderRadius: 8, minWidth: 16, textAlign: 'center',
-                }}>
-                  {count}
-                </span>
-              )}
-            </button>
-          )
-        })}
+      {/* ── Filter Tabs ── */}
+      <div style={{ marginBottom: 20 }}>
+        {/* Row 1 */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 6, alignItems: 'center' }}>
+          <span className="eyebrow">show</span>
+          {ROW_1_FILTERS.map(renderFilterButton)}
+        </div>
+        {/* Row 2 */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center', paddingLeft: 36 }}>
+          {ROW_2_FILTERS.map(renderFilterButton)}
+        </div>
       </div>
 
-      {/* ── Friends Activity ── */}
-      {showFriends && friends.length > 0 && (
-        <section className="mb-6">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-            <span className="eyebrow">Friends · {friends.length}</span>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {friends.map((rel) => {
-              const color = factionColor(rel.to_faction_slug)
-              return (
-                <div
-                  key={rel.id}
-                  className="sidebar-card"
-                  style={{ borderLeft: `4px solid ${TYPE_COLORS.friend}`, padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 10, position: 'relative' }}
-                >
-                  <Link to={`/characters/${rel.to_character_id}`}>
-                    <div style={{ width: 28, height: 28, borderRadius: '50%', background: `linear-gradient(135deg, ${color}, ${color}88)`, flexShrink: 0 }} />
-                  </Link>
-                  <Link to={`/characters/${rel.to_character_id}`} className="font-body" style={{ fontSize: 11, fontWeight: 700, color, textDecoration: 'none' }}>
-                    {rel.to_display_name}
-                  </Link>
-                  <span style={{ position: 'absolute', top: 8, right: 10, fontSize: 7, textTransform: 'uppercase', letterSpacing: '0.1em', color: TYPE_COLORS.friend, fontFamily: "'Courier Prime', monospace", fontWeight: 700 }}>
-                    {rel.display_status}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
-          {/* Friends' recent praxis */}
-          {friendSubmissions.length > 0 && (
-            <div style={{ marginTop: 12 }}>
-              <span className="eyebrow" style={{ marginBottom: 8, display: 'block' }}>Friends' recent praxis</span>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {friendSubmissions.map((s) => <SubmissionCard key={s.id} submission={s} />)}
-              </div>
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* ── Foes ── */}
-      {showFoes && foes.length > 0 && (
-        <section className="mb-6">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-            <span className="eyebrow">Foes · {foes.length}</span>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {foes.map((rel) => {
-              const color = factionColor(rel.to_faction_slug)
-              return (
-                <div
-                  key={rel.id}
-                  className="sidebar-card"
-                  style={{ borderLeft: `4px solid ${TYPE_COLORS.foe}`, padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 10 }}
-                >
-                  <Link to={`/characters/${rel.to_character_id}`}>
-                    <div style={{ width: 28, height: 28, borderRadius: '50%', background: `linear-gradient(135deg, ${color}, ${color}88)`, flexShrink: 0 }} />
-                  </Link>
-                  <Link to={`/characters/${rel.to_character_id}`} className="font-body" style={{ fontSize: 11, fontWeight: 700, color: '#dc2626', textDecoration: 'none' }}>
-                    {rel.to_display_name}
-                  </Link>
-                </div>
-              )
-            })}
-          </div>
-        </section>
-      )}
-
-      {/* ── Messages Section ── */}
-      {showMessages && messages.length > 0 && (
-        <section className="mb-6">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-            <span className="eyebrow">Messages</span>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {messages.map((m) => (
-              <div
-                key={m.id}
-                className="sidebar-card"
-                style={{ borderLeft: `4px solid ${TYPE_COLORS.message}`, padding: '10px 14px', position: 'relative' }}
-              >
-                <span style={{ position: 'absolute', top: 8, right: 10, fontSize: 7, textTransform: 'uppercase', letterSpacing: '0.1em', color: TYPE_COLORS.message, fontFamily: "'Courier Prime', monospace", fontWeight: 700 }}>
-                  {!m.read_at && '● '}message
-                </span>
-                <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)', marginBottom: 4, paddingRight: 60 }}>{m.body}</p>
-                <span className="eyebrow">from #{m.from_character_id} · {relativeTime(m.created_at)}</span>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* ── Tasks in Progress Section ── */}
-      {showTasks && (
-        <section className="mb-6">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-            <span className="eyebrow">Tasks in progress</span>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-          </div>
-          {inProgressTasks.length === 0 ? (
-            <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>
-              No tasks in progress. <Link to="/tasks" className="underline" style={{ color: 'var(--color-text-secondary)' }}>Browse tasks</Link>
-            </p>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {inProgressTasks.map((ct) => {
-                const color = factionColor(ct.task.primary_faction_slug)
-                return (
-                  <div key={ct.id} className="sidebar-card" style={{ borderLeft: `4px solid ${color}`, padding: '10px 14px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-                    <div style={{ minWidth: 0 }}>
-                      <Link to={`/tasks/${ct.task.id}`} className="font-body block truncate" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}>{ct.task.title}</Link>
-                      <span className="eyebrow">{ct.task.point_value} pts · {relativeTime(ct.signed_up_at)}</span>
-                    </div>
-                    <Link to={`/tasks/${ct.task.id}/submit`} style={{ background: color, color: 'white', fontFamily: "'Courier Prime', monospace", fontSize: 9, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', padding: '5px 12px', textDecoration: 'none', whiteSpace: 'nowrap', position: 'relative' }}>
-                      <span style={{ position: 'absolute', inset: 2, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-                      Submit proof
-                    </Link>
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* ── Your Praxis Section ── */}
-      {showPraxis && (
-        <section>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-            <span className="eyebrow">Your praxis</span>
-            <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
-          </div>
-          {submissions.length === 0 ? (
-            <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>No praxis yet.</p>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {submissions.map((s) => <SubmissionCard key={s.id} submission={s} />)}
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* Global placeholder */}
-      {showGlobal && (
+      {/* ── Feed ── */}
+      {loading ? (
+        <div className="py-8 font-body text-muted">Loading...</div>
+      ) : items.length === 0 ? (
         <div className="sidebar-card" style={{ padding: 20, textAlign: 'center' }}>
-          <p className="eyebrow mb-2">Global activity feed</p>
           <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>
-            Coming soon — site-wide events, new tasks, and era announcements.
+            No updates yet. Activity from friends, foes, and the community will appear here.
           </p>
         </div>
-      )}
-
-      {/* Friends empty state */}
-      {filter === 'Friends' && friends.length === 0 && (
-        <div className="sidebar-card" style={{ padding: 20, textAlign: 'center' }}>
-          <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>No friends yet. Visit a player's profile to add them.</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {renderFeedWithDividers()}
         </div>
       )}
-      {filter === 'Foes' && foes.length === 0 && (
-        <div className="sidebar-card" style={{ padding: 20, textAlign: 'center' }}>
-          <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>No foes yet.</p>
+
+      {/* ── Load More ── */}
+      {nextCursor && !loading && (
+        <div style={{ textAlign: 'center', marginTop: 24 }}>
+          <button
+            onClick={loadMore}
+            disabled={loadingMore}
+            style={{
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              background: 'transparent',
+              color: '#c49a3a',
+              border: 'none',
+              cursor: loadingMore ? 'not-allowed' : 'pointer',
+              padding: '8px 16px',
+            }}
+          >
+            {loadingMore ? 'Loading...' : 'Load Older Updates \u2192'}
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- **Unified activity feed** (`GET /activity-feed`) with server-side aggregation of 10 event types, 6 filter modes, badge counts, and cursor-based pagination
- **Collab/duel invite flow** with `invite_status` on submissions and accept/decline endpoints
- **Complete Updates.tsx rewrite** as a unified chronological feed matching the design mockup
- **13 feed card components** for all activity types including faction invitation letters and friend defections
- **Sidebar updates** with pending requests panel, votes stat, and global activity ticker

## Test plan
- [ ] Run `alembic upgrade head` to apply the invite_status migration
- [ ] Verify `GET /activity-feed` returns mixed activity types with correct filtering
- [ ] Test `POST /submissions/{id}/accept-invite` and `decline-invite` endpoints
- [ ] Verify Updates page renders with filter tabs, date dividers, and all card types
- [ ] Test "Load Older Updates" pagination
- [ ] Verify sidebar shows pending requests, votes count, and global activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)