### PR TITLE
Fix foe feed, modified points, collab/duel invites, era config slots

### DIFF
--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -32,6 +32,7 @@ FEED_ITEM_TYPE_DUEL_CHALLENGE = "duel_challenge"
 FEED_ITEM_TYPE_FRIEND_SIGNUP = "friend_signup"
 FEED_ITEM_TYPE_INVITATION_LETTER = "invitation_letter"
 FEED_ITEM_TYPE_FRIEND_DEFECTION = "friend_defection"
+FEED_ITEM_TYPE_FOE_COMPLETION = "foe_completion"
 
 # Which sub-queries each filter includes
 FILTER_QUERIES: dict[str, set[str]] = {
@@ -46,13 +47,14 @@ FILTER_QUERIES: dict[str, set[str]] = {
         FEED_ITEM_TYPE_FRIEND_SIGNUP,
         FEED_ITEM_TYPE_INVITATION_LETTER,
         FEED_ITEM_TYPE_FRIEND_DEFECTION,
+        FEED_ITEM_TYPE_FOE_COMPLETION,
     },
     "friends": {
         FEED_ITEM_TYPE_FRIEND_COMPLETION,
         FEED_ITEM_TYPE_FRIEND_SIGNUP,
         FEED_ITEM_TYPE_FRIEND_DEFECTION,
     },
-    "foes": {FEED_ITEM_TYPE_FOE_TAUNT},
+    "foes": {FEED_ITEM_TYPE_FOE_TAUNT, FEED_ITEM_TYPE_FOE_COMPLETION},
     "your_stuff": {
         FEED_ITEM_TYPE_VOTE_ON_MINE,
         FEED_ITEM_TYPE_COLLAB_INVITE,
@@ -75,6 +77,21 @@ async def _get_friend_ids(
         select(Relationship.to_character_id).where(
             Relationship.from_character_id == character_id,
             Relationship.type == RelationshipType.friend,
+            Relationship.status == RelationshipStatus.active,
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def _get_foe_ids(
+    character_id: int,
+    session: AsyncSession,
+) -> list[int]:
+    """Get IDs of characters the current character has declared as foes."""
+    result = await session.execute(
+        select(Relationship.to_character_id).where(
+            Relationship.from_character_id == character_id,
+            Relationship.type == RelationshipType.foe,
             Relationship.status == RelationshipStatus.active,
         )
     )
@@ -233,6 +250,60 @@ async def _fetch_foe_taunts(
                 "message": taunt.message,
                 "trigger_type": taunt.trigger_type.value,
                 "from_character_id": taunt.from_character_id,
+            },
+        ))
+    return items
+
+
+async def _fetch_foe_completions(
+    foe_ids: list[int],
+    session: AsyncSession,
+    before: Optional[datetime],
+) -> list[ActivityFeedItem]:
+    """Recent submissions (completions) from foes."""
+    if not foe_ids:
+        return []
+
+    query = (
+        select(
+            Submission.id,
+            Submission.title,
+            Submission.created_at,
+            Submission.character_id,
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+            Character.display_name.label("author_display_name"),
+            Character.faction_slug.label("author_faction_slug"),
+            Character.avatar_url.label("author_avatar_url"),
+        )
+        .join(Task, Submission.task_id == Task.id)
+        .join(Character, Submission.character_id == Character.id)
+        .where(
+            Submission.character_id.in_(foe_ids),
+            Submission.is_withdrawn == False,  # noqa: E712
+        )
+    )
+    if before is not None:
+        query = query.where(Submission.created_at < before)
+    query = query.order_by(Submission.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+    result = await session.execute(query)
+    items: list[ActivityFeedItem] = []
+    for row in result.all():
+        items.append(ActivityFeedItem(
+            type=FEED_ITEM_TYPE_FOE_COMPLETION,
+            timestamp=row.created_at,
+            actor_display_name=row.author_display_name,
+            actor_faction_slug=row.author_faction_slug,
+            actor_avatar_url=row.author_avatar_url,
+            payload={
+                "submission_id": row.id,
+                "submission_title": row.title,
+                "task_title": row.task_title,
+                "task_point_value": row.task_point_value,
+                "task_faction_slug": row.task_faction_slug,
+                "character_id": row.character_id,
             },
         ))
     return items
@@ -713,7 +784,19 @@ async def _compute_counts(
     friend_signups_count = await count_friend_signups()
     friend_defections_count = await count_friend_defections()
     friends_count = friend_completions_count + friend_signups_count + friend_defections_count
-    foes_count = await count_foe_taunts()
+    foe_ids_for_count = await _get_foe_ids(character_id, session)
+    foe_completions_count = 0
+    if foe_ids_for_count:
+        foe_completions_result = await session.execute(
+            select(func.count())
+            .select_from(Submission)
+            .where(
+                Submission.character_id.in_(foe_ids_for_count),
+                Submission.is_withdrawn == False,  # noqa: E712
+            )
+        )
+        foe_completions_count = foe_completions_result.scalar_one()
+    foes_count = await count_foe_taunts() + foe_completions_count
     your_stuff_count = await count_your_stuff()
     global_count = await count_global()
     requests_count = await count_requests()
@@ -752,16 +835,20 @@ async def get_activity_feed(
 
     # Pre-fetch relationship and task context needed by multiple sub-queries
     friend_ids: list[int] = []
+    foe_ids: list[int] = []
     my_task_ids: list[int] = []
 
     needs_friends = bool(allowed_types & {
         FEED_ITEM_TYPE_FRIEND_COMPLETION, FEED_ITEM_TYPE_FRIEND_SIGNUP,
         FEED_ITEM_TYPE_FRIEND_DEFECTION,
     })
+    needs_foes = FEED_ITEM_TYPE_FOE_COMPLETION in allowed_types
     needs_my_tasks = FEED_ITEM_TYPE_FRIEND_SIGNUP in allowed_types
 
     if needs_friends:
         friend_ids = await _get_friend_ids(character_id, session)
+    if needs_foes:
+        foe_ids = await _get_foe_ids(character_id, session)
     if needs_my_tasks:
         my_task_ids = await _get_my_task_ids(character_id, session)
 
@@ -776,6 +863,9 @@ async def get_activity_feed(
 
     if FEED_ITEM_TYPE_FOE_TAUNT in allowed_types:
         fetch_tasks.append(_fetch_foe_taunts(character_id, session, before_cursor))
+
+    if FEED_ITEM_TYPE_FOE_COMPLETION in allowed_types:
+        fetch_tasks.append(_fetch_foe_completions(foe_ids, session, before_cursor))
 
     if FEED_ITEM_TYPE_GLOBAL_TASK in allowed_types:
         fetch_tasks.append(_fetch_global_tasks(session, before_cursor))

--- a/frontend/src/api/gameConfig.ts
+++ b/frontend/src/api/gameConfig.ts
@@ -1,0 +1,31 @@
+import api from './axios'
+
+export interface FactionConfigOut {
+  slug: string
+  name: string
+  description: string
+  color: string
+  is_selectable: boolean
+  can_always_rejoin: boolean
+  own_task_modifier: number
+  other_task_modifier: number
+  collab_own_modifier: number
+  collab_other_modifier: number
+  duel_win_modifier: number
+  duel_loss_modifier: number
+}
+
+export interface GameConfigOut {
+  era_name: string
+  level_thresholds: number[]
+  max_task_signups: number
+  vote_budget_base: number
+  vote_budget_multiplier: number
+  task_submit_level_gap: number
+  factions: FactionConfigOut[]
+}
+
+export async function getGameConfig(): Promise<GameConfigOut> {
+  const { data } = await api.get<GameConfigOut>('/game-config')
+  return data
+}

--- a/frontend/src/components/feed/FeedCardFoeCompletion.tsx
+++ b/frontend/src/components/feed/FeedCardFoeCompletion.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { factionColor } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import FeedBadge from './FeedBadge'
+
+interface Props {
+  item: ActivityFeedItem
+}
+
+export default function FeedCardFoeCompletion({ item }: Props) {
+  const { submission_id, task_title, task_point_value, task_faction_slug, character_id } = item.payload
+  const actorColor = factionColor(item.actor_faction_slug)
+  const taskColor = factionColor(task_faction_slug)
+
+  return (
+    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <Link to={`/characters/${character_id}`}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          />
+        </Link>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <Link
+              to={`/characters/${character_id}`}
+              className="font-body"
+              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            >
+              {item.actor_display_name}
+            </Link>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              completed a task
+            </span>
+            <FeedBadge type="duel" label="Foe" />
+          </div>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            {relativeTime(item.timestamp)}
+          </span>
+        </div>
+      </div>
+
+      <div
+        style={{
+          marginTop: 10,
+          marginLeft: 38,
+          borderLeft: `3px solid ${taskColor}`,
+          paddingLeft: 10,
+        }}
+      >
+        <Link
+          to={`/submissions/${submission_id}`}
+          className="font-body"
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: 'var(--color-text-primary)',
+            textDecoration: 'none',
+            display: 'block',
+            lineHeight: 1.3,
+          }}
+        >
+          {task_title}
+        </Link>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {task_point_value} pts
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedCardRouter.tsx
+++ b/frontend/src/components/feed/FeedCardRouter.tsx
@@ -9,11 +9,13 @@ import FeedCardGlobalTask from './FeedCardGlobalTask'
 import FeedCardFriendSignup from './FeedCardFriendSignup'
 import FeedCardInvitationLetter from './FeedCardInvitationLetter'
 import FeedCardFriendDefection from './FeedCardFriendDefection'
+import FeedCardFoeCompletion from './FeedCardFoeCompletion'
 
 const CARD_MAP: Record<string, React.ComponentType<{ item: ActivityFeedItem }>> = {
   era_announcement: FeedCardEraAnnouncement,
   vote_on_mine: FeedCardVoteNotification,
   foe_taunt: FeedCardFoeTaunt,
+  foe_completion: FeedCardFoeCompletion,
   friend_completion: FeedCardFriendActivity,
   collab_invite: FeedCardCollabInvite,
   duel_challenge: FeedCardDuelChallenge,

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,8 +9,9 @@ import FeedBadge from '../feed/FeedBadge'
 import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
 import { useMyCharacterStats } from '../../hooks/useMyCharacterStats'
 import { usePendingRequests } from '../../hooks/usePendingRequests'
+import { useGameConfig } from '../../hooks/useGameConfig'
 
-const MAX_TASK_SLOTS = 20
+const DEFAULT_MAX_TASK_SLOTS = 20
 
 /**
  * Always-on right sidebar (Style Guide §4.2).
@@ -23,6 +24,7 @@ export default function Sidebar() {
   const { activeTasks } = useMyActiveTasks()
   const { votesReceived } = useMyCharacterStats(character?.id)
   const { pendingRequests } = usePendingRequests()
+  const gameConfig = useGameConfig()
   const [globalActivity, setGlobalActivity] = useState<ActivityFeedItem[]>([])
 
   useEffect(() => {
@@ -33,8 +35,9 @@ export default function Sidebar() {
       .catch(() => {})
   }, [user])
 
+  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS
   const slotCount = activeTasks.length
-  const slotPercent = Math.min((slotCount / MAX_TASK_SLOTS) * 100, 100)
+  const slotPercent = Math.min((slotCount / maxTaskSlots) * 100, 100)
 
   return (
     <aside className="flex flex-col gap-3" style={{ width: 256 }}>
@@ -219,7 +222,7 @@ export default function Sidebar() {
             />
           </div>
           <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)', marginTop: 3 }}>
-            {slotCount} / {MAX_TASK_SLOTS} slots
+            {slotCount} / {maxTaskSlots} slots
           </p>
         </div>
       </div>

--- a/frontend/src/hooks/useGameConfig.ts
+++ b/frontend/src/hooks/useGameConfig.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { getGameConfig, type GameConfigOut } from '../api/gameConfig'
+
+let cachedConfig: GameConfigOut | null = null
+let fetchPromise: Promise<GameConfigOut> | null = null
+
+/**
+ * Hook to fetch and cache the current era game config.
+ * Config is fetched once and shared across all consumers.
+ */
+export function useGameConfig() {
+  const [config, setConfig] = useState<GameConfigOut | null>(cachedConfig)
+
+  useEffect(() => {
+    if (cachedConfig) {
+      setConfig(cachedConfig)
+      return
+    }
+    if (!fetchPromise) {
+      fetchPromise = getGameConfig()
+        .then((data) => {
+          cachedConfig = data
+          return data
+        })
+        .catch(() => {
+          fetchPromise = null
+          return null as unknown as GameConfigOut
+        })
+    }
+    fetchPromise.then((data) => {
+      if (data) setConfig(data)
+    })
+  }, [])
+
+  return config
+}

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -14,8 +14,9 @@ import { useTheme } from '../hooks/useTheme'
 import { factionColor, factionName } from '../utils/factions'
 import { extractError } from '../utils/errors'
 import { mediaUrl } from '../utils/media'
+import { useGameConfig } from '../hooks/useGameConfig'
 
-const MAX_TASK_SLOTS = 20
+const DEFAULT_MAX_TASK_SLOTS = 20
 const VISIBLE_SIGNUPS = 4
 
 type CollabMode = 'solo' | 'collab' | 'duel'
@@ -54,6 +55,10 @@ export default function TaskDetail() {
   const [inviteQuery, setInviteQuery] = useState('')
   const [searchResults, setSearchResults] = useState<CharacterOut[]>([])
   const [showSearch, setShowSearch] = useState(false)
+
+  // Game config
+  const gameConfig = useGameConfig()
+  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS
 
   // Submission sort
   const [submissionSort, setSubmissionSort] = useState<'score' | 'recent'>('score')
@@ -184,10 +189,26 @@ export default function TaskDetail() {
   const fname = factionName(task.primary_faction_slug)
   const canSignUp = user && !mySubmission && !isInProgress && (user.character?.level ?? 0) >= task.level_required
   const meetsLevel = (user?.character?.level ?? 0) >= task.level_required
-  const slotsOpen = MAX_TASK_SLOTS - taskSlotCount
+  const slotsOpen = maxTaskSlots - taskSlotCount
   const avgVote = submissions.length > 0
     ? (submissions.reduce((sum, s) => sum + (s.score ?? 0), 0) / submissions.length).toFixed(1)
     : '—'
+
+  // Compute faction modifier for the current user
+  const myFaction = user?.character?.faction_slug
+  const taskFaction = task.primary_faction_slug
+  const factionConfig = myFaction && gameConfig
+    ? gameConfig.factions.find((f) => f.slug === myFaction)
+    : null
+  const isOwnFaction = factionConfig && (taskFaction === myFaction || taskFaction === 'na' || !taskFaction)
+  const factionMultiplier = factionConfig
+    ? (selectedMode === 'duel'
+        ? factionConfig.duel_win_modifier
+        : selectedMode === 'collab'
+          ? (isOwnFaction ? factionConfig.collab_own_modifier : factionConfig.collab_other_modifier)
+          : (isOwnFaction ? factionConfig.own_task_modifier : factionConfig.other_task_modifier))
+    : 1.0
+  const modifiedPoints = Math.round(task.point_value * factionMultiplier)
 
   const sortedSubmissions = [...submissions].sort((a, b) => {
     if (submissionSort === 'score') return (b.score ?? 0) - (a.score ?? 0)
@@ -252,9 +273,10 @@ export default function TaskDetail() {
             </h1>
 
             {/* Stats row */}
-            <div className="grid grid-cols-4 gap-2 mb-4">
+            <div style={{ display: 'grid', gridTemplateColumns: `repeat(${user && factionMultiplier !== 1.0 ? 5 : 4}, 1fr)`, gap: 8, marginBottom: 16 }}>
               {[
                 { label: 'Base Pts', value: task.point_value },
+                ...(user && factionMultiplier !== 1.0 ? [{ label: `Your Pts (×${factionMultiplier})`, value: modifiedPoints }] : []),
                 { label: 'Completed', value: submissions.length },
                 { label: 'In Progress', value: signups.length },
                 { label: 'Avg Vote', value: avgVote },
@@ -284,7 +306,7 @@ export default function TaskDetail() {
           </div>
 
           {/* ── Mode Selector + Signup Block ── */}
-          {user && !mySubmission && !isInProgress && (
+          {user && !mySubmission && (
             <div className="sidebar-card mb-5" style={{ padding: '16px 20px' }}>
               <p className="eyebrow mb-3">How do you want to do this?</p>
 
@@ -347,6 +369,13 @@ export default function TaskDetail() {
                     <button
                       type="button"
                       disabled={!inviteQuery.trim()}
+                      onClick={() => {
+                        if (searchResults.length > 0) {
+                          addPartner(searchResults[0])
+                        } else {
+                          handleInviteSearch(inviteQuery)
+                        }
+                      }}
                       style={{
                         fontFamily: "'Courier Prime', monospace",
                         fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
@@ -432,46 +461,50 @@ export default function TaskDetail() {
                 </div>
               )}
 
-              {/* Sign up button */}
-              {canSignUp ? (
-                <button
-                  onClick={handleSignup}
-                  style={{
-                    width: '100%',
-                    background: color, color: 'white',
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: 13, fontWeight: 700, textTransform: 'uppercase',
-                    letterSpacing: '0.15em', padding: '10px 20px',
-                    border: 'none', cursor: 'pointer', position: 'relative',
-                  }}
-                >
-                  <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-                  Sign up · earn up to {task.point_value} pts
-                </button>
-              ) : (
-                <button
-                  disabled
-                  style={{
-                    width: '100%',
-                    background: 'var(--color-bg-surface-alt)',
-                    color: 'var(--color-text-tertiary)',
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: 11, textTransform: 'uppercase',
-                    letterSpacing: '0.1em', padding: '10px 20px',
-                    border: 'none', cursor: 'not-allowed',
-                  }}
-                >
-                  {!meetsLevel ? `Level ${task.level_required} required` : 'Sign up'}
-                </button>
-              )}
+              {/* Sign up button (only when not yet signed up) */}
+              {!isInProgress && (
+                <>
+                  {canSignUp ? (
+                    <button
+                      onClick={handleSignup}
+                      style={{
+                        width: '100%',
+                        background: color, color: 'white',
+                        fontFamily: "'Courier Prime', monospace",
+                        fontSize: 13, fontWeight: 700, textTransform: 'uppercase',
+                        letterSpacing: '0.15em', padding: '10px 20px',
+                        border: 'none', cursor: 'pointer', position: 'relative',
+                      }}
+                    >
+                      <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
+                      Sign up · earn up to {modifiedPoints} pts
+                    </button>
+                  ) : (
+                    <button
+                      disabled
+                      style={{
+                        width: '100%',
+                        background: 'var(--color-bg-surface-alt)',
+                        color: 'var(--color-text-tertiary)',
+                        fontFamily: "'Courier Prime', monospace",
+                        fontSize: 11, textTransform: 'uppercase',
+                        letterSpacing: '0.1em', padding: '10px 20px',
+                        border: 'none', cursor: 'not-allowed',
+                      }}
+                    >
+                      {!meetsLevel ? `Level ${task.level_required} required` : 'Sign up'}
+                    </button>
+                  )}
 
-              <div className="eyebrow" style={{ marginTop: 6, display: 'flex', justifyContent: 'space-between' }}>
-                <span>You have {slotsOpen} of {MAX_TASK_SLOTS} task slots open</span>
-                <span>Level {task.level_required} required {meetsLevel ? '✓' : ''}</span>
-              </div>
+                  <div className="eyebrow" style={{ marginTop: 6, display: 'flex', justifyContent: 'space-between' }}>
+                    <span>You have {slotsOpen} of {maxTaskSlots} task slots open</span>
+                    <span>Level {task.level_required} required {meetsLevel ? '✓' : ''}</span>
+                  </div>
 
-              {signupError && (
-                <p className="font-body" style={{ fontSize: 9, color: '#dc2626', marginTop: 6 }}>{signupError}</p>
+                  {signupError && (
+                    <p className="font-body" style={{ fontSize: 9, color: '#dc2626', marginTop: 6 }}>{signupError}</p>
+                  )}
+                </>
               )}
             </div>
           )}
@@ -511,6 +544,7 @@ export default function TaskDetail() {
               </div>
               <Link
                 to={`/tasks/${task.id}/submit`}
+                state={{ mode: selectedMode, partners: invitedPartners }}
                 style={{
                   background: color, color: 'white',
                   fontFamily: "'Courier Prime', monospace",


### PR DESCRIPTION
## Summary
- **Foe activity feed**: Foe tab now shows task completions from your foes (not just taunts). New `foe_completion` feed type with backend query + frontend card.
- **Modified point total**: Task detail page shows your faction-adjusted points (e.g., "Your Pts (x0.7)") using a new `useGameConfig` hook that fetches from `GET /game-config`.
- **Collab/duel invites**: Fixed `+ Add` button (was missing onClick), mode selector now visible when already signed up for a task, "Submit proof" link passes collab state.
- **Era config task slots**: Sidebar and TaskDetail read `max_task_signups` from era config instead of hardcoded 20.

## Test plan
- [ ] Check Foes tab in Updates page shows task completions from foes
- [ ] Check task detail shows modified points when your faction has a non-1.0 multiplier
- [ ] Check collab/duel: search players, click "+ Add", verify it works
- [ ] Check mode selector shows when already signed up for a task
- [ ] Verify sidebar task slot count reads from era config

🤖 Generated with [Claude Code](https://claude.com/claude-code)