### PR TITLE
Wire up meta tasks end-to-end

### DIFF
--- a/backend/routers/meta_tasks.py
+++ b/backend/routers/meta_tasks.py
@@ -1,11 +1,18 @@
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from models.meta_task import MetaTask
+from dependencies import get_current_character
+from models.account import Account
+from models.character import Character
+from models.meta_task import BonusType, MetaTask
+from models.roles import AccountRole, Role
 from models.task import Task
-from schemas.meta_task import MetaTaskOut
+from schemas.meta_task import MetaTaskCreate, MetaTaskOut
+from services.auth import get_current_account
 
 GENERIC_FACTION_SLUG = "na"
 
@@ -14,20 +21,69 @@ router = APIRouter()
 
 @router.get("", response_model=list[MetaTaskOut])
 async def list_meta_tasks(
-    task_id: int,
+    task_id: Optional[int] = None,
     session: AsyncSession = Depends(get_db),
 ) -> list[MetaTaskOut]:
-    """List meta tasks applicable to a given task (matching faction or generic)."""
-    task = await session.get(Task, task_id)
-    if task is None:
-        raise HTTPException(status_code=404, detail="Task not found.")
+    """List meta tasks.
 
-    result = await session.execute(
-        select(MetaTask).where(
-            or_(
-                MetaTask.faction_slug == task.primary_faction_slug,
-                MetaTask.faction_slug == GENERIC_FACTION_SLUG,
-            )
-        ).order_by(MetaTask.level_required.asc())
-    )
+    If task_id is provided, returns meta tasks applicable to that task (matching
+    faction or generic). If omitted, returns all meta tasks ordered by level_required.
+    """
+    if task_id is not None:
+        task = await session.get(Task, task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail="Task not found.")
+        result = await session.execute(
+            select(MetaTask).where(
+                or_(
+                    MetaTask.faction_slug == task.primary_faction_slug,
+                    MetaTask.faction_slug == GENERIC_FACTION_SLUG,
+                )
+            ).order_by(MetaTask.level_required.asc())
+        )
+    else:
+        result = await session.execute(
+            select(MetaTask).order_by(MetaTask.level_required.asc())
+        )
     return [MetaTaskOut.model_validate(meta_task) for meta_task in result.scalars().all()]
+
+
+@router.post("", response_model=MetaTaskOut, status_code=201)
+async def create_meta_task(
+    data: MetaTaskCreate,
+    character: Character = Depends(get_current_character),
+    account: Account = Depends(get_current_account),
+    session: AsyncSession = Depends(get_db),
+) -> MetaTaskOut:
+    """Create a meta task. Requires level 5+ or admin."""
+    admin_result = await session.execute(
+        select(AccountRole)
+        .join(Role, AccountRole.role_id == Role.id)
+        .where(AccountRole.account_id == account.id, Role.name == "admin")
+    )
+    is_admin = admin_result.scalar_one_or_none() is not None
+
+    if not is_admin and character.level < 5:
+        raise HTTPException(
+            status_code=403,
+            detail="Creating meta tasks requires level 5 or higher.",
+        )
+
+    if data.faction_slug == GENERIC_FACTION_SLUG:
+        raise HTTPException(
+            status_code=422,
+            detail="Meta tasks must belong to a specific faction, not 'na'.",
+        )
+
+    meta_task = MetaTask(
+        name=data.name,
+        description=data.description,
+        faction_slug=data.faction_slug,
+        bonus_type=BonusType.flat,
+        bonus_value=float(data.bonus_value),
+        level_required=data.level_required,
+    )
+    session.add(meta_task)
+    await session.commit()
+    await session.refresh(meta_task)
+    return MetaTaskOut.model_validate(meta_task)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -13,6 +13,7 @@ from config import settings
 from db import get_db
 from dependencies import get_current_character
 from models.character import Character
+from models.meta_task import MetaTask, PraxisMetaTask
 from models.praxis import MediaItem, MediaType, ModerationStatus, Praxis
 from models.task import CharacterTask, Task
 from schemas.praxis import MediaItemOut, PraxisCreate, PraxisOut
@@ -78,7 +79,24 @@ async def create_praxis_route(
     task = await session.get(Task, data.task_id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found.")
+
+    meta_task: Optional[MetaTask] = None
+    if data.meta_task_id is not None:
+        meta_task = await session.get(MetaTask, data.meta_task_id)
+        if meta_task is None:
+            raise HTTPException(status_code=404, detail="Meta task not found.")
+        if character.level < meta_task.level_required:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Meta task requires level {meta_task.level_required}.",
+            )
+
     praxis = await create_praxis(character, task, data, session)
+
+    if meta_task is not None:
+        session.add(PraxisMetaTask(praxis_id=praxis.id, meta_task_id=meta_task.id))
+        await session.commit()
+
     return await build_praxis_out(praxis, session)
 
 

--- a/backend/schemas/meta_task.py
+++ b/backend/schemas/meta_task.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class MetaTaskOut(BaseModel):
@@ -11,3 +11,11 @@ class MetaTaskOut(BaseModel):
     bonus_type: str
     bonus_value: float
     level_required: int
+
+
+class MetaTaskCreate(BaseModel):
+    name: str = Field(..., max_length=200)
+    description: str
+    faction_slug: str
+    bonus_value: int = Field(..., gt=0)
+    level_required: int = Field(0, ge=0)

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -40,3 +40,4 @@ class PraxisCreate(BaseModel):
     task_id: int
     title: str = Field(..., max_length=200)
     body_text: Optional[str] = Field(None, max_length=10000)
+    meta_task_id: Optional[int] = None

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -28,6 +28,7 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction, FactionStatus
+from models.meta_task import BonusType, MetaTask
 from models.roles import AccountRole, Role
 from models.task import Task, TaskStatus
 
@@ -192,6 +193,26 @@ async def seed(env: str, yes: bool) -> None:
                 ))
         else:
             print(f"  >Tasks already exist ({task_count}) — skipping")
+
+        # ------------------------------------------------------------------
+        # Phase 4: Meta Tasks (placeholder)
+        # ------------------------------------------------------------------
+        from sqlalchemy import func as sqlfunc
+        meta_task_count = (
+            await session.execute(select(sqlfunc.count()).select_from(MetaTask))
+        ).scalar()
+        if meta_task_count == 0:
+            print("  >Meta tasks (1 placeholder)")
+            session.add(MetaTask(
+                name="Upside Down",
+                description="Do this task upside down",
+                faction_slug="ua_masters",
+                bonus_type=BonusType.flat,
+                bonus_value=100.0,
+                level_required=0,
+            ))
+        else:
+            print(f"  >Meta tasks already exist ({meta_task_count}) — skipping")
 
         await session.commit()
         print("\nSeed complete!\n")

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -22,8 +22,13 @@ from services.scoring import (
 )
 
 
-async def _get_meta_task_points(praxis_id: int, session: AsyncSession) -> int:
-    """Return flat bonus points from any meta task attached to a solo praxis."""
+async def _get_meta_task_points(
+    praxis_id: int, character_level: int, session: AsyncSession
+) -> int:
+    """Return flat bonus points from any meta task attached to a solo praxis.
+
+    Returns 0 if the character does not meet the meta task's level_required.
+    """
     from models.meta_task import MetaTask, PraxisMetaTask
 
     result = await session.execute(
@@ -34,6 +39,8 @@ async def _get_meta_task_points(praxis_id: int, session: AsyncSession) -> int:
         return 0
     meta_task = await session.get(MetaTask, praxis_meta_task.meta_task_id)
     if meta_task is None:
+        return 0
+    if character_level < meta_task.level_required:
         return 0
     # bonus_type "flat" adds bonus_value directly; "percentage" is not yet implemented.
     if meta_task.bonus_type.value == "flat":
@@ -93,7 +100,9 @@ async def recalculate_character_stats(
             era,
             collaboration_mode=COLLABORATION_MODE_SOLO,
         )
-        meta_task_points = await _get_meta_task_points(praxis.id, session)
+        meta_task_points = await _get_meta_task_points(
+            praxis.id, author.level if author else 0, session
+        )
         sum_result = await session.execute(
             select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
         )

--- a/frontend/src/api/metaTasks.ts
+++ b/frontend/src/api/metaTasks.ts
@@ -10,7 +10,21 @@ export interface MetaTaskOut {
   level_required: number
 }
 
-export async function getMetaTasks(taskId: number): Promise<MetaTaskOut[]> {
-  const { data } = await api.get<MetaTaskOut[]>('/meta-tasks', { params: { task_id: taskId } })
+export interface MetaTaskCreate {
+  name: string
+  description: string
+  faction_slug: string
+  bonus_value: number
+  level_required: number
+}
+
+export async function getMetaTasks(taskId?: number): Promise<MetaTaskOut[]> {
+  const params = taskId !== undefined ? { task_id: taskId } : {}
+  const { data } = await api.get<MetaTaskOut[]>('/meta-tasks', { params })
+  return data
+}
+
+export async function createMetaTask(body: MetaTaskCreate): Promise<MetaTaskOut> {
+  const { data } = await api.post<MetaTaskOut>('/meta-tasks', body)
   return data
 }

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -31,6 +31,7 @@ export interface PraxisCreate {
   task_id: number
   title: string
   body_text?: string
+  meta_task_id?: number
 }
 
 export async function listPraxes(params?: { task_id?: number; character_id?: number }): Promise<PraxisOut[]> {

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { proposeTask } from '../api/tasks'
+import { createMetaTask } from '../api/metaTasks'
 import { getFactions, type FactionOut } from '../api/factions'
 import PageTitle from '../components/ui/PageTitle'
 import FilterLevelNodes from '../components/ui/FilterLevelNodes'
@@ -31,6 +32,8 @@ export default function ProposeTask() {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
+  const [isMetaTask, setIsMetaTask] = useState(false)
+  const [metaBonusValue, setMetaBonusValue] = useState('10')
 
   useEffect(() => {
     getFactions().then(setFactions).catch(() => {})
@@ -65,8 +68,19 @@ export default function ProposeTask() {
       <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}>
         <PageTitle title="Propose a Task" />
         <div className="sidebar-card" style={{ padding: 24, textAlign: 'center' }}>
-          <p className="font-display italic" style={{ fontSize: 22, color, marginBottom: 6 }}>Task proposed!</p>
-          <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-secondary)' }}>An admin will review it soon.</p>
+          {isMetaTask ? (
+            <>
+              <p className="font-display italic" style={{ fontSize: 22, color, marginBottom: 6 }}>Meta task created!</p>
+              <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-secondary)' }}>
+                Players can now select it as a bonus when submitting {factionName(factionSlug)} praxis.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="font-display italic" style={{ fontSize: 22, color, marginBottom: 6 }}>Task proposed!</p>
+              <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-secondary)' }}>An admin will review it soon.</p>
+            </>
+          )}
         </div>
       </div>
     )
@@ -77,16 +91,30 @@ export default function ProposeTask() {
     setSubmitting(true)
     setError(null)
     try {
-      await proposeTask({
-        title,
-        description: description || undefined,
-        point_value: parseInt(pointValue) || 10,
-        level_required: levelRequired === '' ? 0 : levelRequired,
-        primary_faction_slug: factionSlug || undefined,
-      })
+      if (isMetaTask) {
+        if (!factionSlug || factionSlug === 'na') {
+          setError('Meta tasks must belong to a specific faction.')
+          return
+        }
+        await createMetaTask({
+          name: title,
+          description,
+          faction_slug: factionSlug,
+          bonus_value: parseInt(metaBonusValue) || 10,
+          level_required: levelRequired === '' ? 0 : levelRequired,
+        })
+      } else {
+        await proposeTask({
+          title,
+          description: description || undefined,
+          point_value: parseInt(pointValue) || 10,
+          level_required: levelRequired === '' ? 0 : levelRequired,
+          primary_faction_slug: factionSlug || undefined,
+        })
+      }
       setSuccess(true)
     } catch (err) {
-      setError(extractError(err, 'Could not propose task.'))
+      setError(extractError(err, isMetaTask ? 'Could not create meta task.' : 'Could not propose task.'))
     } finally {
       setSubmitting(false)
     }
@@ -207,26 +235,50 @@ export default function ProposeTask() {
 
               {/* Suggested Difficulty (§20.4) */}
               <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start', marginBottom: 12 }}>
-                <div>
-                  <span className="eyebrow" style={{ display: 'block', marginBottom: 6 }}>Base points</span>
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={pointValue}
-                    onChange={(e) => setPointValue(e.target.value.replace(/[^0-9]/g, ''))}
-                    disabled={submitting}
-                    placeholder="pts"
-                    style={{
-                      width: 80,
-                      fontFamily: "'Courier Prime', monospace", fontSize: 20, fontWeight: 700,
-                      color: 'var(--color-text-primary)',
-                      background: 'transparent', border: 'none',
-                      borderBottom: `2px solid ${dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
-                      outline: 'none', textAlign: 'center',
-                    }}
-                  />
-                  <span className="eyebrow" style={{ display: 'block', marginTop: 4, fontSize: 7 }}>Admin may adjust</span>
-                </div>
+                {!isMetaTask && (
+                  <div>
+                    <span className="eyebrow" style={{ display: 'block', marginBottom: 6 }}>Base points</span>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={pointValue}
+                      onChange={(e) => setPointValue(e.target.value.replace(/[^0-9]/g, ''))}
+                      disabled={submitting}
+                      placeholder="pts"
+                      style={{
+                        width: 80,
+                        fontFamily: "'Courier Prime', monospace", fontSize: 20, fontWeight: 700,
+                        color: 'var(--color-text-primary)',
+                        background: 'transparent', border: 'none',
+                        borderBottom: `2px solid ${dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'}`,
+                        outline: 'none', textAlign: 'center',
+                      }}
+                    />
+                    <span className="eyebrow" style={{ display: 'block', marginTop: 4, fontSize: 7 }}>Admin may adjust</span>
+                  </div>
+                )}
+                {isMetaTask && (
+                  <div>
+                    <span className="eyebrow" style={{ display: 'block', marginBottom: 6 }}>Bonus points</span>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={metaBonusValue}
+                      onChange={(e) => setMetaBonusValue(e.target.value.replace(/[^0-9]/g, ''))}
+                      disabled={submitting}
+                      placeholder="pts"
+                      style={{
+                        width: 80,
+                        fontFamily: "'Courier Prime', monospace", fontSize: 20, fontWeight: 700,
+                        color: 'var(--color-text-primary)',
+                        background: 'transparent', border: 'none',
+                        borderBottom: `2px solid ${color}`,
+                        outline: 'none', textAlign: 'center',
+                      }}
+                    />
+                    <span className="eyebrow" style={{ display: 'block', marginTop: 4, fontSize: 7 }}>Flat bonus added to score</span>
+                  </div>
+                )}
                 <div>
                   <span className="eyebrow" style={{ display: 'block', marginBottom: 6 }}>Minimum level</span>
                   <FilterLevelNodes
@@ -237,32 +289,57 @@ export default function ProposeTask() {
                   <span className="eyebrow" style={{ display: 'block', marginTop: 4, fontSize: 7 }}>Level 0 = anyone can attempt</span>
                 </div>
               </div>
+
+              {/* Meta Task Toggle — level 5+ or admin only */}
+              {(characterLevel >= 5 || user?.is_admin) && (
+                <div style={{
+                  borderTop: '1px dashed var(--color-border)',
+                  paddingTop: 12, marginTop: 4,
+                }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                    <input
+                      type="checkbox"
+                      checked={isMetaTask}
+                      onChange={(e) => setIsMetaTask(e.target.checked)}
+                      style={{ accentColor: color, width: 14, height: 14, cursor: 'pointer' }}
+                    />
+                    <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)', fontWeight: isMetaTask ? 700 : 400 }}>
+                      Create as meta task
+                    </span>
+                    <span className="eyebrow" style={{ fontSize: 7, color: 'var(--color-text-tertiary)' }}>
+                      applies as a bonus to all {factionSlug !== 'na' ? factionName(factionSlug) : ''} submissions
+                    </span>
+                  </label>
+                </div>
+              )}
             </div>
 
-            {/* Notes to Admin (§20.5) */}
-            <div style={{ marginBottom: 16 }}>
-              <span className="eyebrow" style={{ display: 'block', marginBottom: 6 }}>Notes to admin (optional)</span>
-              <textarea
-                rows={3}
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                disabled={submitting}
-                placeholder="Why do you want this task to exist? What inspired it?"
-                style={{
-                  width: '100%',
-                  fontFamily: "'Courier Prime', monospace", fontSize: 11,
-                  color: 'var(--color-text-primary)',
-                  background: 'transparent',
-                  border: `1px solid ${dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'}`,
-                  borderRadius: 6, padding: '0.6rem 0.7rem',
-                  outline: 'none', resize: 'vertical',
-                }}
-                onFocus={(e) => { e.currentTarget.style.borderColor = color }}
-                onBlur={(e) => { e.currentTarget.style.borderColor = dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}
-              />
-            </div>
+            {/* Notes to Admin (§20.5) — hidden for meta tasks */}
+            {!isMetaTask && (
+              <div style={{ marginBottom: 16 }}>
+                <span className="eyebrow" style={{ display: 'block', marginBottom: 6 }}>Notes to admin (optional)</span>
+                <textarea
+                  rows={3}
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  disabled={submitting}
+                  placeholder="Why do you want this task to exist? What inspired it?"
+                  style={{
+                    width: '100%',
+                    fontFamily: "'Courier Prime', monospace", fontSize: 11,
+                    color: 'var(--color-text-primary)',
+                    background: 'transparent',
+                    border: `1px solid ${dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'}`,
+                    borderRadius: 6, padding: '0.6rem 0.7rem',
+                    outline: 'none', resize: 'vertical',
+                  }}
+                  onFocus={(e) => { e.currentTarget.style.borderColor = color }}
+                  onBlur={(e) => { e.currentTarget.style.borderColor = dark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}
+                />
+              </div>
+            )}
 
-            {/* Task Preview Strip (§20.6) */}
+            {/* Task / Meta Task Preview Strip (§20.6) */}
             {title && (
               <div
                 style={{
@@ -271,7 +348,7 @@ export default function ProposeTask() {
                 }}
               >
                 <span className="eyebrow" style={{ color, marginBottom: 4, display: 'block' }}>
-                  Task preview — {fname} · Pending
+                  {isMetaTask ? `Meta task preview — ${fname}` : `Task preview — ${fname} · Pending`}
                 </span>
                 <p className="font-body" style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text-primary)', marginBottom: 2 }}>
                   {title}
@@ -282,9 +359,12 @@ export default function ProposeTask() {
                   </p>
                 )}
                 <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
-                  <span className="eyebrow">{pointValue || '?'} pts</span>
+                  {isMetaTask
+                    ? <span className="eyebrow" style={{ color: '#15803d' }}>+{metaBonusValue || '?'} bonus pts</span>
+                    : <span className="eyebrow">{pointValue || '?'} pts</span>
+                  }
                   <span className="eyebrow">lvl {levelRequired === '' ? 0 : levelRequired}+</span>
-                  <span className="eyebrow" style={{ color }}>Pending review</span>
+                  {!isMetaTask && <span className="eyebrow" style={{ color }}>Pending review</span>}
                 </div>
               </div>
             )}
@@ -308,13 +388,13 @@ export default function ProposeTask() {
                 }}
               >
                 <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-                {submitting ? 'Submitting...' : 'Submit proposal'}
+                {submitting ? 'Submitting...' : isMetaTask ? 'Create meta task' : 'Submit proposal'}
               </button>
               <button type="button" onClick={() => navigate(-1)} className="btn-outline" style={{ fontSize: 10, padding: '8px 16px' }}>
                 Cancel
               </button>
               <span className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)', marginLeft: 'auto' }}>
-                Your proposal goes to admin for review.
+                {isMetaTask ? 'Goes live immediately.' : 'Your proposal goes to admin for review.'}
               </span>
             </div>
           </form>

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -5,6 +5,7 @@ import { createPraxis, uploadMedia } from '../api/praxis'
 import { createCollaboration, inviteMember } from '../api/collaborations'
 import { getTask, dropTask, type TaskOut } from '../api/tasks'
 import { listCharacters, type CharacterOut } from '../api/characters'
+import { getMetaTasks, type MetaTaskOut } from '../api/metaTasks'
 import LevelPill from '../components/ui/LevelPill'
 import { useAuth } from '../auth/AuthContext'
 import { useTheme } from '../hooks/useTheme'
@@ -39,6 +40,8 @@ export default function SubmitProof() {
   const [files, setFiles] = useState<File[]>([])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  const [metaTasks, setMetaTasks] = useState<MetaTaskOut[]>([])
+  const [selectedMetaTaskId, setSelectedMetaTaskId] = useState<number | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
 
   // Collab/duel state — initialize from location state if navigated from TaskDetail
@@ -54,8 +57,16 @@ export default function SubmitProof() {
   const [showSearch, setShowSearch] = useState(false)
 
   useEffect(() => {
-    if (id) getTask(parseInt(id, 10)).then(setTask).catch(() => {})
-  }, [id])
+    if (!id) return
+    const taskId = parseInt(id, 10)
+    getTask(taskId).then(setTask).catch(() => {})
+    getMetaTasks(taskId)
+      .then((all) => {
+        const characterLevel = user?.character?.level ?? 0
+        setMetaTasks(all.filter((mt) => characterLevel >= mt.level_required))
+      })
+      .catch(() => {})
+  }, [id, user?.character?.level])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -82,6 +93,7 @@ export default function SubmitProof() {
           task_id: parseInt(id, 10),
           title,
           body_text: body || undefined,
+          meta_task_id: selectedMetaTaskId ?? undefined,
         })
         for (const file of files) {
           await uploadMedia(praxis.id, file)
@@ -376,6 +388,64 @@ export default function SubmitProof() {
           </div>
         )}
       </div>
+
+      {/* ── Meta Task Selection (solo only; hidden when no applicable meta tasks) ── */}
+      {selectedMode === 'solo' && metaTasks.length > 0 && (
+        <div className="sidebar-card mb-5" style={{ padding: '16px 18px' }}>
+          <p className="eyebrow mb-3">Optional meta task bonus</p>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {metaTasks.map((mt, index) => {
+              const mtColor = factionColor(mt.faction_slug)
+              const selected = selectedMetaTaskId === mt.id
+              return (
+                <button
+                  key={mt.id}
+                  type="button"
+                  onClick={() => setSelectedMetaTaskId(selected ? null : mt.id)}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    padding: '10px 12px',
+                    borderTop: index === 0 ? 'none' : '1px dashed var(--color-border)',
+                    background: selected ? `${mtColor}12` : 'transparent',
+                    border: selected ? `1.5px solid ${mtColor}60` : 'none',
+                    borderRadius: selected ? 4 : 0,
+                    cursor: 'pointer', textAlign: 'left', width: '100%',
+                    marginBottom: selected ? 2 : 0,
+                  }}
+                >
+                  <span style={{
+                    width: 10, height: 10, borderRadius: '50%',
+                    background: selected ? mtColor : 'var(--color-border)',
+                    flexShrink: 0, transition: 'background 120ms',
+                  }} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', display: 'block' }}>
+                      {mt.name}
+                    </span>
+                    <span className="font-body" style={{ fontSize: 9, color: 'var(--color-text-secondary)' }}>
+                      {mt.description}
+                    </span>
+                  </div>
+                  <span style={{
+                    fontFamily: "'Courier Prime', monospace",
+                    fontSize: 11, fontWeight: 700,
+                    color: selected ? '#15803d' : 'var(--color-text-tertiary)',
+                    whiteSpace: 'nowrap',
+                  }}>
+                    +{mt.bonus_value} pts
+                  </span>
+                  {mt.level_required > 0 && <LevelPill level={mt.level_required} />}
+                </button>
+              )
+            })}
+          </div>
+          {selectedMetaTaskId !== null && (
+            <p className="eyebrow" style={{ marginTop: 8, fontSize: 8, color: 'var(--color-text-tertiary)' }}>
+              Click again to deselect
+            </p>
+          )}
+        </div>
+      )}
 
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.1rem' }}>
         {/* ── Section 1: Proof Title (§18.3) ── */}

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -3,14 +3,17 @@ import { useNavigate } from 'react-router-dom'
 import { listTasks, signupTask, type TaskOut } from '../api/tasks'
 import { getFactions, type FactionOut } from '../api/factions'
 import { getGameConfig, type FactionConfigOut } from '../api/gameConfig'
+import { getMetaTasks, type MetaTaskOut } from '../api/metaTasks'
 import TaskCard from '../components/TaskCard'
 import PageTitle from '../components/ui/PageTitle'
 import FilterStamps from '../components/ui/FilterStamps'
 import FilterFactionTabs from '../components/ui/FilterFactionTabs'
 import FilterLevelNodes from '../components/ui/FilterLevelNodes'
+import LevelPill from '../components/ui/LevelPill'
 import { extractError } from '../utils/errors'
 import { useAuth } from '../auth/AuthContext'
 import { computeDisplayPoints } from '../utils/points'
+import { factionColor, factionName } from '../utils/factions'
 
 const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
 
@@ -29,6 +32,9 @@ export default function Tasks() {
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [signupMsg, setSignupMsg] = useState<{ id: number; msg: string; ok: boolean } | null>(null)
+  const [showMetaTasks, setShowMetaTasks] = useState(false)
+  const [metaTaskList, setMetaTaskList] = useState<MetaTaskOut[]>([])
+  const [metaTasksLoading, setMetaTasksLoading] = useState(false)
 
   // Fetch factions (filter tabs) and game config (faction modifiers) once
   useEffect(() => {
@@ -39,6 +45,16 @@ export default function Tasks() {
   }, [])
 
   useEffect(() => {
+    if (!showMetaTasks) return
+    setMetaTasksLoading(true)
+    getMetaTasks()
+      .then(setMetaTaskList)
+      .catch(() => setMetaTaskList([]))
+      .finally(() => setMetaTasksLoading(false))
+  }, [showMetaTasks])
+
+  useEffect(() => {
+    if (showMetaTasks) return
     setLoading(true)
     setFetchError(null)
     listTasks({
@@ -50,7 +66,7 @@ export default function Tasks() {
       .then(setTasks)
       .catch((err) => setFetchError(extractError(err, "Couldn't load tasks.")))
       .finally(() => setLoading(false))
-  }, [status, faction, level, characterId])
+  }, [status, faction, level, characterId, showMetaTasks])
 
   const handleSignup = async (id: number) => {
     setSignupMsg(null)
@@ -67,14 +83,43 @@ export default function Tasks() {
   if (characterLevel >= 2) statusFilters.push('retired')
   if (characterLevel >= 3) statusFilters.push('pending')
 
+  // Client-side filter for meta tasks (faction + level)
+  const visibleMetaTasks = metaTaskList.filter((mt) => {
+    if (faction && mt.faction_slug !== faction) return false
+    if (level !== '' && mt.level_required < level) return false
+    return true
+  })
+
   return (
     <div className="py-8">
-      <PageTitle title="Tasks" eyebrow={`${tasks.length} shown`} />
+      <PageTitle
+        title="Tasks"
+        eyebrow={showMetaTasks ? `${visibleMetaTasks.length} meta tasks` : `${tasks.length} shown`}
+      />
 
       {/* Filters — three distinct visual types (Style Guide §5.3) */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 24 }}>
-        <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
-        <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
+        {!showMetaTasks && (
+          <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
+          <button
+            type="button"
+            onClick={() => setShowMetaTasks((v) => !v)}
+            style={{
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.1em', padding: '4px 12px',
+              background: showMetaTasks ? '#15803d' : 'transparent',
+              color: showMetaTasks ? '#fff' : 'var(--color-text-tertiary)',
+              border: `1.5px solid ${showMetaTasks ? '#15803d' : 'var(--color-border)'}`,
+              cursor: 'pointer', whiteSpace: 'nowrap',
+            }}
+          >
+            Meta Tasks
+          </button>
+        </div>
         <FilterLevelNodes levels={LEVEL_FILTERS} value={level} onChange={setLevel} />
       </div>
 
@@ -84,7 +129,59 @@ export default function Tasks() {
         </p>
       )}
 
-      {loading ? (
+      {showMetaTasks ? (
+        metaTasksLoading ? (
+          <p className="font-body text-muted">Loading meta tasks...</p>
+        ) : visibleMetaTasks.length === 0 ? (
+          <p className="font-body text-muted">No meta tasks match your filters.</p>
+        ) : (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
+            {visibleMetaTasks.map((mt) => {
+              const mtColor = factionColor(mt.faction_slug)
+              return (
+                <div
+                  key={mt.id}
+                  className="sidebar-card"
+                  style={{
+                    borderLeft: `4px solid ${mtColor}`,
+                    padding: '16px 18px',
+                    minWidth: 220, maxWidth: 320, flex: '1 1 220px',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                    <span
+                      style={{
+                        clipPath: 'polygon(0 0, 100% 0, 95% 100%, 5% 100%)',
+                        background: mtColor, color: 'white',
+                        fontFamily: "'Courier Prime', monospace",
+                        fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                        letterSpacing: '0.07em', padding: '2px 10px',
+                      }}
+                    >
+                      {factionName(mt.faction_slug)}
+                    </span>
+                    {mt.level_required > 0 && <LevelPill level={mt.level_required} />}
+                  </div>
+                  <p className="font-body" style={{ fontSize: 13, fontWeight: 700, color: 'var(--color-text-primary)', marginBottom: 4 }}>
+                    {mt.name}
+                  </p>
+                  <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-secondary)', lineHeight: 1.5, marginBottom: 10 }}>
+                    {mt.description}
+                  </p>
+                  <span
+                    style={{
+                      fontFamily: "'Courier Prime', monospace",
+                      fontSize: 11, fontWeight: 700, color: '#15803d',
+                    }}
+                  >
+                    +{mt.bonus_value} pts bonus
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )
+      ) : loading ? (
         <p className="font-body text-muted">Loading tasks...</p>
       ) : fetchError ? (
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">


### PR DESCRIPTION
## Summary
- **Backend**: `POST /meta-tasks` (level 5+ or admin); `GET /meta-tasks` now works without `task_id` for browsing; praxis creation accepts `meta_task_id`, validates level requirement, and writes the `PraxisMetaTask` join record; fixes a silent bug where `level_required` on meta tasks was never enforced during scoring
- **Seed**: Adds "Upside Down" placeholder meta task (+100 pts flat, `ua_masters` faction, level 0 required)
- **SubmitProof**: Fetches applicable meta tasks for the task, shows a selectable bonus panel above the form (solo mode only; filtered to meta tasks the player's level qualifies for)
- **ProposeTask**: Level 5+ players see a "Create as meta task" checkbox; when checked, the form swaps to bonus-points mode and calls `POST /meta-tasks` directly (no admin review queue)
- **Tasks list**: New "Meta Tasks" toggle filter fetches and renders meta task cards (faction color, name, description, bonus badge); faction and level filters apply client-side

## Test plan
- [ ] Run `python seed.py` — confirm "Upside Down" meta task is seeded
- [ ] `/tasks` → click "Meta Tasks" toggle → "Upside Down" card appears
- [ ] `/tasks/propose` as level 5+ → check "Create as meta task" → bonus pts field appears, `na` faction blocked → submit → meta task visible in task list
- [ ] Sign up for a `ua_masters` task → go to submit proof → "Upside Down" appears in bonus panel → select it → publish → `praxis_meta_task` row exists in DB
- [ ] Vote on that praxis → character score includes +100 bonus
- [ ] Level 0 player submitting against a `level_required=3` meta task → meta task hidden in SubmitProof
- [ ] `pytest` from `/backend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)