### PR TITLE
SESSION R.5: vote budget on-read recomputation

### DIFF
--- a/backend/alembic/versions/0005_vote_budget_recompute.py
+++ b/backend/alembic/versions/0005_vote_budget_recompute.py
@@ -1,0 +1,111 @@
+"""R.5 — Vote budget: on-read recomputation.
+
+Replaces the running `votes_available` counter on `character_stats` with a
+monotonic `votes_spent_this_era` column. Spendable votes are now computed on
+every read via services.scoring.compute_votes_available:
+
+    votes_available = era.vote_budget_base
+                    + floor(era.vote_budget_multiplier * stats.score)
+                    - stats.votes_spent_this_era
+
+Data migration strategy:
+- For each existing CharacterStats row, compute the historical cap from the
+  current era's `vote_budget_base` and `vote_budget_multiplier` (stored on
+  the `era` table via EraConfig → values at seed time), then derive
+  `votes_spent_this_era = max(0, cap - votes_available)`.
+- Where the era row does not carry the formula inputs (older data), we
+  fall back to zero. The exact historical drift is unrecoverable; zero is
+  conservative — it credits the player the full new on-read budget.
+
+Downgrade:
+- Re-adds `votes_available`. Populates it from the recomputation formula
+  using `vote_budget_base` / `vote_budget_multiplier` from the current
+  EraConfig (CURRENT_ERA) imported at runtime. This produces a correct
+  snapshot for the live era; stats for prior eras are recalculated against
+  the live era's parameters (best effort — prior-era formula values are not
+  persisted on the era row).
+
+Revision ID: 0005_vote_budget_recompute
+Revises: 0004_praxis_unification
+Create Date: 2026-04-17
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_vote_budget_recompute"
+down_revision: Union[str, None] = "0004_praxis_unification"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add the new monotonic column with a zero default. Idempotent.
+    op.execute(sa.text("""
+        ALTER TABLE character_stats
+        ADD COLUMN IF NOT EXISTS votes_spent_this_era INTEGER NOT NULL DEFAULT 0
+    """))
+
+    # 2. Best-effort data recovery. The era row does not persist the EraConfig
+    #    values (vote_budget_base / multiplier), so we cannot reconstruct the
+    #    exact historical cap from the DB alone. We import CURRENT_ERA at
+    #    migration time and apply its formula uniformly. If existing
+    #    `votes_available` is less than the computed cap, treat the delta as
+    #    votes spent. Never go negative.
+    #
+    #    Rationale: the old counter drifted from the formula over time, so it
+    #    is not a reliable signal either. Setting votes_spent_this_era = 0 for
+    #    every row would be the safest choice, but it would give every player
+    #    the full fresh budget. Using max(0, cap - votes_available) is a
+    #    closer approximation: players who had spent votes will see their
+    #    spend preserved against the new cap.
+    from game_config import CURRENT_ERA
+
+    base = CURRENT_ERA.vote_budget_base
+    multiplier = float(CURRENT_ERA.vote_budget_multiplier)
+
+    op.execute(sa.text(f"""
+        UPDATE character_stats
+        SET votes_spent_this_era = GREATEST(
+            0,
+            ({base} + FLOOR({multiplier} * score)::INTEGER) - votes_available
+        )
+    """))
+
+    # 3. Drop the legacy counter.
+    op.execute(sa.text("""
+        ALTER TABLE character_stats
+        DROP COLUMN IF EXISTS votes_available
+    """))
+
+
+def downgrade() -> None:
+    # 1. Re-add votes_available with a zero default.
+    op.execute(sa.text("""
+        ALTER TABLE character_stats
+        ADD COLUMN IF NOT EXISTS votes_available INTEGER NOT NULL DEFAULT 0
+    """))
+
+    # 2. Recompute votes_available for existing rows from CURRENT_ERA formula.
+    #    This is a best-effort reconstruction — prior eras' formula values are
+    #    not persisted on the era row. Clamped at zero.
+    from game_config import CURRENT_ERA
+
+    base = CURRENT_ERA.vote_budget_base
+    multiplier = float(CURRENT_ERA.vote_budget_multiplier)
+
+    op.execute(sa.text(f"""
+        UPDATE character_stats
+        SET votes_available = GREATEST(
+            0,
+            ({base} + FLOOR({multiplier} * score)::INTEGER) - votes_spent_this_era
+        )
+    """))
+
+    # 3. Drop the new column.
+    op.execute(sa.text("""
+        ALTER TABLE character_stats
+        DROP COLUMN IF EXISTS votes_spent_this_era
+    """))

--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -180,7 +180,8 @@ ERA_N_TAUNT_TEMPLATES: dict[str, dict[str, list[str]]] = {
 # Reset flags: what happens to characters when THIS era begins.
 #   reset_all_time_score should almost always be False.
 #
-# Vote budget formula: votes_available = base + floor(multiplier x score)
+# Vote budget formula (on-read, see services/scoring.compute_votes_available):
+#   votes_available = base + floor(multiplier x score) - votes_spent_this_era
 
 ERA_N = EraConfig(
     name="Era N",                        # TODO: Human-readable era name

--- a/backend/models/character.py
+++ b/backend/models/character.py
@@ -41,7 +41,8 @@ class Character(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )
-    # score, level, votes_available, all_time_score live in CharacterStats (star schema split)
+    # score, level, votes_spent_this_era, all_time_score live in CharacterStats (star schema split)
+    # votes_available is computed on read: services.scoring.compute_votes_available
 
     account: Mapped["Account"] = relationship(
         "Account", back_populates="characters", lazy="raise"

--- a/backend/models/character_stats.py
+++ b/backend/models/character_stats.py
@@ -12,6 +12,13 @@ class CharacterStats(Base):
     One row per (character, era). Era resets insert new rows; old rows are
     preserved for historical queries. All scoring, levelling, and vote budget
     state lives here — Character is a pure dimension table.
+
+    Vote budget is computed on read from the formula
+        votes_available = era.vote_budget_base + floor(era.vote_budget_multiplier * score)
+                        - votes_spent_this_era
+    See services/scoring.py::compute_votes_available. `votes_spent_this_era`
+    is monotonic within an era: it increments on first-cast votes and resets
+    to zero on era reset.
     """
 
     __tablename__ = "character_stats"
@@ -23,7 +30,9 @@ class CharacterStats(Base):
     score: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     all_time_score: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     level: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
-    votes_available: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    votes_spent_this_era: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -53,6 +53,7 @@ from services.admin_service import (
 )
 from services.character_stats import recalculate_character_stats
 from services.era import apply_era_reset, get_current_era_row
+from services.scoring import compute_votes_available
 from services.auth import create_jwt
 
 router = APIRouter()
@@ -196,7 +197,7 @@ async def admin_patch_character_stats(
         score=stats.score,
         all_time_score=stats.all_time_score,
         level=stats.level,
-        votes_available=stats.votes_available,
+        votes_available=compute_votes_available(stats),
     )
 
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -171,7 +171,7 @@ async def seed(env: str, yes: bool) -> None:
                 score=0,
                 all_time_score=0,
                 level=0,
-                votes_available=era.vote_budget_base,
+                votes_spent_this_era=0,
             ))
             await session.flush()
 

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -26,6 +26,7 @@ from schemas.admin import (
     OverviewStats,
 )
 from services.era import get_current_era_row, get_or_create_stats
+from services.scoring import compute_votes_available
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +86,7 @@ async def list_characters(
     session: AsyncSession,
     faction: str | None = None,
     status: str | None = None,
+    era: EraConfig = CURRENT_ERA,
 ) -> list[CharacterSummary]:
     era_row = await get_current_era_row(session)
 
@@ -119,7 +121,7 @@ async def list_characters(
             status=character.status.value,
             score=stats.score if stats else 0,
             level=stats.level if stats else 0,
-            votes_available=stats.votes_available if stats else 0,
+            votes_available=compute_votes_available(stats, era) if stats else era.vote_budget_base,
             created_at=character.created_at,
         )
         for character, stats in rows
@@ -213,7 +215,6 @@ async def admin_create_character(
         session,
         character_id=character.id,
         era_id=era_row.id,
-        initial_votes=era.vote_budget_base,
     )
 
     await session.commit()
@@ -238,7 +239,6 @@ async def set_character_stats(
         session,
         character_id=character_id,
         era_id=era_row.id,
-        initial_votes=era.vote_budget_base,
     )
 
     if patch.level is not None:
@@ -248,7 +248,12 @@ async def set_character_stats(
     if patch.all_time_score is not None:
         stats.all_time_score = patch.all_time_score
     if patch.votes_available is not None:
-        stats.votes_available = patch.votes_available
+        # Translate a desired `votes_available` into `votes_spent_this_era`
+        # so the on-read formula lands on the requested value.
+        # votes_spent = cap - desired (clamped at 0).
+        score_for_cap = patch.score if patch.score is not None else stats.score
+        cap = era.vote_budget_base + int(era.vote_budget_multiplier * score_for_cap)
+        stats.votes_spent_this_era = max(0, cap - patch.votes_available)
 
     await session.commit()
     await session.refresh(stats)

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -129,7 +129,6 @@ async def create_character(
         session,
         character_id=character.id,
         era_id=era_row.id,
-        initial_votes=era.vote_budget_base,
     )
 
     await session.commit()

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -21,7 +21,6 @@ from services.scoring import (
     compute_faction_multiplier,
     compute_level,
     compute_praxis_score,
-    compute_vote_budget,
 )
 
 
@@ -209,14 +208,10 @@ async def recalculate_character_stats(
 
     new_score = int(total_score)
     stats = current_stats
-    old_score = stats.score
 
-    old_budget_capacity = compute_vote_budget(old_score, era)
-    new_budget_capacity = compute_vote_budget(new_score, era)
-    budget_delta = new_budget_capacity - old_budget_capacity
-    if budget_delta > 0:
-        stats.votes_available += budget_delta
-
+    # Vote budget is computed on read (services.scoring.compute_votes_available)
+    # from stats.score and stats.votes_spent_this_era, so no bookkeeping is
+    # needed here when score changes.
     stats.score = new_score
     stats.all_time_score = max(stats.all_time_score, new_score)
     stats.level = compute_level(new_score, era)

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -47,9 +47,13 @@ async def get_or_create_stats(
     session: AsyncSession,
     character_id: int,
     era_id: int,
-    initial_votes: int = 0,
 ) -> CharacterStats:
-    """Fetch or create the CharacterStats row for a given (character, era) pair."""
+    """Fetch or create the CharacterStats row for a given (character, era) pair.
+
+    Vote budget is computed on read from score + votes_spent_this_era
+    (see services.scoring.compute_votes_available), so new rows start with
+    votes_spent_this_era = 0 — no explicit seeding of the budget is required.
+    """
     result = await session.execute(
         select(CharacterStats).where(
             CharacterStats.character_id == character_id,
@@ -61,7 +65,7 @@ async def get_or_create_stats(
         stats = CharacterStats(
             character_id=character_id,
             era_id=era_id,
-            votes_available=initial_votes,
+            votes_spent_this_era=0,
         )
         session.add(stats)
         await session.flush()
@@ -89,14 +93,18 @@ async def apply_era_reset(
         prev_stats = prev_result.scalar_one_or_none()
         prev_all_time = prev_stats.all_time_score if prev_stats else 0
 
+        # Vote budget is computed on read. On era reset with reset_vote_budget=True
+        # we zero votes_spent_this_era so the on-read budget reflects the full
+        # formula against the (possibly reset) score. Otherwise we carry over
+        # the previous era's spend count.
         new_stats = CharacterStats(
             character_id=character.id,
             era_id=new_era_row.id,
             score=0 if era.reset_score else (prev_stats.score if prev_stats else 0),
             all_time_score=0 if era.reset_all_time_score else prev_all_time,
             level=0 if era.reset_level else (prev_stats.level if prev_stats else 0),
-            votes_available=era.vote_budget_base if era.reset_vote_budget else (
-                prev_stats.votes_available if prev_stats else era.vote_budget_base
+            votes_spent_this_era=0 if era.reset_vote_budget else (
+                prev_stats.votes_spent_this_era if prev_stats else 0
             ),
         )
         session.add(new_stats)

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -1,7 +1,10 @@
 from math import floor
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from game_config import CURRENT_ERA, EraConfig
+
+if TYPE_CHECKING:
+    from models.character_stats import CharacterStats
 
 COLLABORATION_MODE_SOLO = "solo"
 COLLABORATION_MODE_COLLAB = "collab"
@@ -11,7 +14,33 @@ SNIDE_FACTION_SLUG = "snide"
 
 
 def compute_vote_budget(score: int, era: EraConfig = CURRENT_ERA) -> int:
+    """Return the total vote budget capacity for a given score.
+
+    This is the *cap* before any spending. Spendable votes are computed by
+    subtracting `votes_spent_this_era`; use `compute_votes_available` for that.
+    """
     return era.vote_budget_base + floor(era.vote_budget_multiplier * score)
+
+
+def compute_votes_available(
+    stats: "CharacterStats", era: EraConfig = CURRENT_ERA
+) -> int:
+    """Compute the spendable vote count for a character from persisted stats.
+
+    Formula:
+        era.vote_budget_base + floor(era.vote_budget_multiplier * stats.score)
+        - stats.votes_spent_this_era
+
+    The stored column is `votes_spent_this_era` (monotonic per era). The
+    returned budget is always on-read — it grows as `stats.score` grows and
+    shrinks as more first-cast votes are spent. Clamped at zero: if the
+    character has spent more than the formula currently allows (possible
+    after a score rollback / stat patch), the helper returns 0 rather than
+    a negative value. Callers should treat `<= 0` as "no votes remaining".
+    """
+    cap = era.vote_budget_base + floor(era.vote_budget_multiplier * stats.score)
+    remaining = cap - stats.votes_spent_this_era
+    return remaining if remaining > 0 else 0
 
 
 def compute_level(score: int, era: EraConfig = CURRENT_ERA) -> int:

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -8,6 +8,7 @@ from models.praxis import Praxis, PraxisMember, PraxisType
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
+from services.scoring import compute_votes_available
 
 
 async def cast_or_update_vote(
@@ -38,11 +39,11 @@ async def cast_or_update_vote(
         await session.refresh(existing)
         return existing
 
-    # New vote — deduct from budget via CharacterStats
+    # New vote — deduct from budget via CharacterStats (on-read recomputation)
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, voter.id, era_row.id)
 
-    if stats.votes_available <= 0:
+    if compute_votes_available(stats, era) <= 0:
         raise HTTPException(status_code=403, detail="No votes remaining in your budget.")
 
     vote = Vote(
@@ -51,7 +52,7 @@ async def cast_or_update_vote(
         voter_account_id=voter.account_id,
         stars=stars,
     )
-    stats.votes_available -= 1
+    stats.votes_spent_this_era += 1
     session.add(vote)
     await session.flush()
     await recalculate_character_stats(praxis.created_by_id, session, era)
@@ -123,11 +124,11 @@ async def cast_or_update_duel_vote(
         await session.refresh(existing)
         return existing
 
-    # New vote — deduct from budget
+    # New vote — deduct from budget (on-read recomputation)
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, voter.id, era_row.id)
 
-    if stats.votes_available <= 0:
+    if compute_votes_available(stats, era) <= 0:
         raise HTTPException(status_code=403, detail="No votes remaining in your budget.")
 
     # Look up the character_id for the targeted member
@@ -145,7 +146,7 @@ async def cast_or_update_duel_vote(
         stars=stars,
         praxis_member_id=praxis_member_id,
     )
-    stats.votes_available -= 1
+    stats.votes_spent_this_era += 1
     session.add(vote)
     await session.flush()
     for member_id in member_ids:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -188,7 +188,7 @@ async def character(db_session: AsyncSession, account: Account, era: Era, factio
         score=0,
         all_time_score=0,
         level=0,
-        votes_available=10,
+        votes_spent_this_era=0,
     )
     db_session.add(stats)
     await db_session.commit()
@@ -214,7 +214,7 @@ async def character2(db_session: AsyncSession, account2: Account, era: Era, fact
         score=500,
         all_time_score=500,
         level=5,
-        votes_available=10,
+        votes_spent_this_era=0,
     )
     db_session.add(stats)
     await db_session.commit()

--- a/backend/tests/integration/test_messages.py
+++ b/backend/tests/integration/test_messages.py
@@ -187,7 +187,7 @@ async def test_read_message_not_party(
         score=0,
         all_time_score=0,
         level=0,
-        votes_available=10,
+        votes_spent_this_era=0,
     )
     db_session.add(stats3)
     await db_session.commit()

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -13,6 +13,7 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
 from models.task import Task
+from services.scoring import compute_votes_available
 
 
 @pytest.mark.asyncio
@@ -101,7 +102,7 @@ async def test_update_vote_is_free(
     )
     stats = result.scalar_one()
     await db_session.refresh(stats)
-    budget_before = stats.votes_available
+    budget_before = compute_votes_available(stats)
 
     # Initial vote
     resp1 = await client.post(
@@ -110,7 +111,7 @@ async def test_update_vote_is_free(
     assert resp1.status_code == 200
 
     await db_session.refresh(stats)
-    budget_after_first = stats.votes_available
+    budget_after_first = compute_votes_available(stats)
     assert budget_after_first == budget_before - 1
 
     # Update vote (no additional cost)
@@ -121,7 +122,7 @@ async def test_update_vote_is_free(
     assert resp2.json()["stars"] == 5
 
     await db_session.refresh(stats)
-    assert stats.votes_available == budget_after_first  # unchanged
+    assert compute_votes_available(stats) == budget_after_first  # unchanged
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_era_reset.py
+++ b/backend/tests/unit/test_era_reset.py
@@ -4,6 +4,9 @@ Unit tests for Era reset logic.
 These tests validate the reset flag semantics from SPEC-game-rules.md § 11.
 They do NOT hit the DB — they test the logic of what *should* happen to
 a character dict given a particular EraConfig's reset flags.
+
+Vote budget is on-read (see services/scoring.compute_votes_available), so
+reset_vote_budget zeros `votes_spent_this_era`, not a stored budget counter.
 """
 from dataclasses import replace
 
@@ -25,7 +28,7 @@ def apply_era_reset(character: dict, new_era: EraConfig) -> dict:
     if new_era.reset_faction:
         result["faction_slug"] = "na"
     if new_era.reset_vote_budget:
-        result["votes_available"] = new_era.vote_budget_base
+        result["votes_spent_this_era"] = 0
     if new_era.reset_all_time_score:
         result["all_time_score"] = 0
     return result
@@ -37,7 +40,7 @@ def sample_character():
         "score": 500,
         "level": 4,
         "faction_slug": "gestalt",
-        "votes_available": 1100,
+        "votes_spent_this_era": 50,
         "all_time_score": 2000,
     }
 
@@ -81,9 +84,9 @@ def test_full_reset_sets_faction_to_aged_out(sample_character, full_reset_era):
     assert result["faction_slug"] == "na"
 
 
-def test_full_reset_resets_vote_budget_to_base(sample_character, full_reset_era):
+def test_full_reset_zeroes_votes_spent_this_era(sample_character, full_reset_era):
     result = apply_era_reset(sample_character, full_reset_era)
-    assert result["votes_available"] == full_reset_era.vote_budget_base
+    assert result["votes_spent_this_era"] == 0
 
 
 def test_full_reset_zeroes_all_time_score(sample_character, full_reset_era):
@@ -121,10 +124,10 @@ def test_era1_reset_clears_faction(sample_character):
     assert result["faction_slug"] == "na"
 
 
-def test_era1_reset_resets_vote_budget(sample_character):
+def test_era1_reset_zeroes_votes_spent_this_era(sample_character):
     assert ERA_1.reset_vote_budget is True
     result = apply_era_reset(sample_character, ERA_1)
-    assert result["votes_available"] == ERA_1.vote_budget_base
+    assert result["votes_spent_this_era"] == 0
 
 
 def test_selective_reset_only_score():
@@ -136,10 +139,10 @@ def test_selective_reset_only_score():
         reset_vote_budget=False,
         reset_all_time_score=False,
     )
-    char = {"score": 300, "level": 3, "faction_slug": "snide", "votes_available": 700, "all_time_score": 1000}
+    char = {"score": 300, "level": 3, "faction_slug": "snide", "votes_spent_this_era": 25, "all_time_score": 1000}
     result = apply_era_reset(char, era)
     assert result["score"] == 0
     assert result["level"] == 3
     assert result["faction_slug"] == "snide"
-    assert result["votes_available"] == 700
+    assert result["votes_spent_this_era"] == 25
     assert result["all_time_score"] == 1000

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from game_config import ERA_1
 from services.scoring import (
     COLLABORATION_MODE_COLLAB,
@@ -8,7 +10,15 @@ from services.scoring import (
     compute_level,
     compute_praxis_score,
     compute_vote_budget,
+    compute_votes_available,
 )
+
+
+@dataclass
+class _StatsStub:
+    """Minimal CharacterStats-shaped stub for scoring unit tests."""
+    score: int
+    votes_spent_this_era: int
 
 
 def test_vote_budget_base():
@@ -19,6 +29,66 @@ def test_vote_budget_with_score():
     score = 50
     expected = ERA_1.vote_budget_base + int(ERA_1.vote_budget_multiplier * score)
     assert compute_vote_budget(score=score, era=ERA_1) == expected
+
+
+# ---------------------------------------------------------------------------
+# compute_votes_available — on-read recomputation (R.5)
+# ---------------------------------------------------------------------------
+
+
+def test_votes_available_zero_score_no_spend():
+    """score=0, votes_spent=0 → vote_budget_base."""
+    stats = _StatsStub(score=0, votes_spent_this_era=0)
+    assert compute_votes_available(stats, era=ERA_1) == ERA_1.vote_budget_base
+
+
+def test_votes_available_formula():
+    """base=10, multiplier=0.1, score=100, spent=3 → 10 + 10 - 3 = 17."""
+    from game_config import EraConfig, ERA_1_FACTIONS
+    era = EraConfig(
+        name="test",
+        config_key="test",
+        max_task_signups=20,
+        max_duel_participants=2,
+        max_collab_participants=20,
+        vote_budget_base=10,
+        vote_budget_multiplier=0.1,
+        level_thresholds=ERA_1.level_thresholds,
+        reset_score=False,
+        reset_level=False,
+        reset_faction=False,
+        reset_vote_budget=False,
+        reset_all_time_score=False,
+        factions=ERA_1_FACTIONS,
+        tasks=(),
+        taunt_templates={},
+    )
+    stats = _StatsStub(score=100, votes_spent_this_era=3)
+    assert compute_votes_available(stats, era=era) == 17
+
+
+def test_votes_available_clamps_at_zero_when_overspent():
+    """votes_spent > cap → 0 (never negative).
+
+    Can occur after a score rollback or admin stat patch. Callers treat 0
+    as 'no votes remaining'.
+    """
+    # base=100, multiplier=2.0, score=0 → cap=100; spent=500 → would be -400
+    stats = _StatsStub(score=0, votes_spent_this_era=500)
+    assert compute_votes_available(stats, era=ERA_1) == 0
+
+
+def test_votes_available_grows_with_score():
+    """Budget grows as score grows without any explicit refresh."""
+    low = _StatsStub(score=10, votes_spent_this_era=0)
+    high = _StatsStub(score=100, votes_spent_this_era=0)
+    assert compute_votes_available(high, era=ERA_1) > compute_votes_available(low, era=ERA_1)
+
+
+def test_votes_available_matches_compute_vote_budget_when_no_spend():
+    """When nothing has been spent, available == cap."""
+    stats = _StatsStub(score=50, votes_spent_this_era=0)
+    assert compute_votes_available(stats, era=ERA_1) == compute_vote_budget(50, era=ERA_1)
 
 
 def test_vote_budget_floors_fractional():

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -376,7 +376,7 @@ legacy `praxis` (old table), `collaboration`, `collaboration_member`,
 
 ---
 
-### TASK R.5 — Vote budget: on-read recomputation
+### TASK R.5 ✅ 2026-04-17 — Vote budget: on-read recomputation
 
 **Problem:** `votes_available` is stored as a running counter and decremented on each vote. It drifts from the formula if score changes (era reset, stat patch, etc.) and does not grow as the character earns points.
 

--- a/docs/spec/SPEC-data-models.md
+++ b/docs/spec/SPEC-data-models.md
@@ -57,7 +57,7 @@ status               -- enum: active | paused | banned (CharacterStatus)
 created_at
 updated_at
 ```
-*Score, level, votes_available, and all_time_score live in CharacterStats (star schema split).*
+*Score, level, votes_spent_this_era, and all_time_score live in CharacterStats (star schema split).*
 *Faction graduation (level >= 3 to pick a real faction) is enforced at API layer, not DB.*
 
 ### CharacterStats
@@ -68,7 +68,10 @@ era_id               -- FK -> Era
 score                -- sum of non-flagged praxis scores for this era (default 0)
 all_time_score       -- cumulative, never resets (default 0)
 level                -- integer 0-8; derived from score (default 0)
-votes_available      -- spendable budget; formula from EraConfig (default 0)
+votes_spent_this_era -- monotonic count of first-cast votes this era (default 0)
+                       spendable `votes_available` is computed on read from
+                       era.vote_budget_base + floor(era.vote_budget_multiplier * score)
+                       - votes_spent_this_era (see services.scoring.compute_votes_available).
 updated_at
 CONSTRAINT: unique(character_id, era_id)
 ```


### PR DESCRIPTION
## Summary
Replaces stored `votes_available` with `votes_spent_this_era` and computes the available budget on read. Fixes drift from score changes (era reset, admin patches) and makes the budget grow naturally as a character earns points.

```
votes_available = era.vote_budget_base + floor(era.vote_budget_multiplier * stats.score) - stats.votes_spent_this_era
```

## Migration
- **New**: `backend/alembic/versions/0005_vote_budget_recompute.py`
- Adds `votes_spent_this_era` (NOT NULL default 0), backfills best-effort from current era config, drops `votes_available`.
- Round-trip `upgrade → downgrade -1 → upgrade head` verified on dev DB.

## API compatibility
Public schemas still expose `votes_available` (computed on read); `votes_spent_this_era` is internal.

## Test plan
- [x] `pytest backend/tests/unit/ -v` — 109 passed (5 new tests for `compute_votes_available`)
- [x] Migration round-trip on dev DB
- [ ] After merging, verify on staging: character earns points → vote budget reflects new score immediately
- [ ] Era reset zeroes `votes_spent_this_era`, budget recalculates

🤖 Generated with [Claude Code](https://claude.com/claude-code)