### PR TITLE
refactor: apply deferred ponytail shrink/yagni findings

### DIFF
--- a/backend/routers/activity_feed.py
+++ b/backend/routers/activity_feed.py
@@ -12,8 +12,6 @@ from models.character import Character
 from schemas.activity_feed import ActivityFeedResponse
 from services.activity_feed import get_activity_feed
 
-VALID_FILTERS = {"all", "friends", "foes", "your_stuff", "global", "requests"}
-
 router = APIRouter()
 
 
@@ -26,8 +24,7 @@ async def activity_feed(
     session: AsyncSession = Depends(get_db),
 ) -> ActivityFeedResponse:
     """Return a unified, paginated activity feed for the current character."""
-    feed_filter = filter if filter in VALID_FILTERS else "all"
-
+    # Unknown filters fall back to "all" in the service (FILTER_QUERIES.get default).
     before_cursor: Optional[datetime] = None
     if before:
         before_cursor = datetime.fromisoformat(before)
@@ -35,7 +32,7 @@ async def activity_feed(
     dc_response = await get_activity_feed(
         character_id=character.id,
         session=session,
-        feed_filter=feed_filter,
+        feed_filter=filter,
         before_cursor=before_cursor,
         limit=limit,
     )

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -132,7 +132,7 @@ async def admin_get_account(
 @router.get("/characters", response_model=list[CharacterSummary])
 async def admin_list_characters(
     faction: str | None = None,
-    status: str | None = None,
+    status: CharacterStatus | None = None,
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ) -> list[CharacterSummary]:

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
 from schemas.character import CharacterOut
-from services.character import build_character_out, list_leaderboard
+from services.character import build_character_out, list_characters_for_viewer
 
 router = APIRouter()
 
@@ -18,7 +18,7 @@ async def get_leaderboard(
     session: AsyncSession = Depends(get_db),
 ):
     """Top characters by current era score, optionally filtered by faction."""
-    rows = await list_leaderboard(
+    rows = await list_characters_for_viewer(
         session, faction_slug=faction, limit=limit, offset=offset
     )
     return [build_character_out(character, stats) for character, stats in rows]

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -102,30 +102,16 @@ FILTER_QUERIES: dict[str, set[str]] = {
 SUB_QUERY_LIMIT = 50
 
 
-async def _get_friend_ids(
+async def _get_related_ids(
     character_id: int,
+    rel_type: RelationshipType,
     session: AsyncSession,
 ) -> list[int]:
-    """Get IDs of characters the current character has declared as friends."""
+    """Get IDs of characters the current character has declared with this relationship type."""
     result = await session.execute(
         select(Relationship.to_character_id).where(
             Relationship.from_character_id == character_id,
-            Relationship.type == RelationshipType.friend,
-            Relationship.status == RelationshipStatus.active,
-        )
-    )
-    return list(result.scalars().all())
-
-
-async def _get_foe_ids(
-    character_id: int,
-    session: AsyncSession,
-) -> list[int]:
-    """Get IDs of characters the current character has declared as foes."""
-    result = await session.execute(
-        select(Relationship.to_character_id).where(
-            Relationship.from_character_id == character_id,
-            Relationship.type == RelationshipType.foe,
+            Relationship.type == rel_type,
             Relationship.status == RelationshipStatus.active,
         )
     )
@@ -199,13 +185,14 @@ async def _fetch_votes_on_mine(
     return items
 
 
-async def _fetch_friend_completions(
-    friend_ids: list[int],
+async def _fetch_completions(
+    character_ids: list[int],
+    item_type: str,
     session: AsyncSession,
     before: Optional[datetime],
 ) -> list[ActivityFeedItemDC]:
-    """Recent praxis (completions) from friends."""
-    if not friend_ids:
+    """Recent praxis (completions) from the given characters (friends or foes)."""
+    if not character_ids:
         return []
 
     query = (
@@ -224,7 +211,7 @@ async def _fetch_friend_completions(
         .join(Task, Praxis.task_id == Task.id)
         .join(Character, Praxis.created_by_id == Character.id)
         .where(
-            Praxis.created_by_id.in_(friend_ids),
+            Praxis.created_by_id.in_(character_ids),
             Praxis.is_withdrawn == False,  # noqa: E712
             Praxis.status == PraxisStatus.submitted,
         )
@@ -237,7 +224,7 @@ async def _fetch_friend_completions(
     items: list[ActivityFeedItemDC] = []
     for row in result.all():
         items.append(ActivityFeedItemDC(
-            type=FEED_ITEM_TYPE_FRIEND_COMPLETION,
+            type=item_type,
             timestamp=row.created_at,
             actor_display_name=row.author_display_name,
             actor_faction_slug=row.author_faction_slug,
@@ -288,61 +275,6 @@ async def _fetch_foe_taunts(
                 "message": taunt.message,
                 "trigger_type": taunt.trigger_type.value,
                 "from_character_id": taunt.from_character_id,
-            },
-        ))
-    return items
-
-
-async def _fetch_foe_completions(
-    foe_ids: list[int],
-    session: AsyncSession,
-    before: Optional[datetime],
-) -> list[ActivityFeedItemDC]:
-    """Recent praxis (completions) from foes."""
-    if not foe_ids:
-        return []
-
-    query = (
-        select(
-            Praxis.id,
-            Praxis.title,
-            Praxis.created_at,
-            Praxis.created_by_id.label("character_id"),
-            Task.title.label("task_title"),
-            Task.point_value.label("task_point_value"),
-            Task.primary_faction_slug.label("task_faction_slug"),
-            Character.display_name.label("author_display_name"),
-            Character.faction_slug.label("author_faction_slug"),
-            Character.avatar_url.label("author_avatar_url"),
-        )
-        .join(Task, Praxis.task_id == Task.id)
-        .join(Character, Praxis.created_by_id == Character.id)
-        .where(
-            Praxis.created_by_id.in_(foe_ids),
-            Praxis.is_withdrawn == False,  # noqa: E712
-            Praxis.status == PraxisStatus.submitted,
-        )
-    )
-    if before is not None:
-        query = query.where(Praxis.created_at < before)
-    query = query.order_by(Praxis.created_at.desc()).limit(SUB_QUERY_LIMIT)
-
-    result = await session.execute(query)
-    items: list[ActivityFeedItemDC] = []
-    for row in result.all():
-        items.append(ActivityFeedItemDC(
-            type=FEED_ITEM_TYPE_FOE_COMPLETION,
-            timestamp=row.created_at,
-            actor_display_name=row.author_display_name,
-            actor_faction_slug=row.author_faction_slug,
-            actor_avatar_url=row.author_avatar_url,
-            payload={
-                "praxis_id": row.id,
-                "praxis_title": row.title,
-                "task_title": row.task_title,
-                "task_point_value": row.task_point_value,
-                "task_faction_slug": row.task_faction_slug,
-                "character_id": row.character_id,
             },
         ))
     return items
@@ -417,13 +349,16 @@ async def _fetch_era_announcements(
     return items
 
 
-async def _fetch_collab_invites(
+async def _fetch_praxis_invites(
     character_id: int,
+    praxis_type: PraxisType,
+    item_type: str,
+    actor_id_key: str,
     session: AsyncSession,
     before: Optional[datetime],
     pending_only: bool = False,
 ) -> list[ActivityFeedItemDC]:
-    """Collab invites sent to the current character."""
+    """Praxis invites (collab invites / duel challenges) sent to the current character."""
     query = (
         select(
             PraxisInvite.id,
@@ -435,16 +370,16 @@ async def _fetch_collab_invites(
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
             Task.level_required.label("task_level_required"),
-            Character.display_name.label("inviter_display_name"),
-            Character.faction_slug.label("inviter_faction_slug"),
-            Character.avatar_url.label("inviter_avatar_url"),
+            Character.display_name.label("actor_display_name"),
+            Character.faction_slug.label("actor_faction_slug"),
+            Character.avatar_url.label("actor_avatar_url"),
         )
         .join(Praxis, PraxisInvite.praxis_id == Praxis.id)
         .join(Task, Praxis.task_id == Task.id)
         .join(Character, PraxisInvite.inviter_id == Character.id)
         .where(
             PraxisInvite.invitee_id == character_id,
-            Praxis.type == PraxisType.collab,
+            Praxis.type == praxis_type,
         )
     )
     if pending_only:
@@ -456,79 +391,25 @@ async def _fetch_collab_invites(
     result = await session.execute(query)
     items: list[ActivityFeedItemDC] = []
     for row in result.all():
+        payload = {
+            "invite_id": row.id,
+            "praxis_id": row.praxis_id,
+            "task_title": row.task_title,
+            "task_point_value": row.task_point_value,
+            "task_faction_slug": row.task_faction_slug,
+            "invite_status": row.status.value,
+            actor_id_key: row.inviter_id,
+        }
+        # ponytail: only collab cards render a level badge; duel payload omits it
+        if praxis_type == PraxisType.collab:
+            payload["task_level_required"] = row.task_level_required
         items.append(ActivityFeedItemDC(
-            type=FEED_ITEM_TYPE_COLLAB_INVITE,
+            type=item_type,
             timestamp=row.created_at,
-            actor_display_name=row.inviter_display_name,
-            actor_faction_slug=row.inviter_faction_slug,
-            actor_avatar_url=row.inviter_avatar_url,
-            payload={
-                "invite_id": row.id,
-                "praxis_id": row.praxis_id,
-                "task_title": row.task_title,
-                "task_point_value": row.task_point_value,
-                "task_faction_slug": row.task_faction_slug,
-                "task_level_required": row.task_level_required,
-                "invite_status": row.status.value,
-                "inviter_character_id": row.inviter_id,
-            },
-        ))
-    return items
-
-
-async def _fetch_duel_challenges(
-    character_id: int,
-    session: AsyncSession,
-    before: Optional[datetime],
-    pending_only: bool = False,
-) -> list[ActivityFeedItemDC]:
-    """Duel challenges sent to the current character."""
-    query = (
-        select(
-            PraxisInvite.id,
-            PraxisInvite.created_at,
-            PraxisInvite.status,
-            PraxisInvite.inviter_id,
-            PraxisInvite.praxis_id,
-            Task.title.label("task_title"),
-            Task.point_value.label("task_point_value"),
-            Task.primary_faction_slug.label("task_faction_slug"),
-            Character.display_name.label("challenger_display_name"),
-            Character.faction_slug.label("challenger_faction_slug"),
-            Character.avatar_url.label("challenger_avatar_url"),
-        )
-        .join(Praxis, PraxisInvite.praxis_id == Praxis.id)
-        .join(Task, Praxis.task_id == Task.id)
-        .join(Character, PraxisInvite.inviter_id == Character.id)
-        .where(
-            PraxisInvite.invitee_id == character_id,
-            Praxis.type == PraxisType.duel,
-        )
-    )
-    if pending_only:
-        query = query.where(PraxisInvite.status == PraxisInviteStatus.pending)
-    if before is not None:
-        query = query.where(PraxisInvite.created_at < before)
-    query = query.order_by(PraxisInvite.created_at.desc()).limit(SUB_QUERY_LIMIT)
-
-    result = await session.execute(query)
-    items: list[ActivityFeedItemDC] = []
-    for row in result.all():
-        items.append(ActivityFeedItemDC(
-            type=FEED_ITEM_TYPE_DUEL_CHALLENGE,
-            timestamp=row.created_at,
-            actor_display_name=row.challenger_display_name,
-            actor_faction_slug=row.challenger_faction_slug,
-            actor_avatar_url=row.challenger_avatar_url,
-            payload={
-                "invite_id": row.id,
-                "praxis_id": row.praxis_id,
-                "task_title": row.task_title,
-                "task_point_value": row.task_point_value,
-                "task_faction_slug": row.task_faction_slug,
-                "invite_status": row.status.value,
-                "challenger_character_id": row.inviter_id,
-            },
+            actor_display_name=row.actor_display_name,
+            actor_faction_slug=row.actor_faction_slug,
+            actor_avatar_url=row.actor_avatar_url,
+            payload=payload,
         ))
     return items
 
@@ -818,7 +699,7 @@ async def _compute_counts(
     friend_signups_count = await count_friend_signups()
     friend_defections_count = await count_friend_defections()
     friends_count = friend_completions_count + friend_signups_count + friend_defections_count
-    foe_ids_for_count = await _get_foe_ids(character_id, session)
+    foe_ids_for_count = await _get_related_ids(character_id, RelationshipType.foe, session)
     foe_completions_count = 0
     if foe_ids_for_count:
         foe_completions_result = await session.execute(
@@ -881,9 +762,9 @@ async def get_activity_feed(
     needs_my_tasks = FEED_ITEM_TYPE_FRIEND_SIGNUP in allowed_types
 
     if needs_friends:
-        friend_ids = await _get_friend_ids(character_id, session)
+        friend_ids = await _get_related_ids(character_id, RelationshipType.friend, session)
     if needs_foes:
-        foe_ids = await _get_foe_ids(character_id, session)
+        foe_ids = await _get_related_ids(character_id, RelationshipType.foe, session)
     if needs_my_tasks:
         my_task_ids = await _get_my_task_ids(character_id, session)
 
@@ -894,13 +775,13 @@ async def get_activity_feed(
         fetch_tasks.append(_fetch_votes_on_mine(character_id, session, before_cursor))
 
     if FEED_ITEM_TYPE_FRIEND_COMPLETION in allowed_types:
-        fetch_tasks.append(_fetch_friend_completions(friend_ids, session, before_cursor))
+        fetch_tasks.append(_fetch_completions(friend_ids, FEED_ITEM_TYPE_FRIEND_COMPLETION, session, before_cursor))
 
     if FEED_ITEM_TYPE_FOE_TAUNT in allowed_types:
         fetch_tasks.append(_fetch_foe_taunts(character_id, session, before_cursor))
 
     if FEED_ITEM_TYPE_FOE_COMPLETION in allowed_types:
-        fetch_tasks.append(_fetch_foe_completions(foe_ids, session, before_cursor))
+        fetch_tasks.append(_fetch_completions(foe_ids, FEED_ITEM_TYPE_FOE_COMPLETION, session, before_cursor))
 
     if FEED_ITEM_TYPE_GLOBAL_TASK in allowed_types:
         fetch_tasks.append(_fetch_global_tasks(session, before_cursor))
@@ -909,13 +790,15 @@ async def get_activity_feed(
         fetch_tasks.append(_fetch_era_announcements(session, before_cursor))
 
     if FEED_ITEM_TYPE_COLLAB_INVITE in allowed_types:
-        fetch_tasks.append(_fetch_collab_invites(
-            character_id, session, before_cursor, pending_only=is_requests_filter,
+        fetch_tasks.append(_fetch_praxis_invites(
+            character_id, PraxisType.collab, FEED_ITEM_TYPE_COLLAB_INVITE,
+            "inviter_character_id", session, before_cursor, pending_only=is_requests_filter,
         ))
 
     if FEED_ITEM_TYPE_DUEL_CHALLENGE in allowed_types:
-        fetch_tasks.append(_fetch_duel_challenges(
-            character_id, session, before_cursor, pending_only=is_requests_filter,
+        fetch_tasks.append(_fetch_praxis_invites(
+            character_id, PraxisType.duel, FEED_ITEM_TYPE_DUEL_CHALLENGE,
+            "challenger_character_id", session, before_cursor, pending_only=is_requests_filter,
         ))
 
     if FEED_ITEM_TYPE_FRIEND_SIGNUP in allowed_types:

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -26,7 +26,7 @@ from schemas.admin import (
     OverviewStats,
 )
 from services.era import get_current_era_row, get_or_create_stats
-from services.scoring import compute_votes_available
+from services.scoring import compute_vote_budget, compute_votes_available
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +85,7 @@ async def get_account_detail(account_id: int, session: AsyncSession) -> AccountD
 async def list_characters(
     session: AsyncSession,
     faction: str | None = None,
-    status: str | None = None,
+    status: CharacterStatus | None = None,
     era: EraConfig = CURRENT_ERA,
 ) -> list[CharacterSummary]:
     era_row = await get_current_era_row(session)
@@ -102,11 +102,7 @@ async def list_characters(
     if faction:
         query = query.where(Character.faction_slug == faction)
     if status:
-        try:
-            status_enum = CharacterStatus(status)
-        except ValueError:
-            raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
-        query = query.where(Character.status == status_enum)
+        query = query.where(Character.status == status)
 
     result = await session.execute(query)
     rows = result.all()
@@ -286,7 +282,7 @@ async def set_character_stats(
         # so the on-read formula lands on the requested value.
         # votes_spent = cap - desired (clamped at 0).
         score_for_cap = patch.score if patch.score is not None else stats.score
-        cap = era.vote_budget_base + int(era.vote_budget_multiplier * score_for_cap)
+        cap = compute_vote_budget(score_for_cap, era)
         stats.votes_spent_this_era = max(0, cap - patch.votes_available)
 
     await session.flush()
@@ -325,43 +321,34 @@ async def assign_or_revoke_role(
     role_result = await session.execute(select(Role).where(Role.name == role_name))
     role = role_result.scalar_one_or_none()
 
-    if action == "grant":
-        if role is None:
-            role = Role(name=role_name, description="")
-            session.add(role)
-            await session.flush()
+    if role is None:
+        if action == "revoke":
+            raise HTTPException(status_code=404, detail=f"Role '{role_name}' does not exist.")
+        role = Role(name=role_name, description="")
+        session.add(role)
+        await session.flush()
 
-        existing_result = await session.execute(
-            select(AccountRole).where(
-                AccountRole.account_id == account_id,
-                AccountRole.role_id == role.id,
-            )
+    existing_result = await session.execute(
+        select(AccountRole).where(
+            AccountRole.account_id == account_id,
+            AccountRole.role_id == role.id,
         )
-        if existing_result.scalar_one_or_none() is not None:
-            return  # Already has the role — idempotent
+    )
+    account_role = existing_result.scalar_one_or_none()
 
-        account_role = AccountRole(
+    if action == "grant":
+        if account_role is not None:
+            return  # Already has the role — idempotent
+        session.add(AccountRole(
             account_id=account_id,
             role_id=role.id,
             granted_by=admin_account_id,
-        )
-        session.add(account_role)
+        ))
         await session.flush()
 
     elif action == "revoke":
-        if role is None:
-            raise HTTPException(status_code=404, detail=f"Role '{role_name}' does not exist.")
-
-        existing_result = await session.execute(
-            select(AccountRole).where(
-                AccountRole.account_id == account_id,
-                AccountRole.role_id == role.id,
-            )
-        )
-        account_role = existing_result.scalar_one_or_none()
         if account_role is None:
             return  # Doesn't have the role — idempotent
-
         await session.delete(account_role)
         await session.flush()
 

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -266,30 +266,6 @@ async def list_characters_for_viewer(
     return list(result.all())
 
 
-async def list_leaderboard(
-    session: AsyncSession,
-    *,
-    faction_slug: Optional[str] = None,
-    limit: int = 50,
-    offset: int = 0,
-) -> list[tuple[Character, CharacterStats | None]]:
-    """Top active characters by current-era score, optionally faction-filtered."""
-    era_row = await get_current_era_row_safe(session)
-    era_id = era_row.id if era_row else None
-
-    query = _character_stats_era_join(era_id)
-    if faction_slug:
-        query = query.where(Character.faction_slug == faction_slug)
-    query = (
-        query.order_by(CharacterStats.score.desc().nulls_last())
-        .limit(limit)
-        .offset(offset)
-    )
-
-    result = await session.execute(query)
-    return list(result.all())
-
-
 def check_faction_graduation(
     character: Character,
     stats: CharacterStats,

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -113,6 +113,11 @@ async def compute_praxis_score_from_db(
     if task is None:
         return 0.0
 
+    sum_result = await session.execute(
+        select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
+    )
+    total_stars = int(sum_result.scalar_one_or_none() or 0)
+
     if praxis.type == PraxisType.solo:
         creator = praxis.created_by
         character_faction_slug = creator.faction_slug if creator else "na"
@@ -130,10 +135,6 @@ async def compute_praxis_score_from_db(
         else:
             creator_level = 0
         meta_task_points = await get_meta_task_points(praxis.id, creator_level, session)
-        sum_result = await session.execute(
-            select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
-        )
-        total_stars = int(sum_result.scalar_one_or_none() or 0)
         return compute_praxis_score(task.point_value, faction_multiplier, total_stars, meta_task_points)
 
     elif praxis.type == PraxisType.collab:
@@ -151,18 +152,10 @@ async def compute_praxis_score_from_db(
             era,
             collaboration_mode=COLLABORATION_MODE_COLLAB,
         )
-        sum_result = await session.execute(
-            select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
-        )
-        total_stars = int(sum_result.scalar_one_or_none() or 0)
         return compute_praxis_score(task.point_value, faction_multiplier, total_stars)
 
     elif praxis.type == PraxisType.duel:
         # For a duel, return the combined star total across members
-        sum_result = await session.execute(
-            select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
-        )
-        total_stars = int(sum_result.scalar_one_or_none() or 0)
         faction_multiplier = 1.0
         return compute_praxis_score(task.point_value, faction_multiplier, total_stars)
 

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from "react-router-dom";
 import PageTitle from "../components/ui/PageTitle";
 import { factionCssVar } from "../utils/factions";
 import { pickVariant } from "../utils/factionDispatch";
-import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFactionDetail";
+import { useFactionDetail } from "./factionDetail/useFactionDetail";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import EphemeristsFactionHero from "../components/cards/EphemeristsFactionHero";
 import SnideFactionHero from "../components/cards/SnideFactionHero";
@@ -13,16 +13,14 @@ import SnideFactionHero from "../components/cards/SnideFactionHero";
  * SPEC-faction-ui-profile.md: shows the faction's description, its members, its
  * tasks, and recently completed praxis.
  *
- * Two independent per-faction dispatchers cover the page:
- *   - FACTION_HEROES — the frontispiece. A faction opts into a bespoke hero by
- *     registering here; otherwise the shared title + description chrome is used.
- *   - FACTION_BODY — the members / tasks / recent-praxis sections. A faction
- *     opts into a bespoke body the same way; otherwise DefaultFactionBody (the
- *     original placeholder layout) is used. Both fall back faction-agnostically
- *     via pickVariant.
+ * The frontispiece is dispatched per-faction via FACTION_HEROES: a faction opts
+ * into a bespoke hero by registering here; otherwise the shared title +
+ * description chrome is used. The body (members / tasks / recent-praxis) is
+ * always DefaultFactionBody for now — add a pickVariant dispatch here when a
+ * faction wants a bespoke body.
  *
  * Data + the page backdrop come from useFactionDetail; this component only
- * routes the loading / error / not-found guards and the two dispatches.
+ * routes the loading / error / not-found guards and the hero dispatch.
  */
 export interface FactionHeroProps {
   name: string;
@@ -37,12 +35,6 @@ const FACTION_HEROES: Record<string, ComponentType<FactionHeroProps>> = {
   journeymen: EphemeristsFactionHero,
   snide: SnideFactionHero,
 };
-
-type BodyArchetype = (props: { state: FactionDetailState }) => JSX.Element | null;
-
-// Only factions with a bespoke body are listed; everything else (incl.
-// albescent / aged_out) falls through to DefaultFactionBody.
-const FACTION_BODY: Record<string, BodyArchetype> = {};
 
 export default function FactionDetail() {
   const { slug } = useParams<{ slug: string }>();
@@ -78,7 +70,6 @@ export default function FactionDetail() {
   // (Hero is undefined) the shared title + description chrome is used. The page
   // backdrop is themed per-faction by useFactionDetail either way.
   const Hero = pickVariant(FACTION_HEROES, faction.slug);
-  const Body = pickVariant(FACTION_BODY, faction.slug, DefaultFactionBody);
 
   return (
     <div className="py-8">
@@ -106,7 +97,7 @@ export default function FactionDetail() {
         </>
       )}
 
-      <Body state={state} />
+      <DefaultFactionBody state={state} />
     </div>
   );
 }

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -8,16 +8,11 @@
  * not-found guards live here so archetypes can assume a non-null praxis.
  */
 import { useParams } from 'react-router-dom'
-import { pickVariant } from '../utils/factionDispatch'
-import { usePraxisDetail, type PraxisDetailState } from './praxisDetail/usePraxisDetail'
+import { usePraxisDetail } from './praxisDetail/usePraxisDetail'
 import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
 
-type Archetype = (props: { state: PraxisDetailState }) => JSX.Element | null
-
-// Only factions with a bespoke archetype are listed; everything else (incl.
-// albescent / aged_out) falls through to DefaultPraxisDetail.
-const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {}
-
+// ponytail: no faction has a bespoke archetype yet — everyone renders
+// DefaultPraxisDetail. Add a pickVariant dispatch here when one does.
 export default function PraxisDetail() {
   const { id } = useParams<{ id: string }>()
   const state = usePraxisDetail(id)
@@ -33,8 +28,5 @@ export default function PraxisDetail() {
   )
   if (!state.praxis) return <div className="py-8 font-body text-muted">Not found.</div>
 
-  const slug = state.praxis.task_faction_slug ?? null
-  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, slug, DefaultPraxisDetail)
-
-  return <Archetype state={state} />
+  return <DefaultPraxisDetail state={state} />
 }

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -8,17 +8,12 @@
  * eligibility gates live here so archetypes only ever render the happy-path
  * form (or its success screen).
  */
-import { useProposeTask, type ProposeTaskState } from "./proposeTask/useProposeTask";
+import { useProposeTask } from "./proposeTask/useProposeTask";
 import PageTitle from "../components/ui/PageTitle";
-import { pickVariant } from "../utils/factionDispatch";
 import DefaultProposeTask from "./proposeTask/archetypes/DefaultProposeTask";
 
-type Archetype = (props: { state: ProposeTaskState }) => JSX.Element | null;
-
-// Only factions with a bespoke proposal form are listed; everything else
-// (incl. albescent / aged_out) falls through to DefaultProposeTask.
-const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {};
-
+// ponytail: no faction has a bespoke proposal form yet — everyone renders
+// DefaultProposeTask. Add a pickVariant dispatch here when one does.
 export default function ProposeTask() {
   const state = useProposeTask();
 
@@ -48,6 +43,5 @@ export default function ProposeTask() {
     );
   }
 
-  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, state.factionSlug, DefaultProposeTask);
-  return <Archetype state={state} />;
+  return <DefaultProposeTask state={state} />;
 }

--- a/frontend/src/utils/factionDispatch.ts
+++ b/frontend/src/utils/factionDispatch.ts
@@ -12,16 +12,7 @@
  */
 import type { ComponentType } from 'react'
 
-/**
- * Faction-identity aliases: members of a derived/retired faction render with
- * their canonical faction's archetype. Mirrors the albescent / aged_out → ua
- * rows of CSS_KEY in utils/factions.ts (kept local because that map also encodes
- * unrelated CSS-key hyphenation, which dispatch doesn't care about).
- */
-const SLUG_ALIASES: Record<string, string> = {
-  albescent: 'ua',
-  aged_out: 'ua',
-}
+import { FACTION_ALIASES } from './factions'
 
 /**
  * Resolve a faction slug to its archetype component.
@@ -52,6 +43,6 @@ export function pickVariant<P>(
   fallback?: ComponentType<P>,
 ): ComponentType<P> | undefined {
   if (!slug) return fallback
-  const alias = SLUG_ALIASES[slug]
+  const alias = FACTION_ALIASES[slug]
   return map[slug] ?? (alias ? map[alias] : undefined) ?? fallback
 }

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -55,6 +55,18 @@ export function populateFactionRegistry(
 }
 
 /**
+ * Faction-identity aliases: derived/retired factions render with their
+ * canonical faction's identity (archetype + CSS theme). Single source of truth
+ * for the relationship — consumed here by factionCssVar and by pickVariant in
+ * utils/factionDispatch.ts. (FACTION_FALLBACKS still carries their distinct
+ * display names; only the visual identity aliases.)
+ */
+export const FACTION_ALIASES: Record<string, string> = {
+  albescent: "ua",
+  aged_out: "ua",
+};
+
+/**
  * Slug-to-CSS-variable-key mapping.
  * Faction slugs use underscores in the DB but CSS variables use hyphens.
  */
@@ -67,8 +79,6 @@ const CSS_KEY: Record<string, string> = {
   singularity: "singularity",
   everymen: "everymen",
   ua_masters: "ua-masters",
-  albescent: "ua",
-  aged_out: "ua",
 };
 
 /**
@@ -88,7 +98,8 @@ export function factionCssVar(
   slug: string | null | undefined,
   suffix?: string,
 ): string {
-  const key = CSS_KEY[slug ?? ""] ?? "ua";
+  const resolved = FACTION_ALIASES[slug ?? ""] ?? slug ?? "";
+  const key = CSS_KEY[resolved] ?? "ua";
   const prop = suffix ? `--faction-${key}-${suffix}` : `--faction-${key}`;
   return `var(${prop})`;
 }


### PR DESCRIPTION
Applies the remaining shrink / yagni / native findings from the prior `/ponytail-audit` that were deliberately deferred from the dead-code passes (#147, #148). These touch **live** code, so each was traced caller-by-caller and verified.

Per-faction archetype duplication (TaskCard*, *Avatar, *Vote, EditPraxis*, etc.) was left intact per CLAUDE.md — "each faction has its own card archetype; don't unify."

## Backend (dedup / shrink)
1. `activity_feed`: `_fetch_friend_completions` + `_fetch_foe_completions` → one `_fetch_completions(ids, item_type, …)`.
2. `activity_feed`: `_fetch_collab_invites` + `_fetch_duel_challenges` → one `_fetch_praxis_invites(…, praxis_type, item_type, actor_id_key, …)`. Payload keys preserved exactly (collab keeps `task_level_required` + `inviter_character_id`; duel keeps `challenger_character_id`).
3. `character`: `list_leaderboard` was `list_characters_for_viewer` minus the search filter → collapsed to one.
4. `activity_feed`: `_get_friend_ids` + `_get_foe_ids` → `_get_related_ids(…, rel_type)`.
5. `praxis.compute_praxis_score_from_db`: hoist the single `total_stars` vote-sum query above the solo/collab/duel branches.
6. `admin_service.assign_or_revoke_role`: hoist the shared `AccountRole` lookup above the grant/revoke split.
7. `admin list_characters`: type the `status` query param as `CharacterStatus | None` and let FastAPI coerce + 422; drop the manual try/except.
8. `activity_feed` router: drop the `VALID_FILTERS` guard — the service already defaults unknown filters to "all".
9. `admin_service.set_character_stats`: reuse `compute_vote_budget` instead of re-spelling the cap formula.

## Frontend (yagni / native)
10. `ProposeTask`, `PraxisDetail`, `FactionDetail` (body): each built an always-empty `Record` then called `pickVariant(map, slug, Default)` — with no entries that's just `Default`. Inlined the default, dropped the empty map + now-unused `pickVariant` import / archetype type. `FactionDetail` keeps `pickVariant` for `FACTION_HEROES` (≥2 entries).
12. `factions.ts` + `factionDispatch.ts`: the albescent/aged_out → ua alias was spelled twice on the JS side. Defined `FACTION_ALIASES` once in `factions.ts`; `factionCssVar` resolves through it and `factionDispatch` imports it. Behavior-preserving. Left the JS/CSS source-of-truth split intact (only the JS side consolidated), per the audit note.

### Skipped
11. `dates.ts relativeTime()` → `Intl.RelativeTimeFormat`. Skipped: `Intl.RelativeTimeFormat` only formats a `(value, unit)` pair — it doesn't pick the unit, so the minute/hour/day/month bucketing stays either way. Native would only replace the string template for ~zero line savings while changing output (`just now`→`now`). Fails the ladder's "native covers it" test. The audit flagged this as low-priority and conditional on acceptable output.

## Verification
- Backend: `alembic upgrade head` + `pytest --cov=. --cov-fail-under=58` → **357 passed, 6 skipped, 77.45% coverage**.
- Frontend: `tsc --noEmit` clean (only pre-existing `react-router-dom` module-resolution noise remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)