### PR TITLE
Add praxis-card rating/grade/date data (#159)

### DIFF
--- a/backend/alembic/versions/0003_add_praxis_submitted_at.py
+++ b/backend/alembic/versions/0003_add_praxis_submitted_at.py
@@ -1,0 +1,30 @@
+"""Add praxis.submitted_at — sealed-date for the in_progress → submitted transition.
+
+Revision ID: 0003_add_praxis_submitted_at
+Revises: 0002_drop_praxis_is_withdrawn
+Create Date: 2026-06-24
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003_add_praxis_submitted_at"
+down_revision: Union[str, None] = "0002_drop_praxis_is_withdrawn"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "praxis",
+        sa.Column(
+            "submitted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("praxis", "submitted_at")

--- a/backend/alembic/versions/0003_add_praxis_submitted_at.py
+++ b/backend/alembic/versions/0003_add_praxis_submitted_at.py
@@ -16,14 +16,12 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "praxis",
-        sa.Column(
-            "submitted_at",
-            sa.DateTime(timezone=True),
-            nullable=True,
-        ),
-    )
+    # IF NOT EXISTS: fresh DBs built from 0001_squashed already have this column
+    # because the squashed baseline reflects the post-add ORM model.
+    op.execute(sa.text(
+        "ALTER TABLE praxis ADD COLUMN IF NOT EXISTS"
+        " submitted_at TIMESTAMP WITH TIME ZONE"
+    ))
 
 
 def downgrade() -> None:

--- a/backend/models/praxis.py
+++ b/backend/models/praxis.py
@@ -72,6 +72,10 @@ class Praxis(TimestampMixin, Base):
     flagged_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # submitted_at is set once on the in_progress → submitted transition; NULL means not yet sealed
+    submitted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_by_id: Mapped[int] = mapped_column(ForeignKey("character.id"), nullable=False)
 
     task: Mapped["Task"] = relationship(

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -82,6 +82,7 @@ class PraxisCardOut(BaseModel):
     task_id: int
     task_title: str
     task_point_value: int
+    task_level_required: int
     type: PraxisType
     status: PraxisStatus
     title: Optional[str]
@@ -90,8 +91,11 @@ class PraxisCardOut(BaseModel):
     created_by_display_name: str
     created_at: datetime
     updated_at: datetime
+    submitted_at: Optional[datetime] = None
     member_count: int
     score: float
+    average_stars: Optional[float] = None
+    total_votes: int = 0
     task_faction_slug: Optional[str] = None
 
     model_config = {"from_attributes": True}

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -248,15 +248,25 @@ async def build_praxis_card_out(
     """Lightweight card for list views."""
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
+    task_level_required = praxis.task.level_required if praxis.task else 0
 
     score = await compute_praxis_score_from_db(praxis, session, era)
     created_by_display_name = praxis.created_by.display_name if praxis.created_by else ""
+
+    vote_stats_result = await session.execute(
+        select(func.avg(Vote.stars), func.count(Vote.id))
+        .where(Vote.praxis_id == praxis.id)
+    )
+    average_stars_raw, total_votes_raw = vote_stats_result.one()
+    average_stars = float(average_stars_raw) if average_stars_raw is not None else None
+    total_votes = int(total_votes_raw) if total_votes_raw is not None else 0
 
     return PraxisCardOut(
         id=praxis.id,
         task_id=praxis.task_id,
         task_title=task_title,
         task_point_value=task_point_value,
+        task_level_required=task_level_required,
         type=praxis.type,
         status=praxis.status,
         title=praxis.title,
@@ -265,8 +275,11 @@ async def build_praxis_card_out(
         created_by_display_name=created_by_display_name,
         created_at=praxis.created_at,
         updated_at=praxis.updated_at,
+        submitted_at=praxis.submitted_at,
         member_count=len(praxis.members),
         score=score,
+        average_stars=average_stars,
+        total_votes=total_votes,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
     )
 
@@ -943,6 +956,7 @@ async def submit_praxis(
 
     if all(m.has_submitted for m in praxis.members):
         praxis.status = PraxisStatus.submitted
+        praxis.submitted_at = datetime.now(timezone.utc)
         await session.flush()
         era_row = await get_current_era_row(session)
         for member in praxis.members:

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1354,3 +1354,105 @@ async def test_create_praxis_retired_task_allowed_for_ephemerists(
         headers=auth_headers,
     )
     assert resp.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# PraxisCardOut new fields: task_level_required, average_stars, total_votes,
+# submitted_at (issue #159)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_praxis_card_includes_new_fields(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """GET /praxes list returns task_level_required, average_stars (null), total_votes (0),
+    and submitted_at (null) for a newly-created in_progress praxis."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Card Fields Test"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    list_resp = await client.get("/praxes")
+    assert list_resp.status_code == 200
+    cards = list_resp.json()
+    card = next((c for c in cards if c["id"] == praxis_id), None)
+    assert card is not None
+
+    assert "task_level_required" in card
+    assert isinstance(card["task_level_required"], int)
+    assert card["task_level_required"] == active_task.level_required
+
+    assert card["average_stars"] is None
+    assert card["total_votes"] == 0
+    assert card["submitted_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_submitted_at_set_on_submit(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """submitted_at is null before submit and non-null after the in_progress → submitted transition."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "SubmittedAt Test"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    pre_list = await client.get("/praxes")
+    pre_card = next(c for c in pre_list.json() if c["id"] == praxis_id)
+    assert pre_card["submitted_at"] is None
+
+    submit_resp = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+    assert submit_resp.status_code == 200
+    assert submit_resp.json()["status"] == "submitted"
+
+    post_list = await client.get("/praxes")
+    post_card = next(c for c in post_list.json() if c["id"] == praxis_id)
+    assert post_card["submitted_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_average_stars_and_total_votes_after_vote(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """average_stars and total_votes reflect votes cast on the praxis."""
+    # character2 creates a praxis
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Vote Fields Test"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    # character votes 4 stars
+    vote_resp = await client.post(
+        f"/praxes/{praxis_id}/vote",
+        json={"stars": 4},
+        headers=auth_headers,
+    )
+    assert vote_resp.status_code == 200
+
+    list_resp = await client.get("/praxes")
+    card = next(c for c in list_resp.json() if c["id"] == praxis_id)
+
+    assert card["total_votes"] == 1
+    assert card["average_stars"] is not None
+    assert abs(card["average_stars"] - 4.0) < 0.01

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -79,6 +79,7 @@ export interface PraxisCardOut {
   task_id: number
   task_title: string
   task_point_value: number
+  task_level_required: number
   type: PraxisType
   status: PraxisStatus
   title: string | null
@@ -87,8 +88,11 @@ export interface PraxisCardOut {
   created_by_display_name: string
   created_at: string
   updated_at: string
+  submitted_at: string | null
   member_count: number
   score: number
+  average_stars: number | null
+  total_votes: number
   task_faction_slug: string | null
 }
 

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -12,6 +12,7 @@ import {
   PraxisByline,
   PraxisSeal,
   PraxisStats,
+  VoteUISummary,
   type AdminProps,
 } from "./praxisCard/shared";
 import { usePraxisCard } from "./praxisCard/usePraxisCard";
@@ -57,6 +58,12 @@ function PlaceholderPraxisBody({
   sealLabel?: string;
   titleStyle?: CSSProperties;
 }) {
+  const hero =
+    praxis.average_stars !== null && praxis.average_stars !== undefined ? (
+      <VoteUISummary praxis={praxis} color={tint} border={tint} />
+    ) : (
+      <PraxisSeal praxis={praxis} color={tint} border={tint} label={sealLabel} />
+    );
   return (
     <>
       <div
@@ -71,7 +78,7 @@ function PlaceholderPraxisBody({
           <PraxisTitle praxis={praxis} style={titleStyle} />
           <PraxisTaskLink praxis={praxis} style={{ color: muted }} />
         </div>
-        <PraxisSeal praxis={praxis} color={tint} border={tint} label={sealLabel} />
+        {hero}
       </div>
       <PraxisStats praxis={praxis} style={{ color: muted, marginTop: 8 }} />
       <PraxisByline praxis={praxis} style={{ color: muted }} />

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -36,6 +36,7 @@ const PRAXIS: PraxisCardOut = {
   task_id: 7,
   task_title: "Reforestation",
   task_point_value: 10,
+  task_level_required: 1,
   type: "solo",
   status: "submitted",
   title: "Photosynthesis",
@@ -44,8 +45,11 @@ const PRAXIS: PraxisCardOut = {
   created_by_display_name: "Ada",
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
+  submitted_at: "2026-01-02T00:00:00Z",
   member_count: 1,
   score: 4.2,
+  average_stars: null,
+  total_votes: 0,
   task_faction_slug: "ua",
 };
 

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -155,6 +155,64 @@ export function PraxisSeal({
   );
 }
 
+/**
+ * Slot: compact read-only vote summary — the card hero once the praxis has been
+ * rated. Replaces PraxisSeal when average_stars is present.
+ *
+ * Shows the average star rating (1–5) + vote count in a compact badge. Per-faction
+ * reframe labels (Concordance, Signal, etc.) are wired per archetype when their
+ * designs land; this is the generic fallback that drives the slot.
+ */
+export function VoteUISummary({
+  praxis,
+  color,
+  border,
+}: {
+  praxis: PraxisCardOut;
+  color?: string;
+  border?: string;
+}) {
+  if (praxis.average_stars === null || praxis.average_stars === undefined) return null;
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        minWidth: 50,
+        padding: "5px 8px",
+        border: `2px solid ${border ?? "currentColor"}`,
+        borderRadius: 4,
+        transform: "rotate(-3deg)",
+        color: color ?? "inherit",
+        lineHeight: 1,
+        gap: 2,
+      }}
+    >
+      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)" }}>
+        {praxis.average_stars.toFixed(1)}
+      </span>
+      <span
+        style={{
+          fontSize: 7,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          opacity: 0.75,
+        }}
+      >
+        ★ avg
+      </span>
+      {praxis.total_votes > 0 && (
+        <span style={{ fontSize: 7, opacity: 0.6 }}>
+          {praxis.total_votes}v
+        </span>
+      )}
+    </div>
+  );
+}
+
 /** Slot: base points + collaboration mode — a compact stat line. */
 export function PraxisStats({
   praxis,
@@ -164,14 +222,29 @@ export function PraxisStats({
   style?: CSSProperties;
 }) {
   const collaborators = praxis.member_count - 1;
+  const submittedDate = praxis.submitted_at
+    ? new Date(praxis.submitted_at).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+    : null;
   return (
     <div
       className="flex items-center gap-2 font-body"
       style={{ fontSize: "var(--text-xs)", ...style }}
     >
+      {praxis.task_level_required > 0 && (
+        <>
+          <span style={{ fontWeight: 600, opacity: 0.75 }}>L{praxis.task_level_required}</span>
+          <span aria-hidden>·</span>
+        </>
+      )}
       <span style={{ fontWeight: 700 }}>{praxis.task_point_value} pts</span>
       <span aria-hidden>·</span>
       <span>{collaborators > 0 ? `+${collaborators} crew` : "solo"}</span>
+      {submittedDate && (
+        <>
+          <span aria-hidden>·</span>
+          <span style={{ opacity: 0.65 }}>{submittedDate}</span>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #159

## What changed

**Backend**
- `Praxis` model: added `submitted_at` (nullable `DateTime(timezone=True)`) — stamped once on the `in_progress → submitted` transition in `submit_praxis()`
- Alembic migration `0003_add_praxis_submitted_at` (forward: `ADD COLUMN submitted_at TIMESTAMPTZ`, downgrade: `DROP COLUMN`)
- `PraxisCardOut` schema: four new fields — `task_level_required: int`, `average_stars: Optional[float]`, `total_votes: int`, `submitted_at: Optional[datetime]`
- `build_praxis_card_out`: populates the new fields; `average_stars`/`total_votes` via a single aggregate query (`AVG + COUNT`) — no N+1

**Frontend**
- `PraxisCardOut` interface: mirrored all four new fields
- `shared.tsx`: new `VoteUISummary` slot — compact read-only badge showing `average_stars` and `total_votes` (the card hero that replaces the placeholder `PraxisSeal` once the praxis is rated)
- `PraxisStats`: now shows `task_level_required` as a level badge (`L1`, `L2` …) and `submitted_at` as a formatted date
- `PlaceholderPraxisBody`: selects `VoteUISummary` as the hero when `average_stars` is present; falls back to `PraxisSeal` otherwise

**Tests**
- `factionCardSlots.test.tsx`: fixture updated with the four new required fields — all 16 slot-invariant tests still pass
- `test_praxes.py`: three new integration tests — new card fields present on list, `submitted_at` null pre-submit and non-null post-submit, `average_stars`/`total_votes` reflect a cast vote

## Test results

Frontend: 16/16 slot-invariant tests pass (`vitest run`)  
TypeScript: `tsc --noEmit` clean (no new errors beyond pre-existing `NavBar` warning)  
Backend: syntax-checked; integration tests require CI PostgreSQL (no local DB in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4RZbTRqJCmouQuhhAowRS

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4RZbTRqJCmouQuhhAowRS)_