### PR TITLE
Extract inline route handler logic to service functions (#128)

### DIFF
--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -22,6 +22,7 @@ from services.faction_service import (
     defect_to_faction,
     get_defection_history,
     get_invitation_status,
+    update_faction,
 )
 from models.invitation_letter import InvitationLetter
 
@@ -38,7 +39,7 @@ async def list_factions(session: AsyncSession = Depends(get_db)):
 
 
 @router.put("/{slug}", response_model=FactionOut)
-async def update_faction(
+async def update_faction_route(
     slug: str,
     data: FactionUpdate,
     _: Account = Depends(require_admin),
@@ -48,11 +49,8 @@ async def update_faction(
     faction = await session.get(Faction, slug)
     if faction is None:
         raise HTTPException(status_code=404, detail="Faction not found.")
-    faction.name = data.name
-    faction.description = data.description
-    await session.flush()
-    await session.refresh(faction)
-    return FactionOut.model_validate(faction)
+    updated = await update_faction(faction, data, session)
+    return FactionOut.model_validate(updated)
 
 
 @router.post("/choose", response_model=FactionOut)

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -11,7 +11,7 @@ from dependencies import (
 )
 from models.account import Account
 from models.character import Character
-from models.task import Task, TaskStatus, TaskType
+from models.task import Task
 from schemas.task import TaskCreate, TaskOut
 from services.auth import get_current_account
 from services.task import (
@@ -20,6 +20,7 @@ from services.task import (
     list_signups_for_task,
     list_tasks as service_list_tasks,
     propose_task,
+    update_task,
 )
 
 router = APIRouter()
@@ -113,20 +114,4 @@ async def update_task_route(
     task = await session.get(Task, task_id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found.")
-    # Proposer can edit their own pending tasks only
-    if task.created_by != character.id or task.status != TaskStatus.pending:
-        raise HTTPException(
-            status_code=403,
-            detail="Only the proposer can edit a pending task.",
-        )
-    task.title = data.title
-    task.description = data.description or ""
-    task.point_value = data.point_value
-    task.level_required = data.level_required
-    task.primary_faction_slug = data.primary_faction_slug or "na"
-    # Only allow editing metatask_faction_slug for metatasks.
-    if task.task_type == TaskType.metatask and data.metatask_faction_slug is not None:
-        task.metatask_faction_slug = data.metatask_faction_slug
-    await session.flush()
-    await session.refresh(task)
-    return build_task_out(task)
+    return build_task_out(await update_task(task, data, character, session))

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -7,9 +7,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.character_stats import CharacterStats
+from models.faction import Faction
 from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
 from models.task import Task
+from schemas.faction import FactionUpdate
 from services.era import clear_defection_history_for_era, get_current_era_row, get_or_create_stats
 
 UA_FACTION_SLUG: str = "ua"
@@ -165,3 +167,20 @@ async def get_invitation_status(
             status_map[slug] = "not_invited"
 
     return status_map
+
+
+# ---------------------------------------------------------------------------
+# Admin mutations
+# ---------------------------------------------------------------------------
+
+
+async def update_faction(
+    faction: Faction,
+    data: FactionUpdate,
+    session: AsyncSession,
+) -> Faction:
+    faction.name = data.name
+    faction.description = data.description
+    await session.flush()
+    await session.refresh(faction)
+    return faction

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -82,6 +82,29 @@ async def propose_task(
     return task
 
 
+async def update_task(
+    task: Task,
+    data: TaskCreate,
+    character: Character,
+    session: AsyncSession,
+) -> Task:
+    if task.created_by != character.id or task.status != TaskStatus.pending:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the proposer can edit a pending task.",
+        )
+    task.title = data.title
+    task.description = data.description or ""
+    task.point_value = data.point_value
+    task.level_required = data.level_required
+    task.primary_faction_slug = data.primary_faction_slug or "na"
+    if task.task_type == TaskType.metatask and data.metatask_faction_slug is not None:
+        task.metatask_faction_slug = data.metatask_faction_slug
+    await session.flush()
+    await session.refresh(task)
+    return task
+
+
 def build_task_out(task: Task) -> TaskOut:
     """Convert a Task ORM instance to a TaskOut schema.
 

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -7,6 +7,7 @@ from models.account import Account
 from models.character import Character
 from models.era import Era
 from models.faction import Faction, FactionStatus
+from models.roles import AccountRole, Role
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +141,74 @@ async def test_choose_nonexistent_faction(
     resp = await client.post(
         "/factions/choose",
         json={"faction_slug": "does_not_exist"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Update faction (admin-only)
+# ---------------------------------------------------------------------------
+
+
+async def _make_admin(account: Account, session: AsyncSession) -> None:
+    role = Role(name="admin", description="Administrator")
+    session.add(role)
+    await session.flush()
+    ar = AccountRole(account_id=account.id, role_id=role.id, granted_by=account.id)
+    session.add(ar)
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_update_faction_admin_success(
+    client: AsyncClient,
+    account: Account,
+    auth_headers: dict,
+    faction_ua: Faction,
+    db_session: AsyncSession,
+):
+    """Admin can update a faction's name and description."""
+    await _make_admin(account, db_session)
+    resp = await client.put(
+        "/factions/ua",
+        json={"name": "United Alliance", "description": "Updated description."},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "United Alliance"
+    assert data["description"] == "Updated description."
+    assert data["slug"] == "ua"
+
+
+@pytest.mark.asyncio
+async def test_update_faction_non_admin_forbidden(
+    client: AsyncClient,
+    auth_headers: dict,
+    faction_ua: Faction,
+):
+    """Non-admin accounts get 403 when attempting to update a faction."""
+    resp = await client.put(
+        "/factions/ua",
+        json={"name": "Hijacked", "description": "Nope."},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_faction_not_found(
+    client: AsyncClient,
+    account: Account,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """PUT /factions/{slug} returns 404 for an unknown slug."""
+    await _make_admin(account, db_session)
+    resp = await client.put(
+        "/factions/does_not_exist",
+        json={"name": "Ghost", "description": ""},
         headers=auth_headers,
     )
     assert resp.status_code == 404


### PR DESCRIPTION
Closes #128

## What changed

Two PUT route handlers were mutating ORM rows directly inline, violating the thin-routes spec (`SPEC-backend-architecture.md §1`: "Route handlers should be thin enough to read in one glance… No business logic.").

**`services/task.py` — new `update_task(task, data, character, session) → Task`**
- Authorization check (proposer + pending status) moved from router to service
- Field mutations (title, description, point_value, level_required, primary_faction_slug, metatask_faction_slug) moved to service
- `update_task_route` is now a 4-line 404-check + delegate

**`services/faction_service.py` — new `update_faction(faction, data, session) → Faction`**
- Field mutations (name, description) moved to service
- Route handler renamed from `update_faction` to `update_faction_route` to avoid import collision with the new service function
- `update_faction_route` is now a 4-line 404-check + delegate

**Cleanup:** removed unused `TaskStatus` / `TaskType` imports from `routers/tasks.py`.

**New tests:** 3 integration tests for `PUT /factions/{slug}` (admin success, non-admin 403, unknown-slug 404) — this endpoint had no test coverage.

## Test results

Integration tests require a live PostgreSQL instance (not available in this environment). All five changed files pass AST syntax checks. Existing tests for the task update path (`test_edit_pending_task_by_proposer`, `test_edit_task_wrong_owner`, `test_edit_active_task_rejected`, `test_edit_task_not_found`) continue to exercise the same behavior via the thin route.

---
_Generated by [Claude Code](https://claude.ai/code/session_014WDnqDTxTPTZxJfx91kHqZ)_