### PR TITLE
Fix task signup crash and improve error messaging

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db import get_db
 from dependencies import get_current_character
 from models.character import Character
+from models.faction import Faction, FactionStatus
 from models.task import CharacterTask, CharacterTaskStatus, Task, TaskStatus
 from schemas.task import CharacterTaskOut, TaskCreate, TaskOut, TaskSignupOut
 from services.task import build_task_out, drop_task, list_tasks as service_list_tasks, propose_task, signup_for_task
@@ -207,7 +208,7 @@ async def signup_for_task_route(
         if faction and faction.status != FactionStatus.visible:
             raise HTTPException(status_code=422, detail="Cannot sign up for tasks from a hidden faction.")
     ct = await signup_for_task(character, task, session)
-    return await _build_character_task_out(ct, session)
+    return _build_character_task_out(ct)
 
 
 @router.delete("/{task_id}/signup", status_code=204)

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -276,7 +276,17 @@ export default function TaskDetail() {
               </div>
 
               {signupError && (
-                <p className="font-body" style={{ fontSize: 9, color: '#dc2626', marginTop: 6 }}>{signupError}</p>
+                <div
+                  className="font-body"
+                  style={{
+                    fontSize: 11, color: '#dc2626', marginTop: 8,
+                    padding: '8px 12px',
+                    background: 'rgba(220,38,38,0.06)',
+                    border: '1px solid rgba(220,38,38,0.2)',
+                  }}
+                >
+                  {signupError}
+                </div>
               )}
             </div>
           )}

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -4,10 +4,11 @@ import type { AxiosError } from 'axios'
  * Extracts a user-friendly error message from an axios error.
  *
  * Priority:
- *   1. FastAPI `detail` string from response body
+ *   1. FastAPI `detail` string from response body (skip generic "Internal Server Error")
  *   2. FastAPI `detail` array (Pydantic validation errors) — uses first item's msg
- *   3. Network error (no response) — connection message
- *   4. Caller-provided fallback, or generic default
+ *   3. Server error (5xx) with no useful detail — server-side problem message
+ *   4. Network error (no response at all) — connection message
+ *   5. Caller-provided fallback, or generic default
  */
 export function extractError(
   err: unknown,
@@ -15,13 +16,27 @@ export function extractError(
 ): string {
   const e = err as AxiosError<{ detail?: string | Array<{ msg: string }> }>
 
-  if (e?.response?.data?.detail) {
-    const d = e.response.data.detail
-    if (typeof d === 'string') return d
-    if (Array.isArray(d) && d[0]?.msg) return d[0].msg
+  const status = e?.response?.status
+  const detail = e?.response?.data?.detail
+
+  // Surface meaningful detail strings from the backend (e.g. "Task requires level 3")
+  if (detail) {
+    if (typeof detail === 'string' && detail !== 'Internal Server Error') return detail
+    if (Array.isArray(detail) && detail[0]?.msg) return detail[0].msg
   }
 
-  if (e?.message === 'Network Error') {
+  // 5xx with no useful detail — the server hit an unhandled error
+  if (status && status >= 500) {
+    return 'The server ran into an unexpected problem. Try again in a moment.'
+  }
+
+  // 4xx we didn't already handle (missing detail, unusual format)
+  if (status && status >= 400) {
+    return fallback
+  }
+
+  // No response object at all — genuine network failure
+  if (e?.message === 'Network Error' || !e?.response) {
     return 'Unable to reach the server. Check your connection and try again.'
   }
 


### PR DESCRIPTION
## Summary
- **Fixed two bugs** in the task signup route that caused every signup to crash with an unhandled 500: missing `Faction`/`FactionStatus` imports and a wrong function call signature
- **Improved frontend error extraction** to distinguish between server errors (5xx), client errors (4xx), and true network failures — users now see specific, actionable messages instead of the generic "Unable to reach the server"
- **Upgraded signup error display** from near-invisible 9px text to a proper styled error box

## Test plan
- [ ] Sign up for a task — should succeed without error
- [ ] Verify 4xx errors (e.g. level too low, already signed up) show the backend's specific message
- [ ] Verify genuine network failures still show the connection error message
- [ ] Check error box styling is visible and readable on both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)