### PR TITLE
fix: drop task from edit page (#157)

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
@@ -16,7 +16,7 @@ import MarkdownPreview from "../blocks/MarkdownPreview";
 import MediaArt from "../blocks/MediaArt";
 import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
 import { Breadcrumb, ErrorBanner, formatAutosave } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
 import { EphMark, Foxing, LapisLastWord, toRoman } from "../../../components/cards/ephemeristsAtoms";
 import type { EditPraxisState } from "../useEditPraxis";
 
@@ -438,6 +438,23 @@ export default function EditPraxisEphemeris({ state }: Props) {
           >
             {state.saving ? "saving…" : "Keep as marginalia"}
           </button>
+          <DropButton
+            state={state}
+            skin={{
+              label: "withdraw entry",
+              style: {
+                background: "transparent",
+                border: "none",
+                color: MUTED,
+                fontFamily: "var(--eph-serif)",
+                fontSize: 11,
+                fontStyle: "italic",
+                letterSpacing: "0.06em",
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
           <span style={{ fontSize: 11, fontStyle: "italic", color: MUTED, marginLeft: "auto" }}>
             {state.autosaveAt ? `↳ entered ${formatAutosave(state.autosaveAt)}` : "↳ not yet sealed"}
           </span>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
@@ -19,6 +19,7 @@ import {
   TaskMetaInline,
   formatAutosave,
 } from "./shared";
+import { DropButton } from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -626,23 +627,23 @@ export default function EditPraxisEverymen({ state }: Props) {
           >
             {state.saving ? "Saving…" : "Save Draft"}
           </button>
-          <button
-            type="button"
-            onClick={state.cancel}
-            style={{
-              marginLeft: "auto",
-              background: "transparent",
-              border: "none",
-              color: MUTED,
-              fontFamily: BODY_FONT,
-              fontSize: 11,
-              fontStyle: "italic",
-              textDecoration: "underline",
-              cursor: "pointer",
+          <DropButton
+            state={state}
+            skin={{
+              label: "cancel",
+              style: {
+                marginLeft: "auto",
+                background: "transparent",
+                border: "none",
+                color: MUTED,
+                fontFamily: BODY_FONT,
+                fontSize: 11,
+                fontStyle: "italic",
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
             }}
-          >
-            cancel
-          </button>
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisGazette.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisGazette.tsx
@@ -17,7 +17,7 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -694,6 +694,22 @@ export default function EditPraxisGazette({ state }: Props) {
           >
             {state.saving ? "saving..." : "save as draft"}
           </button>
+          <DropButton
+            state={state}
+            skin={{
+              label: "abandon this story",
+              style: {
+                background: "transparent",
+                border: "none",
+                color: muted,
+                fontFamily: "'IM Fell English', serif",
+                fontStyle: "italic",
+                fontSize: 11,
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
           <div style={{ flex: 1 }} />
           <span
             style={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
@@ -16,7 +16,7 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -754,21 +754,21 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                 {state.saving ? "saving..." : "save draft"}
               </button>
               <div style={{ flex: 1 }} />
-              <button
-                type="button"
-                onClick={state.cancel}
-                style={{
-                  background: "transparent",
-                  color: muted,
-                  fontFamily: cardFont,
-                  fontSize: 18,
-                  fontWeight: 700,
-                  border: "none",
-                  cursor: "pointer",
+              <DropButton
+                state={state}
+                skin={{
+                  label: "cancel",
+                  style: {
+                    background: "transparent",
+                    color: muted,
+                    fontFamily: cardFont,
+                    fontSize: 18,
+                    fontWeight: 700,
+                    border: "none",
+                    cursor: "pointer",
+                  },
                 }}
-              >
-                cancel
-              </button>
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
@@ -18,7 +18,7 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -714,21 +714,21 @@ export default function EditPraxisPunkZine({ state }: Props) {
             {state.saving ? "saving..." : "save draft"}
           </button>
           <div style={{ flex: 1 }} />
-          <button
-            type="button"
-            onClick={state.cancel}
-            style={{
-              background: "transparent",
-              color: muted,
-              fontFamily: "'Special Elite', serif",
-              fontSize: 11,
-              border: "none",
-              cursor: "pointer",
-              textDecoration: "underline",
+          <DropButton
+            state={state}
+            skin={{
+              label: "cancel",
+              style: {
+                background: "transparent",
+                color: muted,
+                fontFamily: "'Special Elite', serif",
+                fontSize: 11,
+                border: "none",
+                cursor: "pointer",
+                textDecoration: "underline",
+              },
             }}
-          >
-            cancel
-          </button>
+          />
         </div>
 
         <div

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
@@ -16,7 +16,7 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -619,6 +619,21 @@ export default function EditPraxisStickyNote({ state }: Props) {
           >
             {state.saving ? "saving..." : "save for later"}
           </button>
+          <DropButton
+            state={state}
+            skin={{
+              label: "throw it away",
+              style: {
+                background: "transparent",
+                border: "none",
+                color: SLATE_DEEP,
+                fontFamily: "'Caveat', cursive",
+                fontSize: 16,
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
           <div style={{ flex: 1 }} />
           <span
             style={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
@@ -8,7 +8,7 @@ import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MarkdownPreview from "../blocks/MarkdownPreview";
 import { Breadcrumb, ErrorBanner, TitleCounter, formatClock } from "./shared";
-import { FilePicker, InviteSearch, MetatasksList } from "./controls";
+import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -714,21 +714,21 @@ export default function EditPraxisTerminal({ state }: Props) {
             {state.saving ? ":saving" : ":w (save draft)"}
           </button>
           <div style={{ flex: 1 }} />
-          <button
-            type="button"
-            onClick={state.cancel}
-            style={{
-              background: "transparent",
-              color: dim,
-              fontFamily: "'Share Tech Mono', monospace",
-              fontSize: 9,
-              border: "none",
-              cursor: "pointer",
-              textDecoration: "underline",
+          <DropButton
+            state={state}
+            skin={{
+              label: "[esc] :q",
+              style: {
+                background: "transparent",
+                color: dim,
+                fontFamily: "'Share Tech Mono', monospace",
+                fontSize: 9,
+                border: "none",
+                cursor: "pointer",
+                textDecoration: "underline",
+              },
             }}
-          >
-            [esc] :q
-          </button>
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -206,6 +206,29 @@ export function FilePicker({
   );
 }
 
+export interface DropButtonSkin {
+  style?: CSSProperties;
+  label?: string;
+}
+
+export function DropButton({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin?: DropButtonSkin;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => void state.cancel()}
+      style={skin?.style}
+    >
+      {skin?.label ?? "drop task"}
+    </button>
+  );
+}
+
 export interface MetataskListSkin {
   containerStyle?: CSSProperties;
   rowStyle?: (selected: boolean) => CSSProperties;

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -76,12 +76,12 @@ export interface EditPraxisState {
   applyingMetatask: number | null;
   toggleMetatask: (mt: TaskOut) => Promise<void>;
 
-  // Save / publish
+  // Save / publish / drop
   saving: boolean;
   submitting: boolean;
   save: (event?: React.FormEvent) => Promise<void>;
   publish: () => Promise<void>;
-  cancel: () => void;
+  cancel: () => Promise<void>;
 
   // Autosave
   autosaveAt: Date | null;
@@ -322,9 +322,24 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     }
   }, [idParam, title, persistEdits, navigate, refetch]);
 
-  const cancel = useCallback(() => {
-    if (idParam) navigate(`/praxes/${idParam}`);
-  }, [idParam, navigate]);
+  const cancel = useCallback(async () => {
+    if (!praxis) return;
+    const confirmed = window.confirm(
+      "Drop this task? Your draft will be lost.",
+    );
+    if (!confirmed) return;
+    if (autosaveTimerRef.current) {
+      clearTimeout(autosaveTimerRef.current);
+      autosaveTimerRef.current = null;
+    }
+    try {
+      await deletePraxis(praxis.id);
+    } catch (err) {
+      setError(extractError(err, "Could not drop the task."));
+      return;
+    }
+    navigate("/tasks");
+  }, [praxis, navigate]);
 
   // ---- Mode switching ----
   const hasDraftContent = useCallback((): boolean => {


### PR DESCRIPTION
Closes #157

## What changed

`cancel()` in `useEditPraxis.ts` previously just navigated to `/praxes/:id` without deleting the draft, leaving the praxis in place and trapping the signup slot. This fix makes it a proper "drop task" action:

1. **Confirm** — `window.confirm("Drop this task? Your draft will be lost.")` before acting.
2. **Clear autosave timer** — prevents the 2s debounce from firing a PUT against the just-deleted praxis (which would 404).
3. **Delete** — calls `deletePraxis(praxis.id)`.
4. **Navigate** — goes to `/tasks` so the user can pick another task.

## Shared `DropButton` component

Added `DropButton` to `controls.tsx` following the `FilePicker` skin pattern. Each archetype passes its own themed `label` and `style`:

| Archetype | Label |
|---|---|
| Ephemeris | "withdraw entry" |
| Gazette | "abandon this story" |
| StickyNote | "throw it away" |
| Everymen | "cancel" (replaced inline button) |
| PunkZine | "cancel" (replaced inline button) |
| PaperCollage | "cancel" (replaced inline button) |
| Terminal | "[esc] :q" (replaced inline button) |

Ephemeris, Gazette, and StickyNote previously had no drop affordance at all — they now do.

## Test results

- Backend unit tests: **124 passed** (frontend-only change; no backend changes)
- TypeScript: no new type errors (only pre-existing env issues in `NavBar.tsx`)

---
_Generated by [Claude Code](https://claude.ai/code/session_019va6amnEYf3HQhbG6Kd56a)_