### PR TITLE
SESSION P cleanup: mark P.1-P.8 done, fix stale doc ref

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -57,7 +57,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.1 — Alembic migration: unify to single Praxis table
+### TASK P.1 ✅ 2026-04-17 — Alembic migration: unify to single Praxis table
 
 **Scope:** Database only. No Python model/service code changes yet.
 
@@ -90,7 +90,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.2 — Backend models: rewrite to unified Praxis
+### TASK P.2 ✅ 2026-04-17 — Backend models: rewrite to unified Praxis
 
 **Depends on:** P.1
 
@@ -123,7 +123,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.3 — Backend schemas: rewrite to unified Praxis
+### TASK P.3 ✅ 2026-04-17 — Backend schemas: rewrite to unified Praxis
 
 **Depends on:** P.2
 
@@ -151,7 +151,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.4 — Backend services: rewrite to unified Praxis
+### TASK P.4 ✅ 2026-04-17 — Backend services: rewrite to unified Praxis
 
 **Depends on:** P.3
 
@@ -193,7 +193,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.5 — Backend routes: single unified praxes router
+### TASK P.5 ✅ 2026-04-17 — Backend routes: single unified praxes router
 
 **Depends on:** P.4
 
@@ -230,7 +230,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.6 — Frontend API: single unified praxis client
+### TASK P.6 ✅ 2026-04-17 — Frontend API: single unified praxis client
 
 **Depends on:** P.5 (backend must be running with new routes)
 
@@ -255,7 +255,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.7 — Frontend pages + components: wire to new API
+### TASK P.7 ✅ 2026-04-17 — Frontend pages + components: wire to new API
 
 **Depends on:** P.6
 
@@ -279,7 +279,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK P.8 — Tests and spec docs
+### TASK P.8 ✅ 2026-04-17 — Tests and spec docs
 
 **Depends on:** P.5
 

--- a/docs/spec/SPEC-backend-architecture.md
+++ b/docs/spec/SPEC-backend-architecture.md
@@ -89,7 +89,7 @@ themselves are frozen dataclasses.
   through its own service function.** This keeps invariants provable in
   isolation.
 - **Aggregate-internal consistency can be enforced in the service that owns
-  it.** E.g. `create_submission` is free to write both `Submission` and its
+  it.** E.g. `create_praxis` is free to write both `Praxis` and its
   `MediaItem` children in one transaction.
 
 ### What we deliberately skip


### PR DESCRIPTION
## Summary
SESSION P (Praxis Unification) is already shipped — P.1 through P.8 landed as separate commits between a8c0289 and 35269f4. This PR is just the paperwork:
- Marks **P.1–P.8 ✅** in [docs/TASKS.md](docs/TASKS.md) with today's date.
- Fixes one stale `create_submission`/`Submission` example in `docs/spec/SPEC-backend-architecture.md` §6 → `create_praxis`/`Praxis`.

## Verification
- Local DB at `0004_praxis_unification` (head).
- No `Submission` / `Collaboration` / `CharacterTask` references in `backend/{models,schemas,services,routers,tests}/` outside of benign comments.
- No `SubmissionOut`/`CollaborationOut` types in `frontend/src/`.
- Backend integration test file is `test_praxes.py` (renamed from `test_submissions.py`).

## Flagged for follow-up (not this PR)
- `alembic check` reports minor drift between SQLAlchemy models and live DB on `vote` unique constraints and `created_at/updated_at` nullability for a few tables. Pre-existing hygiene, unrelated to P. Spawned as a separate task.

## Test plan
- [ ] CI passes
- [ ] `alembic current` reports `0004_praxis_unification (head)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)