### PR TITLE
refactor(backend): retroactive /simplify pass on database and backend layers

### DIFF
--- a/backend/alembic/versions/0007_moderation_status_enum.py
+++ b/backend/alembic/versions/0007_moderation_status_enum.py
@@ -1,0 +1,65 @@
+"""Convert praxis.moderation_status from VARCHAR to the existing moderationstatus enum.
+
+The ``moderationstatus`` Postgres enum type is already created by the
+``0001_squashed`` baseline (alongside every other enum). The praxis column
+itself, however, has been carrying ``VARCHAR`` as its type ever since the
+table was recreated in ``0004_praxis_unification``. This migration brings the
+column back in line with the ORM side (`Enum(ModerationStatus)`).
+
+Safe to re-run: the cast is idempotent because ``moderation_status::text``
+round-trips cleanly through both types.
+
+Revision ID: 0007_moderation_status_enum
+Revises: 0006_metatask_unification
+Create Date: 2026-04-20
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007_moderation_status_enum"
+down_revision: Union[str, None] = "0006_metatask_unification"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # The ``moderationstatus`` enum type already exists (created in 0001); no
+    # CREATE TYPE needed. Postgres refuses to ALTER TYPE while a DEFAULT of a
+    # different type is attached, so drop the default, cast the column, then
+    # re-apply the default against the new enum type.
+    op.execute(sa.text(
+        "ALTER TABLE praxis ALTER COLUMN moderation_status DROP DEFAULT"
+    ))
+    op.execute(sa.text(
+        """
+        ALTER TABLE praxis
+        ALTER COLUMN moderation_status TYPE moderationstatus
+        USING moderation_status::moderationstatus
+        """
+    ))
+    op.execute(sa.text(
+        "ALTER TABLE praxis ALTER COLUMN moderation_status SET DEFAULT 'visible'"
+    ))
+
+
+def downgrade() -> None:
+    # Revert to VARCHAR so the old ORM shape (``Mapped[str]``) is restored.
+    # Same dance as upgrade: drop the enum-typed default first.
+    op.execute(sa.text(
+        "ALTER TABLE praxis ALTER COLUMN moderation_status DROP DEFAULT"
+    ))
+    op.execute(sa.text(
+        """
+        ALTER TABLE praxis
+        ALTER COLUMN moderation_status TYPE VARCHAR
+        USING moderation_status::text
+        """
+    ))
+    op.execute(sa.text(
+        "ALTER TABLE praxis ALTER COLUMN moderation_status SET DEFAULT 'visible'"
+    ))
+    # The moderationstatus enum type is shared across migrations and is owned
+    # by the 0001_squashed baseline, so we do NOT drop it here.

--- a/backend/alembic/versions/0008_drop_task_faction.py
+++ b/backend/alembic/versions/0008_drop_task_faction.py
@@ -1,0 +1,43 @@
+"""Drop the unused ``task_faction`` join table.
+
+The table was created in ``0001_squashed`` as a placeholder for "future
+multi-faction task support" and never used by any service, router, or test.
+CLAUDE.md forbids YAGNI scaffolding, so the table (and the matching ORM
+class) are being removed together.
+
+The downgrade path recreates the table with the original schema so we can
+bisect across this revision without data loss (the table was always empty
+in practice, so no DML is needed in either direction).
+
+Revision ID: 0008_drop_task_faction
+Revises: 0007_moderation_status_enum
+Create Date: 2026-04-20
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008_drop_task_faction"
+down_revision: Union[str, None] = "0007_moderation_status_enum"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("DROP TABLE IF EXISTS task_faction"))
+
+
+def downgrade() -> None:
+    op.create_table(
+        "task_faction",
+        sa.Column("task_id", sa.Integer(), sa.ForeignKey("task.id"), primary_key=True),
+        sa.Column(
+            "faction_slug",
+            sa.String(),
+            sa.ForeignKey("faction.slug"),
+            primary_key=True,
+        ),
+        sa.Column("is_primary", sa.Boolean(), nullable=False),
+    )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -5,7 +5,7 @@ from models.roles import Role, AccountRole
 from models.character import Character
 from models.era import Era
 from models.character_stats import CharacterStats
-from models.task import Task, TaskFaction, TaskStatus, TaskType
+from models.task import Task, TaskStatus, TaskType
 from models.praxis import (
     Praxis,
     PraxisMember,
@@ -38,7 +38,6 @@ __all__ = [
     "Era",
     "CharacterStats",
     "Task",
-    "TaskFaction",
     "TaskStatus",
     "TaskType",
     "Praxis",

--- a/backend/models/account.py
+++ b/backend/models/account.py
@@ -1,11 +1,11 @@
 import enum
-from datetime import datetime
 from typing import TYPE_CHECKING, List
 
-from sqlalchemy import DateTime, Enum, ForeignKey, String, func
+from sqlalchemy import Enum, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
+from models.mixins import TimestampMixin
 
 if TYPE_CHECKING:
     from models.character import Character
@@ -17,19 +17,13 @@ class AccountStatus(enum.Enum):
     deleted = "deleted"
 
 
-class Account(Base):
+class Account(TimestampMixin, Base):
     __tablename__ = "account"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     email: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     status: Mapped[AccountStatus] = mapped_column(
         Enum(AccountStatus, create_type=False), nullable=False, default=AccountStatus.active
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )
 
     characters: Mapped[List["Character"]] = relationship(
@@ -40,7 +34,7 @@ class Account(Base):
     )
 
 
-class OAuthProvider(Base):
+class OAuthProvider(TimestampMixin, Base):
     __tablename__ = "oauth_provider"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -48,12 +42,6 @@ class OAuthProvider(Base):
     provider: Mapped[str] = mapped_column(String, nullable=False)
     provider_user_id: Mapped[str] = mapped_column(String, nullable=False)
     access_token: Mapped[str] = mapped_column(String, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
-    )
 
     account: Mapped["Account"] = relationship(
         "Account", back_populates="oauth_providers", lazy="raise"

--- a/backend/models/analog_double_dipper.py
+++ b/backend/models/analog_double_dipper.py
@@ -1,12 +1,11 @@
-from datetime import datetime
-
-from sqlalchemy import DateTime, ForeignKey, Integer, UniqueConstraint, func
+from sqlalchemy import ForeignKey, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from models.base import Base
+from models.mixins import CreatedAtMixin
 
 
-class AnalogDoubleDipper(Base):
+class AnalogDoubleDipper(CreatedAtMixin, Base):
     """One row per level tier for Analog faction players.
 
     The Double Dipper ability lets an Analog player designate one task per level
@@ -27,7 +26,4 @@ class AnalogDoubleDipper(Base):
     level_tier: Mapped[int] = mapped_column(Integer, nullable=False)
     task_id: Mapped[int] = mapped_column(
         ForeignKey("task.id"), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/models/character.py
+++ b/backend/models/character.py
@@ -1,11 +1,11 @@
 import enum
-from datetime import datetime
 from typing import TYPE_CHECKING, List
 
-from sqlalchemy import DateTime, Enum, ForeignKey, String, Text, func
+from sqlalchemy import Enum, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
+from models.mixins import TimestampMixin
 
 if TYPE_CHECKING:
     from models.account import Account
@@ -18,7 +18,7 @@ class CharacterStatus(enum.Enum):
     banned = "banned"
 
 
-class Character(Base):
+class Character(TimestampMixin, Base):
     __tablename__ = "character"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -34,12 +34,6 @@ class Character(Base):
     )
     status: Mapped[CharacterStatus] = mapped_column(
         Enum(CharacterStatus, create_type=False), nullable=False, default=CharacterStatus.active
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )
     # score, level, votes_spent_this_era, all_time_score live in CharacterStats (star schema split)
     # votes_available is computed on read: services.scoring.compute_votes_available

--- a/backend/models/faction.py
+++ b/backend/models/faction.py
@@ -1,10 +1,10 @@
 import enum
-from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, String, func
+from sqlalchemy import Enum, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from models.base import Base
+from models.mixins import TimestampMixin
 
 
 class FactionStatus(enum.Enum):
@@ -13,7 +13,7 @@ class FactionStatus(enum.Enum):
     deprecated = "deprecated"
 
 
-class Faction(Base):
+class Faction(TimestampMixin, Base):
     __tablename__ = "faction"
 
     slug: Mapped[str] = mapped_column(String, primary_key=True)
@@ -24,9 +24,3 @@ class Faction(Base):
     )
     # No multiplier columns: faction rules live in game_config.py, not the DB.
     # This table exists for FK references and UI display only.
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
-    )

--- a/backend/models/flag.py
+++ b/backend/models/flag.py
@@ -1,25 +1,22 @@
-from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy import ForeignKey, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
+from models.mixins import CreatedAtMixin
 
 if TYPE_CHECKING:
     from models.praxis import Praxis
 
 
-class Flag(Base):
+class Flag(CreatedAtMixin, Base):
     __tablename__ = "flag"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     praxis_id: Mapped[int] = mapped_column(ForeignKey("praxis.id"), nullable=False)
     flagged_by: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
     reason: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
 
     praxis: Mapped["Praxis"] = relationship(
         "Praxis", back_populates="flags", lazy="raise"

--- a/backend/models/mixins.py
+++ b/backend/models/mixins.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class CreatedAtMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class TimestampMixin(CreatedAtMixin):
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/models/praxis.py
+++ b/backend/models/praxis.py
@@ -6,6 +6,7 @@ from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Tex
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
+from models.mixins import CreatedAtMixin, TimestampMixin
 
 if TYPE_CHECKING:
     from models.character import Character
@@ -44,7 +45,7 @@ class PraxisInviteStatus(enum.Enum):
     declined = "declined"
 
 
-class Praxis(Base):
+class Praxis(TimestampMixin, Base):
     __tablename__ = "praxis"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -63,8 +64,11 @@ class Praxis(Base):
     is_withdrawn: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
     )
-    moderation_status: Mapped[str] = mapped_column(
-        String, nullable=False, server_default="visible"
+    moderation_status: Mapped[ModerationStatus] = mapped_column(
+        Enum(ModerationStatus, create_type=False),
+        nullable=False,
+        default=ModerationStatus.visible,
+        server_default="visible",
     )
     admin_note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     # flagged_at is nullable: NULL means "not yet flagged" — semantic NULL, not missing data
@@ -72,12 +76,6 @@ class Praxis(Base):
         DateTime(timezone=True), nullable=True
     )
     created_by_id: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
-    )
 
     task: Mapped["Task"] = relationship(
         "Task", back_populates="praxes", lazy="selectin"
@@ -94,30 +92,35 @@ class Praxis(Base):
         lazy="selectin",
         cascade="all, delete-orphan",
     )
+    # invites, votes, media_items, and flags are load-on-demand. Only the
+    # praxis detail view and admin-moderation flows read them, so the list
+    # view (and most service-layer reads) do not pay for the joins. Call
+    # sites that need them must use ``.options(selectinload(Praxis.foo))``;
+    # accessing these attributes on an un-loaded Praxis raises.
     invites: Mapped[List["PraxisInvite"]] = relationship(
         "PraxisInvite",
         back_populates="praxis",
-        lazy="selectin",
+        lazy="raise",
         cascade="all, delete-orphan",
     )
     votes: Mapped[List["Vote"]] = relationship(
         "Vote",
         foreign_keys="Vote.praxis_id",
         back_populates="praxis",
-        lazy="selectin",
+        lazy="raise",
     )
     media_items: Mapped[List["MediaItem"]] = relationship(
         "MediaItem",
         foreign_keys="MediaItem.praxis_id",
         back_populates="praxis",
         order_by="MediaItem.display_order",
-        lazy="selectin",
+        lazy="raise",
     )
     flags: Mapped[List["Flag"]] = relationship(
         "Flag",
         foreign_keys="Flag.praxis_id",
         back_populates="praxis",
-        lazy="selectin",
+        lazy="raise",
     )
 
 
@@ -145,7 +148,7 @@ class PraxisMember(Base):
     )
 
 
-class MediaItem(Base):
+class MediaItem(CreatedAtMixin, Base):
     __tablename__ = "media_item"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -155,16 +158,13 @@ class MediaItem(Base):
     )
     file_path: Mapped[str] = mapped_column(String, nullable=False)
     display_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
 
     praxis: Mapped["Praxis"] = relationship(
         "Praxis", foreign_keys=[praxis_id], back_populates="media_items", lazy="raise"
     )
 
 
-class PraxisInvite(Base):
+class PraxisInvite(CreatedAtMixin, Base):
     __tablename__ = "praxis_invite"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -175,9 +175,6 @@ class PraxisInvite(Base):
         Enum(PraxisInviteStatus, create_type=False),
         nullable=False,
         server_default="pending",
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
     praxis: Mapped["Praxis"] = relationship(

--- a/backend/models/relationship.py
+++ b/backend/models/relationship.py
@@ -1,10 +1,10 @@
 import enum
-from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, ForeignKey, UniqueConstraint, func
+from sqlalchemy import Enum, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from models.base import Base
+from models.mixins import TimestampMixin
 
 
 class RelationshipType(enum.Enum):
@@ -17,7 +17,7 @@ class RelationshipStatus(enum.Enum):
     blocked = "blocked"
 
 
-class Relationship(Base):
+class Relationship(TimestampMixin, Base):
     __tablename__ = "relationship"
     __table_args__ = (UniqueConstraint("from_character_id", "to_character_id"),)
 
@@ -33,10 +33,4 @@ class Relationship(Base):
     )
     status: Mapped[RelationshipStatus] = mapped_column(
         Enum(RelationshipStatus, create_type=False), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )

--- a/backend/models/roles.py
+++ b/backend/models/roles.py
@@ -4,20 +4,15 @@ from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from models.base import Base
+from models.mixins import TimestampMixin
 
 
-class Role(Base):
+class Role(TimestampMixin, Base):
     __tablename__ = "role"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     description: Mapped[str] = mapped_column(String, nullable=False, server_default="")
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
-    )
 
 
 class AccountRole(Base):

--- a/backend/models/task.py
+++ b/backend/models/task.py
@@ -1,11 +1,11 @@
 import enum
-from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Boolean, Enum, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
+from models.mixins import TimestampMixin
 
 if TYPE_CHECKING:
     from models.praxis import Praxis
@@ -29,7 +29,7 @@ class TaskType(enum.Enum):
     metatask = "metatask"
 
 
-class Task(Base):
+class Task(TimestampMixin, Base):
     __tablename__ = "task"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -59,25 +59,7 @@ class Task(Base):
     is_task_vision_eligible: Mapped[bool] = mapped_column(
         Boolean, default=False, nullable=False
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
-    )
 
     praxes: Mapped[List["Praxis"]] = relationship(
         "Praxis", back_populates="task", lazy="raise"
     )
-
-
-class TaskFaction(Base):
-    """Join table for future multi-faction task support."""
-
-    __tablename__ = "task_faction"
-
-    task_id: Mapped[int] = mapped_column(ForeignKey("task.id"), primary_key=True)
-    faction_slug: Mapped[str] = mapped_column(
-        ForeignKey("faction.slug"), primary_key=True
-    )
-    is_primary: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/models/taunt_message.py
+++ b/backend/models/taunt_message.py
@@ -1,10 +1,10 @@
 import enum
-from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Text, func
+from sqlalchemy import Enum, ForeignKey, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from models.base import Base
+from models.mixins import CreatedAtMixin
 
 
 class TauntTriggerType(enum.Enum):
@@ -13,7 +13,7 @@ class TauntTriggerType(enum.Enum):
     praxis_complete = "praxis_complete"
 
 
-class TauntMessage(Base):
+class TauntMessage(CreatedAtMixin, Base):
     __tablename__ = "taunt_message"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -26,7 +26,4 @@ class TauntMessage(Base):
     message: Mapped[str] = mapped_column(Text, nullable=False)
     trigger_type: Mapped[TauntTriggerType] = mapped_column(
         Enum(TauntTriggerType, create_type=False), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from config import settings
 from db import get_db
@@ -11,9 +12,7 @@ from dependencies import require_admin
 from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character, CharacterStatus
-from models.contact import ContactMessage
 from models.era import Era
-from models.roles import AccountRole, Role
 from models.praxis import ModerationStatus, Praxis
 from models.task import Task, TaskStatus, TaskType
 from schemas.admin import (
@@ -22,11 +21,11 @@ from schemas.admin import (
     AdminCharacterCreate,
     AdminTaskPatch,
     CharacterStatsPatch,
+    AdminFactionOut,
     CharacterStatsOut,
     CharacterSummary,
     CliTokenResponse,
     FactionCreate,
-    FactionOut,
     ModerationAction,
     OverviewStats,
     RoleAction,
@@ -43,10 +42,13 @@ from services.admin_service import (
     archive_message,
     assign_or_revoke_role,
     create_faction,
+    find_admin_accounts,
     game_overview,
     get_account_detail,
     list_accounts,
+    list_active_characters,
     list_characters,
+    list_contact_messages,
     list_pending_tasks_with_proposer,
     reactivate_task,
     set_character_stats,
@@ -95,11 +97,8 @@ async def admin_list_messages(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ) -> list[ContactMessageOut]:
-    query = select(ContactMessage).where(
-        ContactMessage.is_archived == archived
-    ).order_by(ContactMessage.created_at.desc())
-    result = await session.execute(query)
-    return [ContactMessageOut.model_validate(m) for m in result.scalars().all()]
+    messages = await list_contact_messages(session, archived=archived)
+    return [ContactMessageOut.model_validate(message) for message in messages]
 
 
 @router.patch("/messages/{message_id}/archive", response_model=ContactMessageOut)
@@ -145,14 +144,14 @@ async def admin_list_characters(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/factions", response_model=FactionOut, status_code=201)
+@router.post("/factions", response_model=AdminFactionOut, status_code=201)
 async def admin_create_faction(
     data: FactionCreate,
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-) -> FactionOut:
+) -> AdminFactionOut:
     faction = await create_faction(data, session)
-    return FactionOut(
+    return AdminFactionOut(
         slug=faction.slug,
         name=faction.name,
         description=faction.description,
@@ -208,15 +207,8 @@ async def backfill_all_character_stats(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Recompute CharacterStats for every character using current vote data.
-
-    Safe to call repeatedly. Use after a scoring formula change to bring all
-    persisted scores in sync.
-    """
-    result = await session.execute(
-        select(Character).where(Character.status != CharacterStatus.banned)
-    )
-    characters = result.scalars().all()
+    """Recompute CharacterStats for every character using current vote data."""
+    characters = await list_active_characters(session)
     era_row = await get_current_era_row(session)
     for character in characters:
         await recalculate_character_stats(character.id, session, era_row=era_row)
@@ -229,24 +221,12 @@ async def admin_era_reset(
     admin: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Trigger an era reset: create a new Era row and reset all character stats.
-
-    Behaviour controlled by EraConfig reset flags (reset_score, reset_level,
-    reset_faction, reset_vote_budget, reset_all_time_score).
-    """
-    new_era_row = Era(
-        name=CURRENT_ERA.name,
-        config_key=CURRENT_ERA.config_key,
-        started_by=admin.id,
-    )
+    """Trigger an era reset: new Era row + reset stats per EraConfig flags."""
+    new_era_row = Era(name=CURRENT_ERA.name, config_key=CURRENT_ERA.config_key, started_by=admin.id)
     session.add(new_era_row)
     await session.flush()
-
-    result = await session.execute(select(Character).where(Character.status != CharacterStatus.banned))
-    characters = result.scalars().all()
-
+    characters = await list_active_characters(session)
     await apply_era_reset(characters, new_era_row, session)
-
     return {"era_id": new_era_row.id, "characters_reset": len(characters)}
 
 
@@ -303,31 +283,16 @@ async def admin_cli_token(
     x_admin_cli_secret: str = Header(..., alias="X-Admin-Cli-Secret"),
     session: AsyncSession = Depends(get_db),
 ) -> CliTokenResponse:
-    """Return a JWT for the admin account using a static secret.
-
-    Requires ADMIN_CLI_SECRET to be set in the environment. Returns 403 if
-    the secret is blank (disabled) or does not match.
-    """
+    """Return a JWT for the first admin account when the CLI secret matches."""
     if not settings.ADMIN_CLI_SECRET:
         raise HTTPException(status_code=403, detail="CLI token endpoint is disabled.")
     if x_admin_cli_secret != settings.ADMIN_CLI_SECRET:
         raise HTTPException(status_code=403, detail="Invalid CLI secret.")
 
-    # Find the admin account (first account with the admin role)
-    result = await session.execute(
-        select(Account)
-        .join(AccountRole, AccountRole.account_id == Account.id)
-        .join(Role, Role.id == AccountRole.role_id)
-        .where(Role.name == "admin")
-        .limit(1)
-    )
-    admin_account = result.scalar_one_or_none()
-
-    if admin_account is None:
+    admins = await find_admin_accounts(session)
+    if not admins:
         raise HTTPException(status_code=500, detail="No admin account found. Run seed first.")
-
-    token = create_jwt(admin_account.id)
-    return CliTokenResponse(access_token=token)
+    return CliTokenResponse(access_token=create_jwt(admins[0].id))
 
 
 # ---------------------------------------------------------------------------
@@ -343,7 +308,8 @@ async def admin_list_flagged_praxes(
     """Return praxes with moderation_status == flagged."""
     result = await session.execute(
         select(Praxis)
-        .where(Praxis.moderation_status == ModerationStatus.flagged.value)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
+        .where(Praxis.moderation_status == ModerationStatus.flagged)
         .order_by(Praxis.created_at.desc())
     )
     praxis_list = result.scalars().all()
@@ -406,8 +372,8 @@ async def list_pending_tasks(
             description=task.description,
             point_value=task.point_value,
             level_required=task.level_required,
-            status=task.status.value,
-            task_type=task.task_type.value,
+            status=task.status,
+            task_type=task.task_type,
             created_by=task.created_by,
             primary_faction_slug=task.primary_faction_slug,
             metatask_faction_slug=task.metatask_faction_slug,
@@ -469,7 +435,7 @@ async def admin_delete_praxis(
     praxis = await session.get(Praxis, praxis_id)
     if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
-    praxis.moderation_status = ModerationStatus.hidden.value
+    praxis.moderation_status = ModerationStatus.hidden
     await session.commit()
 
 

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -10,13 +10,13 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 logger = logging.getLogger(__name__)
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from config import settings
 from db import get_db
 from dependencies import get_current_character
 from models.account import Account
 from models.character import Character, CharacterStatus
-from models.character_stats import CharacterStats
 from models.relationship import Relationship
 from models.praxis import Praxis
 from models.vote import Vote
@@ -28,10 +28,11 @@ from services.character import (
     CharacterCreationResult,
     build_character_out,
     create_character,
+    list_characters_for_viewer,
     soft_delete_character,
     update_character,
 )
-from services.era import get_current_era_row_safe, load_current_era_stats
+from services.era import load_current_era_stats
 from services.praxis import build_praxis_out
 
 router = APIRouter()
@@ -46,29 +47,10 @@ async def list_characters(
     session: AsyncSession = Depends(get_db),
 ):
     """List all active characters. Optionally filter by name or faction."""
-    era_row = await get_current_era_row_safe(session)
-    era_id = era_row.id if era_row else None
-
-    query = (
-        select(Character, CharacterStats)
-        .outerjoin(
-            CharacterStats,
-            (CharacterStats.character_id == Character.id)
-            & (CharacterStats.era_id == era_id if era_id else False),
-        )
-        .where(Character.status == CharacterStatus.active)
+    rows = await list_characters_for_viewer(
+        session, search=search, faction_slug=faction, limit=limit, offset=offset
     )
-    if search:
-        query = query.where(Character.username.ilike(f"%{search}%"))
-    if faction:
-        query = query.where(Character.faction_slug == faction)
-    query = query.order_by(
-        CharacterStats.score.desc().nulls_last()
-    ).limit(limit).offset(offset)
-
-    result = await session.execute(query)
-    rows = result.all()
-    return [build_character_out(c, s) for c, s in rows]
+    return [build_character_out(character, stats) for character, stats in rows]
 
 
 @router.get("/{character_id}", response_model=CharacterOut)
@@ -134,6 +116,7 @@ async def get_character_praxes(
 ):
     result = await session.execute(
         select(Praxis)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
         .where(Praxis.created_by_id == character_id)
         .order_by(Praxis.created_at.desc())
         .limit(limit)

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -1,16 +1,11 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
-from sqlalchemy.sql import false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from models.character import Character, CharacterStatus
-from models.character_stats import CharacterStats
 from schemas.character import CharacterOut
-from services.character import build_character_out
-from services.era import get_current_era_row_safe
+from services.character import build_character_out, list_leaderboard
 
 router = APIRouter()
 
@@ -23,26 +18,7 @@ async def get_leaderboard(
     session: AsyncSession = Depends(get_db),
 ):
     """Top characters by current era score, optionally filtered by faction."""
-    era_row = await get_current_era_row_safe(session)
-    era_id = era_row.id if era_row else None
-
-    join_condition = CharacterStats.character_id == Character.id
-    if era_id is not None:
-        join_condition = join_condition & (CharacterStats.era_id == era_id)
-    else:
-        join_condition = join_condition & sa_false()
-
-    query = (
-        select(Character, CharacterStats)
-        .outerjoin(CharacterStats, join_condition)
-        .where(Character.status == CharacterStatus.active)
+    rows = await list_leaderboard(
+        session, faction_slug=faction, limit=limit, offset=offset
     )
-    if faction:
-        query = query.where(Character.faction_slug == faction)
-    query = query.order_by(
-        CharacterStats.score.desc().nulls_last()
-    ).limit(limit).offset(offset)
-
-    result = await session.execute(query)
-    rows = result.all()
-    return [build_character_out(c, s) for c, s in rows]
+    return [build_character_out(character, stats) for character, stats in rows]

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -10,7 +10,9 @@ import re
 from typing import Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from config import settings
 from db import get_db
@@ -57,7 +59,7 @@ from services.praxis import (
     update_praxis,
     withdraw_praxis,
 )
-from services.vote import cast_or_update_duel_vote, cast_or_update_vote
+from services.vote import cast_vote_on_praxis
 
 logger = logging.getLogger(__name__)
 
@@ -115,8 +117,13 @@ async def get_praxis_route(
     session: AsyncSession = Depends(get_db),
     viewer: Optional[Character] = Depends(get_current_character_optional),
 ):
-    praxis = await session.get(Praxis, praxis_id)
-    if praxis is None or praxis.moderation_status == ModerationStatus.hidden.value:
+    result = await session.execute(
+        select(Praxis)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
+        .where(Praxis.id == praxis_id)
+    )
+    praxis = result.scalar_one_or_none()
+    if praxis is None or praxis.moderation_status == ModerationStatus.hidden:
         raise HTTPException(status_code=404, detail="Praxis not found.")
     return await build_praxis_out(praxis, session, viewer=viewer)
 
@@ -367,7 +374,12 @@ async def respond_to_invite_route(
         session=session,
         era=CURRENT_ERA,
     )
-    praxis = await session.get(Praxis, invite.praxis_id)
+    result = await session.execute(
+        select(Praxis)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
+        .where(Praxis.id == invite.praxis_id)
+    )
+    praxis = result.scalar_one_or_none()
     if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
     return await build_praxis_out(praxis, session, viewer=character)
@@ -386,7 +398,12 @@ async def kick_member_route(
         requester_id=character.id,
         session=session,
     )
-    praxis = await session.get(Praxis, praxis_id)
+    result = await session.execute(
+        select(Praxis)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
+        .where(Praxis.id == praxis_id)
+    )
+    praxis = result.scalar_one_or_none()
     if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
     return await build_praxis_out(praxis, session, viewer=character)
@@ -425,40 +442,11 @@ async def cast_vote_route(
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    """Cast a vote on a praxis.
-
-    - Solo/collab: omit ``praxis_member_id``. Uses ``cast_or_update_vote``.
-    - Duel: ``praxis_member_id`` must be set to a duel member's row id.
-    """
-    from models.praxis import PraxisType
-    praxis = await session.get(Praxis, praxis_id)
-    if praxis is None or praxis.moderation_status == ModerationStatus.hidden.value:
-        raise HTTPException(status_code=404, detail="Praxis not found.")
-
-    if praxis.type == PraxisType.duel:
-        if data.praxis_member_id is None:
-            raise HTTPException(status_code=422, detail="praxis_member_id is required for duel votes.")
-        vote = await cast_or_update_duel_vote(
-            voter=character,
-            praxis_id=praxis_id,
-            praxis_member_id=data.praxis_member_id,
-            stars=data.stars,
-            session=session,
-            era=CURRENT_ERA,
-        )
-    else:
-        # Solo or collaboration — anti-self-vote at account level
-        if praxis.created_by_id is not None:
-            author = await session.get(Character, praxis.created_by_id)
-            if author and author.account_id == character.account_id:
-                raise HTTPException(status_code=403, detail="Cannot vote on your own praxis.")
-        vote = await cast_or_update_vote(
-            voter=character,
-            praxis=praxis,
-            stars=data.stars,
-            session=session,
-            era=CURRENT_ERA,
-        )
+    """Cast a vote. Solo/collab: omit praxis_member_id. Duel: set it."""
+    vote = await cast_vote_on_praxis(
+        character, praxis_id, data.stars, session,
+        praxis_member_id=data.praxis_member_id, era=CURRENT_ERA,
+    )
     return VoteOut.model_validate(vote)
 
 

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
@@ -12,13 +11,13 @@ from dependencies import (
 )
 from models.account import Account
 from models.character import Character
-from models.praxis import Praxis, PraxisMember, PraxisStatus
 from models.task import Task, TaskStatus, TaskType
 from schemas.task import TaskCreate, TaskOut
 from services.auth import get_current_account
 from services.task import (
     build_task_out,
     build_task_out_for_viewer,
+    list_signups_for_task,
     list_tasks as service_list_tasks,
     propose_task,
 )
@@ -57,39 +56,25 @@ async def list_tasks(
     ]
 
 
+def _build_signup_dict(member, character, praxis) -> dict:
+    return {
+        "character_id": character.id,
+        "display_name": character.display_name,
+        "avatar_url": character.avatar_url,
+        "faction_slug": character.faction_slug,
+        "praxis_type": praxis.type.value,
+        "joined_at": member.joined_at,
+    }
+
+
 @router.get("/{task_id}/signups", response_model=list[dict])
 async def list_task_signups(
     task_id: int,
     session: AsyncSession = Depends(get_db),
 ):
     """List characters currently working on a task via praxis membership."""
-    task = await session.get(Task, task_id)
-    if task is None:
-        raise HTTPException(status_code=404, detail="Task not found.")
-
-    result = await session.execute(
-        select(PraxisMember, Character, Praxis)
-        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
-        .join(Character, PraxisMember.character_id == Character.id)
-        .where(
-            Praxis.task_id == task_id,
-            Praxis.status == PraxisStatus.in_progress,
-            Praxis.is_withdrawn == False,  # noqa: E712
-        )
-        .order_by(PraxisMember.joined_at.asc())
-    )
-    rows = result.all()
-    return [
-        {
-            "character_id": character.id,
-            "display_name": character.display_name,
-            "avatar_url": character.avatar_url,
-            "faction_slug": character.faction_slug,
-            "praxis_type": praxis.type.value,
-            "joined_at": member.joined_at,
-        }
-        for member, character, praxis in rows
-    ]
+    rows = await list_signups_for_task(task_id, session)
+    return [_build_signup_dict(*row) for row in rows]
 
 
 @router.get("/{task_id}", response_model=TaskOut)

--- a/backend/routers/votes.py
+++ b/backend/routers/votes.py
@@ -21,20 +21,9 @@ async def cast_vote(
     voter: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    result = await session.execute(
-        select(Praxis, Character)
-        .outerjoin(Character, Character.id == Praxis.created_by_id)
-        .where(Praxis.id == praxis_id)
-    )
-    row = result.first()
-    if row is None:
+    praxis = await session.get(Praxis, praxis_id)
+    if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
-    praxis, author = row
-
-    # Account-level anti-self-vote check
-    if author and author.account_id == voter.account_id:
-        raise HTTPException(status_code=403, detail="Cannot vote on your own praxis.")
-
     vote = await cast_or_update_vote(voter, praxis, data.stars, session)
     return VoteOut.model_validate(vote)
 

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -75,7 +75,7 @@ class FactionCreate(BaseModel):
     hidden: bool = False
 
 
-class FactionOut(BaseModel):
+class AdminFactionOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     slug: str

--- a/backend/schemas/faction.py
+++ b/backend/schemas/faction.py
@@ -1,6 +1,12 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
+
+
+FactionMembershipStatus = Literal[
+    "member", "invited", "not_invited", "defected", "can_return"
+]
 
 
 class FactionOut(BaseModel):
@@ -24,7 +30,7 @@ class FactionChoiceRequest(BaseModel):
 class FactionStatusOut(BaseModel):
     slug: str
     name: str
-    status: str  # member, invited, not_invited, defected, can_return
+    status: FactionMembershipStatus
 
 
 class FactionPageOut(BaseModel):

--- a/backend/schemas/relationship.py
+++ b/backend/schemas/relationship.py
@@ -1,6 +1,6 @@
 import enum
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -8,6 +8,18 @@ from pydantic import BaseModel, ConfigDict
 class RelationshipTypeEnum(str, enum.Enum):
     friend = "friend"
     foe = "foe"
+
+
+RelationshipDisplayStatus = Literal[
+    "Mutual Friends",
+    "Rivals",
+    "Tsundere",
+    "One-sided Friend",
+    "One-sided Foe",
+    "Secret Admirer",
+    "Targeted",
+    "Unknown",
+]
 
 
 class RelationshipOut(BaseModel):
@@ -54,4 +66,4 @@ class RelationshipListItem(BaseModel):
     to_avatar_url: str
     to_faction_slug: str
     reverse_type: Optional[str] = None
-    display_status: str
+    display_status: RelationshipDisplayStatus

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -3,17 +3,19 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from models.task import TaskStatus, TaskType
+
 
 class TaskOut(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
 
     id: int
     title: str
     description: str
     point_value: int
     level_required: int
-    status: str
-    task_type: str
+    status: TaskStatus
+    task_type: TaskType
     created_by: int
     primary_faction_slug: str
     metatask_faction_slug: Optional[str] = None

--- a/backend/schemas/taunt_message.py
+++ b/backend/schemas/taunt_message.py
@@ -3,15 +3,17 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 
+from models.taunt_message import TauntTriggerType
+
 
 class TauntMessageOut(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
 
     id: int
     from_character_id: int
     to_character_id: int
     message: str
-    trigger_type: str
+    trigger_type: TauntTriggerType
     created_at: datetime
     # Enriched display fields (joined from Character)
     from_display_name: str = ""

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -3,6 +3,7 @@
 from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account, AccountStatus
@@ -128,6 +129,40 @@ async def list_characters(
     ]
 
 
+async def list_active_characters(session: AsyncSession) -> list[Character]:
+    """Return every non-banned character — shared by era-reset and stats-backfill."""
+    result = await session.execute(
+        select(Character).where(Character.status != CharacterStatus.banned)
+    )
+    return list(result.scalars().all())
+
+
+async def find_admin_accounts(session: AsyncSession) -> list[Account]:
+    """Return accounts holding the ``admin`` role, ordered by account id."""
+    result = await session.execute(
+        select(Account)
+        .join(AccountRole, AccountRole.account_id == Account.id)
+        .join(Role, Role.id == AccountRole.role_id)
+        .where(Role.name == "admin")
+        .order_by(Account.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def list_contact_messages(
+    session: AsyncSession,
+    *,
+    archived: bool = False,
+) -> list[ContactMessage]:
+    """Return contact messages filtered by archived flag, newest first."""
+    result = await session.execute(
+        select(ContactMessage)
+        .where(ContactMessage.is_archived == archived)
+        .order_by(ContactMessage.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
 async def game_overview(session: AsyncSession) -> OverviewStats:
     account_count_result = await session.execute(select(func.count()).select_from(Account))
     character_count_result = await session.execute(select(func.count()).select_from(Character))
@@ -138,7 +173,7 @@ async def game_overview(session: AsyncSession) -> OverviewStats:
     vote_count_result = await session.execute(select(func.count()).select_from(Vote))
     flagged_count_result = await session.execute(
         select(func.count()).select_from(Praxis).where(
-            Praxis.moderation_status == ModerationStatus.flagged.value
+            Praxis.moderation_status == ModerationStatus.flagged
         )
     )
     suspended_count_result = await session.execute(
@@ -357,12 +392,21 @@ async def moderate_praxis(
     admin_note: str | None,
     session: AsyncSession,
 ) -> Praxis:
-    """Set the moderation status of a praxis. Admin can override any state."""
-    praxis = await session.get(Praxis, praxis_id)
+    """Set the moderation status of a praxis. Admin can override any state.
+
+    Loads ``invites`` and ``media_items`` because the admin router pipes the
+    returned praxis into ``build_praxis_out`` for the response body.
+    """
+    result = await session.execute(
+        select(Praxis)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
+        .where(Praxis.id == praxis_id)
+    )
+    praxis = result.scalar_one_or_none()
     if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
 
-    praxis.moderation_status = new_status.value
+    praxis.moderation_status = new_status
 
     if new_status == ModerationStatus.failed:
         praxis.admin_note = admin_note or ""
@@ -370,8 +414,13 @@ async def moderate_praxis(
         praxis.admin_note = None
 
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    # Re-fetch with detail eager-loads for the router's build_praxis_out.
+    result = await session.execute(
+        select(Praxis)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
+        .where(Praxis.id == praxis_id)
+    )
+    return result.scalar_one()
 
 
 async def archive_message(

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -1,14 +1,16 @@
 import dataclasses
+from typing import Optional
 
 from fastapi import HTTPException
 from sqlalchemy import func, select
+from sqlalchemy.sql import Select, false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character, CharacterStatus
 from models.character_stats import CharacterStats
 from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
-from services.era import get_current_era_row, get_or_create_stats
+from services.era import get_current_era_row, get_current_era_row_safe, get_or_create_stats
 from services.scoring import compute_level, compute_vote_budget, compute_votes_available
 
 
@@ -216,6 +218,78 @@ async def soft_delete_character(character_id: int, session: AsyncSession) -> Non
         raise HTTPException(status_code=404, detail="Character not found.")
     character.status = CharacterStatus.banned
     await session.commit()
+
+
+def _character_stats_era_join(era_id: int | None) -> Select:
+    """Return a ``select(Character, CharacterStats)`` outer-joined on the given era.
+
+    When ``era_id`` is None (era unseeded), the join evaluates to false so every
+    ``CharacterStats`` column is NULL — the caller still gets a row per Character
+    and ``build_character_out`` substitutes zero stats.
+    """
+    if era_id is None:
+        join_condition = (CharacterStats.character_id == Character.id) & sa_false()
+    else:
+        join_condition = (
+            (CharacterStats.character_id == Character.id)
+            & (CharacterStats.era_id == era_id)
+        )
+    return (
+        select(Character, CharacterStats)
+        .outerjoin(CharacterStats, join_condition)
+        .where(Character.status == CharacterStatus.active)
+    )
+
+
+async def list_characters_for_viewer(
+    session: AsyncSession,
+    *,
+    search: Optional[str] = None,
+    faction_slug: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[tuple[Character, CharacterStats | None]]:
+    """List active characters with current-era stats. Optional name/faction filters."""
+    era_row = await get_current_era_row_safe(session)
+    era_id = era_row.id if era_row else None
+
+    query = _character_stats_era_join(era_id)
+    if search:
+        query = query.where(Character.username.ilike(f"%{search}%"))
+    if faction_slug:
+        query = query.where(Character.faction_slug == faction_slug)
+    query = (
+        query.order_by(CharacterStats.score.desc().nulls_last())
+        .limit(limit)
+        .offset(offset)
+    )
+
+    result = await session.execute(query)
+    return list(result.all())
+
+
+async def list_leaderboard(
+    session: AsyncSession,
+    *,
+    faction_slug: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[tuple[Character, CharacterStats | None]]:
+    """Top active characters by current-era score, optionally faction-filtered."""
+    era_row = await get_current_era_row_safe(session)
+    era_id = era_row.id if era_row else None
+
+    query = _character_stats_era_join(era_id)
+    if faction_slug:
+        query = query.where(Character.faction_slug == faction_slug)
+    query = (
+        query.order_by(CharacterStats.score.desc().nulls_last())
+        .limit(limit)
+        .offset(offset)
+    )
+
+    result = await session.execute(query)
+    return list(result.all())
 
 
 def check_faction_graduation(

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.praxis import (
+    ModerationStatus,
     Praxis,
     PraxisMember,
     PraxisStatus,
@@ -14,7 +15,9 @@ from models.praxis import (
 from models.task import Task
 from models.vote import Vote
 from models.era import Era
+from services.character import check_faction_graduation
 from services.era import get_current_era_row, get_or_create_stats
+from services.meta_task import get_meta_task_points
 from services.scoring import (
     COLLABORATION_MODE_COLLAB,
     COLLABORATION_MODE_SOLO,
@@ -23,33 +26,6 @@ from services.scoring import (
     compute_level,
     compute_praxis_score,
 )
-
-
-async def _get_meta_task_points(
-    praxis_id: int, character_level: int, session: AsyncSession
-) -> int:
-    """Return flat bonus points from metatask tasks attached to a praxis.
-
-    Metatasks are Task rows with ``task_type == TaskType.metatask`` whose
-    ``point_value`` is the flat bonus. Each metatask is only counted when the
-    character's level meets the metatask's own ``level_required``.
-    """
-    from models.meta_task import PraxisMetaTask
-    from models.task import TaskType
-
-    result = await session.execute(
-        select(Task)
-        .join(PraxisMetaTask, PraxisMetaTask.task_id == Task.id)
-        .where(PraxisMetaTask.praxis_id == praxis_id)
-    )
-    total = 0
-    for task in result.scalars().all():
-        if task.task_type != TaskType.metatask:
-            continue
-        if character_level < task.level_required:
-            continue
-        total += int(task.point_value)
-    return total
 
 
 async def _get_duel_vote_totals_by_member(
@@ -100,7 +76,7 @@ async def recalculate_character_stats(
         select(Praxis).where(
             Praxis.type == PraxisType.solo,
             Praxis.created_by_id == character_id,
-            Praxis.moderation_status != "hidden",
+            Praxis.moderation_status != ModerationStatus.hidden,
             Praxis.is_withdrawn == False,  # noqa: E712
         )
     )
@@ -115,7 +91,7 @@ async def recalculate_character_stats(
             era,
             collaboration_mode=COLLABORATION_MODE_SOLO,
         )
-        meta_task_points = await _get_meta_task_points(
+        meta_task_points = await get_meta_task_points(
             praxis.id, author_level, session
         )
         sum_result = await session.execute(
@@ -223,7 +199,6 @@ async def recalculate_character_stats(
     stats.level = compute_level(new_score, era)
 
     if author:
-        from services.character import check_faction_graduation
         new_faction = check_faction_graduation(author, stats, era)
         if new_faction:
             author.faction_slug = new_faction

--- a/backend/services/meta_task.py
+++ b/backend/services/meta_task.py
@@ -1,0 +1,40 @@
+"""Shared metatask scoring helper.
+
+A metatask is a Task row with ``task_type == TaskType.metatask``. Its
+``point_value`` is the flat bonus added to any praxis it has been applied to
+(subject to the viewing character's level meeting the metatask's
+``level_required``). This helper centralises the lookup so scoring code in
+``services.praxis`` and ``services.character_stats`` stays in sync.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.meta_task import PraxisMetaTask
+from models.task import Task, TaskType
+
+
+async def get_meta_task_points(
+    praxis_id: int, character_level: int, session: AsyncSession
+) -> int:
+    """Return flat bonus points from metatask tasks attached to a praxis.
+
+    A metatask is a Task row with ``task_type == TaskType.metatask``. Its flat
+    bonus is ``task.point_value``. Applied only when the viewing character
+    meets the metatask's own ``level_required``. Sums across every attached
+    metatask; standard tasks should never be linked here (service guards
+    prevent that) but are defensively skipped if encountered.
+    """
+    result = await session.execute(
+        select(Task)
+        .join(PraxisMetaTask, PraxisMetaTask.task_id == Task.id)
+        .where(PraxisMetaTask.praxis_id == praxis_id)
+    )
+    total = 0
+    for task in result.scalars().all():
+        if task.task_type != TaskType.metatask:
+            continue
+        if character_level < task.level_required:
+            continue
+        total += int(task.point_value)
+    return total

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -10,10 +10,12 @@ from typing import Optional
 from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.flag import Flag
+from models.meta_task import PraxisMetaTask
 from models.praxis import (
     MediaItem,
     ModerationStatus,
@@ -35,7 +37,9 @@ from schemas.praxis import (
     PraxisOut,
     PraxisUpdate,
 )
+from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
+from services.meta_task import get_meta_task_points
 from services.scoring import (
     COLLABORATION_MODE_COLLAB,
     COLLABORATION_MODE_DUEL,
@@ -86,34 +90,6 @@ def _build_invite_out(invite: PraxisInvite) -> PraxisInviteOut:
     )
 
 
-async def _get_meta_task_points(
-    praxis_id: int, character_level: int, session: AsyncSession
-) -> int:
-    """Return flat bonus points from metatask tasks attached to a praxis.
-
-    A metatask is a Task row with ``task_type == TaskType.metatask``. Its flat
-    bonus is ``task.point_value``. Applied only when the viewing character
-    meets the metatask's own ``level_required``. Sums across every attached
-    metatask; standard tasks should never be linked here (service guards
-    prevent that) but are defensively skipped if encountered.
-    """
-    from models.meta_task import PraxisMetaTask
-
-    result = await session.execute(
-        select(Task)
-        .join(PraxisMetaTask, PraxisMetaTask.task_id == Task.id)
-        .where(PraxisMetaTask.praxis_id == praxis_id)
-    )
-    total = 0
-    for task in result.scalars().all():
-        if task.task_type != TaskType.metatask:
-            continue
-        if character_level < task.level_required:
-            continue
-        total += int(task.point_value)
-    return total
-
-
 async def _count_in_progress_praxes(character_id: int, session: AsyncSession) -> int:
     """Count in-progress praxis memberships for bank capacity enforcement."""
     result = await session.execute(
@@ -160,8 +136,11 @@ async def compute_praxis_score_from_db(
             creator_level = creator_stats.level
         else:
             creator_level = 0
-        meta_task_points = await _get_meta_task_points(praxis.id, creator_level, session)
-        total_stars = int(sum(vote.stars for vote in praxis.votes))
+        meta_task_points = await get_meta_task_points(praxis.id, creator_level, session)
+        sum_result = await session.execute(
+            select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
+        )
+        total_stars = int(sum_result.scalar_one_or_none() or 0)
         return compute_praxis_score(task.point_value, faction_multiplier, total_stars, meta_task_points)
 
     elif praxis.type == PraxisType.collab:
@@ -240,10 +219,6 @@ async def build_praxis_out(
 
     created_by_display_name = praxis.created_by.display_name if praxis.created_by else ""
 
-    moderation_status_val = praxis.moderation_status
-    if isinstance(moderation_status_val, str):
-        moderation_status_val = ModerationStatus(moderation_status_val)
-
     return PraxisOut(
         id=praxis.id,
         task_id=praxis.task_id,
@@ -254,7 +229,7 @@ async def build_praxis_out(
         title=praxis.title,
         body_text=praxis.body_text,
         is_withdrawn=praxis.is_withdrawn,
-        moderation_status=moderation_status_val,
+        moderation_status=praxis.moderation_status,
         admin_note=praxis.admin_note,
         flagged_at=praxis.flagged_at,
         created_by_id=praxis.created_by_id,
@@ -282,10 +257,6 @@ async def build_praxis_card_out(
     score = await compute_praxis_score_from_db(praxis, session, era)
     created_by_display_name = praxis.created_by.display_name if praxis.created_by else ""
 
-    moderation_status_val = praxis.moderation_status
-    if isinstance(moderation_status_val, str):
-        moderation_status_val = ModerationStatus(moderation_status_val)
-
     return PraxisCardOut(
         id=praxis.id,
         task_id=praxis.task_id,
@@ -295,7 +266,7 @@ async def build_praxis_card_out(
         status=praxis.status,
         title=praxis.title,
         is_withdrawn=praxis.is_withdrawn,
-        moderation_status=moderation_status_val,
+        moderation_status=praxis.moderation_status,
         created_by_id=praxis.created_by_id,
         created_by_display_name=created_by_display_name,
         created_at=praxis.created_at,
@@ -345,8 +316,19 @@ async def _build_duel_vote_summary(
 
 
 async def get_praxis(praxis_id: int, session: AsyncSession) -> Praxis:
-    """Get a praxis by id. Raises 404 if not found."""
-    praxis = await session.get(Praxis, praxis_id)
+    """Get a praxis by id with detail-view relationships eager-loaded.
+
+    Loads ``invites`` and ``media_items`` (in addition to the always-loaded
+    ``task``/``created_by``/``members``) because every service consumer of
+    this helper ultimately feeds a ``build_praxis_out`` caller. The list
+    endpoint uses :func:`list_praxes` which loads only what the card needs.
+    """
+    result = await session.execute(
+        select(Praxis)
+        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
+        .where(Praxis.id == praxis_id)
+    )
+    praxis = result.scalar_one_or_none()
     if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
     return praxis
@@ -372,11 +354,11 @@ async def list_praxes(
     if moderation_status is not None:
         try:
             mod_enum = ModerationStatus(moderation_status)
-            query = query.where(Praxis.moderation_status == mod_enum.value)
+            query = query.where(Praxis.moderation_status == mod_enum)
         except ValueError:
             pass
     else:
-        query = query.where(Praxis.moderation_status != ModerationStatus.hidden.value)
+        query = query.where(Praxis.moderation_status != ModerationStatus.hidden)
 
     if task_id is not None:
         query = query.where(Praxis.task_id == task_id)
@@ -462,7 +444,7 @@ async def create_praxis(
         title=title,
         body_text=body_text or "",
         is_withdrawn=False,
-        moderation_status=ModerationStatus.visible.value,
+        moderation_status=ModerationStatus.visible,
         created_by_id=character_id,
     )
     session.add(praxis)
@@ -475,8 +457,9 @@ async def create_praxis(
     )
     session.add(member)
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    # Reload with detail-view options so ``build_praxis_out`` can read invites
+    # and media_items without tripping lazy='raise'.
+    return await get_praxis(praxis.id, session)
 
 
 async def update_praxis(
@@ -494,8 +477,9 @@ async def update_praxis(
     if data.body_text is not None:
         praxis.body_text = data.body_text
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    # Re-fetch rather than session.refresh(praxis): refresh expires the
+    # lazy='raise' relationships and breaks the subsequent build_praxis_out.
+    return await get_praxis(praxis_id, session)
 
 
 async def withdraw_praxis(
@@ -515,11 +499,9 @@ async def withdraw_praxis(
     praxis.status = PraxisStatus.in_progress
     await session.commit()
 
-    from services.character_stats import recalculate_character_stats
     await recalculate_character_stats(character_id, session, era)
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 async def resubmit_praxis(
@@ -538,11 +520,9 @@ async def resubmit_praxis(
     praxis.is_withdrawn = False
     await session.commit()
 
-    from services.character_stats import recalculate_character_stats
     await recalculate_character_stats(character_id, session, era)
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 async def delete_praxis(
@@ -662,7 +642,8 @@ def is_task_eligible_for_character(
     (``task.metatask_faction_slug``). Anonymous viewers are never eligible.
 
     Note this mirrors the metatask scoring gate in
-    :func:`_get_meta_task_points` (``character_level >= task.level_required``)
+    :func:`services.meta_task.get_meta_task_points`
+    (``character_level >= task.level_required``)
     rather than the stricter :func:`apply_metatask` service gate. The flag is
     intended for UI affordances such as "metatasks this character could use
     if they had one" — apply time still runs the full guard.
@@ -699,7 +680,7 @@ async def flag_praxis(
             detail=f"Must be level {FLAG_LEVEL_REQUIRED} or above to flag a praxis.",
         )
 
-    praxis.moderation_status = ModerationStatus.flagged.value
+    praxis.moderation_status = ModerationStatus.flagged
     praxis.flagged_at = datetime.now(timezone.utc)
 
     flag = Flag(
@@ -709,8 +690,7 @@ async def flag_praxis(
     )
     session.add(flag)
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 # ---------------------------------------------------------------------------
@@ -942,13 +922,11 @@ async def submit_praxis(
     if all(m.has_submitted for m in praxis.members):
         praxis.status = PraxisStatus.submitted
         await session.flush()
-        from services.character_stats import recalculate_character_stats
         for member in praxis.members:
             await recalculate_character_stats(member.character_id, session, era)
 
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 async def reopen_praxis(
@@ -967,8 +945,7 @@ async def reopen_praxis(
         member.has_submitted = False
 
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 async def moderate_praxis(
@@ -985,7 +962,7 @@ async def moderate_praxis(
     except ValueError:
         raise HTTPException(status_code=422, detail=f"Invalid moderation status: {new_status}")
 
-    praxis.moderation_status = mod_enum.value
+    praxis.moderation_status = mod_enum
 
     if mod_enum == ModerationStatus.flagged:
         praxis.flagged_at = datetime.now(timezone.utc)
@@ -995,8 +972,7 @@ async def moderate_praxis(
         praxis.admin_note = None
 
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 # ---------------------------------------------------------------------------
@@ -1022,8 +998,6 @@ async def apply_metatask(
         * Otherwise the character must be at least ``METATASK_APPLY_LEVEL``
           AND their ``faction_slug`` must match ``task.metatask_faction_slug``.
     """
-    from models.meta_task import PraxisMetaTask
-
     praxis = await get_praxis(praxis_id, session)
     task = await session.get(Task, task_id)
     if task is None:
@@ -1089,12 +1063,10 @@ async def apply_metatask(
     session.add(PraxisMetaTask(praxis_id=praxis_id, task_id=task_id))
     await session.commit()
 
-    from services.character_stats import recalculate_character_stats
     for member in praxis.members:
         await recalculate_character_stats(member.character_id, session, era)
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 async def remove_metatask(
@@ -1105,8 +1077,6 @@ async def remove_metatask(
     era: EraConfig = CURRENT_ERA,
 ) -> Praxis:
     """Remove a metatask from a praxis. Any praxis member can remove."""
-    from models.meta_task import PraxisMetaTask
-
     praxis = await get_praxis(praxis_id, session)
 
     member_ids = {member.character_id for member in praxis.members}
@@ -1129,12 +1099,10 @@ async def remove_metatask(
     await session.delete(link)
     await session.commit()
 
-    from services.character_stats import recalculate_character_stats
     for member in praxis.members:
         await recalculate_character_stats(member.character_id, session, era)
     await session.commit()
-    await session.refresh(praxis)
-    return praxis
+    return await get_praxis(praxis_id, session)
 
 
 __all__ = [

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -11,6 +11,11 @@ from models.praxis import Praxis, PraxisMember, PraxisStatus
 from models.task import Task, TaskStatus, TaskType
 from schemas.task import TaskCreate, TaskOut
 from services.era import get_current_era_row, get_or_create_stats
+from services.praxis import (
+    allowed_praxis_modes,
+    can_submit_praxis_for_task,
+    is_task_eligible_for_character,
+)
 
 
 async def propose_task(
@@ -91,8 +96,8 @@ def build_task_out(task: Task) -> TaskOut:
         description=task.description,
         point_value=task.point_value,
         level_required=task.level_required,
-        status=task.status.value,
-        task_type=task.task_type.value,
+        status=task.status,
+        task_type=task.task_type,
         created_by=task.created_by,
         primary_faction_slug=task.primary_faction_slug,
         metatask_faction_slug=task.metatask_faction_slug,
@@ -114,12 +119,6 @@ async def build_task_out_for_viewer(
     (``None`` for anonymous callers). All three flags default to the same
     safe values as :func:`build_task_out` when ``viewer`` is ``None``.
     """
-    from services.praxis import (
-        allowed_praxis_modes,
-        can_submit_praxis_for_task,
-        is_task_eligible_for_character,
-    )
-
     base = build_task_out(task)
 
     if viewer is None:
@@ -134,6 +133,32 @@ async def build_task_out_for_viewer(
         viewer, task, stats.level
     )
     return base
+
+
+async def list_signups_for_task(
+    task_id: int,
+    session: AsyncSession,
+) -> list[tuple[PraxisMember, Character, Praxis]]:
+    """List in-progress praxis members for a task (characters currently working on it).
+
+    Raises 404 if the task does not exist.
+    """
+    task = await session.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found.")
+
+    result = await session.execute(
+        select(PraxisMember, Character, Praxis)
+        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+        .join(Character, PraxisMember.character_id == Character.id)
+        .where(
+            Praxis.task_id == task_id,
+            Praxis.status == PraxisStatus.in_progress,
+            Praxis.is_withdrawn == False,  # noqa: E712
+        )
+        .order_by(PraxisMember.joined_at.asc())
+    )
+    return list(result.all())
 
 
 async def list_tasks(

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -1,14 +1,43 @@
+from typing import Optional
+
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
-from models.praxis import Praxis, PraxisMember, PraxisType
+from models.praxis import ModerationStatus, Praxis, PraxisMember, PraxisType
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
 from services.scoring import compute_votes_available
+
+
+async def cast_vote_on_praxis(
+    voter: Character,
+    praxis_id: int,
+    stars: int,
+    session: AsyncSession,
+    *,
+    praxis_member_id: Optional[int] = None,
+    era: EraConfig = CURRENT_ERA,
+) -> Vote:
+    """Dispatch a vote to the solo/collab or duel handler based on praxis type.
+
+    Raises 404 if the praxis is missing or hidden, 422 if a duel vote omits
+    ``praxis_member_id``. Solo/collab votes additionally enforce account-level
+    anti-self-vote inside :func:`cast_or_update_vote`.
+    """
+    praxis = await session.get(Praxis, praxis_id)
+    if praxis is None or praxis.moderation_status == ModerationStatus.hidden:
+        raise HTTPException(status_code=404, detail="Praxis not found.")
+    if praxis.type == PraxisType.duel:
+        if praxis_member_id is None:
+            raise HTTPException(status_code=422, detail="praxis_member_id is required for duel votes.")
+        return await cast_or_update_duel_vote(
+            voter, praxis_id, praxis_member_id, stars, session, era
+        )
+    return await cast_or_update_vote(voter, praxis, stars, session, era)
 
 
 async def cast_or_update_vote(
@@ -18,9 +47,21 @@ async def cast_or_update_vote(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> Vote:
-    """Cast or update a vote on a solo or collab praxis."""
+    """Cast or update a vote on a solo or collab praxis.
+
+    Enforces account-level anti-self-vote so alt characters on the same account
+    cannot vote on each other's praxes.
+    """
     if not 1 <= stars <= 5:
         raise HTTPException(status_code=422, detail="Stars must be between 1 and 5.")
+
+    # Account-level anti-self-vote. Praxis.created_by is selectin-loaded,
+    # but fall back to an explicit lookup if it isn't populated.
+    author = praxis.created_by
+    if author is None and praxis.created_by_id is not None:
+        author = await session.get(Character, praxis.created_by_id)
+    if author is not None and author.account_id == voter.account_id:
+        raise HTTPException(status_code=403, detail="Cannot vote on your own praxis.")
 
     result = await session.execute(
         select(Vote).where(

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -36,9 +36,9 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction
-from models.praxis import Praxis  # noqa: F401
+from models.praxis import Praxis, PraxisMember, PraxisType
 from models.task import Task
-from models.vote import Vote  # noqa: F401
+from models.vote import Vote
 from services.auth import create_jwt
 
 # ---------------------------------------------------------------------------
@@ -273,3 +273,71 @@ async def signed_up_task2(
     Kept for test compatibility; simply returns the active_task.
     """
     return active_task
+
+
+# ---------------------------------------------------------------------------
+# Praxis / Vote fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def praxis_solo(
+    db_session: AsyncSession, active_task: Task, character: Character
+) -> Praxis:
+    """Minimal solo Praxis authored by ``character`` on ``active_task``."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        title="Solo Praxis",
+        body_text="proof",
+    )
+    db_session.add(praxis)
+    await db_session.commit()
+    await db_session.refresh(praxis)
+    return praxis
+
+
+@pytest_asyncio.fixture
+async def praxis_collab(
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+) -> Praxis:
+    """Collab Praxis with two members (``character`` and ``character2``)."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.collab,
+        title="Collab Praxis",
+        body_text="proof",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            PraxisMember(praxis_id=praxis.id, character_id=character.id),
+            PraxisMember(praxis_id=praxis.id, character_id=character2.id),
+        ]
+    )
+    await db_session.commit()
+    await db_session.refresh(praxis)
+    return praxis
+
+
+@pytest_asyncio.fixture
+async def vote(
+    db_session: AsyncSession, praxis_solo: Praxis, character2: Character
+) -> Vote:
+    """A single four-star Vote cast by ``character2`` on ``praxis_solo``."""
+    vote_row = Vote(
+        praxis_id=praxis_solo.id,
+        voter_character_id=character2.id,
+        voter_account_id=character2.account_id,
+        stars=4,
+    )
+    db_session.add(vote_row)
+    await db_session.commit()
+    await db_session.refresh(vote_row)
+    return vote_row

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -683,7 +683,7 @@ async def _seed_praxis(
         task_id=active_task.id,
         type=PraxisType.solo,
         title=title,
-        moderation_status=ModerationStatus.visible.value,
+        moderation_status=ModerationStatus.visible,
         created_by_id=character.id,
     )
     db_session.add(praxis)
@@ -718,7 +718,7 @@ async def test_admin_delete_praxis_hides_it(
     # Verify the row is still in the DB but now hidden
     result = await db_session.execute(select(Praxis).where(Praxis.id == praxis.id))
     updated = result.scalar_one()
-    assert updated.moderation_status == ModerationStatus.hidden.value
+    assert updated.moderation_status == ModerationStatus.hidden
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -663,7 +663,7 @@ async def test_get_hidden_praxis_returns_404(
     praxis_id = create_resp.json()["id"]
 
     praxis = await db_session.get(Praxis, praxis_id)
-    praxis.moderation_status = ModerationStatus.hidden.value
+    praxis.moderation_status = ModerationStatus.hidden
     await db_session.commit()
 
     resp = await client.get(f"/praxes/{praxis_id}")
@@ -688,7 +688,7 @@ async def test_list_praxes_excludes_hidden(
     praxis_id = create_resp.json()["id"]
 
     praxis = await db_session.get(Praxis, praxis_id)
-    praxis.moderation_status = ModerationStatus.hidden.value
+    praxis.moderation_status = ModerationStatus.hidden
     await db_session.commit()
 
     resp = await client.get("/praxes", params={"character_id": character.id})


### PR DESCRIPTION
## Summary

Four-batch retroactive `/simplify` sweep of the backend (`models/`, `services/`, `routers/`, `schemas/`, `tests/`) against CLAUDE.md and `docs/spec/SPEC-backend-architecture.md` conventions. Structured as independent batches so any one can be reverted without touching the others.

- **Batch 1 — pure-Python duplication** (no migration): `TimestampMixin`/`CreatedAtMixin`, dedupe `_get_meta_task_points`, hoist 11 function-scoped imports, rename colliding `FactionOut`, new integration fixtures.
- **Batch 2 — schema-changing fixes** (migrations 0007, 0008): `Praxis.moderation_status` String → `Enum(ModerationStatus)` (reuses the existing Postgres type from 0001); drop unused `TaskFaction` table.
- **Batch 3 — layer separation**: 9 inline queries moved from handlers to services (every touched handler now ≤15 lines); anti-self-vote check unified in `services/vote.py::cast_or_update_vote`; public schemas typed with `Literal`/Enum.
- **Batch 4 — Praxis eager-loading audit**: flipped `Praxis.votes/invites/media_items/flags` to `lazy="raise"` with explicit `selectinload()` at real consumers (kept `task`/`created_by`/`members` as selectin); discovered `flags` was dead code; harmonized `compute_praxis_score_from_db` to SQL `SUM()` across all three vote types.

**Test posture preserved**: 345 passed / 6 skipped, coverage **83.94%** (up from 83.83%). Migrations round-trip cleanly. Autogenerate shows zero drift on anything this PR touches.

## Explicitly deferred (not in this PR)

Each needs its own session — bundling would make this unreviewable:

- `session.commit()` in services (50+ sites) — transactional refactor, not simplification.
- `HTTPException` raised in services — pragmatic codebase choice; worth a discussion, not a mechanical fix.
- `activity_feed.py` returning Pydantic schemas — 925-line rewrite.
- Hardcoded game-rule numbers in services — era-portability design call.
- N+1 in `recalculate_character_stats` — needs perf-focused coverage.
- Long functions in `praxis.py` (`invite_to_praxis`, `apply_metatask`, etc.).
- Router-level image processing (`upload_avatar`, `upload_media_route`).
- Migration squash of 0002–0004.
- Pre-existing nullability drift on `contact_messages`/`message`/`vote`.

## Test plan

- [x] `pytest --cov=. --cov-fail-under=80` from `backend/` — 345 passed, 6 skipped, 83.94% coverage.
- [x] `alembic upgrade head` applies cleanly from fresh DB.
- [x] `alembic downgrade -2` then `upgrade head` round-trips 0007 and 0008.
- [x] `alembic revision --autogenerate` shows zero drift on anything this PR touches.
- [ ] Live browser smoke (frontend + backend + OAuth) — not run; integration suite exercises the same API surface end-to-end via AsyncClient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)