### PR TITLE
Refactor era config into self-contained per-era files

### DIFF
--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -1,0 +1,206 @@
+"""
+Era Configuration Template
+==========================
+Copy this file to create a new era configuration.
+
+Steps:
+  1. Copy this file: cp _template.py era_N.py  (where N is the era number)
+  2. Rename all ERA_N references to match (e.g. ERA_2, ERA_2_FACTIONS, etc.)
+  3. Fill in every section marked with TODO
+  4. Update backend/game_config.py:
+       - Add: from eras.era_N import ERA_N
+       - Change: CURRENT_ERA = ERA_N
+  5. Run: python seed.py --env dev
+  6. Run tests: pytest tests/unit/test_era_config.py
+
+Each era defines:
+  - Factions: the groups players can join, with their point modifiers
+  - Tasks: the activities players can sign up for and complete
+  - Taunt templates: the faction-flavored trash talk between foes
+  - Game rules: task limits, vote budget formula, level thresholds, reset behavior
+"""
+from game_config import EraConfig, FactionConfig, TaskDef
+
+
+# =============================================================================
+# FACTIONS
+# =============================================================================
+# Each faction needs a unique slug (lowercase, underscores). The slug is the
+# primary key in the database and must be stable once deployed.
+#
+# Required system factions (include these in every era):
+#   "ua"       -- default starting faction (is_selectable=False)
+#   "aged_out" -- placeholder for characters who hit level 3 offline
+#   "na"       -- sentinel for tasks with no faction affiliation
+#
+# Modifier guide (1.0 = no change, >1.0 = bonus, <1.0 = penalty):
+#   own_task_modifier       -- solo task from your own faction
+#   other_task_modifier     -- solo task from another faction
+#   collab_own_modifier     -- collaborative task from your own faction
+#   collab_other_modifier   -- collaborative task from another faction
+#   duel_win_modifier       -- base points when you win a duel
+#   duel_loss_modifier      -- base points when you lose a duel
+
+ERA_N_FACTIONS = {
+    # --- Required system factions (copy and customize) ---
+    #
+    # "ua": FactionConfig(
+    #     slug="ua",
+    #     name="UA",
+    #     description="The default starting faction.",
+    #     color="#6b6a7a",
+    #     is_selectable=False,
+    #     can_always_rejoin=False,
+    #     own_task_modifier=1.0,
+    #     other_task_modifier=1.0,
+    #     collab_own_modifier=1.0,
+    #     collab_other_modifier=1.0,
+    #     duel_win_modifier=1.0,
+    #     duel_loss_modifier=1.0,
+    # ),
+    # "aged_out": FactionConfig(
+    #     slug="aged_out",
+    #     name="AgedOutOfUA",
+    #     description="Placeholder for characters who hit level 3 while offline.",
+    #     color="#6b6a7a",
+    #     is_selectable=False,
+    #     can_always_rejoin=False,
+    #     own_task_modifier=1.0, other_task_modifier=1.0,
+    #     collab_own_modifier=1.0, collab_other_modifier=1.0,
+    #     duel_win_modifier=1.0, duel_loss_modifier=1.0,
+    # ),
+    # "na": FactionConfig(
+    #     slug="na",
+    #     name="None",
+    #     description="Sentinel for tasks with no specific faction.",
+    #     color="#a9a9a9",
+    #     is_selectable=False,
+    #     can_always_rejoin=False,
+    #     own_task_modifier=1.0, other_task_modifier=1.0,
+    #     collab_own_modifier=1.0, collab_other_modifier=1.0,
+    #     duel_win_modifier=1.0, duel_loss_modifier=1.0,
+    # ),
+    #
+    # --- TODO: Add your player-selectable factions below ---
+    #
+    # "your_faction": FactionConfig(
+    #     slug="your_faction",
+    #     name="Your Faction",
+    #     description="What makes this faction unique.",
+    #     color="#hexcolor",
+    #     is_selectable=True,
+    #     can_always_rejoin=False,
+    #     own_task_modifier=1.0,
+    #     other_task_modifier=1.0,
+    #     collab_own_modifier=1.0,
+    #     collab_other_modifier=1.0,
+    #     duel_win_modifier=1.0,
+    #     duel_loss_modifier=1.0,
+    # ),
+}
+
+
+# =============================================================================
+# TASKS
+# =============================================================================
+# Each task defines an activity players can sign up for and submit proof of.
+#
+#   title               -- display name (unique within this era)
+#   description         -- full task description shown to players
+#   faction_slug        -- which faction owns this task (must match a key above)
+#                          Use "na" for cross-faction tasks
+#   level_required      -- minimum character level to sign up (0 = anyone)
+#   point_value         -- base points awarded on completion (before modifiers)
+#   is_task_vision_eligible -- True if Journeymen can see this after retirement
+
+ERA_N_TASKS = (
+    # TODO: Define your tasks. Example:
+    #
+    # TaskDef(
+    #     title="Example Task",
+    #     description="Do something interesting and submit proof.",
+    #     faction_slug="ua",
+    #     level_required=1,
+    #     point_value=10,
+    # ),
+)
+
+
+# =============================================================================
+# TAUNT TEMPLATES
+# =============================================================================
+# Faction-flavored trash talk. Templates use {from_name} and {to_name}.
+#
+# Structure: faction_slug -> trigger_type -> list of template strings
+# The "default" key provides fallbacks for factions without custom taunts.
+#
+# Trigger types:
+#   "score_overtake"       -- when one foe passes another on the leaderboard
+#   "level_up"             -- when a foe levels up
+#   "submission_complete"  -- when a foe completes a task
+
+ERA_N_TAUNT_TEMPLATES: dict[str, dict[str, list[str]]] = {
+    "default": {
+        "score_overtake": [
+            # TODO: Add default score overtake taunts
+        ],
+        "level_up": [
+            # TODO: Add default level up taunts
+        ],
+        "submission_complete": [
+            # TODO: Add default submission complete taunts
+        ],
+    },
+    # TODO: Add per-faction taunts (one dict per faction slug):
+    #
+    # "your_faction": {
+    #     "score_overtake": [
+    #         "{from_name} outscored {to_name}. Classic.",
+    #     ],
+    #     "level_up": [
+    #         "{from_name} leveled up. {to_name} didn't.",
+    #     ],
+    #     "submission_complete": [
+    #         "{from_name} submitted proof. {to_name} is still planning.",
+    #     ],
+    # },
+}
+
+
+# =============================================================================
+# ERA DEFINITION
+# =============================================================================
+# Combine everything above into a single EraConfig instance.
+#
+# Level thresholds: index = level number, value = cumulative points to reach it.
+#   level_thresholds[0] = 0 (everyone starts at level 0)
+#   level_thresholds[1] = points to reach level 1, etc.
+#   The tuple length determines the maximum achievable level.
+#
+# Reset flags: what happens to characters when THIS era begins.
+#   reset_all_time_score should almost always be False.
+#
+# Vote budget formula: votes_available = base + floor(multiplier x score)
+
+ERA_N = EraConfig(
+    name="Era N",                        # TODO: Human-readable era name
+    config_key="era_n",                  # TODO: Unique key stored in DB (lowercase, underscored)
+
+    max_task_signups=20,                 # Max active task signups per character
+    task_submit_level_gap=2,             # Can submit up to N levels above own level
+
+    vote_budget_base=100,                # Starting vote budget
+    vote_budget_multiplier=2.0,          # Extra votes per point of score
+
+    level_thresholds=(0, 10, 70, 170, 330, 610, 1090, 1840, 3040),  # TODO: Adjust
+
+    reset_score=True,
+    reset_level=True,
+    reset_faction=True,
+    reset_vote_budget=True,
+    reset_all_time_score=False,          # Almost always False
+
+    factions=ERA_N_FACTIONS,
+    tasks=ERA_N_TASKS,
+    taunt_templates=ERA_N_TAUNT_TEMPLATES,
+)

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -1,0 +1,498 @@
+"""
+Era 1 — the founding era of World Zero.
+
+This file is the complete, self-contained configuration for Era 1.
+Everything needed to start this era lives here: factions, tasks, taunts, and rules.
+"""
+from game_config import EraConfig, FactionConfig, TaskDef
+
+
+# =============================================================================
+# FACTIONS
+# =============================================================================
+
+ERA_1_FACTIONS = {
+    "ua": FactionConfig(
+        slug="ua",
+        name="UA",
+        description="The default starting faction. Full points on all tasks. Must leave at level 3.",
+        color="#6b6a7a",
+        is_selectable=False,          # assigned automatically; not a choosable destination
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+    "ua_masters": FactionConfig(
+        slug="ua_masters",
+        name="UA Masters",
+        description="Veterans who aged out of UA. Can sign up for any task at reduced points.",
+        color="#555555",
+        is_selectable=True,
+        can_always_rejoin=True,       # can always be rejoined after defecting
+        own_task_modifier=0.8,
+        other_task_modifier=0.8,
+        collab_own_modifier=0.8,
+        collab_other_modifier=0.8,
+        duel_win_modifier=0.8,
+        duel_loss_modifier=0.8,
+    ),
+    "snide": FactionConfig(
+        slug="snide",
+        name="S.N.I.D.E.",
+        description="Specialists in one-on-one competition. Bonus points for winning duels.",
+        color="#8a6a20",
+        is_selectable=True,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=0.7,
+        collab_own_modifier=1.0,
+        collab_other_modifier=0.7,
+        duel_win_modifier=1.5,        # duel win: 150% of base
+        duel_loss_modifier=0.5,       # duel loss: 50% of base
+    ),
+    "gestalt": FactionConfig(
+        slug="gestalt",
+        name="Gestalt",
+        description="Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
+        color="#14532d",
+        is_selectable=True,
+        can_always_rejoin=False,
+        own_task_modifier=1.1,        # +10% on solo own-faction
+        other_task_modifier=0.7,      # -30% on solo other-faction
+        collab_own_modifier=1.1,      # +10% on collab own-faction
+        collab_other_modifier=0.9,    # -10% on collab other-faction (less penalty)
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+    "journeymen": FactionConfig(
+        slug="journeymen",
+        name="Journeymen",
+        description="Explorers with access to select retired tasks (Task Vision ability).",
+        color="#c49a3a",
+        is_selectable=True,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=0.7,
+        collab_own_modifier=1.0,
+        collab_other_modifier=0.7,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+    "analog": FactionConfig(
+        slug="analog",
+        name="Analog",
+        description="Depth over breadth. Can repeat one task per level for points (Double Dipper).",
+        color="#15803d",
+        is_selectable=True,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=0.7,
+        collab_own_modifier=1.0,
+        collab_other_modifier=0.7,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+    "singularity": FactionConfig(
+        slug="singularity",
+        name="Singularity",
+        description="TBD",
+        color="#7c3aed",
+        is_selectable=True,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+    "albescent": FactionConfig(
+        slug="albescent",
+        name="/Albescent",
+        description="Full points and any meta tasks from any group. Unlock-only.",
+        color="#6b6a7a",
+        is_selectable=False,          # only available as additional character unlock
+        can_always_rejoin=True,       # can always be rejoined after defecting
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+    "aged_out": FactionConfig(
+        slug="aged_out",
+        name="AgedOutOfUA",
+        description="Placeholder faction for characters who hit level 3 while offline.",
+        color="#6b6a7a",
+        is_selectable=False,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+    "na": FactionConfig(
+        slug="na",
+        name="None",
+        description="Sentinel value for tasks with no specific faction affiliation.",
+        color="#a9a9a9",
+        is_selectable=False,
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.0,
+        duel_loss_modifier=1.0,
+    ),
+}
+
+
+# =============================================================================
+# TASKS
+# =============================================================================
+
+ERA_1_TASKS = (
+    TaskDef(
+        title="Contribute to Shahid's Strigiformic Sketchbook",
+        description='From Shahid\'s diary:\n"Wednesday, October the fourteenth.  #812 had the finest feathers ever drawn.  Still it was spurned..."\nShahid fell in love three years ago with a woman who refused to give him any attention because he presented her with a "subpar" drawing of a Eurasian eagle-owl. Since then, Shahid has tried again and again to draw her a suitable owl, only to be continually rejected.\nHelp Shahid find new inspiration by hand-drawing an owl of any species in any circumstances, especially with unusual style.',
+        faction_slug="ua", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Permaculture Shock",
+        description='Install a community garden (ideally in secret, or somewhere a garden may not be expected).\nTo qualify for the "community" modifier prefix, it must be in an area where you can share its bounty and responsibility, though you need not involve anyone else in its care if you believe your own thumbs to be the greenest.\nCrop variety and size is your choice, but it must yield a harvest to feed at least 3 people one meal.\nPlayers: 1 to 20',
+        faction_slug="analog", level_required=6, point_value=100,
+    ),
+    TaskDef(
+        title="Somewhere No One Needs To Be",
+        description="There are many places people have physically passed through: along a path, in a store, on a game field. There are also many places people have not passed through in quite some time: the bark dust beside a building, the inside of a sewer, a random patch of grass \nHow long did a human last occupy these spaces? What could it mean for a place to exist beside humanity, not dangerous or necessarily forbidden, but ordinary and nondescript, without humanities touch for so long? What does it mean, to you?\nin a large and empty field.\nExist somewhere no one has existed in for a long time, and consider what that means.",
+        faction_slug="journeymen", level_required=1, point_value=10,
+    ),
+    TaskDef(
+        title="Lacunae",
+        description="Share something which exemplifies emptiness.\nSee also: https://en.wikipedia.org/wiki/4%E2%80%B233%E2%80%B3",
+        faction_slug="analog", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Knowledge Is Free",
+        description="You have skills and knowledge. This is true even if you don't know it, whether by way of your unique experience of the world or by the time you've spent on something that someone else hasn't. There's more to do and know than there are years for anyone to learn it all, so everyone brings with themselves a piece of truth looking to be more whole.\nVolunteer your time teaching someone or someone's something. A skill, a practice, some amount of a field of knowledge, etc.\nLibraries are a good place for this, as a place of knowledge and creativity most libraries support workshops and other learning opportunities, which you can have a hand in leading.",
+        faction_slug="gestalt", level_required=4, point_value=40,
+    ),
+    TaskDef(
+        title="The L Word",
+        description="Find someone you love. Tell them you love them.",
+        faction_slug="gestalt", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="The Rotation Of Cubes In Your Mind",
+        description='Recall one of the many cubes you\'ve no doubt experienced in your long life.\nDescribe what the cube was, what it meant, and where it came from.\nQualifying cube examples:\nRubiks Cube, The Companion Cube, Cube 2: Hypercube on DVD, Gamecube, Gateway2000s Cow Cube, a 6 sided die, a laundry machine, a poorly designed car, half a brick, several full bricks stacked into a cube, etc...\nThe object need not be perfectly cubic, so long as it embodies cubehood.\nPlayers: 1 to 2',
+        faction_slug="singularity", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Feed the Animals",
+        description="Find some animals and feed them. Human is an acceptable type of animal.",
+        faction_slug="gestalt", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="It's for all of us",
+        description="Make something more accessible.\nInstalling a ramp where one is missing, place/install a seat/bench somewhere, make signage larger and easier to read, install a sign where one is missing, update software with color blind options. The world is an oyster.",
+        faction_slug="gestalt", level_required=5, point_value=75,
+    ),
+    TaskDef(
+        title="A little something special",
+        description="Install/place artwork in public",
+        faction_slug="ua", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="You can learn anything",
+        description="Spend 30 minutes learning a new skill/craft",
+        faction_slug="ua", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Beauty through limitation",
+        description="Make a piece of art that's small. 7.5cm canvas square, 50x50 pixel digital image",
+        faction_slug="ua", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Stronger Together",
+        description="Start a Union.",
+        faction_slug="gestalt", level_required=7, point_value=500,
+    ),
+    TaskDef(
+        title="The Seed",
+        description="Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 250 words.",
+        faction_slug="ua", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="The Sprout",
+        description="Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 1000 words",
+        faction_slug="ua", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="The Bud",
+        description="Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 5,000 words",
+        faction_slug="ua", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="The Bloom",
+        description="Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 10,000 words",
+        faction_slug="ua_masters", level_required=4, point_value=50,
+    ),
+    TaskDef(
+        title="The Bush",
+        description="Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 15,000 words",
+        faction_slug="ua_masters", level_required=5, point_value=75,
+    ),
+    TaskDef(
+        title="The Thicket",
+        description="Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 25,000 words",
+        faction_slug="ua_masters", level_required=6, point_value=100,
+    ),
+    TaskDef(
+        title="The Forest",
+        description="Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 40,000 words",
+        faction_slug="ua_masters", level_required=7, point_value=500,
+    ),
+    TaskDef(
+        title="Communication is arbitrary",
+        description="Invent a language. Write a paragraph in that language.",
+        faction_slug="snide", level_required=5, point_value=75,
+    ),
+    TaskDef(
+        title='"DO A KICKFLIP"',
+        description="Do a kickflip. Bonus if you don't use a skateboard.",
+        faction_slug="snide", level_required=2, point_value=25,
+    ),
+    TaskDef(
+        title="There",
+        description="Pick some place to travel to at random (dart thrown at a map, random wikipedia article selection, etc.). Travel there.",
+        faction_slug="journeymen", level_required=4, point_value=50,
+    ),
+    TaskDef(
+        title="Invisible White Elephant",
+        description="Give someone a gift, anonymously.",
+        faction_slug="gestalt", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="What if the curtains were red",
+        description="Mod a game.",
+        faction_slug="singularity", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="Creating Fun",
+        description="Make a game.",
+        faction_slug="ua_masters", level_required=4, point_value=50,
+    ),
+    TaskDef(
+        title="You deserve it.",
+        description="Forgive yourself.",
+        faction_slug="gestalt", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Patron of the arts",
+        description="Commission art from an artist",
+        faction_slug="gestalt", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="Expanding your world",
+        description="Learn a stranger's name",
+        faction_slug="gestalt", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Closer, together",
+        description="learn about and share a friend's hobby",
+        faction_slug="gestalt", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Become a Villager",
+        description="Advertise and provide a skill or good to your community",
+        faction_slug="gestalt", level_required=4, point_value=50,
+    ),
+    TaskDef(
+        title="One of many Cultural Bridges",
+        description="Learn a new language",
+        faction_slug="gestalt", level_required=4, point_value=40,
+    ),
+    TaskDef(
+        title="Trash Transformation",
+        description="Find some trash in a public place. Make it into something else.",
+        faction_slug="ua", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="When The Sun Blinks",
+        description="Experience a Solar Eclipse. Write about your experience.",
+        faction_slug="journeymen", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="A Very Human Thing",
+        description="Create a ritual to be kind to yourself. Document it.",
+        faction_slug="analog", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Understanding through Data",
+        description="Perform a census. On anything, of anything. Provide your details, and consider what your data says",
+        faction_slug="singularity", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="Create a spell.",
+        description="Create a spell.",
+        faction_slug="albescent", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Make it your own",
+        description="Remove the branding from something you own, and replace it with something else.",
+        faction_slug="snide", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Improv Fixture",
+        description="Take an item with a logo or brand on it that you use every day. Study the item, and how it was made. Compare it to other, similar interpretations of that item made by other people. After this, throw it away and make your own version of the item.",
+        faction_slug="analog", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="Why did you do that",
+        description="break something. Write down your thoughts (what did you break, why did you choose to break it, do you feel better or worse for breaking it, is it worth fixing or replacing or putting behind you, etc.)",
+        faction_slug="journeymen", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Why do I even have this actually",
+        description='you have a pile somewhere in your house. The pile of things has a proper place, but it is in that pile instead. Consider why that pile exists, why those items ended up in that pile, where they are meant to go and why (is The Place convenient? Next other other Like things? Is that the righr place for such things?). Then, take an action: redefine where "the right place" is for that pile of things, and thrn make things right. Or, unpack the pile to the place where it\'s meant to go.',
+        faction_slug="ua", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="A key to many locks",
+        description="If you don't have a passport already, get one.",
+        faction_slug="journeymen", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Tierlist of Me",
+        description="Score your living space, according to a rubric you yourself come up with. Justify your grading.",
+        faction_slug="singularity", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Cultural Exchange",
+        description="Interview someone from another country",
+        faction_slug="gestalt", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="Depth through Repetition",
+        description="Have a meal, and try to identify each ingredient. Then, make that meal yourself, and then try again to identify each ingredient again",
+        faction_slug="analog", level_required=2, point_value=10,
+    ),
+)
+
+
+# =============================================================================
+# TAUNT TEMPLATES
+# =============================================================================
+# Keyed by faction slug -> trigger type -> list of template strings.
+# Use {from_name} and {to_name} as placeholders.
+# A generic "default" key provides fallbacks for factions without custom taunts.
+
+ERA_1_TAUNT_TEMPLATES: dict[str, dict[str, list[str]]] = {
+    "default": {
+        "score_overtake": [
+            "{from_name} just passed {to_name} on the leaderboard. Awkward.",
+            "{to_name}, meet {from_name}'s dust.",
+            "{from_name} overtook {to_name}. The scoreboard doesn't lie.",
+        ],
+        "level_up": [
+            "{from_name} leveled up while {to_name} was napping.",
+            "{from_name} hit a new level. {to_name} remains where they are.",
+        ],
+        "submission_complete": [
+            "{from_name} just completed a task. {to_name} is still thinking about it.",
+            "{from_name} submitted praxis. {to_name}... did not.",
+        ],
+    },
+    "snide": {
+        "score_overtake": [
+            "{from_name} danced past {to_name} on the scoreboard. Elegant, really.",
+            "Oh, {to_name}. {from_name} just made you look silly.",
+            "{from_name} sends their regards from above {to_name} on the leaderboard.",
+        ],
+        "level_up": [
+            "{from_name} ascended. {to_name} can see them from down there.",
+        ],
+        "submission_complete": [
+            "{from_name} finished what {to_name} couldn't start.",
+        ],
+    },
+    "gestalt": {
+        "score_overtake": [
+            "The collective lifts {from_name} above {to_name}. Together, always.",
+            "{from_name} rose past {to_name}. The whole is greater than the parts.",
+        ],
+        "level_up": [
+            "{from_name} grew stronger through community. {to_name} walks alone.",
+        ],
+        "submission_complete": [
+            "{from_name} contributed to the whole. {to_name} remained apart.",
+        ],
+    },
+    "journeymen": {
+        "score_overtake": [
+            "{from_name} found a path past {to_name}. The road provides.",
+            "{from_name} wandered ahead of {to_name}. Not all who wander are lost.",
+        ],
+        "level_up": [
+            "{from_name} discovered a new horizon. {to_name} hasn't packed yet.",
+        ],
+        "submission_complete": [
+            "{from_name} returned from the journey with proof. {to_name} stayed home.",
+        ],
+    },
+    "analog": {
+        "score_overtake": [
+            "{from_name} carved past {to_name} by hand. No shortcuts.",
+            "{from_name} overtook {to_name} the old-fashioned way.",
+        ],
+        "level_up": [
+            "{from_name} leveled up through repetition. {to_name} got bored.",
+        ],
+        "submission_complete": [
+            "{from_name} made something real. {to_name} is still scrolling.",
+        ],
+    },
+    "singularity": {
+        "score_overtake": [
+            "{from_name} computed a path past {to_name}. Inevitable.",
+            "{from_name} surpassed {to_name}. The algorithm does not care.",
+        ],
+        "level_up": [
+            "{from_name} optimized beyond {to_name}'s level.",
+        ],
+        "submission_complete": [
+            "{from_name} executed. {to_name} is still in the queue.",
+        ],
+    },
+}
+
+
+# =============================================================================
+# ERA DEFINITION
+# =============================================================================
+
+ERA_1 = EraConfig(
+    name="Era 1",
+    config_key="era_1",
+    max_task_signups=20,
+    task_submit_level_gap=2,
+    vote_budget_base=100,
+    vote_budget_multiplier=2.0,
+    level_thresholds=(0, 10, 70, 170, 330, 610, 1090, 1840, 3040),
+    reset_score=True,
+    reset_level=True,
+    reset_faction=True,
+    reset_vote_budget=True,
+    reset_all_time_score=False,
+    factions=ERA_1_FACTIONS,
+    tasks=ERA_1_TASKS,
+    taunt_templates=ERA_1_TAUNT_TEMPLATES,
+)

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -10,6 +10,17 @@ from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
+class TaskDef:
+    """Definition of a single task within an era."""
+    title: str
+    description: str
+    faction_slug: str
+    level_required: int
+    point_value: int
+    is_task_vision_eligible: bool = False
+
+
+@dataclass(frozen=True)
 class FactionConfig:
     slug: str
     name: str
@@ -53,265 +64,28 @@ class EraConfig:
     # Faction configs, keyed by slug
     factions: dict
 
+    # Task definitions for this era
+    tasks: tuple = ()                # tuple[TaskDef, ...]
 
-# -- Faction definitions for Era 1 ------------------------------------------
-
-ERA_1_FACTIONS = {
-    "ua": FactionConfig(
-        slug="ua",
-        name="UA",
-        description="The default starting faction. Full points on all tasks. Must leave at level 3.",
-        color="#6b6a7a",
-        is_selectable=False,          # assigned automatically; not a choosable destination
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=1.0,
-        collab_own_modifier=1.0,
-        collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-    "ua_masters": FactionConfig(
-        slug="ua_masters",
-        name="UA Masters",
-        description="Veterans who aged out of UA. Can sign up for any task at reduced points.",
-        color="#555555",
-        is_selectable=True,
-        can_always_rejoin=True,       # can always be rejoined after defecting
-        own_task_modifier=0.8,
-        other_task_modifier=0.8,
-        collab_own_modifier=0.8,
-        collab_other_modifier=0.8,
-        duel_win_modifier=0.8,
-        duel_loss_modifier=0.8,
-    ),
-    "snide": FactionConfig(
-        slug="snide",
-        name="S.N.I.D.E.",
-        description="Specialists in one-on-one competition. Bonus points for winning duels.",
-        color="#8a6a20",
-        is_selectable=True,
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=0.7,
-        collab_own_modifier=1.0,
-        collab_other_modifier=0.7,
-        duel_win_modifier=1.5,        # duel win: 150% of base
-        duel_loss_modifier=0.5,       # duel loss: 50% of base
-    ),
-    "gestalt": FactionConfig(
-        slug="gestalt",
-        name="Gestalt",
-        description="Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
-        color="#14532d",
-        is_selectable=True,
-        can_always_rejoin=False,
-        own_task_modifier=1.1,        # +10% on solo own-faction
-        other_task_modifier=0.7,      # -30% on solo other-faction
-        collab_own_modifier=1.1,      # +10% on collab own-faction
-        collab_other_modifier=0.9,    # -10% on collab other-faction (less penalty)
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-    "journeymen": FactionConfig(
-        slug="journeymen",
-        name="Journeymen",
-        description="Explorers with access to select retired tasks (Task Vision ability).",
-        color="#c49a3a",
-        is_selectable=True,
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=0.7,
-        collab_own_modifier=1.0,
-        collab_other_modifier=0.7,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-    "analog": FactionConfig(
-        slug="analog",
-        name="Analog",
-        description="Depth over breadth. Can repeat one task per level for points (Double Dipper).",
-        color="#15803d",
-        is_selectable=True,
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=0.7,
-        collab_own_modifier=1.0,
-        collab_other_modifier=0.7,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-    "singularity": FactionConfig(
-        slug="singularity",
-        name="Singularity",
-        description="TBD",
-        color="#7c3aed",
-        is_selectable=True,
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=1.0,
-        collab_own_modifier=1.0,
-        collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-    "albescent": FactionConfig(
-        slug="albescent",
-        name="/Albescent",
-        description="Full points and any meta tasks from any group. Unlock-only.",
-        color="#6b6a7a",
-        is_selectable=False,          # only available as additional character unlock
-        can_always_rejoin=True,       # can always be rejoined after defecting
-        own_task_modifier=1.0,
-        other_task_modifier=1.0,
-        collab_own_modifier=1.0,
-        collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-    "aged_out": FactionConfig(
-        slug="aged_out",
-        name="AgedOutOfUA",
-        description="Placeholder faction for characters who hit level 3 while offline.",
-        color="#6b6a7a",
-        is_selectable=False,
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=1.0,
-        collab_own_modifier=1.0,
-        collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-    "na": FactionConfig(
-        slug="na",
-        name="None",
-        description="Sentinel value for tasks with no specific faction affiliation.",
-        color="#a9a9a9",
-        is_selectable=False,
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=1.0,
-        collab_own_modifier=1.0,
-        collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
-    ),
-}
+    # Taunt templates for this era
+    taunt_templates: dict = field(default_factory=dict)  # faction slug → trigger → templates
 
 
-# -- Era definitions ---------------------------------------------------------
-
-ERA_1 = EraConfig(
-    name="Era 1",
-    config_key="era_1",
-    max_task_signups=20,
-    task_submit_level_gap=2,
-    vote_budget_base=100,
-    vote_budget_multiplier=2.0,
-    level_thresholds=(0, 10, 70, 170, 330, 610, 1090, 1840, 3040),
-    reset_score=True,
-    reset_level=True,
-    reset_faction=True,
-    reset_vote_budget=True,
-    reset_all_time_score=False,
-    factions=ERA_1_FACTIONS,
-)
-
-# Future era example -- different mechanics, same structure
-# ERA_2 = EraConfig(
-#     name="Foo Era",
-#     config_key="era_2",
-#     max_task_signups=3,
-#     vote_budget_base=20,
-#     vote_budget_multiplier=3.0,
-#     ...
-# )
-
-# -- The one lever that controls live game mechanics -------------------------
-CURRENT_ERA: EraConfig = ERA_1
+# -- Era configs live in backend/eras/ (one file per era) --------------------
+# To create a new era, copy eras/_template.py and fill it in.
+#
+# Era instances (ERA_1, CURRENT_ERA, etc.) are loaded lazily via __getattr__
+# to avoid circular imports with eras/ package files.
 
 
-# -- Taunt templates ---------------------------------------------------------
-# Keyed by faction slug → trigger type → list of template strings.
-# Use {from_name} and {to_name} as placeholders.
-# A generic "default" key provides fallbacks for factions without custom taunts.
-
-TAUNT_TEMPLATES: dict[str, dict[str, list[str]]] = {
-    "default": {
-        "score_overtake": [
-            "{from_name} just passed {to_name} on the leaderboard. Awkward.",
-            "{to_name}, meet {from_name}'s dust.",
-            "{from_name} overtook {to_name}. The scoreboard doesn't lie.",
-        ],
-        "level_up": [
-            "{from_name} leveled up while {to_name} was napping.",
-            "{from_name} hit a new level. {to_name} remains where they are.",
-        ],
-        "submission_complete": [
-            "{from_name} just completed a task. {to_name} is still thinking about it.",
-            "{from_name} submitted praxis. {to_name}... did not.",
-        ],
-    },
-    "snide": {
-        "score_overtake": [
-            "{from_name} danced past {to_name} on the scoreboard. Elegant, really.",
-            "Oh, {to_name}. {from_name} just made you look silly.",
-            "{from_name} sends their regards from above {to_name} on the leaderboard.",
-        ],
-        "level_up": [
-            "{from_name} ascended. {to_name} can see them from down there.",
-        ],
-        "submission_complete": [
-            "{from_name} finished what {to_name} couldn't start.",
-        ],
-    },
-    "gestalt": {
-        "score_overtake": [
-            "The collective lifts {from_name} above {to_name}. Together, always.",
-            "{from_name} rose past {to_name}. The whole is greater than the parts.",
-        ],
-        "level_up": [
-            "{from_name} grew stronger through community. {to_name} walks alone.",
-        ],
-        "submission_complete": [
-            "{from_name} contributed to the whole. {to_name} remained apart.",
-        ],
-    },
-    "journeymen": {
-        "score_overtake": [
-            "{from_name} found a path past {to_name}. The road provides.",
-            "{from_name} wandered ahead of {to_name}. Not all who wander are lost.",
-        ],
-        "level_up": [
-            "{from_name} discovered a new horizon. {to_name} hasn't packed yet.",
-        ],
-        "submission_complete": [
-            "{from_name} returned from the journey with proof. {to_name} stayed home.",
-        ],
-    },
-    "analog": {
-        "score_overtake": [
-            "{from_name} carved past {to_name} by hand. No shortcuts.",
-            "{from_name} overtook {to_name} the old-fashioned way.",
-        ],
-        "level_up": [
-            "{from_name} leveled up through repetition. {to_name} got bored.",
-        ],
-        "submission_complete": [
-            "{from_name} made something real. {to_name} is still scrolling.",
-        ],
-    },
-    "singularity": {
-        "score_overtake": [
-            "{from_name} computed a path past {to_name}. Inevitable.",
-            "{from_name} surpassed {to_name}. The algorithm does not care.",
-        ],
-        "level_up": [
-            "{from_name} optimized beyond {to_name}'s level.",
-        ],
-        "submission_complete": [
-            "{from_name} executed. {to_name} is still in the queue.",
-        ],
-    },
-}
+def __getattr__(name: str):
+    """Lazy-load era instances to avoid circular imports with eras/ package."""
+    if name in ("ERA_1", "ERA_1_FACTIONS", "CURRENT_ERA", "TAUNT_TEMPLATES"):
+        from eras.era_1 import ERA_1 as _era_1
+        from eras.era_1 import ERA_1_FACTIONS as _factions
+        globals()["ERA_1"] = _era_1
+        globals()["ERA_1_FACTIONS"] = _factions
+        globals()["CURRENT_ERA"] = _era_1
+        globals()["TAUNT_TEMPLATES"] = _era_1.taunt_templates
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -2,10 +2,11 @@
 Seed script for World Zero — production bootstrap.
 
 Prerequisites: run `alembic upgrade head` first.
-Migrations handle schema + faction rows. This script adds:
-  - Era 1 row
+Migrations handle schema. This script adds:
+  - Factions (from the era config)
+  - Era row
   - Pixie admin account + character + admin role
-  - All live tasks (from the real task list)
+  - All live tasks (from the era config)
 
 Run from /backend:
     python seed.py               # dev (default)
@@ -20,256 +21,22 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from sqlalchemy import func, select, text
 
-from game_config import ERA_1
+from game_config import CURRENT_ERA
 from script_utils import add_env_argument, get_settings
 from models.account import Account, OAuthProvider
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
+from models.faction import Faction, FactionStatus
 from models.roles import AccountRole, Role
 from models.task import Task, TaskStatus
 
 
 # ---------------------------------------------------------------------------
-# Tasks (from CSV — corrections applied inline)
-#
-# Corrections:
-#   anolog      → analog        (Permaculture Shock, Lacunae, A Very Human Thing,
-#                                Improv Fixture, Depth through Repetition)
-#   us_masters  → ua_masters    (Creating Fun)
-#   (empty)     → singularity   (The Rotation Of Cubes In Your Mind)
-#   ? / ?       → level=4, pts=40 (One of many Cultural Bridges)
-#
-# Format: (title, description, faction_slug, level_required, point_value)
+# Faction status mapping
 # ---------------------------------------------------------------------------
-
-TASKS_DEF = [
-    (
-        "Contribute to Shahid's Strigiformic Sketchbook",
-        'From Shahid\'s diary:\n"Wednesday, October the fourteenth.  #812 had the finest feathers ever drawn.  Still it was spurned..."\nShahid fell in love three years ago with a woman who refused to give him any attention because he presented her with a "subpar" drawing of a Eurasian eagle-owl. Since then, Shahid has tried again and again to draw her a suitable owl, only to be continually rejected.\nHelp Shahid find new inspiration by hand-drawing an owl of any species in any circumstances, especially with unusual style.',
-        "ua", 1, 5,
-    ),
-    (
-        "Permaculture Shock",
-        'Install a community garden (ideally in secret, or somewhere a garden may not be expected).\nTo qualify for the "community" modifier prefix, it must be in an area where you can share its bounty and responsibility, though you need not involve anyone else in its care if you believe your own thumbs to be the greenest.\nCrop variety and size is your choice, but it must yield a harvest to feed at least 3 people one meal.\nPlayers: 1 to 20',
-        "analog", 6, 100,
-    ),
-    (
-        "Somewhere No One Needs To Be",
-        "There are many places people have physically passed through: along a path, in a store, on a game field. There are also many places people have not passed through in quite some time: the bark dust beside a building, the inside of a sewer, a random patch of grass \nHow long did a human last occupy these spaces? What could it mean for a place to exist beside humanity, not dangerous or necessarily forbidden, but ordinary and nondescript, without humanities touch for so long? What does it mean, to you?\nin a large and empty field.\nExist somewhere no one has existed in for a long time, and consider what that means.",
-        "journeymen", 1, 10,
-    ),
-    (
-        "Lacunae",
-        "Share something which exemplifies emptiness.\nSee also: https://en.wikipedia.org/wiki/4%E2%80%B233%E2%80%B3",
-        "analog", 2, 10,
-    ),
-    (
-        "Knowledge Is Free",
-        "You have skills and knowledge. This is true even if you don't know it, whether by way of your unique experience of the world or by the time you've spent on something that someone else hasn't. There's more to do and know than there are years for anyone to learn it all, so everyone brings with themselves a piece of truth looking to be more whole.\nVolunteer your time teaching someone or someone's something. A skill, a practice, some amount of a field of knowledge, etc.\nLibraries are a good place for this, as a place of knowledge and creativity most libraries support workshops and other learning opportunities, which you can have a hand in leading.",
-        "gestalt", 4, 40,
-    ),
-    (
-        "The L Word",
-        "Find someone you love. Tell them you love them.",
-        "gestalt", 1, 5,
-    ),
-    (
-        "The Rotation Of Cubes In Your Mind",
-        "Recall one of the many cubes you've no doubt experienced in your long life.\nDescribe what the cube was, what it meant, and where it came from.\nQualifying cube examples:\nRubiks Cube, The Companion Cube, Cube 2: Hypercube on DVD, Gamecube, Gateway2000s Cow Cube, a 6 sided die, a laundry machine, a poorly designed car, half a brick, several full bricks stacked into a cube, etc...\nThe object need not be perfectly cubic, so long as it embodies cubehood.\nPlayers: 1 to 2",
-        "singularity", 2, 10,
-    ),
-    (
-        "Feed the Animals",
-        "Find some animals and feed them. Human is an acceptable type of animal.",
-        "gestalt", 1, 5,
-    ),
-    (
-        "It's for all of us",
-        "Make something more accessible.\nInstalling a ramp where one is missing, place/install a seat/bench somewhere, make signage larger and easier to read, install a sign where one is missing, update software with color blind options. The world is an oyster.",
-        "gestalt", 5, 75,
-    ),
-    (
-        "A little something special",
-        "Install/place artwork in public",
-        "ua", 2, 10,
-    ),
-    (
-        "You can learn anything",
-        "Spend 30 minutes learning a new skill/craft",
-        "ua", 2, 10,
-    ),
-    (
-        "Beauty through limitation",
-        "Make a piece of art that's small. 7.5cm canvas square, 50x50 pixel digital image",
-        "ua", 1, 5,
-    ),
-    (
-        "Stronger Together",
-        "Start a Union.",
-        "gestalt", 7, 500,
-    ),
-    (
-        "The Seed",
-        "Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 250 words.",
-        "ua", 1, 5,
-    ),
-    (
-        "The Sprout",
-        "Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 1000 words",
-        "ua", 2, 10,
-    ),
-    (
-        "The Bud",
-        "Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 5,000 words",
-        "ua", 3, 25,
-    ),
-    (
-        "The Bloom",
-        "Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 10,000 words",
-        "ua_masters", 4, 50,
-    ),
-    (
-        "The Bush",
-        "Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 15,000 words",
-        "ua_masters", 5, 75,
-    ),
-    (
-        "The Thicket",
-        "Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 25,000 words",
-        "ua_masters", 6, 100,
-    ),
-    (
-        "The Forest",
-        "Think about something you think you know about, but haven't actually looked into. Research that assumption, and report back what you've found. Minimum 40,000 words",
-        "ua_masters", 7, 500,
-    ),
-    (
-        "Communication is arbitrary",
-        "Invent a language. Write a paragraph in that language.",
-        "snide", 5, 75,
-    ),
-    (
-        '"DO A KICKFLIP"',
-        "Do a kickflip. Bonus if you don't use a skateboard.",
-        "snide", 2, 25,
-    ),
-    (
-        "There",
-        "Pick some place to travel to at random (dart thrown at a map, random wikipedia article selection, etc.). Travel there.",
-        "journeymen", 4, 50,
-    ),
-    (
-        "Invisible White Elephant",
-        "Give someone a gift, anonymously.",
-        "gestalt", 2, 10,
-    ),
-    (
-        "What if the curtains were red",
-        "Mod a game.",
-        "singularity", 3, 25,
-    ),
-    (
-        "Creating Fun",
-        "Make a game.",
-        "ua_masters", 4, 50,
-    ),
-    (
-        "You deserve it.",
-        "Forgive yourself.",
-        "gestalt", 1, 5,
-    ),
-    (
-        "Patron of the arts",
-        "Commission art from an artist",
-        "gestalt", 3, 25,
-    ),
-    (
-        "Expanding your world",
-        "Learn a stranger's name",
-        "gestalt", 1, 5,
-    ),
-    (
-        "Closer, together",
-        "learn about and share a friend's hobby",
-        "gestalt", 2, 10,
-    ),
-    (
-        "Become a Villager",
-        "Advertise and provide a skill or good to your community",
-        "gestalt", 4, 50,
-    ),
-    (
-        "One of many Cultural Bridges",
-        "Learn a new language",
-        "gestalt", 4, 40,
-    ),
-    (
-        "Trash Transformation",
-        "Find some trash in a public place. Make it into something else.",
-        "ua", 1, 5,
-    ),
-    (
-        "When The Sun Blinks",
-        "Experience a Solar Eclipse. Write about your experience.",
-        "journeymen", 3, 25,
-    ),
-    (
-        "A Very Human Thing",
-        "Create a ritual to be kind to yourself. Document it.",
-        "analog", 1, 5,
-    ),
-    (
-        "Understanding through Data",
-        "Perform a census. On anything, of anything. Provide your details, and consider what your data says",
-        "singularity", 3, 25,
-    ),
-    (
-        "Create a spell.",
-        "Create a spell.",
-        "albescent", 1, 5,
-    ),
-    (
-        "Make it your own",
-        "Remove the branding from something you own, and replace it with something else.",
-        "snide", 1, 5,
-    ),
-    (
-        "Improv Fixture",
-        "Take an item with a logo or brand on it that you use every day. Study the item, and how it was made. Compare it to other, similar interpretations of that item made by other people. After this, throw it away and make your own version of the item.",
-        "analog", 3, 25,
-    ),
-    (
-        "Why did you do that",
-        "break something. Write down your thoughts (what did you break, why did you choose to break it, do you feel better or worse for breaking it, is it worth fixing or replacing or putting behind you, etc.)",
-        "journeymen", 2, 10,
-    ),
-    (
-        "Why do I even have this actually",
-        "you have a pile somewhere in your house. The pile of things has a proper place, but it is in that pile instead. Consider why that pile exists, why those items ended up in that pile, where they are meant to go and why (is The Place convenient? Next other other Like things? Is that the righr place for such things?). Then, take an action: redefine where \"the right place\" is for that pile of things, and thrn make things right. Or, unpack the pile to the place where it's meant to go.",
-        "ua", 2, 10,
-    ),
-    (
-        "A key to many locks",
-        "If you don't have a passport already, get one.",
-        "journeymen", 2, 10,
-    ),
-    (
-        "Tierlist of Me",
-        "Score your living space, according to a rubric you yourself come up with. Justify your grading.",
-        "singularity", 2, 10,
-    ),
-    (
-        "Cultural Exchange",
-        "Interview someone from another country",
-        "gestalt", 3, 25,
-    ),
-    (
-        "Depth through Repetition",
-        "Have a meal, and try to identify each ingredient. Then, make that meal yourself, and then try again to identify each ingredient again",
-        "analog", 2, 10,
-    ),
-]
+# System factions that should be hidden in the UI.
+HIDDEN_FACTION_SLUGS = frozenset({"aged_out", "na"})
 
 
 # ---------------------------------------------------------------------------
@@ -277,11 +44,13 @@ TASKS_DEF = [
 # ---------------------------------------------------------------------------
 
 async def seed(env: str, yes: bool) -> None:
+    era = CURRENT_ERA
     settings = get_settings(env)
     db_host = settings.DATABASE_URL.split("@")[-1]
 
     print(f"Environment : {env}")
-    print(f"Database    : {db_host}\n")
+    print(f"Database    : {db_host}")
+    print(f"Era         : {era.name} ({era.config_key})\n")
 
     if env == "prod" and not yes:
         print("WARNING: You are about to seed a PRODUCTION database.")
@@ -310,10 +79,32 @@ async def seed(env: str, yes: bool) -> None:
             return
 
         print("Seeding World Zero...\n")
-        print("  (Factions seeded by Alembic migrations — skipping)")
 
         # ------------------------------------------------------------------
-        # 1. Pixie account + character (skip if already exists)
+        # Phase 1: Factions (from era config, upsert)
+        # ------------------------------------------------------------------
+        faction_count = 0
+        for slug, faction_config in era.factions.items():
+            existing = await session.execute(
+                select(Faction).where(Faction.slug == slug)
+            )
+            if existing.scalar_one_or_none() is None:
+                status = FactionStatus.hidden if slug in HIDDEN_FACTION_SLUGS else FactionStatus.visible
+                session.add(Faction(
+                    slug=slug,
+                    name=faction_config.name,
+                    description=faction_config.description,
+                    status=status,
+                ))
+                faction_count += 1
+        await session.flush()
+        if faction_count > 0:
+            print(f"  >Factions ({faction_count} new)")
+        else:
+            print("  >Factions already exist — skipping")
+
+        # ------------------------------------------------------------------
+        # Phase 2: Admin bootstrap (Pixie account + character + role)
         # ------------------------------------------------------------------
         if pixie_acc:
             print("  >Pixie account already exists — skipping account/era/admin setup")
@@ -347,10 +138,10 @@ async def seed(env: str, yes: bool) -> None:
             # ------------------------------------------------------------------
             # Era
             # ------------------------------------------------------------------
-            print("  >Era 1")
+            print(f"  >{era.name}")
             era_row = Era(
-                name=ERA_1.name,
-                config_key=ERA_1.config_key,
+                name=era.name,
+                config_key=era.config_key,
                 started_by=pixie_acc.id,
             )
             session.add(era_row)
@@ -379,34 +170,36 @@ async def seed(env: str, yes: bool) -> None:
                 score=0,
                 all_time_score=0,
                 level=0,
-                votes_available=ERA_1.vote_budget_base,
+                votes_available=era.vote_budget_base,
             ))
             await session.flush()
 
         # ------------------------------------------------------------------
-        # Tasks (only if missing)
+        # Phase 3: Tasks (from era config)
         # ------------------------------------------------------------------
         if task_count == 0:
-            print(f"  >Tasks ({len(TASKS_DEF)})")
-            for title, desc, faction_slug, level_req, pts in TASKS_DEF:
+            print(f"  >Tasks ({len(era.tasks)})")
+            for task_def in era.tasks:
                 session.add(Task(
-                    title=title,
-                    description=desc,
-                    point_value=pts,
-                    level_required=level_req,
+                    title=task_def.title,
+                    description=task_def.description,
+                    point_value=task_def.point_value,
+                    level_required=task_def.level_required,
                     status=TaskStatus.active,
                     created_by=pixie_char.id,
-                    primary_faction_slug=faction_slug,
-                    is_task_vision_eligible=False,
+                    primary_faction_slug=task_def.faction_slug,
+                    is_task_vision_eligible=task_def.is_task_vision_eligible,
                 ))
         else:
             print(f"  >Tasks already exist ({task_count}) — skipping")
 
         await session.commit()
         print("\nSeed complete!\n")
+        print(f"  era            : {era.name} ({era.config_key})")
+        print(f"  factions       : {len(era.factions)}")
         print(f"  pixie account  : pixieofhugs@gmail.com")
         print(f"  pixie character: @pixie (admin)")
-        print(f"  tasks          : {len(TASKS_DEF)}")
+        print(f"  tasks          : {len(era.tasks)}")
 
     await engine.dispose()
 

--- a/backend/services/taunt_service.py
+++ b/backend/services/taunt_service.py
@@ -9,7 +9,7 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from game_config import TAUNT_TEMPLATES
+from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.taunt_message import TauntMessage, TauntTriggerType
 
@@ -19,13 +19,15 @@ DEFAULT_FACTION = "default"
 def pick_taunt_template(
     faction_slug: str,
     trigger_type: str,
+    era: EraConfig = CURRENT_ERA,
 ) -> Optional[str]:
     """Select a random template string for the given faction and trigger."""
-    faction_templates = TAUNT_TEMPLATES.get(faction_slug, {})
+    templates_dict = era.taunt_templates
+    faction_templates = templates_dict.get(faction_slug, {})
     templates = faction_templates.get(trigger_type)
 
     if not templates:
-        fallback_templates = TAUNT_TEMPLATES.get(DEFAULT_FACTION, {})
+        fallback_templates = templates_dict.get(DEFAULT_FACTION, {})
         templates = fallback_templates.get(trigger_type)
 
     if not templates:
@@ -39,11 +41,13 @@ async def generate_taunt(
     to_character: Character,
     trigger_type: TauntTriggerType,
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
 ) -> Optional[TauntMessage]:
     """Generate and persist a taunt message between foes."""
     template = pick_taunt_template(
         from_character.faction_slug,
         trigger_type.value,
+        era=era,
     )
     if template is None:
         return None

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -104,3 +104,50 @@ def test_task_submit_level_gap_non_negative():
 def test_reset_all_time_score_is_false():
     # Per spec: reset_all_time_score is almost always False
     assert ERA_1.reset_all_time_score is False
+
+
+# ---------------------------------------------------------------------------
+# Task definitions
+# ---------------------------------------------------------------------------
+
+
+def test_era1_has_tasks():
+    assert len(ERA_1.tasks) > 0
+
+
+def test_era1_task_count():
+    assert len(ERA_1.tasks) == 45
+
+
+def test_era1_task_faction_slugs_valid():
+    for task_def in ERA_1.tasks:
+        assert task_def.faction_slug in ERA_1.factions, (
+            f"Task '{task_def.title}' references unknown faction '{task_def.faction_slug}'"
+        )
+
+
+def test_era1_task_level_requirements_positive():
+    for task_def in ERA_1.tasks:
+        assert task_def.level_required >= 0, (
+            f"Task '{task_def.title}' has negative level_required"
+        )
+
+
+def test_era1_task_point_values_positive():
+    for task_def in ERA_1.tasks:
+        assert task_def.point_value > 0, (
+            f"Task '{task_def.title}' has non-positive point_value"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Taunt templates
+# ---------------------------------------------------------------------------
+
+
+def test_era1_has_taunt_templates():
+    assert len(ERA_1.taunt_templates) > 0
+
+
+def test_era1_taunt_templates_has_default():
+    assert "default" in ERA_1.taunt_templates

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -37,6 +37,8 @@ def test_vote_budget_floors_fractional():
         reset_vote_budget=False,
         reset_all_time_score=False,
         factions=ERA_1_FACTIONS,
+        tasks=(),
+        taunt_templates={},
     )
     # 1.5 * 3 = 4.5 → floor = 4, total = 14
     assert compute_vote_budget(score=3, era=era) == 14


### PR DESCRIPTION
## Summary
- Each era is now a single file (`backend/eras/era_1.py`) containing factions, tasks, taunt templates, and game rules
- Seed script reads everything from `CURRENT_ERA` instead of hardcoding task definitions — also seeds factions from the era config
- Added `TaskDef` dataclass and `tasks`/`taunt_templates` fields to `EraConfig`
- Includes `eras/_template.py` — copy and fill to create a new era
- `taunt_service.py` updated to accept `era` parameter (follows service convention)

## Test plan
- [x] All 98 unit tests pass
- [x] Backward-compat imports verified (`ERA_1`, `ERA_1_FACTIONS`, `TAUNT_TEMPLATES`, `CURRENT_ERA`)
- [x] Direct import from `eras.era_1` works (no circular import)
- [ ] Run `python seed.py --env dev` against a fresh DB to verify seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)