### PR TITLE
Reskin Analog as Everymen (reuse slug)

### DIFF
--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -83,10 +83,15 @@ ERA_1_FACTIONS = {
         duel_loss_modifier=0.5,
     ),
     "analog": FactionConfig(
+        # Reskinned/rebranded as Everymen. The slug stays "analog" so existing DB
+        # rows, tasks, members, and the Double Dipper ability carry over with no
+        # new-faction plumbing. TODO: confirm whether Everymen should keep Analog's
+        # Double Dipper ability (keyed on ANALOG_FACTION_SLUG="analog").
         slug="analog",
-        name="Analog",
-        description="Depth over breadth. Can repeat one task per level for points (Double Dipper).",
-        color="#15803d",
+        name="Everymen",
+        description="No inner circle, no waiting to be chosen. Reliable hands who "
+        "do the work in front of them and finish what they start.",
+        color="#c1272d",              # the missing red
         is_selectable=True,
         can_always_rejoin=False,
         own_task_modifier=1.0,
@@ -107,27 +112,6 @@ ERA_1_FACTIONS = {
         other_task_modifier=1.0,
         collab_own_modifier=1.0,
         collab_other_modifier=1.0,
-        duel_win_modifier=1.5,
-        duel_loss_modifier=0.5,
-    ),
-    "everymen": FactionConfig(
-        slug="everymen",
-        name="Everymen",
-        description="No inner circle, no waiting to be chosen. Reliable hands who do the "
-        "work in front of them and finish what they start.",
-        color="#c1272d",              # the rainbow's missing red
-        # ---------------------------------------------------------------------
-        # TODO(everymen): PLACEHOLDER gameplay values — confirm before launch.
-        # These mirror a standard selectable faction; they feed services/scoring.py
-        # so wrong values silently change scoring. Revisit selectability + modifiers
-        # with the design intent ("solidarity / collective / finish what you start").
-        # ---------------------------------------------------------------------
-        is_selectable=True,
-        can_always_rejoin=False,
-        own_task_modifier=1.0,
-        other_task_modifier=0.7,
-        collab_own_modifier=1.0,
-        collab_other_modifier=0.7,
         duel_win_modifier=1.5,
         duel_loss_modifier=0.5,
     ),

--- a/backend/tests/unit/test_faction_config.py
+++ b/backend/tests/unit/test_faction_config.py
@@ -84,8 +84,8 @@ def test_selectable_factions_count():
         slug for slug, config in ERA_1.factions.items()
         if config.is_selectable
     ]
-    # ua_masters, snide, gestalt, journeymen, analog, singularity, everymen = 7
-    assert len(selectable) == 7
+    # ua_masters, snide, gestalt, journeymen, analog, singularity = 6
+    assert len(selectable) == 6
 
 
 def test_can_always_rejoin_only_two():

--- a/docs/IMPLEMENTATION-PROGRESS-factions.md
+++ b/docs/IMPLEMENTATION-PROGRESS-factions.md
@@ -17,6 +17,19 @@
 - Gestalt: only the *primary/tint/border/accent* tokens were flipped to pink in Session 1. The full
   window-chrome (`.exe`) token set + component re-skin lands in Session 4, together, so each checkpoint stays coherent.
 
+## Update 2026-06-06 — Everymen reskinned onto the `analog` slug
+To avoid new-faction friction (prod DB insert + image rebuild for a brand-new slug), the **Everymen
+faction is now the rebranded `analog` faction** — the slug stays `analog`, so the existing DB row,
+tasks, members, and Double Dipper ability carry over with zero new plumbing. The standalone
+`everymen` *slug* was removed (backend config + frontend registry). The Everymen **components/CSS
+namespace** (`--faction-everymen-*`, `EverymenCard`, etc.) live on as the *skin*: every `analog`
+dispatcher entry now points at the Everymen component, and `--faction-analog-*` is aliased to the
+everymen palette in index.css. Backend `analog` config → name "Everymen", color `#c1272d`.
+- **Deploy:** code deploy + one-time `UPDATE faction SET name='Everymen', description='…' WHERE slug='analog';`
+  (the existing-row update the seed won't do — far less friction than the new-slug INSERT).
+- **Open question:** Everymen currently keeps Analog's Double Dipper ability (keyed on `ANALOG_FACTION_SLUG`). Confirm if desired.
+- **Known gap:** the praxis-card display for `analog` (`PraxisCard.tsx`) still uses the old field-journal skin (no Everymen praxis-display was built); task cards / edit-praxis / vote / etc. are all Everymen.
+
 ## Sessions
 - [x] **Session 1 — Foundation** (committed)
   - `backend/eras/era_1.py`: added `everymen` FactionConfig (red `#c1272d`, selectable, placeholder modifiers); fixed `gestalt` color `#14532d`→`#ec5f99`.

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -3,7 +3,6 @@ import { useAuth } from '../auth/AuthContext'
 import { useAdminMode } from '../auth/AdminModeContext'
 import { updateTaskStatus } from '../api/admin'
 import TaskCardUA from './cards/TaskCardUA'
-import TaskCardAnalog from './cards/TaskCardAnalog'
 import TaskCardGestalt from './cards/TaskCardGestalt'
 import TaskCardSNIDE from './cards/TaskCardSNIDE'
 import TaskCardJourneymen from './cards/TaskCardJourneymen'
@@ -22,12 +21,11 @@ interface CardProps {
 /** Style Guide §6 — one card archetype per faction. */
 const CARD_COMPONENTS: Record<string, ComponentType<CardProps>> = {
   ua: TaskCardUA,
-  analog: TaskCardAnalog,
+  analog: TaskCardEverymen,
   gestalt: TaskCardGestalt,
   snide: TaskCardSNIDE,
   journeymen: TaskCardJourneymen,
   singularity: TaskCardSingularity,
-  everymen: TaskCardEverymen,
   ua_masters: TaskCardUAMasters,
 }
 

--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -138,7 +138,7 @@ export function BadgedAvatar({
 }
 
 const FACTION_AVATARS: Record<string, ComponentType<FactionAvatarProps>> = {
-  everymen: EverymenAvatar,
+  analog: EverymenAvatar,
   gestalt: GestaltAvatar,
 }
 

--- a/frontend/src/components/backdrop/FactionBackdrop.tsx
+++ b/frontend/src/components/backdrop/FactionBackdrop.tsx
@@ -11,7 +11,7 @@ import { useBackdropSlug } from './BackdropContext'
  * rainbow watercolor. Render once, fixed behind page content at z-index 0.
  */
 const FACTION_BACKDROPS: Record<string, ComponentType> = {
-  everymen: EverymenBackdrop,
+  analog: EverymenBackdrop,
   gestalt: GestaltBackdrop,
 }
 

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -330,84 +330,11 @@ function UACard({
   );
 }
 
-function AnalogCard({
-  faction,
-  status,
-  invitationNote,
-  ...actions
-}: FactionCardProps) {
-  const desc = faction.description
-    ? faction.description.slice(0, 100) +
-      (faction.description.length > 100 ? "…" : "")
-    : "";
-  return (
-    <div
-      style={{
-        width: "100%",
-        background: factionCssVar("analog", "card-bg"),
-        border: "1px solid var(--color-border)",
-        clipPath:
-          "polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)",
-        position: "relative",
-        padding: "14px 16px 28px 28px",
-        fontFamily: factionCssVar("analog", "card-font"),
-        color: factionCssVar("analog", "card-text"),
-        backgroundImage:
-          "repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.08) 17px, rgba(100,140,200,0.08) 18px)",
-        transition: "background 150ms, color 150ms",
-        boxSizing: "border-box",
-      }}
-    >
-      {/* Red margin line */}
-      <div
-        style={{
-          position: "absolute",
-          left: 22,
-          top: 0,
-          bottom: 0,
-          width: 1,
-          background: "rgba(220,80,80,0.2)",
-        }}
-      />
-      {invitationNote && (
-        <InvitationNote slug={faction.slug} note={invitationNote} />
-      )}
-      <div
-        className="card-meta"
-        style={{
-          color: factionCssVar("analog", "card-accent"),
-          fontFamily: "var(--font-body)",
-          marginBottom: 6,
-        }}
-      >
-        <StatusBadge status={status} slug="analog" />
-      </div>
-      <div
-        style={{
-          fontSize: "var(--text-lg)",
-          fontWeight: 400,
-          lineHeight: 1.3,
-          marginBottom: 8,
-        }}
-      >
-        {faction.name}
-      </div>
-      {desc && (
-        <div
-          className="card-description"
-          style={{
-            fontSize: "var(--text-sm)",
-            color: factionCssVar("analog", "card-muted"),
-            lineHeight: 1.5,
-            marginBottom: 10,
-          }}
-        >
-          {desc}
-        </div>
-      )}
-      <ActionRow faction={faction} status={status} {...actions} />
-    </div>
-  );
+// Analog is reskinned as Everymen (the Analog identity is being deprecated).
+// The slug stays "analog" so no new DB row / registration is needed; it just
+// renders the Everymen faction card.
+function AnalogCard(props: FactionCardProps) {
+  return <EverymenCard {...props} />;
 }
 
 // ─── Gestalt ".exe" window atoms ──────────────────────────────────────────────

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -18,7 +18,7 @@ export interface FactionFeedFrameProps {
 }
 
 const FACTION_FEED_FRAMES: Record<string, ComponentType<FactionFeedFrameProps>> = {
-  everymen: EverymenFeedFrame,
+  analog: EverymenFeedFrame,
   gestalt: GestaltFeedFrame,
 }
 

--- a/frontend/src/components/progression/Progression.tsx
+++ b/frontend/src/components/progression/Progression.tsx
@@ -15,7 +15,7 @@ export interface ProgressionProps {
 }
 
 const FACTION_PROGRESSION: Record<string, ComponentType<ProgressionProps>> = {
-  everymen: EverymenProgression,
+  analog: EverymenProgression,
   gestalt: GestaltProgression,
 }
 

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -17,7 +17,7 @@ export interface VoteUIProps {
 }
 
 const FACTION_VOTE: Record<string, ComponentType<VoteUIProps>> = {
-  everymen: EverymenVote,
+  analog: EverymenVote,
   gestalt: GestaltVote,
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -162,6 +162,17 @@
   --faction-everymen-card-muted: var(--everymen-muted);
   --faction-everymen-card-font: var(--font-accent); /* Bebas Neue */
 
+  /* ── Analog is reskinned as Everymen: alias its tokens to the everymen
+        palette (slug kept; later declaration wins over the originals above) ── */
+  --faction-analog: var(--faction-everymen);
+  --faction-analog-light: var(--faction-everymen-light);
+  --faction-analog-border: var(--faction-everymen-border);
+  --faction-analog-card-bg: var(--faction-everymen-card-bg);
+  --faction-analog-card-text: var(--faction-everymen-card-text);
+  --faction-analog-card-accent: var(--faction-everymen-card-accent);
+  --faction-analog-card-muted: var(--faction-everymen-card-muted);
+  --faction-analog-card-font: var(--faction-everymen-card-font);
+
   /* ── Vote stamp colors (orange → yellow → green → blue → magenta) ── */
   --vote-1: #c2410c;
   --vote-2: #ca8a04;
@@ -376,6 +387,15 @@
   --everymen-muted: #b6a079;
   --everymen-field: #3c1416;
   --everymen-field-deep: #5a1d20;
+
+  /* ── Analog→Everymen alias (dark): override the original analog dark values ── */
+  --faction-analog: var(--faction-everymen);
+  --faction-analog-light: var(--faction-everymen-light);
+  --faction-analog-border: var(--faction-everymen-border);
+  --faction-analog-card-bg: var(--faction-everymen-card-bg);
+  --faction-analog-card-text: var(--faction-everymen-card-text);
+  --faction-analog-card-accent: var(--faction-everymen-card-accent);
+  --faction-analog-card-muted: var(--faction-everymen-card-muted);
 }
 
 /* ══ Everymen poster-wall backdrop (faction-context pages; theme-aware) ══ */

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -11,7 +11,6 @@ import {
   useEditPraxis,
   type EditPraxisState,
 } from "./editPraxis/useEditPraxis";
-import EditPraxisFieldJournal from "./editPraxis/archetypes/EditPraxisFieldJournal";
 import EditPraxisPunkZine from "./editPraxis/archetypes/EditPraxisPunkZine";
 import EditPraxisTerminal from "./editPraxis/archetypes/EditPraxisTerminal";
 import EditPraxisPaperCollage from "./editPraxis/archetypes/EditPraxisPaperCollage";
@@ -23,13 +22,12 @@ import EditPraxisEverymen from "./editPraxis/archetypes/EditPraxisEverymen";
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
 const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
-  analog: EditPraxisFieldJournal,
+  analog: EditPraxisEverymen,
   snide: EditPraxisPunkZine,
   singularity: EditPraxisTerminal,
   gestalt: EditPraxisPaperCollage,
   journeymen: EditPraxisLuggageManifest,
   ua_masters: EditPraxisGazette,
-  everymen: EditPraxisEverymen,
   ua: EditPraxisStickyNote,
   albescent: EditPraxisStickyNote,
   aged_out: EditPraxisStickyNote,

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -14,11 +14,10 @@ const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8];
 const FACTION_DESCRIPTORS: Record<string, string> = {
   ua: "Unaffiliated",
   gestalt: "Collective",
-  analog: "Document",
+  analog: "Mobilize",
   snide: "Mischief",
   journeymen: "Explore",
   singularity: "Discover",
-  everymen: "Mobilize",
   ua_masters: "Chronicle",
 };
 

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -26,12 +26,12 @@ export interface FactionConfig {
  *  before the API response arrives. Do not use these values directly; call factionColor(). */
 const FACTION_FALLBACKS: Record<string, FactionConfig> = {
   ua: { slug: "ua", name: "UA", color: "#7c3aed" },
-  analog: { slug: "analog", name: "Analog", color: "#ca8a04" },
+  // Analog is reskinned/rebranded as Everymen (slug kept to avoid new-faction plumbing).
+  analog: { slug: "analog", name: "Everymen", color: "#c1272d" },
   gestalt: { slug: "gestalt", name: "Gestalt", color: "#ec5f99" },
   snide: { slug: "snide", name: "S.N.I.D.E.", color: "#16a34a" },
   journeymen: { slug: "journeymen", name: "Journeymen", color: "#0e7490" },
   singularity: { slug: "singularity", name: "Singularity", color: "#2563eb" },
-  everymen: { slug: "everymen", name: "Everymen", color: "#c1272d" },
   ua_masters: { slug: "ua_masters", name: "UA Masters", color: "#c2410c" },
   albescent: { slug: "albescent", name: "/Albescent", color: "#7c3aed" },
   aged_out: { slug: "aged_out", name: "Aged Out", color: "#7c3aed" },


### PR DESCRIPTION
@
Rebrands the existing **`analog`** faction as **Everymen** instead of shipping a new slug — so theres **no prod DB insert and no new registration**. The slug stays `analog`; its existing row, tasks, members, and Double Dipper ability carry over.

- **Backend:** `analog` config → name "Everymen", color `#c1272d`; removed the standalone `everymen` FactionConfig; selectable-count test back to 6.
- **Frontend:** every `analog` dispatcher entry (task card, faction card, edit-praxis, vote, progression, avatar, backdrop, feed) now renders the Everymen component; `AnalogCard` is a thin `EverymenCard` wrapper; `--faction-analog-*` aliased to the everymen palette (light + dark); registry/descriptor → "Everymen"/"Mobilize".

The Everymen component + `--faction-everymen-*` CSS namespace live on as the *skin*.

**Verified:** `tsc` + `vite build` clean, backend unit tests pass, and visually confirmed — Factions page shows the Everymen recruitment card, and former analog tasks render as Everymen "Rally Bill" cards.

**Deploy:** one-time `UPDATE faction SET name=Everymen, description=… WHERE slug=analog;` (the seed wont update existing rows).

**Open question:** Everymen keeps Analogs Double Dipper ability (keyed on `ANALOG_FACTION_SLUG`) — confirm if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@