### PR TITLE
Add per-faction completion gate to Albescent unlock (#127)

### DIFF
--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -9,6 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character, CharacterStatus
 from models.character_stats import CharacterStats
+from models.praxis import ModerationStatus, Praxis, PraxisStatus
+from models.task import Task
 from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
 from services.era import get_current_era_row, get_current_era_row_safe, get_or_create_stats
 from services.scoring import compute_level, compute_vote_budget, compute_votes_available
@@ -56,6 +58,8 @@ async def get_character_by_id(character_id: int, session: AsyncSession) -> Chara
 
 
 ALBESCENT_FACTION_SLUG = "albescent"
+
+_ALBESCENT_SENTINEL_SLUGS: frozenset[str] = frozenset({"na", "aged_out", "albescent"})
 
 
 async def _account_has_character_at_level(
@@ -105,12 +109,57 @@ async def can_start_as_albescent(
 ) -> bool:
     """True when this account may create a new character in the Albescent faction.
 
-    Requires at least one existing active character at level
-    ``era.albescent_level_required`` or above in the current era.
+    Both conditions must hold on the *same* character:
+    (a) active and at level ``era.albescent_level_required`` or above, and
+    (b) has a submitted, non-hidden qualifying praxis for every non-sentinel
+        faction in the era (i.e. every faction except ``na``, ``aged_out``,
+        and ``albescent``).
     """
-    return await _account_has_character_at_level(
-        account_id, era.albescent_level_required, session
+    required_faction_slugs = frozenset(
+        slug for slug in era.factions if slug not in _ALBESCENT_SENTINEL_SLUGS
     )
+    era_row = await get_current_era_row(session)
+
+    level_result = await session.execute(
+        select(Character.id)
+        .join(
+            CharacterStats,
+            (CharacterStats.character_id == Character.id)
+            & (CharacterStats.era_id == era_row.id),
+        )
+        .where(
+            Character.account_id == account_id,
+            Character.status == CharacterStatus.active,
+            CharacterStats.level >= era.albescent_level_required,
+        )
+    )
+    qualifying_character_ids = [row[0] for row in level_result.all()]
+
+    if not qualifying_character_ids:
+        return False
+
+    if not required_faction_slugs:
+        return True
+
+    for character_id in qualifying_character_ids:
+        covered_result = await session.execute(
+            select(Task.primary_faction_slug)
+            .distinct()
+            .join(Praxis, Praxis.task_id == Task.id)
+            .where(
+                Praxis.created_by_id == character_id,
+                Praxis.status == PraxisStatus.submitted,
+                Praxis.moderation_status.in_(
+                    [ModerationStatus.visible, ModerationStatus.flagged]
+                ),
+                Task.primary_faction_slug.in_(list(required_faction_slugs)),
+            )
+        )
+        covered_slugs = frozenset(row[0] for row in covered_result.all())
+        if covered_slugs >= required_faction_slugs:
+            return True
+
+    return False
 
 
 async def create_character(
@@ -151,7 +200,7 @@ async def create_character(
                 status_code=403,
                 detail=(
                     f"Albescent characters require a level-{era.albescent_level_required} "
-                    "character on the account."
+                    "character on the account who has completed a task from each faction."
                 ),
             )
         starting_faction_slug = ALBESCENT_FACTION_SLUG

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -360,11 +360,15 @@ async def test_me_can_start_as_albescent_true_when_level_8_plus(
     auth_headers: dict,
     db_session: AsyncSession,
     era,
+    faction_ua,
 ):
-    """Account with a level-8 character: both flags true (level 8 is above 5 too)."""
-    from sqlalchemy import select
-
+    """Account with a level-8 character who has all faction completions: both flags true."""
+    from game_config import CURRENT_ERA
     from models.character_stats import CharacterStats
+    from models.faction import Faction, FactionStatus
+    from models.praxis import Praxis, PraxisStatus, PraxisType
+    from models.task import Task, TaskStatus
+    from sqlalchemy import select
 
     result = await db_session.execute(
         select(CharacterStats).where(
@@ -374,6 +378,49 @@ async def test_me_can_start_as_albescent_true_when_level_8_plus(
     )
     stats = result.scalar_one()
     stats.level = 8
+    await db_session.commit()
+
+    # Seed one submitted praxis per non-sentinel faction so the full gate passes
+    sentinel_slugs = frozenset({"na", "aged_out", "albescent"})
+    for faction_slug in CURRENT_ERA.factions:
+        if faction_slug in sentinel_slugs:
+            continue
+        faction_result = await db_session.execute(
+            select(Faction).where(Faction.slug == faction_slug)
+        )
+        if faction_result.scalar_one_or_none() is None:
+            db_session.add(
+                Faction(
+                    slug=faction_slug,
+                    name=faction_slug,
+                    description=f"{faction_slug} test faction",
+                    status=FactionStatus.visible,
+                )
+            )
+            await db_session.flush()
+
+        task = Task(
+            title=f"Albescent gate task: {faction_slug}",
+            description="test",
+            point_value=5,
+            level_required=0,
+            status=TaskStatus.active,
+            created_by=character.id,
+            primary_faction_slug=faction_slug,
+        )
+        db_session.add(task)
+        await db_session.flush()
+
+        praxis = Praxis(
+            task_id=task.id,
+            created_by_id=character.id,
+            type=PraxisType.solo,
+            title=f"Albescent gate praxis: {faction_slug}",
+            body_text="proof",
+            status=PraxisStatus.submitted,
+        )
+        db_session.add(praxis)
+
     await db_session.commit()
 
     resp = await client.get("/auth/me", headers=auth_headers)

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -341,8 +341,68 @@ async def test_second_character_allowed_at_level5(
     assert "account_id" not in data
 
 
+async def _seed_all_faction_completions(
+    db_session: AsyncSession,
+    character: Character,
+) -> None:
+    """Seed one submitted praxis per non-sentinel era faction for the given character.
+
+    Creates faction DB rows, tasks, and submitted praxes as needed. Safe to
+    call multiple times — skips faction rows that already exist.
+    """
+    from game_config import CURRENT_ERA
+    from models.faction import Faction, FactionStatus
+    from models.praxis import Praxis, PraxisStatus, PraxisType
+    from models.task import Task, TaskStatus
+    from sqlalchemy import select
+
+    sentinel_slugs = frozenset({"na", "aged_out", "albescent"})
+    required_slugs = [
+        slug for slug in CURRENT_ERA.factions if slug not in sentinel_slugs
+    ]
+
+    for faction_slug in required_slugs:
+        result = await db_session.execute(
+            select(Faction).where(Faction.slug == faction_slug)
+        )
+        if result.scalar_one_or_none() is None:
+            db_session.add(
+                Faction(
+                    slug=faction_slug,
+                    name=faction_slug,
+                    description=f"{faction_slug} test faction",
+                    status=FactionStatus.visible,
+                )
+            )
+            await db_session.flush()
+
+        task = Task(
+            title=f"Albescent gate task: {faction_slug}",
+            description="test",
+            point_value=5,
+            level_required=0,
+            status=TaskStatus.active,
+            created_by=character.id,
+            primary_faction_slug=faction_slug,
+        )
+        db_session.add(task)
+        await db_session.flush()
+
+        praxis = Praxis(
+            task_id=task.id,
+            created_by_id=character.id,
+            type=PraxisType.solo,
+            title=f"Albescent gate praxis: {faction_slug}",
+            body_text="proof",
+            status=PraxisStatus.submitted,
+        )
+        db_session.add(praxis)
+
+    await db_session.commit()
+
+
 @pytest.mark.asyncio
-async def test_albescent_requires_level8_character_on_account(
+async def test_albescent_requires_level8_and_faction_completions(
     client: AsyncClient,
     db_session: AsyncSession,
     account2: Account,
@@ -351,20 +411,22 @@ async def test_albescent_requires_level8_character_on_account(
     faction_ua: Faction,
     auth_headers2: dict,
 ):
-    """Creating an Albescent second character requires a level-8 character on the account (R.7)."""
+    """Creating an Albescent character requires a level-8 character who has
+    completed a task from every non-sentinel faction (R.7)."""
     from models.faction import FactionStatus
     from sqlalchemy import select
 
     # Ensure the albescent faction exists (required FK)
     result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
     if result.scalar_one_or_none() is None:
-        albescent = Faction(
-            slug="albescent",
-            name="Albescent",
-            description="Albescent faction",
-            status=FactionStatus.visible,
+        db_session.add(
+            Faction(
+                slug="albescent",
+                name="Albescent",
+                description="Albescent faction",
+                status=FactionStatus.visible,
+            )
         )
-        db_session.add(albescent)
         await db_session.commit()
 
     # character2 is level 5 — raise to 7 (still below 8)
@@ -378,7 +440,7 @@ async def test_albescent_requires_level8_character_on_account(
     stats.level = 7
     await db_session.commit()
 
-    # Level 7 — Albescent should be blocked
+    # Level 7 — Albescent should be blocked (fails the level gate first)
     resp_blocked = await client.post(
         "/characters",
         json={
@@ -391,9 +453,10 @@ async def test_albescent_requires_level8_character_on_account(
     assert resp_blocked.status_code == 403
     assert "8" in resp_blocked.json()["detail"]
 
-    # Raise to level 8 — Albescent should succeed
+    # Raise to level 8 and seed all faction completions
     stats.level = 8
     await db_session.commit()
+    await _seed_all_faction_completions(db_session, character2)
 
     resp_allowed = await client.post(
         "/characters",
@@ -425,16 +488,17 @@ async def test_albescent_character_starts_in_albescent_faction(
     # Ensure the albescent faction exists
     result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
     if result.scalar_one_or_none() is None:
-        albescent = Faction(
-            slug="albescent",
-            name="Albescent",
-            description="Albescent faction",
-            status=FactionStatus.visible,
+        db_session.add(
+            Faction(
+                slug="albescent",
+                name="Albescent",
+                description="Albescent faction",
+                status=FactionStatus.visible,
+            )
         )
-        db_session.add(albescent)
         await db_session.commit()
 
-    # Raise character2 to level 8 so Albescent is unlocked
+    # Raise character2 to level 8 and seed all faction completions
     stats_result = await db_session.execute(
         select(CharacterStats).where(
             CharacterStats.character_id == character2.id,
@@ -444,6 +508,7 @@ async def test_albescent_character_starts_in_albescent_faction(
     stats = stats_result.scalar_one()
     stats.level = 8
     await db_session.commit()
+    await _seed_all_faction_completions(db_session, character2)
 
     resp = await client.post(
         "/characters",
@@ -459,6 +524,107 @@ async def test_albescent_character_starts_in_albescent_faction(
     # Must land directly in Albescent, not UA
     assert data["faction_slug"] == "albescent"
     assert data["faction_slug"] != "ua"
+
+
+@pytest.mark.asyncio
+async def test_albescent_blocked_when_one_faction_missing(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account2: Account,
+    character2: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers2: dict,
+):
+    """Albescent is blocked when a level-8 character is missing a completion
+    from exactly one non-sentinel faction."""
+    from game_config import CURRENT_ERA
+    from models.faction import Faction, FactionStatus
+    from models.praxis import Praxis, PraxisStatus, PraxisType
+    from models.task import Task, TaskStatus
+    from sqlalchemy import select
+
+    # Ensure albescent faction row exists
+    result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
+    if result.scalar_one_or_none() is None:
+        db_session.add(
+            Faction(
+                slug="albescent",
+                name="Albescent",
+                description="Albescent faction",
+                status=FactionStatus.visible,
+            )
+        )
+        await db_session.commit()
+
+    # Raise character2 to level 8
+    stats_result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character2.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = stats_result.scalar_one()
+    stats.level = 8
+    await db_session.commit()
+
+    sentinel_slugs = frozenset({"na", "aged_out", "albescent"})
+    required_slugs = [
+        slug for slug in CURRENT_ERA.factions if slug not in sentinel_slugs
+    ]
+    # Seed completions for all factions except the last one
+    slugs_to_seed = required_slugs[:-1]
+
+    for faction_slug in slugs_to_seed:
+        result = await db_session.execute(
+            select(Faction).where(Faction.slug == faction_slug)
+        )
+        if result.scalar_one_or_none() is None:
+            db_session.add(
+                Faction(
+                    slug=faction_slug,
+                    name=faction_slug,
+                    description=f"{faction_slug} test faction",
+                    status=FactionStatus.visible,
+                )
+            )
+            await db_session.flush()
+
+        task = Task(
+            title=f"Albescent gate task: {faction_slug}",
+            description="test",
+            point_value=5,
+            level_required=0,
+            status=TaskStatus.active,
+            created_by=character2.id,
+            primary_faction_slug=faction_slug,
+        )
+        db_session.add(task)
+        await db_session.flush()
+
+        praxis = Praxis(
+            task_id=task.id,
+            created_by_id=character2.id,
+            type=PraxisType.solo,
+            title=f"Albescent gate praxis: {faction_slug}",
+            body_text="proof",
+            status=PraxisStatus.submitted,
+        )
+        db_session.add(praxis)
+
+    await db_session.commit()
+
+    # One faction missing — Albescent must still be blocked
+    resp = await client.post(
+        "/characters",
+        json={
+            "username": "alb_almost",
+            "display_name": "Alb Almost",
+            "faction_slug": "albescent",
+        },
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 403
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #127

## What changed

`can_start_as_albescent` (`backend/services/character.py`) now enforces **both** halves of the spec rule on the **same** character:

1. Level ≥ `era.albescent_level_required` (existing gate, unchanged)
2. **New:** At least one submitted, non-hidden praxis for every non-sentinel faction in the era — i.e. every slug in `era.factions` except `na`, `aged_out`, `albescent`

For Era 1 the required set is: `ephemerists`, `everymen`, `singularity`, `snide`, `ua`, `wow` (6 factions). The set is derived dynamically from `era.factions` so it stays correct across era configs without hardcoding.

A "qualifying completion" = a `Praxis` where `created_by_id == character.id`, `status == submitted`, and `moderation_status in (visible, flagged)` (i.e. not hidden, not failed), joined to a `Task` whose `primary_faction_slug` is in the required set.

## Files changed

- `backend/services/character.py` — added `_ALBESCENT_SENTINEL_SLUGS` constant; rewrote `can_start_as_albescent` to combine level + faction-completion checks on the same character; updated the 403 error message to describe both requirements.
- `backend/tests/integration/test_characters.py` — added `_seed_all_faction_completions` helper; updated the two existing Albescent success-path tests to seed faction completions; renamed the level-gate test to reflect the combined requirement; added `test_albescent_blocked_when_one_faction_missing` (seeds 5/6 factions, asserts 403).

## Test results

- 129 unit tests: all pass
- Integration tests require a live PostgreSQL instance (not available in this environment); test logic reviewed for correctness against the conftest SAVEPOINT pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b3tWmTSLqEtewvTGw2atV)_