### PR TITLE
P.1 praxis migration + fix task sign-up API wiring

### DIFF
--- a/backend/alembic/versions/0004_praxis_unification.py
+++ b/backend/alembic/versions/0004_praxis_unification.py
@@ -166,6 +166,16 @@ def upgrade() -> None:
         FROM submission_member
     """))
 
+    # Reset sequence after bulk-inserting explicit IDs from submission_member,
+    # so the auto-increment in step 6 doesn't collide with those IDs.
+    op.execute(sa.text("""
+        SELECT setval(
+            pg_get_serial_sequence('praxis_member', 'id'),
+            COALESCE((SELECT MAX(id) FROM praxis_member), 0) + 1,
+            false
+        )
+    """))
+
     # ── 6. Insert praxis_member for every solo submission (creator = only member) ─
 
     op.execute(sa.text("""

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -13,13 +13,6 @@ export interface TaskOut {
   created_at: string
 }
 
-export interface CharacterTaskOut {
-  id: number
-  task: TaskOut
-  status: string
-  signed_up_at: string
-}
-
 export interface TaskCreate {
   title: string
   description?: string
@@ -45,22 +38,8 @@ export async function getTask(id: number): Promise<TaskOut> {
   return data
 }
 
-export async function signupTask(id: number): Promise<CharacterTaskOut> {
-  const { data } = await api.post<CharacterTaskOut>(`/tasks/${id}/signup`)
-  return data
-}
-
-export async function dropTask(id: number): Promise<void> {
-  await api.delete(`/tasks/${id}/signup`)
-}
-
 export async function proposeTask(body: TaskCreate): Promise<TaskOut> {
   const { data } = await api.post<TaskOut>('/tasks', body)
-  return data
-}
-
-export async function getMyTasks(status?: string): Promise<CharacterTaskOut[]> {
-  const { data } = await api.get<CharacterTaskOut[]>('/tasks/my-tasks', { params: status ? { status } : undefined })
   return data
 }
 

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import { respondToInvite } from '../../api/praxis'
-import { getMyTasks } from '../../api/tasks'
 import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
@@ -37,16 +36,8 @@ export default function FeedCardCollabInvite({ item }: Props) {
       setStatus('accepted')
       setShowDropModal(false)
       navigate(`/praxes/${praxis_id}`)
-    } catch (err: unknown) {
-      const axiosErr = err as { response?: { status?: number } }
-      if (axiosErr?.response?.status === 409) {
-        // Task list full — load tasks and show modal
-        const tasks = await getMyTasks('in_progress')
-        setMyTasks(tasks as { id: number; task: { id: number; title: string } }[])
-        setShowDropModal(true)
-      } else {
-        setDropError('Could not accept invite. Please try again.')
-      }
+    } catch {
+      setDropError('Could not accept invite. Please try again.')
     }
     setLoading(false)
   }

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import { respondToInvite } from '../../api/praxis'
-import { getMyTasks } from '../../api/tasks'
 import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
@@ -37,15 +36,8 @@ export default function FeedCardDuelChallenge({ item }: Props) {
       setStatus('accepted')
       setShowDropModal(false)
       navigate(`/praxes/${praxis_id}`)
-    } catch (err: unknown) {
-      const axiosErr = err as { response?: { status?: number } }
-      if (axiosErr?.response?.status === 409) {
-        const tasks = await getMyTasks('in_progress')
-        setMyTasks(tasks as { id: number; task: { id: number; title: string } }[])
-        setShowDropModal(true)
-      } else {
-        setDropError('Could not accept duel. Please try again.')
-      }
+    } catch {
+      setDropError('Could not accept duel. Please try again.')
     }
     setLoading(false)
   }

--- a/frontend/src/hooks/useMyActiveTasks.ts
+++ b/frontend/src/hooks/useMyActiveTasks.ts
@@ -1,25 +1,25 @@
 import { useCallback, useEffect, useState } from 'react'
-import { getMyTasks, type CharacterTaskOut } from '../api/tasks'
+import { listPraxes, type PraxisCardOut } from '../api/praxis'
 import { useAuth } from '../auth/AuthContext'
 
 /**
- * Hook to fetch the current character's in-progress task signups.
+ * Hook to fetch the current character's in-progress praxes.
  * Re-fetches when the authenticated user changes.
  */
 export function useMyActiveTasks() {
   const { user } = useAuth()
-  const [activeTasks, setActiveTasks] = useState<CharacterTaskOut[]>([])
+  const [activeTasks, setActiveTasks] = useState<PraxisCardOut[]>([])
   const [loading, setLoading] = useState(true)
 
   const refetch = useCallback(() => {
-    if (!user) {
+    if (!user?.character) {
       setActiveTasks([])
       setLoading(false)
       return
     }
     setLoading(true)
-    getMyTasks('in_progress')
-      .then(setActiveTasks)
+    listPraxes({ character_id: user.character.id, status: 'in_progress' })
+      .then((praxes) => setActiveTasks(praxes.filter((p) => !p.is_withdrawn)))
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [user])

--- a/frontend/src/pages/SubmitProof.tsx
+++ b/frontend/src/pages/SubmitProof.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import { createPraxis, uploadPraxisMedia, inviteToPraxis } from '../api/praxis'
-import { getTask, dropTask, type TaskOut } from '../api/tasks'
+import { getTask, type TaskOut } from '../api/tasks'
 import { listCharacters, type CharacterOut } from '../api/characters'
 import { getMetaTasks, type MetaTaskOut } from '../api/metaTasks'
 import LevelPill from '../components/ui/LevelPill'
@@ -161,13 +161,8 @@ export default function SubmitProof() {
   }
 
   const handleDrop = async () => {
-    if (!task || !window.confirm('Drop this task? You can sign up again later.')) return
-    try {
-      await dropTask(task.id)
-      navigate(`/tasks/${task.id}`)
-    } catch {
-      setError('Could not drop this task.')
-    }
+    if (!task) return
+    navigate(`/tasks/${task.id}`)
   }
 
   const color = factionColor(task?.primary_faction_slug)

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link, useNavigate, useLocation } from 'react-router-dom'
-import { getTask, getMyTasks, signupTask, dropTask, getTaskSignups, type TaskOut, type TaskSignupOut } from '../api/tasks'
-import { listPraxes, type PraxisCardOut } from '../api/praxis'
+import { getTask, getTaskSignups, type TaskOut, type TaskSignupOut } from '../api/tasks'
+import { listPraxes, createPraxis, withdrawPraxis, type PraxisCardOut } from '../api/praxis'
 import { listRelationships } from '../api/relationships'
 import { getMetaTasks, type MetaTaskOut } from '../api/metaTasks'
 import PraxisCard from '../components/PraxisCard'
@@ -56,7 +56,7 @@ export default function TaskDetail() {
       getMetaTasks(taskId).catch(() => []),
     ]
     if (user) {
-      fetches.push(getMyTasks('in_progress'))
+      fetches.push(listPraxes({ character_id: user.character?.id, status: 'in_progress' }))
       fetches.push(
         listRelationships({ type: 'friend' }).then((rels) =>
           new Set(rels.filter((r) => r.status === 'active').map((r) => r.to_character_id))
@@ -76,9 +76,9 @@ export default function TaskDetail() {
         setSignups(sg as TaskSignupOut[])
         setMetaTasks(mt as MetaTaskOut[])
         if (myTasks) {
-          const tasks = myTasks as { task: { id: number } }[]
-          setIsInProgress(tasks.some((ct) => ct.task.id === taskId))
-          setTaskSlotCount(tasks.length)
+          const praxes = myTasks as PraxisCardOut[]
+          setIsInProgress(praxes.some((p) => p.task_id === taskId && !p.is_withdrawn))
+          setTaskSlotCount(praxes.filter((p) => !p.is_withdrawn).length)
         }
         if (friendSet) setFriends(friendSet as Set<number>)
         if (foeSet) setFoes(foeSet as Set<number>)
@@ -96,26 +96,27 @@ export default function TaskDetail() {
   }, [submissionSort, id])
 
   const mySubmission = user?.character
-    ? submissions.find((s) => s.created_by_id === user.character!.id)
+    ? submissions.find((s) => s.created_by_id === user.character!.id && !s.is_withdrawn)
     : undefined
 
   const handleSignup = async () => {
     if (!task) return
     setSignupError(null)
     try {
-      await signupTask(task.id)
-      navigate(`/tasks/${task.id}/submit`)
+      const praxis = await createPraxis({ task_id: task.id, type: 'solo' })
+      navigate(`/praxes/${praxis.id}/edit`)
     } catch (err) {
       setSignupError(extractError(err, 'Could not sign up for this task.'))
     }
   }
 
   const handleDrop = async () => {
-    if (!task || !window.confirm('Drop this task? You can sign up again later.')) return
+    if (!task || !mySubmission || !window.confirm('Drop this task? You can sign up again later.')) return
     setSignupError(null)
     try {
-      await dropTask(task.id)
+      await withdrawPraxis(mySubmission.id)
       setIsInProgress(false)
+      setSubmissions((prev) => prev.map((s) => s.id === mySubmission.id ? { ...s, is_withdrawn: true } : s))
     } catch (err) {
       setSignupError(extractError(err, 'Could not drop this task.'))
     }

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { listTasks, signupTask, type TaskOut } from '../api/tasks'
+import { listTasks, type TaskOut } from '../api/tasks'
+import { createPraxis } from '../api/praxis'
 import { getFactions, type FactionOut } from '../api/factions'
 import { getGameConfig, type FactionConfigOut } from '../api/gameConfig'
 import { getMetaTasks, type MetaTaskOut } from '../api/metaTasks'
@@ -71,8 +72,8 @@ export default function Tasks() {
   const handleSignup = async (id: number) => {
     setSignupMsg(null)
     try {
-      await signupTask(id)
-      navigate(`/tasks/${id}/submit`)
+      const praxis = await createPraxis({ task_id: id, type: 'solo' })
+      navigate(`/praxes/${praxis.id}/edit`)
     } catch (err) {
       setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
     }

--- a/scripts/create_task.py
+++ b/scripts/create_task.py
@@ -1,0 +1,192 @@
+"""
+Interactively create a task in the Render production database via the admin API.
+
+Usage (from repo root):
+    python scripts/create_task.py
+
+Requires RENDER_API_URL and ADMIN_CLI_SECRET in backend/.env.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import urllib.request
+import urllib.error
+import json
+
+# ---------------------------------------------------------------------------
+# Load backend/.env
+# ---------------------------------------------------------------------------
+
+env_path = Path(__file__).resolve().parent.parent / "backend" / ".env"
+if not env_path.exists():
+    print(f"ERROR: .env not found at {env_path}")
+    sys.exit(1)
+
+for line in env_path.read_text().splitlines():
+    line = line.strip()
+    if line and not line.startswith("#") and "=" in line:
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+API_URL = os.environ.get("RENDER_API_URL", "").rstrip("/")
+CLI_SECRET = os.environ.get("ADMIN_CLI_SECRET", "")
+
+if not API_URL or not CLI_SECRET:
+    print("ERROR: RENDER_API_URL and ADMIN_CLI_SECRET must be set in backend/.env")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Faction choices (from era_1.py — update here if factions change)
+# ---------------------------------------------------------------------------
+
+FACTIONS = [
+    ("na",          "None (cross-faction)"),
+    ("ua",          "UA"),
+    ("ua_masters",  "UA Masters"),
+    ("snide",       "S.N.I.D.E."),
+    ("gestalt",     "Gestalt"),
+    ("journeymen",  "Journeymen"),
+    ("analog",      "Analog"),
+    ("singularity", "Singularity"),
+    ("albescent",   "/Albescent"),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def api_post(path: str, payload: dict, token: str | None = None) -> dict:
+    url = f"{API_URL}{path}"
+    body = json.dumps(payload).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode()
+        print(f"\nAPI error {exc.code}: {detail}")
+        sys.exit(1)
+
+
+def prompt(label: str, default: str | None = None, required: bool = True) -> str:
+    suffix = f" [{default}]" if default is not None else ""
+    while True:
+        value = input(f"{label}{suffix}: ").strip()
+        if not value and default is not None:
+            return default
+        if value:
+            return value
+        if not required:
+            return ""
+        print("  (required)")
+
+
+def prompt_int(label: str, default: int | None = None, min_val: int = 0) -> int:
+    default_str = str(default) if default is not None else None
+    while True:
+        raw = prompt(label, default=default_str)
+        try:
+            val = int(raw)
+            if val < min_val:
+                print(f"  (must be >= {min_val})")
+                continue
+            return val
+        except ValueError:
+            print("  (must be a whole number)")
+
+
+def prompt_multiline(label: str) -> str:
+    print(f"{label} (blank line to finish):")
+    lines = []
+    while True:
+        line = input()
+        if line == "":
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def choose_faction() -> str:
+    print("\nFaction:")
+    for i, (slug, name) in enumerate(FACTIONS, 1):
+        print(f"  {i}. {name} ({slug})")
+    while True:
+        raw = input("Choose [1]: ").strip()
+        if not raw:
+            return FACTIONS[0][0]
+        try:
+            idx = int(raw) - 1
+            if 0 <= idx < len(FACTIONS):
+                return FACTIONS[idx][0]
+        except ValueError:
+            pass
+        print(f"  (enter a number 1–{len(FACTIONS)})")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    print("=== Create Task ===\n")
+
+    # Authenticate
+    print("Authenticating with admin API...")
+    url = f"{API_URL}/admin/cli-token"
+    req = urllib.request.Request(
+        url,
+        data=b"{}",
+        headers={
+            "Content-Type": "application/json",
+            "X-Admin-Cli-Secret": CLI_SECRET,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            token = json.loads(resp.read())["access_token"]
+    except urllib.error.HTTPError as exc:
+        print(f"Auth failed {exc.code}: {exc.read().decode()}")
+        sys.exit(1)
+    print("Authenticated.\n")
+
+    # Collect fields
+    title = prompt("Title")
+    description = prompt_multiline("Description")
+    point_value = prompt_int("Point value", default=5, min_val=1)
+    level_required = prompt_int("Level required", default=0, min_val=0)
+    faction_slug = choose_faction()
+
+    # Confirm
+    print("\n--- Review ---")
+    print(f"  Title:          {title}")
+    print(f"  Description:    {description[:80] + '...' if len(description) > 80 else description or '(none)'}")
+    print(f"  Points:         {point_value}")
+    print(f"  Level required: {level_required}")
+    print(f"  Faction:        {faction_slug}")
+    print(f"  Status:         active (immediately live)")
+    confirm = input("\nCreate this task? [y/N]: ").strip().lower()
+    if confirm != "y":
+        print("Aborted.")
+        sys.exit(0)
+
+    # Create
+    payload = {
+        "title": title,
+        "description": description or None,
+        "point_value": point_value,
+        "level_required": level_required,
+        "primary_faction_slug": faction_slug,
+    }
+
+    result = api_post("/admin/tasks", payload, token=token)
+    print(f"\nTask created! ID: {result['id']}, status: {result['status']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reset_render_db.py
+++ b/scripts/reset_render_db.py
@@ -1,0 +1,69 @@
+"""
+Reset the Render production database.
+
+Drops and recreates the public schema (wipes all tables/data), then runs
+alembic upgrade head to rebuild the schema from scratch.
+
+Usage (from repo root):
+    python scripts/reset_render_db.py
+
+Requires RENDER_DATABASE_URL in backend/.env.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Load backend/.env
+env_path = Path(__file__).resolve().parent.parent / "backend" / ".env"
+if not env_path.exists():
+    print(f"ERROR: .env not found at {env_path}")
+    sys.exit(1)
+
+for line in env_path.read_text().splitlines():
+    line = line.strip()
+    if line and not line.startswith("#") and "=" in line:
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+db_url = os.environ.get("RENDER_DATABASE_URL")
+if not db_url:
+    print("ERROR: RENDER_DATABASE_URL not set in backend/.env")
+    sys.exit(1)
+
+print("WARNING: This will wipe ALL data in the Render production database.")
+confirm = input("Type 'yes' to continue: ").strip().lower()
+if confirm != "yes":
+    print("Aborted.")
+    sys.exit(0)
+
+# Drop and recreate the public schema using psycopg2 (sync driver)
+try:
+    import psycopg2
+except ImportError:
+    print("ERROR: psycopg2 not installed. Run: pip install psycopg2-binary")
+    sys.exit(1)
+
+print("\n[1/2] Dropping and recreating public schema...")
+conn = psycopg2.connect(db_url)
+conn.autocommit = True
+with conn.cursor() as cur:
+    cur.execute("DROP SCHEMA public CASCADE;")
+    cur.execute("CREATE SCHEMA public;")
+conn.close()
+print("      Done.")
+
+# Run alembic upgrade head
+print("\n[2/2] Running alembic upgrade head...")
+backend_dir = Path(__file__).resolve().parent.parent / "backend"
+result = subprocess.run(
+    [sys.executable, "-m", "alembic", "upgrade", "head"],
+    cwd=backend_dir,
+    env={**os.environ, "DATABASE_URL": db_url},
+)
+if result.returncode != 0:
+    print("\nERROR: alembic upgrade failed.")
+    sys.exit(result.returncode)
+
+print("\nDone. Database reset complete.")


### PR DESCRIPTION
## Summary

- Completes the P.1 praxis unification migration (solo praxis replaces character_task as the sign-up mechanism)
- Fixes task sign-up being broken: frontend was calling three removed endpoints (`POST /tasks/{id}/signup`, `DELETE /tasks/{id}/signup`, `GET /tasks/my-tasks`) left over from the character_task era
- Adds admin utility scripts (`scripts/reset_render_db.py`, `scripts/create_task.py`) for managing the Render production database

## What was broken
After the P.6/P.7 frontend migration removed the old submission/collaboration API clients, `tasks.ts` still exported `signupTask`, `dropTask`, and `getMyTasks` pointing at dead backend routes. Clicking "Sign Up" on any task returned 404.

## Changes
- `frontend/src/api/tasks.ts` — removed `signupTask`, `dropTask`, `getMyTasks`, `CharacterTaskOut`
- `frontend/src/pages/TaskDetail.tsx` — sign up via `createPraxis({task_id, type:'solo'})`, drop via `withdrawPraxis(mySubmission.id)`, in-progress state derived from praxis list
- `frontend/src/pages/Tasks.tsx` — same sign-up fix
- `frontend/src/hooks/useMyActiveTasks.ts` — replaced `getMyTasks` with `listPraxes` (used by Sidebar for slot count)
- `frontend/src/components/feed/FeedCardCollabInvite.tsx` + `FeedCardDuelChallenge.tsx` — removed stale 409/`getMyTasks` handler
- `frontend/src/pages/SubmitProof.tsx` — removed `dropTask` reference (page is no longer in primary flow)
- `scripts/reset_render_db.py` — wipes and remigrates the Render production DB
- `scripts/create_task.py` — interactive CLI to create tasks via the admin API

## Test plan
- [ ] Log in and navigate to any task — "Sign Up" button should appear for eligible tasks
- [ ] Click Sign Up — should create a praxis and redirect to `/praxes/:id/edit`
- [ ] Sign up confirmation: task should appear in sidebar active-tasks slot count
- [ ] Drop (withdraw) from task detail page — should mark praxis withdrawn and re-show Sign Up button
- [ ] Run `python scripts/reset_render_db.py` from repo root — drops schema and remigrates
- [ ] Run `python scripts/create_task.py` from repo root — interactive task creation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)