### PR TITLE
fix(frontend): unbreak Groups.tsx and clear remaining tsc errors

### DIFF
--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -1,357 +1,790 @@
-import { useState } from 'react'
-import { Link } from 'react-router-dom'
-import type { PraxisCardOut } from '../api/praxis'
-import { useAuth } from '../auth/AuthContext'
-import { useAdminMode } from '../auth/AdminModeContext'
-import { moderatePraxis } from '../api/admin'
-import { factionCssVar } from '../utils/factions'
-import { extractError } from '../utils/errors'
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import type { PraxisCardOut } from "../api/praxis";
+import { useAuth } from "../auth/AuthContext";
+import { useAdminMode } from "../auth/AdminModeContext";
+import { moderatePraxis } from "../api/admin";
+import { factionCssVar } from "../utils/factions";
+import { extractError } from "../utils/errors";
 
 interface Props {
-  praxis: PraxisCardOut
-  onModerated?: () => void
+  praxis: PraxisCardOut;
+  onModerated?: () => void;
 }
 
 // ─── Shared praxis content ────────────────────────────────────────────────────
 
 interface ContentProps {
-  praxis: PraxisCardOut
-  titleStyle?: React.CSSProperties
-  bodyStyle?: React.CSSProperties
-  metaStyle?: React.CSSProperties
+  praxis: PraxisCardOut;
+  titleStyle?: React.CSSProperties;
+  bodyStyle?: React.CSSProperties;
+  metaStyle?: React.CSSProperties;
 }
 
-function PraxisContent({ praxis, titleStyle, bodyStyle, metaStyle }: ContentProps) {
+function PraxisContent({ praxis, titleStyle, metaStyle }: ContentProps) {
   return (
     <>
       <Link to={`/praxes/${praxis.id}`}>
-        <h3 className="font-display font-semibold leading-tight hover:underline" style={{ fontSize: 'var(--text-lg)', marginBottom: 6, ...titleStyle }}>
+        <h3
+          className="font-display font-semibold leading-tight hover:underline"
+          style={{ fontSize: "var(--text-lg)", marginBottom: 6, ...titleStyle }}
+        >
           {praxis.title}
         </h3>
       </Link>
-      {praxis.body_text && (
-        <p className="font-body text-sm leading-relaxed line-clamp-3" style={{ marginBottom: 6, ...bodyStyle }}>
-          {praxis.body_text}
-        </p>
-      )}
-      <Link to={`/tasks/${praxis.task_id}`} className="font-body hover:underline" style={{ fontSize: 'var(--text-xs)', ...metaStyle }}>
+      <Link
+        to={`/tasks/${praxis.task_id}`}
+        className="font-body hover:underline"
+        style={{ fontSize: "var(--text-xs)", ...metaStyle }}
+      >
         {praxis.task_title}
       </Link>
-      <div className="flex justify-between items-center font-body" style={{ fontSize: 'var(--text-xs)', marginTop: 8, paddingTop: 6, borderTop: '1px dashed rgba(128,128,128,0.3)', ...metaStyle }}>
-        <Link to={`/characters/${praxis.created_by_id}`} className="hover:underline">
+      <div
+        className="flex justify-between items-center font-body"
+        style={{
+          fontSize: "var(--text-xs)",
+          marginTop: 8,
+          paddingTop: 6,
+          borderTop: "1px dashed rgba(128,128,128,0.3)",
+          ...metaStyle,
+        }}
+      >
+        <Link
+          to={`/characters/${praxis.created_by_id}`}
+          className="hover:underline"
+        >
           {praxis.created_by_display_name || `#${praxis.created_by_id}`}
         </Link>
         {praxis.score !== null && (
-          <span className="font-display font-bold" style={{ fontSize: 'var(--text-sm)', color: 'inherit' }}>
+          <span
+            className="font-display font-bold"
+            style={{ fontSize: "var(--text-sm)", color: "inherit" }}
+          >
             {praxis.score.toFixed(1)}
           </span>
         )}
       </div>
     </>
-  )
+  );
 }
 
 // ─── Admin overlay ────────────────────────────────────────────────────────────
 
 interface AdminProps {
-  praxis: PraxisCardOut
-  showAdminControls: boolean
-  onHide: (e: React.MouseEvent) => void
-  onFail: (e: React.MouseEvent) => void
-  moderateError: string | null
+  praxis: PraxisCardOut;
+  showAdminControls: boolean;
+  onHide: (e: React.MouseEvent) => void;
+  onFail: (e: React.MouseEvent) => void;
+  moderateError: string | null;
 }
 
-function AdminOverlay({ praxis, showAdminControls, onHide, onFail, moderateError }: AdminProps) {
+function AdminOverlay({
+  praxis,
+  showAdminControls,
+  onHide,
+  onFail,
+  moderateError,
+}: AdminProps) {
   return (
     <>
-      {praxis.moderation_status === 'flagged' && (
-        <span className="eyebrow" style={{ position: 'absolute', top: 8, right: 8, fontSize: 7, padding: '1px 5px', border: '1px solid rgba(220,38,38,0.4)', color: 'var(--color-danger)', background: 'rgba(220,38,38,0.05)' }}>
+      {praxis.moderation_status === "flagged" && (
+        <span
+          className="eyebrow"
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            fontSize: 7,
+            padding: "1px 5px",
+            border: "1px solid rgba(220,38,38,0.4)",
+            color: "var(--color-danger)",
+            background: "rgba(220,38,38,0.05)",
+          }}
+        >
           under review
         </span>
       )}
-      {praxis.moderation_status === 'failed' && (
-        <span className="eyebrow" style={{ position: 'absolute', top: 8, right: 8, fontSize: 7, padding: '1px 5px', border: '1px solid rgba(245,158,11,0.4)', color: 'var(--color-warning)', background: 'rgba(245,158,11,0.05)' }}>
+      {praxis.moderation_status === "failed" && (
+        <span
+          className="eyebrow"
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            fontSize: 7,
+            padding: "1px 5px",
+            border: "1px solid rgba(245,158,11,0.4)",
+            color: "var(--color-warning)",
+            background: "rgba(245,158,11,0.05)",
+          }}
+        >
           failed
         </span>
       )}
-      {praxis.moderation_status === 'hidden' && (
-        <span className="eyebrow" style={{ position: 'absolute', top: 8, right: 8, fontSize: 7, padding: '1px 5px', border: '1px solid rgba(107,114,128,0.4)', color: 'var(--color-text-secondary)', background: 'rgba(107,114,128,0.05)' }}>
+      {praxis.moderation_status === "hidden" && (
+        <span
+          className="eyebrow"
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            fontSize: 7,
+            padding: "1px 5px",
+            border: "1px solid rgba(107,114,128,0.4)",
+            color: "var(--color-text-secondary)",
+            background: "rgba(107,114,128,0.05)",
+          }}
+        >
           hidden
         </span>
       )}
       {moderateError && (
-        <p className="font-body" style={{ fontSize: 'var(--text-xs)', color: 'var(--color-danger)', marginBottom: 4 }}>{moderateError}</p>
+        <p
+          className="font-body"
+          style={{
+            fontSize: "var(--text-xs)",
+            color: "var(--color-danger)",
+            marginBottom: 4,
+          }}
+        >
+          {moderateError}
+        </p>
       )}
-      {showAdminControls && praxis.moderation_status === 'visible' && (
-        <div style={{ position: 'absolute', top: 8, right: 8, display: 'flex', gap: 4 }}>
-          <button onClick={onHide} className="eyebrow" style={{ fontSize: 7, padding: '1px 5px', border: '1px solid rgba(220,38,38,0.3)', color: 'var(--color-danger)', background: 'rgba(220,38,38,0.05)', cursor: 'pointer' }}>hide</button>
-          <button onClick={onFail} className="eyebrow" style={{ fontSize: 7, padding: '1px 5px', border: '1px solid rgba(245,158,11,0.3)', color: 'var(--color-warning)', background: 'rgba(245,158,11,0.05)', cursor: 'pointer' }}>fail</button>
+      {showAdminControls && praxis.moderation_status === "visible" && (
+        <div
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            display: "flex",
+            gap: 4,
+          }}
+        >
+          <button
+            onClick={onHide}
+            className="eyebrow"
+            style={{
+              fontSize: 7,
+              padding: "1px 5px",
+              border: "1px solid rgba(220,38,38,0.3)",
+              color: "var(--color-danger)",
+              background: "rgba(220,38,38,0.05)",
+              cursor: "pointer",
+            }}
+          >
+            hide
+          </button>
+          <button
+            onClick={onFail}
+            className="eyebrow"
+            style={{
+              fontSize: 7,
+              padding: "1px 5px",
+              border: "1px solid rgba(245,158,11,0.3)",
+              color: "var(--color-warning)",
+              background: "rgba(245,158,11,0.05)",
+              cursor: "pointer",
+            }}
+          >
+            fail
+          </button>
         </div>
       )}
     </>
-  )
+  );
 }
 
 // ─── Per-faction archetypes ───────────────────────────────────────────────────
 
-const ROTATIONS = [-2, 1.5, -1, 2.5]
+const ROTATIONS = [-2, 1.5, -1, 2.5];
 
-function UAPraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
-  const rotation = ROTATIONS[(praxis.task_faction_slug ?? '').length % ROTATIONS.length]
+function UAPraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
+  const rotation =
+    ROTATIONS[(praxis.task_faction_slug ?? "").length % ROTATIONS.length];
   return (
     <div
       style={{
-        width: '100%', flex: '1 1 280px', minWidth: 280,
-        background: factionCssVar('ua', 'card-bg'),
-        clipPath: 'polygon(0 0, 100% 0, 100% 88%, 88% 100%, 0 100%)',
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        background: factionCssVar("ua", "card-bg"),
+        clipPath: "polygon(0 0, 100% 0, 100% 88%, 88% 100%, 0 100%)",
         transform: `rotate(${rotation}deg)`,
-        position: 'relative',
-        padding: '28px 16px 20px',
+        position: "relative",
+        padding: "28px 16px 20px",
         fontFamily: "'Courier Prime', monospace",
-        color: factionCssVar('ua', 'card-text'),
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
+        color: factionCssVar("ua", "card-text"),
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
       }}
     >
-      <div style={{ position: 'absolute', top: 8, left: '50%', transform: 'translateX(-50%)', width: 10, height: 10, borderRadius: '50%', background: factionCssVar('ua', 'card-accent'), border: '2px solid rgba(0,0,0,0.25)' }} />
-      <AdminOverlay {...adminProps} />
-      <PraxisContent praxis={praxis} bodyStyle={{ color: factionCssVar('ua', 'card-muted') }} metaStyle={{ color: factionCssVar('ua', 'card-muted') }} />
-    </div>
-  )
-}
-
-function AnalogPraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
-  return (
-    <div
-      style={{
-        width: '100%', flex: '1 1 280px', minWidth: 280,
-        background: factionCssVar('analog', 'card-bg'),
-        border: '1px solid var(--color-border)',
-        clipPath: 'polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)',
-        position: 'relative',
-        padding: '14px 16px 28px 28px',
-        fontFamily: "'Special Elite', serif",
-        color: factionCssVar('analog', 'card-text'),
-        backgroundImage: 'repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.08) 17px, rgba(100,140,200,0.08) 18px)',
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
-      }}
-    >
-      <div style={{ position: 'absolute', left: 22, top: 0, bottom: 0, width: 1, background: 'rgba(220,80,80,0.2)' }} />
-      <AdminOverlay {...adminProps} />
-      <PraxisContent praxis={praxis} bodyStyle={{ color: factionCssVar('analog', 'card-muted') }} metaStyle={{ color: factionCssVar('analog', 'card-muted') }} />
-    </div>
-  )
-}
-
-function GestaltPraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
-  return (
-    <div style={{ position: 'relative', width: '100%', flex: '1 1 280px', minWidth: 280, minHeight: 140, boxSizing: 'border-box' }}>
-      <div style={{ position: 'absolute', top: 10, left: -4, right: -4, height: 24, background: 'var(--faction-gestalt-scrap-deep)', border: '1.5px solid rgba(0,0,0,0.12)', transform: 'rotate(-4deg)', borderRadius: 1 }} />
-      <div style={{ position: 'absolute', top: 4, left: -2, right: -2, height: 36, background: 'var(--faction-gestalt-scrap-mid)', border: '1.5px solid rgba(0,0,0,0.12)', transform: 'rotate(3deg)', borderRadius: 1 }} />
       <div
         style={{
-          position: 'relative',
-          background: factionCssVar('gestalt', 'card-bg'),
-          border: '1.5px solid rgba(0,0,0,0.12)',
-          transform: 'rotate(-2deg)',
-          padding: '22px 14px 16px',
-          fontFamily: "'Courier Prime', monospace",
-          color: factionCssVar('gestalt', 'card-text'),
-          zIndex: 2,
-          transition: 'background 150ms, color 150ms',
-          boxSizing: 'border-box',
+          position: "absolute",
+          top: 8,
+          left: "50%",
+          transform: "translateX(-50%)",
+          width: 10,
+          height: 10,
+          borderRadius: "50%",
+          background: factionCssVar("ua", "card-accent"),
+          border: "2px solid rgba(0,0,0,0.25)",
         }}
-      >
-        <div style={{ position: 'absolute', top: 5, left: '50%', transform: 'translateX(-50%) rotate(-1deg)', width: 48, height: 14, background: 'var(--faction-gestalt-tape)', borderRadius: 1 }} />
-        <AdminOverlay {...adminProps} />
-        <PraxisContent praxis={praxis} bodyStyle={{ color: factionCssVar('gestalt', 'card-muted') }} metaStyle={{ color: factionCssVar('gestalt', 'card-muted') }} />
-      </div>
+      />
+      <AdminOverlay {...adminProps} />
+      <PraxisContent
+        praxis={praxis}
+        bodyStyle={{ color: factionCssVar("ua", "card-muted") }}
+        metaStyle={{ color: factionCssVar("ua", "card-muted") }}
+      />
     </div>
-  )
+  );
 }
 
-const SNIDE_TORN_CLIP = 'polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)'
-
-function SnidePraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
+function AnalogPraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
   return (
     <div
       style={{
-        width: '100%', flex: '1 1 280px', minWidth: 280,
-        background: factionCssVar('snide', 'card-bg'),
-        position: 'relative',
-        padding: '14px 14px 16px',
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        background: factionCssVar("analog", "card-bg"),
+        border: "1px solid var(--color-border)",
+        clipPath:
+          "polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)",
+        position: "relative",
+        padding: "14px 16px 28px 28px",
         fontFamily: "'Special Elite', serif",
-        color: factionCssVar('snide', 'card-text'),
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
+        color: factionCssVar("analog", "card-text"),
+        backgroundImage:
+          "repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.08) 17px, rgba(100,140,200,0.08) 18px)",
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
       }}
     >
-      <div style={{ position: 'absolute', top: -1, left: 0, right: 0, height: 6, background: 'var(--color-bg-page)', clipPath: SNIDE_TORN_CLIP }} />
-      <div style={{ position: 'absolute', bottom: -1, left: 0, right: 0, height: 6, background: 'var(--color-bg-page)', clipPath: SNIDE_TORN_CLIP }} />
-      <div style={{ fontSize: 7, textTransform: 'uppercase', letterSpacing: '0.25em', color: factionCssVar('snide', 'card-muted'), borderBottom: `1.5px solid ${factionCssVar('snide', 'card-accent')}`, paddingBottom: 3, marginBottom: 6 }}>
+      <div
+        style={{
+          position: "absolute",
+          left: 22,
+          top: 0,
+          bottom: 0,
+          width: 1,
+          background: "rgba(220,80,80,0.2)",
+        }}
+      />
+      <AdminOverlay {...adminProps} />
+      <PraxisContent
+        praxis={praxis}
+        bodyStyle={{ color: factionCssVar("analog", "card-muted") }}
+        metaStyle={{ color: factionCssVar("analog", "card-muted") }}
+      />
+    </div>
+  );
+}
+
+function GestaltPraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        minHeight: 140,
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: 10,
+          left: -4,
+          right: -4,
+          height: 24,
+          background: "var(--faction-gestalt-scrap-deep)",
+          border: "1.5px solid rgba(0,0,0,0.12)",
+          transform: "rotate(-4deg)",
+          borderRadius: 1,
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 4,
+          left: -2,
+          right: -2,
+          height: 36,
+          background: "var(--faction-gestalt-scrap-mid)",
+          border: "1.5px solid rgba(0,0,0,0.12)",
+          transform: "rotate(3deg)",
+          borderRadius: 1,
+        }}
+      />
+      <div
+        style={{
+          position: "relative",
+          background: factionCssVar("gestalt", "card-bg"),
+          border: "1.5px solid rgba(0,0,0,0.12)",
+          transform: "rotate(-2deg)",
+          padding: "22px 14px 16px",
+          fontFamily: "'Courier Prime', monospace",
+          color: factionCssVar("gestalt", "card-text"),
+          zIndex: 2,
+          transition: "background 150ms, color 150ms",
+          boxSizing: "border-box",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 5,
+            left: "50%",
+            transform: "translateX(-50%) rotate(-1deg)",
+            width: 48,
+            height: 14,
+            background: "var(--faction-gestalt-tape)",
+            borderRadius: 1,
+          }}
+        />
+        <AdminOverlay {...adminProps} />
+        <PraxisContent
+          praxis={praxis}
+          bodyStyle={{ color: factionCssVar("gestalt", "card-muted") }}
+          metaStyle={{ color: factionCssVar("gestalt", "card-muted") }}
+        />
+      </div>
+    </div>
+  );
+}
+
+const SNIDE_TORN_CLIP =
+  "polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)";
+
+function SnidePraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        background: factionCssVar("snide", "card-bg"),
+        position: "relative",
+        padding: "14px 14px 16px",
+        fontFamily: "'Special Elite', serif",
+        color: factionCssVar("snide", "card-text"),
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -1,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: "var(--color-bg-page)",
+          clipPath: SNIDE_TORN_CLIP,
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: -1,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: "var(--color-bg-page)",
+          clipPath: SNIDE_TORN_CLIP,
+        }}
+      />
+      <div
+        style={{
+          fontSize: 7,
+          textTransform: "uppercase",
+          letterSpacing: "0.25em",
+          color: factionCssVar("snide", "card-muted"),
+          borderBottom: `1.5px solid ${factionCssVar("snide", "card-accent")}`,
+          paddingBottom: 3,
+          marginBottom: 6,
+        }}
+      >
         The Daily Snide Gazette
       </div>
       <AdminOverlay {...adminProps} />
-      <PraxisContent praxis={praxis} bodyStyle={{ color: factionCssVar('snide', 'card-muted') }} metaStyle={{ color: factionCssVar('snide', 'card-muted') }} />
+      <PraxisContent
+        praxis={praxis}
+        bodyStyle={{ color: factionCssVar("snide", "card-muted") }}
+        metaStyle={{ color: factionCssVar("snide", "card-muted") }}
+      />
     </div>
-  )
+  );
 }
 
-function JourneymenPraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
+function JourneymenPraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
   return (
-    <div style={{ paddingTop: 26, position: 'relative', width: '100%', flex: '1 1 280px', minWidth: 280, boxSizing: 'border-box' }}>
-      <div style={{ position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-        <div style={{ width: 0, height: 14, borderLeft: `2px dashed ${factionCssVar('journeymen', 'card-accent')}` }} />
-        <div style={{ width: 10, height: 10, borderRadius: '50%', border: `2px solid ${factionCssVar('journeymen', 'card-accent')}`, background: 'var(--color-bg-page)' }} />
+    <div
+      style={{
+        paddingTop: 26,
+        position: "relative",
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: "50%",
+          transform: "translateX(-50%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <div
+          style={{
+            width: 0,
+            height: 14,
+            borderLeft: `2px dashed ${factionCssVar("journeymen", "card-accent")}`,
+          }}
+        />
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            border: `2px solid ${factionCssVar("journeymen", "card-accent")}`,
+            background: "var(--color-bg-page)",
+          }}
+        />
       </div>
       <div
         style={{
-          border: `2px solid ${factionCssVar('journeymen', 'card-accent')}`,
-          background: factionCssVar('journeymen', 'card-bg'),
+          border: `2px solid ${factionCssVar("journeymen", "card-accent")}`,
+          background: factionCssVar("journeymen", "card-bg"),
           fontFamily: "'Courier Prime', monospace",
-          color: factionCssVar('journeymen', 'card-text'),
-          position: 'relative',
-          transition: 'background 150ms, color 150ms',
+          color: factionCssVar("journeymen", "card-text"),
+          position: "relative",
+          transition: "background 150ms, color 150ms",
         }}
       >
-        <div style={{ height: 4, backgroundImage: `repeating-linear-gradient(90deg, var(--faction-journeymen-stripe-red) 0, var(--faction-journeymen-stripe-red) 8px, ${factionCssVar('journeymen', 'card-bg')} 8px, ${factionCssVar('journeymen', 'card-bg')} 16px, var(--faction-journeymen-stripe-amber) 16px, var(--faction-journeymen-stripe-amber) 24px, ${factionCssVar('journeymen', 'card-bg')} 24px, ${factionCssVar('journeymen', 'card-bg')} 32px)` }} />
-        <div style={{ padding: '10px 14px 14px' }}>
+        <div
+          style={{
+            height: 4,
+            backgroundImage: `repeating-linear-gradient(90deg, var(--faction-journeymen-stripe-red) 0, var(--faction-journeymen-stripe-red) 8px, ${factionCssVar("journeymen", "card-bg")} 8px, ${factionCssVar("journeymen", "card-bg")} 16px, var(--faction-journeymen-stripe-amber) 16px, var(--faction-journeymen-stripe-amber) 24px, ${factionCssVar("journeymen", "card-bg")} 24px, ${factionCssVar("journeymen", "card-bg")} 32px)`,
+          }}
+        />
+        <div style={{ padding: "10px 14px 14px" }}>
           <AdminOverlay {...adminProps} />
-          <PraxisContent praxis={praxis} bodyStyle={{ color: factionCssVar('journeymen', 'card-muted') }} metaStyle={{ color: factionCssVar('journeymen', 'card-muted') }} />
+          <PraxisContent
+            praxis={praxis}
+            bodyStyle={{ color: factionCssVar("journeymen", "card-muted") }}
+            metaStyle={{ color: factionCssVar("journeymen", "card-muted") }}
+          />
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 function SingularityHoles() {
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', gap: 6, padding: '4px 0' }}>
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        gap: 6,
+        padding: "4px 0",
+      }}
+    >
       {Array.from({ length: 5 }).map((_, index) => (
-        <div key={index} style={{ width: 6, height: 4, background: 'rgba(10,26,14)', border: '1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))', borderRadius: 1 }} />
+        <div
+          key={index}
+          style={{
+            width: 6,
+            height: 4,
+            background: "rgba(10,26,14)",
+            border:
+              "1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))",
+            borderRadius: 1,
+          }}
+        />
       ))}
     </div>
-  )
+  );
 }
 
-function SingularityPraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
+function SingularityPraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
   return (
     <div
       style={{
-        width: '100%', flex: '1 1 280px', minWidth: 280,
-        background: 'var(--faction-singularity-card-bg)',
-        border: '1px solid var(--faction-singularity-border-hard)',
-        position: 'relative',
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        background: "var(--faction-singularity-card-bg)",
+        border: "1px solid var(--faction-singularity-border-hard)",
+        position: "relative",
         fontFamily: "'Share Tech Mono', monospace",
-        color: 'var(--faction-singularity-card-text)',
-        overflow: 'hidden',
-        boxSizing: 'border-box',
+        color: "var(--faction-singularity-card-text)",
+        overflow: "hidden",
+        boxSizing: "border-box",
       }}
     >
-      <div style={{ position: 'absolute', inset: 0, backgroundImage: 'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)', pointerEvents: 'none', zIndex: 1 }} />
-      <div style={{ position: 'absolute', top: 3, left: 3, width: 10, height: 10, borderTop: '1px solid var(--faction-singularity-card-text)', borderLeft: '1px solid var(--faction-singularity-card-text)' }} />
-      <div style={{ position: 'absolute', top: 3, right: 3, width: 10, height: 10, borderTop: '1px solid var(--faction-singularity-card-text)', borderRight: '1px solid var(--faction-singularity-card-text)' }} />
-      <div style={{ position: 'absolute', bottom: 3, left: 3, width: 10, height: 10, borderBottom: '1px solid var(--faction-singularity-card-text)', borderLeft: '1px solid var(--faction-singularity-card-text)' }} />
-      <div style={{ position: 'absolute', bottom: 3, right: 3, width: 10, height: 10, borderBottom: '1px solid var(--faction-singularity-card-text)', borderRight: '1px solid var(--faction-singularity-card-text)' }} />
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage:
+            "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)",
+          pointerEvents: "none",
+          zIndex: 1,
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 3,
+          left: 3,
+          width: 10,
+          height: 10,
+          borderTop: "1px solid var(--faction-singularity-card-text)",
+          borderLeft: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 3,
+          right: 3,
+          width: 10,
+          height: 10,
+          borderTop: "1px solid var(--faction-singularity-card-text)",
+          borderRight: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: 3,
+          left: 3,
+          width: 10,
+          height: 10,
+          borderBottom: "1px solid var(--faction-singularity-card-text)",
+          borderLeft: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: 3,
+          right: 3,
+          width: 10,
+          height: 10,
+          borderBottom: "1px solid var(--faction-singularity-card-text)",
+          borderRight: "1px solid var(--faction-singularity-card-text)",
+        }}
+      />
       <SingularityHoles />
-      <div style={{ padding: '6px 16px 12px', position: 'relative', zIndex: 2 }}>
-        <div style={{ fontSize: 8, color: 'var(--faction-singularity-card-muted)', textTransform: 'uppercase', letterSpacing: '0.15em', marginBottom: 8 }}>
+      <div
+        style={{ padding: "6px 16px 12px", position: "relative", zIndex: 2 }}
+      >
+        <div
+          style={{
+            fontSize: 8,
+            color: "var(--faction-singularity-card-muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.15em",
+            marginBottom: 8,
+          }}
+        >
           singularity protocol
-          <span style={{ display: 'inline-block', width: 5, height: 9, background: 'var(--faction-singularity-card-text)', marginLeft: 3, verticalAlign: 'middle', animation: 'blink 1s step-end infinite' }} />
+          <span
+            style={{
+              display: "inline-block",
+              width: 5,
+              height: 9,
+              background: "var(--faction-singularity-card-text)",
+              marginLeft: 3,
+              verticalAlign: "middle",
+              animation: "blink 1s step-end infinite",
+            }}
+          />
         </div>
         <AdminOverlay {...adminProps} />
-        <PraxisContent praxis={praxis} bodyStyle={{ color: 'var(--faction-singularity-card-muted)', fontSize: 9 }} metaStyle={{ color: 'var(--faction-singularity-card-muted)' }} />
+        <PraxisContent
+          praxis={praxis}
+          bodyStyle={{
+            color: "var(--faction-singularity-card-muted)",
+            fontSize: 9,
+          }}
+          metaStyle={{ color: "var(--faction-singularity-card-muted)" }}
+        />
       </div>
       <SingularityHoles />
       <style>{`@keyframes blink { 50% { opacity: 0; } }`}</style>
     </div>
-  )
+  );
 }
 
-function UAMastersPraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
+function UAMastersPraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
   return (
     <div
       style={{
-        width: '100%', flex: '1 1 280px', minWidth: 280,
-        background: factionCssVar('ua_masters', 'card-bg'),
-        border: '1px solid var(--color-border)',
-        clipPath: 'polygon(0 0, 98% 0, 100% 2%, 100% 98%, 98% 100%, 2% 100%, 0 98%, 0 2%)',
-        padding: '12px 14px 16px',
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        background: factionCssVar("ua_masters", "card-bg"),
+        border: "1px solid var(--color-border)",
+        clipPath:
+          "polygon(0 0, 98% 0, 100% 2%, 100% 98%, 98% 100%, 2% 100%, 0 98%, 0 2%)",
+        padding: "12px 14px 16px",
         fontFamily: "'Special Elite', serif",
-        color: factionCssVar('ua_masters', 'card-text'),
-        position: 'relative',
-        transition: 'background 150ms, color 150ms',
-        boxSizing: 'border-box',
+        color: factionCssVar("ua_masters", "card-text"),
+        position: "relative",
+        transition: "background 150ms, color 150ms",
+        boxSizing: "border-box",
       }}
     >
-      <div style={{ fontSize: 7, textTransform: 'uppercase', letterSpacing: '0.2em', color: factionCssVar('ua_masters', 'card-muted'), borderBottom: `2px solid ${factionCssVar('ua_masters', 'card-accent')}`, paddingBottom: 4, marginBottom: 6 }}>
+      <div
+        style={{
+          fontSize: 7,
+          textTransform: "uppercase",
+          letterSpacing: "0.2em",
+          color: factionCssVar("ua_masters", "card-muted"),
+          borderBottom: `2px solid ${factionCssVar("ua_masters", "card-accent")}`,
+          paddingBottom: 4,
+          marginBottom: 6,
+        }}
+      >
         The UA Masters Gazette
       </div>
       <AdminOverlay {...adminProps} />
-      <PraxisContent praxis={praxis} bodyStyle={{ color: factionCssVar('ua_masters', 'card-muted') }} metaStyle={{ color: factionCssVar('ua_masters', 'card-muted') }} />
+      <PraxisContent
+        praxis={praxis}
+        bodyStyle={{ color: factionCssVar("ua_masters", "card-muted") }}
+        metaStyle={{ color: factionCssVar("ua_masters", "card-muted") }}
+      />
     </div>
-  )
+  );
 }
 
-function GenericPraxisCard({ praxis, adminProps }: { praxis: PraxisCardOut; adminProps: AdminProps }) {
-  const slug = praxis.task_faction_slug ?? 'ua'
+function GenericPraxisCard({
+  praxis,
+  adminProps,
+}: {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+}) {
+  const slug = praxis.task_faction_slug ?? "ua";
   return (
     <div
       style={{
-        width: '100%', flex: '1 1 280px', minWidth: 280,
-        background: factionCssVar(slug, 'card-bg'),
-        borderLeft: `4px solid ${factionCssVar(slug, 'card-accent')}`,
-        color: factionCssVar(slug, 'card-text'),
-        padding: '14px 16px',
-        position: 'relative',
-        boxSizing: 'border-box',
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        background: factionCssVar(slug, "card-bg"),
+        borderLeft: `4px solid ${factionCssVar(slug, "card-accent")}`,
+        color: factionCssVar(slug, "card-text"),
+        padding: "14px 16px",
+        position: "relative",
+        boxSizing: "border-box",
       }}
     >
       <AdminOverlay {...adminProps} />
-      <PraxisContent praxis={praxis} bodyStyle={{ color: factionCssVar(slug, 'card-muted') }} metaStyle={{ color: factionCssVar(slug, 'card-muted') }} />
+      <PraxisContent
+        praxis={praxis}
+        bodyStyle={{ color: factionCssVar(slug, "card-muted") }}
+        metaStyle={{ color: factionCssVar(slug, "card-muted") }}
+      />
     </div>
-  )
+  );
 }
 
 // ─── Switcher ─────────────────────────────────────────────────────────────────
 
 export default function PraxisCard({ praxis, onModerated }: Props) {
-  const { user } = useAuth()
-  const { adminMode } = useAdminMode()
-  const showAdminControls = (user?.is_admin && adminMode) ?? false
-  const [localPraxis, setLocalPraxis] = useState(praxis)
-  const [moderateError, setModerateError] = useState<string | null>(null)
+  const { user } = useAuth();
+  const { adminMode } = useAdminMode();
+  const showAdminControls = (user?.is_admin && adminMode) ?? false;
+  const [localPraxis, setLocalPraxis] = useState(praxis);
+  const [moderateError, setModerateError] = useState<string | null>(null);
 
-  const applyModeration = (status: 'hidden' | 'failed' | 'visible' | 'flagged') => {
-    setLocalPraxis((prev) => ({ ...prev, moderation_status: status }))
-  }
+  const applyModeration = (
+    status: "hidden" | "failed" | "visible" | "flagged",
+  ) => {
+    setLocalPraxis((prev) => ({ ...prev, moderation_status: status }));
+  };
 
   const handleHide = async (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setModerateError(null)
+    e.preventDefault();
+    e.stopPropagation();
+    setModerateError(null);
     try {
-      const updated = await moderatePraxis(localPraxis.id, 'hidden')
-      applyModeration(updated.moderation_status)
-      onModerated?.()
+      const updated = await moderatePraxis(localPraxis.id, "hidden");
+      applyModeration(updated.moderation_status);
+      onModerated?.();
     } catch (err) {
-      setModerateError(extractError(err, 'Failed to hide.'))
+      setModerateError(extractError(err, "Failed to hide."));
     }
-  }
+  };
 
   const handleFail = async (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setModerateError(null)
+    e.preventDefault();
+    e.stopPropagation();
+    setModerateError(null);
     try {
-      const updated = await moderatePraxis(localPraxis.id, 'failed')
-      applyModeration(updated.moderation_status)
-      onModerated?.()
+      const updated = await moderatePraxis(localPraxis.id, "failed");
+      applyModeration(updated.moderation_status);
+      onModerated?.();
     } catch (err) {
-      setModerateError(extractError(err, 'Failed to fail.'))
+      setModerateError(extractError(err, "Failed to fail."));
     }
-  }
+  };
 
   const adminProps: AdminProps = {
     praxis: localPraxis,
@@ -359,24 +792,30 @@ export default function PraxisCard({ praxis, onModerated }: Props) {
     onHide: handleHide,
     onFail: handleFail,
     moderateError,
-  }
+  };
 
   switch (localPraxis.task_faction_slug) {
-    case 'ua':
-      return <UAPraxisCard praxis={localPraxis} adminProps={adminProps} />
-    case 'analog':
-      return <AnalogPraxisCard praxis={localPraxis} adminProps={adminProps} />
-    case 'gestalt':
-      return <GestaltPraxisCard praxis={localPraxis} adminProps={adminProps} />
-    case 'snide':
-      return <SnidePraxisCard praxis={localPraxis} adminProps={adminProps} />
-    case 'journeymen':
-      return <JourneymenPraxisCard praxis={localPraxis} adminProps={adminProps} />
-    case 'singularity':
-      return <SingularityPraxisCard praxis={localPraxis} adminProps={adminProps} />
-    case 'ua_masters':
-      return <UAMastersPraxisCard praxis={localPraxis} adminProps={adminProps} />
+    case "ua":
+      return <UAPraxisCard praxis={localPraxis} adminProps={adminProps} />;
+    case "analog":
+      return <AnalogPraxisCard praxis={localPraxis} adminProps={adminProps} />;
+    case "gestalt":
+      return <GestaltPraxisCard praxis={localPraxis} adminProps={adminProps} />;
+    case "snide":
+      return <SnidePraxisCard praxis={localPraxis} adminProps={adminProps} />;
+    case "journeymen":
+      return (
+        <JourneymenPraxisCard praxis={localPraxis} adminProps={adminProps} />
+      );
+    case "singularity":
+      return (
+        <SingularityPraxisCard praxis={localPraxis} adminProps={adminProps} />
+      );
+    case "ua_masters":
+      return (
+        <UAMastersPraxisCard praxis={localPraxis} adminProps={adminProps} />
+      );
     default:
-      return <GenericPraxisCard praxis={localPraxis} adminProps={adminProps} />
+      return <GenericPraxisCard praxis={localPraxis} adminProps={adminProps} />;
   }
 }

--- a/frontend/src/components/cards/TaskCardSingularity.tsx
+++ b/frontend/src/components/cards/TaskCardSingularity.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import type { TaskOut } from "../../api/tasks";
+import { factionCssVar } from "../../utils/factions";
 
 /**
  * Singularity — Terminal Printout.

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -29,7 +29,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
   const [loading, setLoading] = useState(false);
   // Task-list-full modal state
   const [showDropModal, setShowDropModal] = useState(false);
-  const [myTasks, setMyTasks] = useState<
+  const [myTasks] = useState<
     { id: number; task: { id: number; title: string } }[]
   >([]);
   const [dropError, setDropError] = useState("");

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -1,77 +1,86 @@
-import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import type { ActivityFeedItem } from '../../api/activityFeed'
-import { respondToInvite } from '../../api/praxis'
-import { factionColor, factionCssVar } from '../../utils/factions'
-import { relativeTime } from '../../utils/dates'
-import FeedBadge from './FeedBadge'
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import type { ActivityFeedItem } from "../../api/activityFeed";
+import { respondToInvite } from "../../api/praxis";
+import { factionColor, factionCssVar } from "../../utils/factions";
+import { relativeTime } from "../../utils/dates";
+import FeedBadge from "./FeedBadge";
 
 interface Props {
-  item: ActivityFeedItem
+  item: ActivityFeedItem;
 }
 
 export default function FeedCardDuelChallenge({ item }: Props) {
   const {
-    invite_id, praxis_id, task_title, task_point_value, task_faction_slug,
-    invite_status, challenger_character_id,
-  } = item.payload
-  const taskColor = factionColor(task_faction_slug)
-  const actorColor = factionColor(item.actor_faction_slug)
-  const navigate = useNavigate()
+    invite_id,
+    praxis_id,
+    task_title,
+    task_point_value,
+    task_faction_slug,
+    invite_status,
+    challenger_character_id,
+  } = item.payload;
+  const taskColor = factionColor(task_faction_slug);
+  const actorColor = factionColor(item.actor_faction_slug);
+  const navigate = useNavigate();
 
-  const [status, setStatus] = useState<string | null>(invite_status)
-  const [loading, setLoading] = useState(false)
+  const [status, setStatus] = useState<string | null>(invite_status);
+  const [loading, setLoading] = useState(false);
   // Task-list-full modal state
-  const [showDropModal, setShowDropModal] = useState(false)
-  const [myTasks, setMyTasks] = useState<{ id: number; task: { id: number; title: string } }[]>([])
-  const [dropError, setDropError] = useState('')
+  const [showDropModal, setShowDropModal] = useState(false);
+  const [myTasks] = useState<
+    { id: number; task: { id: number; title: string } }[]
+  >([]);
+  const [dropError, setDropError] = useState("");
 
   const doAccept = async (drop_task_id?: number) => {
-    setLoading(true)
+    setLoading(true);
     try {
-      await respondToInvite(praxis_id, invite_id, true)
+      await respondToInvite(praxis_id, invite_id, true);
       if (drop_task_id) {
         // Drop task was selected from modal — handled server-side via the task list
       }
-      setStatus('accepted')
-      setShowDropModal(false)
-      navigate(`/praxes/${praxis_id}`)
+      setStatus("accepted");
+      setShowDropModal(false);
+      navigate(`/praxes/${praxis_id}`);
     } catch {
-      setDropError('Could not accept duel. Please try again.')
+      setDropError("Could not accept duel. Please try again.");
     }
-    setLoading(false)
-  }
+    setLoading(false);
+  };
 
-  const handleAccept = () => doAccept()
+  const handleAccept = () => doAccept();
 
   const handleDecline = async () => {
-    setLoading(true)
+    setLoading(true);
     try {
-      await respondToInvite(praxis_id, invite_id, false)
-      setStatus('declined')
-    } catch { /* swallow */ }
-    setLoading(false)
-  }
+      await respondToInvite(praxis_id, invite_id, false);
+      setStatus("declined");
+    } catch {
+      /* swallow */
+    }
+    setLoading(false);
+  };
 
-  const isPending = status === 'pending' || status === null
+  const isPending = status === "pending" || status === null;
 
   return (
     <>
       <div
         className="sidebar-card"
         style={{
-          padding: '12px 16px',
-          borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}`,
-          background: factionCssVar(task_faction_slug, 'card-bg'),
+          padding: "12px 16px",
+          borderLeft: `4px solid ${factionCssVar(task_faction_slug, "card-accent")}`,
+          background: factionCssVar(task_faction_slug, "card-bg"),
         }}
       >
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
           <Link to={`/characters/${challenger_character_id}`}>
             <div
               style={{
                 width: 28,
                 height: 28,
-                borderRadius: '50%',
+                borderRadius: "50%",
                 background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
                 flexShrink: 0,
                 marginTop: 2,
@@ -80,32 +89,80 @@ export default function FeedCardDuelChallenge({ item }: Props) {
           </Link>
 
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                flexWrap: "wrap",
+              }}
+            >
               <Link
                 to={`/characters/${challenger_character_id}`}
                 className="font-body"
-                style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: "var(--color-text-primary)",
+                  textDecoration: "none",
+                }}
               >
                 {item.actor_display_name}
               </Link>
-              <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              <span
+                className="font-body"
+                style={{ fontSize: 11, color: "var(--color-text-secondary)" }}
+              >
                 has challenged you to a duel
               </span>
               <FeedBadge type="duel" label="Duel" />
             </div>
-            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+            <span
+              className="eyebrow"
+              style={{
+                color: "var(--color-text-tertiary)",
+                display: "block",
+                marginTop: 2,
+              }}
+            >
               {relativeTime(item.timestamp)}
             </span>
           </div>
         </div>
 
         {/* Task detail */}
-        <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ width: 8, height: 8, borderRadius: '50%', background: taskColor, flexShrink: 0 }} />
-          <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+        <div
+          style={{
+            marginTop: 10,
+            marginLeft: 38,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: taskColor,
+              flexShrink: 0,
+            }}
+          />
+          <span
+            className="font-body"
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: "var(--color-text-primary)",
+            }}
+          >
             {task_title}
           </span>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          <span
+            className="eyebrow"
+            style={{ color: "var(--color-text-tertiary)" }}
+          >
             {task_point_value} pts · winner takes the points
           </span>
           <span style={{ fontSize: 12 }}>&#x2694;</span>
@@ -113,7 +170,16 @@ export default function FeedCardDuelChallenge({ item }: Props) {
 
         {/* Accept/Decline buttons */}
         {isPending && (
-          <div style={{ marginTop: 10, marginLeft: 38, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <div
+            style={{
+              marginTop: 10,
+              marginLeft: 38,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flexWrap: "wrap",
+            }}
+          >
             <button
               onClick={handleAccept}
               disabled={loading}
@@ -121,13 +187,13 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 9,
                 fontWeight: 700,
-                textTransform: 'uppercase',
-                letterSpacing: '0.1em',
-                background: 'var(--badge-duel)',
-                color: 'var(--color-text-on-accent)',
-                border: 'none',
-                padding: '5px 14px',
-                cursor: loading ? 'not-allowed' : 'pointer',
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                background: "var(--badge-duel)",
+                color: "var(--color-text-on-accent)",
+                border: "none",
+                padding: "5px 14px",
+                cursor: loading ? "not-allowed" : "pointer",
               }}
             >
               Accept Duel
@@ -139,33 +205,47 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 9,
                 fontWeight: 700,
-                textTransform: 'uppercase',
-                letterSpacing: '0.1em',
-                background: 'transparent',
-                color: 'var(--color-text-secondary)',
-                border: '1px solid var(--color-border)',
-                padding: '5px 14px',
-                cursor: loading ? 'not-allowed' : 'pointer',
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                background: "transparent",
+                color: "var(--color-text-secondary)",
+                border: "1px solid var(--color-border)",
+                padding: "5px 14px",
+                cursor: loading ? "not-allowed" : "pointer",
               }}
             >
               Decline
             </button>
             {dropError && (
-              <span className="eyebrow" style={{ color: 'var(--color-danger)' }}>{dropError}</span>
+              <span
+                className="eyebrow"
+                style={{ color: "var(--color-danger)" }}
+              >
+                {dropError}
+              </span>
             )}
           </div>
         )}
 
-        {status === 'accepted' && (
+        {status === "accepted" && (
           <div style={{ marginTop: 8, marginLeft: 38 }}>
-            <Link to={`/praxes/${praxis_id}`} className="eyebrow" style={{ color: 'var(--badge-duel)', textDecoration: 'none' }}>
+            <Link
+              to={`/praxes/${praxis_id}`}
+              className="eyebrow"
+              style={{ color: "var(--badge-duel)", textDecoration: "none" }}
+            >
               Duel Accepted — view duel
             </Link>
           </div>
         )}
-        {status === 'declined' && (
+        {status === "declined" && (
           <div style={{ marginTop: 8, marginLeft: 38 }}>
-            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Declined</span>
+            <span
+              className="eyebrow"
+              style={{ color: "var(--color-text-tertiary)" }}
+            >
+              Declined
+            </span>
           </div>
         )}
       </div>
@@ -174,42 +254,63 @@ export default function FeedCardDuelChallenge({ item }: Props) {
       {showDropModal && (
         <div
           style={{
-            position: 'fixed', inset: 0, zIndex: 1000,
-            background: 'rgba(0,0,0,0.5)',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000,
+            background: "rgba(0,0,0,0.5)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
             padding: 20,
           }}
           onClick={() => setShowDropModal(false)}
         >
           <div
             style={{
-              background: 'var(--color-bg-surface)',
-              border: '1px solid var(--color-border)',
-              padding: '24px',
+              background: "var(--color-bg-surface)",
+              border: "1px solid var(--color-border)",
+              padding: "24px",
               maxWidth: 420,
-              width: '100%',
+              width: "100%",
             }}
             onClick={(e) => e.stopPropagation()}
           >
-            <p className="eyebrow" style={{ marginBottom: 8 }}>Task list full</p>
-            <p className="font-body" style={{ fontSize: 11, marginBottom: 16, color: 'var(--color-text-secondary)' }}>
+            <p className="eyebrow" style={{ marginBottom: 8 }}>
+              Task list full
+            </p>
+            <p
+              className="font-body"
+              style={{
+                fontSize: 11,
+                marginBottom: 16,
+                color: "var(--color-text-secondary)",
+              }}
+            >
               You have 20 in-progress tasks. Drop one to accept this duel:
             </p>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 260, overflowY: 'auto' }}>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
+                maxHeight: 260,
+                overflowY: "auto",
+              }}
+            >
               {myTasks.map((ct) => (
                 <button
                   key={ct.id}
                   onClick={() => doAccept(ct.task.id)}
                   disabled={loading}
                   style={{
-                    background: 'var(--color-bg-surface-alt)',
-                    border: '1px solid var(--color-border)',
-                    padding: '8px 12px',
-                    cursor: 'pointer',
-                    textAlign: 'left',
+                    background: "var(--color-bg-surface-alt)",
+                    border: "1px solid var(--color-border)",
+                    padding: "8px 12px",
+                    cursor: "pointer",
+                    textAlign: "left",
                     fontFamily: "'Courier Prime', monospace",
                     fontSize: 10,
-                    color: 'var(--color-text-primary)',
+                    color: "var(--color-text-primary)",
                   }}
                 >
                   Drop: {ct.task.title}
@@ -221,10 +322,14 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               style={{
                 marginTop: 14,
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                background: 'transparent', border: '1px solid var(--color-border)',
-                padding: '5px 14px', cursor: 'pointer',
-                color: 'var(--color-text-secondary)',
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                background: "transparent",
+                border: "1px solid var(--color-border)",
+                padding: "5px 14px",
+                cursor: "pointer",
+                color: "var(--color-text-secondary)",
               }}
             >
               Cancel
@@ -233,5 +338,5 @@ export default function FeedCardDuelChallenge({ item }: Props) {
         </div>
       )}
     </>
-  )
+  );
 }

--- a/frontend/src/components/feed/FeedCardFriendDefection.tsx
+++ b/frontend/src/components/feed/FeedCardFriendDefection.tsx
@@ -1,27 +1,40 @@
-import { Link } from 'react-router-dom'
-import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionName, factionCssVar } from '../../utils/factions'
-import { relativeTime } from '../../utils/dates'
-import FeedBadge from './FeedBadge'
+import { Link } from "react-router-dom";
+import type { ActivityFeedItem } from "../../api/activityFeed";
+import { factionColor, factionCssVar } from "../../utils/factions";
+import { relativeTime } from "../../utils/dates";
+import FeedBadge from "./FeedBadge";
 
 interface Props {
-  item: ActivityFeedItem
+  item: ActivityFeedItem;
 }
 
 export default function FeedCardFriendDefection({ item }: Props) {
-  const { character_id, old_faction_slug, old_faction_name, new_faction_slug, new_faction_name } = item.payload
-  const newColor = factionColor(new_faction_slug)
-  const oldColor = factionColor(old_faction_slug)
+  const {
+    character_id,
+    old_faction_slug,
+    old_faction_name,
+    new_faction_slug,
+    new_faction_name,
+  } = item.payload;
+  const newColor = factionColor(new_faction_slug);
+  const oldColor = factionColor(old_faction_slug);
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', background: factionCssVar(new_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(new_faction_slug, 'card-accent')}` }}>
-      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+    <div
+      className="sidebar-card"
+      style={{
+        padding: "12px 16px",
+        background: factionCssVar(new_faction_slug, "card-bg"),
+        borderLeft: `4px solid ${factionCssVar(new_faction_slug, "card-accent")}`,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
         <Link to={`/characters/${character_id}`}>
           <div
             style={{
               width: 28,
               height: 28,
-              borderRadius: '50%',
+              borderRadius: "50%",
               background: `linear-gradient(135deg, ${newColor}, ${newColor}88)`,
               flexShrink: 0,
               marginTop: 2,
@@ -30,27 +43,53 @@ export default function FeedCardFriendDefection({ item }: Props) {
         </Link>
 
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              flexWrap: "wrap",
+            }}
+          >
             <Link
               to={`/characters/${character_id}`}
               className="font-body"
-              style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                color: "var(--color-text-primary)",
+                textDecoration: "none",
+              }}
             >
               {item.actor_display_name}
             </Link>
-            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
-              defected from{' '}
-              <span style={{ color: oldColor, fontWeight: 600 }}>{old_faction_name}</span>
-              {' to '}
-              <span style={{ color: newColor, fontWeight: 600 }}>{new_faction_name}</span>
+            <span
+              className="font-body"
+              style={{ fontSize: 11, color: "var(--color-text-secondary)" }}
+            >
+              defected from{" "}
+              <span style={{ color: oldColor, fontWeight: 600 }}>
+                {old_faction_name}
+              </span>
+              {" to "}
+              <span style={{ color: newColor, fontWeight: 600 }}>
+                {new_faction_name}
+              </span>
             </span>
             <FeedBadge type="friend" label="Friend" />
           </div>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 2 }}>
+          <span
+            className="eyebrow"
+            style={{
+              color: "var(--color-text-tertiary)",
+              display: "block",
+              marginTop: 2,
+            }}
+          >
             {relativeTime(item.timestamp)}
           </span>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -1,45 +1,75 @@
-import { Link } from 'react-router-dom'
-import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionName, factionCssVar } from '../../utils/factions'
-import { relativeTime } from '../../utils/dates'
-import FeedBadge from './FeedBadge'
+import { Link } from "react-router-dom";
+import type { ActivityFeedItem } from "../../api/activityFeed";
+import { factionColor, factionCssVar } from "../../utils/factions";
+import { relativeTime } from "../../utils/dates";
+import FeedBadge from "./FeedBadge";
 
 interface Props {
-  item: ActivityFeedItem
+  item: ActivityFeedItem;
 }
 
 export default function FeedCardInvitationLetter({ item }: Props) {
-  const { faction_slug, faction_name } = item.payload
-  const color = factionColor(faction_slug)
+  const { faction_slug, faction_name } = item.payload;
+  const color = factionColor(faction_slug);
 
   return (
     <div
       className="sidebar-card"
       style={{
-        padding: '16px 20px',
-        borderLeft: `4px solid ${factionCssVar(faction_slug, 'card-accent')}`,
-        background: factionCssVar(faction_slug, 'card-bg'),
-        position: 'relative',
+        padding: "16px 20px",
+        borderLeft: `4px solid ${factionCssVar(faction_slug, "card-accent")}`,
+        background: factionCssVar(faction_slug, "card-bg"),
+        position: "relative",
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 10,
+        }}
+      >
         <span style={{ fontSize: 16 }}>&#x2709;&#xFE0F;</span>
         <span className="eyebrow" style={{ color, fontSize: 8 }}>
           Faction Invitation
         </span>
         <FeedBadge type="your_stuff" label="Your Stuff" />
-        <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)', fontSize: 8 }}>
+        <span
+          className="eyebrow"
+          style={{
+            marginLeft: "auto",
+            color: "var(--color-text-tertiary)",
+            fontSize: 8,
+          }}
+        >
           {relativeTime(item.timestamp)}
         </span>
       </div>
 
-      <p className="font-display italic" style={{ fontSize: 14, color: 'var(--color-text-primary)', lineHeight: 1.4, marginBottom: 8 }}>
-        You've received an invitation to join{' '}
+      <p
+        className="font-display italic"
+        style={{
+          fontSize: 14,
+          color: "var(--color-text-primary)",
+          lineHeight: 1.4,
+          marginBottom: 8,
+        }}
+      >
+        You've received an invitation to join{" "}
         <span style={{ color, fontWeight: 700 }}>{faction_name}</span>.
       </p>
 
-      <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
-        Complete faction tasks to prove your dedication, or visit the factions page to make your choice.
+      <p
+        className="font-body"
+        style={{
+          fontSize: 10,
+          color: "var(--color-text-secondary)",
+          marginBottom: 12,
+        }}
+      >
+        Complete faction tasks to prove your dedication, or visit the factions
+        page to make your choice.
       </p>
 
       <Link
@@ -48,14 +78,14 @@ export default function FeedCardInvitationLetter({ item }: Props) {
           fontFamily: "'Courier Prime', monospace",
           fontSize: 9,
           fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.1em',
+          textTransform: "uppercase",
+          letterSpacing: "0.1em",
           color,
-          textDecoration: 'none',
+          textDecoration: "none",
         }}
       >
         View Factions &rarr;
       </Link>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -1,128 +1,160 @@
-import { useEffect, useState } from 'react'
-import { useParams, Link } from 'react-router-dom'
-import { getCharacter, type CharacterOut } from '../api/characters'
-import { listPraxes, type PraxisCardOut } from '../api/praxis'
-import { listRelationships, createRelationship, deleteRelationship, type RelationshipListItem } from '../api/relationships'
-import PraxisCard from '../components/PraxisCard'
-import PageTitle from '../components/ui/PageTitle'
-import LevelPill from '../components/ui/LevelPill'
-import { useAuth } from '../auth/AuthContext'
-import { useGameConfig } from '../hooks/useGameConfig'
-import { extractError } from '../utils/errors'
-import { factionCssVar, factionName } from '../utils/factions'
-import { mediaUrl } from '../utils/media'
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { getCharacter, type CharacterOut } from "../api/characters";
+import { listPraxes, type PraxisCardOut } from "../api/praxis";
+import {
+  listRelationships,
+  createRelationship,
+  deleteRelationship,
+  type RelationshipListItem,
+} from "../api/relationships";
+import PraxisCard from "../components/PraxisCard";
+import PageTitle from "../components/ui/PageTitle";
+import { useAuth } from "../auth/AuthContext";
+import { useGameConfig } from "../hooks/useGameConfig";
+import { extractError } from "../utils/errors";
+import { factionCssVar, factionName } from "../utils/factions";
+import { mediaUrl } from "../utils/media";
 
 export default function CharacterProfile() {
-  const { id } = useParams<{ id: string }>()
-  const { user } = useAuth()
-  const gameConfig = useGameConfig()
-  const [character, setCharacter] = useState<CharacterOut | null>(null)
-  const [submissions, setSubmissions] = useState<PraxisCardOut[]>([])
-  const [relationship, setRelationship] = useState<RelationshipListItem | null>(null)
-  const [relationshipLoading, setRelationshipLoading] = useState(false)
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
+  const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
+  const gameConfig = useGameConfig();
+  const [character, setCharacter] = useState<CharacterOut | null>(null);
+  const [submissions, setSubmissions] = useState<PraxisCardOut[]>([]);
+  const [relationship, setRelationship] = useState<RelationshipListItem | null>(
+    null,
+  );
+  const [relationshipLoading, setRelationshipLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!id) return
-    const cid = parseInt(id, 10)
+    if (!id) return;
+    const cid = parseInt(id, 10);
     Promise.all([getCharacter(cid), listPraxes({ character_id: cid })])
-      .then(([c, s]) => { setCharacter(c); setSubmissions(s) })
-      .catch((err) => setFetchError(extractError(err, "Couldn't load this character.")))
-      .finally(() => setLoading(false))
-  }, [id])
+      .then(([c, s]) => {
+        setCharacter(c);
+        setSubmissions(s);
+      })
+      .catch((err) =>
+        setFetchError(extractError(err, "Couldn't load this character.")),
+      )
+      .finally(() => setLoading(false));
+  }, [id]);
 
   useEffect(() => {
-    if (!id || !user?.character) return
-    const cid = parseInt(id, 10)
-    if (user.character.id === cid) return
+    if (!id || !user?.character) return;
+    const cid = parseInt(id, 10);
+    if (user.character.id === cid) return;
     listRelationships()
       .then((rels) => {
         const match = rels.find(
-          (r) => r.to_character_id === cid && r.status !== 'blocked'
-        )
-        setRelationship(match ?? null)
+          (r) => r.to_character_id === cid && r.status !== "blocked",
+        );
+        setRelationship(match ?? null);
       })
-      .catch(() => {})
-  }, [id, user])
+      .catch(() => {});
+  }, [id, user]);
 
-  const [relationshipError, setRelationshipError] = useState<string | null>(null)
+  const [relationshipError, setRelationshipError] = useState<string | null>(
+    null,
+  );
 
-  const handleAddRelationship = async (type: 'friend' | 'foe') => {
-    if (!character) return
-    setRelationshipLoading(true)
-    setRelationshipError(null)
+  const handleAddRelationship = async (type: "friend" | "foe") => {
+    if (!character) return;
+    setRelationshipLoading(true);
+    setRelationshipError(null);
     try {
-      await createRelationship(character.id, type)
+      await createRelationship(character.id, type);
       // Re-fetch to get the properly typed RelationshipListItem with display data
-      const rels = await listRelationships()
+      const rels = await listRelationships();
       const match = rels.find(
-        (r) => r.to_character_id === character.id && r.status !== 'blocked'
-      )
-      setRelationship(match ?? null)
+        (r) => r.to_character_id === character.id && r.status !== "blocked",
+      );
+      setRelationship(match ?? null);
     } catch (err: unknown) {
       // Handle 409 (already exists) gracefully — re-fetch existing relationship
-      if (err && typeof err === 'object' && 'response' in err) {
-        const axiosErr = err as { response?: { status?: number } }
+      if (err && typeof err === "object" && "response" in err) {
+        const axiosErr = err as { response?: { status?: number } };
         if (axiosErr.response?.status === 409) {
-          const rels = await listRelationships()
+          const rels = await listRelationships();
           const match = rels.find(
-            (r) => r.to_character_id === character.id && r.status !== 'blocked'
-          )
-          setRelationship(match ?? null)
+            (r) => r.to_character_id === character.id && r.status !== "blocked",
+          );
+          setRelationship(match ?? null);
         } else {
-          setRelationshipError('Could not add relationship.')
+          setRelationshipError("Could not add relationship.");
         }
       } else {
-        setRelationshipError('Could not add relationship.')
+        setRelationshipError("Could not add relationship.");
       }
     } finally {
-      setRelationshipLoading(false)
+      setRelationshipLoading(false);
     }
-  }
+  };
 
   const handleRemoveRelationship = async () => {
-    if (!relationship) return
-    setRelationshipLoading(true)
-    setRelationshipError(null)
+    if (!relationship) return;
+    setRelationshipLoading(true);
+    setRelationshipError(null);
     try {
-      await deleteRelationship(relationship.id)
-      setRelationship(null)
+      await deleteRelationship(relationship.id);
+      setRelationship(null);
     } catch {
-      setRelationshipError('Could not remove relationship.')
+      setRelationshipError("Could not remove relationship.");
     } finally {
-      setRelationshipLoading(false)
+      setRelationshipLoading(false);
     }
-  }
+  };
 
-  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
-  if (fetchError) return (
-    <div className="py-8">
-      <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-        {fetchError}{' '}
-        <button onClick={() => window.location.reload()} className="underline">Try refreshing.</button>
-      </p>
-    </div>
-  )
-  if (!character) return <div className="py-8 font-body text-muted">Character not found.</div>
+  if (loading)
+    return <div className="py-8 font-body text-muted">Loading...</div>;
+  if (fetchError)
+    return (
+      <div className="py-8">
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+          {fetchError}{" "}
+          <button
+            onClick={() => window.location.reload()}
+            className="underline"
+          >
+            Try refreshing.
+          </button>
+        </p>
+      </div>
+    );
+  if (!character)
+    return (
+      <div className="py-8 font-body text-muted">Character not found.</div>
+    );
 
-  const charFactionName = factionName(character.faction_slug)
-  const isOwn = user?.character?.id === character.id
-  const levelThresholds = gameConfig?.level_thresholds ?? []
-  const maxLevel = Math.max(levelThresholds.length - 1, 0)
-  const nextLevel = Math.min(character.level + 1, maxLevel)
-  const nextThreshold = levelThresholds[nextLevel] ?? 999
-  const currentThreshold = levelThresholds[character.level] ?? 0
-  const progressPercent = nextThreshold > currentThreshold
-    ? Math.min(((character.score - currentThreshold) / (nextThreshold - currentThreshold)) * 100, 100)
-    : 100
+  const charFactionName = factionName(character.faction_slug);
+  const isOwn = user?.character?.id === character.id;
+  const levelThresholds = gameConfig?.level_thresholds ?? [];
+  const maxLevel = Math.max(levelThresholds.length - 1, 0);
+  const nextLevel = Math.min(character.level + 1, maxLevel);
+  const nextThreshold = levelThresholds[nextLevel] ?? 999;
+  const currentThreshold = levelThresholds[character.level] ?? 0;
+  const progressPercent =
+    nextThreshold > currentThreshold
+      ? Math.min(
+          ((character.score - currentThreshold) /
+            (nextThreshold - currentThreshold)) *
+            100,
+          100,
+        )
+      : 100;
 
   return (
     <div className="py-8">
       {/* ── Profile Header — Faction-Framed (§14.2) ── */}
       <div
         className="sidebar-card mb-5"
-        style={{ borderLeft: `4px solid ${factionCssVar(character.faction_slug, 'border')}`, padding: '16px 20px' }}
+        style={{
+          borderLeft: `4px solid ${factionCssVar(character.faction_slug, "border")}`,
+          padding: "16px 20px",
+        }}
       >
         <div className="flex gap-5 items-start">
           {/* Avatar orb */}
@@ -132,7 +164,10 @@ export default function CharacterProfile() {
                 src={mediaUrl(character.avatar_url)}
                 alt={character.username}
                 style={{
-                  width: 80, height: 80, borderRadius: '50%', objectFit: 'cover',
+                  width: 80,
+                  height: 80,
+                  borderRadius: "50%",
+                  objectFit: "cover",
                   border: `3px solid white`,
                   boxShadow: `0 0 0 3px ${factionCssVar(character.faction_slug)}`,
                 }}
@@ -140,12 +175,19 @@ export default function CharacterProfile() {
             ) : (
               <div
                 style={{
-                  width: 80, height: 80, borderRadius: '50%',
-                  background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${factionCssVar(character.faction_slug)})`,
-                  border: '3px solid white',
+                  width: 80,
+                  height: 80,
+                  borderRadius: "50%",
+                  background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, "light")}, ${factionCssVar(character.faction_slug)})`,
+                  border: "3px solid white",
                   boxShadow: `0 0 0 3px ${factionCssVar(character.faction_slug)}`,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  fontFamily: "'Lora', serif", fontStyle: 'italic', fontSize: 28, color: 'var(--color-text-on-accent)',
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontFamily: "'Lora', serif",
+                  fontStyle: "italic",
+                  fontSize: 28,
+                  color: "var(--color-text-on-accent)",
                 }}
               >
                 {character.username[0]?.toUpperCase()}
@@ -154,9 +196,13 @@ export default function CharacterProfile() {
             {/* Level badge */}
             <span
               style={{
-                background: factionCssVar(character.faction_slug), color: 'var(--color-text-on-accent)',
-                fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
-                padding: '2px 10px', borderRadius: 10,
+                background: factionCssVar(character.faction_slug),
+                color: "var(--color-text-on-accent)",
+                fontSize: 8,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                padding: "2px 10px",
+                borderRadius: 10,
                 fontFamily: "'Courier Prime', monospace",
               }}
             >
@@ -168,7 +214,12 @@ export default function CharacterProfile() {
                 <Link
                   to={`/characters/${character.id}/edit`}
                   className="btn-outline"
-                  style={{ fontSize: 8, padding: '3px 12px', width: '100%', textAlign: 'center' }}
+                  style={{
+                    fontSize: 8,
+                    padding: "3px 12px",
+                    width: "100%",
+                    textAlign: "center",
+                  }}
                 >
                   Edit Profile
                 </Link>
@@ -176,33 +227,58 @@ export default function CharacterProfile() {
                   <Link
                     to="/characters/create"
                     className="btn-outline"
-                    style={{ fontSize: 8, padding: '3px 12px', width: '100%', textAlign: 'center' }}
+                    style={{
+                      fontSize: 8,
+                      padding: "3px 12px",
+                      width: "100%",
+                      textAlign: "center",
+                    }}
                   >
                     + New Character
                   </Link>
                 )}
               </>
             ) : user?.character ? (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 4, width: '100%' }}>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 4,
+                  width: "100%",
+                }}
+              >
                 {relationship ? (
                   <>
                     {/* Show relationship status */}
                     <div
                       style={{
-                        background: relationship.type === 'friend' ? 'var(--badge-friend)' : 'var(--color-danger)',
-                        color: 'var(--color-text-on-accent)',
+                        background:
+                          relationship.type === "friend"
+                            ? "var(--badge-friend)"
+                            : "var(--color-danger)",
+                        color: "var(--color-text-on-accent)",
                         fontFamily: "'Courier Prime', monospace",
-                        fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
-                        padding: '4px 0', textAlign: 'center', borderRadius: 2,
+                        fontSize: 8,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.1em",
+                        padding: "4px 0",
+                        textAlign: "center",
+                        borderRadius: 2,
                       }}
                     >
-                      {relationship.type === 'friend' ? 'Friends' : 'Foe'}
+                      {relationship.type === "friend" ? "Friends" : "Foe"}
                     </div>
                     <button
                       onClick={handleRemoveRelationship}
                       disabled={relationshipLoading}
                       className="eyebrow"
-                      style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)', textAlign: 'center' }}
+                      style={{
+                        background: "none",
+                        border: "none",
+                        cursor: "pointer",
+                        color: "var(--color-text-tertiary)",
+                        textAlign: "center",
+                      }}
                     >
                       remove
                     </button>
@@ -210,26 +286,38 @@ export default function CharacterProfile() {
                 ) : (
                   <>
                     <button
-                      onClick={() => handleAddRelationship('friend')}
+                      onClick={() => handleAddRelationship("friend")}
                       disabled={relationshipLoading}
                       style={{
-                        background: factionCssVar(character.faction_slug), color: 'var(--color-text-on-accent)',
+                        background: factionCssVar(character.faction_slug),
+                        color: "var(--color-text-on-accent)",
                         fontFamily: "'Courier Prime', monospace",
-                        fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
-                        padding: '4px 0', border: 'none', cursor: 'pointer', borderRadius: 2,
+                        fontSize: 8,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.1em",
+                        padding: "4px 0",
+                        border: "none",
+                        cursor: "pointer",
+                        borderRadius: 2,
                         opacity: relationshipLoading ? 0.5 : 1,
                       }}
                     >
                       Friend
                     </button>
                     <button
-                      onClick={() => handleAddRelationship('foe')}
+                      onClick={() => handleAddRelationship("foe")}
                       disabled={relationshipLoading}
                       style={{
-                        background: 'none', color: 'var(--color-danger)',
+                        background: "none",
+                        color: "var(--color-danger)",
                         fontFamily: "'Courier Prime', monospace",
-                        fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
-                        padding: '3px 0', border: '1.5px solid var(--color-danger)', cursor: 'pointer', borderRadius: 2,
+                        fontSize: 8,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.1em",
+                        padding: "3px 0",
+                        border: "1.5px solid var(--color-danger)",
+                        cursor: "pointer",
+                        borderRadius: 2,
                         opacity: relationshipLoading ? 0.5 : 1,
                       }}
                     >
@@ -240,7 +328,17 @@ export default function CharacterProfile() {
               </div>
             ) : null}
             {relationshipError && (
-              <p className="font-body" style={{ fontSize: 8, color: 'var(--color-danger)', marginTop: 4, textAlign: 'center' }}>{relationshipError}</p>
+              <p
+                className="font-body"
+                style={{
+                  fontSize: 8,
+                  color: "var(--color-danger)",
+                  marginTop: 4,
+                  textAlign: "center",
+                }}
+              >
+                {relationshipError}
+              </p>
             )}
           </div>
 
@@ -248,24 +346,36 @@ export default function CharacterProfile() {
           <div className="flex-1 min-w-0">
             <h1
               className="font-display italic"
-              style={{ fontSize: 26, color: factionCssVar(character.faction_slug), marginBottom: 2 }}
+              style={{
+                fontSize: 26,
+                color: factionCssVar(character.faction_slug),
+                marginBottom: 2,
+              }}
             >
               {character.display_name}
             </h1>
             <p className="eyebrow" style={{ marginBottom: 8 }}>
-              @{character.username} · Joined {new Date(character.created_at).toLocaleDateString(undefined, { month: 'short', year: 'numeric' })}
+              @{character.username} · Joined{" "}
+              {new Date(character.created_at).toLocaleDateString(undefined, {
+                month: "short",
+                year: "numeric",
+              })}
             </p>
 
             {/* Faction pennant */}
             <span
               className="pennant-shape"
               style={{
-                display: 'inline-block',
-                background: factionCssVar(character.faction_slug), color: 'var(--color-text-on-accent)',
+                display: "inline-block",
+                background: factionCssVar(character.faction_slug),
+                color: "var(--color-text-on-accent)",
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                letterSpacing: '0.07em', padding: '3px 14px',
-                textShadow: '0 1px 2px rgba(0,0,0,0.3)',
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.07em",
+                padding: "3px 14px",
+                textShadow: "0 1px 2px rgba(0,0,0,0.3)",
                 marginBottom: 8,
               }}
             >
@@ -277,10 +387,13 @@ export default function CharacterProfile() {
               <p
                 className="font-body"
                 style={{
-                  fontSize: 11, lineHeight: 1.6,
-                  borderLeft: `3px solid ${factionCssVar(character.faction_slug, 'border')}`,
-                  paddingLeft: 10, marginTop: 6, marginBottom: 8,
-                  color: 'var(--color-text-secondary)',
+                  fontSize: 11,
+                  lineHeight: 1.6,
+                  borderLeft: `3px solid ${factionCssVar(character.faction_slug, "border")}`,
+                  paddingLeft: 10,
+                  marginTop: 6,
+                  marginBottom: 8,
+                  color: "var(--color-text-secondary)",
                   fontFamily: "'Special Elite', serif",
                 }}
               >
@@ -289,21 +402,38 @@ export default function CharacterProfile() {
             )}
 
             {/* Stat strip */}
-            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 8 }}>
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                flexWrap: "wrap",
+                marginTop: 8,
+              }}
+            >
               {[
-                { label: 'Era score', value: character.score },
-                { label: 'All-time', value: character.all_time_score },
-                { label: 'Praxis', value: submissions.length },
+                { label: "Era score", value: character.score },
+                { label: "All-time", value: character.all_time_score },
+                { label: "Praxis", value: submissions.length },
               ].map((stat) => (
                 <div
                   key={stat.label}
                   className="sidebar-card"
-                  style={{ padding: '6px 12px', borderRadius: 8, textAlign: 'center', minWidth: 70 }}
+                  style={{
+                    padding: "6px 12px",
+                    borderRadius: 8,
+                    textAlign: "center",
+                    minWidth: 70,
+                  }}
                 >
-                  <div className="font-body font-bold" style={{ fontSize: 14, color: 'var(--color-text-primary)' }}>
+                  <div
+                    className="font-body font-bold"
+                    style={{ fontSize: 14, color: "var(--color-text-primary)" }}
+                  >
                     {stat.value}
                   </div>
-                  <div className="eyebrow" style={{ fontSize: 7 }}>{stat.label}</div>
+                  <div className="eyebrow" style={{ fontSize: 7 }}>
+                    {stat.label}
+                  </div>
                 </div>
               ))}
             </div>
@@ -313,58 +443,108 @@ export default function CharacterProfile() {
 
       {/* ── Level Track (§14.3) ── */}
       {gameConfig && (
-      <div
-        className="sidebar-card mb-5"
-        style={{ padding: '14px 18px' }}
-      >
-        {/* Node track */}
-        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
-          {levelThresholds.map((_threshold, level) => {
-            const completed = character.level > level
-            const current = character.level === level
-            return (
-              <div key={level} style={{ display: 'flex', alignItems: 'center' }}>
-                {level > 0 && (
-                  <div style={{
-                    width: 16, height: 3,
-                    background: completed ? factionCssVar(character.faction_slug) : 'rgba(0,0,0,0.1)',
-                    transition: 'background 200ms',
-                  }} />
-                )}
+        <div className="sidebar-card mb-5" style={{ padding: "14px 18px" }}>
+          {/* Node track */}
+          <div
+            style={{ display: "flex", alignItems: "center", marginBottom: 10 }}
+          >
+            {levelThresholds.map((_threshold, level) => {
+              const completed = character.level > level;
+              const current = character.level === level;
+              return (
                 <div
-                  style={{
-                    width: current ? 32 : 26, height: current ? 32 : 26,
-                    borderRadius: '50%',
-                    background: completed ? factionCssVar(character.faction_slug) : current ? `${factionCssVar(character.faction_slug)}20` : 'var(--level-node-incomplete)',
-                    border: current ? `3px solid ${factionCssVar(character.faction_slug)}` : `2px solid ${completed ? factionCssVar(character.faction_slug) : 'rgba(0,0,0,0.12)'}`,
-                    boxShadow: current ? `0 0 0 3px ${factionCssVar(character.faction_slug)}33` : 'none',
-                    color: completed ? 'var(--color-text-on-accent)' : current ? factionCssVar(character.faction_slug) : 'var(--color-level-inactive)',
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: current ? 10 : 8, fontWeight: 700,
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    transition: 'all 200ms',
-                  }}
+                  key={level}
+                  style={{ display: "flex", alignItems: "center" }}
                 >
-                  {level}
+                  {level > 0 && (
+                    <div
+                      style={{
+                        width: 16,
+                        height: 3,
+                        background: completed
+                          ? factionCssVar(character.faction_slug)
+                          : "rgba(0,0,0,0.1)",
+                        transition: "background 200ms",
+                      }}
+                    />
+                  )}
+                  <div
+                    style={{
+                      width: current ? 32 : 26,
+                      height: current ? 32 : 26,
+                      borderRadius: "50%",
+                      background: completed
+                        ? factionCssVar(character.faction_slug)
+                        : current
+                          ? `${factionCssVar(character.faction_slug)}20`
+                          : "var(--level-node-incomplete)",
+                      border: current
+                        ? `3px solid ${factionCssVar(character.faction_slug)}`
+                        : `2px solid ${completed ? factionCssVar(character.faction_slug) : "rgba(0,0,0,0.12)"}`,
+                      boxShadow: current
+                        ? `0 0 0 3px ${factionCssVar(character.faction_slug)}33`
+                        : "none",
+                      color: completed
+                        ? "var(--color-text-on-accent)"
+                        : current
+                          ? factionCssVar(character.faction_slug)
+                          : "var(--color-level-inactive)",
+                      fontFamily: "'Courier Prime', monospace",
+                      fontSize: current ? 10 : 8,
+                      fontWeight: 700,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      transition: "all 200ms",
+                    }}
+                  >
+                    {level}
+                  </div>
                 </div>
-              </div>
-            )
-          })}
-        </div>
-
-        {/* Progress bar */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span className="eyebrow" style={{ fontSize: 8, whiteSpace: 'nowrap' }}>
-            Lvl {character.level} → {nextLevel}
-          </span>
-          <div style={{ flex: 1, height: 5, borderRadius: 3, background: 'var(--color-bg-surface-alt)', overflow: 'hidden' }}>
-            <div style={{ height: '100%', width: `${progressPercent}%`, background: factionCssVar(character.faction_slug), borderRadius: 3, transition: 'width 300ms' }} />
+              );
+            })}
           </div>
-          <span className="font-body" style={{ fontSize: 9, fontWeight: 700, color: factionCssVar(character.faction_slug), whiteSpace: 'nowrap' }}>
-            {character.score} / {nextThreshold} pts
-          </span>
+
+          {/* Progress bar */}
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span
+              className="eyebrow"
+              style={{ fontSize: 8, whiteSpace: "nowrap" }}
+            >
+              Lvl {character.level} → {nextLevel}
+            </span>
+            <div
+              style={{
+                flex: 1,
+                height: 5,
+                borderRadius: 3,
+                background: "var(--color-bg-surface-alt)",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  height: "100%",
+                  width: `${progressPercent}%`,
+                  background: factionCssVar(character.faction_slug),
+                  borderRadius: 3,
+                  transition: "width 300ms",
+                }}
+              />
+            </div>
+            <span
+              className="font-body"
+              style={{
+                fontSize: 9,
+                fontWeight: 700,
+                color: factionCssVar(character.faction_slug),
+                whiteSpace: "nowrap",
+              }}
+            >
+              {character.score} / {nextThreshold} pts
+            </span>
+          </div>
         </div>
-      </div>
       )}
 
       {/* ── Praxis Grid (§14.4) ── */}
@@ -377,10 +557,12 @@ export default function CharacterProfile() {
           <p className="font-body text-muted">No submissions yet.</p>
         ) : (
           <div className="flex flex-wrap gap-4 items-start">
-            {submissions.map((s) => <PraxisCard key={s.id} praxis={s} />)}
+            {submissions.map((s) => (
+              <PraxisCard key={s.id} praxis={s} />
+            ))}
           </div>
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/CollaborationDetail.tsx
+++ b/frontend/src/pages/CollaborationDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, useCallback } from 'react'
-import { useParams, Link, useNavigate, useLocation } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import { useEffect, useState, useCallback } from "react";
+import { useParams, Link, useLocation } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
 import {
   getPraxis,
   updatePraxis,
@@ -12,213 +12,288 @@ import {
   getPraxisVotes,
   type PraxisOut,
   type DuelVoteSummary,
-} from '../api/praxis'
-import { listCharacters, type CharacterOut } from '../api/characters'
-import { useAuth } from '../auth/AuthContext'
-import { factionColor, factionName, factionCssVar } from '../utils/factions'
-import { formatTimestamp } from '../utils/dates'
+} from "../api/praxis";
+import { listCharacters, type CharacterOut } from "../api/characters";
+import { useAuth } from "../auth/AuthContext";
+import { factionColor, factionName } from "../utils/factions";
+import { formatTimestamp } from "../utils/dates";
 
-const RAINBOW_COLORS = ['#fbbf24', '#be185d', '#4f46e5', '#0e7490', 'var(--color-success)', '#f97316', '#fbbf24', '#be185d']
+const RAINBOW_COLORS = [
+  "#fbbf24",
+  "#be185d",
+  "#4f46e5",
+  "#0e7490",
+  "var(--color-success)",
+  "#f97316",
+  "#fbbf24",
+  "#be185d",
+];
 
 export default function CollaborationDetail() {
-  const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-  const location = useLocation()
-  const { user } = useAuth()
-  const myCharacterId = user?.character?.id
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const { user } = useAuth();
+  const myCharacterId = user?.character?.id;
 
   // Invite errors passed via navigation state when some invites failed on collab creation
-  const locationState = location.state as { inviteErrors?: string[] } | null
-  const [startupInviteErrors] = useState<string[]>(locationState?.inviteErrors ?? [])
+  const locationState = location.state as { inviteErrors?: string[] } | null;
+  const [startupInviteErrors] = useState<string[]>(
+    locationState?.inviteErrors ?? [],
+  );
 
-  const [collab, setCollab] = useState<PraxisOut | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [collab, setCollab] = useState<PraxisOut | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   // Document editing
-  const [editing, setEditing] = useState(false)
-  const [docDraft, setDocDraft] = useState('')
-  const [saving, setSaving] = useState(false)
+  const [editing, setEditing] = useState(false);
+  const [docDraft, setDocDraft] = useState("");
+  const [saving, setSaving] = useState(false);
 
   // Invite
-  const [inviteQuery, setInviteQuery] = useState('')
-  const [inviteResults, setInviteResults] = useState<CharacterOut[]>([])
-  const [showInviteDropdown, setShowInviteDropdown] = useState(false)
-  const [inviteError, setInviteError] = useState('')
+  const [inviteQuery, setInviteQuery] = useState("");
+  const [inviteResults, setInviteResults] = useState<CharacterOut[]>([]);
+  const [showInviteDropdown, setShowInviteDropdown] = useState(false);
+  const [inviteError, setInviteError] = useState("");
 
   // Duel votes
-  const [duelVotes, setDuelVotes] = useState<DuelVoteSummary[]>([])
-  const [votingForMemberId, setVotingForMemberId] = useState<number | null>(null)
-  const [voteStars, setVoteStars] = useState(0)
-  const [castingVote, setCastingVote] = useState(false)
-  const [voteError, setVoteError] = useState('')
-  const [voteSuccess, setVoteSuccess] = useState(false)
+  const [duelVotes, setDuelVotes] = useState<DuelVoteSummary[]>([]);
+  const [votingForMemberId, setVotingForMemberId] = useState<number | null>(
+    null,
+  );
+  const [voteStars, setVoteStars] = useState(0);
+  const [castingVote, setCastingVote] = useState(false);
+  const [voteError, setVoteError] = useState("");
+  const [voteSuccess, setVoteSuccess] = useState(false);
 
   // Action errors
-  const [actionError, setActionError] = useState('')
+  const [actionError, setActionError] = useState("");
 
-  const praxisId = id ? parseInt(id, 10) : null
+  const praxisId = id ? parseInt(id, 10) : null;
 
   const loadCollab = useCallback(async () => {
-    if (!praxisId) return
+    if (!praxisId) return;
     try {
-      const data = await getPraxis(praxisId)
-      setCollab(data)
-      if (!editing) setDocDraft(data.body_text ?? '')
+      const data = await getPraxis(praxisId);
+      setCollab(data);
+      if (!editing) setDocDraft(data.body_text ?? "");
     } catch {
-      setFetchError('Could not load collaboration.')
+      setFetchError("Could not load collaboration.");
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [praxisId, editing])
+  }, [praxisId, editing]);
 
   const loadDuelVotes = useCallback(async () => {
-    if (!praxisId || !collab || collab.type !== 'duel') return
+    if (!praxisId || !collab || collab.type !== "duel") return;
     try {
-      const votes = await getPraxisVotes(praxisId)
-      setDuelVotes(votes as DuelVoteSummary[])
-    } catch { /* non-fatal */ }
-  }, [praxisId, collab])
+      const votes = await getPraxisVotes(praxisId);
+      setDuelVotes(votes as DuelVoteSummary[]);
+    } catch {
+      /* non-fatal */
+    }
+  }, [praxisId, collab]);
 
   useEffect(() => {
-    loadCollab()
-  }, [loadCollab])
+    loadCollab();
+  }, [loadCollab]);
 
   useEffect(() => {
-    if (collab?.type === 'duel') loadDuelVotes()
-  }, [collab, loadDuelVotes])
+    if (collab?.type === "duel") loadDuelVotes();
+  }, [collab, loadDuelVotes]);
 
   if (loading) {
-    return <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}><p className="eyebrow">Loading...</p></div>
+    return (
+      <div className="py-8" style={{ maxWidth: 720, margin: "0 auto" }}>
+        <p className="eyebrow">Loading...</p>
+      </div>
+    );
   }
   if (fetchError || !collab) {
-    return <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}><p className="eyebrow" style={{ color: 'var(--color-danger)' }}>{fetchError ?? 'Not found.'}</p></div>
+    return (
+      <div className="py-8" style={{ maxWidth: 720, margin: "0 auto" }}>
+        <p className="eyebrow" style={{ color: "var(--color-danger)" }}>
+          {fetchError ?? "Not found."}
+        </p>
+      </div>
+    );
   }
 
-  const isMember = collab.members.some((m) => m.character_id === myCharacterId)
-  const myMember = collab.members.find((m) => m.character_id === myCharacterId)
-  const isPublished = collab.status === 'submitted'
-  const isDuel = collab.type === 'duel'
-  const isCollab = collab.type === 'collab'
-  const modeLabel = isDuel ? 'Duel' : 'Collaboration'
-  const modeColor = isDuel ? 'var(--color-danger)' : 'var(--color-success)'
+  const isMember = collab.members.some((m) => m.character_id === myCharacterId);
+  const myMember = collab.members.find((m) => m.character_id === myCharacterId);
+  const isPublished = collab.status === "submitted";
+  const isDuel = collab.type === "duel";
+  const isCollab = collab.type === "collab";
+  const modeLabel = isDuel ? "Duel" : "Collaboration";
+  const modeColor = isDuel ? "var(--color-danger)" : "var(--color-success)";
+
+  const winningStars = duelVotes.length
+    ? Math.max(...duelVotes.map((v) => v.total_stars))
+    : 0;
 
   const handleSaveDocument = async () => {
-    if (!praxisId) return
-    setSaving(true)
+    if (!praxisId) return;
+    setSaving(true);
     try {
-      const updated = await updatePraxis(praxisId, { body_text: docDraft })
-      setCollab(updated)
-      setDocDraft(updated.body_text ?? '')
-      setEditing(false)
+      const updated = await updatePraxis(praxisId, { body_text: docDraft });
+      setCollab(updated);
+      setDocDraft(updated.body_text ?? "");
+      setEditing(false);
     } catch {
-      setActionError('Could not save document.')
+      setActionError("Could not save document.");
     }
-    setSaving(false)
-  }
+    setSaving(false);
+  };
 
   const handleSubmit = async () => {
-    if (!praxisId) return
-    setActionError('')
+    if (!praxisId) return;
+    setActionError("");
     try {
-      const updated = await submitPraxis(praxisId)
-      setCollab(updated)
+      const updated = await submitPraxis(praxisId);
+      setCollab(updated);
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { detail?: string } } }
-      setActionError(axiosErr?.response?.data?.detail ?? 'Could not submit.')
+      const axiosErr = err as { response?: { data?: { detail?: string } } };
+      setActionError(axiosErr?.response?.data?.detail ?? "Could not submit.");
     }
-  }
+  };
 
   const handleReopen = async () => {
-    if (!praxisId) return
-    setActionError('')
+    if (!praxisId) return;
+    setActionError("");
     try {
-      const updated = await reopenPraxis(praxisId)
-      setCollab(updated)
-      setEditing(false)
+      const updated = await reopenPraxis(praxisId);
+      setCollab(updated);
+      setEditing(false);
     } catch {
-      setActionError('Could not reopen.')
+      setActionError("Could not reopen.");
     }
-  }
+  };
 
   const handleKick = async (memberId: number, name: string) => {
-    if (!praxisId || !window.confirm(`Remove ${name} from this ${modeLabel.toLowerCase()}?`)) return
-    setActionError('')
+    if (
+      !praxisId ||
+      !window.confirm(`Remove ${name} from this ${modeLabel.toLowerCase()}?`)
+    )
+      return;
+    setActionError("");
     try {
-      await kickMember(praxisId, memberId)
-      await loadCollab()
+      await kickMember(praxisId, memberId);
+      await loadCollab();
     } catch {
-      setActionError('Could not remove member.')
+      setActionError("Could not remove member.");
     }
-  }
+  };
 
   const handleInviteSearch = async (query: string) => {
-    setInviteQuery(query)
-    if (query.length < 2) { setInviteResults([]); setShowInviteDropdown(false); return }
-    try {
-      const results = await listCharacters({ search: query, limit: 8 })
-      const memberIds = new Set(collab.members.map((m) => m.character_id))
-      const filtered = results.filter((c) => c.id !== myCharacterId && !memberIds.has(c.id))
-      setInviteResults(filtered)
-      setShowInviteDropdown(filtered.length > 0)
-    } catch {
-      setInviteResults([])
+    setInviteQuery(query);
+    if (query.length < 2) {
+      setInviteResults([]);
+      setShowInviteDropdown(false);
+      return;
     }
-  }
+    try {
+      const results = await listCharacters({ search: query, limit: 8 });
+      const memberIds = new Set(collab.members.map((m) => m.character_id));
+      const filtered = results.filter(
+        (c) => c.id !== myCharacterId && !memberIds.has(c.id),
+      );
+      setInviteResults(filtered);
+      setShowInviteDropdown(filtered.length > 0);
+    } catch {
+      setInviteResults([]);
+    }
+  };
 
   const handleSendInvite = async (character: CharacterOut) => {
-    if (!praxisId) return
-    setInviteError('')
-    setInviteQuery('')
-    setShowInviteDropdown(false)
+    if (!praxisId) return;
+    setInviteError("");
+    setInviteQuery("");
+    setShowInviteDropdown(false);
     try {
-      await inviteToPraxis(praxisId, character.id)
-      await loadCollab()
+      await inviteToPraxis(praxisId, character.id);
+      await loadCollab();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { detail?: string } } }
-      setInviteError(axiosErr?.response?.data?.detail ?? 'Could not send invite.')
+      const axiosErr = err as { response?: { data?: { detail?: string } } };
+      setInviteError(
+        axiosErr?.response?.data?.detail ?? "Could not send invite.",
+      );
     }
-  }
+  };
 
   const handleCastVote = async () => {
-    if (!praxisId || !votingForMemberId || !voteStars) return
-    setCastingVote(true)
-    setVoteError('')
+    if (!praxisId || !votingForMemberId || !voteStars) return;
+    setCastingVote(true);
+    setVoteError("");
     try {
-      await votePraxis(praxisId, { stars: voteStars, praxis_member_id: votingForMemberId })
-      setVoteSuccess(true)
-      setVotingForMemberId(null)
-      setVoteStars(0)
-      await loadDuelVotes()
+      await votePraxis(praxisId, {
+        stars: voteStars,
+        praxis_member_id: votingForMemberId,
+      });
+      setVoteSuccess(true);
+      setVotingForMemberId(null);
+      setVoteStars(0);
+      await loadDuelVotes();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { detail?: string } } }
-      setVoteError(axiosErr?.response?.data?.detail ?? 'Could not cast vote.')
+      const axiosErr = err as { response?: { data?: { detail?: string } } };
+      setVoteError(axiosErr?.response?.data?.detail ?? "Could not cast vote.");
     }
-    setCastingVote(false)
-  }
+    setCastingVote(false);
+  };
 
   return (
-    <div className="py-8" style={{ maxWidth: 720, margin: '0 auto' }}>
+    <div className="py-8" style={{ maxWidth: 720, margin: "0 auto" }}>
       {/* Breadcrumb */}
-      <nav className="font-body mb-4" style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--color-text-tertiary)' }}>
-        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>Tasks</Link>
-        {' › '}
-        <Link to={`/tasks/${collab.task_id}`} style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}>{collab.task_title}</Link>
-        {' › '}
-        <span style={{ color: 'var(--color-text-primary)' }}>{modeLabel}</span>
+      <nav
+        className="font-body mb-4"
+        style={{
+          fontSize: 9,
+          letterSpacing: "0.1em",
+          color: "var(--color-text-tertiary)",
+        }}
+      >
+        <Link to="/tasks" style={{ color: "inherit", textDecoration: "none" }}>
+          Tasks
+        </Link>
+        {" › "}
+        <Link
+          to={`/tasks/${collab.task_id}`}
+          style={{
+            color: "var(--color-text-secondary)",
+            textDecoration: "none",
+          }}
+        >
+          {collab.task_title}
+        </Link>
+        {" › "}
+        <span style={{ color: "var(--color-text-primary)" }}>{modeLabel}</span>
       </nav>
 
       {/* Header */}
-      <div className="sidebar-card mb-5" style={{ padding: '16px 20px', borderLeft: `4px solid ${modeColor}` }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+      <div
+        className="sidebar-card mb-5"
+        style={{ padding: "16px 20px", borderLeft: `4px solid ${modeColor}` }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: 12,
+          }}
+        >
           <div>
             <span
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
-                letterSpacing: '0.1em', padding: '2px 8px',
-                background: modeColor, color: 'var(--color-text-on-accent)',
-                marginBottom: 6, display: 'inline-block',
+                fontSize: 8,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                padding: "2px 8px",
+                background: modeColor,
+                color: "var(--color-text-on-accent)",
+                marginBottom: 6,
+                display: "inline-block",
               }}
             >
               {modeLabel}
@@ -226,23 +301,35 @@ export default function CollaborationDetail() {
             <Link
               to={`/tasks/${collab.task_id}`}
               className="font-display italic"
-              style={{ fontSize: 20, color: modeColor, textDecoration: 'none', display: 'block' }}
+              style={{
+                fontSize: 20,
+                color: modeColor,
+                textDecoration: "none",
+                display: "block",
+              }}
             >
               {collab.task_title}
             </Link>
           </div>
-          <div style={{ textAlign: 'right', flexShrink: 0 }}>
+          <div style={{ textAlign: "right", flexShrink: 0 }}>
             <span
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
-                letterSpacing: '0.1em', padding: '3px 10px',
-                background: isPublished ? 'var(--color-success)' : 'var(--color-bg-surface-alt)',
-                color: isPublished ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
-                border: isPublished ? 'none' : '1px solid var(--color-border)',
+                fontSize: 8,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                padding: "3px 10px",
+                background: isPublished
+                  ? "var(--color-success)"
+                  : "var(--color-bg-surface-alt)",
+                color: isPublished
+                  ? "var(--color-text-on-accent)"
+                  : "var(--color-text-secondary)",
+                border: isPublished ? "none" : "1px solid var(--color-border)",
               }}
             >
-              {isPublished ? 'Published' : 'In Progress'}
+              {isPublished ? "Published" : "In Progress"}
             </span>
             <div className="eyebrow" style={{ marginTop: 4, fontSize: 7 }}>
               {formatTimestamp(collab.created_at)}
@@ -252,25 +339,31 @@ export default function CollaborationDetail() {
       </div>
 
       {/* Members */}
-      <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
-        <p className="eyebrow mb-3">{isDuel ? 'Competitors' : 'Members'} ({collab.members.length})</p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div className="sidebar-card mb-4" style={{ padding: "16px 20px" }}>
+        <p className="eyebrow mb-3">
+          {isDuel ? "Competitors" : "Members"} ({collab.members.length})
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           {collab.members.map((member) => {
-            const color = factionColor(null)
-            const isMe = member.character_id === myCharacterId
+            const color = factionColor(null);
+            const isMe = member.character_id === myCharacterId;
             return (
               <div
                 key={member.character_id}
                 style={{
-                  display: 'flex', alignItems: 'center', gap: 10,
-                  padding: '8px 12px',
-                  background: 'var(--color-bg-surface-alt)',
-                  border: '1px solid var(--color-border)',
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "8px 12px",
+                  background: "var(--color-bg-surface-alt)",
+                  border: "1px solid var(--color-border)",
                 }}
               >
                 <div
                   style={{
-                    width: 28, height: 28, borderRadius: '50%',
+                    width: 28,
+                    height: 28,
+                    borderRadius: "50%",
                     background: `linear-gradient(135deg, ${color}, ${color}88)`,
                     flexShrink: 0,
                   }}
@@ -279,33 +372,58 @@ export default function CollaborationDetail() {
                   <Link
                     to={`/characters/${member.character_id}`}
                     className="font-body"
-                    style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 700,
+                      color: "var(--color-text-primary)",
+                      textDecoration: "none",
+                    }}
                   >
                     {member.character_display_name}
-                    {isMe && <span className="eyebrow" style={{ marginLeft: 6, fontSize: 7 }}>(you)</span>}
+                    {isMe && (
+                      <span
+                        className="eyebrow"
+                        style={{ marginLeft: 6, fontSize: 7 }}
+                      >
+                        (you)
+                      </span>
+                    )}
                   </Link>
                 </div>
                 <span
                   style={{
                     fontFamily: "'Courier Prime', monospace",
-                    fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
-                    padding: '2px 8px',
-                    background: member.has_submitted ? 'var(--color-success)' : 'transparent',
-                    color: member.has_submitted ? 'var(--color-text-on-accent)' : 'var(--color-text-tertiary)',
-                    border: member.has_submitted ? 'none' : '1px solid var(--color-border)',
+                    fontSize: 8,
+                    fontWeight: 700,
+                    textTransform: "uppercase",
+                    padding: "2px 8px",
+                    background: member.has_submitted
+                      ? "var(--color-success)"
+                      : "transparent",
+                    color: member.has_submitted
+                      ? "var(--color-text-on-accent)"
+                      : "var(--color-text-tertiary)",
+                    border: member.has_submitted
+                      ? "none"
+                      : "1px solid var(--color-border)",
                   }}
                 >
-                  {member.has_submitted ? 'Submitted' : 'Drafting'}
+                  {member.has_submitted ? "Submitted" : "Drafting"}
                 </span>
                 {/* Kick button — any member can kick others (not themselves) */}
                 {isMember && !isMe && !isPublished && (
                   <button
-                    onClick={() => handleKick(member.id, member.character_display_name)}
+                    onClick={() =>
+                      handleKick(member.id, member.character_display_name)
+                    }
                     style={{
-                      background: 'none', border: 'none', cursor: 'pointer',
-                      color: 'var(--color-text-tertiary)', fontSize: 10,
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: "var(--color-text-tertiary)",
+                      fontSize: 10,
                       fontFamily: "'Courier Prime', monospace",
-                      padding: '2px 6px',
+                      padding: "2px 6px",
                     }}
                     title="Remove from collaboration"
                   >
@@ -313,28 +431,34 @@ export default function CollaborationDetail() {
                   </button>
                 )}
               </div>
-            )
+            );
           })}
         </div>
 
         {/* Pending invites */}
         {collab.invites && collab.invites.length > 0 && (
           <div style={{ marginTop: 12 }}>
-            <p className="eyebrow" style={{ marginBottom: 6, fontSize: 7 }}>Pending invites</p>
+            <p className="eyebrow" style={{ marginBottom: 6, fontSize: 7 }}>
+              Pending invites
+            </p>
             {collab.invites.map((invite) => (
               <div
                 key={invite.id}
                 style={{
-                  display: 'flex', alignItems: 'center', gap: 8,
-                  padding: '5px 12px',
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "5px 12px",
                   opacity: 0.7,
                   fontFamily: "'Courier Prime', monospace",
                   fontSize: 9,
-                  color: 'var(--color-text-secondary)',
+                  color: "var(--color-text-secondary)",
                 }}
               >
                 <span>→ {invite.invitee_display_name}</span>
-                <span className="eyebrow" style={{ fontSize: 7 }}>invited</span>
+                <span className="eyebrow" style={{ fontSize: 7 }}>
+                  invited
+                </span>
               </div>
             ))}
           </div>
@@ -343,33 +467,45 @@ export default function CollaborationDetail() {
         {/* Invite more (collaboration only, in-progress, is member) */}
         {isMember && !isPublished && isCollab && (
           <div style={{ marginTop: 12 }}>
-            <p className="eyebrow" style={{ marginBottom: 6, fontSize: 7 }}>Invite more members</p>
-            <div style={{ position: 'relative', display: 'flex', gap: 6 }}>
+            <p className="eyebrow" style={{ marginBottom: 6, fontSize: 7 }}>
+              Invite more members
+            </p>
+            <div style={{ position: "relative", display: "flex", gap: 6 }}>
               <input
                 type="text"
                 value={inviteQuery}
                 onChange={(e) => handleInviteSearch(e.target.value)}
                 placeholder="Search by name"
-                onFocus={() => { if (inviteResults.length > 0) setShowInviteDropdown(true) }}
-                onBlur={() => setTimeout(() => setShowInviteDropdown(false), 200)}
+                onFocus={() => {
+                  if (inviteResults.length > 0) setShowInviteDropdown(true);
+                }}
+                onBlur={() =>
+                  setTimeout(() => setShowInviteDropdown(false), 200)
+                }
                 style={{
                   flex: 1,
                   fontFamily: "'Courier Prime', monospace",
-                  fontSize: 11, padding: '6px 10px',
-                  background: 'var(--color-bg-surface)',
-                  color: 'var(--color-text-primary)',
-                  border: '1px solid var(--color-border)',
-                  outline: 'none',
+                  fontSize: 11,
+                  padding: "6px 10px",
+                  background: "var(--color-bg-surface)",
+                  color: "var(--color-text-primary)",
+                  border: "1px solid var(--color-border)",
+                  outline: "none",
                 }}
               />
               {showInviteDropdown && (
                 <div
                   style={{
-                    position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 10,
-                    background: 'var(--color-bg-surface)',
-                    border: '1px solid var(--color-border)',
-                    boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                    maxHeight: 180, overflowY: 'auto',
+                    position: "absolute",
+                    top: "100%",
+                    left: 0,
+                    right: 0,
+                    zIndex: 10,
+                    background: "var(--color-bg-surface)",
+                    border: "1px solid var(--color-border)",
+                    boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                    maxHeight: 180,
+                    overflowY: "auto",
                   }}
                 >
                   {inviteResults.map((character) => (
@@ -378,23 +514,40 @@ export default function CollaborationDetail() {
                       type="button"
                       onMouseDown={() => handleSendInvite(character)}
                       style={{
-                        display: 'flex', alignItems: 'center', gap: 8,
-                        width: '100%', padding: '8px 12px',
-                        background: 'transparent', border: 'none',
-                        cursor: 'pointer', textAlign: 'left',
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        width: "100%",
+                        padding: "8px 12px",
+                        background: "transparent",
+                        border: "none",
+                        cursor: "pointer",
+                        textAlign: "left",
                       }}
                     >
                       <div
                         style={{
-                          width: 18, height: 18, borderRadius: '50%',
+                          width: 18,
+                          height: 18,
+                          borderRadius: "50%",
                           background: `linear-gradient(135deg, ${factionColor(character.faction_slug)}, ${factionColor(character.faction_slug)}88)`,
                           flexShrink: 0,
                         }}
                       />
-                      <span className="font-body" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+                      <span
+                        className="font-body"
+                        style={{
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: "var(--color-text-primary)",
+                        }}
+                      >
                         {character.display_name}
                       </span>
-                      <span className="eyebrow" style={{ marginLeft: 'auto', fontSize: 7 }}>
+                      <span
+                        className="eyebrow"
+                        style={{ marginLeft: "auto", fontSize: 7 }}
+                      >
                         {factionName(character.faction_slug)}
                       </span>
                     </button>
@@ -403,25 +556,44 @@ export default function CollaborationDetail() {
               )}
             </div>
             {inviteError && (
-              <p className="eyebrow" style={{ color: 'var(--color-danger)', marginTop: 4 }}>{inviteError}</p>
+              <p
+                className="eyebrow"
+                style={{ color: "var(--color-danger)", marginTop: 4 }}
+              >
+                {inviteError}
+              </p>
             )}
           </div>
         )}
       </div>
 
       {/* Shared Document */}
-      <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+      <div className="sidebar-card mb-4" style={{ padding: "16px 20px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: 10,
+          }}
+        >
           <p className="eyebrow">Shared Document</p>
           {isMember && !editing && (
             <button
-              onClick={() => { setEditing(true); setDocDraft(collab.body_text ?? '') }}
+              onClick={() => {
+                setEditing(true);
+                setDocDraft(collab.body_text ?? "");
+              }}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
-                background: 'transparent', border: '1px solid var(--color-border)',
-                padding: '3px 10px', cursor: 'pointer',
-                color: 'var(--color-text-secondary)',
+                fontSize: 8,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                background: "transparent",
+                border: "1px solid var(--color-border)",
+                padding: "3px 10px",
+                cursor: "pointer",
+                color: "var(--color-text-secondary)",
               }}
             >
               Edit
@@ -437,37 +609,49 @@ export default function CollaborationDetail() {
               rows={14}
               placeholder="Write your shared document here... (supports markdown)"
               style={{
-                width: '100%',
-                fontFamily: "'Lora', serif", fontSize: 14,
-                color: 'var(--color-text-primary)',
-                lineHeight: 1.75, minHeight: 200,
-                background: 'transparent',
-                border: '1px solid var(--color-border)',
-                outline: 'none', resize: 'vertical',
-                padding: '10px 12px',
+                width: "100%",
+                fontFamily: "'Lora', serif",
+                fontSize: 14,
+                color: "var(--color-text-primary)",
+                lineHeight: 1.75,
+                minHeight: 200,
+                background: "transparent",
+                border: "1px solid var(--color-border)",
+                outline: "none",
+                resize: "vertical",
+                padding: "10px 12px",
               }}
             />
-            <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
               <button
                 onClick={handleSaveDocument}
                 disabled={saving}
                 style={{
                   fontFamily: "'Courier Prime', monospace",
-                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                  background: modeColor, color: 'var(--color-text-on-accent)', border: 'none',
-                  padding: '6px 16px', cursor: saving ? 'wait' : 'pointer',
+                  fontSize: 9,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  background: modeColor,
+                  color: "var(--color-text-on-accent)",
+                  border: "none",
+                  padding: "6px 16px",
+                  cursor: saving ? "wait" : "pointer",
                 }}
               >
-                {saving ? 'Saving...' : 'Save'}
+                {saving ? "Saving..." : "Save"}
               </button>
               <button
                 onClick={() => setEditing(false)}
                 style={{
                   fontFamily: "'Courier Prime', monospace",
-                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                  background: 'transparent', border: '1px solid var(--color-border)',
-                  padding: '6px 16px', cursor: 'pointer',
-                  color: 'var(--color-text-secondary)',
+                  fontSize: 9,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  background: "transparent",
+                  border: "1px solid var(--color-border)",
+                  padding: "6px 16px",
+                  cursor: "pointer",
+                  color: "var(--color-text-secondary)",
                 }}
               >
                 Cancel
@@ -475,93 +659,184 @@ export default function CollaborationDetail() {
             </div>
           </div>
         ) : collab.body_text ? (
-          <div className="markdown-preview font-display" style={{ fontSize: 14, lineHeight: 1.75, color: 'var(--color-text-primary)' }}>
+          <div
+            className="markdown-preview font-display"
+            style={{
+              fontSize: 14,
+              lineHeight: 1.75,
+              color: "var(--color-text-primary)",
+            }}
+          >
             <ReactMarkdown>{collab.body_text}</ReactMarkdown>
           </div>
         ) : (
-          <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-tertiary)', fontStyle: 'italic' }}>
-            {isMember ? 'No document yet. Click Edit to start writing.' : 'No document yet.'}
+          <p
+            className="font-body"
+            style={{
+              fontSize: 12,
+              color: "var(--color-text-tertiary)",
+              fontStyle: "italic",
+            }}
+          >
+            {isMember
+              ? "No document yet. Click Edit to start writing."
+              : "No document yet."}
           </p>
         )}
       </div>
 
       {/* Duel vote tally */}
       {isDuel && (
-        <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+        <div className="sidebar-card mb-4" style={{ padding: "16px 20px" }}>
           <p className="eyebrow mb-3">Vote Tally</p>
           {duelVotes.length === 0 ? (
-            <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>No votes yet.</p>
+            <p
+              className="font-body"
+              style={{ fontSize: 11, color: "var(--color-text-tertiary)" }}
+            >
+              No votes yet.
+            </p>
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {duelVotes.map((v) => (
-                <div
-                  key={v.member_id}
-                  style={{
-                    display: 'flex', alignItems: 'center', gap: 12,
-                    padding: '8px 12px',
-                    background: v.is_winning ? 'rgba(220,38,38,0.07)' : 'var(--color-bg-surface-alt)',
-                    border: `1px solid ${v.is_winning ? 'var(--color-danger)' : 'var(--color-border)'}`,
-                  }}
-                >
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {duelVotes.map((v) => {
+                const isWinning =
+                  winningStars > 0 && v.total_stars === winningStars;
+                return (
                   <div
+                    key={v.member_id}
                     style={{
-                      width: 24, height: 24, borderRadius: '50%',
-                      background: 'var(--color-bg-surface-alt)',
-                      border: '1px solid var(--color-border)',
-                      flexShrink: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 12,
+                      padding: "8px 12px",
+                      background: isWinning
+                        ? "rgba(220,38,38,0.07)"
+                        : "var(--color-bg-surface-alt)",
+                      border: `1px solid ${isWinning ? "var(--color-danger)" : "var(--color-border)"}`,
                     }}
-                  />
-                  <span className="font-body" style={{ fontSize: 12, fontWeight: 700, flex: 1 }}>
-                    {v.character_display_name}
-                    {v.is_winning && <span style={{ marginLeft: 8, color: 'var(--color-danger)', fontSize: 10 }}>leading</span>}
-                  </span>
-                  <span className="eyebrow" style={{ fontSize: 9 }}>
-                    {v.total_stars} stars ({v.vote_count} votes)
-                  </span>
-                </div>
-              ))}
+                  >
+                    <div
+                      style={{
+                        width: 24,
+                        height: 24,
+                        borderRadius: "50%",
+                        background: "var(--color-bg-surface-alt)",
+                        border: "1px solid var(--color-border)",
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span
+                      className="font-body"
+                      style={{ fontSize: 12, fontWeight: 700, flex: 1 }}
+                    >
+                      {v.character_display_name}
+                      {isWinning && (
+                        <span
+                          style={{
+                            marginLeft: 8,
+                            color: "var(--color-danger)",
+                            fontSize: 10,
+                          }}
+                        >
+                          leading
+                        </span>
+                      )}
+                    </span>
+                    <span className="eyebrow" style={{ fontSize: 9 }}>
+                      {v.total_stars} stars ({v.vote_count} votes)
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           )}
 
           {/* Cast vote (non-members only, published collab) */}
           {!isMember && isPublished && (
-            <div style={{ marginTop: 14, borderTop: '1px dashed var(--color-border)', paddingTop: 14 }}>
-              <p className="eyebrow mb-2" style={{ fontSize: 8 }}>Cast your vote</p>
+            <div
+              style={{
+                marginTop: 14,
+                borderTop: "1px dashed var(--color-border)",
+                paddingTop: 14,
+              }}
+            >
+              <p className="eyebrow mb-2" style={{ fontSize: 8 }}>
+                Cast your vote
+              </p>
               {voteSuccess ? (
-                <p className="eyebrow" style={{ color: 'var(--color-success)' }}>Vote recorded!</p>
+                <p
+                  className="eyebrow"
+                  style={{ color: "var(--color-success)" }}
+                >
+                  Vote recorded!
+                </p>
               ) : (
                 <>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 10,
+                    }}
+                  >
                     {collab.members.map((member) => (
-                      <div key={member.id} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <div
+                        key={member.id}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 10,
+                        }}
+                      >
                         <button
-                          onClick={() => setVotingForMemberId(votingForMemberId === member.id ? null : member.id)}
+                          onClick={() =>
+                            setVotingForMemberId(
+                              votingForMemberId === member.id
+                                ? null
+                                : member.id,
+                            )
+                          }
                           style={{
                             fontFamily: "'Courier Prime', monospace",
-                            fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                            padding: '4px 12px',
-                            background: votingForMemberId === member.id ? 'var(--color-danger)' : 'transparent',
-                            color: votingForMemberId === member.id ? 'var(--color-text-on-accent)' : 'var(--color-text-primary)',
-                            border: `1px solid ${votingForMemberId === member.id ? 'var(--color-danger)' : 'var(--color-border)'}`,
-                            cursor: 'pointer',
+                            fontSize: 9,
+                            fontWeight: 700,
+                            textTransform: "uppercase",
+                            padding: "4px 12px",
+                            background:
+                              votingForMemberId === member.id
+                                ? "var(--color-danger)"
+                                : "transparent",
+                            color:
+                              votingForMemberId === member.id
+                                ? "var(--color-text-on-accent)"
+                                : "var(--color-text-primary)",
+                            border: `1px solid ${votingForMemberId === member.id ? "var(--color-danger)" : "var(--color-border)"}`,
+                            cursor: "pointer",
                           }}
                         >
                           {member.character_display_name}
                         </button>
                         {votingForMemberId === member.id && (
-                          <div style={{ display: 'flex', gap: 2 }}>
+                          <div style={{ display: "flex", gap: 2 }}>
                             {[1, 2, 3, 4, 5].map((star) => (
                               <button
                                 key={star}
                                 type="button"
                                 onClick={() => setVoteStars(star)}
                                 style={{
-                                  background: 'none', border: 'none', cursor: 'pointer',
-                                  fontSize: 18, lineHeight: 1, padding: '0 2px',
-                                  color: star <= voteStars ? 'var(--color-text-primary)' : 'var(--color-border)',
-                                  transition: 'color 100ms',
+                                  background: "none",
+                                  border: "none",
+                                  cursor: "pointer",
+                                  fontSize: 18,
+                                  lineHeight: 1,
+                                  padding: "0 2px",
+                                  color:
+                                    star <= voteStars
+                                      ? "var(--color-text-primary)"
+                                      : "var(--color-border)",
+                                  transition: "color 100ms",
                                 }}
-                                aria-label={`${star} star${star !== 1 ? 's' : ''}`}
+                                aria-label={`${star} star${star !== 1 ? "s" : ""}`}
                               >
                                 ★
                               </button>
@@ -578,16 +853,26 @@ export default function CollaborationDetail() {
                       style={{
                         marginTop: 10,
                         fontFamily: "'Courier Prime', monospace",
-                        fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                        background: 'var(--color-danger)', color: 'var(--color-text-on-accent)', border: 'none',
-                        padding: '6px 18px', cursor: castingVote ? 'wait' : 'pointer',
+                        fontSize: 9,
+                        fontWeight: 700,
+                        textTransform: "uppercase",
+                        background: "var(--color-danger)",
+                        color: "var(--color-text-on-accent)",
+                        border: "none",
+                        padding: "6px 18px",
+                        cursor: castingVote ? "wait" : "pointer",
                       }}
                     >
-                      {castingVote ? 'Submitting...' : 'Submit Vote'}
+                      {castingVote ? "Submitting..." : "Submit Vote"}
                     </button>
                   )}
                   {voteError && (
-                    <p className="eyebrow" style={{ color: 'var(--color-danger)', marginTop: 6 }}>{voteError}</p>
+                    <p
+                      className="eyebrow"
+                      style={{ color: "var(--color-danger)", marginTop: 6 }}
+                    >
+                      {voteError}
+                    </p>
                   )}
                 </>
               )}
@@ -598,24 +883,40 @@ export default function CollaborationDetail() {
 
       {/* Submit / Reopen controls */}
       {isMember && !isPublished && (
-        <div className="sidebar-card mb-4" style={{ padding: '16px 20px' }}>
+        <div className="sidebar-card mb-4" style={{ padding: "16px 20px" }}>
           <p className="eyebrow mb-2">Submit</p>
-          <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+          <p
+            className="font-body"
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-secondary)",
+              marginBottom: 12,
+            }}
+          >
             {isDuel
-              ? 'When both competitors submit, the duel is published and voting opens.'
-              : 'When all members submit, the collaboration is published.'}
+              ? "When both competitors submit, the duel is published and voting opens."
+              : "When all members submit, the collaboration is published."}
           </p>
           {myMember?.has_submitted ? (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-              <span className="eyebrow" style={{ color: 'var(--color-success)' }}>You have submitted</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span
+                className="eyebrow"
+                style={{ color: "var(--color-success)" }}
+              >
+                You have submitted
+              </span>
               <button
                 onClick={handleReopen}
                 style={{
                   fontFamily: "'Courier Prime', monospace",
-                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                  background: 'transparent', border: '1px solid var(--color-border)',
-                  padding: '4px 12px', cursor: 'pointer',
-                  color: 'var(--color-text-secondary)',
+                  fontSize: 9,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  background: "transparent",
+                  border: "1px solid var(--color-border)",
+                  padding: "4px 12px",
+                  cursor: "pointer",
+                  color: "var(--color-text-secondary)",
                 }}
               >
                 Reopen for editing
@@ -626,14 +927,26 @@ export default function CollaborationDetail() {
               onClick={handleSubmit}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
-                letterSpacing: '0.1em',
-                background: modeColor, color: 'var(--color-text-on-accent)', border: 'none',
-                padding: '8px 20px', cursor: 'pointer',
-                position: 'relative',
+                fontSize: 10,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                background: modeColor,
+                color: "var(--color-text-on-accent)",
+                border: "none",
+                padding: "8px 20px",
+                cursor: "pointer",
+                position: "relative",
               }}
             >
-              <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
+              <span
+                style={{
+                  position: "absolute",
+                  inset: 3,
+                  border: "1px dashed rgba(255,255,255,0.25)",
+                  pointerEvents: "none",
+                }}
+              />
               Mark as submitted
             </button>
           )}
@@ -641,32 +954,83 @@ export default function CollaborationDetail() {
       )}
 
       {isPublished && (
-        <div className="sidebar-card mb-4" style={{ padding: '14px 20px', borderLeft: '4px solid var(--color-success)' }}>
-          <p className="eyebrow" style={{ color: 'var(--color-success)' }}>Published</p>
-          <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginTop: 4 }}>
-            {isDuel ? 'Duel complete. Points have been awarded.' : 'Collaboration published. All members have been scored.'}
+        <div
+          className="sidebar-card mb-4"
+          style={{
+            padding: "14px 20px",
+            borderLeft: "4px solid var(--color-success)",
+          }}
+        >
+          <p className="eyebrow" style={{ color: "var(--color-success)" }}>
+            Published
+          </p>
+          <p
+            className="font-body"
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-secondary)",
+              marginTop: 4,
+            }}
+          >
+            {isDuel
+              ? "Duel complete. Points have been awarded."
+              : "Collaboration published. All members have been scored."}
           </p>
         </div>
       )}
 
       {startupInviteErrors.length > 0 && (
-        <div className="sidebar-card mb-4" style={{ padding: '12px 16px', borderLeft: '3px solid var(--color-warning)' }}>
-          <p className="eyebrow" style={{ color: 'var(--color-warning)', marginBottom: 6 }}>Some invites could not be sent</p>
+        <div
+          className="sidebar-card mb-4"
+          style={{
+            padding: "12px 16px",
+            borderLeft: "3px solid var(--color-warning)",
+          }}
+        >
+          <p
+            className="eyebrow"
+            style={{ color: "var(--color-warning)", marginBottom: 6 }}
+          >
+            Some invites could not be sent
+          </p>
           {startupInviteErrors.map((err, i) => (
-            <p key={i} className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 2 }}>{err}</p>
+            <p
+              key={i}
+              className="font-body"
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-secondary)",
+                marginBottom: 2,
+              }}
+            >
+              {err}
+            </p>
           ))}
-          <p className="eyebrow" style={{ fontSize: 7, marginTop: 6, color: 'var(--color-text-tertiary)' }}>You can invite eligible players from the Members section above.</p>
+          <p
+            className="eyebrow"
+            style={{
+              fontSize: 7,
+              marginTop: 6,
+              color: "var(--color-text-tertiary)",
+            }}
+          >
+            You can invite eligible players from the Members section above.
+          </p>
         </div>
       )}
 
       {actionError && (
-        <p className="eyebrow mb-4" style={{ color: 'var(--color-danger)' }}>{actionError}</p>
+        <p className="eyebrow mb-4" style={{ color: "var(--color-danger)" }}>
+          {actionError}
+        </p>
       )}
 
       {/* Rainbow footer bar */}
-      <div style={{ display: 'flex', height: 3, marginTop: 24, opacity: 0.4 }}>
-        {RAINBOW_COLORS.map((c, i) => <div key={i} style={{ flex: 1, background: c }} />)}
+      <div style={{ display: "flex", height: 3, marginTop: 24, opacity: 0.4 }}>
+        {RAINBOW_COLORS.map((c, i) => (
+          <div key={i} style={{ flex: 1, background: c }} />
+        ))}
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Groups.tsx
+++ b/frontend/src/pages/Groups.tsx
@@ -1,156 +1,100 @@
 // Faction data is static — rules live in game_config.py, no API needed for v1
-import PageTitle from '../components/ui/PageTitle'
+import PageTitle from "../components/ui/PageTitle";
 
-import PageTitle from '../components/ui/PageTitle'
 const FACTIONS = [
-import PageTitle from '../components/ui/PageTitle'
   {
-import PageTitle from '../components/ui/PageTitle'
-    slug: 'ua',
-import PageTitle from '../components/ui/PageTitle'
-    name: 'University of Aesthematics',
-import PageTitle from '../components/ui/PageTitle'
-    theme: 'The self and the other',
-import PageTitle from '../components/ui/PageTitle'
-    colors: 'Purple and yellow',
-import PageTitle from '../components/ui/PageTitle'
-    gameplay: 'Starter faction. Full points on all tasks. Must leave at level 3.',
-import PageTitle from '../components/ui/PageTitle'
-    dotClass: 'bg-ua',
-import PageTitle from '../components/ui/PageTitle'
+    slug: "ua",
+    name: "University of Aesthematics",
+    theme: "The self and the other",
+    colors: "Purple and yellow",
+    gameplay:
+      "Starter faction. Full points on all tasks. Must leave at level 3.",
+    dotClass: "bg-ua",
   },
-import PageTitle from '../components/ui/PageTitle'
   {
-import PageTitle from '../components/ui/PageTitle'
-    slug: 'journeymen',
-import PageTitle from '../components/ui/PageTitle'
-    name: 'The Journeymen',
-import PageTitle from '../components/ui/PageTitle'
-    theme: 'Time and space',
-import PageTitle from '../components/ui/PageTitle'
-    colors: 'Gold on blue',
-import PageTitle from '../components/ui/PageTitle'
-    gameplay: 'Task Vision — access to select retired tasks flagged for Journeymen.',
-import PageTitle from '../components/ui/PageTitle'
-    dotClass: 'bg-journeymen',
-import PageTitle from '../components/ui/PageTitle'
+    slug: "journeymen",
+    name: "The Journeymen",
+    theme: "Time and space",
+    colors: "Gold on blue",
+    gameplay:
+      "Task Vision — access to select retired tasks flagged for Journeymen.",
+    dotClass: "bg-journeymen",
   },
-import PageTitle from '../components/ui/PageTitle'
   {
-import PageTitle from '../components/ui/PageTitle'
-    slug: 'gestalt',
-import PageTitle from '../components/ui/PageTitle'
-    name: 'Gestalt',
-import PageTitle from '../components/ui/PageTitle'
-    theme: 'Sociology and psychology',
-import PageTitle from '../components/ui/PageTitle'
-    colors: 'Gentle lilac and purple',
-import PageTitle from '../components/ui/PageTitle'
-    gameplay: 'Collab with another faction\'s player → points as if in that faction. 1.1× own, 0.7× others.',
-import PageTitle from '../components/ui/PageTitle'
-    dotClass: 'bg-gestalt',
-import PageTitle from '../components/ui/PageTitle'
+    slug: "gestalt",
+    name: "Gestalt",
+    theme: "Sociology and psychology",
+    colors: "Gentle lilac and purple",
+    gameplay:
+      "Collab with another faction's player → points as if in that faction. 1.1× own, 0.7× others.",
+    dotClass: "bg-gestalt",
   },
-import PageTitle from '../components/ui/PageTitle'
   {
-import PageTitle from '../components/ui/PageTitle'
-    slug: 'geo',
-import PageTitle from '../components/ui/PageTitle'
-    name: 'Geoanalogue',
-import PageTitle from '../components/ui/PageTitle'
-    theme: 'Terrain and contact',
-import PageTitle from '../components/ui/PageTitle'
-    colors: 'Earthen shades',
-import PageTitle from '../components/ui/PageTitle'
-    gameplay: 'Double Dipper — repeat one task per level for points.',
-import PageTitle from '../components/ui/PageTitle'
-    dotClass: 'bg-geo',
-import PageTitle from '../components/ui/PageTitle'
+    slug: "geo",
+    name: "Geoanalogue",
+    theme: "Terrain and contact",
+    colors: "Earthen shades",
+    gameplay: "Double Dipper — repeat one task per level for points.",
+    dotClass: "bg-geo",
   },
-import PageTitle from '../components/ui/PageTitle'
   {
-import PageTitle from '../components/ui/PageTitle'
-    slug: 'snide',
-import PageTitle from '../components/ui/PageTitle'
-    name: 'S.N.I.D.E.',
-import PageTitle from '../components/ui/PageTitle'
-    theme: 'Chaos and illusion',
-import PageTitle from '../components/ui/PageTitle'
-    colors: 'Dastardly greens',
-import PageTitle from '../components/ui/PageTitle'
-    gameplay: 'Bonus points from duels (+10%). Collaborate with a player without their knowledge.',
-import PageTitle from '../components/ui/PageTitle'
-    dotClass: 'bg-snide',
-import PageTitle from '../components/ui/PageTitle'
+    slug: "snide",
+    name: "S.N.I.D.E.",
+    theme: "Chaos and illusion",
+    colors: "Dastardly greens",
+    gameplay:
+      "Bonus points from duels (+10%). Collaborate with a player without their knowledge.",
+    dotClass: "bg-snide",
   },
-import PageTitle from '../components/ui/PageTitle'
   {
-import PageTitle from '../components/ui/PageTitle'
-    slug: 'cm',
-import PageTitle from '../components/ui/PageTitle'
-    name: 'Creative Masters',
-import PageTitle from '../components/ui/PageTitle'
-    theme: 'Interpretation and imagination',
-import PageTitle from '../components/ui/PageTitle'
-    colors: 'Autumnal shades',
-import PageTitle from '../components/ui/PageTitle'
-    gameplay: '80% points from all sources — intentional disadvantage to level the field.',
-import PageTitle from '../components/ui/PageTitle'
-    dotClass: 'bg-cm',
-import PageTitle from '../components/ui/PageTitle'
+    slug: "cm",
+    name: "Creative Masters",
+    theme: "Interpretation and imagination",
+    colors: "Autumnal shades",
+    gameplay:
+      "80% points from all sources — intentional disadvantage to level the field.",
+    dotClass: "bg-cm",
   },
-import PageTitle from '../components/ui/PageTitle'
-]
-import PageTitle from '../components/ui/PageTitle'
+];
 
-import PageTitle from '../components/ui/PageTitle'
 export default function Groups() {
-import PageTitle from '../components/ui/PageTitle'
   return (
-import PageTitle from '../components/ui/PageTitle'
     <div className="py-8">
-import PageTitle from '../components/ui/PageTitle'
       <PageTitle title="Groups" />
-import PageTitle from '../components/ui/PageTitle'
-      <p className="font-body text-sm text-muted mb-6">Factions are chosen at level 3. Until then, you start in the University of Aesthematics.</p>
-import PageTitle from '../components/ui/PageTitle'
+      <p className="font-body text-sm text-muted mb-6">
+        Factions are chosen at level 3. Until then, you start in the University
+        of Aesthematics.
+      </p>
 
-import PageTitle from '../components/ui/PageTitle'
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
-import PageTitle from '../components/ui/PageTitle'
         {FACTIONS.map((f) => (
-import PageTitle from '../components/ui/PageTitle'
-          <div key={f.slug} className="card p-5 flex flex-col gap-2 relative overflow-hidden transition-all">
-import PageTitle from '../components/ui/PageTitle'
-            <div className={`absolute left-0 top-0 bottom-0 w-1.5 ${f.dotClass}`} />
-import PageTitle from '../components/ui/PageTitle'
+          <div
+            key={f.slug}
+            className="card p-5 flex flex-col gap-2 relative overflow-hidden transition-all"
+          >
+            <div
+              className={`absolute left-0 top-0 bottom-0 w-1.5 ${f.dotClass}`}
+            />
             <div className="pl-2">
-import PageTitle from '../components/ui/PageTitle'
               <div className="flex items-center gap-2 mb-1">
-import PageTitle from '../components/ui/PageTitle'
-                <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${f.dotClass}`} />
-import PageTitle from '../components/ui/PageTitle'
+                <span
+                  className={`w-2.5 h-2.5 rounded-full shrink-0 ${f.dotClass}`}
+                />
                 <h2 className="font-display text-xl font-bold">{f.name}</h2>
-import PageTitle from '../components/ui/PageTitle'
               </div>
-import PageTitle from '../components/ui/PageTitle'
-              <p className="font-body text-xs text-muted uppercase tracking-widest mb-2">{f.theme}</p>
-import PageTitle from '../components/ui/PageTitle'
-              <p className="font-body text-sm text-ink leading-relaxed">{f.gameplay}</p>
-import PageTitle from '../components/ui/PageTitle'
-              <p className="font-body text-xs text-muted mt-2">Colors: {f.colors}</p>
-import PageTitle from '../components/ui/PageTitle'
+              <p className="font-body text-xs text-muted uppercase tracking-widest mb-2">
+                {f.theme}
+              </p>
+              <p className="font-body text-sm text-ink leading-relaxed">
+                {f.gameplay}
+              </p>
+              <p className="font-body text-xs text-muted mt-2">
+                Colors: {f.colors}
+              </p>
             </div>
-import PageTitle from '../components/ui/PageTitle'
           </div>
-import PageTitle from '../components/ui/PageTitle'
         ))}
-import PageTitle from '../components/ui/PageTitle'
       </div>
-import PageTitle from '../components/ui/PageTitle'
     </div>
-import PageTitle from '../components/ui/PageTitle'
-  )
-import PageTitle from '../components/ui/PageTitle'
+  );
 }
-import PageTitle from '../components/ui/PageTitle'

--- a/frontend/src/pages/admin/AccountsTab.tsx
+++ b/frontend/src/pages/admin/AccountsTab.tsx
@@ -1,81 +1,89 @@
-import { useEffect, useState, useRef } from 'react'
-import { getAccounts, getAccountDetail, suspendAccount, banCharacter } from '../../api/admin'
-import type { AccountSummary, AccountDetail } from '../../api/admin'
-import { extractError } from '../../utils/errors'
-import { formatTimestamp } from '../../utils/dates'
+import { useEffect, useState, useRef } from "react";
+import {
+  getAccounts,
+  getAccountDetail,
+  suspendAccount,
+  banCharacter,
+} from "../../api/admin";
+import type { AccountSummary, AccountDetail } from "../../api/admin";
+import { extractError } from "../../utils/errors";
+import { formatTimestamp } from "../../utils/dates";
 
 export default function AccountsTab() {
-  const [accounts, setAccounts] = useState<AccountSummary[]>([])
-  const [searchEmail, setSearchEmail] = useState('')
-  const [expandedId, setExpandedId] = useState<number | null>(null)
-  const [detail, setDetail] = useState<AccountDetail | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [actionError, setActionError] = useState<string | null>(null)
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
+  const [accounts, setAccounts] = useState<AccountSummary[]>([]);
+  const [searchEmail, setSearchEmail] = useState("");
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [detail, setDetail] = useState<AccountDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const refresh = (email?: string) => {
-    setError(null)
+    setError(null);
     getAccounts(email || undefined)
       .then(setAccounts)
       .catch((err) => setError(extractError(err, "Couldn't load accounts.")))
-      .finally(() => setLoading(false))
-  }
+      .finally(() => setLoading(false));
+  };
 
-  useEffect(() => { refresh() }, [])
+  useEffect(() => {
+    refresh();
+  }, []);
 
   const handleSearch = (value: string) => {
-    setSearchEmail(value)
-    if (debounceRef.current) clearTimeout(debounceRef.current)
+    setSearchEmail(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      refresh(value)
-    }, 300)
-  }
+      refresh(value);
+    }, 300);
+  };
 
   const handleExpand = async (accountId: number) => {
     if (expandedId === accountId) {
-      setExpandedId(null)
-      setDetail(null)
-      return
+      setExpandedId(null);
+      setDetail(null);
+      return;
     }
-    setExpandedId(accountId)
+    setExpandedId(accountId);
     try {
-      const d = await getAccountDetail(accountId)
-      setDetail(d)
+      const d = await getAccountDetail(accountId);
+      setDetail(d);
     } catch (err) {
-      setActionError(extractError(err, 'Could not load account detail.'))
+      setActionError(extractError(err, "Could not load account detail."));
     }
-  }
+  };
 
   const handleSuspend = async (accountId: number, suspended: boolean) => {
-    setActionError(null)
+    setActionError(null);
     try {
-      await suspendAccount(accountId, suspended)
-      refresh(searchEmail)
+      await suspendAccount(accountId, suspended);
+      refresh(searchEmail);
       if (expandedId === accountId) {
-        const d = await getAccountDetail(accountId)
-        setDetail(d)
+        const d = await getAccountDetail(accountId);
+        setDetail(d);
       }
     } catch (err) {
-      setActionError(extractError(err, 'Could not update account.'))
+      setActionError(extractError(err, "Could not update account."));
     }
-  }
+  };
 
   const handleBan = async (characterId: number, banned: boolean) => {
-    setActionError(null)
+    setActionError(null);
     try {
-      await banCharacter(characterId, banned)
+      await banCharacter(characterId, banned);
       if (expandedId) {
-        const d = await getAccountDetail(expandedId)
-        setDetail(d)
+        const d = await getAccountDetail(expandedId);
+        setDetail(d);
       }
     } catch (err) {
-      setActionError(extractError(err, 'Could not update character.'))
+      setActionError(extractError(err, "Could not update character."));
     }
-  }
+  };
 
-  if (loading) return <div className="font-body text-muted text-sm">Loading...</div>
-  if (error) return <p className="font-body text-sm text-red-600">{error}</p>
+  if (loading)
+    return <div className="font-body text-muted text-sm">Loading...</div>;
+  if (error) return <p className="font-body text-sm text-red-600">{error}</p>;
 
   return (
     <div>
@@ -105,56 +113,93 @@ export default function AccountsTab() {
                 <button
                   onClick={() => void handleExpand(account.id)}
                   className="flex-1 text-left"
-                  style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    padding: 0,
+                  }}
                 >
-                  <p className="font-display text-lg font-bold">{account.email}</p>
+                  <p className="font-display text-lg font-bold">
+                    {account.email}
+                  </p>
                   <p className="font-body text-xs text-muted">
                     <span
                       style={{
-                        color: account.status === 'suspended' ? 'var(--color-danger)' : 'var(--color-success)',
+                        color:
+                          account.status === "suspended"
+                            ? "var(--color-danger)"
+                            : "var(--color-success)",
                         fontWeight: 700,
                       }}
                     >
                       {account.status}
-                    </span>
-                    {' '}&middot; ID #{account.id} &middot; {formatTimestamp(account.created_at)}
+                    </span>{" "}
+                    &middot; ID #{account.id} &middot;{" "}
+                    {formatTimestamp(account.created_at)}
                   </p>
                 </button>
                 <button
-                  onClick={() => void handleSuspend(account.id, account.status !== 'suspended')}
+                  onClick={() =>
+                    void handleSuspend(
+                      account.id,
+                      account.status !== "suspended",
+                    )
+                  }
                   className="btn-outline text-xs shrink-0"
-                  style={account.status === 'suspended'
-                    ? { borderColor: 'var(--color-success)', color: 'var(--color-success)' }
-                    : { borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }
+                  style={
+                    account.status === "suspended"
+                      ? {
+                          borderColor: "var(--color-success)",
+                          color: "var(--color-success)",
+                        }
+                      : {
+                          borderColor: "rgba(220,38,38,0.5)",
+                          color: "var(--color-danger)",
+                        }
                   }
                 >
-                  {account.status === 'suspended' ? 'unsuspend' : 'suspend'}
+                  {account.status === "suspended" ? "unsuspend" : "suspend"}
                 </button>
               </div>
 
               {/* Expanded: characters */}
               {expandedId === account.id && detail && (
                 <div className="mt-3 ml-4 border-l-2 border-border pl-4">
-                  <p className="eyebrow mb-2" style={{ color: 'var(--color-text-tertiary)' }}>
+                  <p
+                    className="eyebrow mb-2"
+                    style={{ color: "var(--color-text-tertiary)" }}
+                  >
                     Characters ({detail.characters.length})
                   </p>
                   {detail.characters.length === 0 ? (
-                    <p className="font-body text-xs text-muted">No characters.</p>
+                    <p className="font-body text-xs text-muted">
+                      No characters.
+                    </p>
                   ) : (
                     <div className="flex flex-col gap-2">
                       {detail.characters.map((character) => (
-                        <div key={character.id} className="flex items-center gap-3">
+                        <div
+                          key={character.id}
+                          className="flex items-center gap-3"
+                        >
                           <div className="flex-1">
-                            <span className="font-body text-sm font-bold">{character.display_name}</span>
+                            <span className="font-body text-sm font-bold">
+                              {character.display_name}
+                            </span>
                             <span className="font-body text-xs text-muted ml-2">
-                              @{character.username} &middot; {character.faction_slug}
+                              @{character.username} &middot;{" "}
+                              {character.faction_slug}
                             </span>
                             <span
                               className="ml-2 font-body text-xs"
                               style={{
-                                color: character.status === 'banned' ? 'var(--color-danger)'
-                                  : character.status === 'paused' ? 'var(--color-warning)'
-                                  : 'var(--color-success)',
+                                color:
+                                  character.status === "banned"
+                                    ? "var(--color-danger)"
+                                    : character.status === "paused"
+                                      ? "var(--color-warning)"
+                                      : "var(--color-success)",
                                 fontWeight: 700,
                               }}
                             >
@@ -162,14 +207,30 @@ export default function AccountsTab() {
                             </span>
                           </div>
                           <button
-                            onClick={() => void handleBan(character.id, character.status !== 'banned')}
+                            onClick={() =>
+                              void handleBan(
+                                character.id,
+                                character.status !== "banned",
+                              )
+                            }
                             className="btn-outline text-xs"
-                            style={character.status === 'banned'
-                              ? { borderColor: 'var(--color-success)', color: 'var(--color-success)', fontSize: 9, padding: '2px 8px' }
-                              : { borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)', fontSize: 9, padding: '2px 8px' }
+                            style={
+                              character.status === "banned"
+                                ? {
+                                    borderColor: "var(--color-success)",
+                                    color: "var(--color-success)",
+                                    fontSize: 9,
+                                    padding: "2px 8px",
+                                  }
+                                : {
+                                    borderColor: "rgba(220,38,38,0.5)",
+                                    color: "var(--color-danger)",
+                                    fontSize: 9,
+                                    padding: "2px 8px",
+                                  }
                             }
                           >
-                            {character.status === 'banned' ? 'unban' : 'ban'}
+                            {character.status === "banned" ? "unban" : "ban"}
                           </button>
                         </div>
                       ))}
@@ -182,5 +243,5 @@ export default function AccountsTab() {
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/admin/TasksTab.tsx
+++ b/frontend/src/pages/admin/TasksTab.tsx
@@ -50,7 +50,7 @@ export default function TasksTab() {
     setEditingId(t.id);
     setEditState({
       title: t.title,
-      description: t.description,
+      description: t.description ?? "",
       point_value: String(t.point_value),
       level_required: String(t.level_required),
     });


### PR DESCRIPTION
## Summary
- Fixes corrupted `Groups.tsx` on main where `import PageTitle` lines were interleaved between every line of the static `FACTIONS` array literal (~60 TS1109/TS1128 parse errors).
- Clears 15 unrelated pre-existing TypeScript errors across 8 files surfaced once Groups.tsx parsed.
- `npx tsc --noEmit` from `frontend/` now passes with zero errors.

## Changes
- [Groups.tsx](frontend/src/pages/Groups.tsx) — remove interleaved duplicate imports
- [PraxisCard.tsx](frontend/src/components/PraxisCard.tsx) — drop `body_text` rendering (field is on `PraxisOut`, not `PraxisCardOut`); drop unused `bodyStyle` destructure
- [CollaborationDetail.tsx](frontend/src/pages/CollaborationDetail.tsx) — derive `winningStars` client-side (`DuelVoteSummary` has no `is_winning`); drop unused `useNavigate`/`factionCssVar`
- [TaskCardSingularity.tsx](frontend/src/components/cards/TaskCardSingularity.tsx) — add missing `factionCssVar` import
- [AccountsTab.tsx](frontend/src/pages/admin/AccountsTab.tsx) — `useRef<T \| null>(null)` for mutable timeout ref
- [TasksTab.tsx](frontend/src/pages/admin/TasksTab.tsx) — coerce nullable `description` to `""` for `EditState`
- Misc unused-import / unused-setter cleanup in feed cards and `CharacterProfile`

## Risks / follow-ups
- `body_text` was dead code on praxis cards — `PraxisCardOut` never had the field. If the snippet should render, that's a backend schema fix.
- `bodyStyle` is still on the `ContentProps` interface and 8 callers pass it, but the value is now ignored. Pure cleanup, not correctness.

## Test plan
- [x] `npx tsc --noEmit` from `frontend/` exits 0
- [ ] Smoke-test in browser: praxis cards render, collaboration detail duel-tally highlights leader, account search debounce works

🤖 Generated with [Claude Code](https://claude.com/claude-code)