### PR TITLE
Merge alembic migration heads

### DIFF
--- a/backend/alembic/versions/0003_merge_heads.py
+++ b/backend/alembic/versions/0003_merge_heads.py
@@ -1,0 +1,21 @@
+"""Merge faction models and invite status migration heads.
+
+Revision ID: 0003_merge
+Revises: 0002_faction_models, 0002_invite_status
+Create Date: 2026-04-14
+
+"""
+from typing import Sequence, Union
+
+revision: str = "0003_merge"
+down_revision: tuple[str, str] = ("0002_faction_models", "0002_invite_status")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Merges the two divergent alembic heads (`0002_faction_models` and `0002_invite_status`) into a single `0003_merge` revision
- Fixes `alembic upgrade head` failing with "Multiple head revisions" error

## Test plan
- [ ] Run `alembic upgrade head` — should complete without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)