### PR TITLE
fix(editPraxis): unlock solo/collab toggle after a second member joins (#155)

### DIFF
--- a/frontend/src/pages/editPraxis/useEditPraxis.test.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Guards the mode-switch confirm logic behind #155: once a second member joins,
+ * the picker must stay usable (confirm-then-drop), not silently lock.
+ */
+import { describe, it, expect } from "vitest";
+import { modeSwitchPrompt } from "./useEditPraxis";
+
+describe("modeSwitchPrompt", () => {
+  it("does not lock once a second member joins — it offers a confirm (#155)", () => {
+    // A non-null prompt means the switch proceeds after confirm, not a hard block.
+    expect(modeSwitchPrompt(2, true)).not.toBeNull();
+    expect(modeSwitchPrompt(3, false)).not.toBeNull();
+  });
+
+  it("warns that co-authors will be dropped when collaborators have joined", () => {
+    expect(modeSwitchPrompt(2, false)).toMatch(/co-authors/i);
+  });
+
+  it("warns about discarding an unsaved solo draft", () => {
+    expect(modeSwitchPrompt(1, true)).toMatch(/discard/i);
+  });
+
+  it("proceeds without a confirm for an empty solo praxis", () => {
+    expect(modeSwitchPrompt(1, false)).toBeNull();
+  });
+});

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -101,6 +101,28 @@ export interface EditPraxisState {
 
 const AUTOSAVE_DEBOUNCE_MS = 2000;
 
+/**
+ * Decide whether switching to a new mode needs a confirm, and with what prompt.
+ * Returns the message to confirm, or null to proceed silently.
+ *
+ * A mode switch tears down and recreates the praxis (see `performModeSwitch`),
+ * so the destructive cases warn first instead of locking the control (#155):
+ *  - co-authors present  → they'll be dropped
+ *  - else unsaved draft  → it'll be discarded
+ */
+export function modeSwitchPrompt(
+  memberCount: number,
+  hasDraftContent: boolean,
+): string | null {
+  if (memberCount > 1) {
+    return "Switching mode will drop the collaboration — your co-authors will be removed and the current draft replaced. Continue?";
+  }
+  if (hasDraftContent) {
+    return "Changing mode will discard your current draft (title, body, media, metatasks). Continue?";
+  }
+  return null;
+}
+
 export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const navigate = useNavigate();
   const { user, refetch } = useAuth();
@@ -376,16 +398,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const changeMode = useCallback(
     async (next: PraxisType) => {
       if (!praxis || praxis.type === next) return;
-      if (praxis.members.length > 1) {
-        setError("Mode is locked once co-authors have joined.");
-        return;
-      }
-      if (hasDraftContent()) {
-        const confirmed = window.confirm(
-          "Changing mode will discard your current draft (title, body, media, metatasks). Continue?",
-        );
-        if (!confirmed) return;
-      }
+      const prompt = modeSwitchPrompt(praxis.members.length, hasDraftContent());
+      if (prompt && !window.confirm(prompt)) return;
       await performModeSwitch(next);
     },
     [praxis, hasDraftContent, performModeSwitch],
@@ -487,10 +501,9 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     praxis?.moderation_status === "hidden" ||
     praxis?.moderation_status === "failed";
   const controlsLocked = !!(isPublished || isModerated);
-  const modeIsLocked = !!(
-    controlsLocked ||
-    (praxis && praxis.members.length > 1)
-  );
+  // Locked only once sealed/moderated — co-authors no longer lock the picker;
+  // switching with members joined confirms-then-drops instead (#155).
+  const modeIsLocked = controlsLocked;
   const duelSlotFull = !!(
     praxis &&
     praxis.type === "duel" &&


### PR DESCRIPTION
Closes #155

## Bug
On Edit Praxis, once a praxis had more than one member the solo/collab toggle locked — non-active mode buttons were silently hidden, so a collaboration could never be switched back to solo.

## Root cause
Two enforcement points in `frontend/src/pages/editPraxis/useEditPraxis.ts`:
- `modeIsLocked` included `praxis.members.length > 1` → archetypes' `if (modeIsLocked && !active) return null` hid every non-active mode button.
- `changeMode` hard-errored on the same `members.length > 1` condition.

## Fix
- `modeIsLocked` now reflects only sealed/moderated state (`controlsLocked`); co-authors no longer lock the picker.
- `changeMode` routes through a small pure `modeSwitchPrompt(memberCount, hasDraftContent)` helper: with co-authors joined it confirms "drop the collaboration?" before tearing the praxis down, instead of hiding the control. Per CLAUDE.md the control *is* usable — it just needs confirmation.

Fix lives entirely in the shared hook; all 7 faction archetypes route through `modeIsLocked` / `changeMode`, so none were touched.

## Tests
New `useEditPraxis.test.ts` unit-tests the extracted decision (pure, no DOM): collaborators → confirm-not-lock, co-author warning, solo-draft discard warning, empty-solo no-confirm.

Test results: `vitest run` — 20 passed (16 existing + 4 new). `tsc --noEmit` — clean.