### PR TITLE
Fix Sidebar crash: PraxisCardOut field shape

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -164,34 +164,27 @@ export default function Sidebar() {
           </p>
         ) : (
           <div className="flex flex-col gap-1.5">
-            {activeTasks.map((characterTask) => {
-              const taskFactionColor = factionColor(characterTask.task.primary_faction_slug)
-              const taskFactionName = factionName(characterTask.task.primary_faction_slug)
-              return (
-                <div
-                  key={characterTask.id}
-                  className="flex items-start justify-between"
-                  style={{
-                    borderLeft: `3px solid ${taskFactionColor}`,
-                    paddingLeft: 8,
-                  }}
-                >
-                  <div className="min-w-0">
-                    <Link
-                      to={`/tasks/${characterTask.task.id}/submit`}
-                      className="font-body block"
-                      style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', lineHeight: 1.3 }}
-                    >
-                      {characterTask.task.title}
-                    </Link>
-                    <span className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-                      {taskFactionName} · lvl {characterTask.task.level_required}
-                    </span>
-                  </div>
-                  <FeedBadge type="global" label="Solo" />
+            {activeTasks.map((praxis) => (
+              <div
+                key={praxis.id}
+                className="flex items-start justify-between"
+                style={{
+                  borderLeft: `3px solid var(--color-border)`,
+                  paddingLeft: 8,
+                }}
+              >
+                <div className="min-w-0">
+                  <Link
+                    to={`/praxes/${praxis.id}/edit`}
+                    className="font-body block"
+                    style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', lineHeight: 1.3 }}
+                  >
+                    {praxis.task_title}
+                  </Link>
                 </div>
-              )
-            })}
+                <FeedBadge type="global" label="Solo" />
+              </div>
+            ))}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Cherry-picks the Sidebar crash fix that was committed after PR #92 merged
- `Sidebar.tsx` was accessing `characterTask.task.primary_faction_slug` / `.task.title` etc. — the old `CharacterTaskOut` shape
- The `useMyActiveTasks` hook now returns `PraxisCardOut` objects which have flat `task_title` / `task_id` fields (no nested `.task` object)
- This crash silently brought down the entire page layout

## Test plan
- [ ] Log in, confirm sidebar renders without crashing
- [ ] Confirm active tasks list shows task names linked to `/praxes/:id/edit`
- [ ] Confirm character card + activity feed still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)