### PR TITLE
fix: don't block post-submit navigation on refetch failure

### DIFF
--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -313,7 +313,11 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       const praxisId = parseInt(idParam, 10);
       await persistEdits(praxisId);
       await submitPraxis(praxisId);
-      await refetch();
+      try {
+        await refetch();
+      } catch {
+        // best-effort; praxis was submitted successfully
+      }
       navigate(`/praxes/${idParam}`);
     } catch (err) {
       setError(extractError(err, "Could not publish proof."));


### PR DESCRIPTION
Closes #154

## What changed

In `publish()` (`frontend/src/pages/editPraxis/useEditPraxis.ts`), the post-submit `refetch()` call was inside the same `try` block as `persistEdits` and `submitPraxis`. If the refetch threw (e.g. a transient auth hiccup), the outer `catch` set an error and skipped `navigate()` — leaving the user stranded on the edit page even though the praxis was already successfully submitted server-side.

Wrapped `refetch()` in its own `try/catch` so it is best-effort. Navigation always proceeds once submit succeeds.

## Change

`frontend/src/pages/editPraxis/useEditPraxis.ts` — 5 lines changed, 1 file.

## Test results

Frontend: no test suite configured (Vite-only build). Change is a 4-line structural guard with no logic impact on the success path; the outer catch still handles real submit failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYBTccDCAUYYNbVaKrJUgc)_