### PR TITLE
fix: praxis card faction colors, completions feed, publish proof flow

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 from schemas.praxis import (
     DuelVoteSummary,
     MediaItemOut,
+    PraxisCardOut,
     PraxisCreate,
     PraxisInviteCreate,
     PraxisOut,
@@ -35,6 +36,7 @@ class InviteResponse(BaseModel):
 from schemas.vote import VoteOut
 from services.praxis import (
     _build_invite_out,
+    build_praxis_card_out,
     build_praxis_out,
     create_praxis,
     delete_praxis,
@@ -61,7 +63,7 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 
 
-@router.get("", response_model=list[PraxisOut])
+@router.get("", response_model=list[PraxisCardOut])
 async def list_praxes_route(
     task_id: Optional[int] = None,
     character_id: Optional[int] = None,
@@ -98,7 +100,7 @@ async def list_praxes_route(
         limit=limit,
         offset=offset,
     )
-    return [await build_praxis_out(praxis, session) for praxis in praxes]
+    return [await build_praxis_card_out(praxis, session) for praxis in praxes]
 
 
 @router.get("/{praxis_id}", response_model=PraxisOut)

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -138,7 +138,7 @@ async def _fetch_votes_on_mine(
         .join(Praxis, Vote.praxis_id == Praxis.id)
         .join(Task, Praxis.task_id == Task.id)
         .join(voter_char, Vote.voter_character_id == voter_char.c.id)
-        .where(Praxis.created_by_id == character_id)
+        .where(Praxis.character_id == character_id)
     )
     if before is not None:
         query = query.where(Vote.created_at < before)
@@ -179,7 +179,7 @@ async def _fetch_friend_completions(
             Praxis.id,
             Praxis.title,
             Praxis.created_at,
-            Praxis.created_by_id.label("character_id"),
+            Praxis.character_id,
             Task.title.label("task_title"),
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
@@ -188,10 +188,11 @@ async def _fetch_friend_completions(
             Character.avatar_url.label("author_avatar_url"),
         )
         .join(Task, Praxis.task_id == Task.id)
-        .join(Character, Praxis.created_by_id == Character.id)
+        .join(Character, Praxis.character_id == Character.id)
         .where(
-            Praxis.created_by_id.in_(friend_ids),
+            Praxis.character_id.in_(friend_ids),
             Praxis.is_withdrawn == False,  # noqa: E712
+            Praxis.status == PraxisStatus.submitted,
         )
     )
     if before is not None:
@@ -272,7 +273,7 @@ async def _fetch_foe_completions(
             Praxis.id,
             Praxis.title,
             Praxis.created_at,
-            Praxis.created_by_id.label("character_id"),
+            Praxis.character_id,
             Task.title.label("task_title"),
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
@@ -281,10 +282,11 @@ async def _fetch_foe_completions(
             Character.avatar_url.label("author_avatar_url"),
         )
         .join(Task, Praxis.task_id == Task.id)
-        .join(Character, Praxis.created_by_id == Character.id)
+        .join(Character, Praxis.character_id == Character.id)
         .where(
-            Praxis.created_by_id.in_(foe_ids),
+            Praxis.character_id.in_(foe_ids),
             Praxis.is_withdrawn == False,  # noqa: E712
+            Praxis.status == PraxisStatus.submitted,
         )
     )
     if before is not None:
@@ -676,7 +678,7 @@ async def _compute_counts(
             select(func.count())
             .select_from(Vote)
             .join(Praxis, Vote.praxis_id == Praxis.id)
-            .where(Praxis.created_by_id == character_id)
+            .where(Praxis.character_id == character_id)
         )
         return result.scalar_one()
 
@@ -687,8 +689,9 @@ async def _compute_counts(
             select(func.count())
             .select_from(Praxis)
             .where(
-                Praxis.created_by_id.in_(friend_ids),
+                Praxis.character_id.in_(friend_ids),
                 Praxis.is_withdrawn == False,  # noqa: E712
+                Praxis.status == PraxisStatus.submitted,
             )
         )
         return result.scalar_one()
@@ -788,8 +791,9 @@ async def _compute_counts(
             select(func.count())
             .select_from(Praxis)
             .where(
-                Praxis.created_by_id.in_(foe_ids_for_count),
+                Praxis.character_id.in_(foe_ids_for_count),
                 Praxis.is_withdrawn == False,  # noqa: E712
+                Praxis.status == PraxisStatus.submitted,
             )
         )
         foe_completions_count = foe_completions_result.scalar_one()

--- a/frontend/src/components/feed/FeedCardFoeCompletion.tsx
+++ b/frontend/src/components/feed/FeedCardFoeCompletion.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor } from '../../utils/factions'
+import { factionColor, factionCssVar } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -14,7 +14,7 @@ export default function FeedCardFoeCompletion({ item }: Props) {
   const taskColor = factionColor(task_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative' }}>
+    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <Link to={`/characters/${character_id}`}>
           <div

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import {
   getPraxis,
   updatePraxis,
+  submitPraxis,
   uploadPraxisMedia,
   deletePraxisMedia,
   type MediaItemOut,
@@ -32,6 +33,7 @@ export default function EditPraxis() {
   const [newFiles, setNewFiles] = useState<FileList | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [fileError, setFileError] = useState('')
   const fileRef = useRef<HTMLInputElement>(null)
@@ -101,6 +103,28 @@ export default function EditPraxis() {
       setError(extractError(err, 'Could not save changes.'))
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handlePublish = async () => {
+    if (!id || !title.trim()) { setError('Title is required.'); return }
+    setSubmitting(true)
+    setError('')
+    try {
+      const praxisId = parseInt(id, 10)
+      await updatePraxis(praxisId, { title, body_text: body || undefined })
+      if (newFiles) {
+        for (const file of Array.from(newFiles)) {
+          const uploaded = await uploadPraxisMedia(praxisId, file)
+          setMedia((previous) => [...previous, uploaded])
+        }
+      }
+      await submitPraxis(praxisId)
+      navigate(`/praxes/${id}`)
+    } catch (err) {
+      setError(extractError(err, 'Could not publish proof.'))
+    } finally {
+      setSubmitting(false)
     }
   }
 
@@ -285,18 +309,33 @@ export default function EditPraxis() {
         <div style={{ display: 'flex', gap: 10 }}>
           <button
             type="submit"
-            disabled={saving}
+            disabled={saving || submitting}
+            style={{
+              background: 'var(--color-bg-surface)', color: 'var(--color-text-primary)',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.12em', padding: '10px 24px',
+              border: '1px solid var(--color-border)', cursor: (saving || submitting) ? 'wait' : 'pointer',
+              position: 'relative',
+            }}
+          >
+            {saving ? 'Saving...' : 'Save draft'}
+          </button>
+          <button
+            type="button"
+            onClick={handlePublish}
+            disabled={saving || submitting}
             style={{
               background: 'var(--color-text-primary)', color: 'var(--color-bg-page)',
               fontFamily: "'Courier Prime', monospace",
               fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
               letterSpacing: '0.12em', padding: '10px 24px',
-              border: 'none', cursor: saving ? 'wait' : 'pointer',
+              border: 'none', cursor: (saving || submitting) ? 'wait' : 'pointer',
               position: 'relative',
             }}
           >
             <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-            {saving ? 'Saving...' : 'Save proof'}
+            {submitting ? 'Publishing...' : 'Publish proof'}
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary

- **Praxis list route returning wrong schema** — `GET /praxes` was returning `PraxisOut` (no `task_faction_slug`) instead of `PraxisCardOut`, so faction colors never reached the frontend and every card rendered the fallback gray
- **Completions feed showing in-progress praxes** — activity feed queries had no `status` filter, causing in-progress praxes to appear as completions; added `Praxis.status == submitted` to all four friend/foe completion queries
- **FeedCardFoeCompletion unstyled** — this card never called `factionCssVar`, unlike its sibling `FeedCardFriendActivity`; wired `card-bg`/`card-accent` vars to match
- **No points awarded on proof submission** — "Save proof" only called `updatePraxis` (PUT), never `submitPraxis` (POST /submit), so `Praxis.status` stayed `in_progress` and point calculation was never triggered; split into "Save draft" and "Publish proof"

## Files changed
- `backend/routers/praxes.py` — list endpoint uses `PraxisCardOut` + `build_praxis_card_out`
- `backend/services/activity_feed.py` — `status == submitted` filter on all completion queries
- `frontend/src/components/feed/FeedCardFoeCompletion.tsx` — faction color styling
- `frontend/src/pages/EditPraxis.tsx` — "Save draft" vs "Publish proof" split

## Test plan
- [ ] `/praxis` — cards show faction-specific background and border colors
- [ ] Task detail page completed praxis section — cards show faction colors
- [ ] `/updates` — only submitted praxes appear as completions (not in-progress)
- [ ] EditPraxis — "Save draft" saves without submitting; "Publish proof" submits and points are awarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)