### PR TITLE
fix: sign-up button hides correctly on ineligible tasks (#156)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -434,7 +434,7 @@ async def _check_create_preconditions(
             detail="This task is pending and is not open for new praxes.",
         )
 
-    if not await can_submit_praxis_for_task(character, task, session):
+    if not await can_submit_praxis_for_task(character, task, session, era):
         raise HTTPException(
             status_code=409,
             detail="You have already submitted a praxis for this task.",
@@ -595,28 +595,43 @@ async def can_submit_praxis_for_task(
     character: Optional[Character],
     task: Task,
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
 ) -> bool:
-    """Return True if ``character`` may create a new praxis for ``task``.
+    """Return True if ``character`` passes every signup gate for ``task``.
 
-    Mirrors the duplicate-submission rule enforced in :func:`create_praxis`:
-    - Anonymous viewers never see the submit affordance (False).
-    - A character that already authors a non-withdrawn ``Praxis`` for this
-      ``task`` cannot submit again, except for the Everymen faction (Double
-      Dipper perk). Withdrawn prior praxes do not block a fresh submission.
-
-    This helper intentionally stays focused on the one-praxis-per-task rule.
-    Level gates, bank-cap checks, and faction-visibility are handled by the
-    caller or :func:`create_praxis` itself.
+    Mirrors all guards enforced in :func:`_check_create_preconditions` so the
+    frontend ``can_submit_praxis`` flag on ``TaskOut`` is always truthful:
+    - Anonymous viewers → False.
+    - Character level below ``task.level_required`` → False.
+    - Task is retired/pending and character's faction is not in the
+      ``allow_praxis_on_retired/pending_task_factions`` carve-out → False.
+    - Character already holds an active ``PraxisMember`` row (authored *or*
+      joined via collab invite) on a non-deleted praxis for this task → False.
+      The Everymen faction (Double Dipper perk) is exempt from this last gate
+      only — level and task-status gates still apply to everyone.
     """
     if character is None:
+        return False
+
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, character.id, era_row.id)
+
+    if stats.level < task.level_required:
+        return False
+
+    if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
+        return False
+    if task.status == TaskStatus.pending and character.faction_slug not in era.allow_praxis_on_pending_task_factions:
         return False
 
     if character.faction_slug == EVERYMEN_FACTION_SLUG:
         return True
 
     result = await session.execute(
-        select(Praxis.id).where(
-            Praxis.created_by_id == character.id,
+        select(PraxisMember.id)
+        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+        .where(
+            PraxisMember.character_id == character.id,
             Praxis.task_id == task.id,
         )
     )

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -150,7 +150,7 @@ async def build_task_out_for_viewer(
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, viewer.id, era_row.id)
 
-    base.can_submit_praxis = await can_submit_praxis_for_task(viewer, task, session)
+    base.can_submit_praxis = await can_submit_praxis_for_task(viewer, task, session, era)
     base.allowed_modes = allowed_praxis_modes(viewer, task, stats.level, era)
     base.eligible_for_current_user = is_task_eligible_for_character(
         viewer, task, stats.level

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -960,6 +960,130 @@ async def test_get_task_can_submit_false_for_anonymous(
     assert resp.json()["can_submit_praxis"] is False
 
 
+@pytest.mark.asyncio
+async def test_get_task_can_submit_false_level_too_low(
+    client: AsyncClient,
+    character: Character,
+    db_session: AsyncSession,
+    auth_headers: dict,
+):
+    """Character below task.level_required sees can_submit_praxis=False."""
+    high_level_task = Task(
+        title="Hard Task",
+        description="Requires level 5",
+        point_value=50,
+        level_required=5,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(high_level_task)
+    await db_session.commit()
+    await db_session.refresh(high_level_task)
+
+    # character fixture starts at level 0, so level_required=5 blocks it
+    resp = await client.get(f"/tasks/{high_level_task.id}", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["can_submit_praxis"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_task_can_submit_false_retired_task(
+    client: AsyncClient,
+    character: Character,
+    db_session: AsyncSession,
+    auth_headers: dict,
+):
+    """Character without Task Vision sees can_submit_praxis=False on a retired task."""
+    retired_task = Task(
+        title="Retired Task",
+        description="No longer active",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.retired,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(retired_task)
+    await db_session.commit()
+    await db_session.refresh(retired_task)
+
+    resp = await client.get(f"/tasks/{retired_task.id}", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["can_submit_praxis"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_task_can_submit_false_joined_collaborator(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    db_session: AsyncSession,
+    auth_headers2: dict,
+):
+    """A character who joined someone else's collab sees can_submit_praxis=False."""
+    from models.praxis import Praxis, PraxisMember, PraxisType
+
+    collab = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.collab,
+        title="Collab",
+        body_text="proof",
+    )
+    db_session.add(collab)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=collab.id, character_id=character.id))
+    db_session.add(PraxisMember(praxis_id=collab.id, character_id=character2.id))
+    await db_session.commit()
+
+    # character2 is a joined collaborator, not the author
+    resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers2)
+    assert resp.status_code == 200
+    assert resp.json()["can_submit_praxis"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_task_can_submit_true_everymen_as_collaborator(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    db_session: AsyncSession,
+    auth_headers2: dict,
+):
+    """Everymen (Double Dipper) member of a collab still sees can_submit_praxis=True."""
+    from models.faction import FactionStatus
+    from models.praxis import Praxis, PraxisMember, PraxisType
+    from sqlalchemy import select
+
+    result = await db_session.execute(select(Faction).where(Faction.slug == "everymen"))
+    if result.scalar_one_or_none() is None:
+        db_session.add(Faction(slug="everymen", name="Everymen", description="Double Dipper", status=FactionStatus.visible))
+        await db_session.commit()
+
+    character2.faction_slug = "everymen"
+    await db_session.commit()
+
+    collab = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.collab,
+        title="Collab",
+        body_text="proof",
+    )
+    db_session.add(collab)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=collab.id, character_id=character.id))
+    db_session.add(PraxisMember(praxis_id=collab.id, character_id=character2.id))
+    await db_session.commit()
+
+    resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers2)
+    assert resp.status_code == 200
+    assert resp.json()["can_submit_praxis"] is True
+
+
 # ---------------------------------------------------------------------------
 # Bug 7 — allowed_modes by viewer level
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #156

## What changed

`can_submit_praxis_for_task` was narrowly focused on the one-praxis-per-task duplicate rule, so `task.can_submit_praxis` (the frontend sign-up button visibility flag) returned `true` even when the character was ineligible for other reasons. Clicking sign-up then failed server-side.

This PR expands the function to mirror every gate in `_check_create_preconditions`:

| Gate | Before | After |
|---|---|---|
| Anonymous viewer | False ✓ | False ✓ |
| Level below `task.level_required` | **True (wrong)** | False ✓ |
| Task retired/pending (no carve-out) | **True (wrong)** | False ✓ |
| Joined collaborator (non-author) | **True (wrong)** | False ✓ |
| Everymen Double Dipper | True ✓ | True ✓ (membership gate only) |

**Membership check** is now `PraxisMember`-based (replaces `created_by_id`), which correctly blocks characters who joined someone else's collab for the same task.

**Everymen carve-out** is preserved for the membership gate only — level and task-status gates still apply to everyone.

## Test results

4 new integration tests covering each gate:
- `test_get_task_can_submit_false_level_too_low`
- `test_get_task_can_submit_false_retired_task`
- `test_get_task_can_submit_false_joined_collaborator`
- `test_get_task_can_submit_true_everymen_as_collaborator`

CI runs the full suite against PostgreSQL.

---
_Generated by [Claude Code](https://claude.ai/code/session_011qjXxEHKMC1RxFPgSgdpWf)_