### PR TITLE
Fix 6 frontend bugs: form limits, uploads, leaderboard, scroll, hooks, admin tasks

### DIFF
--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
+from sqlalchemy.sql import false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
@@ -28,13 +29,15 @@ async def get_leaderboard(
     except HTTPException:
         era_id = None
 
+    join_condition = CharacterStats.character_id == Character.id
+    if era_id is not None:
+        join_condition = join_condition & (CharacterStats.era_id == era_id)
+    else:
+        join_condition = join_condition & sa_false()
+
     query = (
         select(Character, CharacterStats)
-        .outerjoin(
-            CharacterStats,
-            (CharacterStats.character_id == Character.id)
-            & (CharacterStats.era_id == era_id if era_id else False),
-        )
+        .outerjoin(CharacterStats, join_condition)
         .where(Character.status == CharacterStatus.active)
     )
     if faction:

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -55,13 +55,14 @@ async def list_tasks(
     hidden_slugs = [row[0] for row in hidden_result.all()]
 
     query = select(Task)
-    if status:
+    if status and status != "all":
         try:
             query = query.where(Task.status == TaskStatus[status])
         except KeyError:
             raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
-    else:
+    elif not status:
         query = query.where(Task.status == TaskStatus.active)
+    # status == "all" -> no status filter, return tasks of every status
     if level is not None:
         query = query.where(Task.level_required >= level)
     if faction:

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -79,7 +79,7 @@ export async function getAccountDetail(id: number): Promise<AccountDetail> {
 }
 
 export async function getAllTasks(): Promise<TaskOut[]> {
-  const { data } = await api.get<TaskOut[]>('/tasks')
+  const { data } = await api.get<TaskOut[]>('/tasks', { params: { status: 'all' } })
   return data
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,6 +11,10 @@ export default function Layout({ children }: { children: ReactNode }) {
   const { pathname } = useLocation()
 
   useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  useEffect(() => {
     if (!loading && user && !user.character && pathname !== '/characters/create') {
       navigate('/characters/create')
     }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../auth/AuthContext'
-import { getMyTasks, type CharacterTaskOut } from '../../api/tasks'
 import { listSubmissions, type SubmissionOut } from '../../api/submissions'
-import { getActivityFeed, type ActivityFeedItem } from '../../api/activityFeed'
-import { getVotesReceived } from '../../api/characters'
 import { relativeTime } from '../../utils/dates'
 import { factionColor, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import FeedBadge from '../feed/FeedBadge'
+import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
+import { useMyCharacterStats } from '../../hooks/useMyCharacterStats'
+import { usePendingRequests } from '../../hooks/usePendingRequests'
 
 const MAX_TASK_SLOTS = 20
 
@@ -20,25 +20,15 @@ export default function Sidebar() {
   const { user } = useAuth()
   const character = user?.character
 
-  const [activeTasks, setActiveTasks] = useState<CharacterTaskOut[]>([])
+  const { activeTasks } = useMyActiveTasks()
+  const { votesReceived } = useMyCharacterStats(character?.id)
+  const { pendingRequests } = usePendingRequests()
   const [globalActivity, setGlobalActivity] = useState<SubmissionOut[]>([])
-  const [pendingRequests, setPendingRequests] = useState<ActivityFeedItem[]>([])
-  const [votesReceived, setVotesReceived] = useState<number>(0)
 
   useEffect(() => {
     if (!user) return
-    getMyTasks('in_progress').then(setActiveTasks).catch(() => {})
-    // Global activity: recent completions from anyone
     listSubmissions({ limit: 5 } as any).then((submissions) => setGlobalActivity(submissions.slice(0, 5))).catch(() => {})
-    // Pending requests (collab invites + duel challenges)
-    getActivityFeed({ filter: 'requests', limit: 5 })
-      .then((response) => setPendingRequests(response.items))
-      .catch(() => {})
-    // Votes received count
-    if (character) {
-      getVotesReceived(character.id).then((data) => setVotesReceived(data.votes_received)).catch(() => {})
-    }
-  }, [user, character])
+  }, [user])
 
   const slotCount = activeTasks.length
   const slotPercent = Math.min((slotCount / MAX_TASK_SLOTS) * 100, 100)

--- a/frontend/src/hooks/useMyActiveTasks.ts
+++ b/frontend/src/hooks/useMyActiveTasks.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getMyTasks, type CharacterTaskOut } from '../api/tasks'
+import { useAuth } from '../auth/AuthContext'
+
+/**
+ * Hook to fetch the current character's in-progress task signups.
+ * Re-fetches when the authenticated user changes.
+ */
+export function useMyActiveTasks() {
+  const { user } = useAuth()
+  const [activeTasks, setActiveTasks] = useState<CharacterTaskOut[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refetch = useCallback(() => {
+    if (!user) {
+      setActiveTasks([])
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    getMyTasks('in_progress')
+      .then(setActiveTasks)
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [user])
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  return { activeTasks, loading, refetch } as const
+}

--- a/frontend/src/hooks/useMyCharacterStats.ts
+++ b/frontend/src/hooks/useMyCharacterStats.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { getVotesReceived } from '../api/characters'
+
+/**
+ * Hook to fetch votes-received count for a character.
+ * Re-fetches when characterId changes.
+ */
+export function useMyCharacterStats(characterId: number | undefined) {
+  const [votesReceived, setVotesReceived] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (characterId === undefined) {
+      setVotesReceived(0)
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    getVotesReceived(characterId)
+      .then((data) => setVotesReceived(data.votes_received))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [characterId])
+
+  return { votesReceived, loading } as const
+}

--- a/frontend/src/hooks/usePendingRequests.ts
+++ b/frontend/src/hooks/usePendingRequests.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import { getActivityFeed, type ActivityFeedItem } from '../api/activityFeed'
+import { useAuth } from '../auth/AuthContext'
+
+/**
+ * Hook to fetch pending collab invites and duel challenges.
+ * Re-fetches when the authenticated user changes.
+ */
+export function usePendingRequests() {
+  const { user } = useAuth()
+  const [pendingRequests, setPendingRequests] = useState<ActivityFeedItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!user) {
+      setPendingRequests([])
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    getActivityFeed({ filter: 'requests', limit: 5 })
+      .then((response) => setPendingRequests(response.items))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [user])
+
+  return { pendingRequests, loading } as const
+}

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -63,6 +63,7 @@ export default function Contact() {
             disabled={submitting}
             className="w-full border-2 border-border bg-card font-body text-sm px-3 py-2 focus:outline-none focus:shadow-sketch-sm disabled:opacity-50"
           />
+          <span className={`font-body text-xs self-end ${form.name.length >= 90 ? 'text-red-600' : 'text-muted'}`} style={{ textAlign: 'right', display: 'block' }}>{form.name.length}/100</span>
         </div>
 
         <div>
@@ -97,6 +98,7 @@ export default function Contact() {
             disabled={submitting}
             className="w-full border-2 border-border bg-card font-body text-sm px-3 py-2 focus:outline-none focus:shadow-sketch-sm disabled:opacity-50 resize-y"
           />
+          <span className={`font-body text-xs ${form.message.length >= 4500 ? 'text-red-600' : 'text-muted'}`} style={{ textAlign: 'right', display: 'block' }}>{form.message.length}/5000</span>
         </div>
 
         {error && (

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -20,8 +20,16 @@ export default function CreateCharacter() {
   const [submitting, setSubmitting] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0] ?? null
+    if (f && f.size > MAX_AVATAR_SIZE) {
+      setFieldErrors((prev) => ({ ...prev, avatar: 'Avatar must be under 10 MB.' }))
+      e.target.value = ''
+      return
+    }
+    setFieldErrors((prev) => { const { avatar, ...rest } = prev; return rest })
     setAvatarFile(f)
     if (f) {
       setAvatarUrl('')
@@ -137,6 +145,9 @@ export default function CreateCharacter() {
               </div>
             </div>
           </div>
+          {fieldErrors.avatar && (
+            <p className="font-body text-xs text-red-600">{fieldErrors.avatar}</p>
+          )}
         </div>
 
         {/* Username */}
@@ -155,9 +166,12 @@ export default function CreateCharacter() {
             required
             className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink"
           />
-          {fieldErrors.username && (
-            <p className="font-body text-xs text-red-600">{fieldErrors.username}</p>
-          )}
+          <div className="flex justify-between">
+            {fieldErrors.username ? (
+              <p className="font-body text-xs text-red-600">{fieldErrors.username}</p>
+            ) : <span />}
+            <span className={`font-body text-xs ${username.length >= 27 ? 'text-red-600' : 'text-muted'}`}>{username.length}/30</span>
+          </div>
         </div>
 
         {/* Display Name */}
@@ -174,9 +188,12 @@ export default function CreateCharacter() {
             required
             className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink"
           />
-          {fieldErrors.displayName && (
-            <p className="font-body text-xs text-red-600">{fieldErrors.displayName}</p>
-          )}
+          <div className="flex justify-between">
+            {fieldErrors.displayName ? (
+              <p className="font-body text-xs text-red-600">{fieldErrors.displayName}</p>
+            ) : <span />}
+            <span className={`font-body text-xs ${displayName.length >= 45 ? 'text-red-600' : 'text-muted'}`}>{displayName.length}/50</span>
+          </div>
         </div>
 
         {/* Bio */}
@@ -192,10 +209,12 @@ export default function CreateCharacter() {
             rows={3}
             className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink resize-none"
           />
-          <span className="font-body text-xs text-muted self-end">{bio.length}/500</span>
-          {fieldErrors.bio && (
-            <p className="font-body text-xs text-red-600">{fieldErrors.bio}</p>
-          )}
+          <div className="flex justify-between">
+            {fieldErrors.bio ? (
+              <p className="font-body text-xs text-red-600">{fieldErrors.bio}</p>
+            ) : <span />}
+            <span className={`font-body text-xs ${bio.length >= 450 ? 'text-red-600' : 'text-muted'}`}>{bio.length}/500</span>
+          </div>
         </div>
 
         {/* Location */}
@@ -211,9 +230,12 @@ export default function CreateCharacter() {
             maxLength={100}
             className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink"
           />
-          {fieldErrors.location && (
-            <p className="font-body text-xs text-red-600">{fieldErrors.location}</p>
-          )}
+          <div className="flex justify-between">
+            {fieldErrors.location ? (
+              <p className="font-body text-xs text-red-600">{fieldErrors.location}</p>
+            ) : <span />}
+            <span className={`font-body text-xs ${location.length >= 90 ? 'text-red-600' : 'text-muted'}`}>{location.length}/100</span>
+          </div>
         </div>
 
         {error && (

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -18,7 +18,21 @@ export default function EditCharacter() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
+  const [avatarError, setAvatarError] = useState('')
   const fileRef = useRef<HTMLInputElement>(null)
+
+  const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0] || null
+    if (f && f.size > MAX_AVATAR_SIZE) {
+      setAvatarError('Avatar must be under 10 MB.')
+      e.target.value = ''
+      return
+    }
+    setAvatarError('')
+    setAvatarFile(f)
+  }
 
   useEffect(() => {
     if (!id) return
@@ -89,9 +103,10 @@ export default function EditCharacter() {
               ref={fileRef}
               type="file"
               accept="image/*"
-              onChange={(e) => setAvatarFile(e.target.files?.[0] || null)}
+              onChange={handleAvatarChange}
               className="font-body text-sm"
             />
+            {avatarError && <p className="font-body text-xs text-red-600 mt-1">{avatarError}</p>}
           </div>
         </div>
 
@@ -104,6 +119,7 @@ export default function EditCharacter() {
             className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none"
             maxLength={50}
           />
+          <span className={`font-body text-xs self-end ${displayName.length >= 45 ? 'text-red-600' : 'text-muted'}`}>{displayName.length}/50</span>
         </div>
 
         <div className="flex flex-col gap-1">
@@ -116,6 +132,7 @@ export default function EditCharacter() {
             maxLength={500}
             placeholder="Tell people about your character..."
           />
+          <span className={`font-body text-xs self-end ${bio.length >= 450 ? 'text-red-600' : 'text-muted'}`}>{bio.length}/500</span>
         </div>
 
         <div className="flex flex-col gap-1">
@@ -128,6 +145,7 @@ export default function EditCharacter() {
             maxLength={100}
             placeholder="Where are you based?"
           />
+          <span className={`font-body text-xs self-end ${location.length >= 90 ? 'text-red-600' : 'text-muted'}`}>{location.length}/100</span>
         </div>
 
         {error && <p className="font-body text-sm text-red-600">{error}</p>}

--- a/frontend/src/pages/EditSubmission.tsx
+++ b/frontend/src/pages/EditSubmission.tsx
@@ -27,7 +27,27 @@ export default function EditSubmission() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  const [fileError, setFileError] = useState('')
   const fileRef = useRef<HTMLInputElement>(null)
+
+  const MAX_FILE_SIZE = 50 * 1024 * 1024 // 50 MB
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return
+    const incoming = Array.from(e.target.files)
+    const tooLarge = incoming.filter((f) => f.size > MAX_FILE_SIZE)
+    if (tooLarge.length > 0) {
+      setFileError(`File${tooLarge.length > 1 ? 's' : ''} too large (50 MB limit): ${tooLarge.map((f) => f.name).join(', ')}`)
+      // Build a DataTransfer with only valid files
+      const dt = new DataTransfer()
+      incoming.filter((f) => f.size <= MAX_FILE_SIZE).forEach((f) => dt.items.add(f))
+      e.target.files = dt.files
+      setNewFiles(dt.files.length > 0 ? dt.files : null)
+    } else {
+      setFileError('')
+      setNewFiles(e.target.files)
+    }
+  }
 
   useEffect(() => {
     if (!id) return
@@ -92,8 +112,10 @@ export default function EditSubmission() {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
+            maxLength={200}
             className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none"
           />
+          <span className={`font-body text-xs self-end ${title.length >= 180 ? 'text-red-600' : 'text-muted'}`}>{title.length}/200</span>
         </div>
 
         {/* Split pane: editor + preview */}
@@ -164,9 +186,10 @@ export default function EditSubmission() {
             type="file"
             multiple
             accept="image/*,video/*,audio/*"
-            onChange={(e) => setNewFiles(e.target.files)}
+            onChange={handleFileChange}
             className="font-body text-sm"
           />
+          {fileError && <p className="font-body text-xs text-red-600 mt-1">{fileError}</p>}
         </div>
 
         {error && <p className="font-body text-sm text-red-600">{error}</p>}

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -181,6 +181,7 @@ export default function ProposeTask() {
                   onFocus={(e) => { e.currentTarget.style.borderBottomColor = color }}
                   onBlur={(e) => { if (!title) e.currentTarget.style.borderBottomColor = dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)' }}
                 />
+                <span className={`eyebrow self-end ${title.length >= 180 ? 'text-red-600' : ''}`} style={{ fontSize: 7, marginTop: 4 }}>{title.length}/200</span>
               </div>
 
               {/* Description (§20.4) */}
@@ -201,6 +202,7 @@ export default function ProposeTask() {
                     resize: 'vertical', minHeight: 120,
                   }}
                 />
+                <span className={`eyebrow self-end ${description.length >= 4500 ? 'text-red-600' : ''}`} style={{ fontSize: 7, marginTop: 4 }}>{description.length}/5000</span>
               </div>
 
               {/* Suggested Difficulty (§20.4) */}

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -48,8 +48,18 @@ export default function SubmitProof() {
     }
   }
 
+  const MAX_FILE_SIZE = 50 * 1024 * 1024 // 50 MB
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) setFiles((prev) => [...prev, ...Array.from(e.target.files!)])
+    if (!e.target.files) return
+    const incoming = Array.from(e.target.files)
+    const tooLarge = incoming.filter((f) => f.size > MAX_FILE_SIZE)
+    if (tooLarge.length > 0) {
+      setError(`File${tooLarge.length > 1 ? 's' : ''} too large (50 MB limit): ${tooLarge.map((f) => f.name).join(', ')}`)
+    }
+    const valid = incoming.filter((f) => f.size <= MAX_FILE_SIZE)
+    if (valid.length > 0) setFiles((prev) => [...prev, ...valid])
+    e.target.value = ''
   }
 
   const removeFile = (index: number) => {
@@ -123,6 +133,7 @@ export default function SubmitProof() {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="What did you do?"
+            maxLength={200}
             style={{
               width: '100%',
               fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: 24,
@@ -141,6 +152,7 @@ export default function SubmitProof() {
               {RAINBOW_COLORS.map((c, i) => <div key={i} style={{ flex: 1, background: c }} />)}
             </div>
           )}
+          <span className={`eyebrow self-end ${title.length >= 180 ? 'text-red-600' : ''}`} style={{ fontSize: 7, marginTop: 4 }}>{title.length}/200</span>
         </div>
 
         {/* ── Section 2: The Proof — Rich Text (§18.3) ── */}


### PR DESCRIPTION
## Summary
- **Footer scroll-to-top**: Clicking footer links now scrolls to page top via `useEffect` on `pathname`
- **Admin retired tasks**: Backend accepts `status=all` param; admin panel fetches all task statuses so retired/pending filter chips work
- **File upload validation**: Client-side 50 MB limit on media uploads, 10 MB on avatars, with error messages for oversized files
- **Character limit counters**: All form inputs now show `{current}/{max}` counters that turn red at 90% capacity
- **Sidebar hooks**: Extracted `useMyActiveTasks`, `useMyCharacterStats`, `usePendingRequests` from inlined Sidebar fetch logic
- **Leaderboard fix**: Replaced Python `False` in SQLAlchemy join condition with proper `sa_false()` to prevent unexpected query behavior

## Test plan
- [ ] Click footer links and verify page scrolls to top
- [ ] Open admin Tasks tab and verify retired/pending tasks appear with correct counts
- [ ] Upload a file > 50 MB in SubmitProof — should show error and reject
- [ ] Upload an avatar > 10 MB — should show error and reject
- [ ] Fill in form fields near max length — counters should turn red
- [ ] Verify sidebar still renders character card, active tasks, and pending requests
- [ ] Check leaderboard shows multiple players (if multiple active characters exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)