### PR TITLE
fix: faction colors on praxis cards + updates page broken after praxis migration

### DIFF
--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -90,6 +90,7 @@ class PraxisCardOut(BaseModel):
     updated_at: datetime
     member_count: int
     score: float
+    task_faction_slug: Optional[str] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -138,7 +138,7 @@ async def _fetch_votes_on_mine(
         .join(Praxis, Vote.praxis_id == Praxis.id)
         .join(Task, Praxis.task_id == Task.id)
         .join(voter_char, Vote.voter_character_id == voter_char.c.id)
-        .where(Praxis.character_id == character_id)
+        .where(Praxis.created_by_id == character_id)
     )
     if before is not None:
         query = query.where(Vote.created_at < before)
@@ -179,7 +179,7 @@ async def _fetch_friend_completions(
             Praxis.id,
             Praxis.title,
             Praxis.created_at,
-            Praxis.character_id,
+            Praxis.created_by_id.label("character_id"),
             Task.title.label("task_title"),
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
@@ -188,9 +188,9 @@ async def _fetch_friend_completions(
             Character.avatar_url.label("author_avatar_url"),
         )
         .join(Task, Praxis.task_id == Task.id)
-        .join(Character, Praxis.character_id == Character.id)
+        .join(Character, Praxis.created_by_id == Character.id)
         .where(
-            Praxis.character_id.in_(friend_ids),
+            Praxis.created_by_id.in_(friend_ids),
             Praxis.is_withdrawn == False,  # noqa: E712
         )
     )
@@ -272,7 +272,7 @@ async def _fetch_foe_completions(
             Praxis.id,
             Praxis.title,
             Praxis.created_at,
-            Praxis.character_id,
+            Praxis.created_by_id.label("character_id"),
             Task.title.label("task_title"),
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
@@ -281,9 +281,9 @@ async def _fetch_foe_completions(
             Character.avatar_url.label("author_avatar_url"),
         )
         .join(Task, Praxis.task_id == Task.id)
-        .join(Character, Praxis.character_id == Character.id)
+        .join(Character, Praxis.created_by_id == Character.id)
         .where(
-            Praxis.character_id.in_(foe_ids),
+            Praxis.created_by_id.in_(foe_ids),
             Praxis.is_withdrawn == False,  # noqa: E712
         )
     )
@@ -676,7 +676,7 @@ async def _compute_counts(
             select(func.count())
             .select_from(Vote)
             .join(Praxis, Vote.praxis_id == Praxis.id)
-            .where(Praxis.character_id == character_id)
+            .where(Praxis.created_by_id == character_id)
         )
         return result.scalar_one()
 
@@ -687,7 +687,7 @@ async def _compute_counts(
             select(func.count())
             .select_from(Praxis)
             .where(
-                Praxis.character_id.in_(friend_ids),
+                Praxis.created_by_id.in_(friend_ids),
                 Praxis.is_withdrawn == False,  # noqa: E712
             )
         )
@@ -788,7 +788,7 @@ async def _compute_counts(
             select(func.count())
             .select_from(Praxis)
             .where(
-                Praxis.character_id.in_(foe_ids_for_count),
+                Praxis.created_by_id.in_(foe_ids_for_count),
                 Praxis.is_withdrawn == False,  # noqa: E712
             )
         )

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -282,6 +282,7 @@ async def build_praxis_card_out(
         updated_at=praxis.updated_at,
         member_count=len(praxis.members),
         score=score,
+        task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
     )
 
 

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -87,6 +87,7 @@ export interface PraxisCardOut {
   updated_at: string
   member_count: number
   score: number
+  task_faction_slug: string | null
 }
 
 export interface PraxisCreate {

--- a/frontend/src/components/CollaborationCard.tsx
+++ b/frontend/src/components/CollaborationCard.tsx
@@ -13,9 +13,9 @@ export default function CollaborationCard({ collab }: Props) {
     <div
       className="card p-4 flex flex-col gap-2 transition-all duration-150"
       style={{
-        background: factionCssVar(null, 'card-bg'),
-        borderLeft: `4px solid ${factionCssVar(null, 'card-accent')}`,
-        color: factionCssVar(null, 'card-text'),
+        background: factionCssVar(collab.task_faction_slug, 'card-bg'),
+        borderLeft: `4px solid ${factionCssVar(collab.task_faction_slug, 'card-accent')}`,
+        color: factionCssVar(collab.task_faction_slug, 'card-text'),
       }}
     >
       {/* Mode label */}

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -49,9 +49,9 @@ export default function PraxisCard({ praxis, onModerated }: Props) {
     <div
       className="card p-4 flex flex-col gap-2 transition-all duration-150 relative"
       style={{
-        background: factionCssVar(null, 'card-bg'),
-        borderLeft: `4px solid ${factionCssVar(null, 'card-accent')}`,
-        color: factionCssVar(null, 'card-text'),
+        background: factionCssVar(localPraxis.task_faction_slug, 'card-bg'),
+        borderLeft: `4px solid ${factionCssVar(localPraxis.task_faction_slug, 'card-accent')}`,
+        color: factionCssVar(localPraxis.task_faction_slug, 'card-text'),
         minWidth: '280px',
         flex: '1 1 280px',
       }}


### PR DESCRIPTION
## Summary

- **Praxis cards all same color** — `PraxisCardOut` didn't include the task's faction slug, so `PraxisCard` and `CollaborationCard` were calling `factionCssVar(null, ...)` and falling back to the default gray for every card. Added `task_faction_slug` to the schema/service and wired it into both card components.
- **Updates page empty** — `activity_feed.py` still referenced `Praxis.character_id` throughout (10 occurrences), which was renamed to `Praxis.created_by_id` in the praxis migration. This silently returned zero results on the Updates feed. All references corrected.

## Files changed
- `backend/schemas/praxis.py` — add `task_faction_slug` field to `PraxisCardOut`
- `backend/services/praxis.py` — populate `task_faction_slug` in `build_praxis_card_out`
- `frontend/src/api/praxis.ts` — add `task_faction_slug` to TS interface
- `frontend/src/components/PraxisCard.tsx` — use `task_faction_slug` in `factionCssVar`
- `frontend/src/components/CollaborationCard.tsx` — use `task_faction_slug` in `factionCssVar`
- `backend/services/activity_feed.py` — replace 10x stale `Praxis.character_id` → `Praxis.created_by_id`

## Test plan
- [ ] Visit `/praxis` — cards should show faction-specific background/border/text colors
- [ ] Visit a task detail page (e.g. `/tasks/35`) — completed praxis section cards should show faction colors
- [ ] Visit `/updates` — feed should now populate with activity items

🤖 Generated with [Claude Code](https://claude.com/claude-code)