### PR TITLE
Fix Sidebar crash: update active tasks list to use PraxisCardOut

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -163,33 +163,27 @@ export default function Sidebar() {
           </p>
         ) : (
           <div className="flex flex-col gap-1.5">
-            {activeTasks.map((characterTask) => {
-              const taskFactionName = factionName(characterTask.task.primary_faction_slug)
-              return (
-                <div
-                  key={characterTask.id}
-                  className="flex items-start justify-between"
-                  style={{
-                    borderLeft: `3px solid ${factionCssVar(characterTask.task.primary_faction_slug, 'border')}`,
-                    paddingLeft: 8,
-                  }}
-                >
-                  <div className="min-w-0">
-                    <Link
-                      to={`/tasks/${characterTask.task.id}/submit`}
-                      className="font-body block"
-                      style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', lineHeight: 1.3 }}
-                    >
-                      {characterTask.task.title}
-                    </Link>
-                    <span className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-                      {taskFactionName} · lvl {characterTask.task.level_required}
-                    </span>
-                  </div>
-                  <FeedBadge type="global" label="Solo" />
+            {activeTasks.map((praxis) => (
+              <div
+                key={praxis.id}
+                className="flex items-start justify-between"
+                style={{
+                  borderLeft: `3px solid var(--color-border)`,
+                  paddingLeft: 8,
+                }}
+              >
+                <div className="min-w-0">
+                  <Link
+                    to={`/praxes/${praxis.id}/edit`}
+                    className="font-body block"
+                    style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', lineHeight: 1.3 }}
+                  >
+                    {praxis.task_title}
+                  </Link>
                 </div>
-              )
-            })}
+                <FeedBadge type="global" label="Solo" />
+              </div>
+            ))}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- `useMyActiveTasks` returns `PraxisCardOut[]` (flat `task_title` / `task_id` at top level) after the P.1 praxis migration
- `Sidebar.tsx` was still iterating as `CharacterTaskOut` and reading `characterTask.task.primary_faction_slug`, `characterTask.task.title`, etc. — the old nested shape
- This caused a TypeError on page load that silently brought down the entire layout, rendering a blank page

## Test plan
- [ ] Log in — page should load correctly
- [ ] Sidebar active tasks panel shows task titles linked to `/praxes/:id/edit`
- [ ] Character card, activity feed, pending requests all visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)