### PR TITLE
Implement Collaboration & Duel feature

### DIFF
--- a/backend/alembic/versions/0005_collaboration_and_duel.py
+++ b/backend/alembic/versions/0005_collaboration_and_duel.py
@@ -1,0 +1,234 @@
+"""Add collaboration/duel tables; drop legacy praxis collab fields; extend vote table.
+
+Revision ID: 0005_collaboration_and_duel
+Revises: 0004_rename_submission_to_praxis
+Create Date: 2026-04-15
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_collaboration_and_duel"
+down_revision: Union[str, None] = "0004_rename_submission_to_praxis"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── 1. New enum types ────────────────────────────────────────────────────
+    op.execute(
+        """
+        DO $$ BEGIN
+            CREATE TYPE collaborationmode AS ENUM ('collaboration', 'duel');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            CREATE TYPE collaborationstatus AS ENUM ('in_progress', 'published');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            CREATE TYPE collaborationinvitestatus AS ENUM ('pending', 'accepted', 'declined');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+    # ── 2. collaboration table ───────────────────────────────────────────────
+    op.create_table(
+        "collaboration",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("task_id", sa.Integer(), sa.ForeignKey("task.id"), nullable=False),
+        sa.Column(
+            "mode",
+            sa.Enum("collaboration", "duel", name="collaborationmode", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.Enum("in_progress", "published", name="collaborationstatus", create_type=False),
+            nullable=False,
+            server_default="in_progress",
+        ),
+        sa.Column("body_text", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "created_by_id", sa.Integer(), sa.ForeignKey("character.id"), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ── 3. collaboration_member table ────────────────────────────────────────
+    op.create_table(
+        "collaboration_member",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "collaboration_id",
+            sa.Integer(),
+            sa.ForeignKey("collaboration.id"),
+            nullable=False,
+        ),
+        sa.Column("character_id", sa.Integer(), sa.ForeignKey("character.id"), nullable=False),
+        sa.Column(
+            "has_submitted", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "joined_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("collaboration_id", "character_id"),
+    )
+
+    # ── 4. collaboration_invite table ────────────────────────────────────────
+    op.create_table(
+        "collaboration_invite",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "collaboration_id",
+            sa.Integer(),
+            sa.ForeignKey("collaboration.id"),
+            nullable=False,
+        ),
+        sa.Column("inviter_id", sa.Integer(), sa.ForeignKey("character.id"), nullable=False),
+        sa.Column("invitee_id", sa.Integer(), sa.ForeignKey("character.id"), nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum("collaboration", "duel", name="collaborationmode", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "accepted",
+                "declined",
+                name="collaborationinvitestatus",
+                create_type=False,
+            ),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ── 5. Praxis: drop legacy collaboration columns ─────────────────────────
+    op.drop_column("praxis", "collaboration_mode")
+    op.drop_column("praxis", "partner_character_id")
+    op.drop_column("praxis", "invite_status")
+
+    # ── 6. Vote: extend for duel votes ───────────────────────────────────────
+    # Make praxis_id nullable (duel votes reference collaboration_id instead)
+    op.alter_column("vote", "praxis_id", existing_type=sa.Integer(), nullable=True)
+
+    # Add collaboration_id FK
+    op.add_column(
+        "vote",
+        sa.Column("collaboration_id", sa.Integer(), sa.ForeignKey("collaboration.id"), nullable=True),
+    )
+
+    # Drop the old unique constraint (was unnamed, so drop by column definition)
+    op.drop_constraint("vote_praxis_id_voter_character_id_key", "vote", type_="unique")
+
+    # Add new named unique constraints
+    op.create_unique_constraint("uq_vote_solo", "vote", ["praxis_id", "voter_character_id"])
+    op.create_unique_constraint(
+        "uq_vote_duel", "vote", ["collaboration_id", "voter_character_id", "duel_vote_for"]
+    )
+
+    # Drop obsolete legacy enum types from praxis
+    op.execute("DROP TYPE IF EXISTS collaborationmode_old CASCADE")
+    op.execute("DROP TYPE IF EXISTS invitestatus CASCADE")
+
+
+def downgrade() -> None:
+    # ── Vote: revert ─────────────────────────────────────────────────────────
+    op.drop_constraint("uq_vote_duel", "vote", type_="unique")
+    op.drop_constraint("uq_vote_solo", "vote", type_="unique")
+    op.drop_column("vote", "collaboration_id")
+    op.alter_column("vote", "praxis_id", existing_type=sa.Integer(), nullable=False)
+    op.create_unique_constraint(
+        "vote_praxis_id_voter_character_id_key", "vote", ["praxis_id", "voter_character_id"]
+    )
+
+    # ── Praxis: restore legacy columns ───────────────────────────────────────
+    op.execute(
+        """
+        DO $$ BEGIN
+            CREATE TYPE collaborationmode_old AS ENUM ('solo', 'collab', 'duel');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            CREATE TYPE invitestatus AS ENUM ('pending', 'accepted', 'declined');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+    op.add_column(
+        "praxis",
+        sa.Column(
+            "collaboration_mode",
+            sa.Enum("solo", "collab", "duel", name="collaborationmode_old", create_type=False),
+            nullable=False,
+            server_default="solo",
+        ),
+    )
+    op.add_column(
+        "praxis",
+        sa.Column(
+            "partner_character_id",
+            sa.Integer(),
+            sa.ForeignKey("character.id"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "praxis",
+        sa.Column(
+            "invite_status",
+            sa.Enum("pending", "accepted", "declined", name="invitestatus", create_type=False),
+            nullable=True,
+        ),
+    )
+
+    # ── Drop new tables ───────────────────────────────────────────────────────
+    op.drop_table("collaboration_invite")
+    op.drop_table("collaboration_member")
+    op.drop_table("collaboration")
+
+    # ── Drop new enum types ───────────────────────────────────────────────────
+    op.execute("DROP TYPE IF EXISTS collaborationinvitestatus CASCADE")
+    op.execute("DROP TYPE IF EXISTS collaborationstatus CASCADE")
+    op.execute("DROP TYPE IF EXISTS collaborationmode CASCADE")

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -23,8 +23,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=1.0,
         collab_own_modifier=1.0,
         collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
     "ua_masters": FactionConfig(
         slug="ua_masters",
@@ -51,8 +51,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=0.7,
         collab_own_modifier=1.0,
         collab_other_modifier=0.7,
-        duel_win_modifier=1.5,        # duel win: 150% of base
-        duel_loss_modifier=0.5,       # duel loss: 50% of base
+        duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
+        duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
     ),
     "gestalt": FactionConfig(
         slug="gestalt",
@@ -65,8 +65,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=0.7,      # -30% on solo other-faction
         collab_own_modifier=1.1,      # +10% on collab own-faction
         collab_other_modifier=0.9,    # -10% on collab other-faction (less penalty)
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
     "journeymen": FactionConfig(
         slug="journeymen",
@@ -79,8 +79,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=0.7,
         collab_own_modifier=1.0,
         collab_other_modifier=0.7,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
     "analog": FactionConfig(
         slug="analog",
@@ -93,8 +93,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=0.7,
         collab_own_modifier=1.0,
         collab_other_modifier=0.7,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
     "singularity": FactionConfig(
         slug="singularity",
@@ -107,8 +107,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=1.0,
         collab_own_modifier=1.0,
         collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
     "albescent": FactionConfig(
         slug="albescent",
@@ -121,8 +121,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=1.0,
         collab_own_modifier=1.0,
         collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
     "aged_out": FactionConfig(
         slug="aged_out",
@@ -135,8 +135,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=1.0,
         collab_own_modifier=1.0,
         collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
     "na": FactionConfig(
         slug="na",
@@ -149,8 +149,8 @@ ERA_1_FACTIONS = {
         other_task_modifier=1.0,
         collab_own_modifier=1.0,
         collab_other_modifier=1.0,
-        duel_win_modifier=1.0,
-        duel_loss_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
     ),
 }
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from starlette.middleware.sessions import SessionMiddleware
 
 from config import settings
-from routers import activity_feed, admin, auth, characters, factions, game_config, leaderboard, messages, meta_tasks, praxes, relationships, tasks, taunts, votes
+from routers import activity_feed, admin, auth, characters, collaborations, factions, game_config, leaderboard, messages, meta_tasks, praxes, relationships, tasks, taunts, votes
 from routers import contact
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,7 @@ app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(characters.router, prefix="/characters", tags=["characters"])
 app.include_router(tasks.router, prefix="/tasks", tags=["tasks"])
 app.include_router(praxes.router, prefix="/praxes", tags=["praxes"])
+app.include_router(collaborations.router, prefix="/collaborations", tags=["collaborations"])
 app.include_router(votes.router, tags=["votes"])  # prefix embedded in routes (/praxes/{id}/vote)
 app.include_router(relationships.router, prefix="/relationships", tags=["relationships"])
 app.include_router(messages.router, prefix="/messages", tags=["messages"])

--- a/backend/models/collaboration.py
+++ b/backend/models/collaboration.py
@@ -1,0 +1,129 @@
+import enum
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from models.base import Base
+
+if TYPE_CHECKING:
+    from models.character import Character
+    from models.task import Task
+    from models.vote import Vote
+
+
+class CollaborationMode(enum.Enum):
+    collaboration = "collaboration"
+    duel = "duel"
+
+
+class CollaborationStatus(enum.Enum):
+    in_progress = "in_progress"
+    published = "published"
+
+
+class CollaborationInviteStatus(enum.Enum):
+    pending = "pending"
+    accepted = "accepted"
+    declined = "declined"
+
+
+class Collaboration(Base):
+    __tablename__ = "collaboration"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    task_id: Mapped[int] = mapped_column(ForeignKey("task.id"), nullable=False)
+    mode: Mapped[CollaborationMode] = mapped_column(
+        Enum(CollaborationMode, create_type=False), nullable=False
+    )
+    status: Mapped[CollaborationStatus] = mapped_column(
+        Enum(CollaborationStatus, create_type=False),
+        nullable=False,
+        server_default="in_progress",
+    )
+    body_text: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    created_by_id: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    task: Mapped["Task"] = relationship("Task", lazy="selectin")
+    created_by: Mapped["Character"] = relationship(
+        "Character", foreign_keys=[created_by_id], lazy="selectin"
+    )
+    members: Mapped[List["CollaborationMember"]] = relationship(
+        "CollaborationMember",
+        back_populates="collaboration",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
+    invites: Mapped[List["CollaborationInvite"]] = relationship(
+        "CollaborationInvite",
+        back_populates="collaboration",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
+    votes: Mapped[List["Vote"]] = relationship(
+        "Vote",
+        foreign_keys="Vote.collaboration_id",
+        back_populates="collaboration",
+        lazy="selectin",
+    )
+
+
+class CollaborationMember(Base):
+    __tablename__ = "collaboration_member"
+    __table_args__ = (UniqueConstraint("collaboration_id", "character_id"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    collaboration_id: Mapped[int] = mapped_column(
+        ForeignKey("collaboration.id"), nullable=False
+    )
+    character_id: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
+    has_submitted: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    collaboration: Mapped["Collaboration"] = relationship(
+        "Collaboration", back_populates="members", lazy="raise"
+    )
+    character: Mapped["Character"] = relationship("Character", lazy="selectin")
+
+
+class CollaborationInvite(Base):
+    __tablename__ = "collaboration_invite"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    collaboration_id: Mapped[int] = mapped_column(
+        ForeignKey("collaboration.id"), nullable=False
+    )
+    inviter_id: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
+    invitee_id: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
+    type: Mapped[CollaborationMode] = mapped_column(
+        Enum(CollaborationMode, create_type=False), nullable=False
+    )
+    status: Mapped[CollaborationInviteStatus] = mapped_column(
+        Enum(CollaborationInviteStatus, create_type=False),
+        nullable=False,
+        server_default="pending",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    collaboration: Mapped["Collaboration"] = relationship(
+        "Collaboration", back_populates="invites", lazy="raise"
+    )
+    inviter: Mapped["Character"] = relationship(
+        "Character", foreign_keys=[inviter_id], lazy="selectin"
+    )
+    invitee: Mapped["Character"] = relationship(
+        "Character", foreign_keys=[invitee_id], lazy="selectin"
+    )

--- a/backend/models/praxis.py
+++ b/backend/models/praxis.py
@@ -20,18 +20,6 @@ class MediaType(enum.Enum):
     audio = "audio"
 
 
-class CollaborationMode(enum.Enum):
-    solo = "solo"
-    collab = "collab"
-    duel = "duel"
-
-
-class InviteStatus(enum.Enum):
-    pending = "pending"
-    accepted = "accepted"
-    declined = "declined"
-
-
 class ModerationStatus(enum.Enum):
     visible = "visible"
     flagged = "flagged"
@@ -40,6 +28,8 @@ class ModerationStatus(enum.Enum):
 
 
 class Praxis(Base):
+    """Solo praxis (submission). Collaboration and duel submissions use models/collaboration.py."""
+
     __tablename__ = "praxis"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -59,15 +49,6 @@ class Praxis(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-    collaboration_mode: Mapped[CollaborationMode] = mapped_column(
-        Enum(CollaborationMode, create_type=False), nullable=False, server_default="solo"
-    )
-    partner_character_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("character.id"), nullable=True
-    )
-    invite_status: Mapped[Optional[InviteStatus]] = mapped_column(
-        Enum(InviteStatus, create_type=False), nullable=True
-    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )
@@ -78,16 +59,14 @@ class Praxis(Base):
         back_populates="praxes",
         lazy="selectin",
     )
-    partner: Mapped[Optional["Character"]] = relationship(
-        "Character",
-        foreign_keys=[partner_character_id],
-        lazy="selectin",
-    )
     task: Mapped["Task"] = relationship(
         "Task", back_populates="praxes", lazy="selectin"
     )
     votes: Mapped[List["Vote"]] = relationship(
-        "Vote", back_populates="praxis", lazy="selectin"
+        "Vote",
+        foreign_keys="Vote.praxis_id",
+        back_populates="praxis",
+        lazy="selectin",
     )
     media_items: Mapped[List["MediaItem"]] = relationship(
         "MediaItem",

--- a/backend/models/vote.py
+++ b/backend/models/vote.py
@@ -7,15 +7,27 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from models.base import Base
 
 if TYPE_CHECKING:
+    from models.collaboration import Collaboration
     from models.praxis import Praxis
 
 
 class Vote(Base):
     __tablename__ = "vote"
-    __table_args__ = (UniqueConstraint("praxis_id", "voter_character_id"),)
+    __table_args__ = (
+        # Solo-praxis votes: one vote per voter per praxis
+        UniqueConstraint("praxis_id", "voter_character_id", name="uq_vote_solo"),
+        # Duel votes: one vote per voter per target player per collaboration
+        UniqueConstraint(
+            "collaboration_id", "voter_character_id", "duel_vote_for", name="uq_vote_duel"
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    praxis_id: Mapped[int] = mapped_column(ForeignKey("praxis.id"), nullable=False)
+    # Exactly one of praxis_id or collaboration_id must be set.
+    praxis_id: Mapped[Optional[int]] = mapped_column(ForeignKey("praxis.id"), nullable=True)
+    collaboration_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("collaboration.id"), nullable=True
+    )
     voter_character_id: Mapped[int] = mapped_column(
         ForeignKey("character.id"), nullable=False
     )
@@ -23,6 +35,7 @@ class Vote(Base):
         ForeignKey("account.id"), nullable=False
     )
     stars: Mapped[int] = mapped_column(Integer, nullable=False)
+    # duel_vote_for is required for duel votes (collaboration_id set); NULL for solo votes.
     duel_vote_for: Mapped[Optional[int]] = mapped_column(
         ForeignKey("character.id"), nullable=True
     )
@@ -33,6 +46,9 @@ class Vote(Base):
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
-    praxis: Mapped["Praxis"] = relationship(
-        "Praxis", back_populates="votes", lazy="raise"
+    praxis: Mapped[Optional["Praxis"]] = relationship(
+        "Praxis", foreign_keys=[praxis_id], back_populates="votes", lazy="raise"
+    )
+    collaboration: Mapped[Optional["Collaboration"]] = relationship(
+        "Collaboration", foreign_keys=[collaboration_id], back_populates="votes", lazy="raise"
     )

--- a/backend/routers/collaborations.py
+++ b/backend/routers/collaborations.py
@@ -1,0 +1,181 @@
+"""Routes for collaborations and duels."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db import get_db
+from dependencies import get_current_character
+from game_config import CURRENT_ERA
+from models.character import Character
+from schemas.collaboration import (
+    CollaborationCreate,
+    CollaborationDocumentUpdate,
+    CollaborationInviteCreate,
+    CollaborationInviteOut,
+    CollaborationOut,
+    CollaborationVoteIn,
+    DuelVoteSummary,
+    InviteResponse,
+)
+from schemas.vote import VoteOut
+from services.collaboration import (
+    build_collaboration_out,
+    create_collaboration,
+    get_duel_vote_summary,
+    invite_member,
+    kick_member,
+    reopen_collaboration,
+    respond_to_invite,
+    submit_for_member,
+    update_document,
+)
+from services.vote import cast_or_update_duel_vote
+
+router = APIRouter()
+
+
+@router.post("", response_model=CollaborationOut)
+async def create_collaboration_route(
+    data: CollaborationCreate,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Create a new collaboration or duel from an in-progress task."""
+    collab = await create_collaboration(
+        task_id=data.task_id,
+        mode=data.mode,
+        character=character,
+        session=session,
+        era=CURRENT_ERA,
+    )
+    return build_collaboration_out(collab, viewer_character_id=character.id)
+
+
+@router.get("/{collaboration_id}", response_model=CollaborationOut)
+async def get_collaboration_route(
+    collaboration_id: int,
+    character: Character | None = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Get collaboration details. Invites visible only to members."""
+    from fastapi import HTTPException
+    from models.collaboration import Collaboration
+
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+    return build_collaboration_out(collab, viewer_character_id=character.id if character else None)
+
+
+@router.post("/{collaboration_id}/document", response_model=CollaborationOut)
+async def update_document_route(
+    collaboration_id: int,
+    data: CollaborationDocumentUpdate,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Update the shared document. Any member can edit."""
+    collab = await update_document(collaboration_id, character, data.body_text, session)
+    return build_collaboration_out(collab, viewer_character_id=character.id)
+
+
+@router.post("/{collaboration_id}/invite", response_model=CollaborationInviteOut)
+async def invite_member_route(
+    collaboration_id: int,
+    data: CollaborationInviteCreate,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Send an invite to another player."""
+    invite = await invite_member(
+        collaboration_id=collaboration_id,
+        inviter=character,
+        invitee_character_id=data.invitee_character_id,
+        session=session,
+        era=CURRENT_ERA,
+    )
+    from services.collaboration import _build_invite_out
+    return _build_invite_out(invite)
+
+
+@router.post("/{collaboration_id}/invites/{invite_id}/respond", response_model=CollaborationOut)
+async def respond_to_invite_route(
+    collaboration_id: int,
+    invite_id: int,
+    data: InviteResponse,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Accept or decline a collaboration/duel invite."""
+    collab = await respond_to_invite(
+        invite_id=invite_id,
+        character=character,
+        accept=data.accept,
+        drop_task_id=data.drop_task_id,
+        session=session,
+        era=CURRENT_ERA,
+    )
+    return build_collaboration_out(collab, viewer_character_id=character.id)
+
+
+@router.post("/{collaboration_id}/submit", response_model=CollaborationOut)
+async def submit_route(
+    collaboration_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Mark this member as having submitted. Publishes when all members submit."""
+    collab = await submit_for_member(collaboration_id, character, session, era=CURRENT_ERA)
+    return build_collaboration_out(collab, viewer_character_id=character.id)
+
+
+@router.post("/{collaboration_id}/edit", response_model=CollaborationOut)
+async def edit_route(
+    collaboration_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Reopen collaboration for editing; reset all submit states."""
+    collab = await reopen_collaboration(collaboration_id, character, session)
+    return build_collaboration_out(collab, viewer_character_id=character.id)
+
+
+@router.post("/{collaboration_id}/kick/{target_character_id}", response_model=CollaborationOut)
+async def kick_member_route(
+    collaboration_id: int,
+    target_character_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Remove a member from the collaboration."""
+    collab = await kick_member(collaboration_id, character, target_character_id, session)
+    return build_collaboration_out(collab, viewer_character_id=character.id)
+
+
+@router.get("/{collaboration_id}/votes", response_model=list[DuelVoteSummary])
+async def get_votes_route(
+    collaboration_id: int,
+    session: AsyncSession = Depends(get_db),
+):
+    """Get live vote tally for a duel (duel only)."""
+    return await get_duel_vote_summary(collaboration_id, session)
+
+
+@router.post("/{collaboration_id}/vote", response_model=VoteOut)
+async def cast_vote_route(
+    collaboration_id: int,
+    data: CollaborationVoteIn,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Cast a vote for a specific player in a duel (duel only, non-members only)."""
+    vote = await cast_or_update_duel_vote(
+        voter=character,
+        collaboration_id=collaboration_id,
+        target_character_id=data.target_character_id,
+        stars=data.stars,
+        session=session,
+        era=CURRENT_ERA,
+    )
+    from schemas.vote import VoteOut
+    return VoteOut.model_validate(vote)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -17,10 +17,8 @@ from models.praxis import MediaItem, MediaType, ModerationStatus, Praxis
 from models.task import CharacterTask, Task
 from schemas.praxis import MediaItemOut, PraxisCreate, PraxisOut
 from services.praxis import (
-    accept_invite,
     build_praxis_out,
     create_praxis,
-    decline_invite,
     edit_praxis,
     flag_praxis,
     resubmit_praxis,
@@ -213,25 +211,6 @@ async def delete_media(
     await session.commit()
     return Response(status_code=204)
 
-
-@router.post("/{praxis_id}/accept-invite", response_model=PraxisOut)
-async def accept_invite_route(
-    praxis_id: int,
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    praxis = await accept_invite(praxis_id, character.id, session)
-    return await build_praxis_out(praxis, session)
-
-
-@router.post("/{praxis_id}/decline-invite", response_model=PraxisOut)
-async def decline_invite_route(
-    praxis_id: int,
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    praxis = await decline_invite(praxis_id, character.id, session)
-    return await build_praxis_out(praxis, session)
 
 
 @router.post("/{praxis_id}/flag", response_model=PraxisOut)

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -226,3 +226,27 @@ async def drop_task_route(
     if ct is None:
         raise HTTPException(status_code=404, detail="Signup not found.")
     await drop_task(ct, session)
+
+
+@router.post("/{task_id}/drop", status_code=204)
+async def drop_task_post_route(
+    task_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Drop an in-progress task to free a slot.
+
+    Alias for DELETE /{task_id}/signup, available as POST for the invite-accept
+    task-list-full flow where DELETE semantics are inconvenient for clients.
+    """
+    result = await session.execute(
+        select(CharacterTask).where(
+            CharacterTask.character_id == character.id,
+            CharacterTask.task_id == task_id,
+            CharacterTask.status == CharacterTaskStatus.in_progress,
+        )
+    )
+    ct = result.scalar_one_or_none()
+    if ct is None:
+        raise HTTPException(status_code=404, detail="Signup not found.")
+    await drop_task(ct, session)

--- a/backend/schemas/collaboration.py
+++ b/backend/schemas/collaboration.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CollaborationCreate(BaseModel):
+    task_id: int
+    mode: str  # "collaboration" or "duel"
+
+
+class CollaborationMemberOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    character_id: int
+    display_name: str
+    faction_slug: str
+    has_submitted: bool
+    joined_at: datetime
+
+
+class CollaborationInviteOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    collaboration_id: int
+    inviter_id: int
+    inviter_display_name: str
+    invitee_id: int
+    invitee_display_name: str
+    type: str
+    status: str
+    created_at: datetime
+
+
+class CollaborationOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    task_id: int
+    task_title: str
+    task_point_value: int
+    mode: str
+    status: str
+    body_text: str
+    created_by_id: int
+    created_at: datetime
+    updated_at: datetime
+    members: list[CollaborationMemberOut] = []
+    # Invites only included when the viewer is a member (populated at service layer)
+    invites: list[CollaborationInviteOut] = []
+
+
+class CollaborationInviteCreate(BaseModel):
+    invitee_character_id: int
+
+
+class InviteResponse(BaseModel):
+    accept: bool
+    # If the invitee's task list is full, they must supply a task_id to drop before accepting.
+    drop_task_id: Optional[int] = None
+
+
+class CollaborationDocumentUpdate(BaseModel):
+    body_text: str = Field(..., max_length=50000)
+
+
+class DuelVoteSummary(BaseModel):
+    character_id: int
+    display_name: str
+    total_stars: int
+    is_winning: bool
+
+
+class CollaborationVoteIn(BaseModel):
+    target_character_id: int
+    stars: int = Field(..., ge=1, le=5)

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -29,10 +29,6 @@ class PraxisOut(BaseModel):
     moderation_status: str = "visible"
     is_withdrawn: bool = False
     admin_note: Optional[str] = None
-    collaboration_mode: str = "solo"
-    partner_character_id: Optional[int] = None
-    partner_display_name: Optional[str] = None
-    invite_status: Optional[str] = None
     created_at: datetime
     updated_at: datetime
     media: list[MediaItemOut] = []
@@ -43,5 +39,3 @@ class PraxisCreate(BaseModel):
     task_id: int
     title: str = Field(..., max_length=200)
     body_text: Optional[str] = Field(None, max_length=10000)
-    collaboration_mode: Optional[str] = "solo"
-    partner_character_id: Optional[int] = None

--- a/backend/schemas/vote.py
+++ b/backend/schemas/vote.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -11,7 +12,9 @@ class VoteOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    praxis_id: int
+    praxis_id: Optional[int] = None        # None for duel votes
+    collaboration_id: Optional[int] = None  # Set for duel votes
+    duel_vote_for: Optional[int] = None     # Set for duel votes
     voter_character_id: int
     stars: int
     created_at: datetime

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -15,7 +15,8 @@ from models.era import Era
 from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
 from models.relationship import Relationship, RelationshipStatus, RelationshipType
-from models.praxis import CollaborationMode, InviteStatus, Praxis
+from models.collaboration import CollaborationInvite, CollaborationInviteStatus, CollaborationMode
+from models.praxis import Praxis
 from models.task import CharacterTask, CharacterTaskStatus, Task, TaskStatus
 from models.taunt_message import TauntMessage
 from models.vote import Vote
@@ -385,13 +386,15 @@ async def _fetch_collab_invites(
     pending_only: bool = False,
 ) -> list[ActivityFeedItem]:
     """Collab invites sent to the current character."""
+    from models.collaboration import Collaboration
+
     query = (
         select(
-            Praxis.id,
-            Praxis.title,
-            Praxis.created_at,
-            Praxis.invite_status,
-            Praxis.character_id,
+            CollaborationInvite.id,
+            CollaborationInvite.created_at,
+            CollaborationInvite.status,
+            CollaborationInvite.inviter_id,
+            CollaborationInvite.collaboration_id,
             Task.title.label("task_title"),
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
@@ -400,23 +403,23 @@ async def _fetch_collab_invites(
             Character.faction_slug.label("inviter_faction_slug"),
             Character.avatar_url.label("inviter_avatar_url"),
         )
-        .join(Task, Praxis.task_id == Task.id)
-        .join(Character, Praxis.character_id == Character.id)
+        .join(Collaboration, CollaborationInvite.collaboration_id == Collaboration.id)
+        .join(Task, Collaboration.task_id == Task.id)
+        .join(Character, CollaborationInvite.inviter_id == Character.id)
         .where(
-            Praxis.partner_character_id == character_id,
-            Praxis.collaboration_mode == CollaborationMode.collab,
+            CollaborationInvite.invitee_id == character_id,
+            CollaborationInvite.type == CollaborationMode.collaboration,
         )
     )
     if pending_only:
-        query = query.where(Praxis.invite_status == InviteStatus.pending)
+        query = query.where(CollaborationInvite.status == CollaborationInviteStatus.pending)
     if before is not None:
-        query = query.where(Praxis.created_at < before)
-    query = query.order_by(Praxis.created_at.desc()).limit(SUB_QUERY_LIMIT)
+        query = query.where(CollaborationInvite.created_at < before)
+    query = query.order_by(CollaborationInvite.created_at.desc()).limit(SUB_QUERY_LIMIT)
 
     result = await session.execute(query)
     items: list[ActivityFeedItem] = []
     for row in result.all():
-        invite_status = row.invite_status.value if row.invite_status else None
         items.append(ActivityFeedItem(
             type=FEED_ITEM_TYPE_COLLAB_INVITE,
             timestamp=row.created_at,
@@ -424,14 +427,14 @@ async def _fetch_collab_invites(
             actor_faction_slug=row.inviter_faction_slug,
             actor_avatar_url=row.inviter_avatar_url,
             payload={
-                "praxis_id": row.id,
-                "praxis_title": row.title,
+                "invite_id": row.id,
+                "collaboration_id": row.collaboration_id,
                 "task_title": row.task_title,
                 "task_point_value": row.task_point_value,
                 "task_faction_slug": row.task_faction_slug,
                 "task_level_required": row.task_level_required,
-                "invite_status": invite_status,
-                "inviter_character_id": row.character_id,
+                "invite_status": row.status.value,
+                "inviter_character_id": row.inviter_id,
             },
         ))
     return items
@@ -444,13 +447,15 @@ async def _fetch_duel_challenges(
     pending_only: bool = False,
 ) -> list[ActivityFeedItem]:
     """Duel challenges sent to the current character."""
+    from models.collaboration import Collaboration
+
     query = (
         select(
-            Praxis.id,
-            Praxis.title,
-            Praxis.created_at,
-            Praxis.invite_status,
-            Praxis.character_id,
+            CollaborationInvite.id,
+            CollaborationInvite.created_at,
+            CollaborationInvite.status,
+            CollaborationInvite.inviter_id,
+            CollaborationInvite.collaboration_id,
             Task.title.label("task_title"),
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
@@ -458,23 +463,23 @@ async def _fetch_duel_challenges(
             Character.faction_slug.label("challenger_faction_slug"),
             Character.avatar_url.label("challenger_avatar_url"),
         )
-        .join(Task, Praxis.task_id == Task.id)
-        .join(Character, Praxis.character_id == Character.id)
+        .join(Collaboration, CollaborationInvite.collaboration_id == Collaboration.id)
+        .join(Task, Collaboration.task_id == Task.id)
+        .join(Character, CollaborationInvite.inviter_id == Character.id)
         .where(
-            Praxis.partner_character_id == character_id,
-            Praxis.collaboration_mode == CollaborationMode.duel,
+            CollaborationInvite.invitee_id == character_id,
+            CollaborationInvite.type == CollaborationMode.duel,
         )
     )
     if pending_only:
-        query = query.where(Praxis.invite_status == InviteStatus.pending)
+        query = query.where(CollaborationInvite.status == CollaborationInviteStatus.pending)
     if before is not None:
-        query = query.where(Praxis.created_at < before)
-    query = query.order_by(Praxis.created_at.desc()).limit(SUB_QUERY_LIMIT)
+        query = query.where(CollaborationInvite.created_at < before)
+    query = query.order_by(CollaborationInvite.created_at.desc()).limit(SUB_QUERY_LIMIT)
 
     result = await session.execute(query)
     items: list[ActivityFeedItem] = []
     for row in result.all():
-        invite_status = row.invite_status.value if row.invite_status else None
         items.append(ActivityFeedItem(
             type=FEED_ITEM_TYPE_DUEL_CHALLENGE,
             timestamp=row.created_at,
@@ -482,13 +487,13 @@ async def _fetch_duel_challenges(
             actor_faction_slug=row.challenger_faction_slug,
             actor_avatar_url=row.challenger_avatar_url,
             payload={
-                "praxis_id": row.id,
-                "praxis_title": row.title,
+                "invite_id": row.id,
+                "collaboration_id": row.collaboration_id,
                 "task_title": row.task_title,
                 "task_point_value": row.task_point_value,
                 "task_faction_slug": row.task_faction_slug,
-                "invite_status": invite_status,
-                "challenger_character_id": row.character_id,
+                "invite_status": row.status.value,
+                "challenger_character_id": row.inviter_id,
             },
         ))
     return items
@@ -741,13 +746,8 @@ async def _compute_counts(
         """Votes on mine + collab invites + duel challenges + invitation letters."""
         collab_result = await session.execute(
             select(func.count())
-            .select_from(Praxis)
-            .where(
-                Praxis.partner_character_id == character_id,
-                Praxis.collaboration_mode.in_([
-                    CollaborationMode.collab, CollaborationMode.duel,
-                ]),
-            )
+            .select_from(CollaborationInvite)
+            .where(CollaborationInvite.invitee_id == character_id)
         )
         collab_count = collab_result.scalar_one()
         votes_count = await count_votes_on_mine()
@@ -768,13 +768,10 @@ async def _compute_counts(
     async def count_requests() -> int:
         result = await session.execute(
             select(func.count())
-            .select_from(Praxis)
+            .select_from(CollaborationInvite)
             .where(
-                Praxis.partner_character_id == character_id,
-                Praxis.collaboration_mode.in_([
-                    CollaborationMode.collab, CollaborationMode.duel,
-                ]),
-                Praxis.invite_status == InviteStatus.pending,
+                CollaborationInvite.invitee_id == character_id,
+                CollaborationInvite.status == CollaborationInviteStatus.pending,
             )
         )
         return result.scalar_one()

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -5,11 +5,53 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
+from models.collaboration import Collaboration, CollaborationMember, CollaborationStatus
 from models.praxis import ModerationStatus, Praxis
 from models.task import Task
 from models.vote import Vote
 from services.era import get_current_era_row, get_or_create_stats
-from services.scoring import compute_faction_multiplier, compute_level, compute_praxis_score, compute_vote_budget
+from services.scoring import (
+    COLLABORATION_MODE_COLLAB,
+    COLLABORATION_MODE_DUEL,
+    COLLABORATION_MODE_SOLO,
+    compute_duel_multiplier,
+    compute_faction_multiplier,
+    compute_level,
+    compute_praxis_score,
+    compute_vote_budget,
+)
+
+
+async def _get_meta_task_points(praxis_id: int, session: AsyncSession) -> int:
+    """Return flat bonus points from any meta task attached to a solo praxis."""
+    from models.meta_task import MetaTask
+
+    result = await session.execute(
+        select(PraxisMetaTask).where(PraxisMetaTask.praxis_id == praxis_id)
+    )
+    praxis_meta_task = result.scalar_one_or_none()
+    if praxis_meta_task is None:
+        return 0
+    meta_task = await session.get(MetaTask, praxis_meta_task.meta_task_id)
+    if meta_task is None:
+        return 0
+    # bonus_type "flat" adds bonus_value directly; "percentage" is not yet implemented.
+    if meta_task.bonus_type.value == "flat":
+        return int(meta_task.bonus_value)
+    return 0
+
+
+async def _get_duel_vote_totals(
+    collaboration_id: int, session: AsyncSession
+) -> dict[int, int]:
+    """Return {character_id: total_stars} for all duel votes on a collaboration."""
+    result = await session.execute(
+        select(Vote.duel_vote_for, func.sum(Vote.stars)).where(
+            Vote.collaboration_id == collaboration_id,
+            Vote.duel_vote_for.is_not(None),
+        ).group_by(Vote.duel_vote_for)
+    )
+    return {character_id: int(stars) for character_id, stars in result.all()}
 
 
 async def recalculate_character_stats(
@@ -19,15 +61,20 @@ async def recalculate_character_stats(
 ) -> None:
     """Recompute and persist score, level, and vote budget for a character.
 
-    Sums point_value * faction_multiplier + total_stars across all submissions.
-    Safe to call on submission creation (0 votes → base points only) or after
-    any vote change.
+    Sums scores across:
+    - All solo praxis records (formula: (base + meta) × faction × duel_multiplier + stars)
+    - All published collaborations/duels the character is a member of
+
+    Safe to call on praxis creation (0 votes → base points only) or after any vote change.
     """
     era_row = await get_current_era_row(session)
 
     author = await session.get(Character, character_id)
     character_faction_slug = author.faction_slug if author else "na"
 
+    total_score = 0.0
+
+    # ── Solo praxes ───────────────────────────────────────────────────────────
     praxis_result = await session.execute(
         select(Praxis).where(
             Praxis.character_id == character_id,
@@ -35,10 +82,7 @@ async def recalculate_character_stats(
             Praxis.is_withdrawn == False,
         )
     )
-    praxis_list = praxis_result.scalars().all()
-
-    total_score = 0.0
-    for praxis in praxis_list:
+    for praxis in praxis_result.scalars().all():
         task = await session.get(Task, praxis.task_id)
         if task is None:
             continue
@@ -47,13 +91,100 @@ async def recalculate_character_stats(
             character_faction_slug,
             task_faction_slug,
             era,
-            collaboration_mode=praxis.collaboration_mode.value,
+            collaboration_mode=COLLABORATION_MODE_SOLO,
         )
+        meta_task_points = await _get_meta_task_points(praxis.id, session)
         sum_result = await session.execute(
             select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
         )
         total_stars = int(sum_result.scalar_one_or_none() or 0)
-        total_score += compute_praxis_score(task.point_value, faction_multiplier, total_stars)
+        total_score += compute_praxis_score(
+            task.point_value,
+            faction_multiplier,
+            total_stars,
+            meta_task_points=meta_task_points,
+            duel_multiplier=1.0,
+        )
+
+    # ── Published collaborations and duels ────────────────────────────────────
+    member_result = await session.execute(
+        select(CollaborationMember).where(
+            CollaborationMember.character_id == character_id,
+        )
+    )
+    for member in member_result.scalars().all():
+        collab = await session.get(Collaboration, member.collaboration_id)
+        if collab is None or collab.status != CollaborationStatus.published:
+            continue
+
+        task = await session.get(Task, collab.task_id)
+        if task is None:
+            continue
+
+        task_faction_slug = task.primary_faction_slug or "na"
+        mode = collab.mode.value  # "collaboration" or "duel"
+
+        if mode == "duel":
+            # Determine duel outcome for this member
+            vote_totals = await _get_duel_vote_totals(collab.id, session)
+            member_stars = vote_totals.get(character_id, 0)
+
+            other_member_result = await session.execute(
+                select(CollaborationMember).where(
+                    CollaborationMember.collaboration_id == collab.id,
+                    CollaborationMember.character_id != character_id,
+                )
+            )
+            other_members = other_member_result.scalars().all()
+            opponent_id = other_members[0].character_id if other_members else None
+            opponent_stars = vote_totals.get(opponent_id, 0) if opponent_id else 0
+
+            opponent = await session.get(Character, opponent_id) if opponent_id else None
+            opponent_faction_slug = opponent.faction_slug if opponent else "na"
+
+            is_tied = member_stars == opponent_stars
+            is_winner = member_stars > opponent_stars
+
+            faction_multiplier = compute_faction_multiplier(
+                character_faction_slug,
+                task_faction_slug,
+                era,
+                collaboration_mode=COLLABORATION_MODE_SOLO,  # own/other task, no duel mode
+            )
+            duel_multiplier = compute_duel_multiplier(
+                character_faction_slug,
+                opponent_faction_slug,
+                is_winner=is_winner,
+                is_tied=is_tied,
+                era=era,
+            )
+            total_score += compute_praxis_score(
+                task.point_value,
+                faction_multiplier,
+                member_stars,
+                meta_task_points=0,  # meta tasks on collaborations not yet wired
+                duel_multiplier=duel_multiplier,
+            )
+        else:
+            # Collaboration
+            faction_multiplier = compute_faction_multiplier(
+                character_faction_slug,
+                task_faction_slug,
+                era,
+                collaboration_mode=COLLABORATION_MODE_COLLAB,
+            )
+            # Votes on collaborations use praxis-style voting (no duel_vote_for needed)
+            sum_result = await session.execute(
+                select(func.sum(Vote.stars)).where(Vote.collaboration_id == collab.id)
+            )
+            total_stars = int(sum_result.scalar_one_or_none() or 0)
+            total_score += compute_praxis_score(
+                task.point_value,
+                faction_multiplier,
+                total_stars,
+                meta_task_points=0,
+                duel_multiplier=1.0,
+            )
 
     new_score = int(total_score)
     stats = await get_or_create_stats(session, character_id, era_row.id)

--- a/backend/services/collaboration.py
+++ b/backend/services/collaboration.py
@@ -1,0 +1,520 @@
+"""Business logic for collaboration and duel praxis."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import HTTPException
+
+from game_config import CURRENT_ERA, EraConfig
+from models.character import Character
+from models.collaboration import (
+    Collaboration,
+    CollaborationInvite,
+    CollaborationInviteStatus,
+    CollaborationMember,
+    CollaborationMode,
+    CollaborationStatus,
+)
+from models.task import CharacterTask, CharacterTaskStatus, Task
+from schemas.collaboration import (
+    CollaborationInviteOut,
+    CollaborationMemberOut,
+    CollaborationOut,
+    DuelVoteSummary,
+)
+from services.era import get_current_era_row, get_or_create_stats
+from services.scoring import SNIDE_FACTION_SLUG
+
+
+DUEL_LEVEL_REQUIRED = 2
+COLLABORATION_LEVEL_REQUIRED = 1
+
+
+def _build_member_out(member: CollaborationMember) -> CollaborationMemberOut:
+    return CollaborationMemberOut(
+        character_id=member.character_id,
+        display_name=member.character.display_name,
+        faction_slug=member.character.faction_slug,
+        has_submitted=member.has_submitted,
+        joined_at=member.joined_at,
+    )
+
+
+def _build_invite_out(invite: CollaborationInvite) -> CollaborationInviteOut:
+    return CollaborationInviteOut(
+        id=invite.id,
+        collaboration_id=invite.collaboration_id,
+        inviter_id=invite.inviter_id,
+        inviter_display_name=invite.inviter.display_name,
+        invitee_id=invite.invitee_id,
+        invitee_display_name=invite.invitee.display_name,
+        type=invite.type.value,
+        status=invite.status.value,
+        created_at=invite.created_at,
+    )
+
+
+def build_collaboration_out(
+    collab: Collaboration,
+    viewer_character_id: int | None = None,
+) -> CollaborationOut:
+    """Serialize a Collaboration. Invites only shown to members."""
+    member_ids = {m.character_id for m in collab.members}
+    include_invites = viewer_character_id in member_ids if viewer_character_id else False
+
+    return CollaborationOut(
+        id=collab.id,
+        task_id=collab.task_id,
+        task_title=collab.task.title,
+        task_point_value=collab.task.point_value,
+        mode=collab.mode.value,
+        status=collab.status.value,
+        body_text=collab.body_text,
+        created_by_id=collab.created_by_id,
+        created_at=collab.created_at,
+        updated_at=collab.updated_at,
+        members=[_build_member_out(m) for m in collab.members],
+        invites=[_build_invite_out(i) for i in collab.invites] if include_invites else [],
+    )
+
+
+async def _count_active_tasks(character_id: int, session: AsyncSession) -> int:
+    """Count in-progress CharacterTask rows for capacity enforcement."""
+    result = await session.execute(
+        select(CharacterTask).where(
+            CharacterTask.character_id == character_id,
+            CharacterTask.status == CharacterTaskStatus.in_progress,
+        )
+    )
+    return len(result.scalars().all())
+
+
+async def _get_character_task(
+    character_id: int, task_id: int, session: AsyncSession
+) -> CharacterTask | None:
+    result = await session.execute(
+        select(CharacterTask).where(
+            CharacterTask.character_id == character_id,
+            CharacterTask.task_id == task_id,
+            CharacterTask.status == CharacterTaskStatus.in_progress,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def create_collaboration(
+    task_id: int,
+    mode: str,
+    character: Character,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Collaboration:
+    """Create a new collaboration or duel from an in-progress task.
+
+    The initiating character automatically becomes the first member.
+    Their existing CharacterTask row is reused (not replaced).
+    """
+    # Level gate
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, character.id, era_row.id)
+    level_required = DUEL_LEVEL_REQUIRED if mode == "duel" else COLLABORATION_LEVEL_REQUIRED
+    if stats.level < level_required:
+        raise HTTPException(
+            status_code=403,
+            detail=f"{'Duels' if mode == 'duel' else 'Collaborations'} require level {level_required}.",
+        )
+
+    # Validate mode
+    try:
+        collab_mode = CollaborationMode(mode)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid mode '{mode}'. Use 'collaboration' or 'duel'.")
+
+    # Character must have the task in-progress
+    character_task = await _get_character_task(character.id, task_id, session)
+    if character_task is None:
+        raise HTTPException(
+            status_code=400,
+            detail="You must have this task in-progress before starting a collaboration.",
+        )
+
+    # Validate task exists
+    task = await session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found.")
+
+    collab = Collaboration(
+        task_id=task_id,
+        mode=collab_mode,
+        status=CollaborationStatus.in_progress,
+        body_text="",
+        created_by_id=character.id,
+    )
+    session.add(collab)
+    await session.flush()  # Get collab.id
+
+    member = CollaborationMember(
+        collaboration_id=collab.id,
+        character_id=character.id,
+        has_submitted=False,
+    )
+    session.add(member)
+    await session.commit()
+    await session.refresh(collab)
+    return collab
+
+
+async def invite_member(
+    collaboration_id: int,
+    inviter: Character,
+    invitee_character_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> CollaborationInvite:
+    """Send a collaboration or duel invite. The inviter must be a current member."""
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    if collab.status == CollaborationStatus.published:
+        raise HTTPException(status_code=400, detail="Cannot invite to a published collaboration.")
+
+    # Inviter must be a member
+    member_ids = {m.character_id for m in collab.members}
+    if inviter.id not in member_ids:
+        raise HTTPException(status_code=403, detail="Only members can send invites.")
+
+    # Duels: max 2 participants
+    if collab.mode == CollaborationMode.duel and len(collab.members) >= 2:
+        raise HTTPException(status_code=400, detail="Duels can only have 2 participants.")
+
+    # Collaborations: max 20 members
+    if len(collab.members) >= era.max_task_signups:
+        raise HTTPException(status_code=400, detail="This collaboration is already at max capacity.")
+
+    # Can't invite yourself
+    if invitee_character_id == inviter.id:
+        raise HTTPException(status_code=400, detail="Cannot invite yourself.")
+
+    # Can't invite someone already in the collaboration
+    if invitee_character_id in member_ids:
+        raise HTTPException(status_code=409, detail="Player is already a member.")
+
+    # Can't send a duplicate pending invite
+    existing_invite = await session.execute(
+        select(CollaborationInvite).where(
+            CollaborationInvite.collaboration_id == collaboration_id,
+            CollaborationInvite.inviter_id == inviter.id,
+            CollaborationInvite.invitee_id == invitee_character_id,
+            CollaborationInvite.status == CollaborationInviteStatus.pending,
+        )
+    )
+    if existing_invite.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="A pending invite already exists. Resolve it before sending another.",
+        )
+
+    invitee = await session.get(Character, invitee_character_id)
+    if invitee is None:
+        raise HTTPException(status_code=404, detail="Invitee not found.")
+
+    invite = CollaborationInvite(
+        collaboration_id=collaboration_id,
+        inviter_id=inviter.id,
+        invitee_id=invitee_character_id,
+        type=collab.mode,
+        status=CollaborationInviteStatus.pending,
+    )
+    session.add(invite)
+    await session.commit()
+    await session.refresh(invite)
+    return invite
+
+
+async def respond_to_invite(
+    invite_id: int,
+    character: Character,
+    accept: bool,
+    drop_task_id: int | None,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Collaboration:
+    """Accept or decline a collaboration invite.
+
+    If accepting with a full task list (20 tasks), the caller must supply
+    drop_task_id — a task to drop before joining. Returns 409 if the list is full
+    and no drop_task_id was provided.
+
+    For duel challenges: if the invitee already has the task as a solo praxis,
+    accepting withdraws that praxis.
+    """
+    invite = await session.get(CollaborationInvite, invite_id)
+    if invite is None:
+        raise HTTPException(status_code=404, detail="Invite not found.")
+
+    if invite.invitee_id != character.id:
+        raise HTTPException(status_code=403, detail="This invite is not for you.")
+
+    if invite.status != CollaborationInviteStatus.pending:
+        raise HTTPException(status_code=400, detail="Invite has already been resolved.")
+
+    if not accept:
+        invite.status = CollaborationInviteStatus.declined
+        await session.commit()
+        collab = await session.get(Collaboration, invite.collaboration_id)
+        return collab
+
+    collab = await session.get(Collaboration, invite.collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration no longer exists.")
+
+    if collab.status == CollaborationStatus.published:
+        raise HTTPException(status_code=400, detail="Cannot join a published collaboration.")
+
+    # Check task list capacity
+    active_count = await _count_active_tasks(character.id, session)
+    existing_task = await _get_character_task(character.id, collab.task_id, session)
+    will_add_task = existing_task is None
+
+    if will_add_task and active_count >= era.max_task_signups:
+        if drop_task_id is None:
+            raise HTTPException(
+                status_code=409,
+                detail="Task list is full (20 tasks). Provide drop_task_id to drop a task and accept.",
+            )
+        # Drop the specified task
+        task_to_drop = await _get_character_task(character.id, drop_task_id, session)
+        if task_to_drop is None:
+            raise HTTPException(
+                status_code=400,
+                detail="The task you want to drop is not in your in-progress list.",
+            )
+        task_to_drop.status = CharacterTaskStatus.abandoned
+        await session.flush()
+
+    # For duels: if the invitee already has this task as an in-progress solo praxis, withdraw it
+    if collab.mode == CollaborationMode.duel and existing_task is not None:
+        from models.praxis import Praxis
+        existing_praxis_result = await session.execute(
+            select(Praxis).where(
+                Praxis.character_id == character.id,
+                Praxis.task_id == collab.task_id,
+                Praxis.is_withdrawn == False,
+            )
+        )
+        existing_praxis = existing_praxis_result.scalar_one_or_none()
+        if existing_praxis is not None:
+            existing_praxis.is_withdrawn = True
+            await session.flush()
+
+    # Add CharacterTask if not already present
+    if will_add_task:
+        new_task = CharacterTask(
+            character_id=character.id,
+            task_id=collab.task_id,
+            status=CharacterTaskStatus.in_progress,
+        )
+        session.add(new_task)
+        await session.flush()
+
+    # Add member
+    member = CollaborationMember(
+        collaboration_id=collab.id,
+        character_id=character.id,
+        has_submitted=False,
+    )
+    session.add(member)
+
+    invite.status = CollaborationInviteStatus.accepted
+    await session.commit()
+    await session.refresh(collab)
+    return collab
+
+
+async def submit_for_member(
+    collaboration_id: int,
+    character: Character,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Collaboration:
+    """Mark this member as having submitted. Publishes when all members have submitted."""
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    member_ids = {m.character_id for m in collab.members}
+    if character.id not in member_ids:
+        raise HTTPException(status_code=403, detail="You are not a member of this collaboration.")
+
+    # Mark this member submitted
+    for member in collab.members:
+        if member.character_id == character.id:
+            member.has_submitted = True
+            break
+
+    await session.flush()
+
+    # Reload to check if all are submitted
+    await session.refresh(collab)
+    if all(m.has_submitted for m in collab.members):
+        collab.status = CollaborationStatus.published
+        await session.flush()
+        # Award base points to each member
+        for member in collab.members:
+            from services.character_stats import recalculate_character_stats
+            await recalculate_character_stats(member.character_id, session, era)
+
+    await session.commit()
+    await session.refresh(collab)
+    return collab
+
+
+async def reopen_collaboration(
+    collaboration_id: int,
+    character: Character,
+    session: AsyncSession,
+) -> Collaboration:
+    """Reset all submit states; reopen for editing. Any member can trigger this."""
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    member_ids = {m.character_id for m in collab.members}
+    if character.id not in member_ids:
+        raise HTTPException(status_code=403, detail="You are not a member of this collaboration.")
+
+    collab.status = CollaborationStatus.in_progress
+    for member in collab.members:
+        member.has_submitted = False
+
+    await session.commit()
+    await session.refresh(collab)
+    return collab
+
+
+async def kick_member(
+    collaboration_id: int,
+    kicker: Character,
+    kickee_character_id: int,
+    session: AsyncSession,
+) -> Collaboration:
+    """Remove a member from the collaboration. Any member can kick any other member.
+
+    - Kicked member's CharacterTask is abandoned (they lose the task and progress).
+    - Their contributed body_text content remains in the shared document.
+    - All submission states reset.
+    """
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    member_ids = {m.character_id for m in collab.members}
+    if kicker.id not in member_ids:
+        raise HTTPException(status_code=403, detail="You are not a member of this collaboration.")
+
+    if kickee_character_id not in member_ids:
+        raise HTTPException(status_code=400, detail="Target player is not a member.")
+
+    if kickee_character_id == kicker.id:
+        raise HTTPException(status_code=400, detail="Cannot kick yourself. Use /edit to leave.")
+
+    # Remove the member record
+    kickee_member_result = await session.execute(
+        select(CollaborationMember).where(
+            CollaborationMember.collaboration_id == collaboration_id,
+            CollaborationMember.character_id == kickee_character_id,
+        )
+    )
+    kickee_member = kickee_member_result.scalar_one_or_none()
+    if kickee_member:
+        await session.delete(kickee_member)
+
+    # Abandon the kicked member's CharacterTask
+    kickee_task = await _get_character_task(kickee_character_id, collab.task_id, session)
+    if kickee_task:
+        kickee_task.status = CharacterTaskStatus.abandoned
+
+    # Reset all submit states
+    for member in collab.members:
+        if member.character_id != kickee_character_id:
+            member.has_submitted = False
+    collab.status = CollaborationStatus.in_progress
+
+    await session.commit()
+    await session.refresh(collab)
+    return collab
+
+
+async def update_document(
+    collaboration_id: int,
+    character: Character,
+    body_text: str,
+    session: AsyncSession,
+) -> Collaboration:
+    """Update the shared document. Any member can edit at any time.
+
+    Editing a published collaboration reopens it (resets all submit states).
+    """
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    member_ids = {m.character_id for m in collab.members}
+    if character.id not in member_ids:
+        raise HTTPException(status_code=403, detail="Only members can edit the document.")
+
+    collab.body_text = body_text
+
+    # Editing a published collab reopens it
+    if collab.status == CollaborationStatus.published:
+        collab.status = CollaborationStatus.in_progress
+        for member in collab.members:
+            member.has_submitted = False
+
+    await session.commit()
+    await session.refresh(collab)
+    return collab
+
+
+async def get_duel_vote_summary(
+    collaboration_id: int,
+    session: AsyncSession,
+) -> list[DuelVoteSummary]:
+    """Return live vote tally per player for a duel, with current winner indicated."""
+    from sqlalchemy import func
+    from models.vote import Vote
+
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    if collab.mode != CollaborationMode.duel:
+        raise HTTPException(status_code=400, detail="Vote summaries are only available for duels.")
+
+    # Sum stars per target player
+    result = await session.execute(
+        select(Vote.duel_vote_for, func.sum(Vote.stars)).where(
+            Vote.collaboration_id == collaboration_id,
+            Vote.duel_vote_for.is_not(None),
+        ).group_by(Vote.duel_vote_for)
+    )
+    vote_totals: dict[int, int] = {char_id: int(stars) for char_id, stars in result.all()}
+
+    summaries = []
+    member_stars_list = [(m.character_id, vote_totals.get(m.character_id, 0)) for m in collab.members]
+    max_stars = max((stars for _, stars in member_stars_list), default=0)
+
+    for member in collab.members:
+        stars = vote_totals.get(member.character_id, 0)
+        # "Winning" means highest stars. Ties show both as winning.
+        is_winning = stars == max_stars and max_stars > 0
+        summaries.append(
+            DuelVoteSummary(
+                character_id=member.character_id,
+                display_name=member.character.display_name,
+                total_stars=stars,
+                is_winning=is_winning,
+            )
+        )
+
+    return summaries

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -5,14 +5,19 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
+from models.character import Character
 from models.flag import Flag
-from models.praxis import CollaborationMode, InviteStatus, ModerationStatus, Praxis
+from models.praxis import ModerationStatus, Praxis
 from models.task import CharacterTask, CharacterTaskStatus, Task
 from schemas.praxis import MediaItemOut, PraxisCreate, PraxisOut
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
 from services.faction_service import check_and_deliver_invitations
-from services.scoring import compute_faction_multiplier, compute_praxis_score
+from services.scoring import (
+    COLLABORATION_MODE_SOLO,
+    compute_faction_multiplier,
+    compute_praxis_score,
+)
 
 
 async def create_praxis(
@@ -20,6 +25,7 @@ async def create_praxis(
     task: Task,
     data: PraxisCreate,
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
 ) -> Praxis:
     character_task_result = await session.execute(
         select(CharacterTask).where(
@@ -32,34 +38,17 @@ async def create_praxis(
     if character_task is None:
         raise HTTPException(status_code=403, detail="Must be signed up for this task to submit proof.")
 
-    collab_mode = CollaborationMode(data.collaboration_mode or "solo")
-    partner_id = data.partner_character_id
-
-    if collab_mode != CollaborationMode.solo:
-        if partner_id is None:
-            raise HTTPException(status_code=422, detail="Partner character required for collab/duel mode.")
-        if partner_id == character.id:
-            raise HTTPException(status_code=422, detail="Cannot partner with yourself.")
-        partner = await session.get(Character, partner_id)
-        if partner is None:
-            raise HTTPException(status_code=404, detail="Partner character not found.")
-
-    invite_status = InviteStatus.pending if collab_mode != CollaborationMode.solo else None
-
     praxis = Praxis(
         task_id=task.id,
         character_id=character.id,
         title=data.title,
         body_text=data.body_text or "",
-        collaboration_mode=collab_mode,
-        partner_character_id=partner_id,
-        invite_status=invite_status,
     )
     session.add(praxis)
     character_task.status = CharacterTaskStatus.submitted
     await session.commit()
     await session.refresh(praxis)
-    await recalculate_character_stats(character.id, session)
+    await recalculate_character_stats(character.id, session, era)
     await check_and_deliver_invitations(character, task, session)
     await session.commit()
     return praxis
@@ -180,46 +169,6 @@ async def flag_praxis(
     return praxis
 
 
-async def accept_invite(
-    praxis_id: int,
-    character_id: int,
-    session: AsyncSession,
-) -> Praxis:
-    """Partner accepts a collab/duel invite."""
-    praxis = await session.get(Praxis, praxis_id)
-    if praxis is None:
-        raise HTTPException(status_code=404, detail="Praxis not found.")
-    if praxis.partner_character_id != character_id:
-        raise HTTPException(status_code=403, detail="Only the invited partner can accept.")
-    if praxis.invite_status != InviteStatus.pending:
-        raise HTTPException(status_code=422, detail="Invite is no longer pending.")
-
-    praxis.invite_status = InviteStatus.accepted
-    await session.commit()
-    await session.refresh(praxis)
-    return praxis
-
-
-async def decline_invite(
-    praxis_id: int,
-    character_id: int,
-    session: AsyncSession,
-) -> Praxis:
-    """Partner declines a collab/duel invite."""
-    praxis = await session.get(Praxis, praxis_id)
-    if praxis is None:
-        raise HTTPException(status_code=404, detail="Praxis not found.")
-    if praxis.partner_character_id != character_id:
-        raise HTTPException(status_code=403, detail="Only the invited partner can decline.")
-    if praxis.invite_status != InviteStatus.pending:
-        raise HTTPException(status_code=422, detail="Invite is no longer pending.")
-
-    praxis.invite_status = InviteStatus.declined
-    await session.commit()
-    await session.refresh(praxis)
-    return praxis
-
-
 async def compute_praxis_score_from_db(
     praxis: Praxis,
     session: AsyncSession,
@@ -234,7 +183,7 @@ async def compute_praxis_score_from_db(
         character_faction_slug,
         task_faction_slug,
         era,
-        collaboration_mode=praxis.collaboration_mode.value,
+        collaboration_mode=COLLABORATION_MODE_SOLO,
     )
     total_stars = int(sum(vote.stars for vote in praxis.votes))
     return compute_praxis_score(task.point_value, faction_multiplier, total_stars)
@@ -252,16 +201,9 @@ async def build_praxis_out(
     media = [MediaItemOut.model_validate(item) for item in praxis.media_items]
 
     character_display_name = praxis.character.display_name if praxis.character else ""
-
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
     task_faction_slug = praxis.task.primary_faction_slug if praxis.task else None
-
-    partner_display_name = praxis.partner.display_name if praxis.partner else None
-
-    invite_status_value = None
-    if praxis.invite_status is not None:
-        invite_status_value = praxis.invite_status.value
 
     return PraxisOut(
         id=praxis.id,
@@ -276,10 +218,6 @@ async def build_praxis_out(
         moderation_status=praxis.moderation_status.value,
         is_withdrawn=praxis.is_withdrawn,
         admin_note=praxis.admin_note,
-        collaboration_mode=praxis.collaboration_mode.value,
-        partner_character_id=praxis.partner_character_id,
-        partner_display_name=partner_display_name,
-        invite_status=invite_status_value,
         created_at=praxis.created_at,
         updated_at=praxis.updated_at,
         media=media,

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -1,6 +1,13 @@
 from math import floor
+from typing import Optional
 
 from game_config import CURRENT_ERA, EraConfig
+
+COLLABORATION_MODE_SOLO = "solo"
+COLLABORATION_MODE_COLLAB = "collab"
+COLLABORATION_MODE_DUEL = "duel"
+UNAFFILIATED_FACTION_SLUG = "na"
+SNIDE_FACTION_SLUG = "snide"
 
 
 def compute_vote_budget(score: int, era: EraConfig = CURRENT_ERA) -> int:
@@ -14,37 +21,22 @@ def compute_level(score: int, era: EraConfig = CURRENT_ERA) -> int:
     return 0
 
 
-COLLABORATION_MODE_SOLO = "solo"
-COLLABORATION_MODE_COLLAB = "collab"
-COLLABORATION_MODE_DUEL = "duel"
-UNAFFILIATED_FACTION_SLUG = "na"
-
-
 def compute_faction_multiplier(
     character_faction_slug: str,
     task_faction_slug: str,
     era: EraConfig,
     collaboration_mode: str = COLLABORATION_MODE_SOLO,
-    is_duel_winner: bool = False,
 ) -> float:
-    """Return the point multiplier for a character doing a given task.
+    """Return the faction-based point multiplier for a character doing a given task.
 
-    Selects the appropriate modifier based on:
-    - Whether the task belongs to the character's own faction or another
-    - The collaboration mode (solo, collab, or duel)
-    - For duels, whether the character won or lost
-
+    For duels, duel outcome is captured separately via compute_duel_multiplier — this
+    function returns the own/other task modifier regardless of collaboration mode.
     Unaffiliated ("na") tasks are treated as own-faction (no penalty).
-    Votes are always added flat after the modifier is applied.
+    Votes are always added flat after all multipliers are applied.
     """
     faction_config = era.factions.get(character_faction_slug)
     if faction_config is None:
         return 1.0
-
-    if collaboration_mode == COLLABORATION_MODE_DUEL:
-        if is_duel_winner:
-            return faction_config.duel_win_modifier
-        return faction_config.duel_loss_modifier
 
     is_own_faction = (
         task_faction_slug == character_faction_slug
@@ -57,20 +49,61 @@ def compute_faction_multiplier(
             return faction_config.collab_own_modifier
         return faction_config.collab_other_modifier
 
-    # Solo (default)
+    # Solo and duel: use own/other task modifier (duel outcome applied separately)
     if is_own_faction:
         return faction_config.own_task_modifier
     return faction_config.other_task_modifier
+
+
+def compute_duel_multiplier(
+    character_faction_slug: str,
+    opponent_faction_slug: str,
+    is_winner: bool,
+    is_tied: bool,
+    era: EraConfig,
+) -> float:
+    """Return the duel outcome multiplier for a single participant.
+
+    Tiebreaker rules:
+    - Tie with one Snide player: Snide gets win rate, other gets loss rate.
+    - Tie with no Snide, or both Snide: both get 1.0×.
+    """
+    if not is_tied:
+        faction_config = era.factions.get(character_faction_slug)
+        if faction_config is None:
+            return 1.5 if is_winner else 0.5
+        return faction_config.duel_win_modifier if is_winner else faction_config.duel_loss_modifier
+
+    # Tied case
+    one_is_snide = (character_faction_slug == SNIDE_FACTION_SLUG) != (
+        opponent_faction_slug == SNIDE_FACTION_SLUG
+    )
+    if not one_is_snide:
+        return 1.0
+
+    # One Snide: Snide wins the tie
+    faction_config = era.factions.get(character_faction_slug)
+    if faction_config is None:
+        return 2.0 if character_faction_slug == SNIDE_FACTION_SLUG else 0.5
+    if character_faction_slug == SNIDE_FACTION_SLUG:
+        return faction_config.duel_win_modifier
+    return faction_config.duel_loss_modifier
 
 
 def compute_praxis_score(
     task_point_value: int,
     faction_multiplier: float,
     total_stars: int,
+    meta_task_points: int = 0,
+    duel_multiplier: float = 1.0,
 ) -> float:
-    """Score for a single praxis.
+    """Score for a single praxis or collaboration member.
 
-    Base points are awarded immediately on submission (point_value × multiplier).
-    Each star from community votes adds directly to the score.
+    Formula: (task_point_value + meta_task_points) × faction_multiplier × duel_multiplier + total_stars
+
+    - Base points are awarded on publication.
+    - Each star from community votes adds flat after all multipliers.
+    - meta_task_points: flat bonus from an attached meta task (0 if none).
+    - duel_multiplier: 1.0 for solo/collab; outcome-based for duels.
     """
-    return task_point_value * faction_multiplier + total_stars
+    return (task_point_value + meta_task_points) * faction_multiplier * duel_multiplier + total_stars

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
+from models.collaboration import Collaboration, CollaborationMember, CollaborationMode
 from models.praxis import Praxis
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
@@ -17,6 +18,7 @@ async def cast_or_update_vote(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> Vote:
+    """Cast or update a vote on a solo praxis."""
     if not 1 <= stars <= 5:
         raise HTTPException(status_code=422, detail="Stars must be between 1 and 5.")
 
@@ -54,6 +56,86 @@ async def cast_or_update_vote(
     session.add(vote)
     await session.flush()  # persist vote before recalculating so avg includes it
     await recalculate_character_stats(praxis.character_id, session, era)
+    await session.commit()
+    await session.refresh(vote)
+    return vote
+
+
+async def cast_or_update_duel_vote(
+    voter: Character,
+    collaboration_id: int,
+    target_character_id: int,
+    stars: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Vote:
+    """Cast or update a vote on a specific player in a duel collaboration.
+
+    - Voters must NOT be members of the duel.
+    - target_character_id must be a member of the duel.
+    - A voter may vote for one or both players; each is a separate Vote row.
+    - First cast costs 1 from vote budget; updating an existing vote is free.
+    """
+    if not 1 <= stars <= 5:
+        raise HTTPException(status_code=422, detail="Stars must be between 1 and 5.")
+
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    if collab.mode != CollaborationMode.duel:
+        raise HTTPException(status_code=400, detail="Duel votes can only be cast on duel collaborations.")
+
+    member_ids = {m.character_id for m in collab.members}
+
+    # Anti-self-vote: members cannot vote on their own duel
+    if voter.id in member_ids:
+        raise HTTPException(status_code=403, detail="Duel participants cannot vote on their own duel.")
+
+    # target must be a duel member
+    if target_character_id not in member_ids:
+        raise HTTPException(status_code=400, detail="Target player is not a member of this duel.")
+
+    # Check for existing vote by this voter for this target in this collaboration
+    existing_result = await session.execute(
+        select(Vote).where(
+            Vote.collaboration_id == collaboration_id,
+            Vote.voter_character_id == voter.id,
+            Vote.duel_vote_for == target_character_id,
+        )
+    )
+    existing = existing_result.scalar_one_or_none()
+
+    if existing is not None:
+        # Update is free
+        existing.stars = stars
+        await session.commit()
+        # Recalculate scores for both duel members
+        for member_id in member_ids:
+            await recalculate_character_stats(member_id, session, era)
+        await session.commit()
+        await session.refresh(existing)
+        return existing
+
+    # New vote — deduct from budget
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, voter.id, era_row.id)
+
+    if stats.votes_available <= 0:
+        raise HTTPException(status_code=403, detail="No votes remaining in your budget.")
+
+    vote = Vote(
+        collaboration_id=collaboration_id,
+        voter_character_id=voter.id,
+        voter_account_id=voter.account_id,
+        stars=stars,
+        duel_vote_for=target_character_id,
+    )
+    stats.votes_available -= 1
+    session.add(vote)
+    await session.flush()
+    for member_id in member_ids:
+        await recalculate_character_stats(member_id, session, era)
     await session.commit()
     await session.refresh(vote)
     return vote

--- a/backend/tests/unit/test_faction_config.py
+++ b/backend/tests/unit/test_faction_config.py
@@ -17,8 +17,8 @@ def test_gestalt_collab_modifiers():
 
 def test_snide_duel_modifiers():
     config = ERA_1.factions["snide"]
-    assert config.duel_win_modifier == 1.5
-    assert config.duel_loss_modifier == 0.5
+    assert config.duel_win_modifier == 2.0   # Snide high-risk bonus
+    assert config.duel_loss_modifier == 0.0  # Snide high-risk penalty
 
 
 def test_snide_other_faction_penalty():

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -3,6 +3,7 @@ from services.scoring import (
     COLLABORATION_MODE_COLLAB,
     COLLABORATION_MODE_DUEL,
     COLLABORATION_MODE_SOLO,
+    compute_duel_multiplier,
     compute_faction_multiplier,
     compute_level,
     compute_praxis_score,
@@ -77,6 +78,16 @@ def test_praxis_score_with_multiplier():
     assert compute_praxis_score(task_point_value=10, faction_multiplier=0.8, total_stars=5) == 13.0
 
 
+def test_praxis_score_with_meta_task_points():
+    # (10 + 5) * 1.0 * 1.0 + 3 = 18.0
+    assert compute_praxis_score(task_point_value=10, faction_multiplier=1.0, total_stars=3, meta_task_points=5) == 18.0
+
+
+def test_praxis_score_with_duel_multiplier():
+    # (10 + 0) * 1.0 * 1.5 + 4 = 19.0
+    assert compute_praxis_score(task_point_value=10, faction_multiplier=1.0, total_stars=4, duel_multiplier=1.5) == 19.0
+
+
 # ---------------------------------------------------------------------------
 # Solo mode faction multiplier tests
 # ---------------------------------------------------------------------------
@@ -141,44 +152,60 @@ def test_collab_unaffiliated_task():
 
 
 # ---------------------------------------------------------------------------
-# Duel mode faction multiplier tests
+# Duel multiplier tests (compute_duel_multiplier)
 # ---------------------------------------------------------------------------
 
 
-def test_duel_win():
-    result = compute_faction_multiplier(
-        "snide", "ua", ERA_1,
-        collaboration_mode=COLLABORATION_MODE_DUEL,
-        is_duel_winner=True,
-    )
+def test_duel_win_snide():
+    result = compute_duel_multiplier("snide", "gestalt", is_winner=True, is_tied=False, era=ERA_1)
     assert result == ERA_1.factions["snide"].duel_win_modifier
+    assert result == 2.0
+
+
+def test_duel_loss_snide():
+    result = compute_duel_multiplier("snide", "gestalt", is_winner=False, is_tied=False, era=ERA_1)
+    assert result == ERA_1.factions["snide"].duel_loss_modifier
+    assert result == 0.0
+
+
+def test_duel_win_standard():
+    result = compute_duel_multiplier("gestalt", "snide", is_winner=True, is_tied=False, era=ERA_1)
+    assert result == ERA_1.factions["gestalt"].duel_win_modifier
     assert result == 1.5
 
 
-def test_duel_loss():
-    result = compute_faction_multiplier(
-        "snide", "ua", ERA_1,
-        collaboration_mode=COLLABORATION_MODE_DUEL,
-        is_duel_winner=False,
-    )
-    assert result == ERA_1.factions["snide"].duel_loss_modifier
+def test_duel_loss_standard():
+    result = compute_duel_multiplier("gestalt", "snide", is_winner=False, is_tied=False, era=ERA_1)
+    assert result == ERA_1.factions["gestalt"].duel_loss_modifier
     assert result == 0.5
 
 
-def test_duel_non_snide_faction():
-    # Non-duel-specialist factions get 1.0 on both win and loss
-    result_win = compute_faction_multiplier(
-        "gestalt", "ua", ERA_1,
-        collaboration_mode=COLLABORATION_MODE_DUEL,
-        is_duel_winner=True,
-    )
-    result_loss = compute_faction_multiplier(
-        "gestalt", "ua", ERA_1,
-        collaboration_mode=COLLABORATION_MODE_DUEL,
-        is_duel_winner=False,
-    )
-    assert result_win == 1.0
-    assert result_loss == 1.0
+def test_duel_tie_no_snide():
+    # No Snide involved → both get 1.0
+    result_a = compute_duel_multiplier("gestalt", "journeymen", is_winner=False, is_tied=True, era=ERA_1)
+    result_b = compute_duel_multiplier("journeymen", "gestalt", is_winner=False, is_tied=True, era=ERA_1)
+    assert result_a == 1.0
+    assert result_b == 1.0
+
+
+def test_duel_tie_one_snide_snide_wins():
+    # Tie with one Snide: Snide gets win rate (2.0), other gets loss rate (0.5)
+    snide_result = compute_duel_multiplier("snide", "gestalt", is_winner=False, is_tied=True, era=ERA_1)
+    other_result = compute_duel_multiplier("gestalt", "snide", is_winner=False, is_tied=True, era=ERA_1)
+    assert snide_result == ERA_1.factions["snide"].duel_win_modifier
+    assert other_result == ERA_1.factions["gestalt"].duel_loss_modifier
+
+
+def test_duel_tie_both_snide():
+    # Both Snide → both get 1.0 (not one-is-snide rule)
+    result = compute_duel_multiplier("snide", "snide", is_winner=False, is_tied=True, era=ERA_1)
+    assert result == 1.0
+
+
+def test_duel_faction_multiplier_ignores_duel_mode():
+    # compute_faction_multiplier with duel context uses own/other task logic (not duel win/loss)
+    result = compute_faction_multiplier("gestalt", "gestalt", ERA_1)
+    assert result == ERA_1.factions["gestalt"].own_task_modifier
 
 
 # ---------------------------------------------------------------------------

--- a/docs/BUILD_STATE.md
+++ b/docs/BUILD_STATE.md
@@ -1,7 +1,7 @@
 # World Zero — Build State
 
-> Last updated: 2026-04-13
-> Updated by: Claude Code — Backend Gaps session complete
+> Last updated: 2026-04-15
+> Updated by: Claude Code — Collaboration & Duel feature complete
 
 This file is the source of truth for what has been built, what is in progress, and what hasn't been started yet. Claude Code agents should read this before beginning any session and update it when tasks are complete.
 
@@ -145,6 +145,35 @@ All migrations use `create_type=False` on `sa.Enum()` in `add_column`/`create_ta
 - `frontend/src/api/taunts.ts` — Taunts API client ✅ 2026-04-14
 - NavBar links verified (Tasks, Praxis /submissions, Players /leaderboard, Groups, Updates) ✅
 - Dev server running on port 5173 (`npm run dev`) ✅
+- **Collaboration & Duel feature ✅ 2026-04-15**
+  - `backend/models/collaboration.py` — Collaboration, CollaborationMember, CollaborationInvite models ✅
+  - `backend/models/praxis.py` — Removed legacy partner/invite collab fields ✅
+  - `backend/models/vote.py` — praxis_id nullable, collaboration_id FK added, uq_vote_solo + uq_vote_duel constraints ✅
+  - `backend/alembic/versions/0005_collaboration_and_duel.py` — Migration ✅
+  - `backend/schemas/collaboration.py` — All collab/duel schemas ✅
+  - `backend/schemas/praxis.py` — Removed legacy collab fields ✅
+  - `backend/schemas/vote.py` — VoteOut updated for duel votes ✅
+  - `backend/services/collaboration.py` — Full business logic (create, invite, respond, submit, reopen, kick, document, vote summary) ✅
+  - `backend/services/scoring.py` — compute_duel_multiplier, meta_task_points in compute_praxis_score ✅
+  - `backend/services/character_stats.py` — Scores both solo praxes and published collaborations/duels ✅
+  - `backend/services/vote.py` — cast_or_update_duel_vote ✅
+  - `backend/services/praxis.py` — Removed accept_invite/decline_invite ✅
+  - `backend/services/activity_feed.py` — Updated to use CollaborationInvite ✅
+  - `backend/routers/collaborations.py` — 10 endpoints ✅
+  - `backend/routers/praxes.py` — Removed legacy invite routes ✅
+  - `backend/routers/tasks.py` — Added POST /tasks/{id}/drop ✅
+  - `backend/main.py` — Collaboration router registered ✅
+  - `backend/eras/era_1.py` — Snide duel 2.0/0.0; standard factions 1.5/0.5; ua_masters 0.8/0.8 ✅
+  - `frontend/src/api/collaborations.ts` — Full collaboration API client ✅
+  - `frontend/src/api/votes.ts` — VoteOut updated for nullable praxis_id + collaboration fields ✅
+  - `frontend/src/api/praxis.ts` — Removed legacy collab fields and invite functions ✅
+  - `frontend/src/pages/CollaborationDetail.tsx` — Shared document, members, submit controls, duel vote widget ✅
+  - `frontend/src/pages/SubmitProof.tsx` — Collab/duel mode creates Collaboration and redirects ✅
+  - `frontend/src/components/feed/FeedCardCollabInvite.tsx` — Uses new collaboration API + task-list-full modal ✅
+  - `frontend/src/components/feed/FeedCardDuelChallenge.tsx` — Uses new collaboration API + task-list-full modal ✅
+  - `frontend/src/App.tsx` — /collaborations/:id route added ✅
+  - Spec files updated (SPEC-backend-architecture.md, SPEC-deployment.md, SPEC-game-rules.md, SPEC-data-models.md, SPEC-api.md) ✅
+  - 105 unit tests passing ✅
 
 Seed data:
 - `backend/seed.py` — 9 factions, 8 accounts/characters, 14 tasks, 24 submissions, ~101 votes ✅

--- a/docs/spec/SPEC-api.md
+++ b/docs/spec/SPEC-api.md
@@ -62,6 +62,29 @@ GET  /submissions/{id}/votes   → VoteSummary { total_votes, average_stars, tot
 GET  /submissions/{id}/voters  → list[VoterDetail]
 ```
 
+### Collaborations (`/collaborations`)
+```
+POST /collaborations                                       → CollaborationCreate { task_id, mode } → CollaborationOut — auth required
+GET  /collaborations/{id}                                  → CollaborationOut (members, document, invite list for members)
+POST /collaborations/{id}/document                         → { body_text } → CollaborationOut (any member)
+POST /collaborations/{id}/invite                           → CollaborationInviteCreate { invitee_character_id } → CollaborationInviteOut (any member)
+POST /collaborations/{id}/invites/{invite_id}/respond      → InviteResponse { accept, drop_task_id? } → CollaborationOut (invitee only)
+POST /collaborations/{id}/submit                           → CollaborationOut (any member; marks caller as submitted)
+POST /collaborations/{id}/edit                             → CollaborationOut (any member; resets all submit states, status → in_progress)
+POST /collaborations/{id}/kick/{character_id}              → CollaborationOut (any member; removes target member)
+GET  /collaborations/{id}/votes                            → list[DuelVoteSummary] (duel only)
+POST /collaborations/{id}/vote                             → CollaborationVoteIn { target_character_id, stars: 1-5 } → VoteOut (duel only; non-members only)
+```
+*Creating a collaboration requires the character to have the task in-progress.*
+*Collaborations require level ≥ 1; duels require level ≥ 2.*
+*Task-list-full (20 tasks): respond with drop_task_id to drop a task and accept in one request.*
+
+### Task Drop (`/tasks`)
+```
+POST /tasks/{id}/drop          → drop an in-progress task to free a slot — auth required
+```
+*(Alias for DELETE /tasks/{id}/signup; added for the invite-accept task-list-full flow.)*
+
 ### Relationships (`/relationships`)
 ```
 GET    /relationships          → list[RelationshipListItem] (query: type, status) — auth required
@@ -175,12 +198,35 @@ level, score, all_time_score,  ← from CharacterStats join
 faction_slug, status, created_at
 ```
 
-### SubmissionOut
+### PraxisOut (solo submissions)
 ```
 id, task_id, character_id, character_display_name, task_title, task_point_value,
 title, body_text, moderation_status, is_withdrawn, admin_note,
-collaboration_mode, partner_character_id, partner_display_name,
 created_at, updated_at, media: list[MediaItemOut], score
+```
+
+### CollaborationOut
+```
+id, task_id, task_title, task_point_value, mode, status, body_text,
+created_by_id, created_at, updated_at,
+members: list[CollaborationMemberOut],
+invites: list[CollaborationInviteOut]  ← only included for members
+```
+
+### CollaborationMemberOut
+```
+character_id, display_name, faction_slug, has_submitted, joined_at
+```
+
+### CollaborationInviteOut
+```
+id, collaboration_id, inviter_id, inviter_display_name,
+invitee_id, invitee_display_name, type, status, created_at
+```
+
+### DuelVoteSummary
+```
+character_id, display_name, total_stars, is_winning
 ```
 
 ### TaskOut

--- a/docs/spec/SPEC-backend-architecture.md
+++ b/docs/spec/SPEC-backend-architecture.md
@@ -218,15 +218,14 @@ Do not "fix" them — they are deliberately parked until v2. See
 
 | Feature | What exists | What's missing |
 |---|---|---|
-| MetaTask scoring | `models/meta_task.py`, `SubmissionMetaTask` schema | No service applies meta-task bonuses. |
-| Duel resolution | `Vote.duel_vote_for` column, `FactionConfig.duel_win_modifier`/`duel_loss_modifier`, `CollaborationMode.duel` | No service decides the duel winner or awards points. |
 | Multi-faction tasks | `TaskFaction` junction table | Unused. `Task.primary_faction_slug` is the only faction link in live code. |
 | Task Vision (Journeymen) | `Task.is_task_vision_eligible` column | No service exposes retired tasks to Journeymen. |
 | Double Dipper (Analog) | `models/analog_double_dipper.py` | No service tracks per-level task repeats. |
 
-**Already implemented — do not confuse with the above:** faction multipliers
-*are* applied by `services/character_stats.py::recalculate_character_stats`
-via `compute_faction_multiplier`. Only the exotic cases above are deferred.
+**Already implemented — do not confuse with the above:** faction multipliers, MetaTask scoring,
+Collaboration, and Duel resolution are *all* live. `services/scoring.py::compute_praxis_score`
+applies meta-task bonuses and duel multipliers. `services/collaboration.py` handles the full
+collab/duel lifecycle. Only the exotic cases in the table above remain deferred.
 
 ---
 

--- a/docs/spec/SPEC-data-models.md
+++ b/docs/spec/SPEC-data-models.md
@@ -121,7 +121,7 @@ updated_at
 ```
 *Active rows capped at `EraConfig.max_task_signups` per character, enforced at API layer.*
 
-### Submission (aka "Praxis")
+### Praxis (solo submissions only)
 ```
 id
 task_id              -- FK -> Task
@@ -132,12 +132,46 @@ moderation_status    -- enum: visible | flagged | hidden | failed (ModerationSta
 is_withdrawn         -- bool, default false
 admin_note           -- text, nullable (for failed/hidden submissions)
 flagged_at           -- nullable; NULL means "not yet flagged"
-collaboration_mode   -- enum: solo | collab | duel (CollaborationMode), default solo
-partner_character_id -- FK -> Character, nullable (for collab/duel)
 created_at
 updated_at
 ```
 *Score is computed on-the-fly from votes; not stored in v1.*
+*Collaboration and duel submissions use the Collaboration model instead — see below.*
+
+### Collaboration
+```
+id
+task_id              -- FK -> Task
+mode                 -- enum: collaboration | duel (CollaborationMode)
+status               -- enum: in_progress | published (CollaborationStatus)
+body_text            -- shared document; all members edit this (default "")
+created_by_id        -- FK -> Character (the player who initiated)
+created_at
+updated_at
+```
+*Score per member computed on-the-fly when status = published.*
+
+### CollaborationMember
+```
+id
+collaboration_id     -- FK -> Collaboration
+character_id         -- FK -> Character
+has_submitted        -- bool; whether this member has pressed Submit (resets on edit or kick)
+joined_at
+CONSTRAINT: unique(collaboration_id, character_id)
+```
+
+### CollaborationInvite
+```
+id
+collaboration_id     -- FK -> Collaboration
+inviter_id           -- FK -> Character
+invitee_id           -- FK -> Character
+type                 -- enum: collaboration | duel (mirrors Collaboration.mode)
+status               -- enum: pending | accepted | declined (CollaborationInviteStatus)
+created_at
+```
+*Only one pending invite per (collaboration_id, inviter_id, invitee_id) is allowed — enforced at service layer.*
 
 ### MediaItem
 ```
@@ -152,15 +186,19 @@ created_at
 ### Vote
 ```
 id
-submission_id        -- FK -> Submission
+praxis_id            -- FK -> Praxis (nullable; NULL for duel votes)
+collaboration_id     -- FK -> Collaboration (nullable; set only for duel votes)
 voter_character_id   -- FK -> Character
 voter_account_id     -- FK -> Account (denormalized for anti-self-vote check)
 stars                -- integer 1-5
-duel_vote_for        -- FK -> Character (nullable; Duels only)
+duel_vote_for        -- FK -> Character (nullable; Duels only — which player this vote is for)
 created_at
 updated_at           -- votes can be updated; update costs 0 additional budget
-CONSTRAINT: unique(submission_id, voter_character_id)
+CONSTRAINT: unique(praxis_id, voter_character_id)  -- solo votes
+CONSTRAINT: unique(collaboration_id, voter_character_id, duel_vote_for)  -- duel votes
 ```
+*Exactly one of praxis_id or collaboration_id must be set. For duel votes, duel_vote_for is required.*
+*Anti-self-vote: duel members cannot vote on their own collaboration.*
 
 ### Flag
 ```
@@ -260,8 +298,10 @@ created_at
 | TaskStatus | pending, active, retired | Task.status |
 | CharacterTaskStatus | in_progress, submitted, abandoned | CharacterTask.status |
 | MediaType | image, video, audio | MediaItem.type |
-| CollaborationMode | solo, collab, duel | Submission.collaboration_mode |
-| ModerationStatus | visible, flagged, hidden, failed | Submission.moderation_status |
+| CollaborationMode | collaboration, duel | Collaboration.mode |
+| CollaborationStatus | in_progress, published | Collaboration.status |
+| CollaborationInviteStatus | pending, accepted, declined | CollaborationInvite.status |
+| ModerationStatus | visible, flagged, hidden, failed | Praxis.moderation_status |
 | RelationshipType | friend, foe | Relationship.type |
 | RelationshipStatus | active, blocked | Relationship.status |
 | BonusType | flat, percentage | MetaTask.bonus_type |

--- a/docs/spec/SPEC-deployment.md
+++ b/docs/spec/SPEC-deployment.md
@@ -36,8 +36,6 @@
 
 ## 17. Out of Scope (v1)
 
-- Meta tasks (DB schema included; UI and enforcement deferred)
-- Duels (Vote.duel_vote_for column present; full flow deferred)
 - Faction multiplier enforcement (FactionConfig values present; application deferred)
 - Task Vision (Journeymen), Double Dipper (Analog)
 - Cloud media storage

--- a/docs/spec/SPEC-game-rules.md
+++ b/docs/spec/SPEC-game-rules.md
@@ -6,14 +6,24 @@ All formulas are driven by `CURRENT_ERA` (or a passed `EraConfig` in tests).
 
 ### Praxis Score (computed on-the-fly)
 ```
-praxis_score = task.point_value × faction_multiplier + total_stars
+praxis_score = (task.point_value + meta_task_points) × faction_multiplier × duel_multiplier + total_stars
 ```
-- `faction_multiplier` — determined by the character's faction relative to the task's faction,
-  the collaboration mode (solo/collab/duel), and duel outcome. See `scoring.py::compute_faction_multiplier`.
+- `meta_task_points` — flat bonus from any attached meta task (0 if none). Applied per-member for
+  collaborations and duels. See `services/scoring.py::compute_meta_task_points`.
+- `faction_multiplier` — determined by the character's faction relative to the task's faction and
+  the collaboration mode (solo/collab). See `scoring.py::compute_faction_multiplier`. For duels,
+  always 1.0 — the duel outcome is captured separately in `duel_multiplier`.
+- `duel_multiplier` — 1.0 for solo and collaboration; outcome-based for duels. See
+  `scoring.py::compute_duel_multiplier`. Win/loss/tie rates are per the Duel Multipliers table:
+  standard Win 1.5×, Loss 0.5×; Snide Win 2.0×, Loss 0.0×; tie with one Snide: Snide wins (2.0×/0.5×);
+  tie with no Snide or both Snide: both 1.0×.
 - `total_stars` — the **sum** of raw star ratings across all votes on this praxis (not an average).
   Each star adds flat to the score regardless of the number of voters.
-- Base points (`task.point_value × faction_multiplier`) are awarded immediately on praxis creation,
-  not deferred until voting. Stars accumulate as votes arrive.
+- Base points are awarded on **publication**: solo praxes publish on creation; collab/duel publish
+  when all current members have submitted. Stars accumulate as votes arrive.
+
+Each participant in a collaboration or duel has this formula applied **individually**, using their
+own `faction_multiplier` and (for duels) their own `duel_multiplier`.
 
 ### Character Score
 ```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import ProposeTask from './pages/ProposeTask'
 import Disclaimer from './pages/Disclaimer'
 import Attributions from './pages/Attributions'
 import Donate from './pages/Donate'
+import CollaborationDetail from './pages/CollaborationDetail'
 
 export default function App() {
   return (
@@ -37,6 +38,7 @@ export default function App() {
             </ProtectedRoute>
           }
         />
+        <Route path="/collaborations/:id" element={<CollaborationDetail />} />
         <Route path="/praxes" element={<Praxes />} />
         <Route path="/praxes/:id" element={<PraxisDetail />} />
         <Route

--- a/frontend/src/api/collaborations.ts
+++ b/frontend/src/api/collaborations.ts
@@ -1,0 +1,124 @@
+import api from './axios'
+
+export type CollaborationMode = 'collaboration' | 'duel'
+export type CollaborationStatus = 'in_progress' | 'published'
+export type CollaborationInviteStatus = 'pending' | 'accepted' | 'declined'
+
+export interface CollaborationMemberOut {
+  character_id: number
+  display_name: string
+  faction_slug: string | null
+  avatar_url: string | null
+  has_submitted: boolean
+  joined_at: string
+}
+
+export interface CollaborationInviteOut {
+  id: number
+  collaboration_id: number
+  inviter_id: number
+  inviter_display_name: string
+  invitee_id: number
+  invitee_display_name: string
+  type: CollaborationMode
+  status: CollaborationInviteStatus
+  created_at: string
+}
+
+export interface CollaborationOut {
+  id: number
+  task_id: number
+  task_title: string
+  mode: CollaborationMode
+  status: CollaborationStatus
+  body_text: string | null
+  members: CollaborationMemberOut[]
+  invites: CollaborationInviteOut[] | null
+  created_by_id: number
+  created_at: string
+  updated_at: string
+}
+
+export interface DuelVoteSummary {
+  character_id: number
+  display_name: string
+  faction_slug: string | null
+  total_stars: number
+  vote_count: number
+  is_winning: boolean
+}
+
+export async function createCollaboration(
+  task_id: number,
+  mode: CollaborationMode,
+): Promise<CollaborationOut> {
+  const { data } = await api.post<CollaborationOut>('/collaborations', { task_id, mode })
+  return data
+}
+
+export async function getCollaboration(id: number): Promise<CollaborationOut> {
+  const { data } = await api.get<CollaborationOut>(`/collaborations/${id}`)
+  return data
+}
+
+export async function updateDocument(id: number, body_text: string): Promise<CollaborationOut> {
+  const { data } = await api.post<CollaborationOut>(`/collaborations/${id}/document`, { body_text })
+  return data
+}
+
+export async function inviteMember(
+  collaboration_id: number,
+  invitee_character_id: number,
+): Promise<CollaborationInviteOut> {
+  const { data } = await api.post<CollaborationInviteOut>(
+    `/collaborations/${collaboration_id}/invite`,
+    { invitee_character_id },
+  )
+  return data
+}
+
+export async function respondToInvite(
+  collaboration_id: number,
+  invite_id: number,
+  accept: boolean,
+  drop_task_id?: number,
+): Promise<CollaborationOut> {
+  const { data } = await api.post<CollaborationOut>(
+    `/collaborations/${collaboration_id}/invites/${invite_id}/respond`,
+    { accept, drop_task_id: drop_task_id ?? null },
+  )
+  return data
+}
+
+export async function submitForMember(collaboration_id: number): Promise<CollaborationOut> {
+  const { data } = await api.post<CollaborationOut>(`/collaborations/${collaboration_id}/submit`)
+  return data
+}
+
+export async function reopenCollaboration(collaboration_id: number): Promise<CollaborationOut> {
+  const { data } = await api.post<CollaborationOut>(`/collaborations/${collaboration_id}/edit`)
+  return data
+}
+
+export async function kickMember(
+  collaboration_id: number,
+  target_character_id: number,
+): Promise<CollaborationOut> {
+  const { data } = await api.post<CollaborationOut>(
+    `/collaborations/${collaboration_id}/kick/${target_character_id}`,
+  )
+  return data
+}
+
+export async function getDuelVoteSummary(collaboration_id: number): Promise<DuelVoteSummary[]> {
+  const { data } = await api.get<DuelVoteSummary[]>(`/collaborations/${collaboration_id}/votes`)
+  return data
+}
+
+export async function castDuelVote(
+  collaboration_id: number,
+  target_character_id: number,
+  stars: number,
+): Promise<void> {
+  await api.post(`/collaborations/${collaboration_id}/vote`, { target_character_id, stars })
+}

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -30,8 +30,6 @@ export interface PraxisCreate {
   task_id: number
   title: string
   body_text?: string
-  collaboration_mode?: string
-  partner_character_id?: number
 }
 
 export async function listPraxes(params?: { task_id?: number; character_id?: number }): Promise<PraxisOut[]> {
@@ -80,12 +78,3 @@ export async function resubmitPraxis(praxisId: number): Promise<PraxisOut> {
   return data
 }
 
-export async function acceptInvite(praxisId: number): Promise<PraxisOut> {
-  const { data } = await api.post<PraxisOut>(`/praxes/${praxisId}/accept-invite`)
-  return data
-}
-
-export async function declineInvite(praxisId: number): Promise<PraxisOut> {
-  const { data } = await api.post<PraxisOut>(`/praxes/${praxisId}/decline-invite`)
-  return data
-}

--- a/frontend/src/api/votes.ts
+++ b/frontend/src/api/votes.ts
@@ -2,7 +2,9 @@ import api from './axios'
 
 export interface VoteOut {
   id: number
-  praxis_id: number
+  praxis_id: number | null
+  collaboration_id: number | null
+  duel_vote_for: number | null
   voter_character_id: number
   stars: number
   created_at: string

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { acceptInvite, declineInvite } from '../../api/praxis'
+import { respondToInvite } from '../../api/collaborations'
+import { getMyTasks } from '../../api/tasks'
 import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
@@ -12,28 +13,46 @@ interface Props {
 
 export default function FeedCardCollabInvite({ item }: Props) {
   const {
-    praxis_id, task_title, task_point_value, task_faction_slug,
+    invite_id, collaboration_id, task_title, task_point_value, task_faction_slug,
     task_level_required, invite_status, inviter_character_id,
   } = item.payload
   const taskColor = factionColor(task_faction_slug)
   const actorColor = factionColor(item.actor_faction_slug)
+  const navigate = useNavigate()
 
   const [status, setStatus] = useState<string | null>(invite_status)
   const [loading, setLoading] = useState(false)
+  // Task-list-full modal state
+  const [showDropModal, setShowDropModal] = useState(false)
+  const [myTasks, setMyTasks] = useState<{ id: number; task: { id: number; title: string } }[]>([])
+  const [dropError, setDropError] = useState('')
 
-  const handleAccept = async () => {
+  const doAccept = async (drop_task_id?: number) => {
     setLoading(true)
     try {
-      await acceptInvite(praxis_id)
+      await respondToInvite(collaboration_id, invite_id, true, drop_task_id)
       setStatus('accepted')
-    } catch { /* swallow */ }
+      setShowDropModal(false)
+      navigate(`/collaborations/${collaboration_id}`)
+    } catch (err: any) {
+      if (err?.response?.status === 409) {
+        // Task list full — load tasks and show modal
+        const tasks = await getMyTasks('in_progress')
+        setMyTasks(tasks as any)
+        setShowDropModal(true)
+      } else {
+        setDropError('Could not accept invite. Please try again.')
+      }
+    }
     setLoading(false)
   }
+
+  const handleAccept = () => doAccept()
 
   const handleDecline = async () => {
     setLoading(true)
     try {
-      await declineInvite(praxis_id)
+      await respondToInvite(collaboration_id, invite_id, false)
       setStatus('declined')
     } catch { /* swallow */ }
     setLoading(false)
@@ -42,109 +61,175 @@ export default function FeedCardCollabInvite({ item }: Props) {
   const isPending = status === 'pending' || status === null
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
-      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
-        <Link to={`/characters/${inviter_character_id}`}>
+    <>
+      <div className="sidebar-card" style={{ padding: '12px 16px', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+          <Link to={`/characters/${inviter_character_id}`}>
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+                flexShrink: 0,
+                marginTop: 2,
+              }}
+            />
+          </Link>
+
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+              <Link
+                to={`/characters/${inviter_character_id}`}
+                className="font-body"
+                style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+              >
+                {item.actor_display_name}
+              </Link>
+              <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+                invited you to collaborate
+              </span>
+              <FeedBadge type="your_stuff" label="Your Stuff" />
+            </div>
+            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+              {relativeTime(item.timestamp)}
+            </span>
+          </div>
+        </div>
+
+        {/* Task detail */}
+        <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
+          <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+            {task_title}
+          </span>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+            {task_point_value} pts · lvl {task_level_required}+
+          </span>
+          <FeedBadge type="collab" label="Collab" />
+        </div>
+
+        {/* Accept/Decline buttons */}
+        {isPending && (
+          <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <button
+              onClick={handleAccept}
+              disabled={loading}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                background: '#14532d',
+                color: '#fff',
+                border: 'none',
+                padding: '5px 14px',
+                cursor: loading ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Accept
+            </button>
+            <button
+              onClick={handleDecline}
+              disabled={loading}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                background: 'transparent',
+                color: 'var(--color-text-secondary)',
+                border: '1px solid var(--color-border)',
+                padding: '5px 14px',
+                cursor: loading ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Decline
+            </button>
+            {dropError && (
+              <span className="eyebrow" style={{ color: '#dc2626' }}>{dropError}</span>
+            )}
+          </div>
+        )}
+
+        {status === 'accepted' && (
+          <div style={{ marginTop: 8, marginLeft: 38 }}>
+            <Link to={`/collaborations/${collaboration_id}`} className="eyebrow" style={{ color: '#14532d', textDecoration: 'none' }}>
+              Accepted — view collaboration
+            </Link>
+          </div>
+        )}
+        {status === 'declined' && (
+          <div style={{ marginTop: 8, marginLeft: 38 }}>
+            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Declined</span>
+          </div>
+        )}
+      </div>
+
+      {/* Task-list-full modal */}
+      {showDropModal && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 1000,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: 20,
+          }}
+          onClick={() => setShowDropModal(false)}
+        >
           <div
             style={{
-              width: 28,
-              height: 28,
-              borderRadius: '50%',
-              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
-              flexShrink: 0,
-              marginTop: 2,
-            }}
-          />
-        </Link>
-
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
-            <Link
-              to={`/characters/${inviter_character_id}`}
-              className="font-body"
-              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-            >
-              {item.actor_display_name}
-            </Link>
-            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
-              invited you to collaborate
-            </span>
-            <FeedBadge type="your_stuff" label="Your Stuff" />
-          </div>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
-            {relativeTime(item.timestamp)}
-          </span>
-        </div>
-      </div>
-
-      {/* Task detail */}
-      <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
-        <Link
-          to={`/tasks/${praxis_id}`}
-          className="font-body"
-          style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-        >
-          {task_title}
-        </Link>
-        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-          {task_point_value} pts · lvl {task_level_required}+
-        </span>
-        <FeedBadge type="collab" label="Collab" />
-      </div>
-
-      {/* Accept/Decline buttons */}
-      {isPending && (
-        <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={handleAccept}
-            disabled={loading}
-            style={{
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 9,
-              fontWeight: 700,
-              textTransform: 'uppercase',
-              letterSpacing: '0.1em',
-              background: '#14532d',
-              color: '#fff',
-              border: 'none',
-              padding: '5px 14px',
-              cursor: loading ? 'not-allowed' : 'pointer',
-            }}
-          >
-            Accept
-          </button>
-          <button
-            onClick={handleDecline}
-            disabled={loading}
-            style={{
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 9,
-              fontWeight: 700,
-              textTransform: 'uppercase',
-              letterSpacing: '0.1em',
-              background: 'transparent',
-              color: 'var(--color-text-secondary)',
+              background: 'var(--color-bg-surface)',
               border: '1px solid var(--color-border)',
-              padding: '5px 14px',
-              cursor: loading ? 'not-allowed' : 'pointer',
+              padding: '24px',
+              maxWidth: 420,
+              width: '100%',
             }}
+            onClick={(e) => e.stopPropagation()}
           >
-            Decline
-          </button>
+            <p className="eyebrow" style={{ marginBottom: 8 }}>Task list full</p>
+            <p className="font-body" style={{ fontSize: 11, marginBottom: 16, color: 'var(--color-text-secondary)' }}>
+              You have 20 in-progress tasks. Drop one to accept this invite:
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 260, overflowY: 'auto' }}>
+              {myTasks.map((ct: any) => (
+                <button
+                  key={ct.id}
+                  onClick={() => doAccept(ct.task.id)}
+                  disabled={loading}
+                  style={{
+                    background: 'var(--color-bg-surface-alt)',
+                    border: '1px solid var(--color-border)',
+                    padding: '8px 12px',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: "'Courier Prime', monospace",
+                    fontSize: 10,
+                    color: 'var(--color-text-primary)',
+                  }}
+                >
+                  Drop: {ct.task.title}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setShowDropModal(false)}
+              style={{
+                marginTop: 14,
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                background: 'transparent', border: '1px solid var(--color-border)',
+                padding: '5px 14px', cursor: 'pointer',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       )}
-
-      {status === 'accepted' && (
-        <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <span className="eyebrow" style={{ color: '#14532d' }}>Accepted</span>
-        </div>
-      )}
-      {status === 'declined' && (
-        <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Declined</span>
-        </div>
-      )}
-    </div>
+    </>
   )
 }

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { acceptInvite, declineInvite } from '../../api/praxis'
+import { respondToInvite } from '../../api/collaborations'
+import { getMyTasks } from '../../api/tasks'
 import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
@@ -12,28 +13,45 @@ interface Props {
 
 export default function FeedCardDuelChallenge({ item }: Props) {
   const {
-    praxis_id, task_title, task_point_value, task_faction_slug,
+    invite_id, collaboration_id, task_title, task_point_value, task_faction_slug,
     invite_status, challenger_character_id,
   } = item.payload
   const taskColor = factionColor(task_faction_slug)
   const actorColor = factionColor(item.actor_faction_slug)
+  const navigate = useNavigate()
 
   const [status, setStatus] = useState<string | null>(invite_status)
   const [loading, setLoading] = useState(false)
+  // Task-list-full modal state
+  const [showDropModal, setShowDropModal] = useState(false)
+  const [myTasks, setMyTasks] = useState<{ id: number; task: { id: number; title: string } }[]>([])
+  const [dropError, setDropError] = useState('')
 
-  const handleAccept = async () => {
+  const doAccept = async (drop_task_id?: number) => {
     setLoading(true)
     try {
-      await acceptInvite(praxis_id)
+      await respondToInvite(collaboration_id, invite_id, true, drop_task_id)
       setStatus('accepted')
-    } catch { /* swallow */ }
+      setShowDropModal(false)
+      navigate(`/collaborations/${collaboration_id}`)
+    } catch (err: any) {
+      if (err?.response?.status === 409) {
+        const tasks = await getMyTasks('in_progress')
+        setMyTasks(tasks as any)
+        setShowDropModal(true)
+      } else {
+        setDropError('Could not accept duel. Please try again.')
+      }
+    }
     setLoading(false)
   }
+
+  const handleAccept = () => doAccept()
 
   const handleDecline = async () => {
     setLoading(true)
     try {
-      await declineInvite(praxis_id)
+      await respondToInvite(collaboration_id, invite_id, false)
       setStatus('declined')
     } catch { /* swallow */ }
     setLoading(false)
@@ -42,112 +60,182 @@ export default function FeedCardDuelChallenge({ item }: Props) {
   const isPending = status === 'pending' || status === null
 
   return (
-    <div
-      className="sidebar-card"
-      style={{
-        padding: '12px 16px',
-        borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}`,
-        background: factionCssVar(task_faction_slug, 'card-bg'),
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
-        <Link to={`/characters/${challenger_character_id}`}>
+    <>
+      <div
+        className="sidebar-card"
+        style={{
+          padding: '12px 16px',
+          borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}`,
+          background: factionCssVar(task_faction_slug, 'card-bg'),
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+          <Link to={`/characters/${challenger_character_id}`}>
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+                flexShrink: 0,
+                marginTop: 2,
+              }}
+            />
+          </Link>
+
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+              <Link
+                to={`/characters/${challenger_character_id}`}
+                className="font-body"
+                style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+              >
+                {item.actor_display_name}
+              </Link>
+              <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+                has challenged you to a duel
+              </span>
+              <FeedBadge type="duel" label="Duel" />
+            </div>
+            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+              {relativeTime(item.timestamp)}
+            </span>
+          </div>
+        </div>
+
+        {/* Task detail */}
+        <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
+          <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+            {task_title}
+          </span>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+            {task_point_value} pts · winner takes the points
+          </span>
+          <span style={{ fontSize: 12 }}>&#x2694;</span>
+        </div>
+
+        {/* Accept/Decline buttons */}
+        {isPending && (
+          <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <button
+              onClick={handleAccept}
+              disabled={loading}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                background: '#dc2626',
+                color: '#fff',
+                border: 'none',
+                padding: '5px 14px',
+                cursor: loading ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Accept Duel
+            </button>
+            <button
+              onClick={handleDecline}
+              disabled={loading}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                background: 'transparent',
+                color: 'var(--color-text-secondary)',
+                border: '1px solid var(--color-border)',
+                padding: '5px 14px',
+                cursor: loading ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Decline
+            </button>
+            {dropError && (
+              <span className="eyebrow" style={{ color: '#dc2626' }}>{dropError}</span>
+            )}
+          </div>
+        )}
+
+        {status === 'accepted' && (
+          <div style={{ marginTop: 8, marginLeft: 38 }}>
+            <Link to={`/collaborations/${collaboration_id}`} className="eyebrow" style={{ color: '#dc2626', textDecoration: 'none' }}>
+              Duel Accepted — view duel
+            </Link>
+          </div>
+        )}
+        {status === 'declined' && (
+          <div style={{ marginTop: 8, marginLeft: 38 }}>
+            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Declined</span>
+          </div>
+        )}
+      </div>
+
+      {/* Task-list-full modal */}
+      {showDropModal && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 1000,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: 20,
+          }}
+          onClick={() => setShowDropModal(false)}
+        >
           <div
             style={{
-              width: 28,
-              height: 28,
-              borderRadius: '50%',
-              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
-              flexShrink: 0,
-              marginTop: 2,
-            }}
-          />
-        </Link>
-
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
-            <Link
-              to={`/characters/${challenger_character_id}`}
-              className="font-body"
-              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-            >
-              {item.actor_display_name}
-            </Link>
-            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
-              has challenged you to a duel
-            </span>
-            <FeedBadge type="duel" label="Duel" />
-          </div>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
-            {relativeTime(item.timestamp)}
-          </span>
-        </div>
-      </div>
-
-      {/* Task detail */}
-      <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
-        <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
-          {task_title}
-        </span>
-        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-          {task_point_value} pts · winner takes all
-        </span>
-        <span style={{ fontSize: 12 }}>&#x1F525;</span>
-      </div>
-
-      {/* Accept/Decline buttons */}
-      {isPending && (
-        <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={handleAccept}
-            disabled={loading}
-            style={{
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 9,
-              fontWeight: 700,
-              textTransform: 'uppercase',
-              letterSpacing: '0.1em',
-              background: '#dc2626',
-              color: '#fff',
-              border: 'none',
-              padding: '5px 14px',
-              cursor: loading ? 'not-allowed' : 'pointer',
-            }}
-          >
-            Accept Duel
-          </button>
-          <button
-            onClick={handleDecline}
-            disabled={loading}
-            style={{
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 9,
-              fontWeight: 700,
-              textTransform: 'uppercase',
-              letterSpacing: '0.1em',
-              background: 'transparent',
-              color: 'var(--color-text-secondary)',
+              background: 'var(--color-bg-surface)',
               border: '1px solid var(--color-border)',
-              padding: '5px 14px',
-              cursor: loading ? 'not-allowed' : 'pointer',
+              padding: '24px',
+              maxWidth: 420,
+              width: '100%',
             }}
+            onClick={(e) => e.stopPropagation()}
           >
-            Decline
-          </button>
+            <p className="eyebrow" style={{ marginBottom: 8 }}>Task list full</p>
+            <p className="font-body" style={{ fontSize: 11, marginBottom: 16, color: 'var(--color-text-secondary)' }}>
+              You have 20 in-progress tasks. Drop one to accept this duel:
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 260, overflowY: 'auto' }}>
+              {myTasks.map((ct: any) => (
+                <button
+                  key={ct.id}
+                  onClick={() => doAccept(ct.task.id)}
+                  disabled={loading}
+                  style={{
+                    background: 'var(--color-bg-surface-alt)',
+                    border: '1px solid var(--color-border)',
+                    padding: '8px 12px',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: "'Courier Prime', monospace",
+                    fontSize: 10,
+                    color: 'var(--color-text-primary)',
+                  }}
+                >
+                  Drop: {ct.task.title}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setShowDropModal(false)}
+              style={{
+                marginTop: 14,
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                background: 'transparent', border: '1px solid var(--color-border)',
+                padding: '5px 14px', cursor: 'pointer',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       )}
-
-      {status === 'accepted' && (
-        <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <span className="eyebrow" style={{ color: '#dc2626' }}>Duel Accepted</span>
-        </div>
-      )}
-      {status === 'declined' && (
-        <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Declined</span>
-        </div>
-      )}
-    </div>
+    </>
   )
 }

--- a/frontend/src/pages/CollaborationDetail.tsx
+++ b/frontend/src/pages/CollaborationDetail.tsx
@@ -1,0 +1,655 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import {
+  getCollaboration,
+  updateDocument,
+  submitForMember,
+  reopenCollaboration,
+  kickMember,
+  inviteMember,
+  getDuelVoteSummary,
+  castDuelVote,
+  type CollaborationOut,
+  type DuelVoteSummary,
+} from '../api/collaborations'
+import { listCharacters, type CharacterOut } from '../api/characters'
+import { useAuth } from '../auth/AuthContext'
+import { factionColor, factionName } from '../utils/factions'
+import { formatTimestamp } from '../utils/dates'
+
+const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '#f97316', '#fbbf24', '#be185d']
+
+export default function CollaborationDetail() {
+  const { id } = useParams<{ id: string }>()
+  const { user } = useAuth()
+  const myCharacterId = user?.character?.id
+
+  const [collab, setCollab] = useState<CollaborationOut | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+
+  // Document editing
+  const [editing, setEditing] = useState(false)
+  const [docDraft, setDocDraft] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  // Invite
+  const [inviteQuery, setInviteQuery] = useState('')
+  const [inviteResults, setInviteResults] = useState<CharacterOut[]>([])
+  const [showInviteDropdown, setShowInviteDropdown] = useState(false)
+  const [inviteError, setInviteError] = useState('')
+
+  // Duel votes
+  const [duelVotes, setDuelVotes] = useState<DuelVoteSummary[]>([])
+  const [votingFor, setVotingFor] = useState<number | null>(null)
+  const [voteStars, setVoteStars] = useState(0)
+  const [castingVote, setCastingVote] = useState(false)
+  const [voteError, setVoteError] = useState('')
+  const [voteSuccess, setVoteSuccess] = useState(false)
+
+  // Action errors
+  const [actionError, setActionError] = useState('')
+
+  const collaborationId = id ? parseInt(id, 10) : null
+
+  const loadCollab = useCallback(async () => {
+    if (!collaborationId) return
+    try {
+      const data = await getCollaboration(collaborationId)
+      setCollab(data)
+      if (!editing) setDocDraft(data.body_text ?? '')
+    } catch {
+      setFetchError('Could not load collaboration.')
+    } finally {
+      setLoading(false)
+    }
+  }, [collaborationId, editing])
+
+  const loadDuelVotes = useCallback(async () => {
+    if (!collaborationId || !collab || collab.mode !== 'duel') return
+    try {
+      const votes = await getDuelVoteSummary(collaborationId)
+      setDuelVotes(votes)
+    } catch { /* non-fatal */ }
+  }, [collaborationId, collab])
+
+  useEffect(() => {
+    loadCollab()
+  }, [loadCollab])
+
+  useEffect(() => {
+    if (collab?.mode === 'duel') loadDuelVotes()
+  }, [collab, loadDuelVotes])
+
+  if (loading) {
+    return <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}><p className="eyebrow">Loading...</p></div>
+  }
+  if (fetchError || !collab) {
+    return <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}><p className="eyebrow" style={{ color: '#dc2626' }}>{fetchError ?? 'Not found.'}</p></div>
+  }
+
+  const isMember = collab.members.some((m) => m.character_id === myCharacterId)
+  const myMember = collab.members.find((m) => m.character_id === myCharacterId)
+  const isPublished = collab.status === 'published'
+  const isDuel = collab.mode === 'duel'
+  const isCollab = collab.mode === 'collaboration'
+  const taskColor = '#6b6a7a' // fallback; task faction not on collab out directly
+  const modeLabel = isDuel ? 'Duel' : 'Collaboration'
+  const modeColor = isDuel ? '#dc2626' : '#15803d'
+
+  const handleSaveDocument = async () => {
+    if (!collaborationId) return
+    setSaving(true)
+    try {
+      const updated = await updateDocument(collaborationId, docDraft)
+      setCollab(updated)
+      setEditing(false)
+    } catch {
+      setActionError('Could not save document.')
+    }
+    setSaving(false)
+  }
+
+  const handleSubmit = async () => {
+    if (!collaborationId) return
+    setActionError('')
+    try {
+      const updated = await submitForMember(collaborationId)
+      setCollab(updated)
+    } catch (err: any) {
+      setActionError(err?.response?.data?.detail ?? 'Could not submit.')
+    }
+  }
+
+  const handleReopen = async () => {
+    if (!collaborationId) return
+    setActionError('')
+    try {
+      const updated = await reopenCollaboration(collaborationId)
+      setCollab(updated)
+      setEditing(false)
+    } catch {
+      setActionError('Could not reopen.')
+    }
+  }
+
+  const handleKick = async (targetId: number, name: string) => {
+    if (!collaborationId || !window.confirm(`Remove ${name} from this ${modeLabel.toLowerCase()}?`)) return
+    setActionError('')
+    try {
+      const updated = await kickMember(collaborationId, targetId)
+      setCollab(updated)
+    } catch {
+      setActionError('Could not remove member.')
+    }
+  }
+
+  const handleInviteSearch = async (query: string) => {
+    setInviteQuery(query)
+    if (query.length < 2) { setInviteResults([]); setShowInviteDropdown(false); return }
+    try {
+      const results = await listCharacters({ search: query, limit: 8 })
+      const memberIds = new Set(collab.members.map((m) => m.character_id))
+      const filtered = results.filter((c) => c.id !== myCharacterId && !memberIds.has(c.id))
+      setInviteResults(filtered)
+      setShowInviteDropdown(filtered.length > 0)
+    } catch {
+      setInviteResults([])
+    }
+  }
+
+  const handleSendInvite = async (character: CharacterOut) => {
+    if (!collaborationId) return
+    setInviteError('')
+    setInviteQuery('')
+    setShowInviteDropdown(false)
+    try {
+      await inviteMember(collaborationId, character.id)
+      await loadCollab()
+    } catch (err: any) {
+      setInviteError(err?.response?.data?.detail ?? 'Could not send invite.')
+    }
+  }
+
+  const handleCastVote = async () => {
+    if (!collaborationId || !votingFor || !voteStars) return
+    setCastingVote(true)
+    setVoteError('')
+    try {
+      await castDuelVote(collaborationId, votingFor, voteStars)
+      setVoteSuccess(true)
+      setVotingFor(null)
+      setVoteStars(0)
+      await loadDuelVotes()
+    } catch (err: any) {
+      setVoteError(err?.response?.data?.detail ?? 'Could not cast vote.')
+    }
+    setCastingVote(false)
+  }
+
+  return (
+    <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}>
+      {/* Breadcrumb */}
+      <nav className="font-body mb-4" style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--color-text-tertiary)' }}>
+        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>Tasks</Link>
+        {' › '}
+        <Link to={`/tasks/${collab.task_id}`} style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}>{collab.task_title}</Link>
+        {' › '}
+        <span style={{ color: 'var(--color-text-primary)' }}>{modeLabel}</span>
+      </nav>
+
+      {/* Header */}
+      <div className="sidebar-card mb-5" style={{ padding: '16px 20px', borderLeft: `4px solid ${modeColor}` }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+          <div>
+            <span
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                letterSpacing: '0.1em', padding: '2px 8px',
+                background: modeColor, color: '#fff',
+                marginBottom: 6, display: 'inline-block',
+              }}
+            >
+              {modeLabel}
+            </span>
+            <Link
+              to={`/tasks/${collab.task_id}`}
+              className="font-display italic"
+              style={{ fontSize: 20, color: modeColor, textDecoration: 'none', display: 'block' }}
+            >
+              {collab.task_title}
+            </Link>
+          </div>
+          <div style={{ textAlign: 'right', flexShrink: 0 }}>
+            <span
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                letterSpacing: '0.1em', padding: '3px 10px',
+                background: isPublished ? '#14532d' : 'var(--color-bg-surface-alt)',
+                color: isPublished ? '#fff' : 'var(--color-text-secondary)',
+                border: isPublished ? 'none' : '1px solid var(--color-border)',
+              }}
+            >
+              {isPublished ? 'Published' : 'In Progress'}
+            </span>
+            <div className="eyebrow" style={{ marginTop: 4, fontSize: 7 }}>
+              {formatTimestamp(collab.created_at)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Members */}
+      <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+        <p className="eyebrow mb-3">{isDuel ? 'Competitors' : 'Members'} ({collab.members.length})</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {collab.members.map((member) => {
+            const color = factionColor(member.faction_slug)
+            const isMe = member.character_id === myCharacterId
+            return (
+              <div
+                key={member.character_id}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 10,
+                  padding: '8px 12px',
+                  background: 'var(--color-bg-surface-alt)',
+                  border: '1px solid var(--color-border)',
+                }}
+              >
+                <div
+                  style={{
+                    width: 28, height: 28, borderRadius: '50%',
+                    background: `linear-gradient(135deg, ${color}, ${color}88)`,
+                    flexShrink: 0,
+                  }}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <Link
+                    to={`/characters/${member.character_id}`}
+                    className="font-body"
+                    style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                  >
+                    {member.display_name}
+                    {isMe && <span className="eyebrow" style={{ marginLeft: 6, fontSize: 7 }}>(you)</span>}
+                  </Link>
+                  <span className="eyebrow" style={{ display: 'block', fontSize: 7, marginTop: 1 }}>
+                    {factionName(member.faction_slug)}
+                  </span>
+                </div>
+                <span
+                  style={{
+                    fontFamily: "'Courier Prime', monospace",
+                    fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                    padding: '2px 8px',
+                    background: member.has_submitted ? '#14532d' : 'transparent',
+                    color: member.has_submitted ? '#fff' : 'var(--color-text-tertiary)',
+                    border: member.has_submitted ? 'none' : '1px solid var(--color-border)',
+                  }}
+                >
+                  {member.has_submitted ? 'Submitted' : 'Drafting'}
+                </span>
+                {/* Kick button — any member can kick others (not themselves) */}
+                {isMember && !isMe && !isPublished && (
+                  <button
+                    onClick={() => handleKick(member.character_id, member.display_name)}
+                    style={{
+                      background: 'none', border: 'none', cursor: 'pointer',
+                      color: 'var(--color-text-tertiary)', fontSize: 10,
+                      fontFamily: "'Courier Prime', monospace",
+                      padding: '2px 6px',
+                    }}
+                    title="Remove from collaboration"
+                  >
+                    &times;
+                  </button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Pending invites */}
+        {collab.invites && collab.invites.length > 0 && (
+          <div style={{ marginTop: 12 }}>
+            <p className="eyebrow" style={{ marginBottom: 6, fontSize: 7 }}>Pending invites</p>
+            {collab.invites.map((invite) => (
+              <div
+                key={invite.id}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 8,
+                  padding: '5px 12px',
+                  opacity: 0.7,
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 9,
+                  color: 'var(--color-text-secondary)',
+                }}
+              >
+                <span>→ {invite.invitee_display_name}</span>
+                <span className="eyebrow" style={{ fontSize: 7 }}>invited</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Invite more (collaboration only, in-progress, is member) */}
+        {isMember && !isPublished && isCollab && (
+          <div style={{ marginTop: 12 }}>
+            <p className="eyebrow" style={{ marginBottom: 6, fontSize: 7 }}>Invite more members</p>
+            <div style={{ position: 'relative', display: 'flex', gap: 6 }}>
+              <input
+                type="text"
+                value={inviteQuery}
+                onChange={(e) => handleInviteSearch(e.target.value)}
+                placeholder="Search by name"
+                onFocus={() => { if (inviteResults.length > 0) setShowInviteDropdown(true) }}
+                onBlur={() => setTimeout(() => setShowInviteDropdown(false), 200)}
+                style={{
+                  flex: 1,
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 11, padding: '6px 10px',
+                  background: 'var(--color-bg-surface)',
+                  color: 'var(--color-text-primary)',
+                  border: '1px solid var(--color-border)',
+                  outline: 'none',
+                }}
+              />
+              {showInviteDropdown && (
+                <div
+                  style={{
+                    position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 10,
+                    background: 'var(--color-bg-surface)',
+                    border: '1px solid var(--color-border)',
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                    maxHeight: 180, overflowY: 'auto',
+                  }}
+                >
+                  {inviteResults.map((character) => (
+                    <button
+                      key={character.id}
+                      type="button"
+                      onMouseDown={() => handleSendInvite(character)}
+                      style={{
+                        display: 'flex', alignItems: 'center', gap: 8,
+                        width: '100%', padding: '8px 12px',
+                        background: 'transparent', border: 'none',
+                        cursor: 'pointer', textAlign: 'left',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: 18, height: 18, borderRadius: '50%',
+                          background: `linear-gradient(135deg, ${factionColor(character.faction_slug)}, ${factionColor(character.faction_slug)}88)`,
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+                        {character.display_name}
+                      </span>
+                      <span className="eyebrow" style={{ marginLeft: 'auto', fontSize: 7 }}>
+                        {factionName(character.faction_slug)}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            {inviteError && (
+              <p className="eyebrow" style={{ color: '#dc2626', marginTop: 4 }}>{inviteError}</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Shared Document */}
+      <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <p className="eyebrow">Shared Document</p>
+          {isMember && !editing && (
+            <button
+              onClick={() => { setEditing(true); setDocDraft(collab.body_text ?? '') }}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                background: 'transparent', border: '1px solid var(--color-border)',
+                padding: '3px 10px', cursor: 'pointer',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              Edit
+            </button>
+          )}
+        </div>
+
+        {editing ? (
+          <div>
+            <textarea
+              value={docDraft}
+              onChange={(e) => setDocDraft(e.target.value)}
+              rows={14}
+              placeholder="Write your shared document here... (supports markdown)"
+              style={{
+                width: '100%',
+                fontFamily: "'Lora', serif", fontSize: 14,
+                color: 'var(--color-text-primary)',
+                lineHeight: 1.75, minHeight: 200,
+                background: 'transparent',
+                border: '1px solid var(--color-border)',
+                outline: 'none', resize: 'vertical',
+                padding: '10px 12px',
+              }}
+            />
+            <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+              <button
+                onClick={handleSaveDocument}
+                disabled={saving}
+                style={{
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                  background: modeColor, color: '#fff', border: 'none',
+                  padding: '6px 16px', cursor: saving ? 'wait' : 'pointer',
+                }}
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                onClick={() => setEditing(false)}
+                style={{
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                  background: 'transparent', border: '1px solid var(--color-border)',
+                  padding: '6px 16px', cursor: 'pointer',
+                  color: 'var(--color-text-secondary)',
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : collab.body_text ? (
+          <div className="markdown-preview font-display" style={{ fontSize: 14, lineHeight: 1.75, color: 'var(--color-text-primary)' }}>
+            <ReactMarkdown>{collab.body_text}</ReactMarkdown>
+          </div>
+        ) : (
+          <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-tertiary)', fontStyle: 'italic' }}>
+            {isMember ? 'No document yet. Click Edit to start writing.' : 'No document yet.'}
+          </p>
+        )}
+      </div>
+
+      {/* Duel vote tally */}
+      {isDuel && (
+        <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+          <p className="eyebrow mb-3">Vote Tally</p>
+          {duelVotes.length === 0 ? (
+            <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>No votes yet.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {duelVotes.map((v) => (
+                <div
+                  key={v.character_id}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 12,
+                    padding: '8px 12px',
+                    background: v.is_winning ? 'rgba(220,38,38,0.07)' : 'var(--color-bg-surface-alt)',
+                    border: `1px solid ${v.is_winning ? '#dc2626' : 'var(--color-border)'}`,
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 24, height: 24, borderRadius: '50%',
+                      background: `linear-gradient(135deg, ${factionColor(v.faction_slug)}, ${factionColor(v.faction_slug)}88)`,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span className="font-body" style={{ fontSize: 12, fontWeight: 700, flex: 1 }}>
+                    {v.display_name}
+                    {v.is_winning && <span style={{ marginLeft: 8, color: '#dc2626', fontSize: 10 }}>★ leading</span>}
+                  </span>
+                  <span className="eyebrow" style={{ fontSize: 9 }}>
+                    {v.total_stars} stars · {v.vote_count} vote{v.vote_count !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Cast vote (non-members only, published collab) */}
+          {!isMember && isPublished && (
+            <div style={{ marginTop: 14, borderTop: '1px dashed var(--color-border)', paddingTop: 14 }}>
+              <p className="eyebrow mb-2" style={{ fontSize: 8 }}>Cast your vote</p>
+              {voteSuccess ? (
+                <p className="eyebrow" style={{ color: '#14532d' }}>Vote recorded!</p>
+              ) : (
+                <>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                    {collab.members.map((member) => (
+                      <div key={member.character_id} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <button
+                          onClick={() => setVotingFor(votingFor === member.character_id ? null : member.character_id)}
+                          style={{
+                            fontFamily: "'Courier Prime', monospace",
+                            fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                            padding: '4px 12px',
+                            background: votingFor === member.character_id ? '#dc2626' : 'transparent',
+                            color: votingFor === member.character_id ? '#fff' : 'var(--color-text-primary)',
+                            border: `1px solid ${votingFor === member.character_id ? '#dc2626' : 'var(--color-border)'}`,
+                            cursor: 'pointer',
+                          }}
+                        >
+                          {member.display_name}
+                        </button>
+                        {votingFor === member.character_id && (
+                          <div style={{ display: 'flex', gap: 2 }}>
+                            {[1, 2, 3, 4, 5].map((star) => (
+                              <button
+                                key={star}
+                                type="button"
+                                onClick={() => setVoteStars(star)}
+                                style={{
+                                  background: 'none', border: 'none', cursor: 'pointer',
+                                  fontSize: 18, lineHeight: 1, padding: '0 2px',
+                                  color: star <= voteStars ? 'var(--color-text-primary)' : 'var(--color-border)',
+                                  transition: 'color 100ms',
+                                }}
+                                aria-label={`${star} star${star !== 1 ? 's' : ''}`}
+                              >
+                                ★
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                  {votingFor !== null && voteStars > 0 && (
+                    <button
+                      onClick={handleCastVote}
+                      disabled={castingVote}
+                      style={{
+                        marginTop: 10,
+                        fontFamily: "'Courier Prime', monospace",
+                        fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                        background: '#dc2626', color: '#fff', border: 'none',
+                        padding: '6px 18px', cursor: castingVote ? 'wait' : 'pointer',
+                      }}
+                    >
+                      {castingVote ? 'Submitting...' : 'Submit Vote'}
+                    </button>
+                  )}
+                  {voteError && (
+                    <p className="eyebrow" style={{ color: '#dc2626', marginTop: 6 }}>{voteError}</p>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Submit / Reopen controls */}
+      {isMember && !isPublished && (
+        <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+          <p className="eyebrow mb-2">Submit</p>
+          <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+            {isDuel
+              ? 'When both competitors submit, the duel is published and voting opens.'
+              : 'When all members submit, the collaboration is published.'}
+          </p>
+          {myMember?.has_submitted ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <span className="eyebrow" style={{ color: '#14532d' }}>You have submitted</span>
+              <button
+                onClick={handleReopen}
+                style={{
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+                  background: 'transparent', border: '1px solid var(--color-border)',
+                  padding: '4px 12px', cursor: 'pointer',
+                  color: 'var(--color-text-secondary)',
+                }}
+              >
+                Reopen for editing
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                background: modeColor, color: '#fff', border: 'none',
+                padding: '8px 20px', cursor: 'pointer',
+                position: 'relative',
+              }}
+            >
+              <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
+              Mark as submitted
+            </button>
+          )}
+        </div>
+      )}
+
+      {isPublished && (
+        <div className="sidebar-card mb-4" style={{ padding: '14px 20px', borderLeft: `4px solid #14532d` }}>
+          <p className="eyebrow" style={{ color: '#14532d' }}>Published</p>
+          <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginTop: 4 }}>
+            {isDuel ? 'Duel complete. Points have been awarded.' : 'Collaboration published. All members have been scored.'}
+          </p>
+        </div>
+      )}
+
+      {actionError && (
+        <p className="eyebrow mb-4" style={{ color: '#dc2626' }}>{actionError}</p>
+      )}
+
+      {/* Rainbow footer bar */}
+      <div style={{ display: 'flex', height: 3, marginTop: 24, opacity: 0.4 }}>
+        {RAINBOW_COLORS.map((c, i) => <div key={i} style={{ flex: 1, background: c }} />)}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import { createPraxis, uploadMedia } from '../api/praxis'
+import { createCollaboration, inviteMember } from '../api/collaborations'
 import { getTask, dropTask, type TaskOut } from '../api/tasks'
 import { listCharacters, type CharacterOut } from '../api/characters'
 import LevelPill from '../components/ui/LevelPill'
@@ -57,24 +58,38 @@ export default function SubmitProof() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!id || !title.trim()) { setError('Title is required.'); return }
+    if (!id) return
     setSaving(true)
     setError('')
     try {
-      const praxis = await createPraxis({
-        task_id: parseInt(id, 10),
-        title,
-        body_text: body || undefined,
-        collaboration_mode: selectedMode !== 'solo' ? selectedMode : undefined,
-        partner_character_id: invitedPartners.length > 0 ? invitedPartners[0].id : undefined,
-      })
-      for (const file of files) {
-        await uploadMedia(praxis.id, file)
+      if (selectedMode !== 'solo') {
+        // Collaboration or duel: create a Collaboration, send invites, redirect to collab page
+        const mode = selectedMode === 'duel' ? 'duel' : 'collaboration'
+        const collab = await createCollaboration(parseInt(id, 10), mode)
+        // Send invites to all selected partners
+        for (const partner of invitedPartners) {
+          try {
+            await inviteMember(collab.id, partner.id)
+          } catch { /* best-effort */ }
+        }
+        void refetch()
+        navigate(`/collaborations/${collab.id}`)
+      } else {
+        // Solo submission: create praxis as before
+        if (!title.trim()) { setError('Title is required.'); setSaving(false); return }
+        const praxis = await createPraxis({
+          task_id: parseInt(id, 10),
+          title,
+          body_text: body || undefined,
+        })
+        for (const file of files) {
+          await uploadMedia(praxis.id, file)
+        }
+        void refetch()
+        navigate(`/praxes/${praxis.id}`)
       }
-      void refetch()
-      navigate(`/praxes/${praxis.id}`)
-    } catch {
-      setError('Could not submit. Check you are signed up for this task.')
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Could not submit. Check you are signed up for this task.')
     } finally {
       setSaving(false)
     }
@@ -542,7 +557,10 @@ export default function SubmitProof() {
             }}
           >
             <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-            {saving ? 'Publishing...' : 'Publish proof'}
+            {saving
+              ? (selectedMode !== 'solo' ? 'Creating...' : 'Publishing...')
+              : (selectedMode === 'duel' ? 'Start duel' : selectedMode === 'collab' ? 'Start collaboration' : 'Publish proof')
+            }
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary

- **New N-player Collaboration system** — players can form a group around any in-progress task, write a shared document, and publish together; each member earns full points
- **Duel mode** — 1v1 competitive variant; non-members vote stars for each competitor; winner gets a multiplied score (Snide: 2×/0×, all others: 1.5×/0.5×)
- **Meta-task scoring wired in** — previously deferred to v2; now included in the scoring formula as a flat point bonus
- **Clean break from legacy 2-player skeleton** — removed `partner_character_id`, `invite_status`, `collaboration_mode` from Praxis; activity feed updated to use new `CollaborationInvite`
- **Task-list-full flow** — accepting an invite when at capacity (20 tasks) shows a drop-task modal

### Backend
- New models: `Collaboration`, `CollaborationMember`, `CollaborationInvite`
- `Vote` extended: `praxis_id` nullable, `collaboration_id` FK, `uq_vote_duel` constraint
- Migration `0005_collaboration_and_duel`
- Full collaboration service (create, invite, respond, submit, reopen, kick, document, vote summary, duel winner logic)
- Updated scoring formula: `(task_pts + meta_task_pts) × faction_mult × duel_mult + stars`
- `compute_duel_multiplier` with Snide high-risk and standard tiebreaker rules
- Era 1 faction duel modifiers set: Snide 2.0/0.0, UA Masters 0.8/0.8, all others 1.5/0.5
- 10 new collaboration endpoints; `POST /tasks/{id}/drop` alias added
- Spec files corrected (removed v2 deferrals for meta-tasks, collaboration, duels)

### Frontend
- `/collaborations/:id` — shared document editor, member list + kick, per-member submit state, duel vote widget with live tally
- `SubmitProof` — collab/duel mode creates a Collaboration, sends invites, redirects to collab page
- Feed invite cards rewired to new API with task-list-full drop modal

## Test plan
- [ ] 105 unit tests passing (`pytest tests/unit/`)
- [ ] `alembic upgrade head` → `alembic downgrade -1` → `alembic upgrade head` is idempotent
- [ ] Happy path: create collaboration → invite → accept → both submit → published + scores
- [ ] Duel path: create duel → accept → both submit → cast votes → winner gets multiplied score
- [ ] Task-list-full: accept invite at capacity → drop modal appears → pick task → accepted
- [ ] Kick member → their CharacterTask abandoned, submission states reset
- [ ] TypeScript: 0 errors (excluding pre-existing Groups.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)