### PR TITLE
Fix four collaboration/duel praxis relationship bugs

### DIFF
--- a/backend/alembic/versions/0002_collab_member_content.py
+++ b/backend/alembic/versions/0002_collab_member_content.py
@@ -1,0 +1,25 @@
+"""Add title and body_text to collaboration_member for per-member content.
+
+Revision ID: 0002_collab_member_content
+Revises: 0001_squashed
+Create Date: 2026-04-15
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002_collab_member_content"
+down_revision: Union[str, None] = "0001_squashed"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("collaboration_member", sa.Column("title", sa.Text(), nullable=True))
+    op.add_column("collaboration_member", sa.Column("body_text", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("collaboration_member", "body_text")
+    op.drop_column("collaboration_member", "title")

--- a/backend/models/collaboration.py
+++ b/backend/models/collaboration.py
@@ -87,6 +87,8 @@ class CollaborationMember(Base):
     has_submitted: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
     )
+    title: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    body_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     joined_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/routers/collaborations.py
+++ b/backend/routers/collaborations.py
@@ -8,10 +8,12 @@ from dependencies import get_current_character
 from game_config import CURRENT_ERA
 from models.character import Character
 from schemas.collaboration import (
+    CollaborationCardOut,
     CollaborationCreate,
     CollaborationDocumentUpdate,
     CollaborationInviteCreate,
     CollaborationInviteOut,
+    CollaborationMemberContentUpdate,
     CollaborationOut,
     CollaborationVoteIn,
     DuelVoteSummary,
@@ -24,14 +26,24 @@ from services.collaboration import (
     get_duel_vote_summary,
     invite_member,
     kick_member,
+    list_published_collaborations,
     reopen_collaboration,
     respond_to_invite,
     submit_for_member,
     update_document,
+    update_member_content,
 )
 from services.vote import cast_or_update_duel_vote
 
 router = APIRouter()
+
+
+@router.get("", response_model=list[CollaborationCardOut])
+async def list_collaborations_route(
+    session: AsyncSession = Depends(get_db),
+):
+    """List all published collaborations and duels for the praxis feed."""
+    return await list_published_collaborations(session)
 
 
 @router.post("", response_model=CollaborationOut)
@@ -76,6 +88,24 @@ async def update_document_route(
 ):
     """Update the shared document. Any member can edit."""
     collab = await update_document(collaboration_id, character, data.body_text, session)
+    return build_collaboration_out(collab, viewer_character_id=character.id)
+
+
+@router.put("/{collaboration_id}/my-content", response_model=CollaborationOut)
+async def update_my_content_route(
+    collaboration_id: int,
+    data: CollaborationMemberContentUpdate,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Update this member's individual title and body content."""
+    collab = await update_member_content(
+        collaboration_id=collaboration_id,
+        character=character,
+        title=data.title,
+        body_text=data.body_text,
+        session=session,
+    )
     return build_collaboration_out(collab, viewer_character_id=character.id)
 
 

--- a/backend/schemas/collaboration.py
+++ b/backend/schemas/collaboration.py
@@ -16,6 +16,8 @@ class CollaborationMemberOut(BaseModel):
     display_name: str
     faction_slug: str
     has_submitted: bool
+    title: Optional[str] = None
+    body_text: Optional[str] = None
     joined_at: datetime
 
 
@@ -51,6 +53,11 @@ class CollaborationOut(BaseModel):
     invites: list[CollaborationInviteOut] = []
 
 
+class CollaborationMemberContentUpdate(BaseModel):
+    title: str = Field(..., max_length=200)
+    body_text: Optional[str] = Field(None, max_length=10000)
+
+
 class CollaborationInviteCreate(BaseModel):
     invitee_character_id: int
 
@@ -75,3 +82,21 @@ class DuelVoteSummary(BaseModel):
 class CollaborationVoteIn(BaseModel):
     target_character_id: int
     stars: int = Field(..., ge=1, le=5)
+
+
+class CollaborationMemberCardOut(BaseModel):
+    character_id: int
+    display_name: str
+    faction_slug: Optional[str] = None
+    score: Optional[float] = None
+
+
+class CollaborationCardOut(BaseModel):
+    id: int
+    task_id: int
+    task_title: str
+    task_faction_slug: Optional[str] = None
+    mode: str
+    status: str
+    created_at: datetime
+    members: list[CollaborationMemberCardOut] = []

--- a/backend/services/collaboration.py
+++ b/backend/services/collaboration.py
@@ -16,7 +16,9 @@ from models.collaboration import (
 )
 from models.task import CharacterTask, CharacterTaskStatus, Task
 from schemas.collaboration import (
+    CollaborationCardOut,
     CollaborationInviteOut,
+    CollaborationMemberCardOut,
     CollaborationMemberOut,
     CollaborationOut,
     DuelVoteSummary,
@@ -35,6 +37,8 @@ def _build_member_out(member: CollaborationMember) -> CollaborationMemberOut:
         display_name=member.character.display_name,
         faction_slug=member.character.faction_slug,
         has_submitted=member.has_submitted,
+        title=member.title,
+        body_text=member.body_text,
         joined_at=member.joined_at,
     )
 
@@ -217,6 +221,39 @@ async def invite_member(
     invitee = await session.get(Character, invitee_character_id)
     if invitee is None:
         raise HTTPException(status_code=404, detail="Invitee not found.")
+
+    # Eligibility check: skip for Analog faction (they can redo tasks via Double Dipper)
+    ANALOG_FACTION_SLUG = "analog"
+    if invitee.faction_slug != ANALOG_FACTION_SLUG:
+        from models.praxis import Praxis
+
+        existing_solo_result = await session.execute(
+            select(Praxis).where(
+                Praxis.character_id == invitee_character_id,
+                Praxis.task_id == collab.task_id,
+                Praxis.is_withdrawn == False,
+            )
+        )
+        if existing_solo_result.scalar_one_or_none() is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="This player has already submitted proof for this task and is not eligible to be invited.",
+            )
+
+        existing_collab_result = await session.execute(
+            select(CollaborationMember)
+            .join(Collaboration, CollaborationMember.collaboration_id == Collaboration.id)
+            .where(
+                CollaborationMember.character_id == invitee_character_id,
+                Collaboration.task_id == collab.task_id,
+                Collaboration.status == CollaborationStatus.published,
+            )
+        )
+        if existing_collab_result.scalar_one_or_none() is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="This player has already completed this task in a collaboration and is not eligible to be invited.",
+            )
 
     invite = CollaborationInvite(
         collaboration_id=collaboration_id,
@@ -474,6 +511,115 @@ async def update_document(
     await session.commit()
     await session.refresh(collab)
     return collab
+
+
+async def update_member_content(
+    collaboration_id: int,
+    character: Character,
+    title: str,
+    body_text: str | None,
+    session: AsyncSession,
+) -> Collaboration:
+    """Update the current member's individual title and body content."""
+    collab = await session.get(Collaboration, collaboration_id)
+    if collab is None:
+        raise HTTPException(status_code=404, detail="Collaboration not found.")
+
+    member_ids = {m.character_id for m in collab.members}
+    if character.id not in member_ids:
+        raise HTTPException(status_code=403, detail="You are not a member of this collaboration.")
+
+    if collab.status == CollaborationStatus.published:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot edit content in a published collaboration. Reopen it first.",
+        )
+
+    for member in collab.members:
+        if member.character_id == character.id:
+            member.title = title
+            member.body_text = body_text
+            break
+
+    await session.commit()
+    await session.refresh(collab)
+    return collab
+
+
+def build_collaboration_card_out(
+    collab: Collaboration,
+    vote_totals: dict[int, int],
+    vote_counts: dict[int, int],
+) -> CollaborationCardOut:
+    """Serialize a published Collaboration for display on the praxis listing."""
+    members_out = []
+    for member in collab.members:
+        total_stars = vote_totals.get(member.character_id, 0)
+        count = vote_counts.get(member.character_id, 0)
+        avg_score = round(total_stars / count, 1) if count > 0 else None
+        members_out.append(
+            CollaborationMemberCardOut(
+                character_id=member.character_id,
+                display_name=member.character.display_name,
+                faction_slug=member.character.faction_slug,
+                score=avg_score,
+            )
+        )
+    return CollaborationCardOut(
+        id=collab.id,
+        task_id=collab.task_id,
+        task_title=collab.task.title,
+        task_faction_slug=collab.task.primary_faction_slug,
+        mode=collab.mode.value,
+        status=collab.status.value,
+        created_at=collab.created_at,
+        members=members_out,
+    )
+
+
+async def list_published_collaborations(
+    session: AsyncSession,
+) -> list[CollaborationCardOut]:
+    """Return all published collaborations for the praxis listing page."""
+    from sqlalchemy import func
+    from models.vote import Vote
+
+    result = await session.execute(
+        select(Collaboration).where(Collaboration.status == CollaborationStatus.published)
+    )
+    collabs = result.scalars().all()
+
+    if not collabs:
+        return []
+
+    collab_ids = [c.id for c in collabs]
+
+    # Fetch vote totals and counts per (collaboration_id, target_character)
+    votes_result = await session.execute(
+        select(
+            Vote.collaboration_id,
+            Vote.duel_vote_for,
+            func.sum(Vote.stars).label("total_stars"),
+            func.count(Vote.id).label("vote_count"),
+        ).where(
+            Vote.collaboration_id.in_(collab_ids),
+            Vote.duel_vote_for.is_not(None),
+        ).group_by(Vote.collaboration_id, Vote.duel_vote_for)
+    )
+
+    # Map: collab_id -> {char_id -> (total_stars, count)}
+    votes_by_collab: dict[int, dict[int, tuple[int, int]]] = {}
+    for collab_id, char_id, total_stars, vote_count in votes_result.all():
+        votes_by_collab.setdefault(collab_id, {})[char_id] = (int(total_stars), int(vote_count))
+
+    cards = []
+    for collab in collabs:
+        char_votes = votes_by_collab.get(collab.id, {})
+        vote_totals = {char_id: data[0] for char_id, data in char_votes.items()}
+        vote_counts = {char_id: data[1] for char_id, data in char_votes.items()}
+        cards.append(build_collaboration_card_out(collab, vote_totals, vote_counts))
+
+    return cards
 
 
 async def get_duel_vote_summary(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import Disclaimer from './pages/Disclaimer'
 import Attributions from './pages/Attributions'
 import Donate from './pages/Donate'
 import CollaborationDetail from './pages/CollaborationDetail'
+import EditCollaboration from './pages/EditCollaboration'
 
 export default function App() {
   return (
@@ -39,6 +40,14 @@ export default function App() {
           }
         />
         <Route path="/collaborations/:id" element={<CollaborationDetail />} />
+        <Route
+          path="/collaborations/:id/edit"
+          element={
+            <ProtectedRoute>
+              <EditCollaboration />
+            </ProtectedRoute>
+          }
+        />
         <Route path="/praxes" element={<Praxes />} />
         <Route path="/praxes/:id" element={<PraxisDetail />} />
         <Route

--- a/frontend/src/api/collaborations.ts
+++ b/frontend/src/api/collaborations.ts
@@ -10,7 +10,27 @@ export interface CollaborationMemberOut {
   faction_slug: string | null
   avatar_url: string | null
   has_submitted: boolean
+  title: string | null
+  body_text: string | null
   joined_at: string
+}
+
+export interface CollaborationMemberCardOut {
+  character_id: number
+  display_name: string
+  faction_slug: string | null
+  score: number | null
+}
+
+export interface CollaborationCardOut {
+  id: number
+  task_id: number
+  task_title: string
+  task_faction_slug: string | null
+  mode: CollaborationMode
+  status: CollaborationStatus
+  created_at: string
+  members: CollaborationMemberCardOut[]
 }
 
 export interface CollaborationInviteOut {
@@ -48,6 +68,11 @@ export interface DuelVoteSummary {
   is_winning: boolean
 }
 
+export async function listPublishedCollaborations(): Promise<CollaborationCardOut[]> {
+  const { data } = await api.get<CollaborationCardOut[]>('/collaborations')
+  return data
+}
+
 export async function createCollaboration(
   task_id: number,
   mode: CollaborationMode,
@@ -63,6 +88,18 @@ export async function getCollaboration(id: number): Promise<CollaborationOut> {
 
 export async function updateDocument(id: number, body_text: string): Promise<CollaborationOut> {
   const { data } = await api.post<CollaborationOut>(`/collaborations/${id}/document`, { body_text })
+  return data
+}
+
+export async function updateMemberContent(
+  collaboration_id: number,
+  title: string,
+  body_text: string | undefined,
+): Promise<CollaborationOut> {
+  const { data } = await api.put<CollaborationOut>(
+    `/collaborations/${collaboration_id}/my-content`,
+    { title, body_text: body_text ?? null },
+  )
   return data
 }
 

--- a/frontend/src/components/CollaborationCard.tsx
+++ b/frontend/src/components/CollaborationCard.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom'
+import type { CollaborationCardOut } from '../api/collaborations'
+import { factionCssVar } from '../utils/factions'
+
+interface Props {
+  collab: CollaborationCardOut
+}
+
+export default function CollaborationCard({ collab }: Props) {
+  const isDuel = collab.mode === 'duel'
+  const separator = isDuel ? ' × ' : ', '
+  const memberNames = collab.members.map((m) => m.display_name).join(separator)
+
+  return (
+    <div
+      className="card p-4 flex flex-col gap-2 transition-all duration-150"
+      style={{
+        background: factionCssVar(collab.task_faction_slug, 'card-bg'),
+        borderLeft: `4px solid ${factionCssVar(collab.task_faction_slug, 'card-accent')}`,
+        color: factionCssVar(collab.task_faction_slug, 'card-text'),
+      }}
+    >
+      {/* Mode label */}
+      <span
+        className="eyebrow self-start"
+        style={{
+          fontSize: 7, padding: '1px 6px',
+          background: isDuel ? 'rgba(220,38,38,0.12)' : 'rgba(21,128,61,0.12)',
+          color: isDuel ? '#dc2626' : '#15803d',
+          border: `1px solid ${isDuel ? 'rgba(220,38,38,0.3)' : 'rgba(21,128,61,0.3)'}`,
+        }}
+      >
+        {isDuel ? 'Duel' : 'Collaboration'}
+      </span>
+
+      {/* Task link */}
+      <Link to={`/tasks/${collab.task_id}`} className="font-body text-xs text-muted hover:underline">
+        {collab.task_title}
+      </Link>
+
+      {/* Members */}
+      <Link to={`/collaborations/${collab.id}`}>
+        <h3 className="font-display text-lg font-semibold leading-tight hover:underline">
+          {memberNames}
+        </h3>
+      </Link>
+
+      {/* Score row */}
+      {collab.members.some((m) => m.score !== null) && (
+        <div className="flex gap-3 font-body text-xs text-muted">
+          {collab.members.map((m) => (
+            <span key={m.character_id}>
+              {m.display_name}: {m.score !== null ? `★ ${m.score.toFixed(1)}` : '—'}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex justify-between items-center pt-2 border-t border-dashed border-border/40 font-body text-xs text-muted mt-auto">
+        <Link to={`/collaborations/${collab.id}`} className="hover:underline">
+          View {isDuel ? 'duel' : 'collaboration'}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/CollaborationDetail.tsx
+++ b/frontend/src/pages/CollaborationDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import {
   getCollaboration,
@@ -22,8 +22,14 @@ const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '
 
 export default function CollaborationDetail() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const location = useLocation()
   const { user } = useAuth()
   const myCharacterId = user?.character?.id
+
+  // Invite errors passed from SubmitProof when some invites failed on collab creation
+  const locationState = location.state as { inviteErrors?: string[] } | null
+  const [startupInviteErrors] = useState<string[]>(locationState?.inviteErrors ?? [])
 
   const [collab, setCollab] = useState<CollaborationOut | null>(null)
   const [loading, setLoading] = useState(true)
@@ -589,6 +595,58 @@ export default function CollaborationDetail() {
         </div>
       )}
 
+      {/* My Proof — edit link for current member */}
+      {isMember && !isPublished && (
+        <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+            <p className="eyebrow">My Proof</p>
+            <button
+              onClick={() => navigate(`/collaborations/${id}/edit`)}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                background: 'transparent', border: `1px solid ${modeColor}`,
+                padding: '3px 10px', cursor: 'pointer',
+                color: modeColor,
+              }}
+            >
+              Edit my proof
+            </button>
+          </div>
+          {myMember?.title ? (
+            <div>
+              <p className="font-display italic" style={{ fontSize: 16, color: 'var(--color-text-primary)', marginBottom: 4 }}>
+                {myMember.title}
+              </p>
+              {myMember.body_text && (
+                <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-secondary)', whiteSpace: 'pre-wrap' }}>
+                  {myMember.body_text.length > 200 ? myMember.body_text.slice(0, 200) + '…' : myMember.body_text}
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-tertiary)', fontStyle: 'italic' }}>
+              No proof written yet. Click "Edit my proof" to add your submission.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* My Proof — read-only view when published */}
+      {isMember && isPublished && myMember?.title && (
+        <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+          <p className="eyebrow mb-3">My Proof</p>
+          <p className="font-display italic" style={{ fontSize: 16, color: 'var(--color-text-primary)', marginBottom: 4 }}>
+            {myMember.title}
+          </p>
+          {myMember.body_text && (
+            <div className="markdown-preview font-display" style={{ fontSize: 14, lineHeight: 1.75, color: 'var(--color-text-primary)', marginTop: 8 }}>
+              <ReactMarkdown>{myMember.body_text}</ReactMarkdown>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Submit / Reopen controls */}
       {isMember && !isPublished && (
         <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
@@ -639,6 +697,16 @@ export default function CollaborationDetail() {
           <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginTop: 4 }}>
             {isDuel ? 'Duel complete. Points have been awarded.' : 'Collaboration published. All members have been scored.'}
           </p>
+        </div>
+      )}
+
+      {startupInviteErrors.length > 0 && (
+        <div className="sidebar-card mb-4" style={{ padding: '12px 16px', borderLeft: '3px solid #d97706' }}>
+          <p className="eyebrow" style={{ color: '#d97706', marginBottom: 6 }}>Some invites could not be sent</p>
+          {startupInviteErrors.map((err, i) => (
+            <p key={i} className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 2 }}>{err}</p>
+          ))}
+          <p className="eyebrow" style={{ fontSize: 7, marginTop: 6, color: 'var(--color-text-tertiary)' }}>You can invite eligible players from the Members section above.</p>
         </div>
       )}
 

--- a/frontend/src/pages/EditCollaboration.tsx
+++ b/frontend/src/pages/EditCollaboration.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import {
+  getCollaboration,
+  updateMemberContent,
+  type CollaborationOut,
+} from '../api/collaborations'
+import { useAuth } from '../auth/AuthContext'
+import { useTheme } from '../hooks/useTheme'
+import { factionName } from '../utils/factions'
+import { extractError } from '../utils/errors'
+
+const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '#f97316', '#fbbf24', '#be185d']
+
+export default function EditCollaboration() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
+
+  const [collab, setCollab] = useState<CollaborationOut | null>(null)
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const collaborationId = id ? parseInt(id, 10) : null
+
+  useEffect(() => {
+    if (!collaborationId) return
+    getCollaboration(collaborationId)
+      .then((data) => {
+        const myCharacterId = user?.character?.id
+        const myMember = data.members.find((m) => m.character_id === myCharacterId)
+        if (!myMember) {
+          navigate(`/collaborations/${id}`, { replace: true })
+          return
+        }
+        if (data.status === 'published') {
+          navigate(`/collaborations/${id}`, { replace: true })
+          return
+        }
+        setCollab(data)
+        setTitle(myMember.title ?? '')
+        setBody(myMember.body_text ?? '')
+      })
+      .catch(() => setError("Couldn't load this collaboration."))
+      .finally(() => setLoading(false))
+  }, [collaborationId, user])
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!collaborationId) return
+    if (!title.trim()) { setError('Title is required.'); return }
+    setSaving(true)
+    setError('')
+    try {
+      await updateMemberContent(collaborationId, title, body || undefined)
+      navigate(`/collaborations/${id}`)
+    } catch (err) {
+      setError(extractError(err, 'Could not save changes.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
+  if (error && !collab) return <div className="py-8 font-body text-sm" style={{ color: '#dc2626' }}>{error}</div>
+  if (!collab) return null
+
+  const isDuel = collab.mode === 'duel'
+  const modeLabel = isDuel ? 'Duel' : 'Collaboration'
+  const modeColor = isDuel ? '#dc2626' : '#15803d'
+  const partners = collab.members.filter((m) => m.character_id !== user?.character?.id)
+  const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0
+
+  return (
+    <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}>
+      {/* Breadcrumb */}
+      <nav className="font-body mb-4" style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--color-text-tertiary)' }}>
+        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>Tasks</Link>
+        {' › '}
+        <Link to={`/tasks/${collab.task_id}`} style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}>{collab.task_title}</Link>
+        {' › '}
+        <Link to={`/collaborations/${id}`} style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}>{modeLabel}</Link>
+        {' › '}
+        <span style={{ color: 'var(--color-text-primary)' }}>Edit My Proof</span>
+      </nav>
+
+      {/* Context header */}
+      <div className="sidebar-card mb-5" style={{ padding: '16px 20px', borderLeft: `4px solid ${modeColor}` }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <span
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                letterSpacing: '0.1em', padding: '2px 8px',
+                background: modeColor, color: '#fff',
+                marginBottom: 6, display: 'inline-block',
+              }}
+            >
+              {modeLabel}
+            </span>
+            <Link
+              to={`/tasks/${collab.task_id}`}
+              className="font-display italic"
+              style={{ fontSize: 18, color: modeColor, textDecoration: 'none', display: 'block', marginBottom: 4 }}
+            >
+              {collab.task_title}
+            </Link>
+            {partners.length > 0 && (
+              <span className="eyebrow" style={{ fontSize: 8, color: 'var(--color-text-secondary)' }}>
+                {isDuel ? 'vs ' : 'with '}
+                {partners.map((p) => p.display_name).join(', ')}
+                {partners[0]?.faction_slug && (
+                  <span style={{ marginLeft: 4, color: 'var(--color-text-tertiary)' }}>
+                    · {factionName(partners[0].faction_slug)}
+                  </span>
+                )}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.1rem' }}>
+        {/* Title */}
+        <div className="sidebar-card" style={{ padding: '16px 18px', borderRadius: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
+            <span className="eyebrow">Title</span>
+            <span className="font-body" style={{ fontSize: 8, fontStyle: 'italic', color: 'var(--color-text-tertiary)' }}>required</span>
+          </div>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What did you do?"
+            maxLength={200}
+            style={{
+              width: '100%',
+              fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: 24,
+              color: 'var(--color-text-primary)',
+              background: 'transparent', border: 'none',
+              borderBottom: `2px solid ${title ? modeColor : (dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)')}`,
+              outline: 'none', paddingBottom: 6,
+              transition: 'border-color 150ms',
+            }}
+            onFocus={(e) => { e.currentTarget.style.borderBottomColor = modeColor }}
+            onBlur={(e) => { if (!title) e.currentTarget.style.borderBottomColor = dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)' }}
+          />
+          {title && (
+            <div style={{ display: 'flex', height: 3, marginTop: 4, opacity: 0.6 }}>
+              {RAINBOW_COLORS.map((c, i) => <div key={i} style={{ flex: 1, background: c }} />)}
+            </div>
+          )}
+          <span
+            className="eyebrow"
+            style={{ fontSize: 7, marginTop: 4, display: 'block', textAlign: 'right', color: title.length >= 180 ? '#dc2626' : undefined }}
+          >
+            {title.length}/200
+          </span>
+        </div>
+
+        {/* Body */}
+        <div className="sidebar-card" style={{ padding: '16px 18px', borderRadius: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
+            <span className="eyebrow">The proof</span>
+            <span className="font-body" style={{ fontSize: 8, fontStyle: 'italic', color: 'var(--color-text-tertiary)' }}>supports markdown</span>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={12}
+              placeholder="Describe what you did..."
+              style={{
+                width: '100%',
+                fontFamily: "'Lora', serif", fontSize: 14, color: dark ? '#e8dcc8' : '#2a1e10',
+                lineHeight: 1.75, minHeight: 180,
+                background: 'transparent', border: 'none', outline: 'none',
+                resize: 'vertical',
+              }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span className="eyebrow">{wordCount} words</span>
+            </div>
+          </div>
+          {body.trim() && (
+            <div style={{ borderTop: '1px dashed var(--color-border)', marginTop: 10, paddingTop: 10 }}>
+              <span className="eyebrow" style={{ marginBottom: 6, display: 'block' }}>Preview</span>
+              <div className="markdown-preview font-display" style={{ fontSize: 14, lineHeight: 1.75, color: dark ? '#e8dcc8' : '#2a1e10' }}>
+                <ReactMarkdown>{body}</ReactMarkdown>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <p className="font-body text-sm" style={{ color: '#dc2626' }}>{error}</p>
+        )}
+
+        {/* Submit */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button
+            type="submit"
+            disabled={saving}
+            style={{
+              background: modeColor, color: '#fff',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.12em', padding: '10px 24px',
+              border: 'none', cursor: saving ? 'wait' : 'pointer',
+              position: 'relative',
+            }}
+          >
+            <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
+            {saving ? 'Saving...' : 'Save proof'}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(`/collaborations/${id}`)}
+            style={{
+              background: 'transparent',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.12em', padding: '10px 24px',
+              border: '1px solid var(--color-border)',
+              cursor: 'pointer', color: 'var(--color-text-secondary)',
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import {
   getPraxis,
@@ -9,17 +9,24 @@ import {
   type MediaItemOut,
 } from '../api/praxis'
 import { useAuth } from '../auth/AuthContext'
+import { useTheme } from '../hooks/useTheme'
+import { factionColor, factionName } from '../utils/factions'
 import { extractError } from '../utils/errors'
 import PageTitle from '../components/ui/PageTitle'
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
+const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', '#16a34a', '#f97316', '#fbbf24', '#be185d']
 
 export default function EditPraxis() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { user } = useAuth()
+  const { theme } = useTheme()
+  const dark = theme === 'dark'
 
   const [taskId, setTaskId] = useState<number | null>(null)
+  const [taskTitle, setTaskTitle] = useState<string>('')
+  const [taskFactionSlug, setTaskFactionSlug] = useState<string | null>(null)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [media, setMedia] = useState<MediaItemOut[]>([])
@@ -38,7 +45,6 @@ export default function EditPraxis() {
     const tooLarge = incoming.filter((f) => f.size > MAX_FILE_SIZE)
     if (tooLarge.length > 0) {
       setFileError(`File${tooLarge.length > 1 ? 's' : ''} too large (50 MB limit): ${tooLarge.map((f) => f.name).join(', ')}`)
-      // Build a DataTransfer with only valid files
       const dt = new DataTransfer()
       incoming.filter((f) => f.size <= MAX_FILE_SIZE).forEach((f) => dt.items.add(f))
       e.target.files = dt.files
@@ -58,6 +64,8 @@ export default function EditPraxis() {
           return
         }
         setTaskId(praxis.task_id)
+        setTaskTitle(praxis.task_title)
+        setTaskFactionSlug(praxis.task_faction_slug)
         setTitle(praxis.title)
         setBody(praxis.body_text ?? '')
         setMedia(praxis.media)
@@ -100,74 +108,153 @@ export default function EditPraxis() {
 
   if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
 
+  const color = factionColor(taskFactionSlug)
+  const fname = factionName(taskFactionSlug)
+  const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0
+
   return (
-    <div className="py-8 max-w-6xl">
+    <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}>
       <PageTitle title="Edit Praxis" />
 
-      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+      {/* Breadcrumb */}
+      <nav className="font-body mb-4" style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--color-text-tertiary)' }}>
+        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>Tasks</Link>
+        {taskId && taskTitle && (
+          <>
+            {' › '}
+            <Link to={`/tasks/${taskId}`} style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}>{taskTitle}</Link>
+          </>
+        )}
+        {' › '}
+        <Link to={`/praxes/${id}`} style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}>Praxis</Link>
+        {' › '}
+        <span style={{ color: 'var(--color-text-primary)' }}>Edit</span>
+      </nav>
+
+      {/* Task context header */}
+      {taskTitle && (
+        <div className="sidebar-card mb-5" style={{ borderLeft: `4px solid ${color}`, padding: '12px 16px' }}>
+          <span className="eyebrow" style={{ marginBottom: 4, display: 'block' }}>Editing proof of completion for</span>
+          <Link
+            to={`/tasks/${taskId}`}
+            className="font-display italic"
+            style={{ fontSize: 18, color, textDecoration: 'none', display: 'block', marginBottom: 4 }}
+          >
+            {taskTitle}
+          </Link>
+          {fname && (
+            <span className="eyebrow" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>{fname}</span>
+          )}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.1rem' }}>
         {/* Title */}
-        <div className="flex flex-col gap-1">
-          <label className="font-body text-sm font-bold">Title *</label>
+        <div className="sidebar-card" style={{ padding: '16px 18px', borderRadius: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
+            <span className="eyebrow">Title</span>
+            <span className="font-body" style={{ fontSize: 8, fontStyle: 'italic', color: 'var(--color-text-tertiary)' }}>required</span>
+          </div>
           <input
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
+            placeholder="What did you do?"
             maxLength={200}
-            className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none"
+            style={{
+              width: '100%',
+              fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: 24,
+              color: 'var(--color-text-primary)',
+              background: 'transparent', border: 'none',
+              borderBottom: `2px solid ${title ? color : (dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)')}`,
+              outline: 'none', paddingBottom: 6,
+              transition: 'border-color 150ms',
+            }}
+            onFocus={(e) => { e.currentTarget.style.borderBottomColor = color }}
+            onBlur={(e) => { if (!title) e.currentTarget.style.borderBottomColor = dark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)' }}
           />
-          <span className={`font-body text-xs self-end ${title.length >= 180 ? 'text-red-600' : 'text-muted'}`}>{title.length}/200</span>
+          {title && (
+            <div style={{ display: 'flex', height: 3, marginTop: 4, opacity: 0.6 }}>
+              {RAINBOW_COLORS.map((c, i) => <div key={i} style={{ flex: 1, background: c }} />)}
+            </div>
+          )}
+          <span
+            className="eyebrow"
+            style={{ fontSize: 7, marginTop: 4, display: 'block', textAlign: 'right', color: title.length >= 180 ? '#dc2626' : undefined }}
+          >
+            {title.length}/200
+          </span>
         </div>
 
-        {/* Split pane: editor + preview */}
-        <div className="flex flex-col md:flex-row gap-4">
-          <div className="flex flex-col gap-1 flex-1">
-            <label className="font-body text-sm font-bold">Body</label>
+        {/* Body */}
+        <div className="sidebar-card" style={{ padding: '16px 18px', borderRadius: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
+            <span className="eyebrow">The proof</span>
+            <span className="font-body" style={{ fontSize: 8, fontStyle: 'italic', color: 'var(--color-text-tertiary)' }}>supports markdown</span>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <textarea
               value={body}
               onChange={(e) => setBody(e.target.value)}
-              rows={16}
-              className="border-2 border-border px-3 py-2 font-body text-sm bg-card focus:outline-none resize-none h-full min-h-64"
-              placeholder="Describe what you did... (supports **markdown**)"
+              rows={12}
+              placeholder="Describe what you did..."
+              style={{
+                width: '100%',
+                fontFamily: "'Lora', serif", fontSize: 14, color: dark ? '#e8dcc8' : '#2a1e10',
+                lineHeight: 1.75, minHeight: 180,
+                background: 'transparent', border: 'none', outline: 'none',
+                resize: 'vertical',
+              }}
             />
-          </div>
-          <div className="flex flex-col gap-1 flex-1">
-            <label className="font-body text-sm font-bold text-muted">Preview</label>
-            <div className="border-2 border-border px-4 py-3 bg-card min-h-64 overflow-auto font-body text-sm markdown-preview">
-              {body.trim() ? (
-                <ReactMarkdown>{body}</ReactMarkdown>
-              ) : (
-                <p className="text-muted italic">Preview will appear here...</p>
-              )}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span className="eyebrow">{wordCount} words</span>
             </div>
           </div>
+          {body.trim() && (
+            <div style={{ borderTop: '1px dashed var(--color-border)', marginTop: 10, paddingTop: 10 }}>
+              <span className="eyebrow" style={{ marginBottom: 6, display: 'block' }}>Preview</span>
+              <div className="markdown-preview font-display" style={{ fontSize: 14, lineHeight: 1.75, color: dark ? '#e8dcc8' : '#2a1e10' }}>
+                <ReactMarkdown>{body}</ReactMarkdown>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Existing media */}
         {media.length > 0 && (
-          <div className="flex flex-col gap-2">
-            <label className="font-body text-sm font-bold">Attached Media</label>
-            <div className="flex flex-col gap-3">
+          <div className="sidebar-card" style={{ padding: '16px 18px', borderRadius: 12 }}>
+            <span className="eyebrow" style={{ display: 'block', marginBottom: 10 }}>Attached media</span>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {media.map((item) => {
                 const src = `${BASE_URL}/media/${item.file_path}`
                 const filename = item.file_path.split('/').pop() ?? item.file_path
                 return (
-                  <div key={item.id} className="flex items-center gap-3 border-2 border-border p-2 bg-card">
+                  <div
+                    key={item.id}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 10,
+                      padding: '8px 10px',
+                      background: 'var(--color-bg-surface-alt)',
+                      border: '1px solid var(--color-border)',
+                    }}
+                  >
                     {item.type === 'image' && (
-                      <img src={src} alt="" className="h-16 w-16 object-cover border border-border shrink-0" />
+                      <img src={src} alt="" style={{ height: 48, width: 48, objectFit: 'cover', border: '1px solid var(--color-border)', flexShrink: 0 }} />
                     )}
                     {item.type === 'video' && (
-                      <video src={src} className="h-16 w-16 object-cover border border-border shrink-0" />
+                      <video src={src} style={{ height: 48, width: 48, objectFit: 'cover', border: '1px solid var(--color-border)', flexShrink: 0 }} />
                     )}
                     {item.type === 'audio' && (
-                      <div className="h-16 w-16 flex items-center justify-center border border-border shrink-0 bg-muted/10 font-body text-xs text-muted">
-                        audio
+                      <div style={{ height: 48, width: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid var(--color-border)', flexShrink: 0, background: 'var(--color-bg-surface)' }}>
+                        <span className="eyebrow" style={{ fontSize: 7 }}>audio</span>
                       </div>
                     )}
-                    <span className="font-body text-xs text-ink flex-1 truncate">{filename}</span>
+                    <span className="font-body" style={{ fontSize: 10, color: 'var(--color-text-primary)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{filename}</span>
                     <button
                       type="button"
                       onClick={() => handleRemoveMedia(item)}
-                      className="font-body text-xs text-red-600 hover:underline shrink-0"
+                      className="eyebrow"
+                      style={{ fontSize: 8, color: '#dc2626', cursor: 'pointer', background: 'none', border: 'none', flexShrink: 0 }}
                     >
                       Remove
                     </button>
@@ -179,8 +266,8 @@ export default function EditPraxis() {
         )}
 
         {/* Add new media */}
-        <div className="flex flex-col gap-1">
-          <label className="font-body text-sm font-bold">Add Media</label>
+        <div className="sidebar-card" style={{ padding: '16px 18px', borderRadius: 12 }}>
+          <span className="eyebrow" style={{ display: 'block', marginBottom: 8 }}>Add media</span>
           <input
             ref={fileRef}
             type="file"
@@ -189,16 +276,44 @@ export default function EditPraxis() {
             onChange={handleFileChange}
             className="font-body text-sm"
           />
-          {fileError && <p className="font-body text-xs text-red-600 mt-1">{fileError}</p>}
+          {fileError && (
+            <p className="font-body" style={{ fontSize: 10, color: '#dc2626', marginTop: 6 }}>{fileError}</p>
+          )}
         </div>
 
-        {error && <p className="font-body text-sm text-red-600">{error}</p>}
+        {error && (
+          <p className="font-body text-sm" style={{ color: '#dc2626' }}>{error}</p>
+        )}
 
-        <div className="flex gap-3">
-          <button type="submit" disabled={saving} className="btn-primary">
-            {saving ? 'Saving...' : 'Save Changes'}
+        {/* Submit buttons */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button
+            type="submit"
+            disabled={saving}
+            style={{
+              background: color, color: '#fff',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.12em', padding: '10px 24px',
+              border: 'none', cursor: saving ? 'wait' : 'pointer',
+              position: 'relative',
+            }}
+          >
+            <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
+            {saving ? 'Saving...' : 'Save proof'}
           </button>
-          <button type="button" onClick={() => navigate(`/praxes/${id}`)} className="btn-outline">
+          <button
+            type="button"
+            onClick={() => navigate(`/praxes/${id}`)}
+            style={{
+              background: 'transparent',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.12em', padding: '10px 24px',
+              border: '1px solid var(--color-border)',
+              cursor: 'pointer', color: 'var(--color-text-secondary)',
+            }}
+          >
             Cancel
           </button>
         </div>

--- a/frontend/src/pages/Praxes.tsx
+++ b/frontend/src/pages/Praxes.tsx
@@ -1,21 +1,30 @@
 import { useEffect, useState } from 'react'
 import { listPraxes } from '../api/praxis'
 import type { PraxisOut } from '../api/praxis'
+import { listPublishedCollaborations } from '../api/collaborations'
+import type { CollaborationCardOut } from '../api/collaborations'
 import PraxisCard from '../components/PraxisCard'
+import CollaborationCard from '../components/CollaborationCard'
 import PageTitle from '../components/ui/PageTitle'
 import { extractError } from '../utils/errors'
 
 export default function Praxes() {
   const [praxes, setPraxes] = useState<PraxisOut[]>([])
+  const [collabs, setCollabs] = useState<CollaborationCardOut[]>([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
 
   useEffect(() => {
-    listPraxes()
-      .then(setPraxes)
+    Promise.all([listPraxes(), listPublishedCollaborations()])
+      .then(([praxData, collabData]) => {
+        setPraxes(praxData)
+        setCollabs(collabData)
+      })
       .catch((err) => setFetchError(extractError(err, "Couldn't load praxes.")))
       .finally(() => setLoading(false))
   }, [])
+
+  const isEmpty = praxes.length === 0 && collabs.length === 0
 
   return (
     <div className="py-8">
@@ -31,12 +40,15 @@ export default function Praxes() {
           {fetchError}{' '}
           <button onClick={() => window.location.reload()} className="underline">Try refreshing.</button>
         </p>
-      ) : praxes.length === 0 ? (
+      ) : isEmpty ? (
         <p className="font-body text-muted">No praxes yet. Be the first.</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {praxes.map((p) => (
-            <PraxisCard key={p.id} praxis={p} />
+            <PraxisCard key={`praxis-${p.id}`} praxis={p} />
+          ))}
+          {collabs.map((c) => (
+            <CollaborationCard key={`collab-${c.id}`} collab={c} />
           ))}
         </div>
       )}

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -78,14 +78,23 @@ export default function SubmitProof() {
         // Collaboration or duel: create a Collaboration, send invites, redirect to collab page
         const mode = selectedMode === 'duel' ? 'duel' : 'collaboration'
         const collab = await createCollaboration(parseInt(id, 10), mode)
-        // Send invites to all selected partners
+        // Send invites to all selected partners; collect any eligibility errors
+        const inviteErrors: string[] = []
         for (const partner of invitedPartners) {
           try {
             await inviteMember(collab.id, partner.id)
-          } catch { /* best-effort */ }
+          } catch (inviteErr: any) {
+            const detail: string = inviteErr?.response?.data?.detail ?? `Could not invite ${partner.name}.`
+            inviteErrors.push(`${partner.name}: ${detail}`)
+          }
         }
         void refetch()
-        navigate(`/collaborations/${collab.id}`)
+        // Navigate even if some invites failed; user can re-invite from the collab page
+        if (inviteErrors.length > 0) {
+          navigate(`/collaborations/${collab.id}`, { state: { inviteErrors } })
+        } else {
+          navigate(`/collaborations/${collab.id}`)
+        }
       } else {
         // Solo submission: create praxis as before
         if (!title.trim()) { setError('Title is required.'); setSaving(false); return }


### PR DESCRIPTION
## Summary

- **Bug 1 (Praxis listing)**: Published collaborations and duels now appear on `/praxes` via a new `CollaborationCard` component. Fetches from new `GET /collaborations` endpoint (published only). Shows all member names, mode label, and per-member scores.
- **Bug 2 (Eligibility)**: `invite_member` service now blocks inviting players who already have a submitted solo praxis or published collaboration for that task. Analog faction players are exempt (Double Dipper). `SubmitProof` surfaces invite errors when creating a collab with partners.
- **Bug 3 (Per-member content)**: `CollaborationMember` gains `title` and `body_text` columns (migration `0002_collab_member_content`). New `PUT /collaborations/:id/my-content` endpoint. New `/collaborations/:id/edit` page styled like `SubmitProof`. `CollaborationDetail` shows "Edit my proof" section.
- **Bug 4 (EditPraxis redesign)**: `/praxes/:id/edit` redesigned to match `SubmitProof` UX — faction-colored header, Courier Prime section labels, rainbow bar, `sidebar-card` sections.

## Test plan

- [ ] Run `alembic upgrade head` to apply migration `0002_collab_member_content`
- [ ] Run `pytest tests/unit/ -q` — all 105 unit tests pass
- [ ] Create a duel with two players, both submit → `/praxes` shows a `CollaborationCard` with both names
- [ ] Try to invite a player who already has a submitted praxis for that task → see 409 error message
- [ ] Try same with an Analog player → invite succeeds
- [ ] Open an in-progress collab → "Edit my proof" section appears → click → fills EditCollaboration form → save → content shows on detail page
- [ ] Open a submitted solo praxis → click "edit" → see redesigned page with faction colors and rainbow bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)