### PR TITLE
feat(factions): faction detail pages + praxis faction filter

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -78,6 +78,7 @@ async def list_praxes_route(
     type: Optional[str] = None,
     status: Optional[str] = None,
     moderation_status: Optional[str] = None,
+    faction: Optional[str] = None,
     sort: Optional[str] = "recent",
     limit: int = 50,
     offset: int = 0,
@@ -105,6 +106,7 @@ async def list_praxes_route(
         praxis_type=praxis_type,
         status=praxis_status,
         moderation_status=moderation_status,
+        faction=faction,
         limit=limit,
         offset=offset,
     )

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -343,11 +343,18 @@ async def list_praxes(
     praxis_type: Optional[PraxisType] = None,
     status: Optional[PraxisStatus] = None,
     moderation_status: Optional[str] = None,
+    faction: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[Praxis]:
     """List praxes with optional filters."""
     query = select(Praxis)
+
+    if faction is not None:
+        # Praxis has no faction of its own; it inherits the linked task's faction.
+        query = query.join(Task, Praxis.task_id == Task.id).where(
+            Task.primary_faction_slug == faction
+        )
 
     if praxis_type is not None:
         query = query.where(Praxis.type == praxis_type)

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -122,6 +122,83 @@ async def test_list_praxes_filter_by_task_id(
         assert item["task_id"] == active_task.id
 
 
+@pytest.mark.asyncio
+async def test_list_praxes_filter_by_faction(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """GET /praxes?faction=X returns only praxes whose task belongs to faction X.
+
+    Praxis has no faction of its own — it inherits the linked task's faction
+    (Task.primary_faction_slug). The filter joins through Task.
+    """
+    from models.faction import Faction, FactionStatus
+    from models.task import TaskStatus
+
+    # active_task is a UA task; add a second task in another faction. The faction
+    # row must exist for the FK constraint.
+    existing = await db_session.execute(
+        select(Faction).where(Faction.slug == "gestalt")
+    )
+    if existing.scalar_one_or_none() is None:
+        db_session.add(
+            Faction(
+                slug="gestalt",
+                name="Gestalt",
+                description="",
+                status=FactionStatus.visible,
+            )
+        )
+        await db_session.commit()
+
+    gestalt_task = Task(
+        title="Gestalt Task",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="gestalt",
+    )
+    db_session.add(gestalt_task)
+    await db_session.commit()
+    await db_session.refresh(gestalt_task)
+
+    # One praxis on each task.
+    ua_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "UA Praxis"},
+        headers=auth_headers,
+    )
+    assert ua_resp.status_code == 201
+    ua_praxis_id = ua_resp.json()["id"]
+
+    gestalt_resp = await client.post(
+        "/praxes",
+        json={"task_id": gestalt_task.id, "type": "solo", "title": "Gestalt Praxis"},
+        headers=auth_headers,
+    )
+    assert gestalt_resp.status_code == 201
+    gestalt_praxis_id = gestalt_resp.json()["id"]
+
+    # Filter to UA — only the UA praxis comes back.
+    ua_list = await client.get("/praxes", params={"faction": "ua"})
+    assert ua_list.status_code == 200
+    ua_ids = {item["id"] for item in ua_list.json()}
+    assert ua_praxis_id in ua_ids
+    assert gestalt_praxis_id not in ua_ids
+
+    # Filter to Gestalt — only the Gestalt praxis comes back.
+    gestalt_list = await client.get("/praxes", params={"faction": "gestalt"})
+    assert gestalt_list.status_code == 200
+    gestalt_ids = {item["id"] for item in gestalt_list.json()}
+    assert gestalt_praxis_id in gestalt_ids
+    assert ua_praxis_id not in gestalt_ids
+
+
 # ---------------------------------------------------------------------------
 # Solo praxis — submit lifecycle
 # ---------------------------------------------------------------------------

--- a/docs/spec/SPEC-faction-ui-profile.md
+++ b/docs/spec/SPEC-faction-ui-profile.md
@@ -15,7 +15,7 @@
 | # | Surface | What varies | Existing example |
 |---|---|---|---|
 | 1 | **Task card** | Whole archetype (shape, layout, ornament, copy voice) | Analog field-journal, S.N.I.D.E. ransom clipping |
-| 2 | **Praxis card** | Mirrors the task-card archetype | per faction |
+| 2 | **Praxis card** | Mirrors the task-card archetype — **⚠ currently reads flat next to the task cards; flagged for a visual rework (pending design)** | per faction |
 | 3 | **Edit-praxis editor** | Mirrors the archetype, as a form | sticky-note / terminal / gazette |
 | 4 | **Faction-selection card** | Bespoke "join me" card | per faction |
 | 5 | **Headline font** | One display face per faction | Bebas Neue (Everymen), Caveat (Gestalt) |
@@ -26,6 +26,7 @@
 | 10 | **Page backdrop** *(Tier 3 new, optional)* | Full-page background **when a faction is the page's context**; falls back to the global rainbow watercolor otherwise | Everymen poster wall; Gestalt lo-fi desktop |
 | 11 | **Avatar + membership badge** *(Tier 3 new)* | Avatar frame treatment + a small faction sigil badge | Everymen cog badge; Gestalt moon badge |
 | 12 | **Activity-feed card** *(Tier 3 new)* | The feed row/card styling for that faction's context | Everymen dispatch slip; Gestalt window row |
+| 13 | **Faction detail page** *(new)* | The per-faction page at `/factions/:slug`: faction description + members + tasks + recently-completed praxis. The page backdrop (#10) themes it to the faction. | shell shipped with placeholder styling; per-faction visual design pending |
 
 ### Global — one shared version for the whole app, regardless of faction
 
@@ -121,4 +122,8 @@ Hand this to whoever wires the faction after design is delivered. (Designer only
 
 ## 6. Change log
 
+- **2026-06-06** — Added surface **#13 Faction detail page** (`/factions/:slug`):
+  description + members + tasks + recent praxis, backdrop-themed. Shell shipped with
+  placeholder styling; per-faction visual design pending. Flagged the **praxis card**
+  (#2) for a visual rework — technically per-faction but reads flat next to task cards.
 - **2026-06-05** — Created. Adopted **Tier 3** boundary. Added surfaces 8–12 (vote, progression, backdrop, avatar, feed card) as per-faction; kept generic controls global. Drafted to support the **Everymen** (new, red, Bebas Neue, union-poster) and **Gestalt redesign** (pink `#ec5f99`/`#f472b6`, Caveat, lo-fi `.exe` desktop) work.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import EditPraxis from './pages/EditPraxis'
 import CharacterProfile from './pages/CharacterProfile'
 import Leaderboard from './pages/Leaderboard'
 import Factions from './pages/Factions'
+import FactionDetail from './pages/FactionDetail'
 import Updates from './pages/Updates'
 import Praxes from './pages/Praxes'
 import Admin from './pages/Admin'
@@ -60,6 +61,7 @@ export default function App() {
         />
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/factions" element={<Factions />} />
+        <Route path="/factions/:slug" element={<FactionDetail />} />
         <Route
           path="/updates"
           element={

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -118,6 +118,7 @@ export async function listPraxes(filters?: {
   character_id?: number
   type?: PraxisType
   status?: PraxisStatus
+  faction?: string
   limit?: number
   offset?: number
 }): Promise<PraxisCardOut[]> {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import { useParams, Link } from "react-router-dom";
+import { getFactions, type FactionOut } from "../api/factions";
+import { listCharacters, type CharacterOut } from "../api/characters";
+import { listTasks, type TaskOut } from "../api/tasks";
+import { listPraxes, type PraxisCardOut } from "../api/praxis";
+import TaskCard from "../components/TaskCard";
+import PraxisCard from "../components/PraxisCard";
+import CharacterBadge from "../components/CharacterBadge";
+import PageTitle from "../components/ui/PageTitle";
+import { useAuth } from "../auth/AuthContext";
+import { useGameConfig } from "../hooks/useGameConfig";
+import { extractError } from "../utils/errors";
+import { factionCssVar } from "../utils/factions";
+import { computeDisplayPoints } from "../utils/points";
+import { useFactionBackdrop } from "../components/backdrop/BackdropContext";
+
+/** Shared flex-wrap card grid — varied card sizes are intentional, not a CSS grid. */
+const CARD_GRID: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "1rem",
+  alignItems: "flex-start",
+};
+
+/**
+ * Faction detail page (`/factions/:slug`). Per-faction surface #13 in
+ * SPEC-faction-ui-profile.md: shows the faction's description, its members, its
+ * tasks, and recently completed praxis.
+ *
+ * NOTE: the styling here is intentionally PLACEHOLDER — real per-faction visual
+ * design is deferred to Claude design. Data wiring + structure are final; the
+ * section chrome (header frame, member tiles, layout) is meant to be restyled.
+ */
+export default function FactionDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const { user } = useAuth();
+
+  const [faction, setFaction] = useState<FactionOut | null>(null);
+  const [members, setMembers] = useState<CharacterOut[]>([]);
+  const [tasks, setTasks] = useState<TaskOut[]>([]);
+  const [recentPraxis, setRecentPraxis] = useState<PraxisCardOut[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  // App-wide cached game config — used for per-faction display-point multipliers.
+  const gameConfig = useGameConfig();
+
+  // Theme the page backdrop to this faction (Tier-3 surface #10). Falls back to
+  // the global watercolor for factions without a backdrop variant.
+  useFactionBackdrop(slug);
+
+  useEffect(() => {
+    if (!slug) return;
+    // Guard against out-of-order responses: if the slug changes mid-fetch, the
+    // stale request must not overwrite the newer faction's data.
+    let cancelled = false;
+    setLoading(true);
+    setFetchError(null);
+    // Clear any prior faction so an unknown slug falls through to "not found"
+    // instead of showing the previously-viewed faction during/after the fetch.
+    setFaction(null);
+    Promise.all([
+      getFactions(),
+      listCharacters({ faction: slug }),
+      listTasks({ faction: slug, status: "active" }),
+      listPraxes({ faction: slug, status: "submitted", limit: 12 }),
+    ])
+      .then(([factions, mems, tsks, praxis]) => {
+        if (cancelled) return;
+        const match = factions.find((f) => f.slug === slug);
+        if (!match) return; // faction stays null → renders the not-found state
+        setFaction(match);
+        setMembers(mems);
+        setTasks(tsks);
+        setRecentPraxis(praxis);
+      })
+      .catch((err) => {
+        if (!cancelled)
+          setFetchError(extractError(err, "Couldn't load this faction."));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (loading)
+    return <div className="py-8 font-body text-muted">Loading...</div>;
+  if (fetchError)
+    return (
+      <div className="py-8">
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+          {fetchError}{" "}
+          <button onClick={() => window.location.reload()} className="underline">
+            Try refreshing.
+          </button>
+        </p>
+      </div>
+    );
+  if (!faction)
+    return (
+      <div className="py-8 font-body text-muted">
+        Faction not found.{" "}
+        <Link to="/factions" className="underline">
+          Back to factions.
+        </Link>
+      </div>
+    );
+
+  const accent = factionCssVar(faction.slug, "border");
+
+  return (
+    <div className="py-8">
+      <PageTitle title={faction.name} eyebrow="Faction" />
+
+      {/* ── Description ── PLACEHOLDER: design to restyle ── */}
+      <div
+        className="sidebar-card mb-6"
+        style={{ borderLeft: `4px solid ${accent}`, padding: "14px 16px" }}
+      >
+        <p className="font-body text-sm text-ink">
+          {faction.description ?? "No description yet."}
+        </p>
+      </div>
+
+      {/* ── Members ── PLACEHOLDER: design to restyle ── */}
+      <section className="mb-8">
+        <h2 className="eyebrow mb-3">Members · {members.length}</h2>
+        {members.length === 0 ? (
+          <p className="font-body text-muted text-sm">No members yet.</p>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {members.map((m) => (
+              <div
+                key={m.id}
+                style={{
+                  border: `1px solid ${accent}`,
+                  padding: "6px 10px",
+                  background: "var(--color-bg-card)",
+                }}
+              >
+                <CharacterBadge character={m} size="sm" />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Tasks ── reuses the per-faction TaskCard archetype ── */}
+      <section className="mb-8">
+        <h2 className="eyebrow mb-3">Tasks · {tasks.length}</h2>
+        {tasks.length === 0 ? (
+          <p className="font-body text-muted text-sm">No tasks yet.</p>
+        ) : (
+          <div style={CARD_GRID}>
+            {tasks.map((task) => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                displayPoints={computeDisplayPoints(
+                  task.point_value,
+                  user?.character?.faction_slug,
+                  task.primary_faction_slug,
+                  gameConfig?.factions ?? [],
+                )}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Recently completed ── PLACEHOLDER: design to restyle ── */}
+      <section className="mb-8">
+        <h2 className="eyebrow mb-3">Recently completed</h2>
+        {recentPraxis.length === 0 ? (
+          <p className="font-body text-muted text-sm">
+            No completed praxis yet.
+          </p>
+        ) : (
+          <div style={CARD_GRID}>
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { getFactions, getFactionStatus, getInvitations, chooseFaction } from '../api/factions'
 import type { FactionOut, FactionPageOut, InvitationLetterOut } from '../api/factions'
 import PageTitle from '../components/ui/PageTitle'
@@ -320,6 +321,22 @@ export default function Factions() {
                   onJoin={character && canJoin ? () => setConfirmSlug(f.slug) : undefined}
                 />
               )}
+
+              {/* Visit the faction's detail page. PLACEHOLDER affordance —
+                  design may fold this into the card archetype later. */}
+              <Link
+                to={`/factions/${f.slug}`}
+                className="font-body no-underline"
+                style={{
+                  display: 'inline-block',
+                  marginTop: 6,
+                  fontSize: 10,
+                  letterSpacing: '0.05em',
+                  color: factionCssVar(f.slug, 'border'),
+                }}
+              >
+                Visit faction →
+              </Link>
 
               {/* Not-invited hint */}
               {character && status === STATUS_NOT_INVITED && !needsFactionChoice && (


### PR DESCRIPTION
## What

Adds a per-faction detail page at `/factions/:slug` — the missing "click a faction → see its page" feature. Shows the faction's **description**, **members**, **tasks**, and **recently-completed praxis**.

- Reuses the per-faction `TaskCard`/`PraxisCard` archetypes, `CharacterBadge`, and `useFactionBackdrop` page theming.
- Entry point: a **"Visit faction →"** link on each `/factions` card.
- Styling is intentionally **placeholder** — recorded as per-faction surface **#13** in `SPEC-faction-ui-profile.md`, pending design. The praxis card is also flagged there for a visual rework (it's per-faction but reads flat vs. task cards).

## Backend

- One data gap closed: an optional **`faction`** filter on the praxis list endpoint, joining `Task.primary_faction_slug`. Members and tasks already filtered by faction.

## Notes / quality

- The page fetch guards against out-of-order responses on rapid faction-to-faction navigation (race-condition fix from /code-review).
- /simplify pass applied: cached `useGameConfig` hook, `CharacterBadge` reuse, shared grid const, dropped redundant state.

## Tests

- New integration test: praxis list filters by faction.
- Full backend suite green (357 passed, 6 skipped); frontend `tsc --noEmit` clean.
- Verified in-browser: Gestalt/Everymen pages render with their backdrops, members/tasks/recent-praxis sections populate, not-found state works, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)