### PR TITLE
Remove forced UA→aged_out graduation (fix #126)

### DIFF
--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -30,7 +30,7 @@ from game_config import EraConfig, FactionConfig, TaskDef
 #
 # Required system factions (include these in every era):
 #   "ua"       -- default starting faction (is_selectable=False)
-#   "aged_out" -- placeholder for characters who hit level 3 offline
+#   "aged_out" -- retired placeholder; kept for existing characters, no new assignments
 #   "na"       -- sentinel for tasks with no faction affiliation
 #
 # Modifier guide (1.0 = no change, >1.0 = bonus, <1.0 = penalty):

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -264,17 +264,3 @@ async def list_characters_for_viewer(
 
     result = await session.execute(query)
     return list(result.all())
-
-
-def check_faction_graduation(
-    character: Character,
-    stats: CharacterStats,
-    era: EraConfig = CURRENT_ERA,
-) -> str | None:
-    """Returns 'aged_out' if the character just hit level 3 while still in 'ua', else None."""
-    if character.faction_slug != "ua":
-        return None
-    current_level = compute_level(stats.score, era)
-    if current_level >= 3:
-        return "aged_out"
-    return None

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -15,7 +15,6 @@ from models.praxis import (
 from models.task import Task
 from models.vote import Vote
 from models.era import Era
-from services.character import check_faction_graduation
 from services.era import get_current_era_row, get_or_create_stats
 from services.meta_task import get_meta_task_points_bulk
 from services.scoring import (
@@ -358,7 +357,3 @@ async def recalculate_character_stats(
     stats.all_time_score = max(stats.all_time_score, new_score)
     stats.level = compute_level(new_score, era)
 
-    if author:
-        new_faction = check_faction_graduation(author, stats, era)
-        if new_faction:
-            author.faction_slug = new_faction

--- a/backend/tests/integration/test_character_stats.py
+++ b/backend/tests/integration/test_character_stats.py
@@ -10,7 +10,7 @@ from sqlalchemy import event
 from models.account import Account
 from models.character import Character
 from models.era import Era
-from models.praxis import Praxis, PraxisType
+from models.praxis import Praxis, PraxisStatus, PraxisType
 from models.task import Task
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
@@ -150,4 +150,38 @@ async def test_recalculate_character_stats_query_count_does_not_grow_with_praxes
         f"recalculate_character_stats issued {small_count} queries for 5 "
         f"praxes and {large_count} queries for 10 praxes — query count must "
         f"be constant in the praxis count (growth indicates N+1 regression)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_ua_character_faction_not_changed_at_level_3(
+    db_session,
+    character: Character,
+    active_task: Task,
+    era: Era,
+):
+    """UA characters must stay in 'ua' after recalculate_character_stats, even at level 3+.
+
+    Regression guard for the removed check_faction_graduation: that function
+    previously forced faction_slug from 'ua' to 'aged_out' on every stat
+    recalculation once the character reached level 3 (score >= 170).
+    """
+    # Seed 20 submitted solo praxes at 10 pts each → score 200, level 3.
+    for index in range(20):
+        praxis = Praxis(
+            task_id=active_task.id,
+            created_by_id=character.id,
+            type=PraxisType.solo,
+            title=f"Level-3 praxis {index}",
+            body_text="proof",
+            status=PraxisStatus.submitted,
+        )
+        db_session.add(praxis)
+    await db_session.commit()
+
+    await recalculate_character_stats(character.id, db_session)
+    await db_session.refresh(character)
+
+    assert character.faction_slug == "ua", (
+        f"recalculate_character_stats must not mutate faction_slug; got {character.faction_slug!r}"
     )

--- a/docs/spec/SPEC-game-rules.md
+++ b/docs/spec/SPEC-game-rules.md
@@ -15,7 +15,7 @@
 
 **2026-06-05 — June reconciliation (vault SOT sync)**
 - Additional character slot level gate: **4** (was 5 in spec and code; confirmed by requirements doc)
-- Faction choice at level 3: **opt-in, not forced**. `aged_out` / `AgedOutOfUA` graduation mechanic is being retired. ⚠️ `check_faction_graduation` should be disabled before launch.
+- Faction choice at level 3: **opt-in, not forced**. `aged_out` / `AgedOutOfUA` graduation mechanic retired. `check_faction_graduation` removed — UA characters no longer auto-graduate.
 - /Albescent unlock condition: account must have a character at **level 8** who has completed **at least one task from each faction** (not "one of every task" — one per faction is the bar)
 - Collaboration participant cap: **removed**. Era 1 collaborations are unlimited. `max_collab_participants` removed from EraConfig.
 
@@ -86,7 +86,7 @@ Per-faction fields on `FactionConfig` (all configurable per era):
 | Flagging minimum level | 4 | `services/praxis.py::flag_praxis` |
 | Second character requires level | 4 on any existing character | `era.second_character_level_required` in `eras/era_1.py` |
 | Albescent faction choosable for new characters | Requires account to have at least one character at level 8 who has completed at least one task from each faction | ⚠️ Not yet enforced — see SESSION R |
-| Faction choice | Level 3+ with a valid faction invite may optionally join a faction. No forced graduation — opt-in only. | ⚠️ `check_faction_graduation` creates `aged_out` state — disable before launch |
+| Faction choice | Level 3+ with a valid faction invite may optionally join a faction. No forced graduation — opt-in only. | ✅ `check_faction_graduation` removed — UA characters no longer auto-graduate |
 | Stars range | 1–5 | `services/vote.py` |
 | Snide tiebreaker rule | Snide always wins a tie vs non-Snide | `services/scoring.py::compute_duel_multiplier` |
 | Unaffiliated task slug | `"na"` | `services/scoring.py::UNAFFILIATED_FACTION_SLUG` |
@@ -256,7 +256,7 @@ Point thresholds come from `era.level_thresholds` and vary per era.
 
 - All characters start in **UA** (not selectable — assigned automatically), **except** /Albescent second-or-later characters which start in `/Albescent` at level 1 and never enter UA. ⚠️ Albescent-at-creation not yet implemented.
 - At level 3, a player **may optionally** choose a faction if they have received at least one valid invitation. There is no forced graduation from UA — players can remain in UA indefinitely.
-- The `aged_out` / `AgedOutOfUA` mechanic is **being retired**. ⚠️ Disable `check_faction_graduation` before launch.
+- The `aged_out` / `AgedOutOfUA` mechanic is **retired**. `check_faction_graduation` removed — existing `aged_out` characters can still choose a faction; no new characters will be put there.
 - **Faction change / defection:** a character can switch factions subject to defection rules tracked in `FactionDefectionHistory`. `can_always_rejoin=True` factions (/Albescent) can always be rejoined after leaving.
 
 ### Era 1 selectable factions
@@ -276,7 +276,7 @@ Point thresholds come from `era.level_thresholds` and vary per era.
 |---|---|---|
 | `ua` | UA | Starting faction. Full points. Players may stay indefinitely (opt-in faction choice from L3). |
 | `albescent` | /Albescent | Second-or-later character starting faction. Unlocked when account has a character at level 8 who has completed at least one task from each faction. Full points on everything, any metatasks. `can_always_rejoin=True`. |
-| `aged_out` | AgedOutOfUA | **Being retired.** Do not use for new characters. ⚠️ Disable `check_faction_graduation`. |
+| `aged_out` | AgedOutOfUA | **Retired.** No new characters will enter this state. Existing `aged_out` characters can still choose a faction normally. |
 | `na` | None | Sentinel for tasks with no faction affiliation. Treated as own-faction. |
 
 ### Albescent — second-or-later character flow


### PR DESCRIPTION
Closes #126

## What changed

- **Removed `check_faction_graduation`** from `services/character.py` — the function that silently reassigned UA characters to `aged_out` on every stat recalculation once they hit level 3.
- **Removed import and call site** from `services/character_stats.py` — `recalculate_character_stats` no longer mutates `faction_slug` at all.
- **Added regression test** in `tests/integration/test_character_stats.py` — seeds 20 submitted solo praxes (200 pts, level 3) and asserts `faction_slug` stays `"ua"` after recalculation.
- **Updated `SPEC-game-rules.md`** — removed 3 `⚠️` markers and marked the mechanic as retired (change log, rules table, faction section, and per-faction sentinel table).
- **Updated `eras/_template.py`** — corrected the `aged_out` comment to reflect it's a retired placeholder, not an active assignment target.

## What didn't change

- `aged_out` stays in the era config and DB — existing characters in that faction are unaffected and can still choose a new faction normally via the existing faction-selection endpoint.
- `faction_graduation_level` in `EraConfig` is about invitation delivery thresholds, not graduation; left unchanged.

## Test results

Integration test `test_ua_character_faction_not_changed_at_level_3` verifies the regression is closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012j1KvPKM3eiRxiR9fmGFng)_