### PR TITLE
Fix card overflow, faction-theme feed and praxis cards

### DIFF
--- a/backend/schemas/submission.py
+++ b/backend/schemas/submission.py
@@ -22,6 +22,7 @@ class SubmissionOut(BaseModel):
     character_display_name: str = ""
     task_title: str = ""
     task_point_value: int = 0
+    task_faction_slug: Optional[str] = None
     title: str
     body_text: Optional[str]
     moderation_status: str = "visible"

--- a/backend/services/submission.py
+++ b/backend/services/submission.py
@@ -264,6 +264,7 @@ async def build_submission_out(
     task = await session.get(Task, submission.task_id)
     task_title = task.title if task else ""
     task_point_value = task.point_value if task else 0
+    task_faction_slug = task.primary_faction_slug if task else None
 
     partner_display_name = None
     if submission.partner_character_id:
@@ -285,6 +286,7 @@ async def build_submission_out(
         character_display_name=character_display_name,
         task_title=task_title,
         task_point_value=task_point_value,
+        task_faction_slug=task_faction_slug,
         title=submission.title,
         body_text=submission.body_text,
         moderation_status=submission.moderation_status.value,

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -14,6 +14,7 @@ export interface SubmissionOut {
   character_display_name: string
   task_title: string
   task_point_value: number
+  task_faction_slug: string | null
   title: string
   body_text: string | null
   moderation_status: string

--- a/frontend/src/components/SubmissionCard.tsx
+++ b/frontend/src/components/SubmissionCard.tsx
@@ -3,6 +3,7 @@ import type { SubmissionOut } from '../api/submissions'
 import { useAuth } from '../auth/AuthContext'
 import { useAdminMode } from '../auth/AdminModeContext'
 import { moderateSubmission } from '../api/admin'
+import { factionCssVar } from '../utils/factions'
 
 interface Props {
   submission: SubmissionOut
@@ -22,7 +23,14 @@ export default function SubmissionCard({ submission, onModerated }: Props) {
   }
 
   return (
-    <div className="card p-4 flex flex-col gap-2 transition-all duration-150 relative">
+    <div
+      className="card p-4 flex flex-col gap-2 transition-all duration-150 relative"
+      style={{
+        background: factionCssVar(submission.task_faction_slug, 'card-bg'),
+        borderLeft: `4px solid ${factionCssVar(submission.task_faction_slug, 'card-accent')}`,
+        color: factionCssVar(submission.task_faction_slug, 'card-text'),
+      }}
+    >
       {/* Moderation status badges */}
       {submission.moderation_status === 'flagged' && (
         <span

--- a/frontend/src/components/cards/TaskCardAnalog.tsx
+++ b/frontend/src/components/cards/TaskCardAnalog.tsx
@@ -38,7 +38,7 @@ export default function TaskCardAnalog({ task, onSignup }: Props) {
       </div>
 
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-        <div style={{ fontSize: 'var(--text-lg)', fontWeight: 400, lineHeight: 1.3, marginBottom: 6 }}>{task.title}</div>
+        <div style={{ fontSize: 'var(--text-lg)', fontWeight: 400, lineHeight: 1.3, marginBottom: 6, overflowWrap: 'anywhere' }}>{task.title}</div>
       </Link>
 
       {task.description && (

--- a/frontend/src/components/cards/TaskCardGestalt.tsx
+++ b/frontend/src/components/cards/TaskCardGestalt.tsx
@@ -43,7 +43,7 @@ export default function TaskCardGestalt({ task, onSignup }: Props) {
         </div>
 
         <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-          <div style={{ fontSize: 'var(--text-md)', fontWeight: 700, lineHeight: 1.3, marginBottom: 6 }}>{task.title}</div>
+          <div style={{ fontSize: 'var(--text-md)', fontWeight: 700, lineHeight: 1.3, marginBottom: 6, overflowWrap: 'anywhere' }}>{task.title}</div>
         </Link>
 
         {task.description && (

--- a/frontend/src/components/cards/TaskCardJourneymen.tsx
+++ b/frontend/src/components/cards/TaskCardJourneymen.tsx
@@ -41,7 +41,7 @@ export default function TaskCardJourneymen({ task, onSignup }: Props) {
           </div>
 
           <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-            <div style={{ fontSize: 'var(--text-md)', fontWeight: 700, lineHeight: 1.3, marginBottom: 5 }}>{task.title}</div>
+            <div style={{ fontSize: 'var(--text-md)', fontWeight: 700, lineHeight: 1.3, marginBottom: 5, overflowWrap: 'anywhere' }}>{task.title}</div>
           </Link>
 
           {task.description && (

--- a/frontend/src/components/cards/TaskCardSNIDE.tsx
+++ b/frontend/src/components/cards/TaskCardSNIDE.tsx
@@ -59,7 +59,7 @@ export default function TaskCardSNIDE({ task, onSignup }: Props) {
       </div>
 
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-        <div style={{ fontSize: 'var(--text-lg)', lineHeight: 1.2, marginBottom: 4 }}>{task.title}</div>
+        <div style={{ fontSize: 'var(--text-lg)', lineHeight: 1.2, marginBottom: 4, overflowWrap: 'anywhere' }}>{task.title}</div>
       </Link>
 
       <div style={{ marginBottom: 6 }}>

--- a/frontend/src/components/cards/TaskCardSingularity.tsx
+++ b/frontend/src/components/cards/TaskCardSingularity.tsx
@@ -87,7 +87,7 @@ export default function TaskCardSingularity({ task, onSignup }: Props) {
         </div>
 
         <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-          <div style={{ fontSize: 'var(--text-sm)', marginBottom: 6, lineHeight: 1.3 }}>
+          <div style={{ fontSize: 'var(--text-sm)', marginBottom: 6, lineHeight: 1.3, overflowWrap: 'anywhere' }}>
             {'> '}{task.title}
           </div>
         </Link>

--- a/frontend/src/components/cards/TaskCardUA.tsx
+++ b/frontend/src/components/cards/TaskCardUA.tsx
@@ -54,7 +54,7 @@ export default function TaskCardUA({ task, onSignup }: Props) {
       </div>
 
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-        <div style={{ fontSize: 'var(--text-md)', fontWeight: 700, lineHeight: 1.3, marginBottom: 6 }}>
+        <div style={{ fontSize: 'var(--text-md)', fontWeight: 700, lineHeight: 1.3, marginBottom: 6, overflowWrap: 'anywhere' }}>
           {task.title}
         </div>
       </Link>

--- a/frontend/src/components/cards/TaskCardUAMasters.tsx
+++ b/frontend/src/components/cards/TaskCardUAMasters.tsx
@@ -39,7 +39,7 @@ export default function TaskCardUAMasters({ task, onSignup }: Props) {
       </div>
 
       <Link to={`/tasks/${task.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-        <div style={{ fontSize: 13, lineHeight: 1.2, marginBottom: 3 }}>{task.title}</div>
+        <div style={{ fontSize: 13, lineHeight: 1.2, marginBottom: 3, overflowWrap: 'anywhere' }}>{task.title}</div>
       </Link>
 
       <div style={{ fontSize: 7, fontStyle: 'italic', color: factionCssVar('ua_masters', 'card-muted'), marginBottom: 6 }}>

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import { acceptInvite, declineInvite } from '../../api/submissions'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -42,7 +42,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
   const isPending = status === 'pending' || status === null
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px' }}>
+    <div className="sidebar-card" style={{ padding: '12px 16px', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <Link to={`/characters/${inviter_character_id}`}>
           <div

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import { acceptInvite, declineInvite } from '../../api/submissions'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -46,8 +46,8 @@ export default function FeedCardDuelChallenge({ item }: Props) {
       className="sidebar-card"
       style={{
         padding: '12px 16px',
-        borderLeft: '4px solid #dc2626',
-        background: 'linear-gradient(135deg, rgba(220,38,38,0.06), transparent)',
+        borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}`,
+        background: factionCssVar(task_faction_slug, 'card-bg'),
       }}
     >
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>

--- a/frontend/src/components/feed/FeedCardFoeTaunt.tsx
+++ b/frontend/src/components/feed/FeedCardFoeTaunt.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 
 interface Props {
@@ -21,8 +21,8 @@ export default function FeedCardFoeTaunt({ item }: Props) {
     <div
       className="sidebar-card"
       style={{
-        background: 'linear-gradient(135deg, rgba(196,154,58,0.12), rgba(196,154,58,0.06))',
-        borderLeft: '4px solid #c49a3a',
+        background: factionCssVar(item.actor_faction_slug, 'card-bg'),
+        borderLeft: `4px solid ${factionCssVar(item.actor_faction_slug, 'card-accent')}`,
         padding: '16px 20px',
         position: 'relative',
       }}

--- a/frontend/src/components/feed/FeedCardFriendActivity.tsx
+++ b/frontend/src/components/feed/FeedCardFriendActivity.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -14,7 +14,7 @@ export default function FeedCardFriendActivity({ item }: Props) {
   const taskColor = factionColor(task_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative' }}>
+    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         {/* Avatar */}
         <Link to={`/characters/${character_id}`}>

--- a/frontend/src/components/feed/FeedCardFriendDefection.tsx
+++ b/frontend/src/components/feed/FeedCardFriendDefection.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionName } from '../../utils/factions'
+import { factionColor, factionName, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -14,7 +14,7 @@ export default function FeedCardFriendDefection({ item }: Props) {
   const oldColor = factionColor(old_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px' }}>
+    <div className="sidebar-card" style={{ padding: '12px 16px', background: factionCssVar(new_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(new_faction_slug, 'card-accent')}` }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <Link to={`/characters/${character_id}`}>
           <div

--- a/frontend/src/components/feed/FeedCardFriendSignup.tsx
+++ b/frontend/src/components/feed/FeedCardFriendSignup.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -14,7 +14,7 @@ export default function FeedCardFriendSignup({ item }: Props) {
   const taskColor = factionColor(task_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px' }}>
+    <div className="sidebar-card" style={{ padding: '12px 16px', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <Link to={`/characters/${character_id}`}>
           <div

--- a/frontend/src/components/feed/FeedCardGlobalTask.tsx
+++ b/frontend/src/components/feed/FeedCardGlobalTask.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -17,7 +17,8 @@ export default function FeedCardGlobalTask({ item }: Props) {
       className="sidebar-card"
       style={{
         padding: '12px 16px',
-        borderLeft: '3px solid var(--color-border-strong)',
+        borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}`,
+        background: factionCssVar(task_faction_slug, 'card-bg'),
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionName } from '../../utils/factions'
+import { factionColor, factionName, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -17,8 +17,8 @@ export default function FeedCardInvitationLetter({ item }: Props) {
       className="sidebar-card"
       style={{
         padding: '16px 20px',
-        borderLeft: `4px solid ${color}`,
-        background: `linear-gradient(135deg, ${color}10, transparent)`,
+        borderLeft: `4px solid ${factionCssVar(faction_slug, 'card-accent')}`,
+        background: factionCssVar(faction_slug, 'card-bg'),
         position: 'relative',
       }}
     >

--- a/frontend/src/components/feed/FeedCardVoteNotification.tsx
+++ b/frontend/src/components/feed/FeedCardVoteNotification.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -13,7 +13,7 @@ export default function FeedCardVoteNotification({ item }: Props) {
   const color = factionColor(item.actor_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative' }}>
+    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative', background: factionCssVar(item.actor_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(item.actor_faction_slug, 'card-accent')}` }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         {/* Avatar */}
         <div


### PR DESCRIPTION
## Summary
- **Card text overflow fix** — added `overflowWrap: 'anywhere'` to title divs in all 7 faction card components. Long unbreakable strings now wrap instead of overflowing the card.
- **Faction-themed feed items** — 9 feed card components now use `factionCssVar()` for background and accent border, replacing generic frosted glass. Each card picks its faction from the task or actor slug already in the API response.
- **Faction-themed praxis cards** — added `task_faction_slug` to backend `SubmissionOut` schema + service. `SubmissionCard` now renders with the task's faction background and accent border.

## Test plan
- [x] TypeScript compilation passes (no errors in changed files)
- [x] Dev server starts without errors, no console errors
- [ ] Manual: verify task card titles with long text wrap properly
- [ ] Manual: verify feed items show faction-colored backgrounds
- [ ] Manual: verify praxis/submission cards show faction theming

🤖 Generated with [Claude Code](https://claude.com/claude-code)