### PR TITLE
SESSION B follow-ups: mark B.4 and B.5 done

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -617,7 +617,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK B.4 — Admin can edit fields on pending/retired tasks
+### TASK B.4 ✅ 2026-04-17 — Admin can edit fields on pending/retired tasks
 
 **Problem:** No admin endpoint or UI exists to edit task title, description, point_value, or level_required after a task is created. `PUT /tasks/{id}` rejects everyone except the original proposer on pending-only tasks.
 
@@ -634,7 +634,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK B.5 — Admin can propose tasks regardless of level
+### TASK B.5 ✅ 2026-04-17 — Admin can propose tasks regardless of level
 
 **Problem:** `services/task.py` gates proposals behind `stats.level < 3`. `ProposeTask.tsx` shows a hard error page for any character below level 3. Admins should bypass both gates.
 


### PR DESCRIPTION
## Summary
Both B.4 (admin edit tasks) and B.5 (admin bypass level gate on propose) were already implemented end-to-end in prior commits. This PR is just the TASKS.md paperwork.

- **B.4**: `AdminTaskPatch`, `admin_edit_task`, `PATCH /admin/tasks/{id}`, `adminPatchTask` in frontend, TasksTab wiring — all live.
- **B.5**: `skip_level_check` param on `propose_task`, admin bypass in router, admin bypass in ProposeTask.tsx gate — all live.

## Test plan
- [ ] Admin edits a pending task's point_value → saves successfully, active tasks show no edit button
- [ ] Admin at level 0 can navigate to Propose Task and submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)