### PR TITLE
Update Render DB plan to pro

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -60,4 +60,4 @@ databases:
   - name: worldzero-db
     databaseName: worldzero
     user: worldzero
-    plan: starter
+    plan: pro


### PR DESCRIPTION
Fixes `databases[0].plan` error — legacy `starter` plan is no longer supported. Updated to `pro` to match the account's current plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)