### PR TITLE
Fix Docker build: use repo root context for Render + docker-compose

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY backend/ .
 RUN chmod +x start.sh
 
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
 
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     depends_on:
       db:
         condition: service_healthy

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,6 @@ services:
     name: worldzero-backend
     runtime: docker
     dockerfilePath: ./backend/Dockerfile
-    dockerContext: ./backend
     branch: main
     autoDeploy: true
     disk:


### PR DESCRIPTION
## Summary
Render ignores `dockerContext` in render.yaml and always uses the repo root as the Docker build context. This fixes the `requirements.txt not found` error by:
- Switching `COPY` paths in `Dockerfile` to `backend/` prefix (works from repo root)
- Updating `docker-compose.yml` context from `./backend` to `.` to match
- Removing the ineffective `dockerContext: ./backend` from `render.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)