### PR TITLE
refactor(api): extract shared helpers, push business logic into services

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -46,7 +46,12 @@
       "Bash(uv run *)",
       "Bash(uv *)",
       "Bash(WZ_API_URL=\"https://api.worldzero.org\" WZ_CLI_SECRET=\"test\" uv run \"C:\\\\Users\\\\MollyShove\\\\Desktop\\\\WorldZeroPlayground\\\\mcp\\\\worldzero-admin\\\\server.py\")",
-      "Bash(docker-compose up *)"
+      "Bash(docker-compose up *)",
+      "Bash(DATABASE_URL=sqlite+aiosqlite:///:memory: SECRET_KEY=x GOOGLE_CLIENT_ID=x GOOGLE_CLIENT_SECRET=x GOOGLE_REDIRECT_URI=x MEDIA_BASE_URL=x python -c \"import routers.praxes, routers.tasks, routers.characters, routers.auth, routers.leaderboard, routers.admin, routers.votes, services.activity_feed, services.character, services.character_stats, services.era, dependencies; print\\('ok'\\)\")",
+      "Bash(DATABASE_URL=postgresql+asyncpg://x/x SECRET_KEY=x GOOGLE_CLIENT_ID=x GOOGLE_CLIENT_SECRET=x GOOGLE_REDIRECT_URI=x MEDIA_BASE_URL=x python -c \"import routers.praxes, routers.tasks, routers.characters, routers.auth, routers.leaderboard, routers.admin, routers.votes, services.activity_feed, services.character, services.character_stats, services.era, dependencies; print\\('ok'\\)\")",
+      "Bash(DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/worldzero_test SECRET_KEY=test GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test GOOGLE_REDIRECT_URI=http://localhost MEDIA_BASE_URL=http://localhost ENVIRONMENT=test python -m pytest tests/integration/test_admin.py -x --no-cov -q)",
+      "Bash(DATABASE_URL=postgresql+asyncpg://x/x SECRET_KEY=test GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test GOOGLE_REDIRECT_URI=http://localhost MEDIA_BASE_URL=http://localhost ENVIRONMENT=test python -m pytest tests/unit -x --no-cov -q)",
+      "Bash(DATABASE_URL=postgresql+asyncpg://x/x SECRET_KEY=test GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test GOOGLE_REDIRECT_URI=http://localhost MEDIA_BASE_URL=http://localhost ENVIRONMENT=test python -m pyflakes routers/ services/ dependencies.py)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,13 +1,18 @@
 """Shared FastAPI dependencies used across multiple routers."""
-from fastapi import Depends, HTTPException
+from typing import Optional
+
+from fastapi import Cookie, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from models.account import Account
+from models.account import Account, AccountStatus
 from models.character import Character, CharacterStatus
 from models.roles import AccountRole, Role
-from services.auth import get_current_account
+from services.auth import decode_jwt, get_current_account
+
+_OPTIONAL_BEARER = HTTPBearer(auto_error=False)
 
 
 async def get_current_character(
@@ -36,16 +41,73 @@ async def get_current_character(
     return character
 
 
+async def get_current_character_optional(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_OPTIONAL_BEARER),
+    access_token: Optional[str] = Cookie(default=None),
+    session: AsyncSession = Depends(get_db),
+) -> Optional[Character]:
+    """Mirror of :func:`get_current_character` that never raises.
+
+    Used by public detail endpoints (praxis, task) that compute viewer-relative
+    fields when a token is present but still serve anonymous traffic.
+    """
+    token = None
+    if credentials:
+        token = credentials.credentials
+    elif access_token:
+        token = access_token
+    if not token:
+        return None
+
+    try:
+        payload = decode_jwt(token)
+    except Exception:
+        return None
+
+    try:
+        account_id = int(payload["sub"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    account_result = await session.execute(
+        select(Account).where(Account.id == account_id)
+    )
+    account = account_result.scalar_one_or_none()
+    if account is None or account.status != AccountStatus.active:
+        return None
+
+    char_result = await session.execute(
+        select(Character)
+        .where(
+            Character.account_id == account.id,
+            Character.status == CharacterStatus.active,
+        )
+        .order_by(Character.created_at)
+        .limit(1)
+    )
+    return char_result.scalar_one_or_none()
+
+
 async def require_admin(
     account: Account = Depends(get_current_account),
     session: AsyncSession = Depends(get_db),
 ) -> Account:
     """Raise 403 unless the authenticated account has the 'admin' role."""
+    if not await account_has_admin_role(account.id, session):
+        raise HTTPException(status_code=403, detail="Admin access required.")
+    return account
+
+
+async def account_has_admin_role(account_id: int, session: AsyncSession) -> bool:
+    """Return True if the given account has the 'admin' role.
+
+    Use this when admin status is informational (e.g. a flag on a response or a
+    behaviour modifier) rather than a hard access gate — for the gate, use
+    :func:`require_admin`.
+    """
     result = await session.execute(
         select(AccountRole)
         .join(Role, AccountRole.role_id == Role.id)
-        .where(AccountRole.account_id == account.id, Role.name == "admin")
+        .where(AccountRole.account_id == account_id, Role.name == "admin")
     )
-    if result.scalar_one_or_none() is None:
-        raise HTTPException(status_code=403, detail="Admin access required.")
-    return account
+    return result.scalar_one_or_none() is not None

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -47,6 +47,7 @@ from services.admin_service import (
     get_account_detail,
     list_accounts,
     list_characters,
+    list_pending_tasks_with_proposer,
     reactivate_task,
     set_character_stats,
     suspend_account,
@@ -216,8 +217,9 @@ async def backfill_all_character_stats(
         select(Character).where(Character.status != CharacterStatus.banned)
     )
     characters = result.scalars().all()
+    era_row = await get_current_era_row(session)
     for character in characters:
-        await recalculate_character_stats(character.id, session)
+        await recalculate_character_stats(character.id, session, era_row=era_row)
     await session.commit()
     return {"recalculated": len(characters)}
 
@@ -396,13 +398,7 @@ async def list_pending_tasks(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ):
-    result = await session.execute(
-        select(Task, Character.display_name)
-        .outerjoin(Character, Character.id == Task.created_by)
-        .where(Task.status == TaskStatus.pending)
-        .order_by(Task.created_at)
-    )
-    rows = result.all()
+    rows = await list_pending_tasks_with_proposer(session)
     return [
         PendingTaskOut(
             id=task.id,
@@ -429,14 +425,7 @@ async def approve_task(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ):
-    task = await session.get(Task, task_id)
-    if task is None:
-        raise HTTPException(status_code=404, detail="Task not found.")
-    if task.status != TaskStatus.pending:
-        raise HTTPException(status_code=422, detail="Only pending tasks can be approved.")
-    task.status = TaskStatus.active
-    await session.commit()
-    await session.refresh(task)
+    task = await update_task_status(task_id, TaskStatus.active, session)
     return build_task_out(task)
 
 
@@ -446,14 +435,7 @@ async def retire_task(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ):
-    task = await session.get(Task, task_id)
-    if task is None:
-        raise HTTPException(status_code=404, detail="Task not found.")
-    if task.status != TaskStatus.active:
-        raise HTTPException(status_code=422, detail="Only active tasks can be retired.")
-    task.status = TaskStatus.retired
-    await session.commit()
-    await session.refresh(task)
+    task = await update_task_status(task_id, TaskStatus.retired, session)
     return build_task_out(task)
 
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -6,18 +6,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from db import get_db
+from dependencies import account_has_admin_role
 from models.account import Account
 from models.character import Character, CharacterStatus
-from models.roles import AccountRole, Role
-from routers.characters import _build_character_out, _load_stats
 from schemas.auth import CurrentUser
-from schemas.character import CharacterOut
 from services.auth import create_jwt, create_or_get_account, get_current_account
 from services.character import (
+    build_character_out,
     can_create_additional_character,
     can_start_as_albescent,
 )
-from services.era import get_current_era_row
+from services.era import load_current_era_stats
 
 router = APIRouter()
 
@@ -96,23 +95,13 @@ async def auth_me(
 
     char_out = None
     if character:
-        try:
-            era_row = await get_current_era_row(session)
-            stats = await _load_stats(character.id, era_row.id, session)
-        except Exception:
-            stats = None
-        char_out = _build_character_out(character, stats)
+        stats = await load_current_era_stats(character.id, session)
+        char_out = build_character_out(character, stats)
 
-    admin_result = await session.execute(
-        select(AccountRole)
-        .join(Role, AccountRole.role_id == Role.id)
-        .where(AccountRole.account_id == account.id, Role.name == "admin")
-    )
-    is_admin = admin_result.scalar_one_or_none() is not None
+    is_admin = await account_has_admin_role(account.id, session)
 
-    # Eligibility flags depend on the current era row. If the era isn't seeded
-    # (edge case in tests / fresh environments) fall back to False — matches the
-    # behaviour of the stats lookup above.
+    # Eligibility flags depend on the era being seeded. Fall back to False in
+    # fresh test environments where no era row exists yet.
     try:
         can_create_more = await can_create_additional_character(account.id, session)
         can_albescent = await can_start_as_albescent(account.id, session)

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -1,7 +1,6 @@
 import io
 import logging
 import os
-import re
 from typing import Optional
 
 from PIL import Image
@@ -27,47 +26,15 @@ from schemas.praxis import PraxisOut
 from services.auth import get_current_account
 from services.character import (
     CharacterCreationResult,
+    build_character_out,
     create_character,
     soft_delete_character,
     update_character,
 )
-from services.era import get_current_era_row
+from services.era import get_current_era_row_safe, load_current_era_stats
 from services.praxis import build_praxis_out
-from services.scoring import compute_votes_available
 
 router = APIRouter()
-
-
-def _build_character_out(character: Character, stats: Optional[CharacterStats]) -> CharacterOut:
-    """Build a flat CharacterOut from a Character row and its optional CharacterStats.
-
-    votes_available is computed on-read from stats (see R.5).
-    """
-    return CharacterOut(
-        id=character.id,
-        username=character.username,
-        display_name=character.display_name,
-        bio=character.bio,
-        avatar_url=character.avatar_url,
-        location=character.location,
-        faction_slug=character.faction_slug,
-        status=character.status.value,
-        created_at=character.created_at,
-        score=stats.score if stats else 0,
-        all_time_score=stats.all_time_score if stats else 0,
-        level=stats.level if stats else 0,
-        votes_available=compute_votes_available(stats) if stats else 0,
-    )
-
-
-async def _load_stats(character_id: int, era_id: int, session: AsyncSession) -> Optional[CharacterStats]:
-    result = await session.execute(
-        select(CharacterStats).where(
-            CharacterStats.character_id == character_id,
-            CharacterStats.era_id == era_id,
-        )
-    )
-    return result.scalar_one_or_none()
 
 
 @router.get("", response_model=list[CharacterOut])
@@ -79,11 +46,8 @@ async def list_characters(
     session: AsyncSession = Depends(get_db),
 ):
     """List all active characters. Optionally filter by name or faction."""
-    try:
-        era_row = await get_current_era_row(session)
-        era_id = era_row.id
-    except HTTPException:
-        era_id = None
+    era_row = await get_current_era_row_safe(session)
+    era_id = era_row.id if era_row else None
 
     query = (
         select(Character, CharacterStats)
@@ -104,7 +68,7 @@ async def list_characters(
 
     result = await session.execute(query)
     rows = result.all()
-    return [_build_character_out(c, s) for c, s in rows]
+    return [build_character_out(c, s) for c, s in rows]
 
 
 @router.get("/{character_id}", response_model=CharacterOut)
@@ -122,13 +86,8 @@ async def get_character(
     if character is None:
         raise HTTPException(status_code=404, detail="Character not found.")
 
-    try:
-        era_row = await get_current_era_row(session)
-        stats = await _load_stats(character_id, era_row.id, session)
-    except HTTPException:
-        stats = None
-
-    return _build_character_out(character, stats)
+    stats = await load_current_era_stats(character_id, session)
+    return build_character_out(character, stats)
 
 
 @router.post("", response_model=CharacterOut, status_code=201)
@@ -138,7 +97,7 @@ async def create_character_route(
     session: AsyncSession = Depends(get_db),
 ):
     result: CharacterCreationResult = await create_character(account.id, data, session)
-    return _build_character_out(result.character, result.stats)
+    return build_character_out(result.character, result.stats)
 
 
 @router.put("/{character_id}", response_model=CharacterOut)
@@ -151,14 +110,8 @@ async def update_character_route(
     if current_character.id != character_id:
         raise HTTPException(status_code=403, detail="Cannot edit another character.")
     character = await update_character(character_id, data, session)
-
-    try:
-        era_row = await get_current_era_row(session)
-        stats = await _load_stats(character_id, era_row.id, session)
-    except HTTPException:
-        stats = None
-
-    return _build_character_out(character, stats)
+    stats = await load_current_era_stats(character_id, session)
+    return build_character_out(character, stats)
 
 
 @router.delete("/{character_id}", status_code=204)
@@ -248,13 +201,8 @@ async def upload_avatar(
     await session.commit()
     await session.refresh(character)
 
-    try:
-        era_row = await get_current_era_row(session)
-        stats = await _load_stats(character_id, era_row.id, session)
-    except HTTPException:
-        stats = None
-
-    return _build_character_out(character, stats)
+    stats = await load_current_era_stats(character_id, session)
+    return build_character_out(character, stats)
 
 
 @router.get("/{character_id}/relationships", response_model=list[RelationshipOut])

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.sql import false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,9 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db import get_db
 from models.character import Character, CharacterStatus
 from models.character_stats import CharacterStats
-from routers.characters import _build_character_out
 from schemas.character import CharacterOut
-from services.era import get_current_era_row
+from services.character import build_character_out
+from services.era import get_current_era_row_safe
 
 router = APIRouter()
 
@@ -23,11 +23,8 @@ async def get_leaderboard(
     session: AsyncSession = Depends(get_db),
 ):
     """Top characters by current era score, optionally filtered by faction."""
-    try:
-        era_row = await get_current_era_row(session)
-        era_id = era_row.id
-    except HTTPException:
-        era_id = None
+    era_row = await get_current_era_row_safe(session)
+    era_id = era_row.id if era_row else None
 
     join_condition = CharacterStats.character_id == Character.id
     if era_id is not None:
@@ -48,4 +45,4 @@ async def get_leaderboard(
 
     result = await session.execute(query)
     rows = result.all()
-    return [_build_character_out(c, s) for c, s in rows]
+    return [build_character_out(c, s) for c, s in rows]

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -14,65 +14,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from db import get_db
-from dependencies import get_current_character
+from dependencies import get_current_character, get_current_character_optional
 from game_config import CURRENT_ERA
-from models.account import Account, AccountStatus
-from models.character import Character, CharacterStatus
+from models.character import Character
 from models.praxis import MediaItem, MediaType, ModerationStatus, Praxis, PraxisType
-from services.auth import decode_jwt
-from fastapi import Cookie
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import select
-
-_OPTIONAL_BEARER = HTTPBearer(auto_error=False)
-
-
-async def get_current_character_optional(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_OPTIONAL_BEARER),
-    access_token: Optional[str] = Cookie(default=None),
-    session: AsyncSession = Depends(get_db),
-) -> Optional[Character]:
-    """Return the authenticated viewer's active character, or None if anonymous.
-
-    Mirrors :func:`dependencies.get_current_character` but never raises — used by
-    public detail endpoints that want to compute viewer-relative fields (such as
-    ``PraxisOut.can_flag``) when a token is present.
-    """
-    token = None
-    if credentials:
-        token = credentials.credentials
-    elif access_token:
-        token = access_token
-    if not token:
-        return None
-
-    try:
-        payload = decode_jwt(token)
-    except Exception:  # invalid/expired token — treat as anonymous
-        return None
-
-    try:
-        account_id = int(payload["sub"])
-    except (KeyError, TypeError, ValueError):
-        return None
-
-    account_result = await session.execute(
-        select(Account).where(Account.id == account_id)
-    )
-    account = account_result.scalar_one_or_none()
-    if account is None or account.status != AccountStatus.active:
-        return None
-
-    char_result = await session.execute(
-        select(Character)
-        .where(
-            Character.account_id == account.id,
-            Character.status == CharacterStatus.active,
-        )
-        .order_by(Character.created_at)
-        .limit(1)
-    )
-    return char_result.scalar_one_or_none()
 from pydantic import BaseModel
 from schemas.praxis import (
     DuelVoteSummary,

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -1,20 +1,21 @@
 from typing import Optional
 
-from fastapi import APIRouter, Cookie, Depends, HTTPException
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import get_current_character
-from models.account import Account, AccountStatus
-from models.character import Character, CharacterStatus
-from models.faction import Faction, FactionStatus
-from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
-from models.roles import AccountRole, Role
+from dependencies import (
+    account_has_admin_role,
+    get_current_character,
+    get_current_character_optional,
+)
+from models.account import Account
+from models.character import Character
+from models.praxis import Praxis, PraxisMember, PraxisStatus
 from models.task import Task, TaskStatus, TaskType
 from schemas.task import TaskCreate, TaskOut
-from services.auth import decode_jwt, get_current_account
+from services.auth import get_current_account
 from services.task import (
     build_task_out,
     build_task_out_for_viewer,
@@ -23,57 +24,6 @@ from services.task import (
 )
 
 router = APIRouter()
-
-
-_OPTIONAL_BEARER = HTTPBearer(auto_error=False)
-
-
-async def get_current_character_optional(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_OPTIONAL_BEARER),
-    access_token: Optional[str] = Cookie(default=None),
-    session: AsyncSession = Depends(get_db),
-) -> Optional[Character]:
-    """Return the authenticated viewer's active character, or None if anonymous.
-
-    Mirrors :func:`dependencies.get_current_character` but never raises — used
-    by public task endpoints that want to compute viewer-relative fields such
-    as ``TaskOut.can_submit_praxis`` when a token is present.
-    """
-    token = None
-    if credentials:
-        token = credentials.credentials
-    elif access_token:
-        token = access_token
-    if not token:
-        return None
-
-    try:
-        payload = decode_jwt(token)
-    except Exception:  # invalid/expired token — treat as anonymous
-        return None
-
-    try:
-        account_id = int(payload["sub"])
-    except (KeyError, TypeError, ValueError):
-        return None
-
-    account_result = await session.execute(
-        select(Account).where(Account.id == account_id)
-    )
-    account = account_result.scalar_one_or_none()
-    if account is None or account.status != AccountStatus.active:
-        return None
-
-    char_result = await session.execute(
-        select(Character)
-        .where(
-            Character.account_id == account.id,
-            Character.status == CharacterStatus.active,
-        )
-        .order_by(Character.created_at)
-        .limit(1)
-    )
-    return char_result.scalar_one_or_none()
 
 
 @router.get("", response_model=list[TaskOut])
@@ -161,12 +111,7 @@ async def propose_task_route(
     account: Account = Depends(get_current_account),
     session: AsyncSession = Depends(get_db),
 ):
-    admin_result = await session.execute(
-        select(AccountRole)
-        .join(Role, AccountRole.role_id == Role.id)
-        .where(AccountRole.account_id == account.id, Role.name == "admin")
-    )
-    is_admin = admin_result.scalar_one_or_none() is not None
+    is_admin = await account_has_admin_role(account.id, session)
     task = await propose_task(character, data, session, skip_level_check=is_admin)
     return build_task_out(task)
 

--- a/backend/routers/votes.py
+++ b/backend/routers/votes.py
@@ -21,13 +21,18 @@ async def cast_vote(
     voter: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    praxis = await session.get(Praxis, praxis_id)
-    if praxis is None:
+    result = await session.execute(
+        select(Praxis, Character)
+        .outerjoin(Character, Character.id == Praxis.created_by_id)
+        .where(Praxis.id == praxis_id)
+    )
+    row = result.first()
+    if row is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
+    praxis, author = row
 
-    # Proper account-level anti-self-vote check
-    author_result = await session.get(Character, praxis.created_by_id)
-    if author_result and author_result.account_id == voter.account_id:
+    # Account-level anti-self-vote check
+    if author and author.account_id == voter.account_id:
         raise HTTPException(status_code=403, detail="Cannot vote on your own praxis.")
 
     vote = await cast_or_update_vote(voter, praxis, data.stars, session)

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -139,7 +139,7 @@ class AdminTaskPatch(BaseModel):
 
 
 class TaskStatusAction(BaseModel):
-    status: Literal["active", "retired"]
+    status: Literal["pending", "active", "retired"]
 
 
 class RoleAction(BaseModel):

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -719,8 +719,9 @@ async def _compute_counts(
         )
         return result.scalar_one()
 
+    era_row = await get_current_era_row(session)
+
     async def count_invitation_letters() -> int:
-        era_row = await get_current_era_row(session)
         result = await session.execute(
             select(func.count())
             .select_from(InvitationLetter)
@@ -734,7 +735,6 @@ async def _compute_counts(
     async def count_friend_defections() -> int:
         if not friend_ids:
             return 0
-        era_row = await get_current_era_row(session)
         result = await session.execute(
             select(func.count())
             .select_from(FactionDefectionHistory)

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -388,6 +388,19 @@ async def archive_message(
     return message
 
 
+async def list_pending_tasks_with_proposer(
+    session: AsyncSession,
+) -> list[tuple[Task, str | None]]:
+    """Return pending tasks paired with their proposer's display name (or None)."""
+    result = await session.execute(
+        select(Task, Character.display_name)
+        .outerjoin(Character, Character.id == Task.created_by)
+        .where(Task.status == TaskStatus.pending)
+        .order_by(Task.created_at)
+    )
+    return list(result.all())
+
+
 async def update_task_status(
     task_id: int,
     new_status: TaskStatus,

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -406,22 +406,21 @@ async def update_task_status(
     new_status: TaskStatus,
     session: AsyncSession,
 ) -> Task:
-    """Unified task status change with transition validation."""
+    """Admin task status change.
+
+    Admins can move a task freely between pending, active, and retired —
+    e.g. dismiss a pending proposal directly to retired, send an active task
+    back to pending for re-review, or reactivate a retired task. Same-state
+    requests 422 as likely-confused intent.
+    """
     task = await session.get(Task, task_id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found.")
 
-    VALID_TRANSITIONS = {
-        TaskStatus.pending: {TaskStatus.active, TaskStatus.retired},
-        TaskStatus.active: {TaskStatus.retired},
-        TaskStatus.retired: {TaskStatus.active},
-    }
-
-    allowed = VALID_TRANSITIONS.get(task.status, set())
-    if new_status not in allowed:
+    if new_status == task.status:
         raise HTTPException(
             status_code=422,
-            detail=f"Cannot transition from {task.status.value} to {new_status.value}.",
+            detail=f"Task is already {task.status.value}.",
         )
 
     task.status = new_status

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -7,9 +7,34 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character, CharacterStatus
 from models.character_stats import CharacterStats
-from schemas.character import CharacterCreate, CharacterUpdate
+from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
 from services.era import get_current_era_row, get_or_create_stats
-from services.scoring import compute_level, compute_vote_budget
+from services.scoring import compute_level, compute_vote_budget, compute_votes_available
+
+
+def build_character_out(
+    character: Character,
+    stats: CharacterStats | None,
+) -> CharacterOut:
+    """Flatten a Character row plus its (optional) CharacterStats into CharacterOut.
+
+    votes_available is computed on read from stats.score and votes_spent_this_era.
+    """
+    return CharacterOut(
+        id=character.id,
+        username=character.username,
+        display_name=character.display_name,
+        bio=character.bio,
+        avatar_url=character.avatar_url,
+        location=character.location,
+        faction_slug=character.faction_slug,
+        status=character.status.value,
+        created_at=character.created_at,
+        score=stats.score if stats else 0,
+        all_time_score=stats.all_time_score if stats else 0,
+        level=stats.level if stats else 0,
+        votes_available=compute_votes_available(stats) if stats else 0,
+    )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -13,6 +13,7 @@ from models.praxis import (
 )
 from models.task import Task
 from models.vote import Vote
+from models.era import Era
 from services.era import get_current_era_row, get_or_create_stats
 from services.scoring import (
     COLLABORATION_MODE_COLLAB,
@@ -68,6 +69,7 @@ async def recalculate_character_stats(
     character_id: int,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
+    era_row: Era | None = None,
 ) -> None:
     """Recompute and persist score, level, and vote budget for a character.
 
@@ -76,8 +78,11 @@ async def recalculate_character_stats(
     - All submitted collaborations/duels the character is a member of
 
     Safe to call on praxis creation (0 votes → base points only) or after any vote change.
+
+    Pass ``era_row`` when calling in a loop to avoid an extra query per iteration.
     """
-    era_row = await get_current_era_row(session)
+    if era_row is None:
+        era_row = await get_current_era_row(session)
 
     author = await session.get(Character, character_id)
     character_faction_slug = author.faction_slug if author else "na"

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -28,19 +28,45 @@ async def get_current_era_row(session: AsyncSession) -> Era:
     Raises 500 if the era has not been seeded yet. Run the initial seed or
     migration before creating characters.
     """
-    result = await session.execute(
-        select(Era)
-        .where(Era.config_key == CURRENT_ERA.config_key)
-        .order_by(Era.id.desc())
-        .limit(1)
-    )
-    era_row = result.scalar_one_or_none()
+    era_row = await get_current_era_row_safe(session)
     if era_row is None:
         raise HTTPException(
             status_code=500,
             detail="No active era configured. Run the initial seed before creating characters.",
         )
     return era_row
+
+
+async def get_current_era_row_safe(session: AsyncSession) -> Era | None:
+    """Like ``get_current_era_row`` but returns None on missing era instead of raising."""
+    result = await session.execute(
+        select(Era)
+        .where(Era.config_key == CURRENT_ERA.config_key)
+        .order_by(Era.id.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def load_current_era_stats(
+    character_id: int,
+    session: AsyncSession,
+) -> CharacterStats | None:
+    """Look up a character's CharacterStats for the current era.
+
+    Returns None when the era is unseeded or the character has no stats row,
+    so callers can fall back to zero stats without try/except.
+    """
+    era_row = await get_current_era_row_safe(session)
+    if era_row is None:
+        return None
+    result = await session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character_id,
+            CharacterStats.era_id == era_row.id,
+        )
+    )
+    return result.scalar_one_or_none()
 
 
 async def get_or_create_stats(

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -149,6 +149,55 @@ async def test_admin_update_task_status(
 
 
 @pytest.mark.asyncio
+async def test_admin_can_move_task_freely_between_states(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """Admin can move a task pending → retired → pending → active without restrictions."""
+    await _make_admin(account, db_session)
+
+    task = Task(
+        title="Free-move",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.pending,
+        created_by=character.id,
+    )
+    db_session.add(task)
+    await db_session.commit()
+
+    # pending → retired (previously rejected by /retire)
+    resp = await client.put(f"/admin/tasks/{task.id}/retire", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "retired"
+
+    # retired → pending (new: previously no path)
+    resp = await client.put(
+        f"/admin/tasks/{task.id}/status",
+        json={"status": "pending"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+    # pending → active via /approve
+    resp = await client.put(f"/admin/tasks/{task.id}/approve", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "active"
+
+    # Same-state is rejected as confused intent
+    resp = await client.put(
+        f"/admin/tasks/{task.id}/status",
+        json={"status": "active"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_admin_create_task(
     client: AsyncClient,
     account: Account,


### PR DESCRIPTION
## Summary

Cleanup pass on the API layer (`backend/routers/` + `backend/services/`) driven by a `/simplify` review, plus a deliberate widening of admin task-status transitions.

**Key changes**
- Cross-router helper duplication eliminated:
  - `get_current_character_optional` (~46 lines, copied verbatim in `praxes.py` and `tasks.py`) moved to [`dependencies.py`](backend/dependencies.py).
  - `_build_character_out` / `_load_stats` (private to `characters.py` but imported by `auth.py` and `leaderboard.py`) promoted to public service helpers in `services/character.py` and `services/era.py`.
- New shared helpers:
  - `account_has_admin_role` — for informational admin checks (the existing `require_admin` is for gating). Replaces hand-rolled `AccountRole`/`Role` joins in `routers/auth.py` and `routers/tasks.py`.
  - `get_current_era_row_safe` — replaces 5 copies of `try: get_current_era_row(); except HTTPException: era_id = None`.
  - `load_current_era_stats` — collapses the `era + stats` two-step into one helper.
- Route handlers thinned:
  - `/admin/tasks/{id}/approve` and `/retire` now delegate to the pre-existing `update_task_status` service.
  - `list_pending_tasks` query moved to `admin_service.list_pending_tasks_with_proposer`.
- Efficiency:
  - `routers/votes.py` — merged TOCTOU `Praxis` + author `Character` lookups into one joined query.
  - `services/activity_feed.py::_compute_counts` — pre-fetch era row once instead of inside each count helper.
  - `routers/admin.py` backfill loop — pre-fetch era row once; `recalculate_character_stats` now accepts optional `era_row`.

### Intentional behavior change: admin task transitions

`update_task_status` previously enforced a narrow DAG:
- `pending → {active, retired}`
- `active → {retired}`
- `retired → {active}`

This PR widens it: **admins can now move a task freely between any of the three states**. Concretely:
- `/admin/tasks/{id}/approve` against a retired task now reactivates it (was 422).
- `/admin/tasks/{id}/retire` against a pending task now dismisses it directly (was 422).
- `PUT /admin/tasks/{id}/status` accepts any cross-state transition; only same-state requests 422.

Rationale: admins should be able to send an active task back to pending for re-review, dismiss a pending proposal directly to retired, or recycle a retired task back into the queue without needing intermediate hops. Test added: `test_admin_can_move_task_freely_between_states`.

The error message for invalid (i.e. same-state) transitions changed from `"Only pending tasks can be approved."` etc. to `"Task is already {state}."` — flag if any frontend/CLI parses these strings.

### Behavior change: `auth_me` failure mode

The old code wrapped era + stats lookup in `except Exception: stats = None`. The new code uses the safe era variant, which only swallows the unseeded-era case — DB errors during stats lookup will now propagate as 500 instead of silently returning a zero-stats character. This is intended (the broad `except Exception` was overly defensive and hid real failures), but worth noting for anyone debugging.

**Diff**: 15 files, +268/-273.

**Not addressed (low severity, deferred):**
- Bare string literals (`"na"` for default faction, `"admin"` for role name).
- Frontend `votePraxis` / `getPraxisVotes` typings.
- Sequential awaits in the activity feed builder were intentionally **kept**: `asyncio.gather` over a shared SQLAlchemy `AsyncSession` (asyncpg driver) would fail because the session can't multiplex concurrent ops on one connection. The pre-existing comment is correct.

## Test plan

- [x] `pytest tests/unit` — 109 passed
- [ ] Integration tests — known broken locally per `MEMORY.md` (asyncpg event loop issue, fix tracked in `docs/TASKS.md` SESSION T). Will rely on CI to exercise them, including the new `test_admin_can_move_task_freely_between_states`.
- [ ] Manual smoke: hit `/auth/me`, `/characters`, `/leaderboard`, `/admin/tasks/pending`, `/admin/tasks/{id}/approve` (against pending and retired tasks), `/admin/tasks/{id}/retire` (against pending and active tasks), `/praxes/{id}/vote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)