### PR TITLE
SESSION T: integration tests for R/M rules (T.5-T.10)

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -33,12 +33,16 @@ from services.character import (
 )
 from services.era import get_current_era_row
 from services.praxis import build_praxis_out
+from services.scoring import compute_votes_available
 
 router = APIRouter()
 
 
 def _build_character_out(character: Character, stats: Optional[CharacterStats]) -> CharacterOut:
-    """Build a flat CharacterOut from a Character row and its optional CharacterStats."""
+    """Build a flat CharacterOut from a Character row and its optional CharacterStats.
+
+    votes_available is computed on-read from stats (see R.5).
+    """
     return CharacterOut(
         id=character.id,
         username=character.username,
@@ -52,6 +56,7 @@ def _build_character_out(character: Character, stats: Optional[CharacterStats]) 
         score=stats.score if stats else 0,
         all_time_score=stats.all_time_score if stats else 0,
         level=stats.level if stats else 0,
+        votes_available=compute_votes_available(stats) if stats else 0,
     )
 
 

--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -4,7 +4,12 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class CharacterOut(BaseModel):
-    """Public character response. Stats (score, level, all_time_score) come from CharacterStats."""
+    """Public character response. Stats (score, level, all_time_score) come from CharacterStats.
+
+    votes_available is the on-read computed vote budget for the current era
+    (see services.scoring.compute_votes_available); it reflects score growth
+    and spent votes without a stored counter.
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -17,6 +22,7 @@ class CharacterOut(BaseModel):
     level: int
     score: int
     all_time_score: int
+    votes_available: int = 0
     faction_slug: str
     status: str
     created_at: datetime

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -995,3 +995,174 @@ async def test_admin_edit_active_task_rejected(
         headers=auth_headers,
     )
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# T.8 SESSION T additions — vote budget recompute + era reset semantics (R.5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_patch_stats_recomputes_votes_available(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    era: Era,
+):
+    """PATCH /admin/characters/{id}/stats with votes_available=5 stores the
+    equivalent votes_spent_this_era so the on-read budget lands at 5 (R.5)."""
+    from math import floor
+    from sqlalchemy import select
+
+    from game_config import CURRENT_ERA
+
+    await _make_admin(account, db_session)
+
+    # Set a known score so we can predict votes_available
+    patch_resp = await client.patch(
+        f"/admin/characters/{character.id}/stats",
+        json={"score": 0, "votes_available": 5},
+        headers=auth_headers,
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["votes_available"] == 5
+
+    # The service should have stored votes_spent_this_era = cap - 5
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    await db_session.refresh(stats)
+    cap = CURRENT_ERA.vote_budget_base + floor(CURRENT_ERA.vote_budget_multiplier * 0)
+    assert stats.votes_spent_this_era == max(0, cap - 5)
+
+    # Re-reading via /admin/characters confirms the computed value
+    list_resp = await client.get(
+        f"/admin/characters?faction={character.faction_slug}",
+        headers=auth_headers,
+    )
+    assert list_resp.status_code == 200
+    matching = [c for c in list_resp.json() if c["id"] == character.id]
+    assert len(matching) == 1
+    assert matching[0]["votes_available"] == 5
+
+
+@pytest.mark.asyncio
+async def test_admin_era_reset_zeros_votes_spent_this_era(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    era: Era,
+):
+    """Era reset with reset_vote_budget=True zeros votes_spent_this_era (R.5)."""
+    from sqlalchemy import select
+    from math import floor
+
+    from game_config import CURRENT_ERA
+
+    await _make_admin(account, db_session)
+
+    # Pre-reset: force character to have votes_spent_this_era > 0
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.votes_spent_this_era = 7
+    stats.score = 50
+    await db_session.commit()
+
+    # Sanity: ERA_1 has reset_vote_budget=True, so the helper won't run
+    # against a different config.
+    assert CURRENT_ERA.reset_vote_budget is True
+
+    reset_resp = await client.put("/admin/era/reset", headers=auth_headers)
+    assert reset_resp.status_code == 200
+    new_era_id = reset_resp.json()["era_id"]
+
+    # Fetch the new-era stats row
+    new_result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == new_era_id,
+        )
+    )
+    new_stats = new_result.scalar_one()
+    await db_session.refresh(new_stats)
+    assert new_stats.votes_spent_this_era == 0
+
+    # With reset_score=True on ERA_1, score is 0 in the new era, so budget == base.
+    expected_budget = CURRENT_ERA.vote_budget_base + floor(
+        CURRENT_ERA.vote_budget_multiplier * new_stats.score
+    )
+    # compute_votes_available should equal the expected budget
+    from services.scoring import compute_votes_available
+    assert compute_votes_available(new_stats, CURRENT_ERA) == expected_budget
+
+
+@pytest.mark.asyncio
+async def test_admin_era_reset_preserves_votes_spent_without_flag(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    era: Era,
+):
+    """With reset_vote_budget=False the new era carries over votes_spent_this_era (R.5)."""
+    from dataclasses import replace
+
+    from game_config import CURRENT_ERA
+    from models.era import Era as EraModel
+    from services.era import apply_era_reset
+    from sqlalchemy import select
+
+    await _make_admin(account, db_session)
+
+    # Pre-reset spend
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.votes_spent_this_era = 9
+    await db_session.commit()
+
+    # Build a new era row and trigger reset directly through the service
+    # with a custom EraConfig that disables reset_vote_budget. The public
+    # /admin/era/reset endpoint uses CURRENT_ERA unconditionally, so to
+    # exercise the preservation branch we invoke the service with an
+    # overridden EraConfig.
+    new_era_row = EraModel(
+        name=CURRENT_ERA.name,
+        config_key=CURRENT_ERA.config_key,
+        started_by=account.id,
+    )
+    db_session.add(new_era_row)
+    await db_session.flush()
+
+    preserving_era = replace(CURRENT_ERA, reset_vote_budget=False)
+    await apply_era_reset([character], new_era_row, db_session, era=preserving_era)
+
+    # Load the new-era stats row
+    new_result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == new_era_row.id,
+        )
+    )
+    new_stats = new_result.scalar_one()
+    await db_session.refresh(new_stats)
+    assert new_stats.votes_spent_this_era == 9

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from httpx import AsyncClient
 from jose import jwt
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from models.account import Account
@@ -207,3 +208,77 @@ async def test_auth_me_with_character_faction(
     assert resp.status_code == 200
     char = resp.json()["character"]
     assert char["faction_slug"] == character.faction_slug
+
+
+@pytest.mark.asyncio
+async def test_auth_me_exposes_votes_available(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    era,
+):
+    """GET /auth/me surfaces the on-read computed vote budget (R.5).
+
+    votes_available = base + floor(multiplier * score) - votes_spent_this_era
+    """
+    from math import floor
+    from sqlalchemy import select
+
+    from game_config import CURRENT_ERA
+    from models.character_stats import CharacterStats
+
+    # Seed a known score on the character
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.score = 100
+    stats.votes_spent_this_era = 0
+    await db_session.commit()
+
+    resp = await client.get("/auth/me", headers=auth_headers)
+    assert resp.status_code == 200
+    char = resp.json()["character"]
+    assert char is not None
+    assert "votes_available" in char
+
+    expected = (
+        CURRENT_ERA.vote_budget_base
+        + floor(CURRENT_ERA.vote_budget_multiplier * 100)
+        - 0
+    )
+    assert char["votes_available"] == expected
+
+    # Admin patches votes_available lower; re-fetch /auth/me and confirm update.
+    # (Uses the admin service layer directly; emulates an admin patch.)
+    from schemas.admin import CharacterStatsPatch
+    from services.admin_service import set_character_stats
+    from models.roles import AccountRole, Role
+
+    # Grant admin to this account so we can call the admin endpoint
+    role = Role(name="admin", description="Administrator")
+    db_session.add(role)
+    await db_session.flush()
+    db_session.add(
+        AccountRole(account_id=account.id, role_id=role.id, granted_by=account.id)
+    )
+    await db_session.commit()
+
+    # Patch votes_available to 42 via the admin service
+    await set_character_stats(
+        character.id,
+        CharacterStatsPatch(votes_available=42),
+        db_session,
+    )
+
+    # Re-fetch /auth/me
+    resp2 = await client.get("/auth/me", headers=auth_headers)
+    assert resp2.status_code == 200
+    updated_char = resp2.json()["character"]
+    # The computed value must reflect the admin patch
+    assert updated_char["votes_available"] == 42

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -288,24 +288,39 @@ async def test_faction_change_via_choose_endpoint(
 
 
 @pytest.mark.asyncio
-async def test_second_character_blocked_below_level3(
+async def test_second_character_blocked_below_level5(
     client: AsyncClient,
+    db_session: AsyncSession,
     character: Character,
     era: Era,
     faction_ua: Faction,
     auth_headers: dict,
 ):
-    """Account with a level-0 character cannot create a second character."""
+    """Account with a level-4 first character cannot create a second character (R.7)."""
+    # Raise the first character's level to 4 — still below the level-5 gate
+    from sqlalchemy import select
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.level = 4
+    await db_session.commit()
+
     resp = await client.post(
         "/characters",
         json={"username": "secondchar", "display_name": "Second"},
         headers=auth_headers,
     )
     assert resp.status_code == 403
+    # The error message must explicitly name the level-5 requirement
+    assert "5" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio
-async def test_second_character_allowed_at_level3(
+async def test_second_character_allowed_at_level5(
     client: AsyncClient,
     db_session: AsyncSession,
     account2: Account,
@@ -313,7 +328,7 @@ async def test_second_character_allowed_at_level3(
     faction_ua: Faction,
     auth_headers2: dict,
 ):
-    """Account whose first character is level 5 can create a second character."""
+    """Account whose first character is level 5 can create a second character (R.7)."""
     # character2 from conftest already exists with level 5; auth_headers2 belongs to account2
     resp = await client.post(
         "/characters",
@@ -324,6 +339,126 @@ async def test_second_character_allowed_at_level3(
     data = resp.json()
     assert data["username"] == "secondcharacter2"
     assert "account_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_albescent_requires_level8_character_on_account(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account2: Account,
+    character2: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers2: dict,
+):
+    """Creating an Albescent second character requires a level-8 character on the account (R.7)."""
+    from models.faction import FactionStatus
+    from sqlalchemy import select
+
+    # Ensure the albescent faction exists (required FK)
+    result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
+    if result.scalar_one_or_none() is None:
+        albescent = Faction(
+            slug="albescent",
+            name="Albescent",
+            description="Albescent faction",
+            status=FactionStatus.visible,
+        )
+        db_session.add(albescent)
+        await db_session.commit()
+
+    # character2 is level 5 — raise to 7 (still below 8)
+    stats_result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character2.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = stats_result.scalar_one()
+    stats.level = 7
+    await db_session.commit()
+
+    # Level 7 — Albescent should be blocked
+    resp_blocked = await client.post(
+        "/characters",
+        json={
+            "username": "alb_second",
+            "display_name": "Alb Second",
+            "faction_slug": "albescent",
+        },
+        headers=auth_headers2,
+    )
+    assert resp_blocked.status_code == 403
+    assert "8" in resp_blocked.json()["detail"]
+
+    # Raise to level 8 — Albescent should succeed
+    stats.level = 8
+    await db_session.commit()
+
+    resp_allowed = await client.post(
+        "/characters",
+        json={
+            "username": "alb_second2",
+            "display_name": "Alb Second 2",
+            "faction_slug": "albescent",
+        },
+        headers=auth_headers2,
+    )
+    assert resp_allowed.status_code == 201
+    assert resp_allowed.json()["faction_slug"] == "albescent"
+
+
+@pytest.mark.asyncio
+async def test_albescent_character_starts_in_albescent_faction(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account2: Account,
+    character2: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers2: dict,
+):
+    """A second character created as Albescent has faction_slug='albescent' (R.8), not 'ua'."""
+    from models.faction import FactionStatus
+    from sqlalchemy import select
+
+    # Ensure the albescent faction exists
+    result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
+    if result.scalar_one_or_none() is None:
+        albescent = Faction(
+            slug="albescent",
+            name="Albescent",
+            description="Albescent faction",
+            status=FactionStatus.visible,
+        )
+        db_session.add(albescent)
+        await db_session.commit()
+
+    # Raise character2 to level 8 so Albescent is unlocked
+    stats_result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character2.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = stats_result.scalar_one()
+    stats.level = 8
+    await db_session.commit()
+
+    resp = await client.post(
+        "/characters",
+        json={
+            "username": "alb_starter",
+            "display_name": "Alb Starter",
+            "faction_slug": "albescent",
+        },
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    # Must land directly in Albescent, not UA
+    assert data["faction_slug"] == "albescent"
+    assert data["faction_slug"] != "ua"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -12,6 +12,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -694,3 +694,193 @@ async def test_list_praxes_excludes_hidden(
     assert resp.status_code == 200
     ids = [item["id"] for item in resp.json()]
     assert praxis_id not in ids
+
+
+# ---------------------------------------------------------------------------
+# T.10 SESSION T additions — R-rule explicit coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_praxis_below_required_level_returns_403(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    auth_headers: dict,
+):
+    """R.1: POST /praxes returns 403 when character.level < task.level_required."""
+    from models.task import Task, TaskStatus
+
+    # character is level 0 by default; seed a task with level_required=5
+    high_task = Task(
+        title="Level 5 Only",
+        description="",
+        point_value=10,
+        level_required=5,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(high_task)
+    await db_session.commit()
+    await db_session.refresh(high_task)
+
+    resp = await client.post(
+        "/praxes",
+        json={"task_id": high_task.id, "type": "solo", "title": "Gate Test"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403
+    # Error message must name the required level
+    assert "5" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_collab_invite_accept_at_cap_returns_400(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    account2: Account,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    era: Era,
+):
+    """R.3: Accepting a collab invite that would exceed era.max_collab_participants returns 400."""
+    from game_config import CURRENT_ERA
+    from models.account import Account as AccountModel
+    from models.character import Character as CharacterModel
+    from models.character_stats import CharacterStats
+    from models.praxis import PraxisMember, PraxisType
+    from services.auth import create_jwt
+    from sqlalchemy import func, select
+
+    cap = CURRENT_ERA.max_collab_participants
+    assert cap > 0
+
+    # character2 (level 5) creates the collab praxis and is member #1
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Cap Test"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    # Seed cap-2 filler members to bring total to cap-1 (creator counts as 1).
+    # This leaves room to issue one legitimate invite to `character`, after
+    # which we will fill the last slot via DB seeding and then try to have
+    # `character` accept — which must fail because the cap is reached at
+    # accept time.
+    filler_accounts: list[AccountModel] = []
+    filler_characters: list[CharacterModel] = []
+    for index in range(cap - 2):
+        filler_account = AccountModel(email=f"filler{index}@example.com")
+        db_session.add(filler_account)
+        await db_session.flush()
+        filler_accounts.append(filler_account)
+
+        filler_character = CharacterModel(
+            account_id=filler_account.id,
+            username=f"filler_char_{index}",
+            display_name=f"Filler {index}",
+            faction_slug="ua",
+        )
+        db_session.add(filler_character)
+        await db_session.flush()
+        filler_characters.append(filler_character)
+
+        db_session.add(
+            CharacterStats(
+                character_id=filler_character.id,
+                era_id=era.id,
+                score=100,
+                all_time_score=100,
+                level=5,
+                votes_spent_this_era=0,
+            )
+        )
+        db_session.add(
+            PraxisMember(
+                praxis_id=praxis_id,
+                character_id=filler_character.id,
+                has_submitted=False,
+            )
+        )
+    await db_session.commit()
+
+    # Confirm the praxis is at cap-1 members (still one slot open for invite)
+    count_result = await db_session.execute(
+        select(func.count()).select_from(PraxisMember).where(
+            PraxisMember.praxis_id == praxis_id
+        )
+    )
+    assert count_result.scalar_one() == cap - 1
+
+    # Issue an invite while under capacity (should succeed)
+    invite_resp = await client.post(
+        f"/praxes/{praxis_id}/invite",
+        json={"invitee_id": character.id},
+        headers=auth_headers2,
+    )
+    assert invite_resp.status_code == 200
+    invite_id = invite_resp.json()["id"]
+
+    # Fill the last slot with a direct-DB filler to bring total to `cap`.
+    final_account = AccountModel(email="finalfiller@example.com")
+    db_session.add(final_account)
+    await db_session.flush()
+    final_character = CharacterModel(
+        account_id=final_account.id,
+        username="final_filler",
+        display_name="Final Filler",
+        faction_slug="ua",
+    )
+    db_session.add(final_character)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=final_character.id,
+            era_id=era.id,
+            score=100,
+            all_time_score=100,
+            level=5,
+            votes_spent_this_era=0,
+        )
+    )
+    db_session.add(
+        PraxisMember(
+            praxis_id=praxis_id,
+            character_id=final_character.id,
+            has_submitted=False,
+        )
+    )
+    await db_session.commit()
+
+    # Confirm we are exactly at cap
+    count_at_cap = await db_session.execute(
+        select(func.count()).select_from(PraxisMember).where(
+            PraxisMember.praxis_id == praxis_id
+        )
+    )
+    assert count_at_cap.scalar_one() == cap
+
+    # character accepts the invite → should fail because the cap is reached
+    accept_resp = await client.post(
+        f"/praxes/{praxis_id}/invite/{invite_id}/respond",
+        json={"accept": True},
+        headers=auth_headers,
+    )
+    assert accept_resp.status_code == 400
+    assert str(cap) in accept_resp.json()["detail"]
+
+    # Verify the extra member was NOT added
+    count_result2 = await db_session.execute(
+        select(func.count()).select_from(PraxisMember).where(
+            PraxisMember.praxis_id == praxis_id,
+            PraxisMember.character_id == character.id,
+        )
+    )
+    assert count_result2.scalar_one() == 0

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -3,6 +3,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.faction import Faction, FactionStatus

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -604,3 +604,134 @@ async def test_list_task_signups_only_in_progress(
     assert resp.status_code == 200
     character_ids = [entry["character_id"] for entry in resp.json()]
     assert character.id not in character_ids
+
+
+# ---------------------------------------------------------------------------
+# T.6 SESSION T additions — admin bypass and my-tasks (praxes) status filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_bypass_propose_level_gate(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """Admin character at level 0 can propose a task despite the level gate (B.5)."""
+    from models.roles import AccountRole, Role
+
+    # character is level 0; grant the owning account admin role
+    role = Role(name="admin", description="Administrator")
+    db_session.add(role)
+    await db_session.flush()
+    account_role = AccountRole(
+        account_id=account.id, role_id=role.id, granted_by=account.id
+    )
+    db_session.add(account_role)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/tasks",
+        json={"title": "Admin Level 0 Task", "point_value": 5, "level_required": 0},
+        headers=auth_headers,
+    )
+    # Without admin bypass this would be 403; with it we expect 201
+    assert resp.status_code == 201, f"Expected 201 but got {resp.status_code}: {resp.json()}"
+    assert resp.json()["title"] == "Admin Level 0 Task"
+
+
+@pytest.mark.asyncio
+async def test_my_tasks_with_status_filter(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character2: Character,
+    auth_headers2: dict,
+):
+    """GET /praxes?character_id=X with status filter returns the right subset.
+
+    The new praxis model has no `abandoned` status — the closest analog is
+    `is_withdrawn=True` on an in_progress praxis. This test covers the two
+    real statuses exposed by PraxisStatus: in_progress and submitted, plus
+    the withdrawal flag.
+    """
+    from models.task import TaskStatus
+
+    # Seed three active tasks for character2
+    tasks = []
+    for index in range(3):
+        task = Task(
+            title=f"MyTask {index}",
+            description="",
+            point_value=5,
+            level_required=0,
+            status=TaskStatus.active,
+            created_by=character2.id,
+            primary_faction_slug="ua",
+        )
+        db_session.add(task)
+        tasks.append(task)
+    await db_session.commit()
+    for task in tasks:
+        await db_session.refresh(task)
+
+    # character2 creates three solo praxes, one per task
+    praxis_ids = []
+    for task in tasks:
+        create_resp = await client.post(
+            "/praxes",
+            json={"task_id": task.id, "type": "solo"},
+            headers=auth_headers2,
+        )
+        assert create_resp.status_code == 201, create_resp.json()
+        praxis_ids.append(create_resp.json()["id"])
+
+    # Submit the first praxis
+    submit_resp = await client.post(
+        f"/praxes/{praxis_ids[0]}/submit",
+        headers=auth_headers2,
+    )
+    assert submit_resp.status_code == 200
+
+    # Withdraw the second praxis
+    withdraw_resp = await client.post(
+        f"/praxes/{praxis_ids[1]}/withdraw",
+        headers=auth_headers2,
+    )
+    assert withdraw_resp.status_code == 200
+
+    # status=submitted returns only the first praxis
+    resp_submitted = await client.get(
+        "/praxes",
+        params={"character_id": character2.id, "status": "submitted"},
+    )
+    assert resp_submitted.status_code == 200
+    submitted_ids = [p["id"] for p in resp_submitted.json()]
+    assert praxis_ids[0] in submitted_ids
+    assert praxis_ids[1] not in submitted_ids
+    assert praxis_ids[2] not in submitted_ids
+
+    # status=in_progress returns the remaining two (withdrawn one stays
+    # in_progress but has is_withdrawn=True; third is fresh in_progress)
+    resp_ip = await client.get(
+        "/praxes",
+        params={"character_id": character2.id, "status": "in_progress"},
+    )
+    assert resp_ip.status_code == 200
+    ip_ids = [p["id"] for p in resp_ip.json()]
+    assert praxis_ids[0] not in ip_ids
+    assert praxis_ids[2] in ip_ids
+    # The withdrawn praxis should also still appear under in_progress
+    # because PraxisStatus doesn't change on withdraw.
+    assert praxis_ids[1] in ip_ids
+
+    # No status filter returns all three
+    resp_all = await client.get(
+        "/praxes",
+        params={"character_id": character2.id},
+    )
+    assert resp_all.status_code == 200
+    all_ids = [p["id"] for p in resp_all.json()]
+    for praxis_id in praxis_ids:
+        assert praxis_id in all_ids

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
@@ -279,3 +280,194 @@ async def test_duel_vote_summary_endpoint(
     # For a solo praxis with no duel members the list is empty
     data = resp.json()
     assert isinstance(data, list)
+
+
+# ---------------------------------------------------------------------------
+# T.10 SESSION T additions — R-rule explicit coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duel_vote_blocked_by_alt_character_on_same_account(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    account2: Account,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """R.4: An account with a character in a duel cannot vote from any of its characters.
+
+    Account A owns character A1. Account B owns character B1. A1 + B1 are
+    members of a duel. Any character on account A (even a different one)
+    trying to vote is blocked at the account level — this test covers the
+    primary vector by having the account that owns a duel participant
+    attempt to vote on the duel, and confirms an unrelated account CAN vote.
+    """
+    from models.account import Account as AccountModel
+    from models.character import Character as CharacterModel
+    from models.character_stats import CharacterStats
+    from models.praxis import PraxisType
+    from services.auth import create_jwt
+    from sqlalchemy import select
+
+    # Raise A1 (character) to level 2 to satisfy the duel level gate
+    a1_stats_result = await db_session.execute(
+        select(CharacterStats).where(CharacterStats.character_id == character.id)
+    )
+    a1_stats = a1_stats_result.scalar_one()
+    a1_stats.level = 2
+    await db_session.commit()
+
+    # character2 (level 5) creates the duel
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "duel", "title": "R4 Duel"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    duel_id = create_resp.json()["id"]
+
+    # character2 invites character (A1) to the duel
+    invite_resp = await client.post(
+        f"/praxes/{duel_id}/invite",
+        json={"invitee_id": character.id},
+        headers=auth_headers2,
+    )
+    assert invite_resp.status_code == 200
+    invite_id = invite_resp.json()["id"]
+
+    # A1 accepts the invite
+    accept_resp = await client.post(
+        f"/praxes/{duel_id}/invite/{invite_id}/respond",
+        json={"accept": True},
+        headers=auth_headers,
+    )
+    assert accept_resp.status_code == 200
+
+    # Find the praxis_member rows (A1 and B1)
+    members = accept_resp.json()["members"]
+    member_for_a1 = next(m for m in members if m["character_id"] == character.id)
+    member_for_b1 = next(m for m in members if m["character_id"] == character2.id)
+
+    # Account A tries to vote on B1 in the duel (A1 is A's participant).
+    # The account-level anti-self-vote rule should block this.
+    block_resp = await client.post(
+        f"/praxes/{duel_id}/vote",
+        json={"stars": 3, "praxis_member_id": member_for_b1["id"]},
+        headers=auth_headers,
+    )
+    assert block_resp.status_code == 403
+    detail = block_resp.json()["detail"].lower()
+    assert "account" in detail or "own" in detail or "participant" in detail
+
+    # Create an unrelated voter on a third account
+    account_c = AccountModel(email="duelvoter_c@example.com")
+    db_session.add(account_c)
+    await db_session.flush()
+    voter_c = CharacterModel(
+        account_id=account_c.id,
+        username="voter_c",
+        display_name="Voter C",
+        faction_slug="ua",
+    )
+    db_session.add(voter_c)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=voter_c.id,
+            era_id=era.id,
+            score=100,
+            all_time_score=100,
+            level=3,
+            votes_spent_this_era=0,
+        )
+    )
+    await db_session.commit()
+
+    c_headers = {"Authorization": f"Bearer {create_jwt(account_c.id)}"}
+
+    # Unrelated account C's character votes — should succeed
+    allow_resp = await client.post(
+        f"/praxes/{duel_id}/vote",
+        json={"stars": 4, "praxis_member_id": member_for_a1["id"]},
+        headers=c_headers,
+    )
+    assert allow_resp.status_code == 200
+    assert allow_resp.json()["stars"] == 4
+
+
+@pytest.mark.asyncio
+async def test_vote_budget_increases_when_score_grows(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+):
+    """R.5: Vote budget grows with score since it is computed on-read."""
+    from math import floor
+    from sqlalchemy import select
+
+    from game_config import CURRENT_ERA
+
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.score = 0
+    stats.votes_spent_this_era = 0
+    await db_session.commit()
+    await db_session.refresh(stats)
+
+    budget_zero_score = compute_votes_available(stats)
+    assert budget_zero_score == CURRENT_ERA.vote_budget_base
+
+    # Raise score to 100 — budget must reflect new formula
+    stats.score = 100
+    await db_session.commit()
+    await db_session.refresh(stats)
+
+    budget_hundred = compute_votes_available(stats)
+    expected = CURRENT_ERA.vote_budget_base + floor(
+        CURRENT_ERA.vote_budget_multiplier * 100
+    )
+    assert budget_hundred == expected
+    assert budget_hundred > budget_zero_score
+
+
+@pytest.mark.asyncio
+async def test_vote_budget_reflects_votes_spent(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+):
+    """R.5: votes_available = base + floor(multiplier * score) - votes_spent_this_era."""
+    from math import floor
+    from sqlalchemy import select
+
+    from game_config import CURRENT_ERA
+
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.score = 500
+    stats.votes_spent_this_era = 2
+    await db_session.commit()
+    await db_session.refresh(stats)
+
+    expected = (
+        CURRENT_ERA.vote_budget_base
+        + floor(CURRENT_ERA.vote_budget_multiplier * 500)
+        - 2
+    )
+    assert compute_votes_available(stats) == expected

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -963,7 +963,7 @@ check to pass.
 
 > **Rescoped 2026-04-17** after auditing the suite against the SESSION R rules changes. Most of T.5–T.9 turned out to be largely done already. The remaining work is: (a) cover the new R rules with explicit tests, (b) rename a couple of test functions whose names now lie about what they test, and (c) fill small gaps. T.10 is new and is the highest-value item here.
 
-### TASK T.5 — Integration tests: characters routes (coverage ~57%)
+### TASK T.5 ✅ 2026-04-17 — Integration tests: characters routes (coverage ~57%)
 
 **Current state:** 31 tests cover CRUD, list filters (search, faction, pagination), stats exposure, avatar upload (including 403 cases), relationships, votes-received, and the second-character level gate. The gate test functions correctly check the **level 5** threshold from R.7, but their names still say "level3".
 
@@ -978,7 +978,7 @@ check to pass.
 
 ---
 
-### TASK T.6 — Integration tests: tasks routes (coverage ~65%)
+### TASK T.6 ✅ 2026-04-17 — Integration tests: tasks routes (coverage ~65%)
 
 **Current state:** 31 tests cover list filters (status, faction, level, points, exclude_character_id), propose at level-3, edit pending tasks, signup lists, hidden-faction exclusion, response field shape.
 
@@ -992,7 +992,7 @@ check to pass.
 
 ---
 
-### TASK T.7 — Integration tests: auth routes (coverage ~60%)
+### TASK T.7 ✅ 2026-04-17 — Integration tests: auth routes (coverage ~60%)
 
 **Current state:** 15 tests cover `/auth/me` (authenticated / unauthenticated / no character / with stats / no email leak / not-admin-by-default), logout + cookie clear, and token validation (expired, malformed, wrong signature, missing Bearer prefix).
 
@@ -1004,7 +1004,7 @@ check to pass.
 
 ---
 
-### TASK T.8 — Integration tests: admin routes (coverage ~60%, no regressions under R.5)
+### TASK T.8 ✅ 2026-04-17 — Integration tests: admin routes (coverage ~60%, no regressions under R.5)
 
 **Current state:** 46 tests including task management, praxis moderation, character stats patching, account management, era reset, role management, and 403 coverage on every endpoint. `test_admin_patch_character_stats` still passes under R.5 because `set_character_stats` translates the `votes_available` patch into `votes_spent_this_era = max(0, cap - desired)` at the service layer.
 
@@ -1029,7 +1029,7 @@ factions.py (8 tests), leaderboard.py (7 tests), messages.py (10 tests), relatio
 
 ---
 
-### TASK T.10 — Cover the new R rules with explicit integration tests (NEW)
+### TASK T.10 ✅ 2026-04-17 — Cover the new R rules with explicit integration tests (NEW)
 
 Each rule that shipped in PRs #105 and #106 deserves a dedicated integration test so a future regression surfaces in CI instead of prod.
 


### PR DESCRIPTION
## Summary
13 new integration tests covering every SESSION R rule change plus a few pre-existing gaps. Full backend suite: **294 passed, 6 skipped** (up from 281).

### New tests by section

**T.5 characters** (4 total — 2 renames + 2 new)
- Renamed `..._below_level3` → `..._below_level5` (R.7)
- Renamed `..._allowed_at_level3` → `..._allowed_at_level5` (R.7)
- `test_albescent_requires_level8_character_on_account` (R.7)
- `test_albescent_character_starts_in_albescent_faction` (R.8)

**T.6 tasks**
- `test_my_tasks_with_status_filter`
- `test_admin_bypass_propose_level_gate` (B.5)

**T.7 auth**
- `test_auth_me_exposes_votes_available` (R.5)

**T.8 admin**
- `test_admin_patch_stats_recomputes_votes_available` (R.5)
- `test_admin_era_reset_zeros_votes_spent_this_era`
- `test_admin_era_reset_preserves_votes_spent_without_flag`

**T.10 R-rule coverage**
- R.1 level gate on create_praxis
- R.3 max_collab_participants cap (reads from `era` config, not hardcoded)
- R.4 account-level duel anti-self-vote
- R.5 × 2 budget-increases-with-score and budget-reflects-spent

### Bonus fix
Discovered while writing T.7: `CharacterOut` was missing the `votes_available` field that R.5's spec required. Added to `schemas/character.py` and populated in `_build_character_out` via `compute_votes_available(stats)`.

## Test plan
- [x] `pytest backend/tests/ --no-cov` — 294 passed, 6 skipped
- [ ] CI
- [ ] After merge, consider raising `--cov-fail-under` from 60 → 80 once coverage % is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)