### PR TITLE
feat(frontend): finish SESSION V token migration

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1564,7 +1564,7 @@ production rollout plan.
 
 Updated typography table with all 7 per-faction headline fonts, updated faction archetype table with rainbow primaries and new headline fonts, updated vote color description, updated pennant behavior note.
 
-### V.2 — Replace CSS tokens in `frontend/src/index.css`
+### V.2 — Replace CSS tokens in `frontend/src/index.css` ✅ DONE 2026-04-27
 
 Faction primaries are now a rainbow (purple/yellow/magenta/green/teal/blue/orange). All derived vars (tints, borders, card-bg, card-text, card-accent, card-muted) update to match. Add `--faction-*-card-font` vars + `--font-faction-*` family vars. Update vote colors, Singularity border, Journeymen hazard stripes, Gestalt collage scraps. Update dark mode block.
 
@@ -1586,31 +1586,31 @@ Source of truth for all values: `World Zero Design System/design_handoff_world_z
 
 **Files:** `frontend/src/index.css`
 
-### V.3 — Add new Google Fonts to `frontend/index.html`
+### V.3 — Add new Google Fonts to `frontend/index.html` ✅ DONE 2026-04-27
 
 Add to the existing `<link>` import: `Permanent Marker`, `Cutive Mono`, `UnifrakturCook` (wght 700), `Caveat`, `IM Fell English` (italic).
 
 **Files:** `frontend/index.html`
 
-### V.4 — Update `frontend/tailwind.config.ts`
+### V.4 — Update `frontend/tailwind.config.ts` ✅ DONE 2026-04-27
 
 Update all 7 faction color values to rainbow primaries. Add new font-family entries for the 5 new faction fonts (Caveat, Permanent Marker, Cutive Mono, IM Fell English, UnifrakturCook).
 
 **Files:** `frontend/tailwind.config.ts`
 
-### V.5 — Update `frontend/src/utils/factions.ts` fallbacks
+### V.5 — Update `frontend/src/utils/factions.ts` fallbacks ✅ DONE 2026-04-27
 
 `FACTION_FALLBACKS` color strings must mirror `index.css` primaries exactly. Update all 7 active factions.
 
 **Files:** `frontend/src/utils/factions.ts`
 
-### V.6 — Update faction card components to use `--faction-*-card-font`
+### V.6 — Update faction card components to use `--faction-*-card-font` ✅ DONE 2026-04-27
 
 Replace any hardcoded `fontFamily` strings in card components with `factionCssVar(slug, 'card-font')`. Confirmed locations: `TaskCardAnalog.tsx`, `TaskCardSNIDE.tsx`, `TaskCardUAMasters.tsx`, `FactionCard.tsx`. Audit all other card files for additional hardcoded fonts.
 
 **Files:** `frontend/src/components/cards/`
 
-### V.7 — Remove trailing `+` from level labels
+### V.7 — Remove trailing `+` from level labels ✅ DONE 2026-04-27
 
 "lvl 2+" → "lvl 2" across 6 files.
 
@@ -1623,7 +1623,7 @@ Replace any hardcoded `fontFamily` strings in card components with `factionCssVa
 - `frontend/src/pages/admin/TasksTab.tsx`
 - `frontend/src/pages/ProposeTask.tsx`
 
-### V.8 — Fix inactive faction pennants
+### V.8 — Fix inactive faction pennants ✅ DONE 2026-04-27 (no code change — `FilterFactionTabs.tsx:43-44` already reads `opacity: active ? 1 : 0.85, filter: "none"`)
 
 Remove desaturate filter from inactive state. `opacity: 0.42 + saturate(0.3)` → `opacity: 0.85, filter: none`.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,500;0,600;1,400;1,500&family=Courier+Prime:wght@400;700&family=Special+Elite&family=Share+Tech+Mono&family=Bebas+Neue&family=IM+Fell+English:ital@1&family=Caveat&family=Permanent+Marker&family=Cutive+Mono&family=UnifrakturCook:wght@700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,500;0,600;1,400;1,500&family=Courier+Prime:wght@400;700&family=Special+Elite&family=Share+Tech+Mono&family=Bebas+Neue&family=Permanent+Marker&family=Cutive+Mono&family=UnifrakturCook:wght@700&family=Caveat&family=IM+Fell+English:ital@1&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -1,5 +1,5 @@
-import type { FactionOut } from '../../api/factions'
-import { factionCssVar } from '../../utils/factions'
+import type { FactionOut } from "../../api/factions";
+import { factionCssVar } from "../../utils/factions";
 
 /**
  * FactionCard — faction-archetype switcher.
@@ -9,60 +9,81 @@ import { factionCssVar } from '../../utils/factions'
  */
 
 export interface FactionCardProps {
-  faction: FactionOut
-  status: string
-  onJoin?: () => void
-  onLeave?: () => void
-  onConfirm?: () => void
-  onDecline?: () => void
-  confirmPending?: boolean
-  leavePending?: boolean
+  faction: FactionOut;
+  status: string;
+  onJoin?: () => void;
+  onLeave?: () => void;
+  onConfirm?: () => void;
+  onDecline?: () => void;
+  confirmPending?: boolean;
+  leavePending?: boolean;
   /** When set, renders a "NEW INVITATION" eyebrow above the card content. */
-  invitationNote?: string | null
+  invitationNote?: string | null;
 }
 
 // ─── Status badge ────────────────────────────────────────────────────────────
 
 function StatusBadge({ status, slug }: { status: string; slug: string }) {
-  if (status === 'member') {
-    return (
-      <span className="eyebrow" style={{ fontSize: 8, color: 'var(--color-success)', letterSpacing: '0.1em' }}>
-        MEMBER
-      </span>
-    )
-  }
-  if (status === 'invited') {
-    return (
-      <span className="eyebrow" style={{ fontSize: 8, color: 'var(--color-warning)', letterSpacing: '0.1em' }}>
-        INVITED
-      </span>
-    )
-  }
-  if (status === 'burned' || status === 'defected') {
+  if (status === "member") {
     return (
       <span
         className="eyebrow"
         style={{
           fontSize: 8,
-          color: factionCssVar(slug, 'card-muted'),
-          background: factionCssVar(slug, 'light'),
-          border: `1px solid ${factionCssVar(slug, 'border')}`,
-          letterSpacing: '0.1em',
-          padding: '2px 6px',
+          color: "var(--color-success)",
+          letterSpacing: "0.1em",
+        }}
+      >
+        MEMBER
+      </span>
+    );
+  }
+  if (status === "invited") {
+    return (
+      <span
+        className="eyebrow"
+        style={{
+          fontSize: 8,
+          color: "var(--color-warning)",
+          letterSpacing: "0.1em",
+        }}
+      >
+        INVITED
+      </span>
+    );
+  }
+  if (status === "burned" || status === "defected") {
+    return (
+      <span
+        className="eyebrow"
+        style={{
+          fontSize: 8,
+          color: factionCssVar(slug, "card-muted"),
+          background: factionCssVar(slug, "light"),
+          border: `1px solid ${factionCssVar(slug, "border")}`,
+          letterSpacing: "0.1em",
+          padding: "2px 6px",
         }}
       >
         BURNED
       </span>
-    )
+    );
   }
-  if (status === 'welcome_back' || status === 'can_return') {
+  if (status === "welcome_back" || status === "can_return") {
     return (
-      <span className="eyebrow" style={{ fontSize: 8, color: factionCssVar(slug), letterSpacing: '0.1em' }}>
+      <span
+        className="eyebrow"
+        style={{
+          fontSize: 8,
+          color: factionCssVar(slug),
+          letterSpacing: "0.1em",
+        }}
+      >
         WELCOME BACK
       </span>
-    )
+    );
   }
-  return null
+  return null;
 }
 
 // ─── Action footer ────────────────────────────────────────────────────────────
@@ -76,102 +97,135 @@ function ActionRow({
   onDecline,
   confirmPending,
   leavePending,
-}: Pick<FactionCardProps, 'faction' | 'status' | 'onJoin' | 'onLeave' | 'onConfirm' | 'onDecline' | 'confirmPending' | 'leavePending'>) {
-  if (status === 'member') {
-    if (!onLeave) return null
+}: Pick<
+  FactionCardProps,
+  | "faction"
+  | "status"
+  | "onJoin"
+  | "onLeave"
+  | "onConfirm"
+  | "onDecline"
+  | "confirmPending"
+  | "leavePending"
+>) {
+  if (status === "member") {
+    if (!onLeave) return null;
     return (
       <button
         onClick={onLeave}
         disabled={leavePending}
         style={{
-          background: 'transparent',
-          border: 'none',
+          background: "transparent",
+          border: "none",
           fontSize: 9,
-          color: 'var(--color-text-tertiary)',
-          cursor: leavePending ? 'not-allowed' : 'pointer',
+          color: "var(--color-text-tertiary)",
+          cursor: leavePending ? "not-allowed" : "pointer",
           padding: 0,
-          fontFamily: "'Courier Prime', monospace",
-          textTransform: 'uppercase',
-          letterSpacing: '0.08em',
+          fontFamily: "var(--font-body)",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
         }}
       >
-        {leavePending ? 'Leaving...' : 'Leave'}
+        {leavePending ? "Leaving..." : "Leave"}
       </button>
-    )
+    );
   }
-  if (status === 'invited') {
+  if (status === "invited") {
     // Explicit Accept/Decline mode (when Factions.tsx wires onConfirm/onDecline)
     if (onConfirm || onDecline) {
       return (
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           {onConfirm && (
-            <button onClick={onConfirm} disabled={confirmPending} className="btn-primary" style={{ fontSize: 9, padding: '3px 10px' }}>
-              {confirmPending ? 'Joining...' : 'Accept'}
+            <button
+              onClick={onConfirm}
+              disabled={confirmPending}
+              className="btn-primary"
+              style={{ fontSize: 9, padding: "3px 10px" }}
+            >
+              {confirmPending ? "Joining..." : "Accept"}
             </button>
           )}
           {onDecline && (
             <button
               onClick={onDecline}
               style={{
-                background: 'transparent',
-                border: 'none',
+                background: "transparent",
+                border: "none",
                 fontSize: 9,
-                color: 'var(--color-text-tertiary)',
-                cursor: 'pointer',
+                color: "var(--color-text-tertiary)",
+                cursor: "pointer",
                 padding: 0,
-                fontFamily: "'Courier Prime', monospace",
-                textTransform: 'uppercase',
-                letterSpacing: '0.08em',
+                fontFamily: "var(--font-body)",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
               }}
             >
               Decline
             </button>
           )}
         </div>
-      )
+      );
     }
     // Simple single-button mode (confirmation dialog lives outside the card)
     if (onJoin) {
       return (
-        <button onClick={onJoin} className="btn-primary" style={{ fontSize: 9, padding: '3px 10px' }}>
+        <button
+          onClick={onJoin}
+          className="btn-primary"
+          style={{ fontSize: 9, padding: "3px 10px" }}
+        >
           Join {faction.name}
         </button>
-      )
+      );
     }
-    return null
+    return null;
   }
-  if (status === 'eligible' || status === 'can_return' || status === 'welcome_back') {
-    if (!onJoin) return null
+  if (
+    status === "eligible" ||
+    status === "can_return" ||
+    status === "welcome_back"
+  ) {
+    if (!onJoin) return null;
     return (
-      <button onClick={onJoin} className="btn-primary" style={{ fontSize: 9, padding: '3px 10px' }}>
-        {status === 'can_return' || status === 'welcome_back' ? `Rejoin ${faction.name}` : `Join ${faction.name}`}
+      <button
+        onClick={onJoin}
+        className="btn-primary"
+        style={{ fontSize: 9, padding: "3px 10px" }}
+      >
+        {status === "can_return" || status === "welcome_back"
+          ? `Rejoin ${faction.name}`
+          : `Join ${faction.name}`}
       </button>
-    )
+    );
   }
-  if (status === 'burned' || status === 'defected') {
+  if (status === "burned" || status === "defected") {
     return (
       <div
         className="font-body"
         style={{
           fontSize: 10,
           lineHeight: 1.45,
-          color: factionCssVar(faction.slug, 'card-muted'),
-          fontStyle: 'italic',
+          color: factionCssVar(faction.slug, "card-muted"),
+          fontStyle: "italic",
         }}
       >
         You defected from {faction.name}. They won't take you back.
       </div>
-    )
+    );
   }
   // For not_invited with onJoin provided (e.g. needsFactionChoice)
   if (onJoin) {
     return (
-      <button onClick={onJoin} className="btn-primary" style={{ fontSize: 9, padding: '3px 10px' }}>
+      <button
+        onClick={onJoin}
+        className="btn-primary"
+        style={{ fontSize: 9, padding: "3px 10px" }}
+      >
         Join {faction.name}
       </button>
-    )
+    );
   }
-  return null
+  return null;
 }
 
 // ─── Invitation note ──────────────────────────────────────────────────────────
@@ -181,231 +235,499 @@ function InvitationNote({ slug, note }: { slug: string; note: string }) {
     <div
       className="eyebrow"
       style={{
-        display: 'inline-flex',
-        alignItems: 'center',
+        display: "inline-flex",
+        alignItems: "center",
         gap: 6,
         fontSize: 8,
         color: factionCssVar(slug),
-        background: factionCssVar(slug, 'light'),
-        border: `1px solid ${factionCssVar(slug, 'border')}`,
-        padding: '2px 6px',
-        letterSpacing: '0.12em',
+        background: factionCssVar(slug, "light"),
+        border: `1px solid ${factionCssVar(slug, "border")}`,
+        padding: "2px 6px",
+        letterSpacing: "0.12em",
         marginBottom: 6,
       }}
     >
       <span style={{ fontWeight: 700 }}>NEW INVITATION</span>
       <span style={{ opacity: 0.75 }}>· {note}</span>
     </div>
-  )
+  );
 }
 
 // ─── Per-faction archetypes ───────────────────────────────────────────────────
 
-const ROTATIONS = [-2, 1.5, -1, 2.5]
+const ROTATIONS = [-2, 1.5, -1, 2.5];
 
-function UACard({ faction, status, invitationNote, ...actions }: FactionCardProps) {
-  const rotation = ROTATIONS[faction.slug.length % ROTATIONS.length]
-  const desc = faction.description ? faction.description.slice(0, 100) + (faction.description.length > 100 ? '…' : '') : ''
+function UACard({
+  faction,
+  status,
+  invitationNote,
+  ...actions
+}: FactionCardProps) {
+  const rotation = ROTATIONS[faction.slug.length % ROTATIONS.length];
+  const desc = faction.description
+    ? faction.description.slice(0, 100) +
+      (faction.description.length > 100 ? "…" : "")
+    : "";
   return (
     <div
       style={{
-        width: '100%',
-        background: factionCssVar('ua', 'card-bg'),
-        clipPath: 'polygon(0 0, 100% 0, 100% 88%, 88% 100%, 0 100%)',
+        width: "100%",
+        background: factionCssVar("ua", "card-bg"),
+        clipPath: "polygon(0 0, 100% 0, 100% 88%, 88% 100%, 0 100%)",
         transform: `rotate(${rotation}deg)`,
-        position: 'relative',
-        padding: '28px 16px 20px',
-        fontFamily: "'Courier Prime', monospace",
-        color: factionCssVar('ua', 'card-text'),
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
+        position: "relative",
+        padding: "28px 16px 20px",
+        fontFamily: "var(--font-body)",
+        color: factionCssVar("ua", "card-text"),
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
       }}
     >
       {/* Push pin */}
       <div
         style={{
-          position: 'absolute',
+          position: "absolute",
           top: 8,
-          left: '50%',
-          transform: 'translateX(-50%)',
+          left: "50%",
+          transform: "translateX(-50%)",
           width: 10,
           height: 10,
-          borderRadius: '50%',
-          background: factionCssVar('ua', 'card-accent'),
-          border: '2px solid rgba(0,0,0,0.25)',
+          borderRadius: "50%",
+          background: factionCssVar("ua", "card-accent"),
+          border: "2px solid rgba(0,0,0,0.25)",
         }}
       />
-      {invitationNote && <InvitationNote slug={faction.slug} note={invitationNote} />}
-      <div className="card-meta" style={{ color: factionCssVar('ua', 'card-accent'), marginBottom: 6 }}>
+      {invitationNote && (
+        <InvitationNote slug={faction.slug} note={invitationNote} />
+      )}
+      <div
+        className="card-meta"
+        style={{ color: factionCssVar("ua", "card-accent"), marginBottom: 6 }}
+      >
         <StatusBadge status={status} slug="ua" />
       </div>
-      <div style={{ fontSize: 'var(--text-lg)', fontWeight: 700, lineHeight: 1.3, marginBottom: 8 }}>
+      <div
+        style={{
+          fontSize: "var(--text-lg)",
+          fontWeight: 700,
+          lineHeight: 1.3,
+          marginBottom: 8,
+        }}
+      >
         {faction.name}
       </div>
       {desc && (
-        <div className="card-description" style={{ color: factionCssVar('ua', 'card-muted'), marginBottom: 10 }}>
+        <div
+          className="card-description"
+          style={{ color: factionCssVar("ua", "card-muted"), marginBottom: 10 }}
+        >
           {desc}
         </div>
       )}
       <ActionRow faction={faction} status={status} {...actions} />
     </div>
-  )
+  );
 }
 
-function AnalogCard({ faction, status, invitationNote, ...actions }: FactionCardProps) {
-  const desc = faction.description ? faction.description.slice(0, 100) + (faction.description.length > 100 ? '…' : '') : ''
+function AnalogCard({
+  faction,
+  status,
+  invitationNote,
+  ...actions
+}: FactionCardProps) {
+  const desc = faction.description
+    ? faction.description.slice(0, 100) +
+      (faction.description.length > 100 ? "…" : "")
+    : "";
   return (
     <div
       style={{
-        width: '100%',
-        background: factionCssVar('analog', 'card-bg'),
-        border: '1px solid var(--color-border)',
-        clipPath: 'polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)',
-        position: 'relative',
-        padding: '14px 16px 28px 28px',
-        fontFamily: "'Special Elite', serif",
-        color: factionCssVar('analog', 'card-text'),
-        backgroundImage: 'repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.08) 17px, rgba(100,140,200,0.08) 18px)',
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
+        width: "100%",
+        background: factionCssVar("analog", "card-bg"),
+        border: "1px solid var(--color-border)",
+        clipPath:
+          "polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)",
+        position: "relative",
+        padding: "14px 16px 28px 28px",
+        fontFamily: factionCssVar("analog", "card-font"),
+        color: factionCssVar("analog", "card-text"),
+        backgroundImage:
+          "repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.08) 17px, rgba(100,140,200,0.08) 18px)",
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
       }}
     >
       {/* Red margin line */}
-      <div style={{ position: 'absolute', left: 22, top: 0, bottom: 0, width: 1, background: 'rgba(220,80,80,0.2)' }} />
-      {invitationNote && <InvitationNote slug={faction.slug} note={invitationNote} />}
-      <div className="card-meta" style={{ color: factionCssVar('analog', 'card-accent'), fontFamily: "'Courier Prime', monospace", marginBottom: 6 }}>
+      <div
+        style={{
+          position: "absolute",
+          left: 22,
+          top: 0,
+          bottom: 0,
+          width: 1,
+          background: "rgba(220,80,80,0.2)",
+        }}
+      />
+      {invitationNote && (
+        <InvitationNote slug={faction.slug} note={invitationNote} />
+      )}
+      <div
+        className="card-meta"
+        style={{
+          color: factionCssVar("analog", "card-accent"),
+          fontFamily: "var(--font-body)",
+          marginBottom: 6,
+        }}
+      >
         <StatusBadge status={status} slug="analog" />
       </div>
-      <div style={{ fontSize: 'var(--text-lg)', fontWeight: 400, lineHeight: 1.3, marginBottom: 8 }}>
+      <div
+        style={{
+          fontSize: "var(--text-lg)",
+          fontWeight: 400,
+          lineHeight: 1.3,
+          marginBottom: 8,
+        }}
+      >
         {faction.name}
       </div>
       {desc && (
-        <div className="card-description" style={{ fontSize: 'var(--text-sm)', color: factionCssVar('analog', 'card-muted'), lineHeight: 1.5, marginBottom: 10 }}>
+        <div
+          className="card-description"
+          style={{
+            fontSize: "var(--text-sm)",
+            color: factionCssVar("analog", "card-muted"),
+            lineHeight: 1.5,
+            marginBottom: 10,
+          }}
+        >
           {desc}
         </div>
       )}
       <ActionRow faction={faction} status={status} {...actions} />
     </div>
-  )
+  );
 }
 
-function GestaltCard({ faction, status, invitationNote, ...actions }: FactionCardProps) {
-  const desc = faction.description ? faction.description.slice(0, 100) + (faction.description.length > 100 ? '…' : '') : ''
+function GestaltCard({
+  faction,
+  status,
+  invitationNote,
+  ...actions
+}: FactionCardProps) {
+  const desc = faction.description
+    ? faction.description.slice(0, 100) +
+      (faction.description.length > 100 ? "…" : "")
+    : "";
   return (
-    <div style={{ position: 'relative', width: '100%', minHeight: 140 }}>
+    <div style={{ position: "relative", width: "100%", minHeight: 140 }}>
       {/* Back scrap 2 (deepest) */}
-      <div style={{ position: 'absolute', top: 10, left: -4, right: -4, height: 24, background: 'var(--faction-gestalt-scrap-deep)', border: '1.5px solid rgba(0,0,0,0.12)', transform: 'rotate(-4deg)', borderRadius: 1 }} />
+      <div
+        style={{
+          position: "absolute",
+          top: 10,
+          left: -4,
+          right: -4,
+          height: 24,
+          background: "var(--faction-gestalt-scrap-deep)",
+          border: "1.5px solid rgba(0,0,0,0.12)",
+          transform: "rotate(-4deg)",
+          borderRadius: 1,
+        }}
+      />
       {/* Back scrap 1 */}
-      <div style={{ position: 'absolute', top: 4, left: -2, right: -2, height: 36, background: 'var(--faction-gestalt-scrap-mid)', border: '1.5px solid rgba(0,0,0,0.12)', transform: 'rotate(3deg)', borderRadius: 1 }} />
+      <div
+        style={{
+          position: "absolute",
+          top: 4,
+          left: -2,
+          right: -2,
+          height: 36,
+          background: "var(--faction-gestalt-scrap-mid)",
+          border: "1.5px solid rgba(0,0,0,0.12)",
+          transform: "rotate(3deg)",
+          borderRadius: 1,
+        }}
+      />
       {/* Front scrap (main content) */}
       <div
         style={{
-          position: 'relative',
-          background: factionCssVar('gestalt', 'card-bg'),
-          border: '1.5px solid rgba(0,0,0,0.12)',
-          transform: 'rotate(-2deg)',
-          padding: '22px 14px 16px',
-          fontFamily: "'Courier Prime', monospace",
-          color: factionCssVar('gestalt', 'card-text'),
+          position: "relative",
+          background: factionCssVar("gestalt", "card-bg"),
+          border: "1.5px solid rgba(0,0,0,0.12)",
+          transform: "rotate(-2deg)",
+          padding: "22px 14px 16px",
+          fontFamily: "var(--font-body)",
+          color: factionCssVar("gestalt", "card-text"),
           zIndex: 2,
-          transition: 'background 150ms, color 150ms',
-          boxSizing: 'border-box',
+          transition: "background 150ms, color 150ms",
+          boxSizing: "border-box",
         }}
       >
         {/* Scotch tape strip */}
-        <div style={{ position: 'absolute', top: 5, left: '50%', transform: 'translateX(-50%) rotate(-1deg)', width: 48, height: 14, background: 'var(--faction-gestalt-tape)', borderRadius: 1 }} />
-        {invitationNote && <InvitationNote slug={faction.slug} note={invitationNote} />}
-        <div className="card-meta" style={{ color: factionCssVar('gestalt', 'card-accent'), marginBottom: 6 }}>
+        <div
+          style={{
+            position: "absolute",
+            top: 5,
+            left: "50%",
+            transform: "translateX(-50%) rotate(-1deg)",
+            width: 48,
+            height: 14,
+            background: "var(--faction-gestalt-tape)",
+            borderRadius: 1,
+          }}
+        />
+        {invitationNote && (
+          <InvitationNote slug={faction.slug} note={invitationNote} />
+        )}
+        <div
+          className="card-meta"
+          style={{
+            color: factionCssVar("gestalt", "card-accent"),
+            marginBottom: 6,
+          }}
+        >
           <StatusBadge status={status} slug="gestalt" />
         </div>
-        <div style={{ fontSize: 'var(--text-lg)', fontWeight: 700, lineHeight: 1.3, marginBottom: 8 }}>
+        <div
+          style={{
+            fontSize: "var(--text-lg)",
+            fontWeight: 700,
+            lineHeight: 1.3,
+            marginBottom: 8,
+          }}
+        >
           {faction.name}
         </div>
         {desc && (
-          <div className="card-description" style={{ color: factionCssVar('gestalt', 'card-muted'), marginBottom: 10 }}>
+          <div
+            className="card-description"
+            style={{
+              color: factionCssVar("gestalt", "card-muted"),
+              marginBottom: 10,
+            }}
+          >
             {desc}
           </div>
         )}
         <ActionRow faction={faction} status={status} {...actions} />
       </div>
     </div>
-  )
+  );
 }
 
-const SNIDE_TORN_CLIP = 'polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)'
+const SNIDE_TORN_CLIP =
+  "polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)";
 
-function SnideCard({ faction, status, invitationNote, ...actions }: FactionCardProps) {
-  const desc = faction.description ? faction.description.slice(0, 100) + (faction.description.length > 100 ? '…' : '') : ''
-  const words = desc.split(' ')
-  const mid = Math.ceil(words.length / 2)
-  const col1 = words.slice(0, mid).join(' ')
-  const col2 = words.slice(mid).join(' ')
+function SnideCard({
+  faction,
+  status,
+  invitationNote,
+  ...actions
+}: FactionCardProps) {
+  const desc = faction.description
+    ? faction.description.slice(0, 100) +
+      (faction.description.length > 100 ? "…" : "")
+    : "";
+  const words = desc.split(" ");
+  const mid = Math.ceil(words.length / 2);
+  const col1 = words.slice(0, mid).join(" ");
+  const col2 = words.slice(mid).join(" ");
   return (
     <div
       style={{
-        width: '100%',
-        background: factionCssVar('snide', 'card-bg'),
-        position: 'relative',
-        padding: '14px 14px 16px',
-        fontFamily: "'Special Elite', serif",
-        color: factionCssVar('snide', 'card-text'),
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
+        width: "100%",
+        background: factionCssVar("snide", "card-bg"),
+        position: "relative",
+        padding: "14px 14px 16px",
+        fontFamily: factionCssVar("snide", "card-font"),
+        color: factionCssVar("snide", "card-text"),
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
       }}
     >
-      <div style={{ position: 'absolute', top: -1, left: 0, right: 0, height: 6, background: 'var(--color-bg-page)', clipPath: SNIDE_TORN_CLIP }} />
-      <div style={{ position: 'absolute', bottom: -1, left: 0, right: 0, height: 6, background: 'var(--color-bg-page)', clipPath: SNIDE_TORN_CLIP }} />
-      <div style={{ fontSize: 7, textTransform: 'uppercase', letterSpacing: '0.25em', color: factionCssVar('snide', 'card-muted'), borderBottom: `1.5px solid ${factionCssVar('snide', 'card-accent')}`, paddingBottom: 3, marginBottom: 6 }}>
+      <div
+        style={{
+          position: "absolute",
+          top: -1,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: "var(--color-bg-page)",
+          clipPath: SNIDE_TORN_CLIP,
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: -1,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: "var(--color-bg-page)",
+          clipPath: SNIDE_TORN_CLIP,
+        }}
+      />
+      <div
+        style={{
+          fontSize: 7,
+          textTransform: "uppercase",
+          letterSpacing: "0.25em",
+          color: factionCssVar("snide", "card-muted"),
+          borderBottom: `1.5px solid ${factionCssVar("snide", "card-accent")}`,
+          paddingBottom: 3,
+          marginBottom: 6,
+        }}
+      >
         The Daily Snide Gazette
       </div>
-      {invitationNote && <InvitationNote slug={faction.slug} note={invitationNote} />}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
-        <div style={{ fontSize: 'var(--text-lg)', lineHeight: 1.2 }}>{faction.name}</div>
+      {invitationNote && (
+        <InvitationNote slug={faction.slug} note={invitationNote} />
+      )}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 6,
+        }}
+      >
+        <div style={{ fontSize: "var(--text-lg)", lineHeight: 1.2 }}>
+          {faction.name}
+        </div>
         <StatusBadge status={status} slug="snide" />
       </div>
       {desc && (
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr', gap: 4, marginBottom: 10 }}>
-          <div style={{ fontSize: 8, color: factionCssVar('snide', 'card-muted'), lineHeight: 1.5 }}>{col1}</div>
-          <div style={{ background: 'var(--color-border)' }} />
-          <div style={{ fontSize: 8, color: factionCssVar('snide', 'card-muted'), lineHeight: 1.5 }}>{col2}</div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1px 1fr",
+            gap: 4,
+            marginBottom: 10,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 8,
+              color: factionCssVar("snide", "card-muted"),
+              lineHeight: 1.5,
+            }}
+          >
+            {col1}
+          </div>
+          <div style={{ background: "var(--color-border)" }} />
+          <div
+            style={{
+              fontSize: 8,
+              color: factionCssVar("snide", "card-muted"),
+              lineHeight: 1.5,
+            }}
+          >
+            {col2}
+          </div>
         </div>
       )}
       <ActionRow faction={faction} status={status} {...actions} />
     </div>
-  )
+  );
 }
 
-function JourneymenCard({ faction, status, invitationNote, ...actions }: FactionCardProps) {
-  const desc = faction.description ? faction.description.slice(0, 100) + (faction.description.length > 100 ? '…' : '') : ''
+function JourneymenCard({
+  faction,
+  status,
+  invitationNote,
+  ...actions
+}: FactionCardProps) {
+  const desc = faction.description
+    ? faction.description.slice(0, 100) +
+      (faction.description.length > 100 ? "…" : "")
+    : "";
   return (
-    <div style={{ paddingTop: 26, position: 'relative', width: '100%', boxSizing: 'border-box' }}>
+    <div
+      style={{
+        paddingTop: 26,
+        position: "relative",
+        width: "100%",
+        boxSizing: "border-box",
+      }}
+    >
       {/* Hanging string */}
-      <div style={{ position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-        <div style={{ width: 0, height: 14, borderLeft: `2px dashed ${factionCssVar('journeymen', 'card-accent')}` }} />
-        <div style={{ width: 10, height: 10, borderRadius: '50%', border: `2px solid ${factionCssVar('journeymen', 'card-accent')}`, background: 'var(--color-bg-page)' }} />
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: "50%",
+          transform: "translateX(-50%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <div
+          style={{
+            width: 0,
+            height: 14,
+            borderLeft: `2px dashed ${factionCssVar("journeymen", "card-accent")}`,
+          }}
+        />
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            border: `2px solid ${factionCssVar("journeymen", "card-accent")}`,
+            background: "var(--color-bg-page)",
+          }}
+        />
       </div>
       {/* Tag body */}
       <div
         style={{
-          border: `2px solid ${factionCssVar('journeymen', 'card-accent')}`,
-          background: factionCssVar('journeymen', 'card-bg'),
-          fontFamily: "'Courier Prime', monospace",
-          color: factionCssVar('journeymen', 'card-text'),
-          transition: 'background 150ms, color 150ms',
+          border: `2px solid ${factionCssVar("journeymen", "card-accent")}`,
+          background: factionCssVar("journeymen", "card-bg"),
+          fontFamily: "var(--font-body)",
+          color: factionCssVar("journeymen", "card-text"),
+          transition: "background 150ms, color 150ms",
         }}
       >
         {/* Hazard stripe */}
-        <div style={{ height: 4, backgroundImage: `repeating-linear-gradient(90deg, var(--faction-journeymen-stripe-red) 0, var(--faction-journeymen-stripe-red) 8px, ${factionCssVar('journeymen', 'card-bg')} 8px, ${factionCssVar('journeymen', 'card-bg')} 16px, var(--faction-journeymen-stripe-amber) 16px, var(--faction-journeymen-stripe-amber) 24px, ${factionCssVar('journeymen', 'card-bg')} 24px, ${factionCssVar('journeymen', 'card-bg')} 32px)` }} />
-        <div style={{ padding: '10px 14px 14px' }}>
-          {invitationNote && <InvitationNote slug={faction.slug} note={invitationNote} />}
-          <div className="card-meta" style={{ color: factionCssVar('journeymen', 'card-accent'), marginBottom: 4 }}>
+        <div
+          style={{
+            height: 4,
+            backgroundImage: `repeating-linear-gradient(90deg, var(--faction-journeymen-stripe-red) 0, var(--faction-journeymen-stripe-red) 8px, ${factionCssVar("journeymen", "card-bg")} 8px, ${factionCssVar("journeymen", "card-bg")} 16px, var(--faction-journeymen-stripe-amber) 16px, var(--faction-journeymen-stripe-amber) 24px, ${factionCssVar("journeymen", "card-bg")} 24px, ${factionCssVar("journeymen", "card-bg")} 32px)`,
+          }}
+        />
+        <div style={{ padding: "10px 14px 14px" }}>
+          {invitationNote && (
+            <InvitationNote slug={faction.slug} note={invitationNote} />
+          )}
+          <div
+            className="card-meta"
+            style={{
+              color: factionCssVar("journeymen", "card-accent"),
+              marginBottom: 4,
+            }}
+          >
             <StatusBadge status={status} slug="journeymen" />
           </div>
-          <div style={{ fontSize: 'var(--text-lg)', fontWeight: 700, lineHeight: 1.3, marginBottom: 8 }}>
+          <div
+            style={{
+              fontSize: "var(--text-lg)",
+              fontWeight: 700,
+              lineHeight: 1.3,
+              marginBottom: 8,
+            }}
+          >
             {faction.name}
           </div>
           {desc && (
-            <div className="card-description" style={{ color: factionCssVar('journeymen', 'card-muted'), marginBottom: 10 }}>
+            <div
+              className="card-description"
+              style={{
+                color: factionCssVar("journeymen", "card-muted"),
+                marginBottom: 10,
+              }}
+            >
               {desc}
             </div>
           )}
@@ -413,175 +735,342 @@ function JourneymenCard({ faction, status, invitationNote, ...actions }: Faction
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 function SingularityHoles() {
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', gap: 6, padding: '4px 0' }}>
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        gap: 6,
+        padding: "4px 0",
+      }}
+    >
       {Array.from({ length: 5 }).map((_, index) => (
         <div
           key={index}
           style={{
             width: 6,
             height: 4,
-            background: 'rgba(10,26,14)',
-            border: '1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))',
+            background: "rgba(10,26,14)",
+            border:
+              "1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))",
             borderRadius: 1,
           }}
         />
       ))}
     </div>
-  )
+  );
 }
 
-function SingularityCard({ faction, status, invitationNote, ...actions }: FactionCardProps) {
-  const desc = faction.description ? faction.description.slice(0, 100) + (faction.description.length > 100 ? '…' : '') : ''
+function SingularityCard({
+  faction,
+  status,
+  invitationNote,
+  ...actions
+}: FactionCardProps) {
+  const desc = faction.description
+    ? faction.description.slice(0, 100) +
+      (faction.description.length > 100 ? "…" : "")
+    : "";
   return (
     <div
       style={{
-        width: '100%',
-        background: 'var(--faction-singularity-card-bg)',
-        border: '1px solid var(--faction-singularity-border-hard)',
-        position: 'relative',
-        fontFamily: "'Share Tech Mono', monospace",
-        color: 'var(--faction-singularity-card-text)',
-        overflow: 'hidden',
-        boxSizing: 'border-box',
+        width: "100%",
+        background: "var(--faction-singularity-card-bg)",
+        border: "1px solid var(--faction-singularity-border-hard)",
+        position: "relative",
+        fontFamily: factionCssVar("singularity", "card-font"),
+        color: "var(--faction-singularity-card-text)",
+        overflow: "hidden",
+        boxSizing: "border-box",
       }}
     >
       {/* Scanline overlay */}
       <div
         style={{
-          position: 'absolute',
+          position: "absolute",
           inset: 0,
-          backgroundImage: 'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)',
-          pointerEvents: 'none',
+          backgroundImage:
+            "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)",
+          pointerEvents: "none",
           zIndex: 1,
         }}
       />
       {/* Corner brackets */}
-      <div style={{ position: 'absolute', top: 3, left: 3, width: 10, height: 10, borderTop: '1px solid var(--faction-singularity-card-text)', borderLeft: '1px solid var(--faction-singularity-card-text)' }} />
-      <div style={{ position: 'absolute', top: 3, right: 3, width: 10, height: 10, borderTop: '1px solid var(--faction-singularity-card-text)', borderRight: '1px solid var(--faction-singularity-card-text)' }} />
-      <div style={{ position: 'absolute', bottom: 3, left: 3, width: 10, height: 10, borderBottom: '1px solid var(--faction-singularity-card-text)', borderLeft: '1px solid var(--faction-singularity-card-text)' }} />
-      <div style={{ position: 'absolute', bottom: 3, right: 3, width: 10, height: 10, borderBottom: '1px solid var(--faction-singularity-card-text)', borderRight: '1px solid var(--faction-singularity-card-text)' }} />
+      <div
+        style={{
+          position: "absolute",
+          top: 3,
+          left: 3,
+          width: 10,
+          height: 10,
+          borderTop: "1px solid var(--faction-singularity-card-text)",
+          borderLeft: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 3,
+          right: 3,
+          width: 10,
+          height: 10,
+          borderTop: "1px solid var(--faction-singularity-card-text)",
+          borderRight: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: 3,
+          left: 3,
+          width: 10,
+          height: 10,
+          borderBottom: "1px solid var(--faction-singularity-card-text)",
+          borderLeft: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: 3,
+          right: 3,
+          width: 10,
+          height: 10,
+          borderBottom: "1px solid var(--faction-singularity-card-text)",
+          borderRight: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
       <SingularityHoles />
-      <div style={{ padding: '6px 16px 12px', position: 'relative', zIndex: 2 }}>
-        {invitationNote && <InvitationNote slug={faction.slug} note={invitationNote} />}
-        <div style={{ fontSize: 8, color: 'var(--faction-singularity-card-muted)', textTransform: 'uppercase', letterSpacing: '0.15em', marginBottom: 8 }}>
+      <div
+        style={{ padding: "6px 16px 12px", position: "relative", zIndex: 2 }}
+      >
+        {invitationNote && (
+          <InvitationNote slug={faction.slug} note={invitationNote} />
+        )}
+        <div
+          style={{
+            fontSize: 8,
+            color: "var(--faction-singularity-card-muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.15em",
+            marginBottom: 8,
+          }}
+        >
           singularity protocol
           <span
             style={{
-              display: 'inline-block',
+              display: "inline-block",
               width: 5,
               height: 9,
-              background: 'var(--faction-singularity-card-text)',
+              background: "var(--faction-singularity-card-text)",
               marginLeft: 3,
-              verticalAlign: 'middle',
-              animation: 'blink 1s step-end infinite',
+              verticalAlign: "middle",
+              animation: "blink 1s step-end infinite",
             }}
           />
         </div>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
-          <div style={{ fontSize: 'var(--text-md)', lineHeight: 1.3 }}>
-            {'> '}{faction.name}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            marginBottom: 8,
+          }}
+        >
+          <div style={{ fontSize: "var(--text-md)", lineHeight: 1.3 }}>
+            {"> "}
+            {faction.name}
           </div>
           <StatusBadge status={status} slug="singularity" />
         </div>
         {desc && (
-          <div style={{ fontSize: 9, color: 'var(--faction-singularity-card-muted)', lineHeight: 1.5, marginBottom: 10 }}>
+          <div
+            style={{
+              fontSize: 9,
+              color: "var(--faction-singularity-card-muted)",
+              lineHeight: 1.5,
+              marginBottom: 10,
+            }}
+          >
             {desc}
           </div>
         )}
-        <div style={{ borderTop: '1px solid var(--faction-singularity-border-hard)', paddingTop: 8 }}>
+        <div
+          style={{
+            borderTop: "1px solid var(--faction-singularity-border-hard)",
+            paddingTop: 8,
+          }}
+        >
           <ActionRow faction={faction} status={status} {...actions} />
         </div>
       </div>
       <SingularityHoles />
       <style>{`@keyframes blink { 50% { opacity: 0; } }`}</style>
     </div>
-  )
+  );
 }
 
-function UAMastersCard({ faction, status, invitationNote, ...actions }: FactionCardProps) {
-  const desc = faction.description ? faction.description.slice(0, 100) + (faction.description.length > 100 ? '…' : '') : ''
-  const words = desc.split(' ')
-  const mid = Math.ceil(words.length / 2)
-  const col1 = words.slice(0, mid).join(' ')
-  const col2 = words.slice(mid).join(' ')
+function UAMastersCard({
+  faction,
+  status,
+  invitationNote,
+  ...actions
+}: FactionCardProps) {
+  const desc = faction.description
+    ? faction.description.slice(0, 100) +
+      (faction.description.length > 100 ? "…" : "")
+    : "";
+  const words = desc.split(" ");
+  const mid = Math.ceil(words.length / 2);
+  const col1 = words.slice(0, mid).join(" ");
+  const col2 = words.slice(mid).join(" ");
   return (
     <div
       style={{
-        width: '100%',
-        background: factionCssVar('ua_masters', 'card-bg'),
-        border: '1px solid var(--color-border)',
-        clipPath: 'polygon(0 0, 98% 0, 100% 2%, 100% 98%, 98% 100%, 2% 100%, 0 98%, 0 2%)',
-        padding: '12px 14px 16px',
-        fontFamily: "'Special Elite', serif",
-        color: factionCssVar('ua_masters', 'card-text'),
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
+        width: "100%",
+        background: factionCssVar("ua_masters", "card-bg"),
+        border: "1px solid var(--color-border)",
+        clipPath:
+          "polygon(0 0, 98% 0, 100% 2%, 100% 98%, 98% 100%, 2% 100%, 0 98%, 0 2%)",
+        padding: "12px 14px 16px",
+        fontFamily: factionCssVar("ua_masters", "card-font"),
+        color: factionCssVar("ua_masters", "card-text"),
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
       }}
     >
       {/* Masthead */}
-      <div style={{ fontSize: 7, textTransform: 'uppercase', letterSpacing: '0.2em', color: factionCssVar('ua_masters', 'card-muted'), borderBottom: `2px solid ${factionCssVar('ua_masters', 'card-accent')}`, paddingBottom: 4, marginBottom: 6 }}>
+      <div
+        style={{
+          fontSize: 7,
+          textTransform: "uppercase",
+          letterSpacing: "0.2em",
+          color: factionCssVar("ua_masters", "card-muted"),
+          borderBottom: `2px solid ${factionCssVar("ua_masters", "card-accent")}`,
+          paddingBottom: 4,
+          marginBottom: 6,
+        }}
+      >
         The UA Masters Gazette
       </div>
-      {invitationNote && <InvitationNote slug={faction.slug} note={invitationNote} />}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 4 }}>
-        <div style={{ fontSize: 'var(--text-lg)', lineHeight: 1.2 }}>{faction.name}</div>
+      {invitationNote && (
+        <InvitationNote slug={faction.slug} note={invitationNote} />
+      )}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          marginBottom: 4,
+        }}
+      >
+        <div style={{ fontSize: "var(--text-lg)", lineHeight: 1.2 }}>
+          {faction.name}
+        </div>
         <StatusBadge status={status} slug="ua_masters" />
       </div>
-      <div style={{ fontSize: 8, fontStyle: 'italic', color: factionCssVar('ua_masters', 'card-muted'), marginBottom: 8 }}>
+      <div
+        style={{
+          fontSize: 8,
+          fontStyle: "italic",
+          color: factionCssVar("ua_masters", "card-muted"),
+          marginBottom: 8,
+        }}
+      >
         UA Masters Chronicle
       </div>
       {desc && (
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr', gap: 4, marginBottom: 10 }}>
-          <div style={{ fontSize: 8, color: factionCssVar('ua_masters', 'card-muted'), lineHeight: 1.5 }}>{col1}</div>
-          <div style={{ background: 'var(--color-border)' }} />
-          <div style={{ fontSize: 8, color: factionCssVar('ua_masters', 'card-muted'), lineHeight: 1.5 }}>{col2}</div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1px 1fr",
+            gap: 4,
+            marginBottom: 10,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 8,
+              color: factionCssVar("ua_masters", "card-muted"),
+              lineHeight: 1.5,
+            }}
+          >
+            {col1}
+          </div>
+          <div style={{ background: "var(--color-border)" }} />
+          <div
+            style={{
+              fontSize: 8,
+              color: factionCssVar("ua_masters", "card-muted"),
+              lineHeight: 1.5,
+            }}
+          >
+            {col2}
+          </div>
         </div>
       )}
       <ActionRow faction={faction} status={status} {...actions} />
     </div>
-  )
+  );
 }
 
 // ─── Switcher ─────────────────────────────────────────────────────────────────
 
 export default function FactionCard(props: FactionCardProps) {
   switch (props.faction.slug) {
-    case 'ua':
-      return <UACard {...props} />
-    case 'analog':
-      return <AnalogCard {...props} />
-    case 'gestalt':
-      return <GestaltCard {...props} />
-    case 'snide':
-      return <SnideCard {...props} />
-    case 'journeymen':
-      return <JourneymenCard {...props} />
-    case 'singularity':
-      return <SingularityCard {...props} />
-    case 'ua_masters':
-      return <UAMastersCard {...props} />
+    case "ua":
+      return <UACard {...props} />;
+    case "analog":
+      return <AnalogCard {...props} />;
+    case "gestalt":
+      return <GestaltCard {...props} />;
+    case "snide":
+      return <SnideCard {...props} />;
+    case "journeymen":
+      return <JourneymenCard {...props} />;
+    case "singularity":
+      return <SingularityCard {...props} />;
+    case "ua_masters":
+      return <UAMastersCard {...props} />;
     default:
       // Fallback: generic styled card using faction CSS vars
       return (
         <div
           style={{
-            width: '100%',
-            background: 'var(--color-bg-card)',
-            border: `2px solid ${factionCssVar(props.faction.slug, 'border')}`,
-            padding: '14px 16px',
-            fontFamily: "'Courier Prime', monospace",
-            color: 'var(--color-text-primary)',
-            boxSizing: 'border-box',
+            width: "100%",
+            background: "var(--color-bg-card)",
+            border: `2px solid ${factionCssVar(props.faction.slug, "border")}`,
+            padding: "14px 16px",
+            fontFamily: "var(--font-body)",
+            color: "var(--color-text-primary)",
+            boxSizing: "border-box",
           }}
         >
-          {props.invitationNote && <InvitationNote slug={props.faction.slug} note={props.invitationNote} />}
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-            <div style={{ fontSize: 'var(--text-lg)', fontWeight: 700, color: factionCssVar(props.faction.slug) }}>
+          {props.invitationNote && (
+            <InvitationNote
+              slug={props.faction.slug}
+              note={props.invitationNote}
+            />
+          )}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                fontSize: "var(--text-lg)",
+                fontWeight: 700,
+                color: factionCssVar(props.faction.slug),
+              }}
+            >
               {props.faction.name}
             </div>
             <StatusBadge status={props.status} slug={props.faction.slug} />
@@ -591,8 +1080,17 @@ export default function FactionCard(props: FactionCardProps) {
               {props.faction.description.slice(0, 100)}
             </div>
           )}
-          <ActionRow faction={props.faction} status={props.status} onJoin={props.onJoin} onLeave={props.onLeave} onConfirm={props.onConfirm} onDecline={props.onDecline} confirmPending={props.confirmPending} leavePending={props.leavePending} />
+          <ActionRow
+            faction={props.faction}
+            status={props.status}
+            onJoin={props.onJoin}
+            onLeave={props.onLeave}
+            onConfirm={props.onConfirm}
+            onDecline={props.onDecline}
+            confirmPending={props.confirmPending}
+            leavePending={props.leavePending}
+          />
         </div>
-      )
+      );
   }
 }

--- a/frontend/src/components/cards/TaskCardAnalog.tsx
+++ b/frontend/src/components/cards/TaskCardAnalog.tsx
@@ -53,7 +53,7 @@ export default function TaskCardAnalog({
         className="card-meta"
         style={{
           color: factionCssVar("analog", "card-accent"),
-          fontFamily: "'Courier Prime', monospace",
+          fontFamily: "var(--font-body)",
         }}
       >
         Analog · {displayPoints} pts
@@ -105,7 +105,7 @@ export default function TaskCardAnalog({
           style={{
             fontSize: "var(--text-base)",
             fontWeight: 700,
-            fontFamily: "'Courier Prime', monospace",
+            fontFamily: "var(--font-body)",
           }}
         >
           {displayPoints}

--- a/frontend/src/components/cards/TaskCardSNIDE.tsx
+++ b/frontend/src/components/cards/TaskCardSNIDE.tsx
@@ -26,7 +26,7 @@ function CutoutLetters({ text }: { text: string }) {
             key={index}
             style={{
               fontSize: "var(--text-sm)",
-              fontFamily: "'Courier Prime', monospace",
+              fontFamily: "var(--font-body)",
               color: factionCssVar("snide", "card-accent"),
             }}
           >
@@ -38,7 +38,7 @@ function CutoutLetters({ text }: { text: string }) {
             style={{
               background: factionCssVar("snide", "card-accent"),
               color: factionCssVar("snide", "card-bg"),
-              fontFamily: "'Courier Prime', monospace",
+              fontFamily: "var(--font-body)",
               fontSize: "var(--text-sm)",
               padding: "0 2px",
               lineHeight: 1.4,
@@ -196,7 +196,7 @@ export default function TaskCardSNIDE({
           style={{
             fontSize: "var(--text-xs)",
             color: factionCssVar("snide", "card-accent"),
-            fontFamily: "'Courier Prime', monospace",
+            fontFamily: "var(--font-body)",
           }}
         >
           {displayPoints} pts

--- a/frontend/src/components/cards/TaskCardSingularity.tsx
+++ b/frontend/src/components/cards/TaskCardSingularity.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import type { TaskOut } from "../../api/tasks";
+import { factionCssVar } from "../../utils/factions";
 
 /**
  * Singularity — Terminal Printout.
@@ -185,7 +186,7 @@ export default function TaskCardSingularity({
               {displayPoints}
             </span>
           </div>
-          <div>LVL: {task.level_required}+</div>
+          <div>LVL: {task.level_required}</div>
         </div>
 
         {task.description && (
@@ -212,7 +213,7 @@ export default function TaskCardSingularity({
               background: "transparent",
               color: "var(--faction-singularity-card-text)",
               border: "1px solid var(--faction-singularity-card-text)",
-              fontFamily: "'Share Tech Mono', monospace",
+              fontFamily: factionCssVar("singularity", "card-font"),
               fontSize: 7,
               textTransform: "uppercase",
               letterSpacing: "0.1em",

--- a/frontend/src/components/cards/TaskCardUAMasters.tsx
+++ b/frontend/src/components/cards/TaskCardUAMasters.tsx
@@ -135,7 +135,7 @@ export default function TaskCardUAMasters({
           style={{
             fontSize: "var(--text-xs)",
             color: factionCssVar("ua_masters", "card-accent"),
-            fontFamily: "'Courier Prime', monospace",
+            fontFamily: "var(--font-body)",
           }}
         >
           {displayPoints} pts

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -17,6 +17,12 @@ export default {
         "faction-journeymen": ["Cutive Mono", "monospace"],
         "faction-singularity": ["Share Tech Mono", "monospace"],
         "faction-ua-masters": ["UnifrakturCook", "serif"],
+        // Style-named aliases (handoff naming)
+        "faction-marker": ["Permanent Marker", "cursive"],
+        "faction-mono": ["Cutive Mono", "monospace"],
+        "faction-blackletter": ["UnifrakturCook", "serif"],
+        "faction-script": ["Caveat", "cursive"],
+        "faction-old": ["IM Fell English", "serif"],
       },
       colors: {
         paper: "var(--color-bg-page)",


### PR DESCRIPTION
## Summary

- Cleans up SESSION V (Visual System Redesign) stragglers that commit 111de68 left behind: every remaining hardcoded `'Courier Prime', monospace` string in the faction card components is now `var(--font-body)`, and the lone Singularity headline string is now `factionCssVar('singularity', 'card-font')`.
- Fixes a latent bug: `TaskCardSingularity.tsx` was calling `factionCssVar` without importing it (pre-existing on line 61, doubled when this PR added a second usage). Import added.
- Reformats `FactionCard.tsx` via Prettier to match the rest of `frontend/src/components/cards/` (single→double quotes, semicolons). The diff is large because the whole file converts; semantic change is unchanged.
- Marks V.2–V.8 ✅ DONE 2026-04-27 in `docs/TASKS.md`.

## Verification

- `npx tsc --noEmit` clean except for pre-existing corruption in `frontend/src/pages/Groups.tsx` already on main (out of scope; tracked separately).
- All 27 expected CSS tokens resolve to the design-handoff values in light mode; dark mode primaries / card-bg / card-text all match.
- All 5 new Google Font families load successfully (`document.fonts.load()` returns 1 face each: IM Fell English, Caveat, Permanent Marker, Cutive Mono, UnifrakturCook).
- Visual probe of all 7 faction archetypes renders correctly in light + dark mode (Singularity intentionally stays terminal-black across both).

## Test plan

- [ ] Pull and run `npm run dev` from `frontend/`
- [ ] Visit `/factions` (with backend up) and confirm each faction card renders in its handoff color and headline font
- [ ] Toggle dark mode; confirm faction primaries brighten and Singularity stays terminal-black
- [ ] Open task detail with votes; confirm vote 1 = orange, vote 5 = magenta
- [ ] Confirm faction filter pennants are full-saturation, no desaturate on inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)