### PR TITLE
Fix 5 bugs after Edit Praxis archetype refactor

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -14,6 +14,7 @@ from models.character import Character
 from models.task import Task, TaskStatus, TaskType
 from schemas.task import TaskCreate, TaskOut
 from services.auth import get_current_account
+from services.era import get_current_era_row, get_or_create_stats
 from services.task import (
     build_task_out,
     build_task_out_for_viewer,
@@ -51,8 +52,24 @@ async def list_tasks(
         limit=limit,
         offset=offset,
     )
+    # Fetch viewer-scoped rows ONCE per request and pass them through to
+    # build_task_out_for_viewer for each task. Without this, every task in
+    # the list would re-fetch the same era row and the same character stats
+    # row, producing an N+1 (2 redundant queries per task).
+    era_row = None
+    viewer_stats = None
+    if viewer is not None:
+        era_row = await get_current_era_row(session)
+        viewer_stats = await get_or_create_stats(session, viewer.id, era_row.id)
     return [
-        await build_task_out_for_viewer(task, viewer, session) for task in tasks
+        await build_task_out_for_viewer(
+            task,
+            viewer,
+            session,
+            era_row=era_row,
+            character_stats=viewer_stats,
+        )
+        for task in tasks
     ]
 
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -14,6 +14,8 @@ from sqlalchemy.orm import selectinload
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
 from models.flag import Flag
 from models.meta_task import PraxisMetaTask
 from models.praxis import (
@@ -401,7 +403,14 @@ async def _check_create_preconditions(
     character = await session.get(Character, character_id)
     if character is None:
         raise HTTPException(status_code=404, detail="Character not found.")
-    if not await can_submit_praxis_for_task(character, task, session):
+    if not await can_submit_praxis_for_task(
+        character,
+        task,
+        session,
+        era,
+        era_row=era_row,
+        character_stats=stats,
+    ):
         raise HTTPException(
             status_code=409,
             detail="You have already submitted a praxis for this task.",
@@ -578,22 +587,76 @@ async def can_submit_praxis_for_task(
     character: Optional[Character],
     task: Task,
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+    *,
+    era_row: Optional[Era] = None,
+    character_stats: Optional[CharacterStats] = None,
 ) -> bool:
     """Return True if ``character`` may create a new praxis for ``task``.
 
-    Mirrors the duplicate-submission rule enforced in :func:`create_praxis`:
-    - Anonymous viewers never see the submit affordance (False).
-    - A character that already authors a non-withdrawn ``Praxis`` for this
-      ``task`` cannot submit again, except for the Analog faction (Double
-      Dipper perk). Withdrawn prior praxes do not block a fresh submission.
+    Combines every gate the frontend "Sign up" affordance needs to reflect, so
+    the button can be hidden truthfully (per the "hide unusable controls" rule)
+    rather than shown disabled. Returns False if any of the following holds:
 
-    This helper intentionally stays focused on the one-praxis-per-task rule.
-    Level gates, bank-cap checks, and faction-visibility are handled by the
-    caller or :func:`create_praxis` itself.
+    - **Anonymous viewer**: no character is authenticated.
+    - **Level gate**: the character's current-era level is below
+      ``task.level_required``.
+    - **Faction eligibility**: for metatask rows, the character must belong to
+      the same faction as the metatask. Standard tasks pass this check
+      unconditionally. Delegated to :func:`is_task_eligible_for_character` so
+      the rule is single-sourced.
+    - **Duplicate authorship**: the character already authors a non-withdrawn
+      ``Praxis`` for this task. The Analog faction (Double Dipper perk) is
+      exempt from this gate. Withdrawn prior praxes do not block a fresh
+      submission.
+    - **Active membership in another character's praxis**: the character is a
+      non-submitted member of an in-flight ``Praxis`` for this task that they
+      did not author (covers being invited to a collab/duel they have not yet
+      completed). Membership in their own authored praxis is handled by the
+      duplicate-authorship gate so the Analog Double Dipper carve-out applies
+      uniformly.
+
+    Bank-cap checks and other run-time guards remain in :func:`create_praxis`.
+
+    ``era_row`` and ``character_stats`` are accepted as optional pre-fetched
+    values so callers that iterate over many tasks (e.g. the ``/tasks`` list
+    endpoint) can avoid the N+1 of re-fetching the same per-viewer rows on
+    every iteration. When omitted, this helper fetches them itself so the
+    function remains usable standalone.
     """
     if character is None:
         return False
 
+    # Level + faction eligibility (single-sourced via is_task_eligible_for_character).
+    if era_row is None:
+        era_row = await get_current_era_row(session)
+    if character_stats is None:
+        character_stats = await get_or_create_stats(session, character.id, era_row.id)
+    if not is_task_eligible_for_character(character, task, character_stats.level):
+        return False
+
+    # Active-membership gate: blocks characters from being members of someone
+    # else's in-flight praxis on this task (covers the invited-to-collab/duel
+    # case). Analog is exempted ONLY for membership in their OWN authored
+    # praxes — Double Dipper is about authorship, not being roped into another
+    # character's praxis. We narrow the query to praxes NOT authored by the
+    # character so the Analog carve-out below is the sole owner of the
+    # duplicate-authorship rule.
+    member_result = await session.execute(
+        select(PraxisMember.id)
+        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+        .where(
+            PraxisMember.character_id == character.id,
+            PraxisMember.has_submitted == False,  # noqa: E712
+            Praxis.task_id == task.id,
+            Praxis.created_by_id != character.id,
+            Praxis.is_withdrawn == False,  # noqa: E712
+        )
+    )
+    if member_result.first() is not None:
+        return False
+
+    # Duplicate-authorship gate, with the Analog Double Dipper carve-out.
     if character.faction_slug == ANALOG_FACTION_SLUG:
         return True
 

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
 from models.faction import Faction, FactionStatus
 from models.praxis import Praxis, PraxisMember, PraxisStatus
 from models.task import Task, TaskStatus, TaskType
@@ -111,6 +113,9 @@ async def build_task_out_for_viewer(
     viewer: Optional[Character],
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
+    *,
+    era_row: Optional[Era] = None,
+    character_stats: Optional[CharacterStats] = None,
 ) -> TaskOut:
     """Build a :class:`TaskOut` with viewer-relative capability flags.
 
@@ -118,19 +123,33 @@ async def build_task_out_for_viewer(
     ``eligible_for_current_user`` using the authenticated viewer's character
     (``None`` for anonymous callers). All three flags default to the same
     safe values as :func:`build_task_out` when ``viewer`` is ``None``.
+
+    ``era_row`` and ``character_stats`` may be supplied by callers that
+    iterate over many tasks for the same viewer (e.g. the ``/tasks`` list
+    endpoint) so the per-viewer fetches happen once per request rather than
+    once per task. When omitted, they are fetched here.
     """
     base = build_task_out(task)
 
     if viewer is None:
         return base
 
-    era_row = await get_current_era_row(session)
-    stats = await get_or_create_stats(session, viewer.id, era_row.id)
+    if era_row is None:
+        era_row = await get_current_era_row(session)
+    if character_stats is None:
+        character_stats = await get_or_create_stats(session, viewer.id, era_row.id)
 
-    base.can_submit_praxis = await can_submit_praxis_for_task(viewer, task, session)
-    base.allowed_modes = allowed_praxis_modes(viewer, task, stats.level, era)
+    base.can_submit_praxis = await can_submit_praxis_for_task(
+        viewer,
+        task,
+        session,
+        era,
+        era_row=era_row,
+        character_stats=character_stats,
+    )
+    base.allowed_modes = allowed_praxis_modes(viewer, task, character_stats.level, era)
     base.eligible_for_current_user = is_task_eligible_for_character(
-        viewer, task, stats.level
+        viewer, task, character_stats.level
     )
     return base
 

--- a/backend/tests/integration/test_can_submit_praxis.py
+++ b/backend/tests/integration/test_can_submit_praxis.py
@@ -1,0 +1,214 @@
+"""Integration tests for ``services.praxis.can_submit_praxis_for_task``.
+
+This helper drives the frontend ``can_submit_praxis`` flag on TaskOut. It must
+combine every signup gate so the UI can hide the "Sign up" button when the
+viewer would not actually be allowed through. Hides, never disables (per
+CLAUDE.md "Hide unusable controls").
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.praxis import Praxis, PraxisMember, PraxisType
+from models.task import Task, TaskType
+from services.praxis import can_submit_praxis_for_task
+
+
+# ---------------------------------------------------------------------------
+# Anonymous viewer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_submit(
+    db_session: AsyncSession, active_task: Task
+) -> None:
+    """No authenticated character means no signup affordance."""
+    assert (
+        await can_submit_praxis_for_task(None, active_task, db_session)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate authorship
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_duplicate_authorship_blocks_non_analog(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    praxis_solo: Praxis,
+    era: Era,
+) -> None:
+    """A non-Analog character who already authors a non-withdrawn praxis is blocked."""
+    assert character.faction_slug != "analog"
+    assert (
+        await can_submit_praxis_for_task(character, active_task, db_session)
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_analog_double_dipper_allowed_despite_duplicate(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+) -> None:
+    """Analog characters bypass the duplicate-authorship gate (Double Dipper perk)."""
+    # Seed the analog faction row and re-faction the character.
+    db_session.add(
+        Faction(
+            slug="analog",
+            name="Analog",
+            description="Test",
+            status=FactionStatus.visible,
+        )
+    )
+    await db_session.commit()
+
+    character.faction_slug = "analog"
+    await db_session.commit()
+
+    # Author a prior, non-withdrawn praxis on the task.
+    db_session.add(
+        Praxis(
+            task_id=active_task.id,
+            created_by_id=character.id,
+            type=PraxisType.solo,
+            title="Prior",
+            body_text="prior",
+        )
+    )
+    await db_session.commit()
+
+    assert (
+        await can_submit_praxis_for_task(character, active_task, db_session)
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Level gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_level_too_low_blocks_signup(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+) -> None:
+    """A character below ``task.level_required`` cannot sign up."""
+    # Bump task requirement above the character's level (default fixture level=0).
+    active_task.level_required = 5
+    await db_session.commit()
+
+    assert (
+        await can_submit_praxis_for_task(character, active_task, db_session)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Faction eligibility (metatasks)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_metatask_faction_mismatch_blocks_signup(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+) -> None:
+    """Metatask rows require matching ``metatask_faction_slug`` on the character."""
+    # Seed a different faction the character does NOT belong to.
+    db_session.add(
+        Faction(
+            slug="other",
+            name="Other",
+            description="Test",
+            status=FactionStatus.visible,
+        )
+    )
+    await db_session.commit()
+
+    active_task.task_type = TaskType.metatask
+    active_task.metatask_faction_slug = "other"
+    await db_session.commit()
+
+    assert character.faction_slug != "other"
+    assert (
+        await can_submit_praxis_for_task(character, active_task, db_session)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Active membership (invited collaborator)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_active_member_of_other_praxis_blocks_signup(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+) -> None:
+    """A character who is a non-submitted member of an in-progress praxis on this
+    task cannot start a new one — even if they are not the author. Covers the
+    invited-to-collab case."""
+    # character2 authors a collab; character is invited as a (non-submitted) member.
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character2.id,
+        type=PraxisType.collab,
+        title="Collab",
+        body_text="collab",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            PraxisMember(
+                praxis_id=praxis.id,
+                character_id=character2.id,
+                has_submitted=False,
+            ),
+            PraxisMember(
+                praxis_id=praxis.id,
+                character_id=character.id,
+                has_submitted=False,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    assert (
+        await can_submit_praxis_for_task(character, active_task, db_session)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_eligible_character_can_submit(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+) -> None:
+    """No prior praxis, level OK, faction OK, no concurrent membership: True."""
+    # Default fixture: level 0, level_required 0, standard task, ua faction.
+    assert (
+        await can_submit_praxis_for_task(character, active_task, db_session)
+        is True
+    )

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -1,197 +1,300 @@
-import { useEffect, useState } from 'react'
-import { useParams, Link, useNavigate, useLocation } from 'react-router-dom'
-import { getTask, getTaskSignups, type TaskOut, type TaskSignupOut } from '../api/tasks'
-import { listPraxes, createPraxis, withdrawPraxis, type PraxisCardOut } from '../api/praxis'
-import { listRelationships } from '../api/relationships'
-import PraxisCard from '../components/PraxisCard'
-import LevelPill from '../components/ui/LevelPill'
-import PageTitle from '../components/ui/PageTitle'
-import FeedBadge from '../components/feed/FeedBadge'
-import { useAuth } from '../auth/AuthContext'
-import { factionCssVar, factionName } from '../utils/factions'
-import { extractError } from '../utils/errors'
-import { mediaUrl } from '../utils/media'
-import { computeDisplayPoints } from '../utils/points'
-import { useGameConfig } from '../hooks/useGameConfig'
+import { useEffect, useState } from "react";
+import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
+import {
+  getTask,
+  getTaskSignups,
+  type TaskOut,
+  type TaskSignupOut,
+} from "../api/tasks";
+import {
+  listPraxes,
+  createPraxis,
+  withdrawPraxis,
+  type PraxisCardOut,
+} from "../api/praxis";
+import { listRelationships } from "../api/relationships";
+import PraxisCard from "../components/PraxisCard";
+import LevelPill from "../components/ui/LevelPill";
+import PageTitle from "../components/ui/PageTitle";
+import FeedBadge from "../components/feed/FeedBadge";
+import { useAuth } from "../auth/AuthContext";
+import {
+  factionCssVar,
+  factionName,
+  getFactionTokens,
+} from "../utils/factions";
+import { extractError } from "../utils/errors";
+import { mediaUrl } from "../utils/media";
+import { computeDisplayPoints } from "../utils/points";
+import { useGameConfig } from "../hooks/useGameConfig";
 
-const DEFAULT_MAX_TASK_SLOTS = 20
-const VISIBLE_SIGNUPS = 4
+const DEFAULT_MAX_TASK_SLOTS = 20;
+const VISIBLE_SIGNUPS = 4;
 
 export default function TaskDetail() {
-  const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-  const location = useLocation()
-  const { user } = useAuth()
-  const [task, setTask] = useState<TaskOut | null>(null)
-  const [submissions, setSubmissions] = useState<PraxisCardOut[]>([])
-  const [signups, setSignups] = useState<TaskSignupOut[]>([])
-  const [isInProgress, setIsInProgress] = useState(false)
-  const [inProgressPraxisId, setInProgressPraxisId] = useState<number | null>(null)
-  const [taskSlotCount, setTaskSlotCount] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-  const [signupError, setSignupError] = useState<string | null>(null)
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useAuth();
+  const [task, setTask] = useState<TaskOut | null>(null);
+  const [submissions, setSubmissions] = useState<PraxisCardOut[]>([]);
+  const [signups, setSignups] = useState<TaskSignupOut[]>([]);
+  const [isInProgress, setIsInProgress] = useState(false);
+  const [inProgressPraxisId, setInProgressPraxisId] = useState<number | null>(
+    null,
+  );
+  const [taskSlotCount, setTaskSlotCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [signupError, setSignupError] = useState<string | null>(null);
 
   // Friend/foe lookup sets
-  const [friends, setFriends] = useState<Set<number>>(new Set())
-  const [foes, setFoes] = useState<Set<number>>(new Set())
+  const [friends, setFriends] = useState<Set<number>>(new Set());
+  const [foes, setFoes] = useState<Set<number>>(new Set());
 
   // Game config
-  const gameConfig = useGameConfig()
-  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS
+  const gameConfig = useGameConfig();
+  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS;
 
   // Submission sort
-  const [submissionSort, setSubmissionSort] = useState<'score' | 'recent'>('score')
+  const [submissionSort, setSubmissionSort] = useState<"score" | "recent">(
+    "score",
+  );
 
   useEffect(() => {
-    if (!id) return
-    setLoading(true)
-    setIsInProgress(false)
-    const taskId = parseInt(id, 10)
+    if (!id) return;
+    setLoading(true);
+    setIsInProgress(false);
+    const taskId = parseInt(id, 10);
 
     const fetches: Promise<unknown>[] = [
       getTask(taskId),
-      listPraxes({ task_id: taskId, status: 'submitted' }),
+      listPraxes({ task_id: taskId, status: "submitted" }),
       getTaskSignups(taskId),
-    ]
+    ];
     if (user) {
-      fetches.push(listPraxes({ character_id: user.character?.id, status: 'in_progress' }))
       fetches.push(
-        listRelationships({ type: 'friend' }).then((rels) =>
-          new Set(rels.filter((r) => r.status === 'active').map((r) => r.to_character_id))
-        ).catch(() => new Set<number>())
-      )
+        listPraxes({ character_id: user.character?.id, status: "in_progress" }),
+      );
       fetches.push(
-        listRelationships({ type: 'foe' }).then((rels) =>
-          new Set(rels.filter((r) => r.status === 'active').map((r) => r.to_character_id))
-        ).catch(() => new Set<number>())
-      )
+        listRelationships({ type: "friend" })
+          .then(
+            (rels) =>
+              new Set(
+                rels
+                  .filter((r) => r.status === "active")
+                  .map((r) => r.to_character_id),
+              ),
+          )
+          .catch(() => new Set<number>()),
+      );
+      fetches.push(
+        listRelationships({ type: "foe" })
+          .then(
+            (rels) =>
+              new Set(
+                rels
+                  .filter((r) => r.status === "active")
+                  .map((r) => r.to_character_id),
+              ),
+          )
+          .catch(() => new Set<number>()),
+      );
     }
 
     Promise.all(fetches)
       .then(([t, s, sg, myTasks, friendSet, foeSet]) => {
-        setTask(t as TaskOut)
-        setSubmissions(s as PraxisCardOut[])
-        setSignups(sg as TaskSignupOut[])
+        setTask(t as TaskOut);
+        setSubmissions(s as PraxisCardOut[]);
+        setSignups(sg as TaskSignupOut[]);
         if (myTasks) {
-          const praxes = myTasks as PraxisCardOut[]
-          const activeForThisTask = praxes.find((p) => p.task_id === taskId && !p.is_withdrawn)
-          setIsInProgress(activeForThisTask !== undefined)
-          setInProgressPraxisId(activeForThisTask?.id ?? null)
-          setTaskSlotCount(praxes.filter((p) => !p.is_withdrawn).length)
+          const praxes = myTasks as PraxisCardOut[];
+          const activeForThisTask = praxes.find(
+            (p) => p.task_id === taskId && !p.is_withdrawn,
+          );
+          setIsInProgress(activeForThisTask !== undefined);
+          setInProgressPraxisId(activeForThisTask?.id ?? null);
+          setTaskSlotCount(praxes.filter((p) => !p.is_withdrawn).length);
         }
-        if (friendSet) setFriends(friendSet as Set<number>)
-        if (foeSet) setFoes(foeSet as Set<number>)
+        if (friendSet) setFriends(friendSet as Set<number>);
+        if (foeSet) setFoes(foeSet as Set<number>);
       })
-      .catch((err) => setFetchError(extractError(err, "Couldn't load this task.")))
-      .finally(() => setLoading(false))
-  }, [id, location.key])
+      .catch((err) =>
+        setFetchError(extractError(err, "Couldn't load this task.")),
+      )
+      .finally(() => setLoading(false));
+  }, [id, location.key]);
 
   const mySubmission = user?.character
-    ? submissions.find((s) => s.created_by_id === user.character!.id && !s.is_withdrawn)
-    : undefined
+    ? submissions.find(
+        (s) => s.created_by_id === user.character!.id && !s.is_withdrawn,
+      )
+    : undefined;
 
   const handleSignup = async () => {
-    if (!task) return
-    setSignupError(null)
+    if (!task) return;
+    setSignupError(null);
     try {
-      const praxis = await createPraxis({ task_id: task.id, type: 'solo' })
-      navigate(`/praxes/${praxis.id}/edit`)
+      const praxis = await createPraxis({ task_id: task.id, type: "solo" });
+      navigate(`/praxes/${praxis.id}/edit`);
     } catch (err) {
-      setSignupError(extractError(err, 'Could not sign up for this task.'))
+      setSignupError(extractError(err, "Could not sign up for this task."));
     }
-  }
+  };
 
   const handleDrop = async () => {
-    if (!task) return
+    if (!task) return;
     // Drop either the submitted praxis (if any) or the in-progress draft.
-    const targetPraxisId = mySubmission?.id ?? inProgressPraxisId
-    if (!targetPraxisId) return
-    if (!window.confirm('Drop this task? You can sign up again later.')) return
-    setSignupError(null)
+    const targetPraxisId = mySubmission?.id ?? inProgressPraxisId;
+    if (!targetPraxisId) return;
+    if (!window.confirm("Drop this task? You can sign up again later.")) return;
+    setSignupError(null);
     try {
-      await withdrawPraxis(targetPraxisId)
-      setIsInProgress(false)
-      setInProgressPraxisId(null)
-      setSubmissions((prev) => prev.map((s) => s.id === targetPraxisId ? { ...s, is_withdrawn: true } : s))
+      await withdrawPraxis(targetPraxisId);
+      setIsInProgress(false);
+      setInProgressPraxisId(null);
+      setSubmissions((prev) =>
+        prev.map((s) =>
+          s.id === targetPraxisId ? { ...s, is_withdrawn: true } : s,
+        ),
+      );
     } catch (err) {
-      setSignupError(extractError(err, 'Could not drop this task.'))
+      setSignupError(extractError(err, "Could not drop this task."));
     }
-  }
+  };
 
-  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
-  if (fetchError) return (
-    <div className="py-8">
-      <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-        {fetchError}{' '}
-        <button onClick={() => window.location.reload()} className="underline">Try refreshing.</button>
-      </p>
-    </div>
-  )
-  if (!task) return <div className="py-8 font-body text-muted">Task not found.</div>
+  if (loading)
+    return <div className="py-8 font-body text-muted">Loading...</div>;
+  if (fetchError)
+    return (
+      <div className="py-8">
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+          {fetchError}{" "}
+          <button
+            onClick={() => window.location.reload()}
+            className="underline"
+          >
+            Try refreshing.
+          </button>
+        </p>
+      </div>
+    );
+  if (!task)
+    return <div className="py-8 font-body text-muted">Task not found.</div>;
 
-  const color = factionCssVar(task.primary_faction_slug)
-  const fname = factionName(task.primary_faction_slug)
+  const slug = task.primary_faction_slug;
+  const {
+    primary: color,
+    surface: heroSurface,
+    text: heroInk,
+    muted: heroMuted,
+    accent: heroAccent,
+    font: heroFont,
+  } = getFactionTokens(slug);
+  const fname = factionName(slug);
   // Backend-authoritative: `can_submit_praxis` covers level, faction gate,
   // one-per-task rule, and Analog carve-out. Keep local `mySubmission`/
   // `isInProgress` checks so we show the right UI state (edit / in-progress)
   // instead of the sign-up button.
-  const canSignUp = !!user && !mySubmission && !isInProgress && task.can_submit_praxis
-  const slotsOpen = maxTaskSlots - taskSlotCount
-  const avgVote = submissions.length > 0
-    ? (submissions.reduce((sum, s) => sum + (s.score ?? 0), 0) / submissions.length).toFixed(1)
-    : '—'
+  const canSignUp =
+    !!user && !mySubmission && !isInProgress && task.can_submit_praxis;
+  const slotsOpen = maxTaskSlots - taskSlotCount;
+  const avgVote =
+    submissions.length > 0
+      ? (
+          submissions.reduce((sum, s) => sum + (s.score ?? 0), 0) /
+          submissions.length
+        ).toFixed(1)
+      : "—";
 
-  const myFaction = user?.character?.faction_slug
-  const taskFaction = task.primary_faction_slug
-  const factionConfig = myFaction && gameConfig
-    ? gameConfig.factions.find((f) => f.slug === myFaction)
-    : null
+  const myFaction = user?.character?.faction_slug;
+  const taskFaction = task.primary_faction_slug;
+  const factionConfig =
+    myFaction && gameConfig
+      ? gameConfig.factions.find((f) => f.slug === myFaction)
+      : null;
   const factionMultiplier = factionConfig
-    ? (!taskFaction || taskFaction === myFaction || taskFaction === 'na'
-        ? factionConfig.own_task_modifier
-        : factionConfig.other_task_modifier)
-    : 1.0
+    ? !taskFaction || taskFaction === myFaction || taskFaction === "na"
+      ? factionConfig.own_task_modifier
+      : factionConfig.other_task_modifier
+    : 1.0;
   const modifiedPoints = gameConfig
-    ? computeDisplayPoints(task.point_value, myFaction, taskFaction, gameConfig.factions)
-    : task.point_value
+    ? computeDisplayPoints(
+        task.point_value,
+        myFaction,
+        taskFaction,
+        gameConfig.factions,
+      )
+    : task.point_value;
 
   const sortedSubmissions = [...submissions].sort((a, b) => {
-    if (submissionSort === 'score') return (b.score ?? 0) - (a.score ?? 0)
-    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-  })
+    if (submissionSort === "score") return (b.score ?? 0) - (a.score ?? 0);
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  });
 
   return (
     <div className="py-8">
       {/* ── Breadcrumb ── */}
       <PageTitle title="Task" eyebrow="Tasks · Detail" />
-      <nav className="font-body mb-4" style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--color-text-tertiary)' }}>
-        <Link to="/tasks" style={{ color: 'var(--faction-journeymen)', textDecoration: 'none' }}>Tasks</Link>
-        {' › '}
-        <span style={{ color: 'var(--color-text-primary)' }}>{task.title}</span>
+      <nav
+        className="font-body mb-4"
+        style={{
+          fontSize: 9,
+          letterSpacing: "0.1em",
+          color: "var(--color-text-tertiary)",
+        }}
+      >
+        <Link
+          to="/tasks"
+          style={{ color: "var(--faction-journeymen)", textDecoration: "none" }}
+        >
+          Tasks
+        </Link>
+        {" › "}
+        <span style={{ color: "var(--color-text-primary)" }}>{task.title}</span>
       </nav>
 
       {/* ── Two-Column Layout ── */}
-      <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start' }}>
+      <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
         {/* ── Main Column ── */}
         <div style={{ flex: 1, minWidth: 0 }}>
-
           {/* ── Task Hero Block ── */}
           <div
-            className="sidebar-card mb-5"
-            style={{ borderLeft: `4px solid ${color}`, padding: '18px 22px' }}
+            className="mb-5"
+            style={{
+              background: heroSurface,
+              color: heroInk,
+              fontFamily: heroFont,
+              borderTop: "1px solid var(--color-border)",
+              borderRight: "1px solid var(--color-border)",
+              borderBottom: "1px solid var(--color-border)",
+              borderLeft: `4px solid ${color}`,
+              padding: "18px 22px",
+              boxShadow: "0 0 0 1px rgba(0,0,0,.04)",
+            }}
           >
             {/* Faction pennant + status + level */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginBottom: 10,
+              }}
+            >
               <span
                 className="pennant-shape"
                 style={{
-                  display: 'inline-block',
-                  background: color, color: 'var(--color-text-on-accent)',
+                  display: "inline-block",
+                  background: color,
+                  color: "var(--color-text-on-accent)",
                   fontFamily: "'Courier Prime', monospace",
-                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                  letterSpacing: '0.07em', padding: '3px 14px',
-                  textShadow: '0 1px 2px rgba(0,0,0,0.3)',
+                  fontSize: 9,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.07em",
+                  padding: "3px 14px",
+                  textShadow: "0 1px 2px rgba(0,0,0,0.3)",
                 }}
               >
                 {fname}
@@ -199,24 +302,36 @@ export default function TaskDetail() {
               <span
                 className="font-body"
                 style={{
-                  fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
-                  padding: '2px 8px', borderRadius: 4,
-                  background: task.status === 'active' ? 'var(--faction-analog-light)' : 'var(--color-bg-surface-alt)',
-                  color: task.status === 'active' ? 'var(--faction-analog)' : 'var(--color-text-tertiary)',
+                  fontSize: 8,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                  padding: "2px 8px",
+                  borderRadius: 4,
+                  background:
+                    task.status === "active"
+                      ? "var(--faction-analog-light)"
+                      : "var(--color-bg-surface-alt)",
+                  color:
+                    task.status === "active"
+                      ? "var(--faction-analog)"
+                      : "var(--color-text-tertiary)",
                 }}
               >
                 {task.status}
               </span>
-              {task.task_type === 'metatask' && (
+              {task.task_type === "metatask" && (
                 <span
                   className="font-body"
                   style={{
-                    fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.15em',
-                    padding: '2px 8px', borderRadius: 4,
+                    fontSize: 8,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.15em",
+                    padding: "2px 8px",
+                    borderRadius: 4,
                     background: factionCssVar(task.metatask_faction_slug),
-                    color: 'var(--color-text-on-accent)',
+                    color: "var(--color-text-on-accent)",
                     fontWeight: 700,
-                    textShadow: '0 1px 2px rgba(0,0,0,0.3)',
+                    textShadow: "0 1px 2px rgba(0,0,0,0.3)",
                   }}
                 >
                   META
@@ -227,14 +342,20 @@ export default function TaskDetail() {
 
             {/* Title */}
             <h1
-              className="font-display italic font-medium"
-              style={{ fontSize: 28, color: 'var(--color-text-primary)', lineHeight: 1.2, marginBottom: task.task_type === 'metatask' ? 4 : 12 }}
+              style={{
+                fontFamily: heroFont,
+                fontSize: 28,
+                fontWeight: 600,
+                color: heroInk,
+                lineHeight: 1.2,
+                marginBottom: task.task_type === "metatask" ? 4 : 12,
+              }}
             >
               {task.title}
             </h1>
 
             {/* Metatask-for line */}
-            {task.task_type === 'metatask' && (
+            {task.task_type === "metatask" && (
               <p
                 className="eyebrow"
                 style={{
@@ -247,23 +368,48 @@ export default function TaskDetail() {
             )}
 
             {/* Stats row */}
-            <div style={{ display: 'grid', gridTemplateColumns: `repeat(${user && factionMultiplier !== 1.0 ? 5 : 4}, 1fr)`, gap: 8, marginBottom: 16 }}>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: `repeat(${user && factionMultiplier !== 1.0 ? 5 : 4}, 1fr)`,
+                gap: 8,
+                marginBottom: 16,
+              }}
+            >
               {[
-                { label: 'Base Pts', value: task.point_value },
-                ...(user && factionMultiplier !== 1.0 ? [{ label: `Your Pts (×${factionMultiplier})`, value: modifiedPoints }] : []),
-                { label: 'Completed', value: submissions.length },
-                { label: 'In Progress', value: signups.length },
-                { label: 'Avg Vote', value: avgVote },
+                { label: "Base Pts", value: task.point_value },
+                ...(user && factionMultiplier !== 1.0
+                  ? [
+                      {
+                        label: `Your Pts (×${factionMultiplier})`,
+                        value: modifiedPoints,
+                      },
+                    ]
+                  : []),
+                { label: "Completed", value: submissions.length },
+                { label: "In Progress", value: signups.length },
+                { label: "Avg Vote", value: avgVote },
               ].map((stat) => (
                 <div
                   key={stat.label}
                   className="text-center py-2"
-                  style={{ border: '1px solid var(--color-border)', background: 'var(--color-bg-surface)' }}
+                  style={{
+                    border: `1px solid ${heroAccent}`,
+                    background: "transparent",
+                  }}
                 >
-                  <div className="font-body font-bold text-lg" style={{ color: 'var(--color-text-primary)' }}>
+                  <div
+                    className="font-body font-bold text-lg"
+                    style={{ color: heroInk }}
+                  >
                     {stat.value}
                   </div>
-                  <div className="eyebrow" style={{ fontSize: 7 }}>{stat.label}</div>
+                  <div
+                    className="eyebrow"
+                    style={{ fontSize: 7, color: heroAccent }}
+                  >
+                    {stat.label}
+                  </div>
                 </div>
               ))}
             </div>
@@ -272,7 +418,12 @@ export default function TaskDetail() {
             {task.description && (
               <p
                 className="font-body"
-                style={{ fontSize: 13, lineHeight: 1.7, color: 'var(--color-text-secondary)', whiteSpace: 'pre-wrap' }}
+                style={{
+                  fontSize: 13,
+                  lineHeight: 1.7,
+                  color: heroMuted,
+                  whiteSpace: "pre-wrap",
+                }}
               >
                 {task.description}
               </p>
@@ -281,35 +432,62 @@ export default function TaskDetail() {
 
           {/* ── Signup Block ── */}
           {canSignUp && (
-            <div className="sidebar-card mb-5" style={{ padding: '16px 20px' }}>
+            <div className="sidebar-card mb-5" style={{ padding: "16px 20px" }}>
               <button
                 onClick={handleSignup}
                 style={{
-                  width: '100%',
-                  background: color, color: 'var(--color-text-on-accent)',
+                  width: "100%",
+                  background: color,
+                  color: "var(--color-text-on-accent)",
                   fontFamily: "'Courier Prime', monospace",
-                  fontSize: 13, fontWeight: 700, textTransform: 'uppercase',
-                  letterSpacing: '0.15em', padding: '10px 20px',
-                  border: 'none', cursor: 'pointer', position: 'relative',
+                  fontSize: 13,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.15em",
+                  padding: "10px 20px",
+                  border: "none",
+                  cursor: "pointer",
+                  position: "relative",
                 }}
               >
-                <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
+                <span
+                  style={{
+                    position: "absolute",
+                    inset: 3,
+                    border: "1px dashed rgba(255,255,255,0.25)",
+                    pointerEvents: "none",
+                  }}
+                />
                 Sign up · earn up to {modifiedPoints} pts
               </button>
 
-              <div className="eyebrow" style={{ marginTop: 6, display: 'flex', justifyContent: 'space-between' }}>
-                <span>You have {slotsOpen} of {maxTaskSlots} task slots open</span>
-                <span>Level {task.level_required} required <span className="eyebrow">MET</span></span>
+              <div
+                className="eyebrow"
+                style={{
+                  marginTop: 6,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>
+                  You have {slotsOpen} of {maxTaskSlots} task slots open
+                </span>
+                <span>
+                  Level {task.level_required} required{" "}
+                  <span className="eyebrow">MET</span>
+                </span>
               </div>
 
               {signupError && (
                 <div
                   className="font-body"
                   style={{
-                    fontSize: 11, color: 'var(--color-danger)', marginTop: 8,
-                    padding: '8px 12px',
-                    background: 'rgba(220,38,38,0.06)',
-                    border: '1px solid rgba(220,38,38,0.2)',
+                    fontSize: 11,
+                    color: "var(--color-danger)",
+                    marginTop: 8,
+                    padding: "8px 12px",
+                    background: "rgba(220,38,38,0.06)",
+                    border: "1px solid rgba(220,38,38,0.2)",
                   }}
                 >
                   {signupError}
@@ -318,100 +496,193 @@ export default function TaskDetail() {
             </div>
           )}
 
-
           {/* Already signed up / submitted states */}
           {user && mySubmission && (
-            <div className="sidebar-card mb-5" style={{ padding: '16px 20px', display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div
+              className="sidebar-card mb-5"
+              style={{
+                padding: "16px 20px",
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
               <div
                 style={{
-                  background: factionCssVar(task.primary_faction_slug, 'light'), border: `1.5px solid ${factionCssVar(task.primary_faction_slug, 'border')}`,
-                  borderRadius: 8, padding: '8px 16px',
-                  display: 'flex', alignItems: 'center', gap: 8, flex: 1,
+                  background: factionCssVar(task.primary_faction_slug, "light"),
+                  border: `1.5px solid ${factionCssVar(task.primary_faction_slug, "border")}`,
+                  borderRadius: 8,
+                  padding: "8px 16px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  flex: 1,
                 }}
               >
-                <span className="eyebrow" style={{ color }}>DONE</span>
-                <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)' }}>
+                <span className="eyebrow" style={{ color }}>
+                  DONE
+                </span>
+                <span
+                  className="font-body"
+                  style={{ fontSize: 11, color: "var(--color-text-primary)" }}
+                >
                   You've submitted praxis for this task
                 </span>
               </div>
-              <Link to={`/praxes/${mySubmission.id}/edit`} className="btn-outline" style={{ fontSize: 8, padding: '4px 12px' }}>
+              <Link
+                to={`/praxes/${mySubmission.id}/edit`}
+                className="btn-outline"
+                style={{ fontSize: 8, padding: "4px 12px" }}
+              >
                 edit
               </Link>
             </div>
           )}
 
-          {user && !mySubmission && isInProgress && inProgressPraxisId !== null && (
-            <div className="sidebar-card mb-5" style={{ padding: '16px 20px', display: 'flex', alignItems: 'center', gap: 10 }}>
+          {user &&
+            !mySubmission &&
+            isInProgress &&
+            inProgressPraxisId !== null && (
               <div
+                className="sidebar-card mb-5"
                 style={{
-                  background: factionCssVar(task.primary_faction_slug, 'light'), border: `1.5px solid ${factionCssVar(task.primary_faction_slug, 'border')}`,
-                  borderRadius: 8, padding: '8px 16px',
-                  display: 'flex', alignItems: 'center', gap: 8, flex: 1,
+                  padding: "16px 20px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
                 }}
               >
-                <span className="eyebrow" style={{ color }}>IN PROGRESS</span>
-                <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)' }}>You're on this task</span>
+                <div
+                  style={{
+                    background: factionCssVar(
+                      task.primary_faction_slug,
+                      "light",
+                    ),
+                    border: `1.5px solid ${factionCssVar(task.primary_faction_slug, "border")}`,
+                    borderRadius: 8,
+                    padding: "8px 16px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    flex: 1,
+                  }}
+                >
+                  <span className="eyebrow" style={{ color }}>
+                    IN PROGRESS
+                  </span>
+                  <span
+                    className="font-body"
+                    style={{ fontSize: 11, color: "var(--color-text-primary)" }}
+                  >
+                    You're on this task
+                  </span>
+                </div>
+                <Link
+                  to={`/praxes/${inProgressPraxisId}/edit`}
+                  style={{
+                    background: color,
+                    color: "var(--color-text-on-accent)",
+                    fontFamily: "'Courier Prime', monospace",
+                    fontSize: 11,
+                    fontWeight: 700,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.12em",
+                    padding: "8px 18px",
+                    textDecoration: "none",
+                    position: "relative",
+                  }}
+                >
+                  <span
+                    style={{
+                      position: "absolute",
+                      inset: 3,
+                      border: "1px dashed rgba(255,255,255,0.25)",
+                      pointerEvents: "none",
+                    }}
+                  />
+                  Continue editing
+                </Link>
+                <button
+                  onClick={handleDrop}
+                  className="eyebrow"
+                  style={{
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    color: "var(--color-text-tertiary)",
+                  }}
+                >
+                  drop
+                </button>
               </div>
-              <Link
-                to={`/praxes/${inProgressPraxisId}/edit`}
-                style={{
-                  background: color, color: 'var(--color-text-on-accent)',
-                  fontFamily: "'Courier Prime', monospace",
-                  fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
-                  letterSpacing: '0.12em', padding: '8px 18px',
-                  textDecoration: 'none', position: 'relative',
-                }}
-              >
-                <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-                Continue editing
-              </Link>
-              <button onClick={handleDrop} className="eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
-                drop
-              </button>
-            </div>
-          )}
+            )}
 
           {/* ── Completed Praxis Section ── */}
           <div className="mt-2">
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
-              <span className="eyebrow">{submissions.length} Completed Praxis</span>
-              <div style={{ display: 'flex', gap: 0 }}>
-                {(['score', 'recent'] as const).map((sort) => (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                marginBottom: 12,
+              }}
+            >
+              <span className="eyebrow">
+                {submissions.length} Completed Praxis
+              </span>
+              <div style={{ display: "flex", gap: 0 }}>
+                {(["score", "recent"] as const).map((sort) => (
                   <button
                     key={sort}
                     onClick={() => setSubmissionSort(sort)}
                     style={{
                       fontFamily: "'Courier Prime', monospace",
-                      fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
-                      letterSpacing: '0.1em', padding: '4px 10px',
-                      background: submissionSort === sort ? 'var(--color-text-primary)' : 'transparent',
-                      color: submissionSort === sort ? 'var(--color-bg-page)' : 'var(--color-text-tertiary)',
-                      border: `1px solid ${submissionSort === sort ? 'transparent' : 'var(--color-border)'}`,
-                      cursor: 'pointer',
+                      fontSize: 8,
+                      fontWeight: 700,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.1em",
+                      padding: "4px 10px",
+                      background:
+                        submissionSort === sort
+                          ? "var(--color-text-primary)"
+                          : "transparent",
+                      color:
+                        submissionSort === sort
+                          ? "var(--color-bg-page)"
+                          : "var(--color-text-tertiary)",
+                      border: `1px solid ${submissionSort === sort ? "transparent" : "var(--color-border)"}`,
+                      cursor: "pointer",
                     }}
                   >
-                    {sort === 'score' ? 'Top Rated' : 'Recent'}
+                    {sort === "score" ? "Top Rated" : "Recent"}
                   </button>
                 ))}
               </div>
             </div>
 
             {sortedSubmissions.length === 0 ? (
-              <p className="font-body text-muted">No submissions yet. Be the first.</p>
+              <p className="font-body text-muted">
+                No submissions yet. Be the first.
+              </p>
             ) : (
               <>
                 <div className="flex flex-wrap gap-4 items-start">
-                  {sortedSubmissions.slice(0, 4).map((s) => <PraxisCard key={s.id} praxis={s} />)}
+                  {sortedSubmissions.slice(0, 4).map((s) => (
+                    <PraxisCard key={s.id} praxis={s} />
+                  ))}
                 </div>
                 {submissions.length > 4 && (
-                  <div style={{ textAlign: 'center', marginTop: 16 }}>
+                  <div style={{ textAlign: "center", marginTop: 16 }}>
                     <Link
                       to={`/praxes?task_id=${task.id}`}
                       style={{
                         fontFamily: "'Courier Prime', monospace",
-                        fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
-                        letterSpacing: '0.1em', color: 'var(--faction-journeymen)',
-                        textDecoration: 'none',
+                        fontSize: 10,
+                        fontWeight: 700,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.1em",
+                        color: "var(--faction-journeymen)",
+                        textDecoration: "none",
                       }}
                     >
                       View all {submissions.length} praxis &rarr;
@@ -428,16 +699,18 @@ export default function TaskDetail() {
           {/* Players in Progress */}
           <div className="sidebar-card mb-3">
             <p className="eyebrow mb-2">{signups.length} Players in Progress</p>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
               {signups.slice(0, VISIBLE_SIGNUPS).map((signup) => {
-                const isFriend = friends.has(signup.character_id)
-                const isFoe = foes.has(signup.character_id)
+                const isFriend = friends.has(signup.character_id);
+                const isFoe = foes.has(signup.character_id);
                 return (
                   <div
                     key={signup.character_id}
                     style={{
-                      display: 'flex', alignItems: 'center', gap: 8,
-                      padding: '4px 0',
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "4px 0",
                     }}
                   >
                     <Link to={`/characters/${signup.character_id}`}>
@@ -445,13 +718,20 @@ export default function TaskDetail() {
                         <img
                           src={mediaUrl(signup.avatar_url)}
                           alt={signup.display_name}
-                          style={{ width: 24, height: 24, borderRadius: '50%', objectFit: 'cover' }}
+                          style={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: "50%",
+                            objectFit: "cover",
+                          }}
                         />
                       ) : (
                         <div
                           style={{
-                            width: 24, height: 24, borderRadius: '50%',
-                            background: `linear-gradient(135deg, ${factionCssVar(signup.faction_slug, 'light')}, ${factionCssVar(signup.faction_slug)})`,
+                            width: 24,
+                            height: 24,
+                            borderRadius: "50%",
+                            background: `linear-gradient(135deg, ${factionCssVar(signup.faction_slug, "light")}, ${factionCssVar(signup.faction_slug)})`,
                           }}
                         />
                       )}
@@ -459,18 +739,27 @@ export default function TaskDetail() {
                     <Link
                       to={`/characters/${signup.character_id}`}
                       className="font-body"
-                      style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', flex: 1 }}
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 700,
+                        color: "var(--color-text-primary)",
+                        textDecoration: "none",
+                        flex: 1,
+                      }}
                     >
                       {signup.display_name}
                     </Link>
                     {isFriend && <FeedBadge type="friend" label="Friend" />}
                     {isFoe && <FeedBadge type="duel" label="Foe" />}
                   </div>
-                )
+                );
               })}
             </div>
             {signups.length > VISIBLE_SIGNUPS && (
-              <p className="eyebrow" style={{ marginTop: 6, color: 'var(--color-text-tertiary)' }}>
+              <p
+                className="eyebrow"
+                style={{ marginTop: 6, color: "var(--color-text-tertiary)" }}
+              >
                 +{signups.length - VISIBLE_SIGNUPS} more &rarr;
               </p>
             )}
@@ -478,5 +767,5 @@ export default function TaskDetail() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisFieldJournal.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisFieldJournal.tsx
@@ -18,6 +18,7 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
+import { DropButton } from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -601,21 +602,19 @@ export default function EditPraxisFieldJournal({ state }: Props) {
             {state.saving ? "saving..." : "save draft"}
           </button>
           <div style={{ flex: 1 }} />
-          <button
-            type="button"
-            onClick={state.cancel}
-            style={{
-              background: "transparent",
-              color: muted,
+          <DropButton
+            onCancel={state.cancel}
+            disabled={
+              state.saving || state.submitting || state.switchingMode !== null
+            }
+            skin={{
+              label: "scrap it",
+              color: ruleRed,
               fontFamily: "'Special Elite', serif",
               fontSize: 11,
               textDecoration: "underline",
-              border: "none",
-              cursor: "pointer",
             }}
-          >
-            cancel
-          </button>
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisGazette.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisGazette.tsx
@@ -17,7 +17,12 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -694,6 +699,23 @@ export default function EditPraxisGazette({ state }: Props) {
           >
             {state.saving ? "saving..." : "save as draft"}
           </button>
+          <DropButton
+            onCancel={state.cancel}
+            disabled={
+              state.saving || state.submitting || state.switchingMode !== null
+            }
+            skin={{
+              label: "❦ retract & burn ❦",
+              color: STRUCK_RED,
+              fontFamily: "'IM Fell English', serif",
+              fontStyle: "italic",
+              fontSize: 13,
+              border: `1px solid ${STRUCK_RED}`,
+              padding: "10px 18px",
+              letterSpacing: "0.08em",
+              textDecoration: "line-through",
+            }}
+          />
           <div style={{ flex: 1 }} />
           <span
             style={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisLuggageManifest.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisLuggageManifest.tsx
@@ -17,7 +17,12 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -555,6 +560,21 @@ export default function EditPraxisLuggageManifest({ state }: Props) {
             >
               {state.saving ? "SAVING..." : "SAVE DRAFT"}
             </button>
+            <DropButton
+              onCancel={state.cancel}
+              disabled={
+                state.saving || state.submitting || state.switchingMode !== null
+              }
+              skin={{
+                label: "✗ VOID TICKET",
+                color: "#b91c1c",
+                fontFamily: "'Bebas Neue', sans-serif",
+                fontSize: 13,
+                letterSpacing: "0.18em",
+                border: `1.5px dashed #b91c1c`,
+                padding: "10px 18px",
+              }}
+            />
             <div style={{ flex: 1 }} />
             <span
               style={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
@@ -17,7 +17,12 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -542,21 +547,20 @@ export default function EditPraxisPaperCollage({ state }: Props) {
             {state.saving ? "saving..." : "save draft"}
           </button>
           <div style={{ flex: 1 }} />
-          <button
-            type="button"
-            onClick={state.cancel}
-            style={{
-              background: "transparent",
-              color: muted,
+          <DropButton
+            onCancel={state.cancel}
+            disabled={
+              state.saving || state.submitting || state.switchingMode !== null
+            }
+            skin={{
+              label: "tear off & toss",
+              color: "#ff8a5b",
               fontFamily: "'Caveat', cursive",
-              fontSize: 16,
-              border: "none",
-              cursor: "pointer",
+              fontSize: 18,
               fontStyle: "italic",
+              textDecoration: "underline wavy",
             }}
-          >
-            cancel
-          </button>
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
@@ -17,7 +17,12 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -712,21 +717,20 @@ export default function EditPraxisPunkZine({ state }: Props) {
             {state.saving ? "saving..." : "save draft"}
           </button>
           <div style={{ flex: 1 }} />
-          <button
-            type="button"
-            onClick={state.cancel}
-            style={{
-              background: "transparent",
-              color: muted,
-              fontFamily: "'Special Elite', serif",
-              fontSize: 11,
-              border: "none",
-              cursor: "pointer",
-              textDecoration: "underline",
+          <DropButton
+            onCancel={state.cancel}
+            disabled={
+              state.saving || state.submitting || state.switchingMode !== null
+            }
+            skin={{
+              label: "BURN IT",
+              color: hot,
+              fontFamily: "'Permanent Marker', cursive",
+              fontSize: 13,
+              textDecoration: "line-through",
+              transform: "rotate(-1.5deg)",
             }}
-          >
-            cancel
-          </button>
+          />
         </div>
 
         <div

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
@@ -17,7 +17,12 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -620,6 +625,21 @@ export default function EditPraxisStickyNote({ state }: Props) {
           >
             {state.saving ? "saving..." : "save for later"}
           </button>
+          <DropButton
+            onCancel={state.cancel}
+            disabled={
+              state.saving || state.submitting || state.switchingMode !== null
+            }
+            skin={{
+              label: "✗ rip it down",
+              color: "#dc2626",
+              fontFamily: "'Permanent Marker', cursive",
+              fontSize: 15,
+              padding: "10px 14px",
+              border: `2px dashed #dc2626`,
+              transform: "rotate(-1.4deg)",
+            }}
+          />
           <div style={{ flex: 1 }} />
           <span
             style={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
@@ -8,7 +8,12 @@ import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MarkdownPreview from "../blocks/MarkdownPreview";
 import { Breadcrumb, ErrorBanner, TitleCounter, formatClock } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -714,21 +719,22 @@ export default function EditPraxisTerminal({ state }: Props) {
             {state.saving ? ":saving" : ":w (save draft)"}
           </button>
           <div style={{ flex: 1 }} />
-          <button
-            type="button"
-            onClick={state.cancel}
-            style={{
-              background: "transparent",
-              color: dim,
+          <DropButton
+            onCancel={state.cancel}
+            disabled={
+              state.saving || state.submitting || state.switchingMode !== null
+            }
+            skin={{
+              label: "$ rm -rf ./draft",
+              color: "#f87171",
               fontFamily: "'Share Tech Mono', monospace",
-              fontSize: 9,
-              border: "none",
-              cursor: "pointer",
-              textDecoration: "underline",
+              fontSize: 11,
+              letterSpacing: "0.1em",
+              padding: "10px 16px",
+              border: `1px solid #f87171`,
+              textTransform: "uppercase",
             }}
-          >
-            [esc] :q
-          </button>
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -206,6 +206,56 @@ export function FilePicker({
   );
 }
 
+export interface DropButtonSkin {
+  label: string;
+  color: string;
+  fontFamily?: string;
+  fontStyle?: CSSProperties["fontStyle"];
+  fontSize?: number | string;
+  background?: string;
+  border?: string;
+  padding?: string;
+  textDecoration?: string;
+  textTransform?: CSSProperties["textTransform"];
+  letterSpacing?: string;
+  transform?: string;
+}
+
+export function DropButton({
+  onCancel,
+  disabled,
+  skin,
+}: {
+  onCancel: () => void;
+  disabled?: boolean;
+  skin: DropButtonSkin;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => void onCancel()}
+      style={{
+        background: skin.background ?? "transparent",
+        color: skin.color,
+        fontFamily: skin.fontFamily,
+        fontStyle: skin.fontStyle,
+        fontSize: skin.fontSize,
+        border: skin.border ?? "none",
+        padding: skin.padding,
+        textDecoration: skin.textDecoration,
+        textTransform: skin.textTransform,
+        letterSpacing: skin.letterSpacing,
+        transform: skin.transform,
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {skin.label}
+    </button>
+  );
+}
+
 export interface MetataskListSkin {
   containerStyle?: CSSProperties;
   rowStyle?: (selected: boolean) => CSSProperties;

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -81,7 +81,7 @@ export interface EditPraxisState {
   submitting: boolean;
   save: (event?: React.FormEvent) => Promise<void>;
   publish: () => Promise<void>;
-  cancel: () => void;
+  cancel: () => Promise<void>;
 
   // Autosave
   autosaveAt: Date | null;
@@ -314,7 +314,11 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       const praxisId = parseInt(idParam, 10);
       await persistEdits(praxisId);
       await submitPraxis(praxisId);
-      await refetch();
+      try {
+        await refetch();
+      } catch {
+        // refetch failure must not block navigation; the praxis is already submitted.
+      }
       navigate(`/praxes/${idParam}`);
     } catch (err) {
       setError(extractError(err, "Could not publish proof."));
@@ -323,9 +327,21 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     }
   }, [idParam, title, persistEdits, navigate, refetch]);
 
-  const cancel = useCallback(() => {
-    if (idParam) navigate(`/praxes/${idParam}`);
-  }, [idParam, navigate]);
+  const cancel = useCallback(async () => {
+    if (!praxis) return;
+    if (
+      !window.confirm(
+        "Drop this task? Your draft will be lost and you'll be able to sign up again later.",
+      )
+    )
+      return;
+    try {
+      await deletePraxis(praxis.id);
+      navigate("/tasks");
+    } catch (err) {
+      setError(extractError(err, "Could not drop this task."));
+    }
+  }, [praxis, navigate]);
 
   // ---- Mode switching ----
   const hasDraftContent = useCallback((): boolean => {
@@ -358,11 +374,13 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const changeMode = useCallback(
     async (next: PraxisType) => {
       if (!praxis || praxis.type === next) return;
-      if (praxis.members.length > 1) {
-        setError("Mode is locked once co-authors have joined.");
-        return;
-      }
-      if (hasDraftContent()) {
+      const hasJoinedCollaborators = praxis.members.length > 1;
+      if (hasJoinedCollaborators) {
+        const confirmed = window.confirm(
+          "Drop the collaboration? Your co-authors will be removed and the draft will be discarded.",
+        );
+        if (!confirmed) return;
+      } else if (hasDraftContent()) {
         const confirmed = window.confirm(
           "Changing mode will discard your current draft (title, body, media, metatasks). Continue?",
         );
@@ -469,10 +487,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     praxis?.moderation_status === "hidden" ||
     praxis?.moderation_status === "failed";
   const controlsLocked = !!(isPublished || isModerated || praxis?.is_withdrawn);
-  const modeIsLocked = !!(
-    controlsLocked ||
-    (praxis && praxis.members.length > 1)
-  );
+  const modeIsLocked = controlsLocked;
   const duelSlotFull = !!(
     praxis &&
     praxis.type === "duel" &&
@@ -537,7 +552,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     autosaveAt,
     saveStatus,
 
-    isPublished: !!isPublished,
+    isPublished,
     controlsLocked,
     modeIsLocked,
     showCollabInvite,

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -335,6 +335,12 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       )
     )
       return;
+    // Cancel any queued autosave so it can't race the delete and 404
+    // against a praxis that no longer exists.
+    if (autosaveTimerRef.current) {
+      clearTimeout(autosaveTimerRef.current);
+      autosaveTimerRef.current = null;
+    }
     try {
       await deletePraxis(praxis.id);
       navigate("/tasks");
@@ -358,6 +364,11 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       if (!praxis) return;
       setError("");
       setSwitchingMode(next);
+      // Cancel any queued autosave so it can't 404 against the deleted praxis.
+      if (autosaveTimerRef.current) {
+        clearTimeout(autosaveTimerRef.current);
+        autosaveTimerRef.current = null;
+      }
       try {
         const taskId = praxis.task_id;
         await deletePraxis(praxis.id);

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -90,6 +90,51 @@ export function factionCssVar(
   return `var(${prop})`;
 }
 
+/**
+ * Bundle of CSS variable references for all faction tokens used by themed pages.
+ * Centralizes the repeated 6+ line destructure of factionCssVar() calls.
+ * Each value is a `var(--faction-*)` reference, theme-aware via the cascade.
+ */
+export interface FactionTokens {
+  /** primary base color (no suffix) */
+  primary: string;
+  /** card-bg */
+  surface: string;
+  /** card-text */
+  text: string;
+  /** card-muted */
+  muted: string;
+  /** card-accent */
+  accent: string;
+  /** card-font */
+  font: string;
+  /** light tint */
+  light: string;
+  /** border */
+  border: string;
+}
+
+/**
+ * Get all common faction CSS variable references for a slug in one call.
+ * Use this in themed pages instead of calling factionCssVar() repeatedly:
+ *   const tokens = getFactionTokens(slug);
+ *   // ... tokens.surface, tokens.text, tokens.accent, etc.
+ */
+export function getFactionTokens(
+  slug: string | null | undefined,
+): FactionTokens {
+  return {
+    primary: factionCssVar(slug),
+    surface: factionCssVar(slug, "card-bg"),
+    text: factionCssVar(slug, "card-text"),
+    muted: factionCssVar(slug, "card-muted"),
+    accent: factionCssVar(slug, "card-accent"),
+    font: factionCssVar(slug, "card-font"),
+    light: factionCssVar(slug, "light"),
+    border: factionCssVar(slug, "border"),
+  };
+}
+
 /** Get faction color by slug, with fallback (raw hex — light mode only) */
 export function factionColor(slug: string | null | undefined): string {
   return factionRegistry[slug ?? ""]?.color ?? "#6b6a7a";


### PR DESCRIPTION
## Summary

Post-`e19f526` sweep of five user-reported bugs around the Edit Praxis flow, task signup eligibility, and Task Detail theming.

- **Bug 1 — Submit doesn't navigate or save:** `publish()` in `useEditPraxis.ts` now wraps `refetch()` in try/catch so a refetch failure can't block post-submit navigation. The praxis was being submitted server-side but the user got stuck on the edit page.
- **Bug 2 — Collaborator toggle becomes one-way:** dropped the hard `members.length > 1` lock from `modeIsLocked`. `changeMode()` now confirms ("Drop the collaboration?") before tearing down a praxis with joined collaborators, instead of silently hiding the solo button.
- **Bug 3 — Sign-up button shows on ineligible tasks:** expanded `can_submit_praxis_for_task` to combine **all** signup gates (anonymous, level, faction eligibility, active membership in someone else's praxis, duplicate authorship — preserving the Analog Double Dipper carve-out). The frontend's existing `task.can_submit_praxis` check is now truthful and the button is hidden, per `CLAUDE.md` ("Hide unusable controls; don't show them disabled").
- **Bug 4 — No way to drop a task:** `cancel()` is now async — confirms ("Drop this task? Your draft will be lost…"), calls `deletePraxis`, navigates to `/tasks`. Each archetype gets a themed Drop button via a new shared `DropButton` in `controls.tsx`: "rip it down" (StickyNote), "scrap it" (FieldJournal), "BURN IT" (PunkZine), "$ rm -rf ./draft" (Terminal), "tear off & toss" (PaperCollage), "VOID TICKET" (LuggageManifest), "retract & burn" (Gazette).
- **Bug 5 — Task Detail page unthemed:** `/tasks/:id` hero now pulls `card-bg`, `card-text`, `card-muted`, `card-accent`, `card-font` per faction via a new `getFactionTokens()` helper in `factions.ts`, matching the archetype pattern Edit Praxis uses.

**N+1 fix bonus:** the `/tasks` list endpoint now fetches `era_row` and the viewer's `character_stats` once per request and threads them through `build_task_out_for_viewer` → `can_submit_praxis_for_task` instead of re-fetching per task (~2 fewer roundtrips per task, ~40 saved on a 20-task page).

## Test plan

- [x] Backend: `pytest --cov=. --cov-fail-under=80` — 363 passed, 6 skipped, 84.82% coverage
- [x] Backend: `pytest backend/tests/integration/test_can_submit_praxis.py -v` — 7 new tests covering each signup gate
- [x] Frontend: `npm run build` — clean, zero TS errors
- [ ] **Manual walkthrough on a live dev backend:**
  - Sign up → fill title + body → submit → land on `/praxes/:id` with status "submitted"
  - Switch to collab → invite + accept a second character → click solo → confirmation appears → accepting drops the collaborator
  - As a low-level character, browse `/tasks` filtered to a level-3+ task → no Sign-up button
  - Sign up → click the Drop button → confirm → task is signup-able again from the same character
  - Open `/tasks/:id` for tasks from different factions → each hero shows its faction's bg / text color / font

## Flagged for follow-up (out of scope here)

- `TaskDetail.tsx` status pill hardcodes Analog colors regardless of task faction; "View all praxis" link hardcodes Journeymen color; several inline `'Courier Prime'` literals that could use `var(--font-body)`.
- A more ambitious per-faction archetype split of `TaskDetail.tsx` (currently it's a single themed page rather than seven archetypes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)