### PR TITLE
feat(factions): per-faction task-detail page architecture + SNIDE archetype

### DIFF
--- a/frontend/src/components/cards/SnideFactionHero.tsx
+++ b/frontend/src/components/cards/SnideFactionHero.tsx
@@ -1,0 +1,274 @@
+import { SnideSigil } from "../snide/snideAtoms";
+
+/**
+ * S.N.I.D.E. faction-page hero — a flyposted wall (NOT a tidy poster): a
+ * photocopier-black field with faint pasted-flyer ghosts, halftone + grain, a
+ * torn acid strip, a slapped sigil sticker, a skewed acid wordmark with a pink
+ * drop-shadow, the motto on a strip, and staggered acid stat chits. Ported from
+ * the SNIDE design kit (SnideHero); conforms to {@link FactionHeroProps}.
+ *
+ * The page passes raw counts; the faction labels them in its own voice. Motto +
+ * full name are faction constants (not backend fields).
+ */
+
+const FULL_NAME = "Society for Nihilistic Intent & Disruptive Efforts";
+const MOTTO = "NOTHING MATTERS — DO IT ANYWAY";
+
+const HERO_GHOSTS = [
+  { w: 122, h: 152, top: -24, left: 54, rot: -12 },
+  { w: 96, h: 128, top: 44, left: 232, rot: 7 },
+  { w: 150, h: 92, top: 158, left: 430, rot: -5 },
+  { w: 84, h: 116, top: 14, left: 690, rot: 11 },
+  { w: 116, h: 150, top: 128, left: 858, rot: -8 },
+];
+
+const CHIT_ROT = [-3, 2.5, -2];
+
+export default function SnideFactionHero({
+  name,
+  description,
+  members,
+  tasks,
+  praxes,
+}: {
+  name: string;
+  description?: string | null;
+  members: number;
+  tasks: number;
+  praxes: number;
+}) {
+  const stats = [
+    { value: members, label: "operatives" },
+    { value: tasks, label: "open jobs" },
+    { value: praxes, label: "filed lately" },
+  ];
+
+  return (
+    <header
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        marginBottom: 24,
+        background: "var(--faction-snide-ink)",
+        color: "#fff",
+        boxShadow: "8px 10px 0 rgba(0,0,0,0.32)",
+        paddingBottom: 4,
+      }}
+    >
+      <div
+        className="ht-dots"
+        style={{
+          position: "absolute",
+          inset: 0,
+          color: "rgba(182,255,46,0.055)",
+          pointerEvents: "none",
+        }}
+      />
+      {/* faint pasted flyers on the wall */}
+      {HERO_GHOSTS.map((g, i) => (
+        <div
+          key={i}
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            top: g.top,
+            left: g.left,
+            width: g.w,
+            height: g.h,
+            border: "1px solid rgba(182,255,46,0.07)",
+            background: i % 2 ? "rgba(255,45,139,0.035)" : "rgba(182,255,46,0.025)",
+            transform: `rotate(${g.rot}deg)`,
+            pointerEvents: "none",
+          }}
+        />
+      ))}
+      {/* torn acid strip */}
+      <div
+        style={{
+          height: 6,
+          background: "var(--faction-snide-acid)",
+          position: "relative",
+          zIndex: 2,
+          clipPath:
+            "polygon(0 0,100% 0,100% 55%,97% 100%,94% 50%,90% 100%,86% 55%,82% 100%,78% 60%,0 100%)",
+        }}
+      />
+
+      {/* slapped sigil sticker, tilted */}
+      <div
+        style={{
+          position: "absolute",
+          top: 34,
+          right: 42,
+          zIndex: 3,
+          transform: "rotate(9deg)",
+        }}
+      >
+        <div
+          style={{
+            position: "relative",
+            width: 104,
+            height: 104,
+            borderRadius: "50%",
+            background: "var(--faction-snide-paper)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            border: "2px solid var(--faction-snide)",
+            boxShadow: "0 0 0 4px var(--faction-snide-ink), 3px 4px 0 rgba(0,0,0,0.4)",
+          }}
+        >
+          <div
+            className="ht-dots"
+            style={{
+              position: "absolute",
+              inset: 0,
+              color: "rgba(20,17,11,0.06)",
+              borderRadius: "50%",
+              pointerEvents: "none",
+            }}
+          />
+          <SnideSigil size={60} color="var(--faction-snide)" />
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            top: -9,
+            left: "50%",
+            marginLeft: -26,
+            width: 52,
+            height: 18,
+            background: "var(--faction-snide-tape)",
+            transform: "rotate(-7deg)",
+          }}
+        />
+      </div>
+
+      <div style={{ position: "relative", zIndex: 2, padding: "26px 38px 2px", maxWidth: 770 }}>
+        {/* eyebrow on tape */}
+        <div
+          style={{
+            display: "inline-block",
+            width: "fit-content",
+            whiteSpace: "nowrap",
+            background: "var(--faction-snide-tape)",
+            color: "var(--faction-snide-ink)",
+            fontFamily: "var(--faction-snide-font-type)",
+            fontSize: 10,
+            letterSpacing: "0.05em",
+            padding: "3px 12px",
+            transform: "rotate(-1.5deg)",
+            boxShadow: "1px 1px 0 rgba(0,0,0,0.3)",
+          }}
+        >
+          World Zero · faction no. 4
+        </div>
+        {/* wordmark */}
+        <h1
+          style={{
+            fontFamily: "var(--faction-snide-font-impact)",
+            fontSize: 86,
+            lineHeight: 0.8,
+            letterSpacing: "0.02em",
+            margin: "14px 0 0",
+            color: "var(--faction-snide-acid)",
+            textShadow: "4px 4px 0 var(--faction-snide-pink)",
+            transform: "skewX(-5deg) rotate(-1.5deg)",
+          }}
+        >
+          {name}
+        </h1>
+        <div
+          style={{
+            fontFamily: "var(--font-body)",
+            fontSize: 10,
+            letterSpacing: "0.16em",
+            textTransform: "uppercase",
+            color: "#b7b5a7",
+            margin: "12px 0 0",
+            transform: "rotate(-0.4deg)",
+          }}
+        >
+          {FULL_NAME}
+        </div>
+        {/* motto */}
+        <div
+          style={{
+            display: "inline-block",
+            marginTop: 14,
+            background: "var(--faction-snide-acid)",
+            color: "var(--faction-snide-ink)",
+            fontFamily: "var(--faction-snide-font-black)",
+            fontSize: 15,
+            letterSpacing: "0.02em",
+            padding: "6px 15px",
+            transform: "rotate(-2deg)",
+            boxShadow: "2px 3px 0 var(--faction-snide-pink)",
+          }}
+        >
+          {MOTTO}
+        </div>
+        <p
+          style={{
+            fontFamily: "var(--font-body)",
+            fontSize: 12.5,
+            lineHeight: 1.6,
+            maxWidth: 600,
+            margin: "16px 0 0",
+            color: "#e7e4d8",
+          }}
+        >
+          {description ?? "Nothing matters. We do it anyway."}
+        </p>
+      </div>
+
+      {/* staggered stat chits — not a clean band */}
+      <div
+        style={{
+          position: "relative",
+          zIndex: 2,
+          display: "flex",
+          gap: 16,
+          flexWrap: "wrap",
+          padding: "24px 38px 28px",
+        }}
+      >
+        {stats.map((s, i) => (
+          <div
+            key={s.label}
+            style={{
+              background: "rgba(0,0,0,0.34)",
+              border: "2px solid var(--faction-snide-acid)",
+              padding: "8px 16px 7px",
+              transform: `rotate(${CHIT_ROT[i % CHIT_ROT.length]}deg)`,
+              boxShadow: "2px 3px 0 rgba(0,0,0,0.4)",
+            }}
+          >
+            <div
+              style={{
+                fontFamily: "var(--faction-snide-font-impact)",
+                fontSize: 34,
+                lineHeight: 0.85,
+                color: "var(--faction-snide-acid)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {s.value}
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-body)",
+                fontSize: 9,
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                color: "#cfcdbf",
+              }}
+            >
+              {s.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/snide/snideAtoms.tsx
+++ b/frontend/src/components/snide/snideAtoms.tsx
@@ -1,0 +1,48 @@
+/**
+ * Shared S.N.I.D.E. craft atoms — the struck-through circle-S sigil reused
+ * across SNIDE surfaces (task detail, faction hero). Mirrors
+ * components/cards/ephemeristsAtoms.tsx. Colors come from the namespaced
+ * --faction-snide-* tokens in index.css. Filter-free (matches the faction's
+ * CSS-only craft layers — no SVG feTurbulence).
+ */
+
+interface SnideSigilProps {
+  size?: number;
+  color?: string;
+}
+
+/** A sprayed, struck-through circle-S — the defiant SNIDE mark. */
+export function SnideSigil({
+  size = 48,
+  color = "var(--faction-snide-acid)",
+}: SnideSigilProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      width={size}
+      height={size}
+      style={{ display: "block" }}
+      aria-hidden="true"
+    >
+      <circle cx="24" cy="24" r="19" fill="none" stroke={color} strokeWidth="3" />
+      <text
+        x="24"
+        y="34"
+        textAnchor="middle"
+        style={{ fontFamily: "var(--faction-snide-font-impact)", fontSize: 30 }}
+        fill={color}
+      >
+        S
+      </text>
+      <line
+        x1="9"
+        y1="40"
+        x2="39"
+        y2="8"
+        stroke={color}
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -15,6 +15,7 @@ import { factionCssVar } from "../utils/factions";
 import { computeDisplayPoints } from "../utils/points";
 import { useFactionBackdrop } from "../components/backdrop/BackdropContext";
 import EphemeristsFactionHero from "../components/cards/EphemeristsFactionHero";
+import SnideFactionHero from "../components/cards/SnideFactionHero";
 
 /**
  * Per-faction page-hero dispatcher (Tier-3 surface). A faction opts in to a
@@ -33,6 +34,7 @@ export interface FactionHeroProps {
 
 const FACTION_HEROES: Record<string, ComponentType<FactionHeroProps>> = {
   journeymen: EphemeristsFactionHero,
+  snide: SnideFactionHero,
 };
 
 /** Shared flex-wrap card grid — varied card sizes are intentional, not a CSS grid. */

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -1,482 +1,58 @@
-import { useEffect, useState } from 'react'
-import { useParams, Link, useNavigate, useLocation } from 'react-router-dom'
-import { getTask, getTaskSignups, type TaskOut, type TaskSignupOut } from '../api/tasks'
-import { listPraxes, createPraxis, withdrawPraxis, type PraxisCardOut } from '../api/praxis'
-import { listRelationships } from '../api/relationships'
-import PraxisCard from '../components/PraxisCard'
-import LevelPill from '../components/ui/LevelPill'
-import PageTitle from '../components/ui/PageTitle'
-import FeedBadge from '../components/feed/FeedBadge'
-import { useAuth } from '../auth/AuthContext'
-import { factionCssVar, factionName } from '../utils/factions'
-import { extractError } from '../utils/errors'
-import { mediaUrl } from '../utils/media'
-import { computeDisplayPoints } from '../utils/points'
-import { useGameConfig } from '../hooks/useGameConfig'
+/**
+ * Task detail dispatcher.
+ *
+ * Loads task + submissions + signups once via `useTaskDetail(id)` and selects
+ * the right faction-archetype page based on `task.primary_faction_slug`. Every
+ * archetype consumes the same `TaskDetailState`; only the visual treatment
+ * differs. Mirrors the EditPraxis dispatcher. Surface #10 in
+ * docs/spec/SPEC-faction-ui-profile.md.
+ */
+import { useParams } from "react-router-dom";
+import PageTitle from "../components/ui/PageTitle";
+import { useTaskDetail, type TaskDetailState } from "./taskDetail/useTaskDetail";
+import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
+import TaskDetailSNIDE from "./taskDetail/archetypes/TaskDetailSNIDE";
 
-const DEFAULT_MAX_TASK_SLOTS = 20
-const VISIBLE_SIGNUPS = 4
+type Archetype = (props: { state: TaskDetailState }) => JSX.Element | null;
+
+// Only factions with a bespoke archetype are listed; everything else (incl.
+// albescent / aged_out) falls through to DefaultTaskDetail below.
+const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
+  snide: TaskDetailSNIDE,
+};
 
 export default function TaskDetail() {
-  const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-  const location = useLocation()
-  const { user } = useAuth()
-  const [task, setTask] = useState<TaskOut | null>(null)
-  const [submissions, setSubmissions] = useState<PraxisCardOut[]>([])
-  const [signups, setSignups] = useState<TaskSignupOut[]>([])
-  const [isInProgress, setIsInProgress] = useState(false)
-  const [inProgressPraxisId, setInProgressPraxisId] = useState<number | null>(null)
-  const [taskSlotCount, setTaskSlotCount] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-  const [signupError, setSignupError] = useState<string | null>(null)
+  const { id } = useParams<{ id: string }>();
+  const state = useTaskDetail(id);
 
-  // Friend/foe lookup sets
-  const [friends, setFriends] = useState<Set<number>>(new Set())
-  const [foes, setFoes] = useState<Set<number>>(new Set())
+  if (state.loading)
+    return <div className="py-8 font-body text-muted">Loading...</div>;
 
-  // Game config
-  const gameConfig = useGameConfig()
-  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS
+  if (state.fetchError)
+    return (
+      <div className="py-8">
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+          {state.fetchError}{" "}
+          <button
+            onClick={() => window.location.reload()}
+            className="underline"
+          >
+            Try refreshing.
+          </button>
+        </p>
+      </div>
+    );
 
-  // Submission sort
-  const [submissionSort, setSubmissionSort] = useState<'score' | 'recent'>('score')
+  if (!state.task)
+    return <div className="py-8 font-body text-muted">Task not found.</div>;
 
-  useEffect(() => {
-    if (!id) return
-    setLoading(true)
-    setIsInProgress(false)
-    const taskId = parseInt(id, 10)
-
-    const fetches: Promise<unknown>[] = [
-      getTask(taskId),
-      listPraxes({ task_id: taskId, status: 'submitted' }),
-      getTaskSignups(taskId),
-    ]
-    if (user) {
-      fetches.push(listPraxes({ character_id: user.character?.id, status: 'in_progress' }))
-      fetches.push(
-        listRelationships({ type: 'friend' }).then((rels) =>
-          new Set(rels.filter((r) => r.status === 'active').map((r) => r.to_character_id))
-        ).catch(() => new Set<number>())
-      )
-      fetches.push(
-        listRelationships({ type: 'foe' }).then((rels) =>
-          new Set(rels.filter((r) => r.status === 'active').map((r) => r.to_character_id))
-        ).catch(() => new Set<number>())
-      )
-    }
-
-    Promise.all(fetches)
-      .then(([t, s, sg, myTasks, friendSet, foeSet]) => {
-        setTask(t as TaskOut)
-        setSubmissions(s as PraxisCardOut[])
-        setSignups(sg as TaskSignupOut[])
-        if (myTasks) {
-          const praxes = myTasks as PraxisCardOut[]
-          const activeForThisTask = praxes.find((p) => p.task_id === taskId && !p.is_withdrawn)
-          setIsInProgress(activeForThisTask !== undefined)
-          setInProgressPraxisId(activeForThisTask?.id ?? null)
-          setTaskSlotCount(praxes.filter((p) => !p.is_withdrawn).length)
-        }
-        if (friendSet) setFriends(friendSet as Set<number>)
-        if (foeSet) setFoes(foeSet as Set<number>)
-      })
-      .catch((err) => setFetchError(extractError(err, "Couldn't load this task.")))
-      .finally(() => setLoading(false))
-  }, [id, location.key])
-
-  const mySubmission = user?.character
-    ? submissions.find((s) => s.created_by_id === user.character!.id && !s.is_withdrawn)
-    : undefined
-
-  const handleSignup = async () => {
-    if (!task) return
-    setSignupError(null)
-    try {
-      const praxis = await createPraxis({ task_id: task.id, type: 'solo' })
-      navigate(`/praxes/${praxis.id}/edit`)
-    } catch (err) {
-      setSignupError(extractError(err, 'Could not sign up for this task.'))
-    }
-  }
-
-  const handleDrop = async () => {
-    if (!task) return
-    // Drop either the submitted praxis (if any) or the in-progress draft.
-    const targetPraxisId = mySubmission?.id ?? inProgressPraxisId
-    if (!targetPraxisId) return
-    if (!window.confirm('Drop this task? You can sign up again later.')) return
-    setSignupError(null)
-    try {
-      await withdrawPraxis(targetPraxisId)
-      setIsInProgress(false)
-      setInProgressPraxisId(null)
-      setSubmissions((prev) => prev.map((s) => s.id === targetPraxisId ? { ...s, is_withdrawn: true } : s))
-    } catch (err) {
-      setSignupError(extractError(err, 'Could not drop this task.'))
-    }
-  }
-
-  if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
-  if (fetchError) return (
-    <div className="py-8">
-      <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-        {fetchError}{' '}
-        <button onClick={() => window.location.reload()} className="underline">Try refreshing.</button>
-      </p>
-    </div>
-  )
-  if (!task) return <div className="py-8 font-body text-muted">Task not found.</div>
-
-  const color = factionCssVar(task.primary_faction_slug)
-  const fname = factionName(task.primary_faction_slug)
-  // Backend-authoritative: `can_submit_praxis` covers level, faction gate,
-  // one-per-task rule, and Analog carve-out. Keep local `mySubmission`/
-  // `isInProgress` checks so we show the right UI state (edit / in-progress)
-  // instead of the sign-up button.
-  const canSignUp = !!user && !mySubmission && !isInProgress && task.can_submit_praxis
-  const slotsOpen = maxTaskSlots - taskSlotCount
-  const avgVote = submissions.length > 0
-    ? (submissions.reduce((sum, s) => sum + (s.score ?? 0), 0) / submissions.length).toFixed(1)
-    : '—'
-
-  const myFaction = user?.character?.faction_slug
-  const taskFaction = task.primary_faction_slug
-  const factionConfig = myFaction && gameConfig
-    ? gameConfig.factions.find((f) => f.slug === myFaction)
-    : null
-  const factionMultiplier = factionConfig
-    ? (!taskFaction || taskFaction === myFaction || taskFaction === 'na'
-        ? factionConfig.own_task_modifier
-        : factionConfig.other_task_modifier)
-    : 1.0
-  const modifiedPoints = gameConfig
-    ? computeDisplayPoints(task.point_value, myFaction, taskFaction, gameConfig.factions)
-    : task.point_value
-
-  const sortedSubmissions = [...submissions].sort((a, b) => {
-    if (submissionSort === 'score') return (b.score ?? 0) - (a.score ?? 0)
-    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-  })
+  const slug = state.task.primary_faction_slug ?? null;
+  const Archetype = (slug ? ARCHETYPE_BY_SLUG[slug] : undefined) ?? DefaultTaskDetail;
 
   return (
-    <div className="py-8">
-      {/* ── Breadcrumb ── */}
+    <>
       <PageTitle title="Task" eyebrow="Tasks · Detail" />
-      <nav className="font-body mb-4" style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--color-text-tertiary)' }}>
-        <Link to="/tasks" style={{ color: 'var(--faction-journeymen)', textDecoration: 'none' }}>Tasks</Link>
-        {' › '}
-        <span style={{ color: 'var(--color-text-primary)' }}>{task.title}</span>
-      </nav>
-
-      {/* ── Two-Column Layout ── */}
-      <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start' }}>
-        {/* ── Main Column ── */}
-        <div style={{ flex: 1, minWidth: 0 }}>
-
-          {/* ── Task Hero Block ── */}
-          <div
-            className="sidebar-card mb-5"
-            style={{ borderLeft: `4px solid ${color}`, padding: '18px 22px' }}
-          >
-            {/* Faction pennant + status + level */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-              <span
-                className="pennant-shape"
-                style={{
-                  display: 'inline-block',
-                  background: color, color: 'var(--color-text-on-accent)',
-                  fontFamily: "'Courier Prime', monospace",
-                  fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
-                  letterSpacing: '0.07em', padding: '3px 14px',
-                  textShadow: '0 1px 2px rgba(0,0,0,0.3)',
-                }}
-              >
-                {fname}
-              </span>
-              <span
-                className="font-body"
-                style={{
-                  fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.1em',
-                  padding: '2px 8px', borderRadius: 4,
-                  background: task.status === 'active' ? 'var(--faction-analog-light)' : 'var(--color-bg-surface-alt)',
-                  color: task.status === 'active' ? 'var(--faction-analog)' : 'var(--color-text-tertiary)',
-                }}
-              >
-                {task.status}
-              </span>
-              {task.task_type === 'metatask' && (
-                <span
-                  className="font-body"
-                  style={{
-                    fontSize: 8, textTransform: 'uppercase', letterSpacing: '0.15em',
-                    padding: '2px 8px', borderRadius: 4,
-                    background: factionCssVar(task.metatask_faction_slug),
-                    color: 'var(--color-text-on-accent)',
-                    fontWeight: 700,
-                    textShadow: '0 1px 2px rgba(0,0,0,0.3)',
-                  }}
-                >
-                  META
-                </span>
-              )}
-              <LevelPill level={task.level_required} />
-            </div>
-
-            {/* Title */}
-            <h1
-              className="font-display italic font-medium"
-              style={{ fontSize: 28, color: 'var(--color-text-primary)', lineHeight: 1.2, marginBottom: task.task_type === 'metatask' ? 4 : 12 }}
-            >
-              {task.title}
-            </h1>
-
-            {/* Metatask-for line */}
-            {task.task_type === 'metatask' && (
-              <p
-                className="eyebrow"
-                style={{
-                  marginBottom: 12,
-                  color: factionCssVar(task.metatask_faction_slug),
-                }}
-              >
-                Metatask for {factionName(task.metatask_faction_slug)}
-              </p>
-            )}
-
-            {/* Stats row */}
-            <div style={{ display: 'grid', gridTemplateColumns: `repeat(${user && factionMultiplier !== 1.0 ? 5 : 4}, 1fr)`, gap: 8, marginBottom: 16 }}>
-              {[
-                { label: 'Base Pts', value: task.point_value },
-                ...(user && factionMultiplier !== 1.0 ? [{ label: `Your Pts (×${factionMultiplier})`, value: modifiedPoints }] : []),
-                { label: 'Completed', value: submissions.length },
-                { label: 'In Progress', value: signups.length },
-                { label: 'Avg Vote', value: avgVote },
-              ].map((stat) => (
-                <div
-                  key={stat.label}
-                  className="text-center py-2"
-                  style={{ border: '1px solid var(--color-border)', background: 'var(--color-bg-surface)' }}
-                >
-                  <div className="font-body font-bold text-lg" style={{ color: 'var(--color-text-primary)' }}>
-                    {stat.value}
-                  </div>
-                  <div className="eyebrow" style={{ fontSize: 7 }}>{stat.label}</div>
-                </div>
-              ))}
-            </div>
-
-            {/* Description */}
-            {task.description && (
-              <p
-                className="font-body"
-                style={{ fontSize: 13, lineHeight: 1.7, color: 'var(--color-text-secondary)', whiteSpace: 'pre-wrap' }}
-              >
-                {task.description}
-              </p>
-            )}
-          </div>
-
-          {/* ── Signup Block ── */}
-          {canSignUp && (
-            <div className="sidebar-card mb-5" style={{ padding: '16px 20px' }}>
-              <button
-                onClick={handleSignup}
-                style={{
-                  width: '100%',
-                  background: color, color: 'var(--color-text-on-accent)',
-                  fontFamily: "'Courier Prime', monospace",
-                  fontSize: 13, fontWeight: 700, textTransform: 'uppercase',
-                  letterSpacing: '0.15em', padding: '10px 20px',
-                  border: 'none', cursor: 'pointer', position: 'relative',
-                }}
-              >
-                <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-                Sign up · earn up to {modifiedPoints} pts
-              </button>
-
-              <div className="eyebrow" style={{ marginTop: 6, display: 'flex', justifyContent: 'space-between' }}>
-                <span>You have {slotsOpen} of {maxTaskSlots} task slots open</span>
-                <span>Level {task.level_required} required <span className="eyebrow">MET</span></span>
-              </div>
-
-              {signupError && (
-                <div
-                  className="font-body"
-                  style={{
-                    fontSize: 11, color: 'var(--color-danger)', marginTop: 8,
-                    padding: '8px 12px',
-                    background: 'rgba(220,38,38,0.06)',
-                    border: '1px solid rgba(220,38,38,0.2)',
-                  }}
-                >
-                  {signupError}
-                </div>
-              )}
-            </div>
-          )}
-
-
-          {/* Already signed up / submitted states */}
-          {user && mySubmission && (
-            <div className="sidebar-card mb-5" style={{ padding: '16px 20px', display: 'flex', alignItems: 'center', gap: 10 }}>
-              <div
-                style={{
-                  background: factionCssVar(task.primary_faction_slug, 'light'), border: `1.5px solid ${factionCssVar(task.primary_faction_slug, 'border')}`,
-                  borderRadius: 8, padding: '8px 16px',
-                  display: 'flex', alignItems: 'center', gap: 8, flex: 1,
-                }}
-              >
-                <span className="eyebrow" style={{ color }}>DONE</span>
-                <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)' }}>
-                  You've submitted praxis for this task
-                </span>
-              </div>
-              <Link to={`/praxes/${mySubmission.id}/edit`} className="btn-outline" style={{ fontSize: 8, padding: '4px 12px' }}>
-                edit
-              </Link>
-            </div>
-          )}
-
-          {user && !mySubmission && isInProgress && inProgressPraxisId !== null && (
-            <div className="sidebar-card mb-5" style={{ padding: '16px 20px', display: 'flex', alignItems: 'center', gap: 10 }}>
-              <div
-                style={{
-                  background: factionCssVar(task.primary_faction_slug, 'light'), border: `1.5px solid ${factionCssVar(task.primary_faction_slug, 'border')}`,
-                  borderRadius: 8, padding: '8px 16px',
-                  display: 'flex', alignItems: 'center', gap: 8, flex: 1,
-                }}
-              >
-                <span className="eyebrow" style={{ color }}>IN PROGRESS</span>
-                <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)' }}>You're on this task</span>
-              </div>
-              <Link
-                to={`/praxes/${inProgressPraxisId}/edit`}
-                style={{
-                  background: color, color: 'var(--color-text-on-accent)',
-                  fontFamily: "'Courier Prime', monospace",
-                  fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
-                  letterSpacing: '0.12em', padding: '8px 18px',
-                  textDecoration: 'none', position: 'relative',
-                }}
-              >
-                <span style={{ position: 'absolute', inset: 3, border: '1px dashed rgba(255,255,255,0.25)', pointerEvents: 'none' }} />
-                Continue editing
-              </Link>
-              <button onClick={handleDrop} className="eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
-                drop
-              </button>
-            </div>
-          )}
-
-          {/* ── Completed Praxis Section ── */}
-          <div className="mt-2">
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
-              <span className="eyebrow">{submissions.length} Completed Praxis</span>
-              <div style={{ display: 'flex', gap: 0 }}>
-                {(['score', 'recent'] as const).map((sort) => (
-                  <button
-                    key={sort}
-                    onClick={() => setSubmissionSort(sort)}
-                    style={{
-                      fontFamily: "'Courier Prime', monospace",
-                      fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
-                      letterSpacing: '0.1em', padding: '4px 10px',
-                      background: submissionSort === sort ? 'var(--color-text-primary)' : 'transparent',
-                      color: submissionSort === sort ? 'var(--color-bg-page)' : 'var(--color-text-tertiary)',
-                      border: `1px solid ${submissionSort === sort ? 'transparent' : 'var(--color-border)'}`,
-                      cursor: 'pointer',
-                    }}
-                  >
-                    {sort === 'score' ? 'Top Rated' : 'Recent'}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {sortedSubmissions.length === 0 ? (
-              <p className="font-body text-muted">No submissions yet. Be the first.</p>
-            ) : (
-              <>
-                <div className="flex flex-wrap gap-4 items-start">
-                  {sortedSubmissions.slice(0, 4).map((s) => <PraxisCard key={s.id} praxis={s} />)}
-                </div>
-                {submissions.length > 4 && (
-                  <div style={{ textAlign: 'center', marginTop: 16 }}>
-                    <Link
-                      to={`/praxes?task_id=${task.id}`}
-                      style={{
-                        fontFamily: "'Courier Prime', monospace",
-                        fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
-                        letterSpacing: '0.1em', color: 'var(--faction-journeymen)',
-                        textDecoration: 'none',
-                      }}
-                    >
-                      View all {submissions.length} praxis &rarr;
-                    </Link>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* ── Right Sidebar Column ── */}
-        <div style={{ width: 240, flexShrink: 0 }}>
-          {/* Players in Progress */}
-          <div className="sidebar-card mb-3">
-            <p className="eyebrow mb-2">{signups.length} Players in Progress</p>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              {signups.slice(0, VISIBLE_SIGNUPS).map((signup) => {
-                const isFriend = friends.has(signup.character_id)
-                const isFoe = foes.has(signup.character_id)
-                return (
-                  <div
-                    key={signup.character_id}
-                    style={{
-                      display: 'flex', alignItems: 'center', gap: 8,
-                      padding: '4px 0',
-                    }}
-                  >
-                    <Link to={`/characters/${signup.character_id}`}>
-                      {signup.avatar_url ? (
-                        <img
-                          src={mediaUrl(signup.avatar_url)}
-                          alt={signup.display_name}
-                          style={{ width: 24, height: 24, borderRadius: '50%', objectFit: 'cover' }}
-                        />
-                      ) : (
-                        <div
-                          style={{
-                            width: 24, height: 24, borderRadius: '50%',
-                            background: `linear-gradient(135deg, ${factionCssVar(signup.faction_slug, 'light')}, ${factionCssVar(signup.faction_slug)})`,
-                          }}
-                        />
-                      )}
-                    </Link>
-                    <Link
-                      to={`/characters/${signup.character_id}`}
-                      className="font-body"
-                      style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', flex: 1 }}
-                    >
-                      {signup.display_name}
-                    </Link>
-                    {isFriend && <FeedBadge type="friend" label="Friend" />}
-                    {isFoe && <FeedBadge type="duel" label="Foe" />}
-                  </div>
-                )
-              })}
-            </div>
-            {signups.length > VISIBLE_SIGNUPS && (
-              <p className="eyebrow" style={{ marginTop: 6, color: 'var(--color-text-tertiary)' }}>
-                +{signups.length - VISIBLE_SIGNUPS} more &rarr;
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
+      <Archetype state={state} />
+    </>
+  );
 }

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -1,0 +1,569 @@
+import { Link } from "react-router-dom";
+import PraxisCard from "../../../components/PraxisCard";
+import LevelPill from "../../../components/ui/LevelPill";
+import FeedBadge from "../../../components/feed/FeedBadge";
+import { factionCssVar, factionName } from "../../../utils/factions";
+import { mediaUrl } from "../../../utils/media";
+import type { TaskDetailState } from "../useTaskDetail";
+
+const VISIBLE_SIGNUPS = 4;
+
+/**
+ * Default task-detail archetype — the original universal layout, now consuming
+ * the shared {@link TaskDetailState}. Any faction without a bespoke archetype
+ * falls through to this, so it must stay visually identical to the pre-refactor
+ * page.
+ */
+export default function DefaultTaskDetail({
+  state,
+}: {
+  state: TaskDetailState;
+}) {
+  const {
+    task,
+    submissions,
+    signups,
+    friends,
+    foes,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    factionMultiplier,
+    modifiedPoints,
+    avgVote,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  const color = factionCssVar(task.primary_faction_slug);
+  const fname = factionName(task.primary_faction_slug);
+  const showMultiplierTile = factionMultiplier !== 1.0;
+
+  return (
+    <div className="py-8">
+      {/* ── Breadcrumb ── */}
+      <nav
+        className="font-body mb-4"
+        style={{
+          fontSize: 9,
+          letterSpacing: "0.1em",
+          color: "var(--color-text-tertiary)",
+        }}
+      >
+        <Link
+          to="/tasks"
+          style={{ color: "var(--faction-journeymen)", textDecoration: "none" }}
+        >
+          Tasks
+        </Link>
+        {" › "}
+        <span style={{ color: "var(--color-text-primary)" }}>{task.title}</span>
+      </nav>
+
+      {/* ── Two-Column Layout ── */}
+      <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
+        {/* ── Main Column ── */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* ── Task Hero Block ── */}
+          <div
+            className="sidebar-card mb-5"
+            style={{ borderLeft: `4px solid ${color}`, padding: "18px 22px" }}
+          >
+            {/* Faction pennant + status + level */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginBottom: 10,
+              }}
+            >
+              <span
+                className="pennant-shape"
+                style={{
+                  display: "inline-block",
+                  background: color,
+                  color: "var(--color-text-on-accent)",
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 9,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.07em",
+                  padding: "3px 14px",
+                  textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+                }}
+              >
+                {fname}
+              </span>
+              <span
+                className="font-body"
+                style={{
+                  fontSize: 8,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                  padding: "2px 8px",
+                  borderRadius: 4,
+                  background:
+                    task.status === "active"
+                      ? "var(--faction-analog-light)"
+                      : "var(--color-bg-surface-alt)",
+                  color:
+                    task.status === "active"
+                      ? "var(--faction-analog)"
+                      : "var(--color-text-tertiary)",
+                }}
+              >
+                {task.status}
+              </span>
+              {task.task_type === "metatask" && (
+                <span
+                  className="font-body"
+                  style={{
+                    fontSize: 8,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.15em",
+                    padding: "2px 8px",
+                    borderRadius: 4,
+                    background: factionCssVar(task.metatask_faction_slug),
+                    color: "var(--color-text-on-accent)",
+                    fontWeight: 700,
+                    textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+                  }}
+                >
+                  META
+                </span>
+              )}
+              <LevelPill level={task.level_required} />
+            </div>
+
+            {/* Title */}
+            <h1
+              className="font-display italic font-medium"
+              style={{
+                fontSize: 28,
+                color: "var(--color-text-primary)",
+                lineHeight: 1.2,
+                marginBottom: task.task_type === "metatask" ? 4 : 12,
+              }}
+            >
+              {task.title}
+            </h1>
+
+            {/* Metatask-for line */}
+            {task.task_type === "metatask" && (
+              <p
+                className="eyebrow"
+                style={{
+                  marginBottom: 12,
+                  color: factionCssVar(task.metatask_faction_slug),
+                }}
+              >
+                Metatask for {factionName(task.metatask_faction_slug)}
+              </p>
+            )}
+
+            {/* Stats row */}
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: `repeat(${showMultiplierTile ? 5 : 4}, 1fr)`,
+                gap: 8,
+                marginBottom: 16,
+              }}
+            >
+              {[
+                { label: "Base Pts", value: task.point_value },
+                ...(showMultiplierTile
+                  ? [
+                      {
+                        label: `Your Pts (×${factionMultiplier})`,
+                        value: modifiedPoints,
+                      },
+                    ]
+                  : []),
+                { label: "Completed", value: submissions.length },
+                { label: "In Progress", value: signups.length },
+                { label: "Avg Vote", value: avgVote },
+              ].map((stat) => (
+                <div
+                  key={stat.label}
+                  className="text-center py-2"
+                  style={{
+                    border: "1px solid var(--color-border)",
+                    background: "var(--color-bg-surface)",
+                  }}
+                >
+                  <div
+                    className="font-body font-bold text-lg"
+                    style={{ color: "var(--color-text-primary)" }}
+                  >
+                    {stat.value}
+                  </div>
+                  <div className="eyebrow" style={{ fontSize: 7 }}>
+                    {stat.label}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Description */}
+            {task.description && (
+              <p
+                className="font-body"
+                style={{
+                  fontSize: 13,
+                  lineHeight: 1.7,
+                  color: "var(--color-text-secondary)",
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {task.description}
+              </p>
+            )}
+          </div>
+
+          {/* ── Signup Block ── */}
+          {canSignUp && (
+            <div className="sidebar-card mb-5" style={{ padding: "16px 20px" }}>
+              <button
+                onClick={handleSignup}
+                style={{
+                  width: "100%",
+                  background: color,
+                  color: "var(--color-text-on-accent)",
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 13,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.15em",
+                  padding: "10px 20px",
+                  border: "none",
+                  cursor: "pointer",
+                  position: "relative",
+                }}
+              >
+                <span
+                  style={{
+                    position: "absolute",
+                    inset: 3,
+                    border: "1px dashed rgba(255,255,255,0.25)",
+                    pointerEvents: "none",
+                  }}
+                />
+                Sign up · earn up to {modifiedPoints} pts
+              </button>
+
+              <div
+                className="eyebrow"
+                style={{
+                  marginTop: 6,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>
+                  You have {slotsOpen} of {maxTaskSlots} task slots open
+                </span>
+                <span>
+                  Level {task.level_required} required{" "}
+                  <span className="eyebrow">MET</span>
+                </span>
+              </div>
+
+              {signupError && (
+                <div
+                  className="font-body"
+                  style={{
+                    fontSize: 11,
+                    color: "var(--color-danger)",
+                    marginTop: 8,
+                    padding: "8px 12px",
+                    background: "rgba(220,38,38,0.06)",
+                    border: "1px solid rgba(220,38,38,0.2)",
+                  }}
+                >
+                  {signupError}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Already signed up / submitted states */}
+          {mySubmission && (
+            <div
+              className="sidebar-card mb-5"
+              style={{
+                padding: "16px 20px",
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              <div
+                style={{
+                  background: factionCssVar(task.primary_faction_slug, "light"),
+                  border: `1.5px solid ${factionCssVar(task.primary_faction_slug, "border")}`,
+                  borderRadius: 8,
+                  padding: "8px 16px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  flex: 1,
+                }}
+              >
+                <span className="eyebrow" style={{ color }}>
+                  DONE
+                </span>
+                <span
+                  className="font-body"
+                  style={{ fontSize: 11, color: "var(--color-text-primary)" }}
+                >
+                  You've submitted praxis for this task
+                </span>
+              </div>
+              <Link
+                to={`/praxes/${mySubmission.id}/edit`}
+                className="btn-outline"
+                style={{ fontSize: 8, padding: "4px 12px" }}
+              >
+                edit
+              </Link>
+            </div>
+          )}
+
+          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+            <div
+              className="sidebar-card mb-5"
+              style={{
+                padding: "16px 20px",
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              <div
+                style={{
+                  background: factionCssVar(task.primary_faction_slug, "light"),
+                  border: `1.5px solid ${factionCssVar(task.primary_faction_slug, "border")}`,
+                  borderRadius: 8,
+                  padding: "8px 16px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  flex: 1,
+                }}
+              >
+                <span className="eyebrow" style={{ color }}>
+                  IN PROGRESS
+                </span>
+                <span
+                  className="font-body"
+                  style={{ fontSize: 11, color: "var(--color-text-primary)" }}
+                >
+                  You're on this task
+                </span>
+              </div>
+              <Link
+                to={`/praxes/${inProgressPraxisId}/edit`}
+                style={{
+                  background: color,
+                  color: "var(--color-text-on-accent)",
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.12em",
+                  padding: "8px 18px",
+                  textDecoration: "none",
+                  position: "relative",
+                }}
+              >
+                <span
+                  style={{
+                    position: "absolute",
+                    inset: 3,
+                    border: "1px dashed rgba(255,255,255,0.25)",
+                    pointerEvents: "none",
+                  }}
+                />
+                Continue editing
+              </Link>
+              <button
+                onClick={handleDrop}
+                className="eyebrow"
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "var(--color-text-tertiary)",
+                }}
+              >
+                drop
+              </button>
+            </div>
+          )}
+
+          {/* ── Completed Praxis Section ── */}
+          <div className="mt-2">
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                marginBottom: 12,
+              }}
+            >
+              <span className="eyebrow">
+                {submissions.length} Completed Praxis
+              </span>
+              <div style={{ display: "flex", gap: 0 }}>
+                {(["score", "recent"] as const).map((sort) => (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: "'Courier Prime', monospace",
+                      fontSize: 8,
+                      fontWeight: 700,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.1em",
+                      padding: "4px 10px",
+                      background:
+                        submissionSort === sort
+                          ? "var(--color-text-primary)"
+                          : "transparent",
+                      color:
+                        submissionSort === sort
+                          ? "var(--color-bg-page)"
+                          : "var(--color-text-tertiary)",
+                      border: `1px solid ${submissionSort === sort ? "transparent" : "var(--color-border)"}`,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {sort === "score" ? "Top Rated" : "Recent"}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {sortedSubmissions.length === 0 ? (
+              <p className="font-body text-muted">
+                No submissions yet. Be the first.
+              </p>
+            ) : (
+              <>
+                <div className="flex flex-wrap gap-4 items-start">
+                  {sortedSubmissions.slice(0, 4).map((s) => (
+                    <PraxisCard key={s.id} praxis={s} />
+                  ))}
+                </div>
+                {submissions.length > 4 && (
+                  <div style={{ textAlign: "center", marginTop: 16 }}>
+                    <Link
+                      to={`/praxes?task_id=${task.id}`}
+                      style={{
+                        fontFamily: "'Courier Prime', monospace",
+                        fontSize: 10,
+                        fontWeight: 700,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.1em",
+                        color: "var(--faction-journeymen)",
+                        textDecoration: "none",
+                      }}
+                    >
+                      View all {submissions.length} praxis &rarr;
+                    </Link>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* ── Right Sidebar Column ── */}
+        <div style={{ width: 240, flexShrink: 0 }}>
+          {/* Players in Progress */}
+          <div className="sidebar-card mb-3">
+            <p className="eyebrow mb-2">{signups.length} Players in Progress</p>
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: 6 }}
+            >
+              {signups.slice(0, VISIBLE_SIGNUPS).map((signup) => {
+                const isFriend = friends.has(signup.character_id);
+                const isFoe = foes.has(signup.character_id);
+                return (
+                  <div
+                    key={signup.character_id}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "4px 0",
+                    }}
+                  >
+                    <Link to={`/characters/${signup.character_id}`}>
+                      {signup.avatar_url ? (
+                        <img
+                          src={mediaUrl(signup.avatar_url)}
+                          alt={signup.display_name}
+                          style={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: "50%",
+                            objectFit: "cover",
+                          }}
+                        />
+                      ) : (
+                        <div
+                          style={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: "50%",
+                            background: `linear-gradient(135deg, ${factionCssVar(signup.faction_slug, "light")}, ${factionCssVar(signup.faction_slug)})`,
+                          }}
+                        />
+                      )}
+                    </Link>
+                    <Link
+                      to={`/characters/${signup.character_id}`}
+                      className="font-body"
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 700,
+                        color: "var(--color-text-primary)",
+                        textDecoration: "none",
+                        flex: 1,
+                      }}
+                    >
+                      {signup.display_name}
+                    </Link>
+                    {isFriend && <FeedBadge type="friend" label="Friend" />}
+                    {isFoe && <FeedBadge type="duel" label="Foe" />}
+                  </div>
+                );
+              })}
+            </div>
+            {signups.length > VISIBLE_SIGNUPS && (
+              <p
+                className="eyebrow"
+                style={{ marginTop: 6, color: "var(--color-text-tertiary)" }}
+              >
+                +{signups.length - VISIBLE_SIGNUPS} more &rarr;
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/archetypes/TaskDetailSNIDE.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/TaskDetailSNIDE.tsx
@@ -1,0 +1,680 @@
+import type { CSSProperties } from "react";
+import { Link } from "react-router-dom";
+import PraxisCard from "../../../components/PraxisCard";
+import { mediaUrl } from "../../../utils/media";
+import { factionName } from "../../../utils/factions";
+import { SnideSigil } from "../../../components/snide/snideAtoms";
+import { ErrorBanner, relationOf } from "./shared";
+import type { TaskSignupOut } from "../../../api/tasks";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * S.N.I.D.E. task-detail archetype — the job rendered as an OPEN-CASE DOSSIER:
+ * evidence file header, the brief, accomplices on file, a read-only mob verdict,
+ * and a "PULL THIS JOB" sign-up CTA. Ported from the SNIDE design kit
+ * (snide-task-detail.jsx); wired to the real {@link TaskDetailState}.
+ *
+ * Decorative / not backend-backed (marked inline): the "job no." (derived from
+ * task.id), and the EvidenceTag labels are relabelled to honest counts.
+ */
+
+const INK = "var(--faction-snide-ink)";
+
+/** The shared "rap sheet" CTA skin — a skewed, ink-shadowed slab button/link.
+ *  `big` is the primary PULL size; default is the secondary edit/continue size. */
+function rapSheetStyle(background: string, big = false): CSSProperties {
+  return {
+    display: "inline-block",
+    cursor: "pointer",
+    border: `2px solid ${INK}`,
+    background,
+    color: "#fff",
+    fontFamily: "var(--faction-snide-font-black)",
+    fontSize: big ? 20 : 18,
+    letterSpacing: "0.04em",
+    padding: big ? "16px 30px" : "14px 26px",
+    textDecoration: "none",
+    transform: "rotate(-1.5deg)",
+    boxShadow: `5px 6px 0 ${INK}`,
+  };
+}
+
+function EvidenceTag({
+  label,
+  value,
+  accent = false,
+}: {
+  label: string;
+  value: string | number;
+  accent?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 3,
+        padding: "10px 14px",
+        border: `1.5px solid ${INK}`,
+        background: accent ? INK : "transparent",
+        transform: `rotate(${accent ? -1.5 : 1}deg)`,
+        boxShadow: accent ? "2px 3px 0 var(--faction-snide-pink)" : "none",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--font-body)",
+          fontSize: 8,
+          letterSpacing: "0.18em",
+          textTransform: "uppercase",
+          color: accent
+            ? "var(--faction-snide-acid)"
+            : "color-mix(in srgb, var(--faction-snide-wall-text) 55%, transparent)",
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontFamily: "var(--faction-snide-font-impact)",
+          fontSize: 26,
+          lineHeight: 0.85,
+          color: accent ? "var(--faction-snide-acid)" : "var(--faction-snide-wall-text)",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** Section marker — acid tape tab with a marker-font label. */
+function MarkerTab({ text, rot = -1.5 }: { text: string; rot?: number }) {
+  return (
+    <div
+      style={{
+        display: "inline-block",
+        background: "var(--faction-snide-acid)",
+        color: INK,
+        fontFamily: "var(--faction-snide-font-marker)",
+        fontSize: 16,
+        padding: "3px 13px",
+        transform: `rotate(${rot}deg)`,
+        boxShadow: "2px 2px 0 var(--faction-snide-pink)",
+        marginBottom: 13,
+      }}
+    >
+      {text}
+    </div>
+  );
+}
+
+/** Accomplices on file — real signup avatars, tilted, with friend/foe dots. */
+function AccompliceRow({
+  signups,
+  friends,
+  foes,
+}: {
+  signups: TaskSignupOut[];
+  friends: Set<number>;
+  foes: Set<number>;
+}) {
+  return (
+    <div
+      style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
+    >
+      {signups.map((m, i) => {
+        const rel = relationOf(m.character_id, friends, foes);
+        const relColor = rel === "friend" ? "var(--faction-snide)" : "var(--faction-snide-pink)";
+        return (
+          <Link
+            key={m.character_id}
+            to={`/characters/${m.character_id}`}
+            title={`${m.display_name}${rel ? ` · ${rel}` : ""}`}
+            style={{
+              position: "relative",
+              width: 38,
+              height: 38,
+              flexShrink: 0,
+              transform: `rotate(${i % 2 ? 4 : -3}deg)`,
+              boxShadow: "1.5px 2px 0 rgba(0,0,0,0.35)",
+            }}
+          >
+            {m.avatar_url ? (
+              <img
+                src={mediaUrl(m.avatar_url)}
+                alt={m.display_name}
+                style={{
+                  width: 38,
+                  height: 38,
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                  border: "2px solid var(--faction-snide)",
+                }}
+              />
+            ) : (
+              <span
+                style={{
+                  display: "flex",
+                  width: 38,
+                  height: 38,
+                  borderRadius: "50%",
+                  background: INK,
+                  border: "2px solid var(--faction-snide)",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "var(--faction-snide-acid)",
+                  fontFamily: "var(--faction-snide-font-impact)",
+                  fontSize: 16,
+                }}
+              >
+                {m.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+            {rel && (
+              <span
+                title={rel}
+                style={{
+                  position: "absolute",
+                  right: -3,
+                  bottom: -3,
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  background: relColor,
+                  border: "1.5px solid var(--faction-snide-paper)",
+                }}
+              />
+            )}
+          </Link>
+        );
+      })}
+      <span
+        style={{
+          fontFamily: "var(--font-body)",
+          fontSize: 10,
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          color: "color-mix(in srgb, var(--faction-snide-wall-text) 55%, transparent)",
+          marginLeft: 6,
+        }}
+      >
+        on the job
+      </span>
+    </div>
+  );
+}
+
+export default function TaskDetailSNIDE({
+  state,
+}: {
+  state: TaskDetailState;
+}) {
+  const {
+    task,
+    signups,
+    submissions,
+    friends,
+    foes,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    modifiedPoints,
+    avgVoteNumber,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  const wall = "var(--faction-snide-wall-text)";
+  const muted = "color-mix(in srgb, var(--faction-snide-wall-text) 55%, transparent)";
+  // Decorative: SNIDE invents a "case file number" — derive it from the real id.
+  const caseNo = String(task.id).padStart(4, "0");
+  const isMeta = task.task_type === "metatask";
+
+  return (
+    <div className="py-8" style={{ fontFamily: "var(--font-body)", color: wall }}>
+      {/* ── Breadcrumb ── */}
+      <nav
+        className="font-body mb-4"
+        style={{ fontSize: 9, letterSpacing: "0.1em", color: muted }}
+      >
+        <Link
+          to="/tasks"
+          style={{ color: "var(--faction-snide)", textDecoration: "none" }}
+        >
+          Tasks
+        </Link>
+        {" › "}
+        <span style={{ fontFamily: "var(--faction-snide-font-cond)", letterSpacing: "0.12em" }}>
+          S.N.I.D.E.
+        </span>
+        {" › "}
+        <span style={{ color: wall }}>{task.title}</span>
+      </nav>
+
+      <div style={{ maxWidth: 760 }}>
+        {/* ── Open-case dossier header ── */}
+        <div
+          style={{
+            position: "relative",
+            background: "var(--faction-snide-paper)",
+            color: INK,
+            border: `1.5px solid ${INK}`,
+            boxShadow: "6px 7px 0 rgba(0,0,0,0.25)",
+            transform: "rotate(-0.5deg)",
+            marginBottom: 30,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            className="ht-dots"
+            style={{
+              position: "absolute",
+              inset: 0,
+              color: "rgba(20,17,11,0.04)",
+              pointerEvents: "none",
+            }}
+          />
+          {/* margin stripe (acid-on-green) */}
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: 7,
+              background: "var(--faction-snide)",
+              backgroundImage:
+                "repeating-linear-gradient(180deg, transparent 0 13px, rgba(0,0,0,0.25) 13px 14px)",
+            }}
+          />
+          <div style={{ position: "relative", display: "flex", gap: 0 }}>
+            {/* mugshot panel */}
+            <div
+              style={{
+                flexShrink: 0,
+                width: 110,
+                background: INK,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "18px 8px",
+                backgroundImage:
+                  "repeating-linear-gradient(180deg, transparent 0 13px, rgba(182,255,46,0.18) 13px 14px)",
+              }}
+            >
+              <SnideSigil size={48} color="var(--faction-snide-acid)" />
+              <div
+                style={{
+                  fontFamily: "var(--faction-snide-font-cond)",
+                  fontSize: 11,
+                  letterSpacing: "0.12em",
+                  color: "var(--faction-snide-acid)",
+                  marginTop: 8,
+                }}
+              >
+                JOB FILE
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-body)",
+                  fontSize: 8,
+                  color: "#a0c080",
+                  letterSpacing: "0.08em",
+                  marginTop: 2,
+                }}
+              >
+                OPEN CASE
+              </div>
+            </div>
+            {/* case details */}
+            <div
+              style={{
+                flex: 1,
+                padding: "18px 20px 18px 16px",
+                position: "relative",
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: "var(--font-body)",
+                  fontSize: 8.5,
+                  letterSpacing: "0.2em",
+                  textTransform: "uppercase",
+                  color: "#6b6253",
+                  marginBottom: 6,
+                }}
+              >
+                S.N.I.D.E. Case File · job no. {caseNo}
+              </div>
+              <h1
+                style={{
+                  fontFamily: "var(--faction-snide-font-impact)",
+                  fontSize: 38,
+                  lineHeight: 0.86,
+                  margin: "0 0 12px",
+                  letterSpacing: "0.02em",
+                  textTransform: "uppercase",
+                  transform: "skewX(-4deg)",
+                  color: INK,
+                }}
+              >
+                {task.title}
+              </h1>
+              {isMeta && (
+                <div
+                  style={{
+                    fontFamily: "var(--faction-snide-font-cond)",
+                    fontSize: 11,
+                    letterSpacing: "0.14em",
+                    textTransform: "uppercase",
+                    color: "var(--faction-snide-pink-deep)",
+                    marginBottom: 10,
+                  }}
+                >
+                  ↳ metatask for {factionName(task.metatask_faction_slug)}
+                </div>
+              )}
+              <div
+                style={{
+                  display: "flex",
+                  gap: 10,
+                  flexWrap: "wrap",
+                  marginBottom: 14,
+                }}
+              >
+                <EvidenceTag label="Points" value={modifiedPoints} accent />
+                <EvidenceTag label="Level" value={`LVL ${task.level_required}`} />
+                {/* Honest counts (kit's "filed N times" → real in-progress / closed) */}
+                <EvidenceTag label="Filed" value={`${signups.length}`} />
+                <EvidenceTag label="Closed" value={`${submissions.length}`} />
+              </div>
+              {/* OPEN CASE stamp */}
+              <span
+                style={{
+                  position: "absolute",
+                  bottom: 14,
+                  right: 14,
+                  fontFamily: "var(--faction-snide-font-cond)",
+                  fontSize: 15,
+                  letterSpacing: "0.14em",
+                  color: "rgba(190,24,93,0.75)",
+                  border: "2.5px solid rgba(190,24,93,0.7)",
+                  padding: "3px 12px",
+                  transform: "rotate(-7deg)",
+                }}
+              >
+                {task.status === "active" ? "OPEN CASE" : task.status.toUpperCase()}
+              </span>
+            </div>
+          </div>
+          {/* tape top-right */}
+          <div
+            className="snide-tape"
+            style={{ top: -8, right: 38, width: 56, height: 18, transform: "rotate(6deg)" }}
+          />
+        </div>
+
+        {/* ── The brief ── */}
+        <div style={{ marginBottom: 28 }}>
+          <MarkerTab text="the brief" rot={-1.5} />
+          <div
+            style={{
+              position: "relative",
+              background: "var(--faction-snide-paper)",
+              color: INK,
+              border: `1.5px solid ${INK}`,
+              borderLeft: "4px solid var(--faction-snide)",
+              padding: "16px 18px",
+              backgroundImage:
+                "repeating-linear-gradient(180deg, transparent 0 27px, rgba(20,17,11,0.09) 27px 28px)",
+              transform: "rotate(0.4deg)",
+              boxShadow: "3px 4px 0 rgba(0,0,0,0.18)",
+            }}
+          >
+            <div
+              className="snide-tape"
+              style={{ top: -8, left: 30, width: 56, height: 17, transform: "rotate(-5deg)" }}
+            />
+            <p
+              style={{
+                fontFamily: "var(--faction-snide-font-type)",
+                fontSize: 13,
+                lineHeight: "28px",
+                margin: 0,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {task.description || "No brief on file. Figure it out."}
+            </p>
+          </div>
+        </div>
+
+        {/* ── Accomplices on file ── */}
+        {signups.length > 0 && (
+          <div style={{ marginBottom: 28 }}>
+            <MarkerTab text="accomplices on file" rot={1} />
+            <AccompliceRow signups={signups} friends={friends} foes={foes} />
+          </div>
+        )}
+
+        {/* ── Mob verdict (read-only aggregate) ── */}
+        <div style={{ marginBottom: 30 }}>
+          <MarkerTab text="mob verdict" rot={-1} />
+          {voteCount > 0 ? (
+            <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
+              <span
+                style={{
+                  fontFamily: "var(--faction-snide-font-impact)",
+                  fontSize: 54,
+                  lineHeight: 0.8,
+                  color: "var(--faction-snide)",
+                }}
+              >
+                {avgVoteNumber.toFixed(1)}
+              </span>
+              <div style={{ paddingBottom: 6 }}>
+                <div
+                  style={{
+                    fontFamily: "var(--faction-snide-font-cond)",
+                    fontSize: 16,
+                    letterSpacing: "0.06em",
+                    color: wall,
+                  }}
+                >
+                  OUT OF 5
+                </div>
+                <div
+                  style={{
+                    fontFamily: "var(--font-body)",
+                    fontSize: 10,
+                    letterSpacing: "0.06em",
+                    color: muted,
+                  }}
+                >
+                  {voteCount} on file ·{" "}
+                  <span style={{ fontFamily: "var(--faction-snide-font-marker)", color: "var(--faction-snide-pink)" }}>
+                    nobody's impressed
+                  </span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p style={{ fontFamily: "var(--faction-snide-font-marker)", fontSize: 14, color: "var(--faction-snide-pink)" }}>
+              no verdict yet. be the first to pull it off.
+            </p>
+          )}
+        </div>
+
+        {/* ── Pull this job / signed-up states ── */}
+        <div
+          style={{
+            borderTop:
+              "2px dashed color-mix(in srgb, var(--faction-snide-wall-text) 22%, transparent)",
+            paddingTop: 24,
+            display: "flex",
+            alignItems: "center",
+            gap: 18,
+            flexWrap: "wrap",
+          }}
+        >
+          {canSignUp && (
+            <>
+              <button onClick={handleSignup} style={rapSheetStyle("var(--faction-snide)", true)}>
+                ★ PULL THIS JOB ★
+              </button>
+              <div
+                style={{
+                  fontFamily: "var(--faction-snide-font-marker)",
+                  fontSize: 14,
+                  color: "var(--faction-snide-pink)",
+                  transform: "rotate(-1.5deg)",
+                }}
+              >
+                ↳ nobody's watching. probably.
+              </div>
+            </>
+          )}
+
+          {mySubmission && (
+            <>
+              <Link
+                to={`/praxes/${mySubmission.id}/edit`}
+                style={rapSheetStyle("var(--faction-snide-pink)")}
+              >
+                → EDIT THE RAP SHEET
+              </Link>
+              <div
+                style={{
+                  fontFamily: "var(--faction-snide-font-marker)",
+                  fontSize: 14,
+                  color: "var(--faction-snide)",
+                  transform: "rotate(-1.5deg)",
+                }}
+              >
+                ↳ filed. on the record.
+              </div>
+            </>
+          )}
+
+          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+            <>
+              <Link
+                to={`/praxes/${inProgressPraxisId}/edit`}
+                style={rapSheetStyle("var(--faction-snide)")}
+              >
+                → CONTINUE THE RAP SHEET
+              </Link>
+              <button
+                onClick={handleDrop}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: "var(--faction-snide-font-marker)",
+                  fontSize: 14,
+                  color: "var(--faction-snide-pink)",
+                  transform: "rotate(-1.5deg)",
+                }}
+              >
+                ↳ ditch the job
+              </button>
+            </>
+          )}
+        </div>
+        <ErrorBanner
+          message={signupError}
+          style={{
+            background: "rgba(255,45,139,0.08)",
+            border: "1px solid rgba(255,45,139,0.3)",
+          }}
+        />
+
+        {/* ── The record (completed praxis) ── */}
+        <div style={{ marginTop: 34 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 14,
+              flexWrap: "wrap",
+              gap: 8,
+            }}
+          >
+            <MarkerTab text={`the record · ${submissions.length}`} rot={-1} />
+            <div style={{ display: "flex", gap: 0 }}>
+              {(["score", "recent"] as const).map((sort) => {
+                const on = submissionSort === sort;
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: "var(--faction-snide-font-cond)",
+                      fontSize: 11,
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      padding: "5px 12px",
+                      background: on ? INK : "transparent",
+                      color: on ? "var(--faction-snide-acid)" : muted,
+                      border: `1.5px solid ${on ? INK : "color-mix(in srgb, var(--faction-snide-wall-text) 30%, transparent)"}`,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {sort === "score" ? "top rated" : "recent"}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {sortedSubmissions.length === 0 ? (
+            <p
+              style={{
+                fontFamily: "var(--faction-snide-font-marker)",
+                fontSize: 15,
+                color: "var(--faction-snide-pink)",
+              }}
+            >
+              no files yet. nobody's pulled it off.
+            </p>
+          ) : (
+            <>
+              <div className="flex flex-wrap gap-4 items-start">
+                {sortedSubmissions.slice(0, 4).map((s) => (
+                  <PraxisCard key={s.id} praxis={s} />
+                ))}
+              </div>
+              {submissions.length > 4 && (
+                <div style={{ marginTop: 16 }}>
+                  <Link
+                    to={`/praxes?task_id=${task.id}`}
+                    style={{
+                      fontFamily: "var(--faction-snide-font-marker)",
+                      fontSize: 15,
+                      color: "var(--faction-snide)",
+                      textDecoration: "none",
+                    }}
+                  >
+                    open all {submissions.length} files &rarr;
+                  </Link>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/archetypes/shared.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/shared.tsx
@@ -1,0 +1,43 @@
+/**
+ * Small presentational + logic helpers shared across task-detail archetypes.
+ * Kept prop-driven and skinnable so wildly-different archetypes can reuse the
+ * behaviour (friend/foe resolution, breadcrumb, error banner) without inheriting
+ * each other's look. Mirrors editPraxis/archetypes/shared.tsx.
+ */
+import type { CSSProperties } from "react";
+
+/** Resolve a signup character's relationship to the viewer (for badges). */
+export function relationOf(
+  characterId: number,
+  friends: Set<number>,
+  foes: Set<number>,
+): "friend" | "foe" | null {
+  if (friends.has(characterId)) return "friend";
+  if (foes.has(characterId)) return "foe";
+  return null;
+}
+
+interface ErrorBannerProps {
+  message: string | null;
+  style?: CSSProperties;
+}
+
+export function ErrorBanner({ message, style }: ErrorBannerProps) {
+  if (!message) return null;
+  return (
+    <div
+      className="font-body"
+      style={{
+        fontSize: 11,
+        color: "var(--color-danger)",
+        marginTop: 8,
+        padding: "8px 12px",
+        background: "rgba(220,38,38,0.06)",
+        border: "1px solid rgba(220,38,38,0.2)",
+        ...style,
+      }}
+    >
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -1,0 +1,278 @@
+/**
+ * useTaskDetail — extracts every piece of state and async behaviour from the
+ * legacy TaskDetail.tsx so that per-faction archetypes can each own their own
+ * visual treatment without re-implementing the data plumbing.
+ *
+ * Behaviour preserved 1:1 from the original page (location.key refetch, the
+ * conditional friend/foe Promise.all, signup → navigate-to-edit, drop/withdraw
+ * with optimistic update, score/recent sort). The returned `TaskDetailState` is
+ * the stable contract every task-detail archetype consumes.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+  getTask,
+  getTaskSignups,
+  type TaskOut,
+  type TaskSignupOut,
+} from "../../api/tasks";
+import {
+  listPraxes,
+  createPraxis,
+  withdrawPraxis,
+  type PraxisCardOut,
+} from "../../api/praxis";
+import { listRelationships } from "../../api/relationships";
+import { useAuth } from "../../auth/AuthContext";
+import { extractError } from "../../utils/errors";
+import { computeDisplayPoints } from "../../utils/points";
+import { useGameConfig } from "../../hooks/useGameConfig";
+
+const DEFAULT_MAX_TASK_SLOTS = 20;
+
+export interface TaskDetailState {
+  // Routing / loading
+  loading: boolean;
+  task: TaskOut | null;
+  fetchError: string | null;
+
+  // Entities
+  submissions: PraxisCardOut[];
+  signups: TaskSignupOut[];
+  friends: Set<number>;
+  foes: Set<number>;
+
+  // My relationship to this task
+  mySubmission: PraxisCardOut | undefined;
+  isInProgress: boolean;
+  inProgressPraxisId: number | null;
+
+  // Derived gameplay numbers
+  canSignUp: boolean;
+  slotsOpen: number;
+  maxTaskSlots: number;
+  factionMultiplier: number;
+  modifiedPoints: number;
+  avgVote: string; // "—" or toFixed(1) — for the default's stat tile
+  avgVoteNumber: number; // numeric form — for SNIDE stamps / VoteUI
+  voteCount: number;
+
+  // Submission sort (shared so every archetype gets the same toggle)
+  submissionSort: "score" | "recent";
+  setSubmissionSort: (sort: "score" | "recent") => void;
+  sortedSubmissions: PraxisCardOut[];
+
+  // Handlers
+  signupError: string | null;
+  handleSignup: () => Promise<void>;
+  handleDrop: () => Promise<void>;
+}
+
+export function useTaskDetail(idParam: string | undefined): TaskDetailState {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useAuth();
+
+  const [task, setTask] = useState<TaskOut | null>(null);
+  const [submissions, setSubmissions] = useState<PraxisCardOut[]>([]);
+  const [signups, setSignups] = useState<TaskSignupOut[]>([]);
+  const [isInProgress, setIsInProgress] = useState(false);
+  const [inProgressPraxisId, setInProgressPraxisId] = useState<number | null>(
+    null,
+  );
+  const [taskSlotCount, setTaskSlotCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [signupError, setSignupError] = useState<string | null>(null);
+
+  // Friend/foe lookup sets
+  const [friends, setFriends] = useState<Set<number>>(new Set());
+  const [foes, setFoes] = useState<Set<number>>(new Set());
+
+  // Game config
+  const gameConfig = useGameConfig();
+  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS;
+
+  // Submission sort
+  const [submissionSort, setSubmissionSort] = useState<"score" | "recent">(
+    "score",
+  );
+
+  useEffect(() => {
+    if (!idParam) return;
+    setLoading(true);
+    setIsInProgress(false);
+    const taskId = parseInt(idParam, 10);
+
+    const fetches: Promise<unknown>[] = [
+      getTask(taskId),
+      listPraxes({ task_id: taskId, status: "submitted" }),
+      getTaskSignups(taskId),
+    ];
+    if (user) {
+      fetches.push(
+        listPraxes({ character_id: user.character?.id, status: "in_progress" }),
+      );
+      fetches.push(
+        listRelationships({ type: "friend" })
+          .then(
+            (rels) =>
+              new Set(
+                rels
+                  .filter((r) => r.status === "active")
+                  .map((r) => r.to_character_id),
+              ),
+          )
+          .catch(() => new Set<number>()),
+      );
+      fetches.push(
+        listRelationships({ type: "foe" })
+          .then(
+            (rels) =>
+              new Set(
+                rels
+                  .filter((r) => r.status === "active")
+                  .map((r) => r.to_character_id),
+              ),
+          )
+          .catch(() => new Set<number>()),
+      );
+    }
+
+    Promise.all(fetches)
+      .then(([t, s, sg, myTasks, friendSet, foeSet]) => {
+        setTask(t as TaskOut);
+        setSubmissions(s as PraxisCardOut[]);
+        setSignups(sg as TaskSignupOut[]);
+        if (myTasks) {
+          const praxes = myTasks as PraxisCardOut[];
+          const activeForThisTask = praxes.find(
+            (p) => p.task_id === taskId && !p.is_withdrawn,
+          );
+          setIsInProgress(activeForThisTask !== undefined);
+          setInProgressPraxisId(activeForThisTask?.id ?? null);
+          setTaskSlotCount(praxes.filter((p) => !p.is_withdrawn).length);
+        }
+        if (friendSet) setFriends(friendSet as Set<number>);
+        if (foeSet) setFoes(foeSet as Set<number>);
+      })
+      .catch((err) =>
+        setFetchError(extractError(err, "Couldn't load this task.")),
+      )
+      .finally(() => setLoading(false));
+    // Depend on the character id, not the whole `user` object: refetch when the
+    // viewer logs in/out or switches character, but not on every auth-object
+    // identity change (e.g. an unrelated refetch()), which would flash "Loading…".
+  }, [idParam, location.key, user?.character?.id]);
+
+  const mySubmission = user?.character
+    ? submissions.find(
+        (s) => s.created_by_id === user.character!.id && !s.is_withdrawn,
+      )
+    : undefined;
+
+  const handleSignup = useCallback(async () => {
+    if (!task) return;
+    setSignupError(null);
+    try {
+      const praxis = await createPraxis({ task_id: task.id, type: "solo" });
+      navigate(`/praxes/${praxis.id}/edit`);
+    } catch (err) {
+      setSignupError(extractError(err, "Could not sign up for this task."));
+    }
+  }, [task, navigate]);
+
+  const handleDrop = useCallback(async () => {
+    if (!task) return;
+    // Drop either the submitted praxis (if any) or the in-progress draft.
+    const targetPraxisId = mySubmission?.id ?? inProgressPraxisId;
+    if (!targetPraxisId) return;
+    if (!window.confirm("Drop this task? You can sign up again later.")) return;
+    setSignupError(null);
+    try {
+      await withdrawPraxis(targetPraxisId);
+      setIsInProgress(false);
+      setInProgressPraxisId(null);
+      setSubmissions((prev) =>
+        prev.map((s) =>
+          s.id === targetPraxisId ? { ...s, is_withdrawn: true } : s,
+        ),
+      );
+    } catch (err) {
+      setSignupError(extractError(err, "Could not drop this task."));
+    }
+  }, [task, mySubmission, inProgressPraxisId]);
+
+  // ── Derived gameplay numbers (null-safe — run every render) ──
+  const myFaction = user?.character?.faction_slug ?? null;
+  const taskFaction = task?.primary_faction_slug ?? null;
+  const factionConfig =
+    myFaction && gameConfig
+      ? gameConfig.factions.find((f) => f.slug === myFaction)
+      : null;
+  const factionMultiplier = factionConfig
+    ? !taskFaction || taskFaction === myFaction || taskFaction === "na"
+      ? factionConfig.own_task_modifier
+      : factionConfig.other_task_modifier
+    : 1.0;
+  const modifiedPoints =
+    task && gameConfig
+      ? computeDisplayPoints(
+          task.point_value,
+          myFaction,
+          taskFaction,
+          gameConfig.factions,
+        )
+      : (task?.point_value ?? 0);
+
+  const canSignUp =
+    !!user && !mySubmission && !isInProgress && !!task?.can_submit_praxis;
+  const slotsOpen = maxTaskSlots - taskSlotCount;
+
+  const voteCount = submissions.length;
+  const avgVoteNumber =
+    submissions.length > 0
+      ? submissions.reduce((sum, s) => sum + (s.score ?? 0), 0) /
+        submissions.length
+      : 0;
+  const avgVote = submissions.length > 0 ? avgVoteNumber.toFixed(1) : "—";
+
+  const sortedSubmissions = useMemo(() => {
+    return [...submissions].sort((a, b) => {
+      if (submissionSort === "score") return (b.score ?? 0) - (a.score ?? 0);
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+  }, [submissions, submissionSort]);
+
+  return {
+    loading,
+    task,
+    fetchError,
+
+    submissions,
+    signups,
+    friends,
+    foes,
+
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    factionMultiplier,
+    modifiedPoints,
+    avgVote,
+    avgVoteNumber,
+    voteCount,
+
+    submissionSort,
+    setSubmissionSort,
+    sortedSubmissions,
+
+    signupError,
+    handleSignup,
+    handleDrop,
+  };
+}


### PR DESCRIPTION
Converts the **task-detail page** from a monolith into the hook + dispatcher + per-faction archetype pattern (mirrors `pages/editPraxis/`) — the architecture the prior SNIDE pass left untouched, so the page stayed uniform regardless of faction.

- `useTaskDetail` → stable `TaskDetailState` contract (behaviour-preserving extraction: `location.key` refetch, friend/foe sets, signup/drop, derived points/votes/sort).
- `TaskDetail` → thin `ARCHETYPE_BY_SLUG` dispatcher; `DefaultTaskDetail` is the prior layout lifted verbatim (zero regression for non-SNIDE factions).
- `TaskDetailSNIDE` → the kit's "open-case dossier" task page.
- `SnideFactionHero` → flyposted-wall faction-page hero (the one SNIDE Tier-3 surface the prior pass didn't fill).

Reconciled onto the existing namespaced `--faction-snide-*` tokens, filter-free (no SVG feTurbulence) to match the faction's CSS-only craft layers.

Verified: `tsc --noEmit` + `vite build` clean; SNIDE task `/tasks/22` and a non-SNIDE task render correctly (no regression), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)