### PR TITLE
Frontend style polish: CSS vars, dark mode, responsive, faction API

### DIFF
--- a/docs/BUILD_STATE.md
+++ b/docs/BUILD_STATE.md
@@ -145,6 +145,12 @@ All migrations use `create_type=False` on `sa.Enum()` in `add_column`/`create_ta
 - `frontend/src/api/taunts.ts` — Taunts API client ✅ 2026-04-14
 - NavBar links verified (Tasks, Praxis /submissions, Players /leaderboard, Groups, Updates) ✅
 - Dev server running on port 5173 (`npm run dev`) ✅
+- Style polish (SESSION Frontend) ✅ 2026-04-15
+  - Dark mode ternaries replaced with CSS vars across all non-card components (NavBar, Sidebar, FilterStamps, FilterLevelNodes, Leaderboard, Updates, TaskDetail, SubmitProof, ProposeTask, CharacterProfile, feed cards)
+  - Inline layout styles → Tailwind classes (Sidebar, FilterFactionTabs, FilterStamps, FilterLevelNodes, Tasks page, Layout)
+  - Responsive breakpoints added: sidebar collapses below `lg`, card wrap via `flex-wrap` already in place
+  - Hardcoded hex audited and replaced with CSS vars in all targeted components; new vars added to index.css (rank, badge, level track, stamp dashed)
+  - Faction colors wired to API: `factionRegistry` in `utils/factions.ts` populated from `GET /game-config` via `useGameConfig`; `getAllFactions()` exposed for component fallback use
 
 Seed data:
 - `backend/seed.py` — 9 factions, 8 accounts/characters, 14 tasks, 24 submissions, ~101 votes ✅

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -10,26 +10,11 @@
 
 ---
 
-## 🎨 SESSION — Frontend Style Polish
+## 🎨 SESSION — Frontend Style Polish (remaining)
 
-> Migrated from `STYLE_MIGRATION_NOTES.md` (deleted 2026-04-14). The original style migration is
-> structurally complete (CSS variables, faction archetypes, dark mode, custom fonts all shipped).
-> These are the remaining polish items.
+> All high and medium priority items are complete. One low-priority item remains.
 >
 > **Read before starting:** `WORLD_ZERO_STYLE.md`, `frontend/src/index.css`, `frontend/src/utils/factions.ts`.
-
-### High priority
-
-- ✅ **Migrate remaining inline styles to Tailwind / CSS classes.** — 2026-04-15. NavBar, Sidebar, FilterStamps, FilterFactionTabs, FilterLevelNodes, Tasks page, Layout.
-- ✅ **Add responsive breakpoints.** — 2026-04-15. Sidebar hidden below `lg` breakpoint; card container already uses `flex-wrap`.
-- ✅ **Audit non-card components for hardcoded hex.** — 2026-04-15. NavBar, Sidebar, Leaderboard, CharacterProfile, all feed card components cleaned up; new CSS vars added to index.css.
-
-### Medium priority
-
-- ✅ **Switch frontend to consume faction colors from API.** — 2026-04-15. `factionRegistry` in `utils/factions.ts` now populated from `GET /game-config` via `useGameConfig`; hardcoded values remain as initial fallback only.
-- ✅ **Consolidate dark mode in non-card components.** — 2026-04-15. All `dark ? x : y` color ternaries replaced with CSS variable cascades in Updates, TaskDetail, SubmitProof, ProposeTask, CharacterProfile, Leaderboard, and filter components.
-
-### Low priority
 
 - **Full inline-style → Tailwind migration.** Convert all remaining `style={{}}` to Tailwind utilities where practical. Large effort, low urgency.
 
@@ -239,8 +224,6 @@ contradiction.
 
 ## 🟣 SESSION 5+ — Ambitious Frontend (post-launch)
 
-## Completed Sessions
-
 > Do not start until the site is live on worldzero.org and the MVP frontend is stable.
 
 **Vision:** Faction-specific UI themes — each faction gets its own color palette, typography, background textures, and layout variations driven by a `data-faction` attribute on `<body>` + CSS custom properties.
@@ -258,3 +241,15 @@ contradiction.
 
 - **Render deploy config** — not started
 - **GoDaddy DNS config** (external — worldzero.org) — not started
+
+---
+
+## ✅ Completed
+
+### 🎨 Frontend Style Polish — 2026-04-15
+
+- ✅ **Migrate remaining inline styles to Tailwind / CSS classes.** NavBar, Sidebar, FilterStamps, FilterFactionTabs, FilterLevelNodes, Tasks page, Layout.
+- ✅ **Add responsive breakpoints.** Sidebar hidden below `lg` breakpoint; card container already uses `flex-wrap`.
+- ✅ **Audit non-card components for hardcoded hex.** NavBar, Sidebar, Leaderboard, CharacterProfile, all feed card components cleaned up; new CSS vars added to index.css.
+- ✅ **Switch frontend to consume faction colors from API.** `factionRegistry` in `utils/factions.ts` now populated from `GET /game-config` via `useGameConfig`; hardcoded values remain as initial fallback only.
+- ✅ **Consolidate dark mode in non-card components.** All `dark ? x : y` color ternaries replaced with CSS variable cascades in Updates, TaskDetail, SubmitProof, ProposeTask, CharacterProfile, Leaderboard, and filter components.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -20,14 +20,14 @@
 
 ### High priority
 
-- **Migrate remaining inline styles to Tailwind / CSS classes.** Components outside `cards/` still use extensive `style={{}}` objects. Priority order: `NavBar`, `Sidebar`, `FilterStamps`, `FilterFactionTabs`, `FilterLevelNodes`.
-- **Add responsive breakpoints.** No media queries currently exist — mobile and tablet views are unhandled. Add Tailwind responsive classes for the layout grid, sidebar collapse, and card wrapping.
-- **Audit non-card components for hardcoded hex.** `NavBar`, `Sidebar`, feed items, profile, leaderboard may still have hardcoded colors that should reference CSS variables.
+- ✅ **Migrate remaining inline styles to Tailwind / CSS classes.** — 2026-04-15. NavBar, Sidebar, FilterStamps, FilterFactionTabs, FilterLevelNodes, Tasks page, Layout.
+- ✅ **Add responsive breakpoints.** — 2026-04-15. Sidebar hidden below `lg` breakpoint; card container already uses `flex-wrap`.
+- ✅ **Audit non-card components for hardcoded hex.** — 2026-04-15. NavBar, Sidebar, Leaderboard, CharacterProfile, all feed card components cleaned up; new CSS vars added to index.css.
 
 ### Medium priority
 
-- **Switch frontend to consume faction colors from API.** Backend already returns colors via `GET /game-config`. `frontend/src/utils/factions.ts` still has hardcoded config — replace with API response.
-- **Consolidate dark mode in non-card components.** Audit `NavBar`, `FilterStamps`, `FilterLevelNodes`, and page components for any remaining `dark ? x : y` ternaries — those should be CSS variable cascades instead.
+- ✅ **Switch frontend to consume faction colors from API.** — 2026-04-15. `factionRegistry` in `utils/factions.ts` now populated from `GET /game-config` via `useGameConfig`; hardcoded values remain as initial fallback only.
+- ✅ **Consolidate dark mode in non-card components.** — 2026-04-15. All `dark ? x : y` color ternaries replaced with CSS variable cascades in Updates, TaskDetail, SubmitProof, ProposeTask, CharacterProfile, Leaderboard, and filter components.
 
 ### Low priority
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -31,15 +31,13 @@ export default function Layout({ children }: { children: ReactNode }) {
         className="flex-1 relative max-w-5xl mx-auto w-full px-4 sm:px-6 py-5"
         style={{ zIndex: 5 }}
       >
-        <div
-          className="gap-4 items-start"
-          style={{
-            display: 'grid',
-            gridTemplateColumns: user ? '1fr 256px' : '1fr',
-          }}
-        >
+        <div className={`gap-4 items-start ${user ? 'lg:grid lg:grid-cols-[1fr_256px]' : ''}`}>
           <main className="min-w-0">{children}</main>
-          {user && <Sidebar />}
+          {user && (
+            <div className="hidden lg:block">
+              <Sidebar />
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -13,18 +13,6 @@ const links = [
   { to: '/updates', label: 'Updates' },
 ]
 
-/** Nav link style — Courier Prime 10px uppercase (Style Guide §5.1) */
-const NAV_LINK_BASE = {
-  fontFamily: "'Courier Prime', monospace",
-  fontSize: 10,
-  textTransform: 'uppercase' as const,
-  letterSpacing: '0.12em',
-  paddingBottom: 2,
-}
-
-const NAV_BG_LIGHT = 'rgba(247, 244, 238, 0.88)'
-const NAV_BG_DARK = 'rgba(19, 18, 26, 0.92)'
-
 export default function NavBar() {
   const { user, refetch } = useAuth()
   const { theme, toggle } = useTheme()
@@ -41,8 +29,8 @@ export default function NavBar() {
       className="sticky top-0"
       style={{
         zIndex: 10,
-        background: dark ? NAV_BG_DARK : NAV_BG_LIGHT,
-        backdropFilter: dark ? 'blur(8px)' : 'blur(6px)',
+        background: 'var(--color-nav-bg)',
+        backdropFilter: 'blur(var(--nav-blur))',
         borderBottom: '1px solid var(--color-border)',
         transition: 'background 150ms',
       }}
@@ -75,9 +63,8 @@ export default function NavBar() {
               <NavLink
                 to={to}
                 end={end}
-                className="transition-colors"
+                className="nav-link"
                 style={({ isActive }) => ({
-                  ...NAV_LINK_BASE,
                   color: isActive ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
                   borderBottom: isActive ? '1.5px solid var(--color-text-primary)' : '1.5px solid transparent',
                 })}
@@ -90,9 +77,8 @@ export default function NavBar() {
             <li>
               <NavLink
                 to="/admin"
-                className="transition-colors"
+                className="nav-link"
                 style={({ isActive }) => ({
-                  ...NAV_LINK_BASE,
                   color: isActive ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
                   borderBottom: isActive ? '1.5px solid var(--color-text-primary)' : '1.5px solid transparent',
                 })}
@@ -146,24 +132,16 @@ export default function NavBar() {
               {user.character ? (
                 <NavLink
                   to={`/characters/${user.character.id}/edit`}
-                  className="font-body transition-colors"
-                  style={{
-                    fontSize: 10,
-                    color: 'var(--color-text-secondary)',
-                    letterSpacing: '0.08em',
-                  }}
+                  className="nav-link transition-colors"
+                  style={{ color: 'var(--color-text-secondary)' }}
                 >
                   {user.character.display_name}
                 </NavLink>
               ) : (
                 <NavLink
                   to="/characters/create"
-                  className="font-body transition-colors"
-                  style={{
-                    fontSize: 10,
-                    color: 'var(--color-text-secondary)',
-                    letterSpacing: '0.08em',
-                  }}
+                  className="nav-link transition-colors"
+                  style={{ color: 'var(--color-text-secondary)' }}
                 >
                   create character
                 </NavLink>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -45,7 +45,7 @@ export default function NavBar() {
               color: 'var(--color-text-primary)',
               display: 'inline-block',
               borderBottom: '2px solid transparent',
-              backgroundImage: 'linear-gradient(var(--color-bg-page), var(--color-bg-page)), linear-gradient(90deg, #4f46e5, #be185d, #f97316, #16a34a)',
+              backgroundImage: 'linear-gradient(var(--color-bg-page), var(--color-bg-page)), linear-gradient(90deg, var(--underline-3), var(--underline-2), var(--underline-6), var(--underline-5))',
               backgroundSize: '100% calc(100% - 2px), 100% 2px',
               backgroundPosition: 'top, bottom',
               backgroundRepeat: 'no-repeat',

--- a/frontend/src/components/feed/FeedBadge.tsx
+++ b/frontend/src/components/feed/FeedBadge.tsx
@@ -1,12 +1,12 @@
 /** Reusable badge chip for feed items (FRIEND, YOUR STUFF, GLOBAL, DUEL, etc.) */
 
 const BADGE_STYLES: Record<string, { bg: string; color: string }> = {
-  friend:    { bg: '#14532d', color: '#fff' },
-  your_stuff: { bg: '#8a6a20', color: '#fff' },
-  global:    { bg: '#6b6a7a', color: '#fff' },
-  duel:      { bg: '#dc2626', color: '#fff' },
-  collab:    { bg: '#15803d', color: '#fff' },
-  admin:     { bg: '#1a1209', color: '#F7F4EE' },
+  friend:    { bg: 'var(--badge-friend)',     color: '#fff' },
+  your_stuff: { bg: 'var(--badge-your-stuff)', color: '#fff' },
+  global:    { bg: 'var(--badge-global)',     color: '#fff' },
+  duel:      { bg: 'var(--badge-duel)',       color: '#fff' },
+  collab:    { bg: 'var(--badge-collab)',     color: '#fff' },
+  admin:     { bg: 'var(--badge-admin-bg)',   color: 'var(--badge-admin-text)' },
 }
 
 interface FeedBadgeProps {

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -105,7 +105,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
               fontWeight: 700,
               textTransform: 'uppercase',
               letterSpacing: '0.1em',
-              background: '#14532d',
+              background: 'var(--badge-collab)',
               color: '#fff',
               border: 'none',
               padding: '5px 14px',
@@ -137,7 +137,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
 
       {status === 'accepted' && (
         <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <span className="eyebrow" style={{ color: '#14532d' }}>Accepted</span>
+          <span className="eyebrow" style={{ color: 'var(--badge-collab)' }}>Accepted</span>
         </div>
       )}
       {status === 'declined' && (

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -108,7 +108,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               fontWeight: 700,
               textTransform: 'uppercase',
               letterSpacing: '0.1em',
-              background: '#dc2626',
+              background: 'var(--badge-duel)',
               color: '#fff',
               border: 'none',
               padding: '5px 14px',
@@ -140,7 +140,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
 
       {status === 'accepted' && (
         <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <span className="eyebrow" style={{ color: '#dc2626' }}>Duel Accepted</span>
+          <span className="eyebrow" style={{ color: 'var(--badge-duel)' }}>Duel Accepted</span>
         </div>
       )}
       {status === 'declined' && (

--- a/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
+++ b/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
@@ -9,19 +9,21 @@ interface Props {
 export default function FeedCardEraAnnouncement({ item }: Props) {
   const { era_name, era_notes } = item.payload
 
+  /* Era announcement is intentionally always-dark (Style Guide §8).
+     Uses --badge-admin-bg/text (stable across themes) for consistent dark-card treatment. */
   return (
     <div
       className="sidebar-card"
       style={{
-        background: '#1a1209',
-        color: '#F7F4EE',
+        background: 'var(--badge-admin-bg)',
+        color: 'var(--badge-admin-text)',
         padding: '20px 24px',
         position: 'relative',
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
         <span style={{ fontSize: 20 }}>&#x1F310;</span>
-        <span className="eyebrow" style={{ color: '#c49a3a', fontSize: 8 }}>
+        <span className="eyebrow" style={{ color: 'var(--rank-silver)', fontSize: 8 }}>
           Era Announcement
         </span>
         <span style={{ marginLeft: 'auto' }}>
@@ -31,7 +33,7 @@ export default function FeedCardEraAnnouncement({ item }: Props) {
 
       <h3
         className="font-display italic"
-        style={{ fontSize: 18, color: '#F7F4EE', marginBottom: 8, lineHeight: 1.3 }}
+        style={{ fontSize: 18, color: 'var(--badge-admin-text)', marginBottom: 8, lineHeight: 1.3 }}
       >
         {era_name} is now active.
       </h3>
@@ -51,8 +53,8 @@ export default function FeedCardEraAnnouncement({ item }: Props) {
             fontWeight: 700,
             textTransform: 'uppercase',
             letterSpacing: '0.1em',
-            background: '#F7F4EE',
-            color: '#1a1209',
+            background: 'var(--badge-admin-text)',
+            color: 'var(--badge-admin-bg)',
             padding: '8px 16px',
             textDecoration: 'none',
           }}
@@ -68,7 +70,7 @@ export default function FeedCardEraAnnouncement({ item }: Props) {
             textTransform: 'uppercase',
             letterSpacing: '0.1em',
             border: '1px solid rgba(247,244,238,0.4)',
-            color: '#F7F4EE',
+            color: 'var(--badge-admin-text)',
             padding: '8px 16px',
             textDecoration: 'none',
           }}

--- a/frontend/src/components/feed/FeedCardFoeTaunt.tsx
+++ b/frontend/src/components/feed/FeedCardFoeTaunt.tsx
@@ -32,7 +32,7 @@ export default function FeedCardFoeTaunt({ item }: Props) {
         <span style={{ fontSize: 14 }}>&#x1F43A;</span>
         <span
           className="eyebrow"
-          style={{ color: '#c49a3a', fontSize: 8 }}
+          style={{ color: 'var(--faction-journeymen)', fontSize: 8 }}
         >
           From Your Foe
         </span>
@@ -75,7 +75,7 @@ export default function FeedCardFoeTaunt({ item }: Props) {
             fontFamily: "'Courier Prime', monospace",
             fontSize: 9,
             fontWeight: 700,
-            color: '#dc2626',
+            color: 'var(--color-danger)',
           }}
         >
           {/* Score comparison would need additional data — placeholder */}

--- a/frontend/src/components/feed/FeedCardVoteNotification.tsx
+++ b/frontend/src/components/feed/FeedCardVoteNotification.tsx
@@ -55,7 +55,7 @@ export default function FeedCardVoteNotification({ item }: Props) {
             width: 28,
             height: 28,
             borderRadius: 4,
-            background: '#14532d',
+            background: 'var(--badge-friend)',
             color: '#fff',
             fontFamily: "'Courier Prime', monospace",
             fontSize: 14,
@@ -80,7 +80,7 @@ export default function FeedCardVoteNotification({ item }: Props) {
             fontFamily: "'Courier Prime', monospace",
             fontSize: 10,
             fontWeight: 700,
-            color: '#14532d',
+            color: 'var(--badge-friend)',
           }}
         >
           +{points_earned} pts

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -40,11 +40,11 @@ export default function Sidebar() {
   const slotPercent = Math.min((slotCount / maxTaskSlots) * 100, 100)
 
   return (
-    <aside className="flex flex-col gap-3" style={{ width: 256 }}>
+    <aside className="flex flex-col gap-3 w-64">
       {/* ── Character Card ── */}
       {character ? (
         <div className="sidebar-card">
-          <div className="eyebrow" style={{ fontSize: 8, marginBottom: 8, color: 'var(--color-text-tertiary)' }}>
+          <div className="eyebrow mb-2" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
             Your Character
           </div>
           <div className="flex items-center gap-3 mb-3">
@@ -119,32 +119,28 @@ export default function Sidebar() {
           <p className="eyebrow mb-2">
             Pending Requests · {pendingRequests.length}
           </p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div className="flex flex-col gap-1.5">
             {pendingRequests.map((item, index) => {
               const actorColor = factionColor(item.actor_faction_slug)
               const isCollab = item.type === 'collab_invite'
               return (
                 <div
                   key={`${item.type}-${index}`}
+                  className="flex items-center gap-2 py-1.5"
                   style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    padding: '6px 0',
                     borderTop: index > 0 ? '1px dashed var(--color-border)' : undefined,
                   }}
                 >
                   <div
+                    className="shrink-0 rounded-full"
                     style={{
                       width: 24,
                       height: 24,
-                      borderRadius: '50%',
                       background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
-                      flexShrink: 0,
                     }}
                   />
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <span className="font-body" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', display: 'block' }}>
+                  <div className="flex-1 min-w-0">
+                    <span className="font-body block" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)' }}>
                       {item.actor_display_name}
                     </span>
                     <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
@@ -167,26 +163,24 @@ export default function Sidebar() {
             No active tasks
           </p>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div className="flex flex-col gap-1.5">
             {activeTasks.map((characterTask) => {
               const taskFactionColor = factionColor(characterTask.task.primary_faction_slug)
               const taskFactionName = factionName(characterTask.task.primary_faction_slug)
               return (
                 <div
                   key={characterTask.id}
+                  className="flex items-start justify-between"
                   style={{
                     borderLeft: `3px solid ${taskFactionColor}`,
                     paddingLeft: 8,
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    justifyContent: 'space-between',
                   }}
                 >
-                  <div style={{ minWidth: 0 }}>
+                  <div className="min-w-0">
                     <Link
                       to={`/tasks/${characterTask.task.id}/submit`}
-                      className="font-body"
-                      style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', display: 'block', lineHeight: 1.3 }}
+                      className="font-body block"
+                      style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', lineHeight: 1.3 }}
                     >
                       {characterTask.task.title}
                     </Link>
@@ -202,20 +196,20 @@ export default function Sidebar() {
         )}
 
         {/* Progress bar */}
-        <div style={{ marginTop: 8 }}>
+        <div className="mt-2">
           <div
+            className="overflow-hidden"
             style={{
               height: 4,
               borderRadius: 2,
               background: 'var(--color-bg-surface-alt)',
-              overflow: 'hidden',
             }}
           >
             <div
               style={{
                 height: '100%',
                 width: `${slotPercent}%`,
-                background: '#4f46e5',
+                background: 'var(--faction-singularity)',
                 borderRadius: 2,
                 transition: 'width 300ms',
               }}
@@ -236,21 +230,21 @@ export default function Sidebar() {
             No activity yet
           </p>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div className="flex flex-col">
             {globalActivity.map((item, index) => {
               const isTask = item.type === 'global_task'
               const isEra = item.type === 'era_announcement'
               return (
                 <div
                   key={`${item.type}-${index}`}
+                  className="py-1"
                   style={{
-                    padding: '5px 0',
                     borderTop: index > 0 ? '1px dashed var(--color-border)' : undefined,
                   }}
                 >
                   <div className="font-body" style={{ fontSize: 9, lineHeight: 1.4 }}>
                     {isEra ? (
-                      <span style={{ fontWeight: 700, color: '#c49a3a' }}>
+                      <span style={{ fontWeight: 700, color: 'var(--faction-journeymen)' }}>
                         {item.payload.era_name} has begun
                       </span>
                     ) : isTask ? (

--- a/frontend/src/components/ui/FilterFactionTabs.tsx
+++ b/frontend/src/components/ui/FilterFactionTabs.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export default function FilterFactionTabs({ factions, value, onChange }: Props) {
   return (
-    <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+    <div className="flex gap-1 items-center">
       <span className="eyebrow">faction:</span>
       {factions.map((faction) => {
         const active = value === faction.slug

--- a/frontend/src/components/ui/FilterLevelNodes.tsx
+++ b/frontend/src/components/ui/FilterLevelNodes.tsx
@@ -1,9 +1,7 @@
-import { useTheme } from '../../hooks/useTheme'
-
 /**
  * Level filter — Connected Nodes (Style Guide §5.3).
  * Row of circles connected by horizontal bars. Active: dark fill, scale(1.15).
- * Dark active: inverted to cream on dark-bg.
+ * Colors use CSS variables so dark mode is handled by the cascade.
  */
 
 interface Props {
@@ -13,18 +11,15 @@ interface Props {
 }
 
 export default function FilterLevelNodes({ levels, value, onChange }: Props) {
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
-
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 0 }}>
-      <span className="eyebrow" style={{ marginRight: 8 }}>level:</span>
+    <div className="flex items-center">
+      <span className="eyebrow mr-2">level:</span>
       {levels.map((level, index) => {
         const active = value === level
         return (
-          <div key={level} style={{ display: 'flex', alignItems: 'center' }}>
+          <div key={level} className="flex items-center">
             {index > 0 && (
-              <div style={{ width: 12, height: 2, background: dark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.2)' }} />
+              <div style={{ width: 12, height: 2, background: 'var(--color-border-strong)' }} />
             )}
             <button
               onClick={() => onChange(value === level ? '' : level)}
@@ -32,9 +27,9 @@ export default function FilterLevelNodes({ levels, value, onChange }: Props) {
                 width: 30,
                 height: 30,
                 borderRadius: '50%',
-                border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
-                background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
-                color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-tertiary)',
+                border: `2px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
+                background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+                color: active ? 'var(--color-bg-page)' : 'var(--color-text-tertiary)',
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 10,
                 fontWeight: 700,

--- a/frontend/src/components/ui/FilterStamps.tsx
+++ b/frontend/src/components/ui/FilterStamps.tsx
@@ -1,9 +1,7 @@
-import { useTheme } from '../../hooks/useTheme'
-
 /**
  * Status filter — Rubber Stamps (Style Guide §5.3).
  * Rectangular, no border-radius, inner dashed border, bold uppercase.
- * Dark active: inverted to cream on dark-bg.
+ * Active/inactive colors use CSS variables so dark mode is handled by the cascade.
  */
 
 interface Props {
@@ -13,11 +11,8 @@ interface Props {
 }
 
 export default function FilterStamps({ options, value, onChange }: Props) {
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
-
   return (
-    <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+    <div className="flex gap-1.5 items-center">
       <span className="eyebrow">status:</span>
       {options.map((option) => {
         const active = value === option
@@ -27,10 +22,10 @@ export default function FilterStamps({ options, value, onChange }: Props) {
             onClick={() => onChange(option)}
             style={{
               position: 'relative',
-              border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
+              border: `2px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
               borderRadius: 0,
-              background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
-              color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-primary)',
+              background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+              color: active ? 'var(--color-bg-page)' : 'var(--color-text-primary)',
               fontFamily: "'Courier Prime', monospace",
               fontSize: 10,
               fontWeight: 700,
@@ -45,7 +40,7 @@ export default function FilterStamps({ options, value, onChange }: Props) {
               style={{
                 position: 'absolute',
                 inset: 2,
-                border: `1px dashed ${active ? (dark ? 'rgba(0,0,0,0.15)' : 'rgba(255,255,255,0.2)') : (dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.15)')}`,
+                border: `1px dashed ${active ? 'var(--stamp-active-dashed)' : 'var(--stamp-inactive-dashed)'}`,
                 pointerEvents: 'none',
               }}
             />

--- a/frontend/src/hooks/useGameConfig.ts
+++ b/frontend/src/hooks/useGameConfig.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { getGameConfig, type GameConfigOut } from '../api/gameConfig'
+import { populateFactionRegistry } from '../utils/factions'
 
 let cachedConfig: GameConfigOut | null = null
 let fetchPromise: Promise<GameConfigOut> | null = null
@@ -20,6 +21,7 @@ export function useGameConfig() {
       fetchPromise = getGameConfig()
         .then((data) => {
           cachedConfig = data
+          populateFactionRegistry(data.factions)
           return data
         })
         .catch(() => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,6 +138,32 @@
   /* ── Filter stamp dashed-border (inverts with active state bg) ── */
   --stamp-active-dashed:   rgba(255, 255, 255, 0.20);
   --stamp-inactive-dashed: rgba(0, 0, 0, 0.15);
+
+  /* ── Leaderboard rank colors (podium — stable across themes) ── */
+  --rank-gold:   #f59e0b;
+  --rank-silver: #c49a3a;
+  --rank-bronze: #888888;
+
+  /* ── Leaderboard rank accent (your-rank strip + score highlight) ── */
+  --color-rank-accent:  #4f46e5;
+  --rank-strip-bg:      rgba(79, 70, 229, 0.08);
+  --rank-strip-border:  rgba(79, 70, 229, 0.25);
+
+  /* ── Leaderboard table row hover ── */
+  --leaderboard-row-hover: rgba(255, 255, 255, 0.55);
+
+  /* ── Level track node colors ── */
+  --color-level-inactive: #c8c0b0;
+  --level-node-incomplete: rgba(255, 255, 255, 0.50);
+
+  /* ── Feed badge colors (stable — white text always legible) ── */
+  --badge-friend:     #14532d;
+  --badge-your-stuff: #8a6a20;
+  --badge-global:     #6b6a7a;
+  --badge-duel:       #dc2626;
+  --badge-collab:     #15803d;
+  --badge-admin-bg:   #1a1209;
+  --badge-admin-text: #F7F4EE;
 }
 
 /* ══════════════════════════════════════════
@@ -249,6 +275,18 @@
   /* ── Filter stamp dashed-border (dark-mode inversions) ── */
   --stamp-active-dashed:   rgba(0, 0, 0, 0.15);
   --stamp-inactive-dashed: rgba(255, 255, 255, 0.10);
+
+  /* ── Leaderboard rank accent (dark) ── */
+  --color-rank-accent:  #818cf8;
+  --rank-strip-bg:      rgba(129, 140, 248, 0.12);
+  --rank-strip-border:  rgba(129, 140, 248, 0.30);
+
+  /* ── Leaderboard table row hover (dark) ── */
+  --leaderboard-row-hover: rgba(255, 255, 255, 0.03);
+
+  /* ── Level track node colors (dark) ── */
+  --color-level-inactive: rgba(255, 255, 255, 0.30);
+  --level-node-incomplete: rgba(255, 255, 255, 0.06);
 }
 
 /* ── Type Scale ── */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -134,6 +134,10 @@
   --radius-md:  8px;
   --radius-lg:  12px;
   --radius-xl:  14px;
+
+  /* ── Filter stamp dashed-border (inverts with active state bg) ── */
+  --stamp-active-dashed:   rgba(255, 255, 255, 0.20);
+  --stamp-inactive-dashed: rgba(0, 0, 0, 0.15);
 }
 
 /* ══════════════════════════════════════════
@@ -241,6 +245,10 @@
 
   /* ── Shared tokens ── */
   --nav-blur: 8px;
+
+  /* ── Filter stamp dashed-border (dark-mode inversions) ── */
+  --stamp-active-dashed:   rgba(0, 0, 0, 0.15);
+  --stamp-inactive-dashed: rgba(255, 255, 255, 0.10);
 }
 
 /* ── Type Scale ── */
@@ -391,6 +399,16 @@
     @apply font-display text-4xl font-bold mb-6;
     font-style: italic;
     color: var(--color-text-primary);
+  }
+
+  /* ── Nav links (Courier Prime 10px uppercase — Style Guide §5.1) ── */
+
+  .nav-link {
+    @apply font-body transition-colors;
+    font-size: var(--text-base);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding-bottom: 2px;
   }
 
   /* ── Markdown preview ── */

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -7,7 +7,6 @@ import SubmissionCard from '../components/SubmissionCard'
 import PageTitle from '../components/ui/PageTitle'
 import LevelPill from '../components/ui/LevelPill'
 import { useAuth } from '../auth/AuthContext'
-import { useTheme } from '../hooks/useTheme'
 import { extractError } from '../utils/errors'
 import { factionColor, factionName } from '../utils/factions'
 import { mediaUrl } from '../utils/media'
@@ -18,8 +17,6 @@ const LEVEL_THRESHOLDS = [0, 10, 70, 170, 330, 610, 1090, 1840, 3040]
 export default function CharacterProfile() {
   const { id } = useParams<{ id: string }>()
   const { user } = useAuth()
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
   const [character, setCharacter] = useState<CharacterOut | null>(null)
   const [submissions, setSubmissions] = useState<SubmissionOut[]>([])
   const [relationship, setRelationship] = useState<RelationshipListItem | null>(null)
@@ -182,7 +179,7 @@ export default function CharacterProfile() {
                     {/* Show relationship status */}
                     <div
                       style={{
-                        background: relationship.type === 'friend' ? '#14532d' : '#dc2626',
+                        background: relationship.type === 'friend' ? 'var(--badge-friend)' : 'var(--color-danger)',
                         color: 'white',
                         fontFamily: "'Courier Prime', monospace",
                         fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
@@ -219,10 +216,10 @@ export default function CharacterProfile() {
                       onClick={() => handleAddRelationship('foe')}
                       disabled={relationshipLoading}
                       style={{
-                        background: 'none', color: '#dc2626',
+                        background: 'none', color: 'var(--color-danger)',
                         fontFamily: "'Courier Prime', monospace",
                         fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
-                        padding: '3px 0', border: '1.5px solid #dc2626', cursor: 'pointer', borderRadius: 2,
+                        padding: '3px 0', border: '1.5px solid var(--color-danger)', cursor: 'pointer', borderRadius: 2,
                         opacity: relationshipLoading ? 0.5 : 1,
                       }}
                     >
@@ -233,7 +230,7 @@ export default function CharacterProfile() {
               </div>
             ) : null}
             {relationshipError && (
-              <p className="font-body" style={{ fontSize: 8, color: '#dc2626', marginTop: 4, textAlign: 'center' }}>{relationshipError}</p>
+              <p className="font-body" style={{ fontSize: 8, color: 'var(--color-danger)', marginTop: 4, textAlign: 'center' }}>{relationshipError}</p>
             )}
           </div>
 
@@ -327,10 +324,10 @@ export default function CharacterProfile() {
                   style={{
                     width: current ? 32 : 26, height: current ? 32 : 26,
                     borderRadius: '50%',
-                    background: completed ? charFactionColor : current ? `${charFactionColor}20` : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.5)'),
+                    background: completed ? charFactionColor : current ? `${charFactionColor}20` : 'var(--level-node-incomplete)',
                     border: current ? `3px solid ${charFactionColor}` : `2px solid ${completed ? charFactionColor : 'rgba(0,0,0,0.12)'}`,
                     boxShadow: current ? `0 0 0 3px ${charFactionColor}33` : 'none',
-                    color: completed ? 'white' : current ? charFactionColor : '#c8c0b0',
+                    color: completed ? 'white' : current ? charFactionColor : 'var(--color-level-inactive)',
                     fontFamily: "'Courier Prime', monospace",
                     fontSize: current ? 10 : 8, fontWeight: 700,
                     display: 'flex', alignItems: 'center', justifyContent: 'center',

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -5,17 +5,19 @@ import type { CharacterOut } from '../api/auth'
 import PageTitle from '../components/ui/PageTitle'
 import LevelPill from '../components/ui/LevelPill'
 import { useAuth } from '../auth/AuthContext'
-import { useTheme } from '../hooks/useTheme'
 import { factionColor, factionName } from '../utils/factions'
 import { extractError } from '../utils/errors'
 import { mediaUrl } from '../utils/media'
 
-const RANK_COLORS = ['#f59e0b', '#c49a3a', '#888'] // gold, silver, bronze
+// Rank colors reference CSS vars defined in index.css (--rank-gold, --rank-silver, --rank-bronze)
+const RANK_STYLES = [
+  { color: 'var(--rank-gold)',   bgSubtle: 'rgba(245,158,11,0.08)',   textFaint: 'rgba(245,158,11,0.13)' },
+  { color: 'var(--rank-silver)', bgSubtle: 'rgba(196,154,58,0.08)',   textFaint: 'rgba(196,154,58,0.13)' },
+  { color: 'var(--rank-bronze)', bgSubtle: 'rgba(136,136,136,0.08)', textFaint: 'rgba(136,136,136,0.13)' },
+]
 
 export default function Leaderboard() {
   const { user } = useAuth()
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
   const [characters, setCharacters] = useState<CharacterOut[]>([])
   const [scoreMode, setScoreMode] = useState<'era' | 'alltime'>('era')
   const [loading, setLoading] = useState(true)
@@ -72,7 +74,7 @@ export default function Leaderboard() {
                       className="sidebar-card"
                       style={{
                         width: cardWidth,
-                        borderLeft: `${isFirst ? 3 : 2}px solid ${isFirst ? '#fbbf24' : color}`,
+                        borderLeft: `${isFirst ? 3 : 2}px solid ${isFirst ? 'var(--rank-gold)' : color}`,
                         padding: '12px 10px',
                         textAlign: 'center',
                         position: 'relative',
@@ -83,7 +85,7 @@ export default function Leaderboard() {
                         style={{
                           position: 'absolute', top: -8, right: -8,
                           width: 22, height: 22, borderRadius: '50%',
-                          background: RANK_COLORS[rank],
+                          background: RANK_STYLES[rank].color,
                           color: 'white', fontFamily: "'Courier Prime', monospace",
                           fontSize: 10, fontWeight: 700,
                           display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -154,11 +156,11 @@ export default function Leaderboard() {
                       style={{
                         width: cardWidth,
                         height: platformHeight,
-                        background: `${RANK_COLORS[rank]}15`,
+                        background: RANK_STYLES[rank].bgSubtle,
                         display: 'flex', alignItems: 'center', justifyContent: 'center',
                         fontFamily: "'Lora', serif", fontStyle: 'italic',
                         fontSize: platformHeight * 0.7, fontWeight: 700,
-                        color: `${RANK_COLORS[rank]}20`,
+                        color: RANK_STYLES[rank].textFaint,
                         borderRadius: '0 0 8px 8px',
                       }}
                     >
@@ -174,15 +176,15 @@ export default function Leaderboard() {
           {myRank >= 0 && myCharId && (
             <div
               style={{
-                background: dark ? 'rgba(79,70,229,0.12)' : 'rgba(79,70,229,0.08)',
-                border: '2px solid rgba(79,70,229,0.25)',
+                background: 'var(--rank-strip-bg)',
+                border: '2px solid var(--rank-strip-border)',
                 borderRadius: 8,
                 padding: '10px 16px',
                 marginBottom: 16,
                 display: 'flex', alignItems: 'center', gap: 12,
               }}
             >
-              <span className="font-display italic" style={{ fontSize: 20, fontWeight: 700, color: '#4f46e5', minWidth: 32, textAlign: 'right' }}>
+              <span className="font-display italic" style={{ fontSize: 20, fontWeight: 700, color: 'var(--color-rank-accent)', minWidth: 32, textAlign: 'right' }}>
                 {myRank + 1}
               </span>
               {user?.character?.avatar_url ? (
@@ -200,14 +202,14 @@ export default function Leaderboard() {
                 />
               )}
               <div className="flex-1">
-                <span className="font-display italic" style={{ fontSize: 12, color: '#4f46e5' }}>
+                <span className="font-display italic" style={{ fontSize: 12, color: 'var(--color-rank-accent)' }}>
                   {user?.character?.display_name}
                 </span>
                 <span className="eyebrow" style={{ marginLeft: 6 }}>
                   {factionName(user?.character?.faction_slug)} · Level {user?.character?.level}
                 </span>
               </div>
-              <span className="font-display italic" style={{ fontSize: 16, fontWeight: 700, color: '#4f46e5' }}>
+              <span className="font-display italic" style={{ fontSize: 16, fontWeight: 700, color: 'var(--color-rank-accent)' }}>
                 {scoreMode === 'era' ? user?.character?.score : user?.character?.all_time_score}
               </span>
               <span className="eyebrow">{scoreMode === 'era' ? 'era pts' : 'all-time'}</span>
@@ -224,17 +226,17 @@ export default function Leaderboard() {
                   onClick={() => setScoreMode(mode)}
                   style={{
                     position: 'relative',
-                    border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
+                    border: `2px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
                     borderRadius: 0,
-                    background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
-                    color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-primary)',
+                    background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+                    color: active ? 'var(--color-bg-page)' : 'var(--color-text-primary)',
                     fontFamily: "'Courier Prime', monospace",
                     fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
                     letterSpacing: '0.1em', padding: '5px 12px',
                     cursor: 'pointer',
                   }}
                 >
-                  {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed rgba(255,255,255,0.2)', pointerEvents: 'none' }} />}
+                  {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed var(--stamp-active-dashed)', pointerEvents: 'none' }} />}
                   {mode === 'era' ? 'Era Score' : 'All-time'}
                 </button>
               )
@@ -280,7 +282,7 @@ export default function Leaderboard() {
                     background: isMe ? `${color}0F` : 'transparent',
                     transition: 'background 120ms',
                   }}
-                  onMouseEnter={(e) => { if (!isMe) e.currentTarget.style.background = dark ? 'rgba(255,255,255,0.03)' : 'rgba(255,255,255,0.55)' }}
+                  onMouseEnter={(e) => { if (!isMe) e.currentTarget.style.background = 'var(--leaderboard-row-hover)' }}
                   onMouseLeave={(e) => { if (!isMe) e.currentTarget.style.background = 'transparent' }}
                 >
                   {/* Faction left accent */}

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -5,8 +5,7 @@ import { getFactions, type FactionOut } from '../api/factions'
 import PageTitle from '../components/ui/PageTitle'
 import FilterLevelNodes from '../components/ui/FilterLevelNodes'
 import { useAuth } from '../auth/AuthContext'
-import { useTheme } from '../hooks/useTheme'
-import { factionColor, factionName, FACTIONS } from '../utils/factions'
+import { factionColor, factionName, getAllFactions } from '../utils/factions'
 import { extractError } from '../utils/errors'
 
 const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5]
@@ -19,8 +18,6 @@ const FACTION_DESCRIPTORS: Record<string, string> = {
 export default function ProposeTask() {
   const { user } = useAuth()
   const navigate = useNavigate()
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
   const [factions, setFactions] = useState<FactionOut[]>([])
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -111,7 +108,7 @@ export default function ProposeTask() {
           <div style={{ marginBottom: 16 }}>
             <span className="eyebrow" style={{ display: 'block', marginBottom: 8 }}>Choose a faction for this task</span>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-              {(factions.length > 0 ? factions : Object.values(FACTIONS)).map((f) => {
+              {(factions.length > 0 ? factions : getAllFactions()).map((f) => {
                 const slug = 'slug' in f ? f.slug : (f as { slug: string }).slug
                 const active = factionSlug === slug
                 const fc = factionColor(slug)
@@ -122,7 +119,7 @@ export default function ProposeTask() {
                     onClick={() => setFactionSlug(slug)}
                     style={{
                       border: `2px solid ${active ? fc : 'var(--color-border)'}`,
-                      background: active ? `${fc}15` : (dark ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.55)'),
+                      background: active ? `${fc}15` : 'var(--color-bg-surface)',
                       borderRadius: 6, padding: '8px 14px',
                       cursor: 'pointer', textAlign: 'center',
                       transition: 'all 120ms',
@@ -174,12 +171,12 @@ export default function ProposeTask() {
                     fontFamily: "'Courier Prime', monospace", fontSize: 22, fontWeight: 700,
                     color: 'var(--color-text-primary)',
                     background: 'transparent', border: 'none',
-                    borderBottom: `2px solid ${title ? color : (dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)')}`,
+                    borderBottom: `2px solid ${title ? color : 'var(--color-border-strong)'}`,
                     outline: 'none', paddingBottom: 6,
                     transition: 'border-color 150ms',
                   }}
                   onFocus={(e) => { e.currentTarget.style.borderBottomColor = color }}
-                  onBlur={(e) => { if (!title) e.currentTarget.style.borderBottomColor = dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)' }}
+                  onBlur={(e) => { if (!title) e.currentTarget.style.borderBottomColor = 'var(--color-border-strong)' }}
                 />
                 <span className={`eyebrow self-end ${title.length >= 180 ? 'text-red-600' : ''}`} style={{ fontSize: 7, marginTop: 4 }}>{title.length}/200</span>
               </div>
@@ -221,7 +218,7 @@ export default function ProposeTask() {
                       fontFamily: "'Courier Prime', monospace", fontSize: 20, fontWeight: 700,
                       color: 'var(--color-text-primary)',
                       background: 'transparent', border: 'none',
-                      borderBottom: `2px solid ${dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
+                      borderBottom: '2px solid var(--color-border-strong)',
                       outline: 'none', textAlign: 'center',
                     }}
                   />
@@ -253,12 +250,12 @@ export default function ProposeTask() {
                   fontFamily: "'Courier Prime', monospace", fontSize: 11,
                   color: 'var(--color-text-primary)',
                   background: 'transparent',
-                  border: `1px solid ${dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'}`,
+                  border: '1px solid var(--color-border)',
                   borderRadius: 6, padding: '0.6rem 0.7rem',
                   outline: 'none', resize: 'vertical',
                 }}
                 onFocus={(e) => { e.currentTarget.style.borderColor = color }}
-                onBlur={(e) => { e.currentTarget.style.borderColor = dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}
+                onBlur={(e) => { e.currentTarget.style.borderColor = 'var(--color-border)' }}
               />
             </div>
 

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -6,7 +6,6 @@ import { getTask, dropTask, type TaskOut } from '../api/tasks'
 import { listCharacters, type CharacterOut } from '../api/characters'
 import LevelPill from '../components/ui/LevelPill'
 import { useAuth } from '../auth/AuthContext'
-import { useTheme } from '../hooks/useTheme'
 import { factionColor, factionName } from '../utils/factions'
 
 const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '#f97316', '#fbbf24', '#be185d']
@@ -29,8 +28,6 @@ export default function SubmitProof() {
   const navigate = useNavigate()
   const location = useLocation()
   const { user, refetch } = useAuth()
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
   const [task, setTask] = useState<TaskOut | null>(null)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
@@ -222,17 +219,17 @@ export default function SubmitProof() {
                 style={{
                   flex: 1,
                   position: 'relative',
-                  border: `2.5px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : 'var(--color-border)'}`,
+                  border: `2.5px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border)'}`,
                   borderRadius: 0,
-                  background: active ? (dark ? '#f0e6d0' : '#1a1209') : 'var(--color-bg-surface-alt)',
-                  color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-primary)',
+                  background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface-alt)',
+                  color: active ? 'var(--color-bg-page)' : 'var(--color-text-primary)',
                   fontFamily: "'Courier Prime', monospace",
                   fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
                   letterSpacing: '0.08em', padding: '10px 8px',
                   cursor: 'pointer', textAlign: 'center',
                 }}
               >
-                {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed rgba(255,255,255,0.2)', pointerEvents: 'none' }} />}
+                {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed var(--stamp-active-dashed)', pointerEvents: 'none' }} />}
                 <span style={{ display: 'block', fontSize: 18, marginBottom: 4 }}>{icon}</span>
                 <span style={{ display: 'block', marginBottom: 2 }}>{label}</span>
                 <span style={{ display: 'block', fontSize: 7, fontWeight: 400, opacity: 0.7, textTransform: 'none', letterSpacing: '0.02em' }}>{desc}</span>
@@ -255,7 +252,7 @@ export default function SubmitProof() {
                   flex: 1,
                   fontFamily: "'Courier Prime', monospace",
                   fontSize: 12, padding: '8px 12px',
-                  background: dark ? '#1a1209' : '#F7F4EE',
+                  background: 'var(--color-bg-page)',
                   color: 'var(--color-text-primary)',
                   border: '2px solid var(--color-border)',
                   outline: 'none',
@@ -382,12 +379,12 @@ export default function SubmitProof() {
               fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: 24,
               color: 'var(--color-text-primary)',
               background: 'transparent', border: 'none',
-              borderBottom: `2px solid ${title ? color : (dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)')}`,
+              borderBottom: `2px solid ${title ? color : 'var(--color-border-strong)'}`,
               outline: 'none', paddingBottom: 6,
               transition: 'border-color 150ms',
             }}
             onFocus={(e) => { e.currentTarget.style.borderBottomColor = color }}
-            onBlur={(e) => { if (!title) e.currentTarget.style.borderBottomColor = dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)' }}
+            onBlur={(e) => { if (!title) e.currentTarget.style.borderBottomColor = 'var(--color-border-strong)' }}
           />
           {/* Rainbow underline — visible when title has text */}
           {title && (
@@ -416,7 +413,7 @@ export default function SubmitProof() {
               placeholder="Describe what you did..."
               style={{
                 width: '100%',
-                fontFamily: "'Lora', serif", fontSize: 14, color: dark ? '#e8dcc8' : '#2a1e10',
+                fontFamily: "'Lora', serif", fontSize: 14, color: 'var(--color-text-primary)',
                 lineHeight: 1.75, minHeight: 180,
                 background: 'transparent', border: 'none', outline: 'none',
                 resize: 'vertical',
@@ -431,7 +428,7 @@ export default function SubmitProof() {
           {body.trim() && (
             <div style={{ borderTop: '1px dashed var(--color-border)', marginTop: 10, paddingTop: 10 }}>
               <span className="eyebrow" style={{ marginBottom: 6, display: 'block' }}>Preview</span>
-              <div className="markdown-preview font-display" style={{ fontSize: 14, lineHeight: 1.75, color: dark ? '#e8dcc8' : '#2a1e10' }}>
+              <div className="markdown-preview font-display" style={{ fontSize: 14, lineHeight: 1.75, color: 'var(--color-text-primary)' }}>
                 <ReactMarkdown>{body}</ReactMarkdown>
               </div>
             </div>

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -9,7 +9,6 @@ import LevelPill from '../components/ui/LevelPill'
 import PageTitle from '../components/ui/PageTitle'
 import FeedBadge from '../components/feed/FeedBadge'
 import { useAuth } from '../auth/AuthContext'
-import { useTheme } from '../hooks/useTheme'
 import { factionColor, factionName } from '../utils/factions'
 import { extractError } from '../utils/errors'
 import { mediaUrl } from '../utils/media'
@@ -23,9 +22,6 @@ export default function TaskDetail() {
   const navigate = useNavigate()
   const location = useLocation()
   const { user } = useAuth()
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
-
   const [task, setTask] = useState<TaskOut | null>(null)
   const [submissions, setSubmissions] = useState<SubmissionOut[]>([])
   const [signups, setSignups] = useState<TaskSignupOut[]>([])
@@ -202,8 +198,8 @@ export default function TaskDetail() {
                 style={{
                   fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
                   padding: '2px 8px', borderRadius: 4,
-                  background: task.status === 'active' ? (dark ? 'rgba(74,222,128,0.15)' : 'rgba(21,128,61,0.1)') : 'var(--color-bg-surface-alt)',
-                  color: task.status === 'active' ? '#15803d' : 'var(--color-text-tertiary)',
+                  background: task.status === 'active' ? 'var(--faction-analog-light)' : 'var(--color-bg-surface-alt)',
+                  color: task.status === 'active' ? 'var(--faction-analog)' : 'var(--color-text-tertiary)',
                 }}
               >
                 {task.status}
@@ -391,8 +387,8 @@ export default function TaskDetail() {
                       fontFamily: "'Courier Prime', monospace",
                       fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
                       letterSpacing: '0.1em', padding: '4px 10px',
-                      background: submissionSort === sort ? (dark ? '#f0e6d0' : '#1a1209') : 'transparent',
-                      color: submissionSort === sort ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-tertiary)',
+                      background: submissionSort === sort ? 'var(--color-text-primary)' : 'transparent',
+                      color: submissionSort === sort ? 'var(--color-bg-page)' : 'var(--color-text-tertiary)',
                       border: `1px solid ${submissionSort === sort ? 'transparent' : 'var(--color-border)'}`,
                       cursor: 'pointer',
                     }}

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -66,7 +66,7 @@ export default function Tasks() {
       <PageTitle title="Tasks" eyebrow={`${tasks.length} shown`} />
 
       {/* Filters — three distinct visual types (Style Guide §5.3) */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 24 }}>
+      <div className="flex flex-col gap-2.5 mb-6">
         <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
         <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
         <FilterLevelNodes levels={LEVEL_FILTERS} value={level} onChange={setLevel} />
@@ -89,7 +89,7 @@ export default function Tasks() {
         <p className="font-body text-muted">No tasks match your filters.</p>
       ) : (
         /* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
+        <div className="flex flex-wrap gap-4 items-start">
           {tasks.map((t) => (
             <TaskCard key={t.id} task={t} onSignup={user && characterLevel >= t.level_required ? handleSignup : undefined} />
           ))}

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -3,7 +3,6 @@ import { getActivityFeed, type ActivityFeedItem, type FeedCounts } from '../api/
 import PageTitle from '../components/ui/PageTitle'
 import FeedCardRouter from '../components/feed/FeedCardRouter'
 import FeedDateDivider, { getDateLabel } from '../components/feed/FeedDateDivider'
-import { useTheme } from '../hooks/useTheme'
 
 type FeedFilter = 'All' | 'Friends' | 'Foes' | 'Your Stuff' | 'Global' | 'Requests'
 
@@ -33,9 +32,6 @@ function getCount(filter: FeedFilter, counts: FeedCounts): number {
 }
 
 export default function Updates() {
-  const { theme } = useTheme()
-  const dark = theme === 'dark'
-
   const [items, setItems] = useState<ActivityFeedItem[]>([])
   const [counts, setCounts] = useState<FeedCounts>({ all: 0, friends: 0, foes: 0, your_stuff: 0, global_count: 0, requests: 0 })
   const [filter, setFilter] = useState<FeedFilter>('All')
@@ -111,10 +107,10 @@ export default function Updates() {
         onClick={() => setFilter(option)}
         style={{
           position: 'relative',
-          border: `2px solid ${active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)')}`,
+          border: `2px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
           borderRadius: 0,
-          background: active ? (dark ? '#f0e6d0' : '#1a1209') : (dark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.6)'),
-          color: active ? (dark ? '#13121a' : '#F7F4EE') : 'var(--color-text-primary)',
+          background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+          color: active ? 'var(--color-bg-page)' : 'var(--color-text-primary)',
           fontFamily: "'Courier Prime', monospace",
           fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
           letterSpacing: '0.1em', padding: '5px 10px',
@@ -122,11 +118,11 @@ export default function Updates() {
           display: 'flex', alignItems: 'center', gap: 5,
         }}
       >
-        {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed rgba(255,255,255,0.2)', pointerEvents: 'none' }} />}
+        {active && <span style={{ position: 'absolute', inset: 2, border: '1px dashed var(--stamp-active-dashed)', pointerEvents: 'none' }} />}
         {option}
         {count > 0 && (
           <span style={{
-            background: hasRedBadge ? '#dc2626' : (active ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.1)'),
+            background: hasRedBadge ? 'var(--color-danger)' : (active ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.1)'),
             color: hasRedBadge ? 'white' : 'inherit',
             fontSize: 8, padding: '0 5px', borderRadius: 8, minWidth: 16, textAlign: 'center',
           }}>

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -9,8 +9,10 @@
  * Use factionCssVar() when you need the CSS variable reference (preferred for styles).
  * Use factionColor() when you need the raw hex value in JS (canvas, SVG generation, etc.).
  *
- * TODO: Replace with API response from GET /factions once the backend returns
- * color fields. Until then, these must be kept in sync manually.
+ * The faction registry is seeded with hardcoded fallback values on startup and overwritten
+ * from GET /game-config via populateFactionRegistry() once the API responds. This means
+ * all components automatically see live API values after the first fetch without any
+ * component-level changes.
  */
 
 export interface FactionConfig {
@@ -20,16 +22,34 @@ export interface FactionConfig {
   color: string
 }
 
-export const FACTIONS: Record<string, FactionConfig> = {
+/** Hardcoded fallback — matches index.css --faction-* values exactly. Used on first render
+ *  before the API response arrives. Do not use these values directly; call factionColor(). */
+const FACTION_FALLBACKS: Record<string, FactionConfig> = {
   ua:          { slug: 'ua',          name: 'UA',          color: '#6b6a7a' },
   analog:      { slug: 'analog',      name: 'Analog',      color: '#15803d' },
   gestalt:     { slug: 'gestalt',     name: 'Gestalt',     color: '#14532d' },
   snide:       { slug: 'snide',       name: 'S.N.I.D.E.',  color: '#8a6a20' },
   journeymen:  { slug: 'journeymen',  name: 'Journeymen',  color: '#c49a3a' },
-  singularity: { slug: 'singularity', name: 'Singularity',  color: '#7c3aed' },
-  ua_masters:  { slug: 'ua_masters',  name: 'UA Masters',   color: '#555555' },
-  albescent:   { slug: 'albescent',   name: '/Albescent',   color: '#6b6a7a' },
-  aged_out:    { slug: 'aged_out',    name: 'Aged Out',     color: '#6b6a7a' },
+  singularity: { slug: 'singularity', name: 'Singularity', color: '#7c3aed' },
+  ua_masters:  { slug: 'ua_masters',  name: 'UA Masters',  color: '#555555' },
+  albescent:   { slug: 'albescent',   name: '/Albescent',  color: '#6b6a7a' },
+  aged_out:    { slug: 'aged_out',    name: 'Aged Out',    color: '#6b6a7a' },
+}
+
+/** Live registry — starts as the fallback, overwritten by populateFactionRegistry(). */
+let factionRegistry: Record<string, FactionConfig> = { ...FACTION_FALLBACKS }
+
+/**
+ * Called once by useGameConfig when the API response arrives.
+ * Updates the runtime registry so all subsequent factionColor() / factionName()
+ * calls return API-sourced values without any component changes.
+ */
+export function populateFactionRegistry(
+  apiFactions: Array<{ slug: string; name: string; color: string }>
+) {
+  for (const f of apiFactions) {
+    factionRegistry[f.slug] = { slug: f.slug, name: f.name, color: f.color }
+  }
 }
 
 /**
@@ -53,13 +73,13 @@ const CSS_KEY: Record<string, string> = {
  * Use this in inline styles: `style={{ background: factionCssVar('analog', 'card-bg') }}`
  *
  * Available suffixes:
- *   (none)       — primary color
- *   'light'      — background tint
- *   'border'     — border color
- *   'card-bg'    — card background
- *   'card-text'  — card text
+ *   (none)        — primary color
+ *   'light'       — background tint
+ *   'border'      — border color
+ *   'card-bg'     — card background
+ *   'card-text'   — card text
  *   'card-accent' — card accent (meta text, decorations)
- *   'card-muted' — card secondary/description text
+ *   'card-muted'  — card secondary/description text
  */
 export function factionCssVar(slug: string | null | undefined, suffix?: string): string {
   const key = CSS_KEY[slug ?? ''] ?? 'ua'
@@ -69,10 +89,15 @@ export function factionCssVar(slug: string | null | undefined, suffix?: string):
 
 /** Get faction color by slug, with fallback (raw hex — light mode only) */
 export function factionColor(slug: string | null | undefined): string {
-  return FACTIONS[slug ?? '']?.color ?? '#6b6a7a'
+  return factionRegistry[slug ?? '']?.color ?? '#6b6a7a'
 }
 
 /** Get faction display name by slug, with fallback */
 export function factionName(slug: string | null | undefined): string {
-  return FACTIONS[slug ?? '']?.name ?? 'Unaffiliated'
+  return factionRegistry[slug ?? '']?.name ?? 'Unaffiliated'
+}
+
+/** Get all factions from the live registry (populated from API after useGameConfig loads) */
+export function getAllFactions(): FactionConfig[] {
+  return Object.values(factionRegistry)
 }


### PR DESCRIPTION
## Summary

- **Inline styles → Tailwind:** NavBar, Sidebar, FilterStamps, FilterFactionTabs, FilterLevelNodes, Tasks page, Layout all migrated from `style={{}}` to Tailwind utilities where appropriate
- **Responsive breakpoints:** Sidebar hidden below `lg` breakpoint via `hidden lg:block`; card container already uses `flex-wrap`
- **Hardcoded hex audit:** NavBar, Leaderboard, CharacterProfile, and all feed card components (`FeedBadge`, `FeedCardEraAnnouncement`, `FeedCardCollabInvite`, `FeedCardDuelChallenge`, `FeedCardVoteNotification`, `FeedCardFoeTaunt`) — hex values replaced with CSS vars; new vars added to `index.css` (`--rank-*`, `--badge-*`, `--color-level-inactive`, `--stamp-*dashed`)
- **Dark mode consolidation:** All `dark ? '#color' : '#color'` ternaries removed from Updates, TaskDetail, SubmitProof, ProposeTask, CharacterProfile, Leaderboard — replaced with CSS cascade vars. `useTheme`/`dark` removed from 5 components.
- **Faction colors from API:** `utils/factions.ts` now has a mutable `factionRegistry`; `useGameConfig` calls `populateFactionRegistry(data.factions)` after `GET /game-config` so all `factionColor()`/`factionName()` calls reflect live API values. Hardcoded values remain as initial-render fallback only.

## Test plan

- [ ] TypeScript build passes (`npx tsc --noEmit` — zero new errors)
- [ ] Tasks page: faction filter pennants, status stamps, and level nodes render correctly in both light and dark mode
- [ ] On mobile (< 1024px): sidebar is hidden, main content uses full width
- [ ] On desktop (≥ 1024px): sidebar visible alongside main content
- [ ] Leaderboard: podium renders with rank colors, "your rank" strip shows, score toggle stamp buttons work in both themes
- [ ] Updates page: filter stamp buttons toggle correctly in both themes
- [ ] NavBar: wordmark rainbow gradient visible, nav links styled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)