### PR TITLE
Fix praxis scoring and repair integration tests

### DIFF
--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -24,7 +24,7 @@ from services.scoring import (
 
 async def _get_meta_task_points(praxis_id: int, session: AsyncSession) -> int:
     """Return flat bonus points from any meta task attached to a solo praxis."""
-    from models.meta_task import MetaTask
+    from models.meta_task import MetaTask, PraxisMetaTask
 
     result = await session.execute(
         select(PraxisMetaTask).where(PraxisMetaTask.praxis_id == praxis_id)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -17,20 +17,16 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from config import settings
 from db import get_db
 from main import app
-from models.account import Account, OAuthProvider  # noqa: F401
+import models  # noqa: F401 — registers all models on Base.metadata for create_all
+from models.account import Account, OAuthProvider
 from models.base import Base
-from models.character import Character  # noqa: F401
-from models.character_stats import CharacterStats  # noqa: F401
-from models.era import Era  # noqa: F401  # ensure all models are registered
-from models.faction import Faction  # noqa: F401
-from models.flag import Flag  # noqa: F401
-from models.message import Message  # noqa: F401
-from models.meta_task import MetaTask  # noqa: F401
-from models.relationship import Relationship  # noqa: F401
-from models.roles import AccountRole, Role  # noqa: F401
-from models.praxis import MediaItem, Praxis  # noqa: F401
-from models.task import CharacterTask, Task, TaskFaction  # noqa: F401
-from models.vote import Vote  # noqa: F401
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction
+from models.praxis import Praxis
+from models.task import CharacterTask, CharacterTaskStatus, Task
+from models.vote import Vote
 from services.auth import create_jwt
 
 # ---------------------------------------------------------------------------
@@ -212,3 +208,33 @@ async def active_task(db_session: AsyncSession, character: Character) -> Task:
     await db_session.commit()
     await db_session.refresh(task)
     return task
+
+
+@pytest_asyncio.fixture
+async def signed_up_task(
+    db_session: AsyncSession, character: Character, active_task: Task
+) -> Task:
+    """An active task with character already signed up."""
+    ct = CharacterTask(
+        character_id=character.id,
+        task_id=active_task.id,
+        status=CharacterTaskStatus.in_progress,
+    )
+    db_session.add(ct)
+    await db_session.commit()
+    return active_task
+
+
+@pytest_asyncio.fixture
+async def signed_up_task2(
+    db_session: AsyncSession, character2: Character, active_task: Task
+) -> Task:
+    """An active task with character2 already signed up."""
+    ct = CharacterTask(
+        character_id=character2.id,
+        task_id=active_task.id,
+        status=CharacterTaskStatus.in_progress,
+    )
+    db_session.add(ct)
+    await db_session.commit()
+    return active_task

--- a/backend/tests/integration/test_submissions.py
+++ b/backend/tests/integration/test_submissions.py
@@ -1,9 +1,12 @@
 """Integration tests for /praxes endpoints."""
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.character import Character
-from models.praxis import Praxis
+from models.character_stats import CharacterStats
+from models.era import Era
 from models.task import Task
 
 
@@ -18,17 +21,17 @@ async def test_list_praxes_public(client: AsyncClient):
 async def test_create_praxis(
     client: AsyncClient,
     character: Character,
-    active_task: Task,
+    signed_up_task: Task,
     auth_headers: dict,
 ):
     resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "My Praxis", "body_text": "I did the thing."},
+        json={"task_id": signed_up_task.id, "title": "My Praxis", "body_text": "I did the thing."},
         headers=auth_headers,
     )
     assert resp.status_code == 201
     data = resp.json()
-    assert data["task_id"] == active_task.id
+    assert data["task_id"] == signed_up_task.id
     assert data["character_id"] == character.id
     assert data["title"] == "My Praxis"
     assert data["moderation_status"] == "visible"
@@ -36,15 +39,64 @@ async def test_create_praxis(
 
 
 @pytest.mark.asyncio
-async def test_get_praxis(
+async def test_create_praxis_requires_signup(
     client: AsyncClient,
     character: Character,
     active_task: Task,
     auth_headers: dict,
 ):
+    """Creating a praxis without signing up first returns 403."""
+    resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "title": "No signup"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_praxis_updates_stats(
+    client: AsyncClient,
+    character: Character,
+    signed_up_task: Task,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    era: Era,
+):
+    """Submitting a praxis awards base points and updates the character's stats."""
+    # Verify score starts at 0
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    assert stats.score == 0
+
+    resp = await client.post(
+        "/praxes",
+        json={"task_id": signed_up_task.id, "title": "Score test"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201
+
+    # Refresh stats from DB — score should now include base task points
+    await db_session.refresh(stats)
+    assert stats.score > 0
+    assert stats.score >= signed_up_task.point_value
+
+
+@pytest.mark.asyncio
+async def test_get_praxis(
+    client: AsyncClient,
+    character: Character,
+    signed_up_task: Task,
+    auth_headers: dict,
+):
     create_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Test Praxis"},
+        json={"task_id": signed_up_task.id, "title": "Test Praxis"},
         headers=auth_headers,
     )
     praxis_id = create_resp.json()["id"]
@@ -57,18 +109,18 @@ async def test_get_praxis(
 async def test_edit_praxis(
     client: AsyncClient,
     character: Character,
-    active_task: Task,
+    signed_up_task: Task,
     auth_headers: dict,
 ):
     create_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Original Title"},
+        json={"task_id": signed_up_task.id, "title": "Original Title"},
         headers=auth_headers,
     )
     praxis_id = create_resp.json()["id"]
     resp = await client.put(
         f"/praxes/{praxis_id}",
-        json={"task_id": active_task.id, "title": "Updated Title"},
+        json={"task_id": signed_up_task.id, "title": "Updated Title"},
         headers=auth_headers,
     )
     assert resp.status_code == 200
@@ -79,19 +131,19 @@ async def test_edit_praxis(
 async def test_edit_praxis_wrong_owner(
     client: AsyncClient,
     character: Character,
-    active_task: Task,
+    signed_up_task: Task,
     auth_headers: dict,
     auth_headers2: dict,
 ):
     create_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "My Praxis"},
+        json={"task_id": signed_up_task.id, "title": "My Praxis"},
         headers=auth_headers,
     )
     praxis_id = create_resp.json()["id"]
     resp = await client.put(
         f"/praxes/{praxis_id}",
-        json={"task_id": active_task.id, "title": "Hacked"},
+        json={"task_id": signed_up_task.id, "title": "Hacked"},
         headers=auth_headers2,
     )
     assert resp.status_code == 403
@@ -101,7 +153,7 @@ async def test_edit_praxis_wrong_owner(
 async def test_flag_praxis_level_gate(
     client: AsyncClient,
     character: Character,
-    active_task: Task,
+    signed_up_task: Task,
     auth_headers: dict,
     auth_headers2: dict,
     character2: Character,
@@ -109,7 +161,7 @@ async def test_flag_praxis_level_gate(
     """character2 (level 5) can flag; character (level 0) cannot."""
     create_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Flaggable Praxis"},
+        json={"task_id": signed_up_task.id, "title": "Flaggable Praxis"},
         headers=auth_headers,
     )
     praxis_id = create_resp.json()["id"]

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -1,8 +1,12 @@
 """Integration tests for vote endpoints."""
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
 from models.task import Task
 
 
@@ -11,14 +15,15 @@ async def test_cast_vote(
     client: AsyncClient,
     character: Character,
     character2: Character,
-    active_task: Task,
+    signed_up_task: Task,
+    signed_up_task2: Task,
     auth_headers: dict,
     auth_headers2: dict,
 ):
     """character2 submits; character votes on it."""
     sub_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Vote me"},
+        json={"task_id": signed_up_task2.id, "title": "Vote me"},
         headers=auth_headers2,
     )
     assert sub_resp.status_code == 201
@@ -39,13 +44,13 @@ async def test_cast_vote(
 async def test_cast_vote_self_blocked(
     client: AsyncClient,
     character: Character,
-    active_task: Task,
+    signed_up_task: Task,
     auth_headers: dict,
 ):
     """Cannot vote on own praxis (account-level check)."""
     sub_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Own praxis"},
+        json={"task_id": signed_up_task.id, "title": "Own praxis"},
         headers=auth_headers,
     )
     praxis_id = sub_resp.json()["id"]
@@ -63,14 +68,14 @@ async def test_update_vote_free(
     client: AsyncClient,
     character: Character,
     character2: Character,
-    active_task: Task,
+    signed_up_task2: Task,
     auth_headers: dict,
     auth_headers2: dict,
 ):
     """Updating a vote does not deduct budget."""
     sub_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Update vote test"},
+        json={"task_id": signed_up_task2.id, "title": "Update vote test"},
         headers=auth_headers2,
     )
     praxis_id = sub_resp.json()["id"]
@@ -91,13 +96,13 @@ async def test_vote_summary(
     client: AsyncClient,
     character: Character,
     character2: Character,
-    active_task: Task,
+    signed_up_task2: Task,
     auth_headers: dict,
     auth_headers2: dict,
 ):
     sub_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Summary test"},
+        json={"task_id": signed_up_task2.id, "title": "Summary test"},
         headers=auth_headers2,
     )
     praxis_id = sub_resp.json()["id"]
@@ -116,13 +121,13 @@ async def test_invalid_stars(
     client: AsyncClient,
     character: Character,
     character2: Character,
-    active_task: Task,
+    signed_up_task2: Task,
     auth_headers: dict,
     auth_headers2: dict,
 ):
     sub_resp = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "title": "Star test"},
+        json={"task_id": signed_up_task2.id, "title": "Star test"},
         headers=auth_headers2,
     )
     praxis_id = sub_resp.json()["id"]
@@ -131,3 +136,48 @@ async def test_invalid_stars(
         f"/praxes/{praxis_id}/vote", json={"stars": 6}, headers=auth_headers
     )
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_vote_updates_author_stats(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    signed_up_task2: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+    era: Era,
+):
+    """Voting on a praxis updates the author's score."""
+    # character2 submits a praxis
+    sub_resp = await client.post(
+        "/praxes",
+        json={"task_id": signed_up_task2.id, "title": "Score via vote"},
+        headers=auth_headers2,
+    )
+    assert sub_resp.status_code == 201
+    praxis_id = sub_resp.json()["id"]
+
+    # Record character2's score after praxis creation
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character2.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    score_after_praxis = stats.score
+
+    # character votes 4 stars
+    vote_resp = await client.post(
+        f"/praxes/{praxis_id}/vote",
+        json={"stars": 4},
+        headers=auth_headers,
+    )
+    assert vote_resp.status_code == 200
+
+    # character2's score should have increased by the star count
+    await db_session.refresh(stats)
+    assert stats.score > score_after_praxis
+    assert stats.score >= score_after_praxis + 4

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -9,6 +9,7 @@ import LevelPill from '../components/ui/LevelPill'
 import { useAuth } from '../auth/AuthContext'
 import { useTheme } from '../hooks/useTheme'
 import { factionColor, factionName } from '../utils/factions'
+import { extractError } from '../utils/errors'
 
 const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '#f97316', '#fbbf24', '#be185d']
 
@@ -89,7 +90,7 @@ export default function SubmitProof() {
         navigate(`/praxes/${praxis.id}`)
       }
     } catch (err: any) {
-      setError(err?.response?.data?.detail ?? 'Could not submit. Check you are signed up for this task.')
+      setError(extractError(err, 'Could not submit. Please try again.'))
     } finally {
       setSaving(false)
     }
@@ -539,7 +540,17 @@ export default function SubmitProof() {
 
         {/* ── Error ── */}
         {error && (
-          <p className="font-body" style={{ fontSize: 10, color: '#dc2626' }}>{error}</p>
+          <div
+            className="font-body"
+            style={{
+              fontSize: 11, color: '#dc2626', marginTop: 8,
+              padding: '8px 12px',
+              background: 'rgba(220,38,38,0.06)',
+              border: '1px solid rgba(220,38,38,0.2)',
+            }}
+          >
+            {error}
+          </div>
         )}
 
         {/* ── Submit Row (§18.4) ── */}


### PR DESCRIPTION
## Summary
- **Fixed root cause of points never updating**: missing `PraxisMetaTask` import in `character_stats.py` crashed `recalculate_character_stats` on every call
- **Fixed misleading frontend error**: SubmitProof now uses `extractError` instead of a hardcoded "not signed up" fallback
- **Repaired all integration tests**: conftest was missing 7 model imports so `create_all` never built all tables — tests have been silently failing in CI
- **Added signup prerequisites**: new `signed_up_task` fixtures ensure praxis tests actually sign up before submitting
- **Added scoring flow tests**: `test_create_praxis_updates_stats` and `test_vote_updates_author_stats` verify the end-to-end points pipeline

## Test plan
- [ ] CI integration tests pass (previously all failing)
- [ ] Unit tests still pass (105/105 verified locally)
- [ ] Submit a praxis in production — points and level should update immediately
- [ ] Verify error messages are specific (not generic "not signed up")

🤖 Generated with [Claude Code](https://claude.com/claude-code)