### PR TITLE
docs: land spec/ADR work (11 ADRs + CONTEXT glossary) from db-config-cleanup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,16 +28,16 @@ faction slug into its archetype, falling back to the default. One dispatcher per
 
 **Slug**:
 The faction's stable identifier in the DB and code. Slugs **match faction identity** —
-the rename `analog→everymen`, `gestalt→wow`, `journeymen→ephemerists` has been applied
+the rename `analog→everymen`, `gestalt→wow`, `journeymen→ephemerists` is being applied
 (see ADR-0004), retiring the legacy-slug reuse trick.
 _Avoid_: faction id, key (CSS uses a separate hyphenated "css key").
 
 **Legacy slug** *(being retired — ADR-0004)*:
 A slug kept after a rebrand to dodge DB/plumbing churn: `analog` shown as "Everymen",
-`gestalt` as "Warriors of Whimsy", `journeymen` as "The Ephemerists". This trick was the
-top source of doc/code drift and has been reversed (ADR-0004) — slugs renamed to match
-identity even at the cost of breaking the (test-only) live site. Historical term; do not
-introduce new legacy slugs.
+`gestalt` as "Warriors of Whimsy", `journeymen` as "The Ephemerists". This trick is the
+top source of doc/code drift and is being reversed — slugs renamed to match identity even
+at the cost of breaking the (test-only) live site. Historical term; do not introduce new
+legacy slugs.
 
 **Alias slug**:
 A slug that inherits another faction's archetype by design rather than rebrand:
@@ -48,7 +48,12 @@ A slug that inherits another faction's archetype by design rather than rebrand:
 An invariant piece of data a surface always renders (a task card's title, description,
 points). The slots are fixed across all factions; only their presentation varies by
 archetype. The per-faction freedom is bounded to *how* slots are drawn, never *which*
-slots exist.
+slots exist. **Made law in ADR-0016:** every per-faction surface exposes **one data
+contract** (its slots); each slot is rendered by a **shared control that owns its own
+binding** (reads the slot from the contract), so an archetype is handed only
+`{contract, skin}` and *cannot* feed a slot different data. Archetypes own **skin +
+arrangement** only; faction-specific copy is catalog content (ADR-0010) keyed by the
+contextual faction, not a structural slot difference.
 
 **Contextual faction**:
 The faction a given surface themes to. Resolved per-surface by a surface-specific rule —
@@ -61,10 +66,101 @@ edit-praxis, vote, and the task/praxis page frame + backdrop. A SNIDE task's who
 reads SNIDE; a praxis of that task reads SNIDE.
 
 **Praxis**:
-The documented completion of a task — the proof Sally posts after doing "jump really
-high". One task has many praxes (one per completion). A published praxis is **sealed** and
-open to community voting.
-_Avoid_: submission, proof, post, entry.
+A character's (or group's) record of doing one task — from claiming it through posting the
+proof Sally shows after "jump really high". One task has many praxes. A praxis exists from
+the moment it's claimed (`in_progress`), so it is *not* synonymous with the completion; it's
+the whole record that spans claim → proof. One praxis becomes open to community voting once
+it is **submitted** (see **Praxis status**).
+_Avoid_: "sealed" (legacy term, retired — the code/DB/UI all say *submitted*); post, entry.
+
+**Praxis type**:
+Which collaboration shape a doing-of-a-task takes: **solo**, **collab**, or **duel**. Solo and
+collab are *one shared praxis* (collab just has many members on it); a **duel** is **two linked
+praxes that compete** — see **Duel**.
+
+**Duel** *(being redesigned — two-linked-praxes model; ADR-0011)*:
+A head-to-head competition between two characters on the same task. Each side authors **its own
+`type=solo` praxis** — own owner, body, media, votes — and the two are joined by a **Duel link**.
+The winner is whichever linked praxis earns more stars; the win/loss multiplier is applied per
+side at scoring time and **floats with the votes until era reset** (no per-duel freeze). *Not*
+one shared praxis with two members and split votes (the current code shape, being retired): a
+voter rates a whole praxis, not a "member".
+_Avoid_: "shared document" for a duel (each duelist has their own); treating a duel as a single
+praxis row.
+
+**Duel link**:
+The row that owns a duel: the pairing (`challenger_praxis_id`, `opponent_praxis_id`) plus the
+challenge handshake (`opponent_character_id`, `status`). Replaces `PraxisInvite` for duels.
+**States:** `pending` (challenged; only the challenger's praxis exists) → `active` (accepted;
+opponent's praxis created) → `settled` (both submitted; voting open, winner provisional until era
+reset). `declined` is terminal. A **cold symmetric challenge**: the challenger's praxis is created
+`in_progress` at challenge time and both sides `submit` independently. On **decline or cancel**
+the link drops and the challenger's praxis stays as a plain solo praxis (**convert-to-solo**).
+
+**Collaboration (collab)**:
+Genuinely shared work on one task: **one** praxis, many `PraxisMember`s, one shared body + media,
+one shared vote pool. Every member is scored off the same star total (through their own faction's
+collab modifier). Contrast **Duel**, which is *not* shared.
+
+**Praxis status**:
+The `in_progress → submitted` axis of a praxis. What flips it depends on type — **solo**:
+immediately; **duel**: each side is its own solo praxis and submits independently; **collab**:
+by **lazy-consensus submission** (see below). A submitted praxis is open to voting and its votes
+count toward its members' score. Distinct from **moderation status**
+(`visible / flagged / hidden / failed`); a hidden praxis is suppressed regardless of status.
+
+**Lazy-consensus submission** *(collab only; ADR-0012)*:
+How a collaboration reaches `submitted`. Any member clicking **Submit** opens a **pending-publish**
+window of `era.collab_auto_submit_days` (10); if every member submits it goes Live at once,
+otherwise **silence is consent** — when the window elapses with no edit, it auto-publishes. Any
+member **editing the document** during the window is a hard reset: it cancels the countdown and
+clears everyone's `has_submitted`, dropping back to plain drafting ("an edit means we're not
+done"). A member may also **leave** to drop their hold. Solo and duel praxes do not use this.
+_Avoid_: "unanimous"/"all must submit" (the timeout publishes without unanimity); "approval".
+
+**In-progress privacy**:
+Who is working on what is **not public knowledge**. An `in_progress` praxis and its membership
+are visible only to its members (e.g. invites surface only to members). This is *why* joining is
+**invite-only**: an outsider can't discover a collab to ask into, so there is **no
+request-to-join** — a member must reach out first. The privacy lifts when the praxis goes
+`submitted` (it becomes votable and public). A **duel** challenge is likewise known only to the
+two parties until both sides are submitted.
+_Avoid_: "request to join", "open collab", public in-progress listings — all deliberate no-s.
+
+**Leave** *(collab member self-removal)*:
+A member removing **their own** `PraxisMember` from a collab. Distinct from **kick** (removing
+*someone else*) and from praxis **withdraw** (`is_withdrawn`, taking the *whole praxis* out of
+scoring). Three different removals — keep them named apart.
+_Avoid_: "withdraw" for a member leaving (withdraw is praxis-level, not member-level).
+
+**Editing mode**:
+A submitted praxis taken back into editing by its creator. Its votes are **preserved but do
+not count** toward score while in editing mode; resubmitting returns it to `submitted` and
+its votes resume counting. Editing mode is the round-trip `submitted → editing → submitted`,
+not a discard — vote history survives the trip.
+_Avoid_: "withdraw" as a synonym for delete (a withdrawn praxis still exists and can return).
+
+**Task bank**:
+The set of a character's `in_progress` praxes, capped per character by the era's
+`max_task_signups`. Claiming a task ("signing up") adds to the bank; submitting or
+withdrawing frees a slot.
+
+**Sign-up eligibility**:
+The single game-logic predicate behind the Sign-up affordance: whether a character may
+*claim* a task right now. One boolean, owned by the service layer, exposed as the
+`can_sign_up` flag — the API and frontend read it, they never assemble it. Its
+governing invariant: it is true **iff `create_praxis` would accept**, so the button
+hides exactly when the action would be rejected (level, metatask faction, **active
+membership**, task bank, Analog carve-out). See ADR-0008.
+_Avoid_: conflating with `can_submit_praxis` (the narrow dup-authorship rule only) or
+`eligible_for_current_user` (level + metatask faction only) — neither is the whole gate.
+
+**Active membership**:
+A character holding a `PraxisMember` row on a non-deleted praxis for a task whose status
+is `in_progress` or `submitted` — i.e. currently working or done, not abandoned. Keyed on
+*membership*, not authorship, so a **joined collaborator** counts too. One shared predicate
+(`is_active_member_of_task`) drives the task-list exclusion, the sign-up guard, and the
+flag, so all three agree.
 
 **Vote reframe**:
 A faction's bespoke rendering of the shared 1–5 rating — Ephemerists' **Concordance**
@@ -72,14 +168,130 @@ A faction's bespoke rendering of the shared 1–5 rating — Ephemerists' **Conc
 NOISE → VERIFIED. The underlying value is always 1–5; only the vocabulary + visual ramp
 change. This is per-faction surface #8; it is the **hero** of a praxis card and has both an
 interactive *caster* form and a read-only *summary* form.
+**Ownership:** the per-faction tier *structure* (value→label key, numeral style) lives in a
+`voteReframes` registry; the label *words* live in the copy catalog (`copy/en.ts`, ADR-0010),
+resolved via `t()`; the *visual ramp* stays in the archetype (don't-unify-the-look). The
+shared caster/login-gate/summary composition is one `VoteScaffold`; an archetype supplies only
+its tiles + theme. One reframe lookup powers the caster, the summary, **and** the per-voter
+breakdown (who voted + their value), so all three speak the same vocabulary.
+
+**Vote** *(value rename in progress — `stars`→`value`)*:
+One character's rating of a praxis, an integer 1–5 — the unit cast in the vote control and
+reframed per faction (see **Vote reframe**). The DB column `Vote.stars` is being renamed
+`Vote.value`; the summed quantity is **points from votes**, never "stars".
+_Avoid_: star, stars (legacy term, retired alongside the column rename).
+
+**Points from votes**:
+The **sum** of a praxis's vote values, added flat to score *after* all multipliers. Surfaced
+as *points* (the "73" in a "15 + 73 points" display = base + points-from-votes), never as its
+own noun. Distinct from **voter count** — how many votes were cast (the "45 votes" label).
+
+**Vote tally** *(read-model; `services/vote_tally.py`)*:
+The single source for a praxis's vote aggregates: `points_from_votes`, `voter_count`, and the
+**per-voter breakdown** (who voted + their value). One query per praxis batch, replacing the
+scattered `func.sum(Vote.stars)` queries and the retired per-member duel summary. The backend
+owns "who voted and how much" even on surfaces the UI does not yet show it.
+
+**Contribution** *(atomic scoring unit; `services/praxis_scoring.py`)*:
+The points **one character** earns from **one praxis** —
+`(base + metatasks) × faction_multiplier × duel_multiplier + points_from_votes`. Scoring is
+per-`(character, praxis)`, *never* "the score of a praxis" (ill-defined the moment two
+factions touch one collab). Computed as a **batch** primitive
+(`compute_contributions(praxes, character, era, session)`; the single-praxis read path is the
+n=1 case), returned as a **breakdown** (base · metatasks · faction_multiplier ·
+duel_multiplier · points_from_votes · total) so the **Praxis Read** page can show the math
+("50 × 0.8 because it's off-faction"). The pure arithmetic stays in `services/scoring.py`;
+`praxis_scoring` is the async gather-and-assemble around it. A character's era score is the
+sum of their Contributions' `total`.
+_Avoid_: "praxis score" as a per-praxis number with multipliers baked in (that conflation is
+what the recalc path and the read path currently disagree on).
+
+**Merit** *(the faction-neutral praxis number)*:
+`task base + points_from_votes` — no faction/duel multiplier, **viewer-independent**. What a
+**praxis card** shows and what task submissions sort by: it compares the *work*, not whose
+faction multiplier was luckier. Distinct from **Contribution** (per-character, multiplied,
+feeds standings + the detail-page breakdown). Splitting Merit from Contribution is the
+locality win of the praxis-scoring deepening — one well-defined number per surface instead of
+one conflated `score` field computed two disagreeing ways.
+
+**Metatask** *(becoming its own model — reverses migration 0006; ADR-0015)*:
+A flat-points **add-on to a praxis**, not a doable task — it has no praxis, no votes, no
+lifecycle of its own beyond **propose → approve → retire**. Owned by a faction
+(`faction_slug`); its `point_value` is a flat bonus that stacks additively and rides the same
+multipliers as base points (`(base + metatask_points) × faction × duel + votes` — unchanged by
+the remodel). Currently modeled as a `Task` row (`task_type=metatask`); being split into a
+standalone `MetaTask` model so `Task` sheds `task_type` + `metatask_faction_slug` and the
+`TaskType` enum collapses.
+- **Access** is **one predicate** — `can_access_metatask` = Albescent **or**
+  (`level ≥ era.metatask_apply_level` **and** own faction). Enforced once **at apply**; the
+  "can apply" UI flag mirrors it. Replaces the three drifted gates (the per-metatask
+  `level_required` check is deleted).
+- **Praxis-wide**: once applied, **every member** of that praxis banks the bonus — scoring does
+  **no** per-member access re-check; `get_meta_task_points` is a dumb sum of attached
+  `point_value`s. _Avoid_: per-member metatask gating (rejected — see ADR-0015).
+- **Duel symmetry**: a metatask applies to **both** linked duel praxes (ADR-0011), so neither
+  duelist gains a base-point head start. (Today's single-praxis duel already gets this via
+  praxis-wide; the two-praxes model needs both-sides attachment — coordinates with #185.)
+- **Propose** (level 6) is a separate gate from **apply** (level 7) — distinct actions, not one
+  rule.
 
 **Register row / Praxis Index**:
-The faction's list view of sealed praxes; the praxis **card** lives here (compact, next to
+The faction's list view of submitted praxes; the praxis **card** lives here (compact, next to
 task cards). Distinct from **Praxis Read** — the detail page showing one praxis in full
 (account body, evidence, the voting control).
 
 **Actor-scoped surface**:
 A surface whose contextual faction is **the acting character's member faction**: the
-avatar/badge, and (planned) the comment box. A SNIDE member's comment reads SNIDE even
+avatar/badge and the comment surface (#14). A SNIDE member's comment reads SNIDE even
 on an Everyman task page; a praxis author's badge reads their own faction even when the
-praxis card reads the task's faction.
+praxis card reads the task's faction. Resolved **live** from `character.faction_slug` (no
+snapshot) — a defector's past comments/badges re-theme to their new faction.
+
+**Comment** *(designed; ADR-0006)*:
+A short text reaction attached to **exactly one of** a praxis or a task (DB `CHECK`). Flat
+(no threading — replies are `@mention`s), chronological, not votable. Authored by a
+Character; the author's member faction drives its theming. Invariant slots: **author
+identity · body · timestamp+edited**. Soft-deleted (`is_withdrawn` by author;
+`moderation_status` hidden/deleted by admin).
+_Avoid_: reply, post, message.
+
+**Comment thread**:
+The neutral, non-faction container that lays out a target's comment rows plus one composer.
+A thread is **multi-faction** — each row themes to its own author — so no faction owns the
+thread; it never blanket-themes (the page-archetype rule of ADR-0002, at row granularity).
+
+**Comment surface (#14)**:
+The single per-faction Comment archetype, dispatched by `pickVariant(COMMENT_COMPONENTS, …)`
+and rendered in two modes — `row` (read-only, keyed on the author's faction) and `composer`
+(input, keyed on the current character's faction). The call site picks the slug; one
+archetype serves both modes (cf. the vote reframe's caster/summary, ADR-0005).
+
+**Relationship edge**:
+A single **directed** declaration `from_character → to_character` carrying a `type`
+(friend | foe) and a `status` (active | blocked). Unique per ordered `(from, to)` pair, so a
+two-character dyad is at most **two independent edges**. Instant — there is no pending/accept
+handshake (unlike a praxis invite). The edge is the *stored* unit of the relationship system;
+the felt "are we friends / rivals" is the **display status**, computed from the pair and never
+stored. Canonical term for the row: **edge**.
+**Lifecycle:** only the **declarer** (`from`) may `delete` the edge. **Either** party may
+`block` it, and a block is **reversible** (`unblock` restores `active`) — so a mis-block can be
+undone without losing the edge. Changing your own edge's `type` (friend↔foe) has no endpoint:
+it is a deliberate `delete` + re-`create` (intended friction; you lose `created_at`).
+_Avoid_: "relationship" for the pairwise feeling (that's the display status); "request" /
+"pending" (there is no acceptance step); treating one edge as covering both directions.
+
+**Display status**:
+The human-readable label for a pair of characters, computed **per-viewer** by
+`compute_display_status` from both edges — Mutual Friends, Rivals, Tsundere, One-sided Friend,
+One-sided Foe, Secret Admirer, Targeted, **Blocked**, Unknown. Not stored; derived at read time.
+- **Blocked wins.** If *either* edge has `status = blocked`, the status is **Blocked** for
+  **both** parties — a block is mutual and **visible**: the blocked person is meant to know
+  (the edge that got blocked is theirs, so it surfaces in their own list). See ADR-0009.
+- Otherwise computed from `(your edge type, their edge type)` over the friend/foe/none matrix.
+  The same active pair yields different labels at each end (you: "One-sided Foe"; them:
+  "Targeted") — the *same situation viewed from opposite ends*, **not** distinct states, and
+  **not** redundant labels (they are the `(foe, none)` and `(none, foe)` cells of one symmetric
+  function). **Tsundere** is the lone perspective-symmetric label — both mixed cases collapse to
+  it — and is a *designed* state: one side feels friend, the other foe.
+_Avoid_: treating One-sided Foe / Targeted as duplicates to reconcile; storing the label;
+hiding a block from the blocked party; calling it "relationship".

--- a/docs/adr/0006-comment-system.md
+++ b/docs/adr/0006-comment-system.md
@@ -1,0 +1,105 @@
+# Comments are an actor-scoped, two-mode surface on praxis and tasks
+
+Comments are in scope for Era 1 (vault design doc, "Open Design Questions"). This records
+the data model, moderation, faction-resolution, and dispatch wiring. Design/lore (each
+faction's comment *voice* and ornament) is canon in the vault (ADR-0001); this ADR owns the
+wiring.
+
+Builds on ADR-0002 (a page is a composition of independently-themed surfaces; content slots
+invariant, presentation per-faction) and ADR-0005 (a surface's per-faction archetype can carry
+more than one render mode — vote caster vs. summary).
+
+## Decisions
+
+- **Attach to both praxis and tasks** — modelled as one `Comment` row with two nullable FKs
+  `praxis_id` / `task_id` and a DB `CHECK (num_nonnulls(praxis_id, task_id) = 1)`. "A comment
+  belongs to exactly one of {praxis, task}" is a database invariant, not a convention. No
+  polymorphic `target_type/target_id` (loses FK integrity), no two tables (doubles every path).
+  Mirrors how `Vote`/`Flag` already hang off the praxis with partial constraints.
+
+- **Flat, not threaded.** No `parent_id` in Era 1. Reply semantics come from **`@mention`**.
+  Ordered **chronological ascending** (conversation-style). `parent_id` is an additive nullable
+  column if real threading ever earns its place.
+
+- **Content slots are invariant; only the archetype varies** (ADR-0002). Every faction's comment
+  renders the same logical slots — **author identity · body · timestamp+edited** — drawn however
+  the faction likes (SNIDE ransom scrawl, Ephemerist marginalia). The **author-identity slot is
+  itself the actor-scoped avatar/badge surface** (composes the `FactionAvatar` dispatcher).
+  Guarded by the same parametrized dispatcher-map test as ADR-0002 (issue #151), extended to walk
+  `COMMENT_COMPONENTS`.
+
+- **Faction resolution is actor-scoped, live, per row + composer** (confirms the prior decision,
+  CONTEXT.md / ADR-0002):
+  - A posted **comment row** themes to *that comment's author's* member faction.
+  - The **composer** themes to *the current character's* member faction.
+  - Resolved **live** from `character.faction_slug` at render — **no snapshot column**. A
+    defector's old comments re-theme to their new faction, matching the avatar/badge surface.
+    `author_faction_slug` is an additive column *then* if the "frozen voice" ever bites.
+
+- **One per-faction surface ("Comment", surface #14), one dispatcher, two render modes.**
+  `COMMENT_COMPONENTS: Record<slug, Component>` + `DefaultComment`, resolved via `pickVariant`.
+  `mode="row"` (read-only, keyed on `comment.author.faction_slug`) and `mode="composer"` (input,
+  keyed on `currentCharacter.faction_slug`). **The call site picks the slug; the component is the
+  same archetype** — a faction's comment voice is defined once and used for both reading and
+  writing (mirrors ADR-0005's one-ramp-two-modes). The **`CommentThread` container is neutral
+  chrome, not a per-faction surface** — a thread is multi-faction, so no single faction owns it;
+  it lays out rows + one composer and never blanket-themes (ADR-0002).
+
+- **Edit: author only, body only.** Sets `is_edited` (`Boolean`, `server_default="false"` — a
+  marker, not a timestamp; the "edited" slot needs only the fact). No history, no edit window.
+  `is_edited` is deliberately not derived from `updated_at`, which also moves on moderation.
+
+- **Delete is soft, two-axis, reusing the praxis moderation machinery:**
+  - **Author delete** → `is_withdrawn = true` (boolean, like `Praxis.is_withdrawn`).
+  - **Admin hide** → `moderation_status = hidden` (reversible hold).
+  - **Admin delete** → `moderation_status = deleted` (terminal tombstone). Requires adding
+    `deleted` to the shared `ModerationStatus` enum (one `ALTER TYPE … ADD VALUE`; praxis never
+    uses it). Reusing the shared enum keeps one moderation vocabulary, per the same-machinery goal.
+  - **Public list filter:** `is_withdrawn == false AND moderation_status == visible`.
+  - The comment surface renders only on a **visible praxis** (withdrawn/hidden → no thread);
+    tasks are commentable while **active**.
+
+- **Not votable.** Voting is the praxis *scoring* mechanism; comments are not game content.
+
+- **Flagging reuses the `Flag` table with the same two-target pattern.** `Flag.praxis_id` becomes
+  nullable, add nullable `Flag.comment_id`, `CHECK (num_nonnulls(praxis_id, comment_id) = 1)`.
+  Self-flag rejected (mirrors `flag_praxis`). When a comment's flag count reaches
+  `era.comment_flag_review_threshold`, set `moderation_status = flagged` → it surfaces on the
+  moderator review page (alongside flagged praxes). Praxis keeps its implicit threshold of 1 (not
+  retrofitted).
+
+- **`@mention` notifies via the activity feed.** The feed is a read-time aggregator with no events
+  table, so mentions must be queryable by recipient. A **`comment_mention` join table**
+  (`comment_id`, `mentioned_character_id`, `UNIQUE` pair) is written on comment create and
+  **reconciled on edit**. Resolution is by **`username`** (unique handle); an unresolved `@handle`
+  stays plain text. A new feed item type **`comment_mention`** (a `_fetch_comment_mentions`
+  sub-query joining `comment_mention → comment → praxis/task`) lands in the `your_stuff` (+ `all`)
+  filter with a `_compute_counts` entry. **No self-notify.** Linkify in the body is a separate
+  render-time concern.
+
+- **Two new `EraConfig` gates** (config rule → `game_config.py` dataclass + `eras/era_1.py`,
+  surfaced on `/auth/me` like the other capability gates):
+  - `comment_level_required: int = 2` — min level to post (social layer opens at L2 in the vault).
+  - `comment_flag_review_threshold: int = 1` — flags before a comment hits the review queue.
+    `# ponytail: hardcoded; compute from active-user count when the site grows.`
+
+## Data the model needs
+
+**`Comment`** — `id`, `praxis_id?`, `task_id?` (CHECK exactly-one), `created_by_id`,
+`body_text` (≤2000 chars, enforced at the API trust boundary), `created_at`, `updated_at`,
+`is_edited`, `is_withdrawn`, `moderation_status`.
+
+**`Flag`** — `praxis_id` made nullable, add `comment_id?`, CHECK exactly-one.
+
+**`comment_mention`** — `id`, `comment_id`, `mentioned_character_id`, `UNIQUE(comment_id,
+mentioned_character_id)`.
+
+**`ModerationStatus`** — add `deleted`.
+
+**`EraConfig`** — add `comment_level_required`, `comment_flag_review_threshold`.
+
+## Status / tracking
+
+- Not yet built. Implementation tracked in the GitHub issue filed from this design session.
+- Per-faction comment *aesthetics* (SNIDE/Everymen/Ephemerists/WoW/Singularity/UA/Albescent
+  voices) are vault design work, not specified here.

--- a/docs/adr/0008-signup-eligibility-single-source.md
+++ b/docs/adr/0008-signup-eligibility-single-source.md
@@ -1,0 +1,97 @@
+# ADR-0008: Sign-up eligibility is one game-logic predicate
+
+Status: Accepted (2026-06-24)
+
+## Context
+
+The Sign-up affordance appeared on tasks a character could not actually submit
+to — wrong level, metatask faction mismatch, bank full, already working the task
+as a collaborator. Clicking through then failed server-side, violating the
+CLAUDE.md rule "hide unusable controls; don't show them disabled" (issue #156).
+
+The root was a **split truth**. `TaskOut` already carried three viewer-relative
+flags, but the Sign-up button gated on only one of them:
+
+- `can_submit_praxis` — the *duplicate-authorship* rule only
+  (`can_submit_praxis_for_task`, praxis.py), with the Analog Double Dipper
+  carve-out. The button at `Home.tsx`, `Tasks.tsx`, and `useTaskDetail.ts` read
+  this and nothing else.
+- `eligible_for_current_user` — level + metatask-faction
+  (`is_task_eligible_for_character`), used only to filter metatasks in
+  editPraxis; the button ignored it.
+- `allowed_modes` — solo/collab/duel by level.
+
+Meanwhile the actual sign-up guard, `_check_create_preconditions`
+(praxis.py:388), enforced a *different* set: level, dup-authorship, bank cap
+(`era.max_task_signups`), and mode-level. And a fourth asymmetry: `list_tasks`
+(task.py:230) hides a task once the character has **any** `PraxisMember` row
+(membership), but `create_praxis` only blocked tasks the character **authored**.
+So a task you joined as a collaborator was hidden from your list yet still
+showed a working Sign-up button if you reached it directly — a real double-dip
+path.
+
+The flag did not mirror enforcement, in several independent ways.
+
+## Decision
+
+There is **one game-logic predicate** for "can this character sign up for this
+task," and it is the single source for both the UI flag and the create guard.
+
+- The game-logic layer (`backend/services/`) owns the decision. The API does not
+  assemble it; the frontend does not assemble it. They read one boolean.
+- **Governing invariant:** the Sign-up flag is true **iff `create_praxis` would
+  accept**. The button hides exactly when sign-up would be rejected — no false
+  positives (button that 4xxs), no false negatives (hidden button that would
+  have worked).
+- The predicate ANDs the gates that already gate sign-up, **using existing rules
+  only**:
+  1. **Authenticated** — anonymous viewers ⇒ false.
+  2. **Level** — `stats.level >= task.level_required`.
+  3. **Metatask faction** — a metatask requires
+     `character.faction_slug == task.metatask_faction_slug`
+     (`is_task_eligible_for_character`). This is the *only* faction rule today;
+     standard tasks are faction-open. Generalising faction gating is deferred —
+     see issue "architect faction rules logic".
+  4. **Not already an active member** — keyed on `PraxisMember` membership, not
+     authorship, so a joined collaborator is blocked too. The Analog Double
+     Dipper carve-out is preserved (Analog bypasses this gate).
+  5. **Sign-up bank** — `in_progress_count < era.max_task_signups`.
+- The membership test is lifted into one shared predicate
+  (`is_active_member_of_task`) consumed by **all three** call sites: the
+  `list_tasks` exclusion filter, the `create_praxis` guard, and the flag. One
+  query, one rule.
+- `_check_create_preconditions` keeps raising gate-specific `HTTPException`s
+  (so the error messages stay precise) but is refactored to evaluate the **same
+  sub-predicates** the flag ANDs, so enforcement and flag cannot drift.
+- Membership/eligibility keys on praxis **status**, per ADR-0007 — the
+  `is_withdrawn` column is being dropped; "active" means a non-deleted praxis
+  whose status is in-progress or submitted.
+
+The consolidated boolean surfaces as a single new `TaskOut` field
+(`can_sign_up`). The existing granular flags (`eligible_for_current_user`,
+`allowed_modes`) stay for their other uses (metatask filtering, mode picker).
+
+## Consequences
+
+- `Home.tsx`, `Tasks.tsx`, and `useTaskDetail.ts` gate the Sign-up button on the
+  one `can_sign_up` flag; they stop reading `can_submit_praxis` for this purpose.
+- `create_praxis` now rejects a character who is already an active member of the
+  task (was: only if they authored a praxis for it), closing the double-dip.
+- `can_submit_praxis_for_task` stays the narrow dup-authorship rule that
+  `create_praxis` single-sources; it is **not** overloaded into a god-predicate.
+- Integration tests cover each gate (anonymous, level, metatask-faction,
+  membership incl. joined-collab, bank cap, Analog carve-out). PR #122's
+  abandoned `test_can_submit_praxis.py` is revived and extended.
+
+## Alternatives considered
+
+- **Overload `can_submit_praxis_for_task` into a fat flag.** Rejected: it is the
+  dup-authorship rule that `create_praxis` references at the one-praxis-per-task
+  gate; widening it muddies that single-source and overloads the name.
+- **Compose the existing flags on the frontend** (`can_submit_praxis &&
+  eligible_for_current_user`). Rejected: that is the frontend thinking, and it
+  still misses bank-cap and membership, which live in neither flag. Layering
+  principle: game logic decides, API and UI stay dumb.
+- **Add standard-task faction locking now.** Rejected: no such rule exists or is
+  spec'd; inventing it is a gameplay change, not a UI-truthfulness fix. Deferred
+  to its own issue (the faction-rules seam).

--- a/docs/adr/0009-blocks-are-mutual-and-visible.md
+++ b/docs/adr/0009-blocks-are-mutual-and-visible.md
@@ -1,0 +1,73 @@
+# ADR-0009: Blocks are mutual and visible
+
+Status: Accepted (2026-06-24)
+
+## Context
+
+A relationship is a single directed **edge** (`from → to`, `type` friend|foe,
+`status` active|blocked). A two-character dyad is at most two independent edges.
+The felt label — "Mutual Friends", "Rivals", "Targeted" — is the **display
+status**, computed per-viewer by `compute_display_status` and never stored (see
+CONTEXT.md).
+
+Either party may `block` an edge; only the declarer may `delete` it. Block is
+the **target's** only lever against an incoming declaration they cannot delete
+(B is declared a foe by A; B can't remove A's edge, so B blocks it).
+
+Two questions had no recorded answer:
+
+1. **Is a block private or visible?** Most social platforms hide a block from
+   the blocked person. The relationship/feed code today is silent on the display
+   side: the feed (`_get_related_ids`) filters `status = active` so a blocked
+   edge stops driving activity and taunts, but `compute_display_status` ignores
+   `status` entirely and labels off `type` alone. So after a block, the feed
+   says "ties cut" while the relationship list still cheerfully says "Rivals" —
+   an unintended leak, and an *accidental* answer of "block is invisible to the
+   label."
+2. **Is a block permanent?** `block_relationship` only ever sets `blocked`;
+   there is no unblock path, so a mis-block can only be cleared by the declarer
+   deleting the whole edge.
+
+## Decision
+
+A block is **mutual and visible**, and **reversible**.
+
+- **Blocked wins the display status.** If *either* edge in a dyad has
+  `status = blocked`, the display status is **`Blocked`** for **both** parties,
+  overriding any type-derived label. `compute_display_status` takes edge
+  **status**, not just type. `Blocked` joins the `RelationshipDisplayStatus`
+  literal.
+- **Visible by design.** The blocked person is *meant* to know. This falls out
+  naturally: the edge that got blocked is the *declarer's* own edge, so it
+  surfaces in their own (outgoing) relationship list as `Blocked`. We do not
+  hide it.
+- **Reversible.** An `unblock` action restores `active` (re-deriving the
+  type-based label), so a block made by mistake can be undone without losing the
+  edge or its `created_at`. Either party may unblock, symmetric with block.
+- Block remains **per-edge** in storage — a dyad has no stored entity to hang a
+  "dyad block" on — but reads as a **dyad-level** `Blocked` because *either*
+  blocked edge is sufficient.
+
+## Consequences
+
+- The feed/label leak is closed: `Blocked` is the one place `status` reaches the
+  display layer, so feed and label finally agree.
+- A blocked party sees `Blocked` rather than a stale "Rivals"/"Mutual Friends" —
+  the signal is intentional game texture, not an accident.
+- We diverge from the common "silent block" convention; this is deliberate and
+  should not be "fixed" toward invisibility without revisiting this ADR.
+
+## Alternatives considered
+
+- **Silent block (hide from the blocked party).** Rejected: the platform is a
+  small, banter-driven game where knowing you've been blocked is part of the
+  social texture, not a safety hazard. The usual privacy rationale (harassment
+  de-escalation at scale) doesn't apply here.
+- **Block reads as *absent* everywhere** (a blocked edge labels as `none`, so
+  the dyad just looks un-declared). Rejected: it hides the block from the
+  blocked party and silently rewrites a Rival into a stranger — strictly less
+  information than `Blocked`, and still leaks differently (the blocker's own
+  list would forget why).
+- **Permanent block (no unblock).** Rejected: a mis-tap shouldn't be
+  irreversible, and forcing a `delete` to clear a block conflates "I changed my
+  mind about blocking" with "I'm retracting my declaration."

--- a/docs/adr/0010-ui-copy-catalog.md
+++ b/docs/adr/0010-ui-copy-catalog.md
@@ -1,0 +1,35 @@
+# UI copy lives in a catalog, not inline JSX
+
+User-facing chrome copy (currently hardcoded in components) moves into a single
+human-editable module, `frontend/src/copy/en.ts`, read through a tiny
+`t(key, vars)` helper. Keys are namespaced (`form.charLimit.reached`,
+`praxis.charLimit.terminal`) and placeholders use `{{max}}` double-brace syntax.
+We chose this over both leaving strings inline and adopting `i18next` now.
+
+## Why
+
+The trigger was issue #51 (whimsical "max characters reached" messages on every
+form). The copy needs to be **editable by a human without touching JSX**, and the
+six praxis archetypes each want the message in their own faction voice — so the
+strings are content, not code, and shouldn't be buried at call sites.
+
+## Considered options
+
+- **Inline strings** — rejected: the thing the issue asks for (one editable home
+  for copy) is exactly what inline JSX prevents; it also keeps the counter markup
+  copy-pasted across ~10 fields.
+- **`i18next` / `react-i18next` now** — rejected *for now*: real locale switching,
+  pluralization, and lazy bundles are scaffolding for a translation effort that
+  isn't scheduled (no second language exists). YAGNI until locale #2.
+- **Plain typed module (chosen)** — zero new dependencies, type-safe, one file to
+  hand an editor.
+
+## Consequences
+
+- The catalog *shape* is deliberately i18next-native: namespaced keys +
+  `{{var}}` placeholders. Migration to `i18next` (the intended future, when a
+  second language lands) is mechanical — swap the `t()` internals, keep the keys.
+  This is marked with a `ponytail:` comment at the helper.
+- The shared `<CharCount>` widget reads its message via `t(messageKey, {max})`,
+  so the copy lookup is centralized in one place alongside the counter +
+  `aria-live` behavior.

--- a/docs/adr/0011-duel-is-two-linked-praxes.md
+++ b/docs/adr/0011-duel-is-two-linked-praxes.md
@@ -1,0 +1,49 @@
+# A duel is two linked praxes, not one shared praxis
+
+/ status: accepted
+
+## Context
+
+A duel is a head-to-head competition between two characters on the same task. The
+original model made a duel **one `Praxis` row with two `PraxisMember`s**, sharing a
+single owner, `body_text`, and `MediaItem` gallery, with votes split per member via
+`Vote.praxis_member_id`. This is internally contradictory: a *competition* in which
+both sides write into the *same* document and photo gallery, where a voter rating
+"member A" has no way to know which evidence is A's (the UI literally renders a
+"Shared Document" for a duel).
+
+## Decision
+
+A duel is **two separate praxes that compete**, joined by a new `Duel` row.
+
+- **Each side is its own `type=solo` praxis** — own owner, body, media, and votes.
+  "Duel-ness" lives entirely on the `Duel` link, not on the praxis. Votes target the
+  praxis directly; the `Vote.praxis_member_id` column, its two partial unique indexes,
+  and `DuelVoteSummary` are retired.
+- **The `Duel` row owns the pairing and the challenge handshake**:
+  `{ task_id, challenger_praxis_id, opponent_character_id, opponent_praxis_id
+  (nullable until accept), status, lifecycle timestamps }`. It **replaces
+  `PraxisInvite` for duels**.
+- **Lifecycle states:** `pending` (challenged, only challenger's praxis exists) →
+  `active` (opponent accepted, opponent's praxis created) → `settled` (both
+  submitted, voting open). `declined` is terminal.
+- **Cold symmetric challenge.** The challenger's praxis is created `in_progress` at
+  challenge time; both sides then work and `submit` independently, exactly like a solo
+  praxis. No "challenger must finish first" rule.
+- **Decline / cancel → convert to solo.** On decline or challenger-cancel, the `Duel`
+  link drops and the challenger's praxis remains as a normal `type=solo` praxis. No
+  data loss, no special delete path.
+- **Voting opens only when both praxes are `submitted`.**
+- **The winner floats with the votes until era reset.** Consistent with the
+  always-live-on-read scoring model; there is no per-duel voting window or freeze. The
+  duel win/loss multiplier is applied per side at scoring time from the current tally.
+
+## Consequences
+
+- Scoring must determine "is this praxis a side of a duel?" via the `Duel` table
+  instead of reading `praxis.type` — one extra lookup in the recalc path.
+- The activity feed's duel-challenge projection must re-point from `PraxisInvite` to
+  the `Duel` row (see `activity_feed.py`); the projection model is retained
+  (issue #181 tracks the broader projection-vs-event-log question).
+- There is no discrete "X won the duel" moment; a definitive winner only exists at era
+  close. The `settled` transition feed event is "duel is live for voting."

--- a/docs/adr/0012-collab-lazy-consensus-submission.md
+++ b/docs/adr/0012-collab-lazy-consensus-submission.md
@@ -1,0 +1,60 @@
+# Collaborations publish by lazy consensus, not unanimous submission
+
+/ status: accepted
+
+## Context
+
+A collaboration is one shared praxis with many members. The original rule required
+**every** member's `has_submitted` to be true before the praxis flipped to `submitted`.
+That stalls on a single absent or unresponsive member: the work is done, but it can
+never go live because one collaborator drifted away.
+
+## Decision
+
+A collab publishes by **lazy consensus with a silence-is-consent timeout**, co-owned
+by all members (see ADR on collab co-ownership).
+
+State machine:
+
+- **Drafting** (`in_progress`, no pending publish) — any member edits freely.
+- A member **Submits** → **Pending publish**: a countdown of
+  `era.collab_auto_submit_days` (= 10) starts; that member's `has_submitted = true`.
+- While pending:
+  - Another member **Submits** → if *all current members* have submitted → **Live** now.
+  - Any member **edits the document** → **hard reset**: countdown cancelled, *everyone's*
+    `has_submitted` cleared → back to Drafting. An edit means "we're not done."
+  - A member **leaves** (removes their own membership) → if all *remaining* members have
+    submitted → **Live**.
+  - The window **elapses with no edit** → **auto-publish** to Live, regardless of who
+    actually clicked Submit. Silence = consent.
+- **Live** (`submitted`) — votes count. Any member edits → editing mode → back to
+  Drafting (votes preserved but not counting, per ADR-0007); re-submit or re-timeout
+  returns it to Live.
+
+Scope: **collab only.** Solo publishes immediately; a duel is two `type=solo` praxes
+(ADR-0011) that each submit independently. Neither uses the timeout.
+
+Naming: a member removing *their own* membership is **leave**; removing *someone else* is
+**kick**; taking the *whole praxis* out of scoring is **withdraw** (`is_withdrawn`). Three
+distinct removals, kept named apart.
+
+## Consequences
+
+- `collab_auto_submit_days` is a new `EraConfig` field (value lives in `eras/era_1.py`),
+  never hardcoded.
+- The pending-publish window stores `submit_proposed_at` on the praxis (set on entering
+  pending, cleared on edit / back-to-drafting).
+- **The timeout fires lazy-on-access, not on a schedule.** There is no scheduler in this
+  app (single uvicorn process; era reset is admin-triggered), and we are not adding one.
+  The two read paths — `get_praxis` and `list_praxes` — call one helper that, on load,
+  flips+persists any pending collab whose window has lapsed and recalcs its members
+  (the same work `submit_praxis` does). Centralizing it there means no other caller needs
+  to know the timeout rule.
+  - Accepted gap: a collab **nobody ever views** stays `in_progress` (members' leaderboard
+    scores understated) until first touch — but it self-heals on the next read of any kind,
+    and if nobody is looking, nobody is affected.
+  - Upgrade path (`ponytail`): if deterministic timing is ever needed, add an in-process
+    periodic sweep; the `submit_proposed_at` field and flip helper are identical either way,
+    so this choice costs nothing later.
+- "What counts as an edit that resets" must be pinned (body/title/media yes; membership
+  changes are their own thing) at implementation time.

--- a/docs/adr/0013-collaborations-are-co-owned.md
+++ b/docs/adr/0013-collaborations-are-co-owned.md
@@ -1,0 +1,39 @@
+# Collaborations are co-owned by all members
+
+/ status: accepted
+
+## Context
+
+A collaboration is one shared praxis with many members. The service pinned the
+mutating actions — edit body/title, reopen, kick — to `created_by` only, while the UI
+exposed them to *any* member. The result was shipping drift: a collaborator who clicked
+"Edit" or "Reopen" on the *Shared Document* got a 403, and the kick button appeared to
+everyone but worked for no one but the creator. For a thing literally called shared
+work, the single-owner model also just reads wrong.
+
+## Decision
+
+A collaboration is **co-owned by all its members**. Every member may:
+
+- **edit** the shared title/body/media,
+- **invite** other eligible players (already the rule),
+- **reopen** a pending/published collab back to drafting,
+- **kick** any other member (including the original creator),
+- **leave** (remove their own membership).
+
+`created_by_id` survives only as a historical "who started it" fact; it carries **no
+special powers** in a collab. The service relaxes edit/reopen/kick from creator-only to
+any-member, which also erases the UI/service drift (the UI already assumed co-ownership).
+
+Membership-changing actions (kick, leave) and edits reset `has_submitted` and cancel any
+pending-publish window — consistent with "a change means we're not done" (ADR-0012).
+
+Accepted risk: any-member kick allows a kick-war or booting the creator. In a small,
+private, invite-only group of cooperating players this is low-stakes and symmetric with
+"anyone can invite." We chose one coherent rule ("co-owned means co-owned") over a
+special-case carve-out for kicking.
+
+## Scope
+
+Collab only. A solo praxis has one member. A duel is two independent `type=solo` praxes
+(ADR-0011), each owned by its own author — co-ownership does not apply.

--- a/docs/adr/0014-praxis-scoring-is-per-character-contribution.md
+++ b/docs/adr/0014-praxis-scoring-is-per-character-contribution.md
@@ -1,0 +1,134 @@
+# ADR-0014: Praxis scoring is per-character Contribution; the card shows Merit
+
+Status: Accepted (2026-06-24)
+
+## Context
+
+A praxis's score is computed in **two independent places that re-derive the same
+formula and can silently disagree**:
+
+- **Read path** — `compute_praxis_score_from_db` (`services/praxis.py`), called by
+  `build_praxis_out` / `build_praxis_card_out` to fill `PraxisOut.score`. It returns
+  **one number for the whole praxis**. For a collab it uses the **first member's**
+  faction multiplier (the docstring admits "caller should use per-member"); for a duel
+  it returns multiplier `1.0` with **combined** stars and **no** duel-outcome
+  multiplier.
+- **Recalc path** — `recalculate_character_stats` (`services/character_stats.py`), the
+  authoritative standings computation. It sums **per-member** contributions: each
+  collab member scored through their *own* faction modifier, each duelist through their
+  *own* faction modifier **and** their duel-outcome multiplier on their *own* stars.
+
+So for collab and duel the number on a praxis card and the number that actually counts
+toward standings are produced by different formulas. The read-path number is not dead:
+the frontend renders it on praxis cards (`praxis.score.toFixed(1)`), on collab cards,
+and **sorts/averages task submissions by it** (`useTaskDetail.ts`).
+
+The root cause is a **conflated concept**. A single `score` field is asked to be two
+things at once: *"how good is this submission"* (comparable across praxes) and *"how
+many points did a person bank"* (per-character, with their multiplier). The moment two
+factions touch one collab, "the score of a praxis" has no single answer.
+
+Two secondary problems ride along:
+
+- **Vote aggregation is scattered.** `func.sum(Vote.stars)` is re-queried in the read
+  path, in three `_score_*` helpers, and the per-member duel tally lives in an *output
+  builder* (`_build_duel_vote_summary`). No module owns "who voted and how much."
+- **Vocabulary.** The DB calls a rating `stars`. The old site (and the desired UX)
+  speaks of **votes**: a count of voters, each casting a 1–5 value, summed into points
+  ("15 + 73 points"), with a per-voter breakdown of who voted and how much.
+
+## Decision
+
+### Scoring
+
+- The atomic unit of scoring is the **Contribution**: the points **one character**
+  earns from **one praxis** —
+  `(base + metatasks) × faction_multiplier × duel_multiplier + points_from_votes`.
+  Scoring is per-`(character, praxis)`. "The score of a praxis" is **not** a primitive.
+- Contributions are computed by a **batch** primitive
+  `compute_contributions(praxes, character, era, session) -> dict[praxis_id, Contribution]`
+  in a new `services/praxis_scoring.py`. The single-praxis read path is the **n=1**
+  case of the batch — one formula, one gather, no N+1 in recalc.
+- A `Contribution` is a **frozen breakdown dataclass**
+  (`base_points · metatask_points · faction_multiplier · duel_multiplier ·
+  points_from_votes · total`), so the praxis detail page can render the math
+  ("50 × 0.8 because it's off-faction") without re-deriving it. Recalc sums `.total`.
+- The pure arithmetic stays in `services/scoring.py` (`compute_praxis_score`, the
+  multiplier helpers). `praxis_scoring` is the async gather-and-assemble around it.
+
+### Merit (the card number)
+
+- The number a **praxis card** shows and that task submissions sort by is the
+  **Merit**: `task base + points_from_votes` — **no** faction/duel multiplier,
+  **viewer-independent**. It compares the *work*, not whose faction multiplier was
+  luckier, and is well-defined for any praxis regardless of who is on it.
+- `PraxisOut.score` / `PraxisCardOut.score` become Merit. The per-character,
+  multiplied number lives only in standings and the detail-page Contribution breakdown.
+
+### Vote tally and vocabulary
+
+- A **Vote tally** read-model (`services/vote_tally.py`) is the single source for a
+  praxis's vote aggregates: `points_from_votes` (sum of values), `voter_count`, and the
+  **per-voter breakdown** (who voted + their value). One batched query, consumed by
+  scoring (the sum), the card (the count), and the detail page (the breakdown). The
+  backend owns "who voted and how much" even where the UI does not yet surface it.
+- Vocabulary: a **vote** is one character's 1–5 value (`Vote.stars` is renamed
+  `Vote.value`; "stars" is retired). **Votes** is the count; the summed value is
+  **points from votes**, displayed as part of *points*.
+
+### Duels — deferred to ADR-0011
+
+- Duel scoring is built against the **ADR-0011** model (each side is its own
+  `type=solo` praxis joined by a duel marker), so this work is **blocked by the duel
+  implementation** and is not built against the retired per-member model.
+- Under ADR-0011 a duel side flows through `compute_contributions` as an ordinary solo
+  praxis plus one input — the `duel_multiplier`:
+  1. `points_from_votes` = the side's own praxis vote sum (votes attach to the praxis;
+     `Vote.praxis_member_id` becomes irrelevant and the per-member duel tally is
+     deleted).
+  2. Resolve the duel marker → opponent praxis → opponent `points_from_votes` + faction.
+  3. `duel_multiplier = compute_duel_multiplier(own, opponent, is_winner, is_tied, era)`
+     (unchanged, incl. the Snide tie-break). Floats with votes; never frozen.
+  4. A `pending`/`declined` marker scores the side as a **plain solo**
+     (`duel_multiplier = 1.0`), per convert-to-solo.
+- The duel-lifecycle question "if one side withdraws, does the other win by default or
+  revert to solo?" belongs to ADR-0011, not here; scoring consumes whatever outcome it
+  defines.
+
+### Deletions
+
+`compute_praxis_score_from_db`, `_build_duel_vote_summary`, and the
+`_score_solo_praxes` / `_score_collab_praxes` / `_score_duel_praxes` /
+`_fetch_duel_context` / `_fetch_membership_context` helpers collapse into
+`compute_contributions` + `vote_tally`. The scattered `func.sum(Vote.stars)` queries
+die.
+
+## Consequences
+
+- One scoring interface, one vote-aggregation interface — the card and standings can no
+  longer use divergent formulas. The drift bug is closed by construction.
+- `PraxisOut.score` changes meaning (author's multiplied score → faction-neutral Merit).
+  The frontend detail page gains a Contribution breakdown; cards/sort are unaffected in
+  shape (still one number) but now comparable and viewer-independent.
+- A `Vote.stars` → `Vote.value` migration and a frontend "stars"→"votes" copy sweep are
+  in scope.
+- Tests hit one interface: `compute_contributions` over a mixed set (solo, collab across
+  two factions, duel win/loss/tie) asserts the breakdowns; a regression test pins
+  Merit ≠ Contribution-formula drift; `vote_tally` gets a unit test.
+- **Blocked by #185** (Build: duels are two linked praxes, ADR-0011).
+
+## Alternatives considered
+
+- **Keep "whole-praxis score" as the primitive and just dedupe the query.** Rejected:
+  it cements the conflation that causes the divergence — collab still has no single
+  honest answer.
+- **Single-praxis primitive `contribution(praxis, character)`.** Rejected: recalc calls
+  it in a loop and reintroduces the N+1 the bulk code exists to avoid, or keeps its own
+  bulk path — the duplication we are deleting.
+- **Fold vote aggregation into the scoring module.** Rejected: scoring needs only the
+  sum; the count and per-voter breakdown are display concerns with a different consumer.
+  Two adapters (scoring uses the sum; UI uses count + breakdown) justify the seam.
+- **Quarantine the retired per-member duel logic behind a swappable resolver and ship
+  the unification now, ahead of ADR-0011.** Rejected: building duel scoring against a
+  model that is about to be replaced is throwaway work; dependency-ordering on #185
+  lets us build duel scoring once, correctly.

--- a/docs/adr/0015-metatask-is-its-own-model.md
+++ b/docs/adr/0015-metatask-is-its-own-model.md
@@ -1,0 +1,109 @@
+# ADR-0015: A metatask is its own model, not a Task subtype
+
+Status: Accepted (2026-06-24)
+
+## Context
+
+A metatask is a **flat-points add-on to a praxis** — apply it to a completion and its
+`point_value` stacks onto the score. It is *not* a doable task: no praxis, no votes, no
+sign-up. Yet migration 0006 modeled it **as** a `Task` (`task_type=metatask`), reusing
+the Task table.
+
+That shallow reuse leaked. A metatask ignores most Task fields (`primary_faction_slug`,
+the praxis relationship, and — after this ADR — `level_required`), and the mismatch
+surfaced as `if task.task_type == metatask` forks scattered through scoring and apply.
+Worse, **metatask access was spelled three different ways** that disagreed:
+
+| Reading | Level source | Faction | Albescent |
+|---|---|---|---|
+| apply-time (`_check_metatask_eligibility`) | `era.metatask_apply_level` | yes | yes |
+| scoring (`get_meta_task_points`) | `task.level_required` | no | no |
+| UI flag (`is_task_eligible_for_character`) | `task.level_required` | yes | no |
+
+The spec (SPEC-game-rules §metatask access) describes **one** access rule — propose at
+level 6, apply at level 7 from your own faction, Albescent applies any faction's — plus a
+flat, additive bonus. The per-metatask `task.level_required` gate is generic Task baggage
+the spec never asked for. (SPEC-data-models is also stale here: it still documents a
+removed `MetaTask` entity and a `percentage` `BonusType` that no longer exists.)
+
+## Decision
+
+### Metatask becomes its own model
+
+```python
+class MetaTask(TimestampMixin, Base):      # standalone table, not a Task
+    id, title, description
+    point_value          # the flat bonus
+    faction_slug         # owning faction (was Task.metatask_faction_slug)
+    status               # MetaTaskStatus: proposed → approved → retired
+    created_by           # the proposer
+```
+
+- `PraxisMetaTask` joins `praxis_id ↔ meta_task_id` (was `task_id`).
+- `Task` **sheds** `task_type` and `metatask_faction_slug`; the `TaskType` enum collapses
+  to a single value and is removed (all tasks are standard).
+- Migration **reverses 0006**: create `meta_task`, copy `task_type=metatask` rows over,
+  repoint `praxis_meta_task`, delete the metatask `Task` rows, drop the columns/enum.
+- The **propose → approve → retire** lifecycle is kept, as `MetaTaskStatus` — the genuine
+  machinery a metatask shares with a task, now an honest small enum rather than borrowed
+  `TaskStatus`.
+
+### Access is one predicate, enforced once
+
+```python
+can_access_metatask(character, metatask, era) -> bool
+    = is_albescent(character) or (
+        character_level >= era.metatask_apply_level
+        and character.faction_slug == metatask.faction_slug
+      )
+```
+
+- Two callers, one definition: the **apply gate** (wrapped for 403 reason strings) and the
+  **"can apply" UI flag**. The drifted `task.level_required` checks are deleted.
+- **Propose** (level 6) stays a *separate* gate — proposing and applying are different
+  actions.
+
+### Access is praxis-wide; scoring does no re-check
+
+- Once a metatask is validly applied, **every member of that praxis banks the bonus**,
+  regardless of their own level/faction. Scoring performs **no** per-member access check —
+  `get_meta_task_points` becomes a dumb sum of attached `point_value`s.
+
+### Scoring formula is unchanged
+
+- Metatask points stay **inside** the multipliers:
+  `(base + metatask_points) × faction_multiplier × duel_multiplier + votes`. A shared
+  metatask therefore amplifies under a winner's duel multiplier — this is intended (a
+  faction's duel-win modifier is *meant* to be a perk). **No change to ADR-0014.**
+
+### Duel symmetry
+
+- A metatask applies to **both** linked duel praxes (ADR-0011), so neither duelist gains a
+  base-point head start; the multiplier asymmetry remains the earned outcome. Today's
+  single-praxis duel already gets this for free via praxis-wide; the two-linked-praxes
+  model needs both-sides attachment, which **coordinates with #185**.
+
+## Consequences
+
+- One access predicate; the three-way gate drift is closed by construction.
+- `Task` loses metatask baggage; `if task_type == metatask` forks disappear.
+- A `stars`-free, percentage-free `MetaTask` — flat bonus only.
+- The propose-metatask UX (today an `isMetaTask` toggle on the propose-task page) is
+  **rewired** to a `/metatasks` endpoint and drops the now-dead `level_required` field — a
+  rewire, not a new page.
+- SPEC-data-models and SPEC-game-rules metatask sections are corrected (no `MetaTask`-as-
+  separate-then-merged confusion, no `percentage` bonus, access = one predicate).
+- A data migration reverses 0006; existing applied metatasks are preserved via the
+  `praxis_meta_task` repoint.
+
+## Alternatives considered
+
+- **Keep metatask as a sharpened `Task` subtype** (document which fields it uses, leave the
+  table). Rejected by the owner: the "task" framing keeps misleading, and the shared
+  machinery (propose/approve) is thin enough to rebuild on a dedicated model.
+- **Per-member metatask access at scoring time.** Rejected: in a duel a higher-level player
+  could metatask only their own side for a base-point advantage; praxis-wide (and
+  both-sides for duels) keeps the field even.
+- **Flat (un-multiplied) metatask points** to make duels perfectly even. Rejected: the duel
+  multiplier is a deliberate faction perk (e.g. SNIDE's duel-win modifier) and should keep
+  applying to metatask points.

--- a/docs/adr/0016-per-faction-surfaces-share-one-data-contract.md
+++ b/docs/adr/0016-per-faction-surfaces-share-one-data-contract.md
@@ -1,0 +1,84 @@
+# ADR-0016: Per-faction surfaces share one data contract; archetypes own only presentation
+
+Status: Accepted (2026-06-24)
+
+## Context
+
+World Zero renders many UI surfaces per faction (SPEC-faction-ui-profile §1: task
+card, praxis card, edit-praxis editor, vote control, comment, activity-feed card, …).
+Each faction ships a bespoke **archetype** of a surface — a drastically different look
+(S.N.I.D.E. ransom clipping vs Everymen union poster).
+
+CONTEXT.md already seeds the boundary with **Content slot**: "the slots are fixed across
+all factions; only their presentation varies by archetype." But that was stated as a
+card detail, not enforced as a law — and it erodes one archetype at a time. The two
+failure modes:
+
+1. **An archetype reaches for different data** than its siblings — fetching its own,
+   or being handed raw slot values a sibling doesn't get. Now the "surface" means
+   different things per faction, and a page can't reason about what it shows.
+2. **Which slots exist drifts per faction** — one archetype renders a field another
+   omits, so the surface has no stable contract.
+
+The edit-praxis editor showed both latently: three controls (`InviteSearch`,
+`FilePicker`, `MetatasksList`) were extracted as shared components that read their data
+from the one `EditPraxisState` contract, while four (title, body, mode, publish) stayed
+inline — structurally identical across all seven archetypes, but each re-binding state by
+hand, i.e. one bespoke edit away from drift.
+
+## Decision
+
+**Every per-faction surface has exactly one data contract — its content slots — and every
+archetype of that surface consumes it identically. Archetypes own only presentation.**
+
+1. **One contract per surface.** The set of slots a surface renders (e.g. edit-praxis:
+   title · body · mode · media · invites · metatasks · publish/save; a card: title ·
+   points · faction flavor · …) is fixed for all factions. A surface exposes its contract
+   as one value (a state object / props type), e.g. `EditPraxisState`.
+2. **Shared, slot-owning controls.** Each slot is rendered by a **shared control that owns
+   its own binding** — it reads the slot from the contract itself. The archetype passes
+   only `{contract, skin}`; it is **never handed raw slot values and never fetches its own
+   data.** This makes "same information" structural, not conventional: an archetype
+   *cannot* feed a slot different data.
+3. **Presentation is unconstrained.** An archetype supplies **skin** (colors/fonts/ornament
+   via CSS vars) and **arrangement** (order, grouping, the wrapping frame). Two archetypes
+   may look nothing alike. Arrangement is the surface's identity (SPEC §1 #3) and stays
+   per-archetype — *not* flattened into a fixed scaffold.
+4. **Faction-specific content is catalog copy, not a structural difference.** Faction-voiced
+   text (flavor lines, vote-tier labels, at-cap messages) is a *slot* whose words come from
+   the copy catalog (ADR-0010) keyed by the **contextual faction** (§2), resolved by the
+   control via `t()`. The slot is invariant; only the words differ.
+
+### Enforcement
+
+- A new piece of data → added to the **contract**, so *every* archetype gets it. Never a
+  prop on one archetype.
+- A new faction → a **skin + arrangement**, never a new or missing slot.
+- Reviews reject: an archetype fetching its own data; a control receiving raw values
+  instead of the contract; a slot present in one archetype and absent in another.
+
+## Consequences
+
+- Pages can reason about a surface uniformly — "the edit-praxis editor always exposes these
+  slots" — regardless of faction.
+- Adding a faction is a presentation task (skin + arrangement), testable as "renders all
+  contract slots," not "re-implements the form."
+- Tests assert each archetype consumes only the contract and renders the required slots;
+  no per-archetype data-shape tests.
+- Applies to all SPEC §1 surfaces. Immediate consumers: the edit-praxis control extraction
+  (title/body/mode/publish join the already-shared three), the vote reframe registry
+  (#194), the comment archetype (ADR-0006), the activity-feed frame.
+- Complements **ADR-0002** (a page is a composition of surfaces) — this governs what each
+  surface *is*; 0002 governs how surfaces compose into a page. And **ADR-0010** (copy
+  catalog) is the mechanism for slot #4.
+
+## Alternatives considered
+
+- **Per-archetype data access (status quo by omission).** Rejected: each archetype
+  re-binding or fetching data is exactly the drift this ADR prevents; "surface" stops
+  meaning one thing.
+- **One fixed-arrangement scaffold per surface** (archetypes become frame skins over a
+  fixed layout). Rejected: it maximizes code reuse by flattening **arrangement**, which is
+  the per-faction identity §1 #3 protects. The contract is shared; the *layout* is not.
+- **Leave it as a CONTEXT.md note.** Rejected: a note doesn't stop erosion. The invariant
+  needs to be citable law a future archetype author is held to.

--- a/docs/adr/0017-praxis-read-page.md
+++ b/docs/adr/0017-praxis-read-page.md
@@ -1,0 +1,153 @@
+# The praxis read page is a per-faction archetype surface with an interactive vote caster
+
+ADR-0005 enriched the praxis **card** (the register-row, list view) and explicitly
+deferred the **Praxis Read** page — `/praxes/:id`, one sealed praxis in full: account
+body, evidence specimens, the **interactive** vote caster, and the full slot set. This
+ADR settles that page.
+
+The scaffolding already exists: `pages/PraxisDetail.tsx` is a hook + dispatcher +
+`DefaultPraxisDetail` surface (mirrors TaskDetail / EditPraxis, per ADR-0002).
+`ARCHETYPE_BY_SLUG` is empty, so every faction currently renders the Default layout.
+
+## Decisions
+
+### 1. Per-faction archetype seam — explicit, separate, generic-until-designed
+
+The read page is a task-scoped surface (it themes to `praxis.task_faction_slug`), so it
+gets a bespoke archetype per faction like every other surface. Rather than build all of
+them at once, the seam is set up so each faction can be swapped in independently with a
+one-line change:
+
+- **`EphemeristsPraxisDetail` is built for real** — it is the only faction with a
+  complete, pixel-level read-page canon (`ephemerists-praxis-read.jsx`). Registered in
+  `ARCHETYPE_BY_SLUG['ephemerists']`.
+- **Every other faction points at `DefaultPraxisDetail` (the generic page)** until its
+  own read-page design lands. Swapping one in = add an archetype file + one map row.
+- **A design-status table tracks the gap** (below) so it is always visible which factions
+  still need a designed read page + a built archetype. SNIDE and Singularity have
+  *Completed-Praxis card* kits but not full read-page designs yet — they are gaps, not
+  builds.
+
+This is the same staged move ADR-0005 made for the card (one shared enriched body now,
+bespoke per-faction designs tracked as follow-ups).
+
+## Design / build status (the gap tracker)
+
+| Faction | Read-page design exists? | Archetype built? | Notes |
+|---|---|---|---|
+| ephemerists | ✅ `ephemerists-praxis-read.jsx` | ▶ this issue | the reference build |
+| snide | ⚠ card kit only | ❌ → Default | needs full read-page design |
+| singularity | ⚠ card kit only | ❌ → Default | needs full read-page design; no `VoteUI` variant yet either |
+| everymen | ❌ | ❌ → Default | extrapolate from slot model |
+| wow | ❌ | ❌ → Default | extrapolate from slot model |
+| ua (+ albescent/aged_out aliases) | ❌ | ❌ → Default | extrapolate from slot model |
+
+### 2. A shared slot module owns the behavior slots; archetypes own presentation
+
+Mirror the card: `pages/praxisDetail/shared.tsx` holds the faction-agnostic,
+behavior-bearing slots that every archetype MUST render identically and may never
+re-implement per faction:
+
+- admin moderation bar
+- withdrawn / failed banners
+- owner actions (edit / withdraw / resubmit)
+- flag block
+
+The archetype owns only the **presentational** slots (masthead, finding headline,
+account body, evidence, vote caster). The content-slot invariant (ADR-0002, guarded by
+#151) extends to the read page.
+
+**The invariant slot set** every read archetype surfaces, regardless of faction skin:
+
+1. **Identity/status** — title/finding, task link ("re:"), grade/level, solo-vs-collab
+   mode, sealed date, moderation status
+2. **Author byline** — avatar + display name + link, themed to the *author's* faction
+   (actor-scoped, per CONTEXT.md)
+3. **Account body** — the full `body_text` (markdown)
+4. **Evidence** — the media specimens
+5. **Vote caster** — interactive `VoteUI` + rating summary/distribution
+6. **Points earned** — vote-weighted score
+7. **Behavior slots** (shared module) — admin bar, banners, owner actions, flag block
+
+### 3. The score readout is the point economy, not a rating distribution
+
+The voting section shows **task points + vote total**, not a per-tier rating histogram:
+
+- **Points from the task** — `task_point_value` (the base the task is worth; already on `PraxisOut`).
+- **Total from votes** — the vote contribution already surfaced today as the
+  "points earned from votes" number (`votes.total_score`).
+- These sum to the praxis `score`
+  (`(task_point_value + meta) × multipliers + total_stars`, per `scoring.py`).
+
+Explicitly rejected: a `star_distribution` / `ConcordMeter` histogram. It would need a new
+backend aggregation and it is not the story this page tells — the page is about *points
+earned*, not *how the rating is spread*. The faction reframe ramp still appears as the
+**interactive caster** (`<VoteUI>` in cast mode); it just isn't rendered as a distribution.
+
+**Backend impact: none for scoring** — both numbers already exist on `PraxisOut` /
+`VoteSummary`.
+
+### 4. Evidence reuses `MediaGallery`; archetype owns only the framing
+
+The evidence slot wraps the existing shared `<MediaGallery>` — it already resolves
+file paths and renders image / video / audio, and is never re-implemented per faction.
+The archetype owns only the **framing** around it (the "The evidence · N specimens"
+section header, faction ornament like the foxing border).
+
+- The canon's `minmax(150px,1fr)` grid (vs MediaGallery's single column) is a layout
+  nicety — add an optional `layout?: 'column' | 'grid'` prop to MediaGallery *only when
+  the Ephemerists build needs it*, not pre-emptively.
+- **Per-item captions deferred** — `media_items` has no caption column; the canon's
+  specimen captions are design filler. Adding them is a schema change. Tracked as a gap,
+  not built now.
+
+### 5. Comments: reserve a marked slot only — designed and built separately
+
+A comment system is a real, wanted feature but is **out of scope for this page** and is
+being designed/built in a separate workstream. The read page only reserves the seam:
+
+- A `{/* Comments slot — actor-scoped surface, see CONTEXT.md; built separately */}`
+  marker at the bottom of the invariant layout, so comments drop into a known location
+  with no re-layout.
+- No comment model, endpoints, or UI are built here.
+
+(Known direction for the separate workstream, from this session: comments will attach to
+both **praxes and tasks**; the data-model choice — dual nullable FKs + CHECK vs polymorphic
+target — is being settled there, not here.)
+
+### 6. Data `PraxisOut` needs beyond the card
+
+Scoring needs nothing new (decision 3). The remaining slots need three fields on
+`PraxisOut`:
+
+- **`task_level_required`** — grade/level slot. `praxis.task` is already joined in
+  `build_praxis_out` (it already reads `praxis.task.point_value`), so this is trivial.
+  Mirrors the field #159 adds to `PraxisCardOut`.
+- **`submitted_at`** — sealed-date slot. The **column + transition** are added by #159
+  (chosen over `created_at`/`updated_at`); this page just also exposes it on `PraxisOut`.
+- **`created_by_faction_slug`** — the praxis author's *member* faction, for the
+  **actor-scoped byline** (the byline themes to the author's own faction, not the task's).
+  Net-new: needs an author-character → faction join in `build_praxis_out`. The Default
+  page currently themes the byline generically (`factionCssVar(null, …)`); actor-scoped
+  theming is what this adds.
+
+Everything else the invariant set needs is already on `PraxisOut` (`type` for
+solo-vs-collab, `body_text`, `media_items`, `moderation_status`, `is_withdrawn`,
+`can_flag`, `task_title`/`task_id`, `created_by_*`).
+
+## Status / tracking
+
+- **Implementation:** GitHub #163.
+- **Depends on #159** for the `submitted_at` column + transition and the `VoteUI`
+  caster/summary refactor.
+- **Comments** are a separate workstream (decision 5).
+- **Read-page designs still missing** (gap tracker above): SNIDE, Singularity, Everymen,
+  WoW, UA — each becomes its own archetype + issue when its design lands. Singularity also
+  lacks a `VoteUI` variant.
+- **MediaGallery `layout` prop** is added only if the Ephemerists build needs the grid.
+
+## Refs
+
+- Builds on ADR-0002 (page = composition of surfaces) and ADR-0005 (praxis card content model).
+- Depends on GitHub #159 (vote-reframe caster/summary + `submitted_at` + grade data).
+- Reference design: `ephemerists-praxis-read.jsx` (PraxisRead, ConcordMeter, MarkCaster, Specimen).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,43 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase. **This repo is multi-context** (a backend context and a frontend context).
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **The per-context `CONTEXT.md`** (`backend/CONTEXT.md`, `frontend/CONTEXT.md`) for the area you're working in.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. Also check `backend/docs/adr/` and `frontend/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## Where the domain knowledge lives today
+
+`CONTEXT.md` / `CONTEXT-MAP.md` / `docs/adr/` do not exist yet (they get created lazily). Until they do, the authoritative domain documentation is the **"Where to look for X" routing table in `CLAUDE.md`** (the single source — don't duplicate it here) plus the `docs/spec/*` files and `WORLD_ZERO_STYLE.md` it points at.
+
+When `/domain-modeling` starts resolving terms, capture the glossary into `backend/CONTEXT.md` / `frontend/CONTEXT.md` and add a root `CONTEXT-MAP.md` pointing at them.
+
+## File structure (target)
+
+```
+/
+├── CONTEXT-MAP.md                     ← points to per-context CONTEXT.md files
+├── docs/adr/                          ← system-wide decisions
+├── backend/
+│   ├── CONTEXT.md
+│   └── docs/adr/                      ← backend-specific decisions
+└── frontend/
+    ├── CONTEXT.md
+    └── docs/adr/                      ← frontend-specific decisions
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md` (or, until those exist, the spec files above). The canonical noun for a completed-task artifact is **Praxis** ("submit" is the verb). Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,32 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `pixieofhugs/WorldZeroPlayground`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+This is a solo/personal project — PRs are the author's own in-flight work, not incoming requests. `/triage` operates on issues only.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## History
+
+This replaced a hand-maintained markdown task queue (`docs/TASKS.md`, retired 2026-06-22 → `docs/archive/TASKS-completed.md`). GitHub Issues were already in active use; the queue's open items were migrated to issues #141–#146.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker. All five labels exist on GitHub (created 2026-06-22; `wontfix` pre-existed).
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+These coexist with the repo's existing non-triage labels (`bug`, `enhancement`, `documentation`, `in progress`, etc.) — a triage label says *readiness*, the others say *kind*. Apply both where useful.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/archive/TASKS-completed.md
+++ b/docs/archive/TASKS-completed.md
@@ -1,0 +1,1689 @@
+# World Zero — Task Queue (ARCHIVED)
+
+> **⚠️ This file is a historical record only. Work is no longer tracked here.**
+>
+> Retired 2026-06-22. The markdown task-queue handoff has been replaced by
+> GitHub Issues + triage labels (see `docs/agents/issue-tracker.md`). The
+> still-open items at retirement time were migrated to GitHub issues:
+>
+> | Was | Now |
+> |---|---|
+> | M.5 deferred — metatask apply/remove panel | #141 |
+> | Frontend inline-style → Tailwind (remaining) | #142 |
+> | T.3 — CI branch protection on `main` | #143 |
+> | Deployment — Render + GoDaddy DNS | #144 |
+> | S.14 — migration squash (blocked) | #145 |
+> | SESSION 5+ — ambitious frontend (epic) | #146 |
+>
+> Everything below is completed-session history, kept for context. Do not add
+> new tasks here — open a GitHub issue instead.
+
+---
+
+<details>
+<summary>Original header (no longer in effect)</summary>
+
+> This file was the handoff from Cowork planning sessions to Claude Code execution sessions.
+> Claude Code agents read it at the start of every session and worked through tasks in order.
+>
+> **Always read CLAUDE.md before starting.**
+> **Read the relevant file in `docs/spec/` before implementing any feature.**
+> **Mark tasks DONE (with date) when complete. Do not delete them.**
+
+</details>
+
+---
+
+## 🏗️ SESSION P — Praxis Unification (architectural refactor)
+
+> Planned 2026-04-16. Touches every layer of the stack. Do NOT start any P task
+> until you have read this section in full **and** `docs/spec/SPEC-data-models.md`,
+> `docs/spec/SPEC-api.md`, and `docs/spec/SPEC-backend-architecture.md`.
+>
+> **Motivation:** Three overlapping submission systems exist (legacy `praxis` table,
+> legacy `collaboration` table, current `submission` table). The canonical noun is
+> **Praxis**. A solo praxis is a collab praxis with one member. A duel is a praxis
+> with config-driven max participants and per-member star voting. All three systems
+> collapse into one table and one service.
+>
+> **Run tasks in order. Each task depends on the previous.**
+
+### TARGET SCHEMA (reference for all P tasks)
+
+**`praxis` table** (replaces `submission`):
+
+- `id`, `task_id` (FK task), `type` (PraxisType: solo|collab|duel)
+- `status` (PraxisStatus: in_progress|submitted)
+- `title` (Text nullable), `body_text` (Text nullable) — shared by all members
+- `is_withdrawn` (bool), `moderation_status` (str), `admin_note`, `flagged_at`
+- `created_by_id` (FK character — always required, never nullable)
+- `created_at`, `updated_at`
+
+**`praxis_member` table** (replaces `submission_member` + `character_task`):
+
+- `id`, `praxis_id` (FK praxis), `character_id` (FK character)
+- `has_submitted` (bool), `joined_at` (datetime)
+- UNIQUE(praxis_id, character_id)
+
+**`praxis_invite` table** (replaces `submission_invite`):
+
+- `id`, `praxis_id` (FK praxis), `inviter_id` (FK character), `invitee_id` (FK character)
+- `status` (PraxisInviteStatus: pending|accepted|declined), `created_at`
+
+**`vote` table changes**:
+
+- `submission_id` → `praxis_id` (FK praxis)
+- `duel_vote_for` (FK character) → `praxis_member_id` (FK praxis_member, nullable)
+- NULL praxis_member_id = solo/collab vote; non-NULL = duel vote for that member
+
+**`media_item`, `flag`, `praxis_meta_task`**: rename `submission_id` → `praxis_id`
+
+**Tables to drop** (after data migration):
+`submission`, `submission_member`, `submission_invite`,
+legacy `praxis` (old table), `collaboration`, `collaboration_member`,
+`collaboration_invite`, `character_task`
+
+---
+
+### TASK P.1 ✅ 2026-04-17 — Alembic migration: unify to single Praxis table
+
+**Scope:** Database only. No Python model/service code changes yet.
+
+**Do:**
+
+1. Write `backend/alembic/versions/XXXX_praxis_unification.py`
+2. Create new `praxis`, `praxis_member`, `praxis_invite` tables per the target schema above
+3. Data migration — execute in this order:
+   a. Migrate legacy `praxis` rows (type='solo') → new `praxis` + `praxis_member` for each `character_id`
+   b. Migrate `collaboration` rows → new `praxis` (type = collaboration.mode) + `praxis_member` per `collaboration_member`
+   c. Migrate `submission` rows → new `praxis` rows:
+   - solo rows: type='solo', `created_by_id` = `character_id`; create `praxis_member`
+   - collab/duel rows: type from `collab_mode`, `created_by_id` from `created_by_id`; create `praxis_member` per `submission_member`
+     d. Migrate `submission_invite` → `praxis_invite`
+     e. Migrate `collaboration_invite` → `praxis_invite` (dedup if same praxis already has the invite)
+     f. Migrate `character_task` rows with no corresponding active praxis → skeleton `praxis` (in_progress, no title/body) + `praxis_member`
+     g. Update `vote.submission_id` → `praxis_id`; map `duel_vote_for` character FK to the corresponding `praxis_member_id`
+     h. Update `media_item.submission_id` → `praxis_id`
+     i. Update `flag.submission_id` → `praxis_id`
+     j. Update `praxis_meta_task.submission_id` → `praxis_id`
+4. Drop old tables: `submission`, `submission_member`, `submission_invite`, legacy `praxis`, `collaboration`, `collaboration_member`, `collaboration_invite`, `character_task`
+5. Write downgrade path (re-create old tables, migrate back)
+
+**Files:** `backend/alembic/versions/XXXX_praxis_unification.py`
+
+**Acceptance:**
+
+- `alembic upgrade head` runs clean against a fresh DB and against a DB with existing data
+- `alembic downgrade -1` returns to previous state without data loss
+- All FK constraints are intact after migration
+- No orphaned rows in `vote`, `media_item`, `flag`, `praxis_meta_task`
+
+---
+
+### TASK P.2 ✅ 2026-04-17 — Backend models: rewrite to unified Praxis
+
+**Depends on:** P.1
+
+**Do:**
+
+1. Rewrite `backend/models/praxis.py` — define `PraxisType`, `PraxisStatus`, `PraxisInviteStatus`, `Praxis`, `PraxisMember`, `PraxisInvite`, `MediaItem` (keep MediaItem here as it already lives in this file; update FK to `praxis_id`)
+2. Delete `backend/models/submission.py` and `backend/models/collaboration.py`
+3. Update `backend/models/vote.py`: rename `submission_id` → `praxis_id`, rename `duel_vote_for` → `praxis_member_id` (FK to `praxis_member.id`, nullable), update unique constraints
+4. Update `backend/models/flag.py`: `submission_id` → `praxis_id`
+5. Update `backend/models/meta_task.py`: `submission_id` → `praxis_id` in `PraxisMetaTask`
+6. Update `backend/models/task.py`: remove `CharacterTask` class, update `Task.praxes` relationship to point to new `Praxis`
+7. Update `backend/models/__init__.py` (or wherever models are registered) to remove old imports
+
+**Key model design notes:**
+
+- `Praxis.created_by_id` is always non-nullable — every praxis has an initiating character
+- Solo praxes have exactly one `PraxisMember` (the creator); this is enforced in the service, not the DB
+- `PraxisMember` has NO `title`/`body_text` — content is on `Praxis` itself
+- `PraxisInvite` has no `invite_type` — the praxis's own `type` is authoritative
+- `Vote.praxis_member_id` is NULL for solo/collab votes, non-NULL for duel votes
+
+**Files:**
+
+- `backend/models/praxis.py` (rewrite)
+- `backend/models/submission.py` (delete)
+- `backend/models/collaboration.py` (delete)
+- `backend/models/vote.py`
+- `backend/models/flag.py`
+- `backend/models/meta_task.py`
+- `backend/models/task.py`
+
+**Acceptance:** `python -c "from models.praxis import Praxis, PraxisMember, PraxisInvite"` succeeds; no import of `Submission`, `Collaboration`, `CharacterTask` anywhere in `models/`
+
+---
+
+### TASK P.3 ✅ 2026-04-17 — Backend schemas: rewrite to unified Praxis
+
+**Depends on:** P.2
+
+**Do:**
+
+1. Rewrite `backend/schemas/praxis.py` as the single canonical schema file:
+   - `PraxisMemberOut` (id, character_id, character_display_name, character_avatar_url, has_submitted, joined_at)
+   - `PraxisInviteOut` (id, praxis_id, inviter, invitee, status, created_at)
+   - `PraxisOut` (all fields; `members: List[PraxisMemberOut]`; `invites: List[PraxisInviteOut]`; `media_items`; `votes`; `score`)
+   - `PraxisCreate` (task_id, type, title optional, body_text optional)
+   - `PraxisUpdate` (title optional, body_text optional)
+   - `PraxisInviteCreate` (invitee_id)
+   - `InviteResponse` (accept: bool)
+   - `DuelVoteSummary` (per-member vote totals)
+   - `PraxisVoteIn` (stars: int, praxis_member_id: Optional[int])
+   - `PraxisCardOut` (lightweight card for lists)
+2. Delete `backend/schemas/submission.py` and `backend/schemas/collaboration.py`
+3. Update any schema files that imported `SubmissionOut` etc.
+
+**Files:**
+
+- `backend/schemas/praxis.py` (rewrite)
+- `backend/schemas/submission.py` (delete)
+- `backend/schemas/collaboration.py` (delete)
+
+**Acceptance:** No reference to `SubmissionOut`, `CollaborationOut`, `SubmissionCreate` anywhere in `schemas/`
+
+---
+
+### TASK P.4 ✅ 2026-04-17 — Backend services: rewrite to unified Praxis
+
+**Depends on:** P.3
+
+**Do:**
+
+1. Rewrite `backend/services/praxis.py` as the single canonical service:
+   - `_count_active_praxes(character_id, session)` — counts PraxisMember rows where praxis.status=in_progress and not withdrawn; used for bank limit enforcement
+   - `build_praxis_out(praxis, session, era)` — unified serializer for all types
+   - `create_praxis(character_id, task_id, type, title, body_text, session, era)` — enforces bank limit, creates Praxis + first PraxisMember
+   - `edit_praxis(praxis_id, character_id, data, session)` — edit title/body_text (only creator or member, only if in_progress)
+   - `withdraw_praxis(praxis_id, character_id, session)` — sets is_withdrawn, removes from bank
+   - `resubmit_praxis(praxis_id, character_id, session)`
+   - `flag_praxis(praxis_id, character_id, reason, session)`
+   - `invite_member(praxis_id, inviter_id, invitee_id, session, era)` — checks duel max via `era.max_duel_participants`
+   - `respond_to_invite(invite_id, invitee_id, accept, session)` — on accept: creates PraxisMember, checks invitee's bank limit
+   - `kick_member(praxis_id, kicker_id, target_character_id, session)`
+   - `submit_for_member(praxis_id, character_id, session)` — sets PraxisMember.has_submitted; if all members submitted, sets Praxis.status=submitted
+   - `reopen_praxis(praxis_id, character_id, session)`
+   - `list_praxes(session, *, type, task_id, character_id, status, limit, offset)`
+   - `cast_vote(praxis_id, voter_character_id, voter_account_id, stars, session, era)`
+   - `cast_duel_vote(praxis_id, voter_character_id, voter_account_id, praxis_member_id, stars, session, era)`
+   - `get_duel_vote_summary(praxis_id, session)`
+2. Update `backend/services/admin_service.py`: replace all `Submission` references with `Praxis`
+3. Update `backend/services/character_stats.py`: query `Praxis` not `Submission`
+4. Update `backend/services/voting.py` if it exists separately
+5. Delete `backend/services/submission.py` and `backend/services/collaboration.py`
+
+**Key rule:** add `max_duel_participants: int` to `EraConfig` in `backend/game_config.py` and set a value in `backend/eras/era_1.py`. The service reads `era.max_duel_participants` — never hardcodes 2.
+
+**Files:**
+
+- `backend/services/praxis.py` (rewrite)
+- `backend/services/submission.py` (delete)
+- `backend/services/collaboration.py` (delete)
+- `backend/services/admin_service.py`
+- `backend/services/character_stats.py`
+- `backend/game_config.py`
+- `backend/eras/era_1.py`
+
+**Acceptance:** No reference to `Submission`, `Collaboration`, or `CharacterTask` in `services/`; `pytest backend/tests/unit/ -v` passes
+
+---
+
+### TASK P.5 ✅ 2026-04-17 — Backend routes: single unified praxes router
+
+**Depends on:** P.4
+
+**Do:**
+
+1. Rewrite `backend/routers/praxes.py` as the single unified router (all endpoints under `/praxes`):
+   - `GET /praxes` — list with `?type=solo|collab|duel`, `?task_id=`, `?character_id=`, `?status=`
+   - `GET /praxes/{id}` — detail
+   - `POST /praxes` — create (solo, collab, or duel based on `type` in body)
+   - `PUT /praxes/{id}` — edit title/body_text
+   - `POST /praxes/{id}/withdraw`
+   - `POST /praxes/{id}/resubmit`
+   - `POST /praxes/{id}/flag`
+   - `POST /praxes/{id}/media` — upload media (any praxis type)
+   - `DELETE /praxes/{id}/media/{media_id}`
+   - `POST /praxes/{id}/invite` — invite a member (collab/duel only)
+   - `POST /praxes/{id}/invites/{invite_id}/respond`
+   - `POST /praxes/{id}/submit` — member marks themselves as submitted
+   - `POST /praxes/{id}/reopen`
+   - `POST /praxes/{id}/kick/{character_id}`
+   - `POST /praxes/{id}/vote` — cast vote (body: `PraxisVoteIn`)
+   - `GET /praxes/{id}/votes` — duel vote summary
+2. Delete `backend/routers/submissions.py` and `backend/routers/collaborations.py`
+3. Update `backend/routers/admin.py`: replace all `Submission` references with `Praxis`; update endpoint paths if any were `/admin/submissions/...` → `/admin/praxes/...`
+4. Update `backend/main.py` to remove old router includes, confirm praxes router is included
+
+**Files:**
+
+- `backend/routers/praxes.py` (rewrite)
+- `backend/routers/submissions.py` (delete)
+- `backend/routers/collaborations.py` (delete)
+- `backend/routers/admin.py`
+- `backend/main.py`
+
+**Acceptance:** `GET /praxes`, `POST /praxes`, and `GET /praxes/{id}` return 200; no `/submissions` or `/collaborations` routes registered; `pytest backend/tests/integration/ -v` passes
+
+---
+
+### TASK P.6 ✅ 2026-04-17 — Frontend API: single unified praxis client
+
+**Depends on:** P.5 (backend must be running with new routes)
+
+**Do:**
+
+1. Rewrite `frontend/src/api/praxis.ts` as the single canonical client:
+   - Types: `PraxisMemberOut`, `PraxisInviteOut`, `PraxisOut`, `PraxisCardOut`, `MediaItemOut`, `DuelVoteSummary`
+   - Functions: `listPraxes`, `getPraxis`, `createPraxis`, `updatePraxis`, `withdrawPraxis`, `resubmitPraxis`, `flagPraxis`
+   - Media: `addMedia`, `deleteMedia`
+   - Collab/duel: `inviteMember`, `respondToInvite`, `submitForMember`, `reopenPraxis`, `kickMember`
+   - Voting: `castVote`, `getDuelVoteSummary`
+2. Delete `frontend/src/api/submissions.ts` and `frontend/src/api/collaborations.ts`
+3. Update `frontend/src/api/admin.ts`: rename `moderatePraxis` if needed, update types
+4. Update `frontend/src/api/votes.ts` if it references submission types
+
+**Files:**
+
+- `frontend/src/api/praxis.ts` (rewrite)
+- `frontend/src/api/submissions.ts` (delete)
+- `frontend/src/api/collaborations.ts` (delete)
+- `frontend/src/api/admin.ts`
+
+**Acceptance:** `npm run build` (or `tsc --noEmit`) from `frontend/` completes with no errors referencing old types
+
+---
+
+### TASK P.7 ✅ 2026-04-17 — Frontend pages + components: wire to new API
+
+**Depends on:** P.6
+
+**Do:**
+
+1. Update `frontend/src/pages/PraxisDetail.tsx`: import from `api/praxis`, use `PraxisOut` type; support solo and collab/duel rendering from the same component (or keep as shared detail view)
+2. Update `frontend/src/pages/Praxes.tsx`: import from `api/praxis`, use `listPraxes`
+3. Update `frontend/src/pages/EditPraxis.tsx`: import from `api/praxis`, use `updatePraxis`
+4. Update `frontend/src/pages/CollaborationDetail.tsx`: import from `api/praxis`; consider whether this page can merge into PraxisDetail (collab/duel praxes now use same shape). Keep them separate if the UX is meaningfully different.
+5. Update `frontend/src/pages/EditCollaboration.tsx`: import from `api/praxis`
+6. Update `frontend/src/pages/SubmitProof.tsx`: import from `api/praxis`, use `createPraxis` with appropriate type
+7. Update `frontend/src/components/PraxisCard.tsx`: use `PraxisOut` from `api/praxis`
+8. Update `frontend/src/components/CollaborationCard.tsx`: use `PraxisCardOut` from `api/praxis`
+9. Update feed components that use `SubmissionInviteOut` or `SubmissionOut` types
+10. Update `frontend/src/App.tsx` routing: remove any `/collaborations` legacy routes if they only existed as shims; confirm `/praxes` routes work
+
+**Files:**
+
+- All pages and components listed above
+- `frontend/src/App.tsx`
+
+**Acceptance:** Dev server starts clean; `/praxes` list renders; detail page for a solo and collab praxis both load; no TypeScript errors; no console errors referencing undefined API functions
+
+---
+
+### TASK P.8 ✅ 2026-04-17 — Tests and spec docs
+
+**Depends on:** P.5
+
+**Do:**
+
+1. Rewrite `backend/tests/integration/test_submissions.py` → rename to `test_praxis.py`; update all imports and endpoint paths to `/praxes`; cover:
+   - Create solo praxis (happy path + bank limit enforcement)
+   - Create collab praxis, invite member, member accepts, both submit
+   - Create duel praxis, invite opponent, vote per member, get vote summary
+   - Withdraw and resubmit
+   - Media upload and delete
+   - Flag + admin moderation
+2. Update `backend/tests/integration/test_admin.py`: update any references to `/admin/submissions/` → `/admin/praxes/`
+3. Update `backend/tests/integration/test_votes.py` if it exists
+4. Update `docs/spec/SPEC-data-models.md`: describe the new unified Praxis schema
+5. Update `docs/spec/SPEC-api.md`: document the `/praxes` endpoints, remove `/submissions` and `/collaborations`
+6. Update `docs/BUILD_STATE.md`: mark SESSION P complete, note deprecated tables dropped
+
+**Note:** Tasks T.4 (integration tests: praxes routes) and T.9 (collaborations coverage) are superseded by this task.
+
+**Files:**
+
+- `backend/tests/integration/test_praxis.py` (rename from test_submissions.py)
+- `backend/tests/integration/test_admin.py`
+- `docs/spec/SPEC-data-models.md`
+- `docs/spec/SPEC-api.md`
+- `docs/BUILD_STATE.md`
+
+**Acceptance:** `pytest backend/tests/ -v` passes; `grep -ri "Submission\|Collaboration\|character_task" backend/ frontend/src/ docs/` returns no hits (except in migration history and git log)
+
+---
+
+## ⚖️ SESSION R — Rules Reconciliation Fixes
+
+> Implements the open items from the April 17 rules reconciliation (see `docs/spec/SPEC-game-rules.md` backend fix list).
+> **Start after SESSION P is complete.**
+> **Read before starting:** `CLAUDE.md`, `docs/spec/SPEC-game-rules.md`, `backend/game_config.py`, `backend/eras/era_1.py`.
+>
+> Items are independent — they can be done in any order unless noted.
+
+### TASK R.1 ✅ 2026-04-17 — Enforce task signup level gate
+
+**Problem:** Praxis creation does not check whether `character.level ≥ task.level_required`.
+
+**Fix:**
+
+1. In `backend/services/praxis.py::create_praxis`, load the task's `level_required` and raise 403 if the character's level is below it.
+2. Return a clear error message: `"Character level {n} is below the required level {m} for this task."`
+
+**Files:** `backend/services/praxis.py`
+
+**Acceptance:** A character below `task.level_required` gets a 403 on `POST /praxes`; a character at or above it succeeds.
+
+---
+
+### TASK R.2 ✅ 2026-04-17 — Remove `task_submit_level_gap` from EraConfig
+
+**Problem:** `task_submit_level_gap` is a dead field — once a character signs up, they can always submit regardless of level. The field adds confusion.
+
+**Fix:**
+
+1. Remove `task_submit_level_gap` from the `EraConfig` dataclass in `backend/game_config.py`.
+2. Remove it from `backend/eras/era_1.py`.
+3. Remove any service code that reads it.
+
+**Files:** `backend/game_config.py`, `backend/eras/era_1.py`, any service that references `task_submit_level_gap`
+
+**Acceptance:** `grep -r "task_submit_level_gap" backend/` returns no hits; tests pass.
+
+---
+
+### TASK R.3 ✅ 2026-04-17 — Add `max_collab_participants` to EraConfig; enforce on collab invite
+
+**Problem:** Collab praxes have no participant cap. The intended limit is 20.
+
+**Fix:**
+
+1. Add `max_collab_participants: int = 20` to `EraConfig` in `backend/game_config.py`.
+2. Set the value in `backend/eras/era_1.py`.
+3. In `backend/services/praxis.py::respond_to_invite`, when the invitee accepts a collab praxis, count current members and reject with 400 if `count >= era.max_collab_participants`.
+
+**Files:** `backend/game_config.py`, `backend/eras/era_1.py`, `backend/services/praxis.py`
+
+**Acceptance:** Accepting an invite that would push a collab over 20 members returns 400; under 20 succeeds.
+
+---
+
+### TASK R.4 ✅ 2026-04-17 — Switch duel anti-self-vote to account-level
+
+**Problem:** Duel vote validation checks `voter.character_id not in duel members` (character-level). It should check `voter.account_id not in duel participants' account_ids` — a voter cannot use _any_ of their characters to rate either side of a duel they participate in.
+
+**Fix:**
+
+1. In `backend/services/praxis.py::cast_duel_vote`, load the account IDs of both duel members and compare against `voter_account_id`.
+2. Reject with 403 if the voter's account owns any member character.
+
+**Files:** `backend/services/praxis.py`
+
+**Acceptance:** A voter whose alt-character is in a duel cannot vote on that duel from any character; an unrelated voter can.
+
+---
+
+### TASK R.5 ✅ 2026-04-17 — Vote budget: on-read recomputation
+
+**Problem:** `votes_available` is stored as a running counter and decremented on each vote. It drifts from the formula if score changes (era reset, stat patch, etc.) and does not grow as the character earns points.
+
+**Fix:**
+
+1. In `CharacterStats`, replace the stored `votes_available` column with `votes_spent_this_era` (count of distinct first-casts this era). **Alembic migration required.**
+2. Add a `compute_votes_available(stats, era)` helper in `backend/services/scoring.py`:
+   ```python
+   return era.vote_budget_base + floor(era.vote_budget_multiplier * stats.score) - stats.votes_spent_this_era
+   ```
+3. Everywhere `votes_available` was read, call the helper instead.
+4. On first vote cast on a praxis, increment `votes_spent_this_era` (not decrement a counter).
+5. On era reset with `reset_vote_budget=True`, zero `votes_spent_this_era` (not restore a fixed value).
+6. Update `CharacterOut` / `CharacterStatsOut` schemas to expose the computed value, not the raw column.
+
+**Files:** `backend/models/character.py` (or wherever CharacterStats lives), `backend/services/scoring.py`, `backend/services/praxis.py`, `backend/services/character_stats.py`, `backend/schemas/character.py`, `backend/alembic/versions/XXXX_vote_budget_recompute.py`
+
+**Acceptance:** After earning points, a character's displayed vote budget reflects the new score without any explicit budget refresh; era reset zeroes `votes_spent_this_era` and the budget recalculates correctly from the new score.
+
+---
+
+### TASK R.6 ✅ 2026-04-17 — Fix Snide tie rule: opponent uses own faction's loss modifier
+
+**Problem:** `backend/services/scoring.py::compute_duel_multiplier` applies Snide's `duel_loss_modifier` (0.0×) to the non-Snide player in a tie. The correct behavior: the non-Snide player receives **their own faction's** `duel_loss_modifier`.
+
+**Fix:**
+
+1. In `compute_duel_multiplier`, when resolving a tie where exactly one participant is Snide: apply `snide_config.duel_win_modifier` to Snide and `opponent_faction_config.duel_loss_modifier` to the opponent (not `snide_config.duel_loss_modifier`).
+
+**Files:** `backend/services/scoring.py`
+
+**Acceptance:** A UA character tied against Snide receives 0.5× (UA's loss modifier), not 0.0×; Snide still receives 2.0×.
+
+---
+
+### TASK R.7 ✅ 2026-04-17 — Second character level gate (level 5) + Albescent faction gate (level 8)
+
+**Problem:** Creating a second character currently requires level 3 on any existing character. Target: level 5. Additionally, choosing Albescent as the starting faction for a new character requires the account to have at least one character at level 8.
+
+**Backend:**
+
+1. In `backend/services/character.py::create_character`, raise the existing level check from 3 → 5.
+2. If the new character's requested faction is `"albescent"`, additionally verify that at least one of the account's existing characters has `stats.level >= 8`. Reject with 403 and a clear message if not.
+
+**Frontend:** 3. Update any frontend copy or gate checks that reference "level 3" for second character creation to "level 5". 4. In the character creation flow, only show Albescent as a choosable starting faction if the account has a character at level 8.
+
+**Files:** `backend/services/character.py`, relevant frontend character creation component
+
+**Acceptance:** Creating a second character at level 4 returns 403; at level 5 succeeds. Choosing Albescent without a level-8 character returns 403; with one succeeds.
+
+---
+
+### TASK R.8 ✅ 2026-04-17 — Albescent onboarding: start in Albescent, skip UA
+
+**Depends on:** R.7
+
+**Problem:** New characters always start in `"ua"`. An Albescent second character should start in `"albescent"` at level 1 and never be assigned to UA.
+
+**Fix:**
+
+1. In `backend/services/character.py::create_character`, if `faction_slug = "albescent"`, set `character.faction_slug = "albescent"` directly instead of the default `"ua"` assignment.
+2. Skip the faction graduation check (UA → aged_out) for Albescent characters — they are never in UA.
+
+**Files:** `backend/services/character.py`
+
+**Acceptance:** A second character created as Albescent has `faction_slug = "albescent"` immediately; `GET /characters/{id}` shows faction as Albescent, not UA.
+
+---
+
+### TASK R.9 ✅ 2026-04-17 — Metatask level privileges (covered by M.3)
+
+**Problem:** The level table has stale metatask access rows (level 4 "meta task access"). Correct model: level 6 = see list + propose; level 7 = apply own faction's metatasks; Albescent = apply any faction.
+
+**Backend:**
+
+1. In `backend/services/meta_task.py` (or wherever metatask access is gated), remove any level-4 gate.
+2. Gate "see metatask list" and "propose metatask" behind `character.level >= 6`.
+3. Gate "apply metatask to praxis" behind `character.level >= 7` OR `character.faction_slug == "albescent"`.
+4. For Albescent: allow applying metatasks from any faction; for level-7 characters: only their own faction's metatasks.
+
+**Frontend:** 5. Remove metatask UI elements for characters below level 6. 6. Show "propose" controls at level 6+; show "apply" controls at level 7+ (or Albescent).
+
+**Files:** `backend/services/meta_task.py`, relevant frontend metatask components
+
+**Acceptance:** Level 5 character sees no metatask UI; level 6 sees list and propose button; level 7 can apply own-faction metatasks; Albescent character can apply any-faction metatasks.
+
+---
+
+### TASK R.10 ✅ 2026-04-17 — Remove "group welcome letters" from level-2 frontend display
+
+**Problem:** The level privileges table in the frontend shows "group welcome letters" under level 2. Letters are part of the faction flow, not a level unlock — this is a display error.
+
+**Fix:** Remove the "group welcome letters" entry from whatever component renders the level privileges table.
+
+**Files:** Whichever frontend component renders level unlocks (search for "welcome letters" or "group welcome")
+
+**Acceptance:** Level 2 row no longer mentions welcome letters anywhere in the UI.
+
+---
+
+## 🧩 SESSION M — Metatask as Task Type
+
+> Rebuild metatasks as a task type rather than a separate model.
+> **Start after SESSION P is complete** (SESSION P unifies the Praxis model which metatasks attach to).
+> **Read before starting:** `CLAUDE.md`, `docs/spec/SPEC-game-rules.md` (Metatask access section), `docs/spec/SPEC-data-models.md`.
+>
+> A metatask is a task with `task_type = "metatask"`. It cannot be done standalone — it must be
+> associated with another (non-metatask) praxis. When applied, its `point_value` is added as a flat
+> bonus to the praxis score before faction multipliers.
+
+### TASK M.1 ✅ 2026-04-17 — Add `task_type` to Task model and seed metatask tasks
+
+**Do:**
+
+1. Add `task_type: TaskType` enum column to the `Task` model (`TaskType.standard | TaskType.metatask`). Default `standard`. **Alembic migration required.**
+2. Add `metatask_faction_slug: Optional[str]` to `Task` — the faction this metatask belongs to (used for access gating at level 7).
+3. Add `TaskType` enum to `backend/models/task.py`.
+4. Update `TaskOut` schema to include `task_type` and `metatask_faction_slug`.
+5. Update `backend/eras/era_1.py` `TaskDef` definitions to include `task_type` (existing tasks are `standard`; add initial metatask definitions).
+6. Update `backend/game_config.py::TaskDef` to include `task_type` and `metatask_faction_slug` fields.
+
+**Files:** `backend/models/task.py`, `backend/schemas/task.py`, `backend/game_config.py`, `backend/eras/era_1.py`, migration file
+
+**Acceptance:** `GET /tasks?task_type=metatask` returns only metatask tasks; `GET /tasks` (no filter) returns all; migration runs clean.
+
+---
+
+### TASK M.2 ✅ 2026-04-17 — Metatask association on Praxis
+
+**Depends on:** M.1, P.1 (praxis unification migration)
+
+**Problem:** Currently `PraxisMetaTask` stores a link between a praxis and an old-model metatask. After M.1, a metatask is just a Task row with `task_type = "metatask"`. The association table needs to point to the task (not a separate metatask model).
+
+**Do:**
+
+1. Rename/rewrite `praxis_meta_task` table: `praxis_id` (FK praxis) + `task_id` (FK task, must have `task_type = "metatask"`). **Alembic migration required.**
+2. Drop any separate `meta_task` or `metatask` model/table that is not the unified `Task` table.
+3. Add a DB check or service-level guard: only tasks with `task_type = "metatask"` can be linked via `praxis_meta_task`.
+4. Update `build_praxis_out` in `backend/services/praxis.py` to compute `meta_task_points` by summing `task.point_value` for all linked metatask tasks.
+
+**Files:** `backend/models/meta_task.py` (or wherever the join table lives), `backend/services/praxis.py`, migration file
+
+**Acceptance:** Linking a standard task as a metatask on a praxis returns 400; linking a metatask task succeeds and adds its points to the praxis score.
+
+---
+
+### TASK M.3 ✅ 2026-04-17 — Metatask apply/remove service + routes
+
+**Depends on:** M.2
+
+**Do:**
+
+1. Add `apply_metatask(praxis_id, task_id, character_id, session, era)` to `backend/services/praxis.py`:
+   - Verify `task.task_type == TaskType.metatask`.
+   - Verify character's level/faction access (level 7 + own faction, or Albescent + any faction).
+   - Verify the praxis is in `in_progress` status.
+   - Insert `praxis_meta_task` row; trigger `recalculate_character_stats`.
+2. Add `remove_metatask(praxis_id, task_id, character_id, session)` — removes the link; recalculates stats.
+3. Add routes to `backend/routers/praxes.py`:
+   - `POST /praxes/{id}/metatasks` — body: `{ task_id: int }`
+   - `DELETE /praxes/{id}/metatasks/{task_id}`
+
+**Files:** `backend/services/praxis.py`, `backend/routers/praxes.py`
+
+**Acceptance:** A level-7 Gestalt character can apply a Gestalt metatask but not a Snide one; an Albescent character can apply either; applying adds the points; removing subtracts them.
+
+---
+
+### TASK M.4 ✅ 2026-04-17 — Metatask propose + admin approve routes
+
+**Depends on:** M.1
+
+**Do:**
+
+1. Level-6+ characters can propose a new metatask task via `POST /tasks` with `task_type = "metatask"` and `metatask_faction_slug`. Proposed metatasks start in `pending` status like any other task.
+2. Admin approves via existing `POST /admin/tasks/{id}/activate` (or equivalent) — no new route needed if the task activation flow already handles `task_type = "metatask"`.
+3. Update `GET /tasks` to support `?task_type=metatask` filter.
+4. Ensure `propose_task` service enforces level-6 gate for metatask proposals (not the standard level-3 gate).
+
+**Files:** `backend/services/task.py`, `backend/routers/tasks.py`
+
+**Acceptance:** A level-6 character can propose a metatask; a level-5 character cannot; admin can activate it; activated metatask appears in `GET /tasks?task_type=metatask`.
+
+---
+
+### TASK M.5 ⚠️ PARTIAL 2026-04-17 — Frontend: metatask list, apply/remove UI
+
+**Done in this session:**
+
+- `frontend/src/api/metaTasks.ts` rewritten — `listMetatasks` and `proposeMetatask` hit the unified `/tasks` endpoint with `task_type=metatask`
+- `frontend/src/api/praxis.ts` — added `applyMetatask(praxisId, taskId)` and `removeMetatask(praxisId, taskId)` calling `/praxes/{id}/metatasks`
+- `frontend/src/api/tasks.ts` — `TaskOut` and `TaskCreate` now carry `task_type` and `metatask_faction_slug`
+- `frontend/src/pages/ProposeTask.tsx` — metatask branch uses the new `proposeMetatask` call with level-6 gate (admin bypass)
+- `frontend/src/pages/TaskDetail.tsx` and `frontend/src/pages/Tasks.tsx` updated to be metatask-aware
+
+**Deferred (follow-up):**
+
+- **Metatask apply/remove panel on `PraxisDetail.tsx`** — a level-7 Gestalt character (or any-level Albescent) should see an "Apply metatask" panel on an in-progress praxis they're a member of, with a list of applicable metatasks and a remove button for already-applied ones. This requires exposing `applied_metatasks: List[TaskOut]` on `PraxisOut` (backend schema + build_praxis_out). The apply/remove APIs already exist — this is pure UI wiring.
+
+**Depends on:** M.3, M.4
+
+**Do:**
+
+1. Add `listMetatasks()` to `frontend/src/api/tasks.ts` (or `praxis.ts`) — calls `GET /tasks?task_type=metatask`.
+2. Add `applyMetatask(praxisId, taskId)` and `removeMetatask(praxisId, taskId)` to `frontend/src/api/praxis.ts`.
+3. On the praxis detail page (for in-progress praxes), show a "Add metatask" panel for eligible characters (level 7+ or Albescent). List available metatasks filtered by access rules. Show applied metatasks with a remove button.
+4. Level-6 characters see the metatask list (read-only) but no apply button.
+5. Characters below level 6 see no metatask UI.
+
+**Files:** `frontend/src/api/tasks.ts`, `frontend/src/api/praxis.ts`, `frontend/src/pages/PraxisDetail.tsx` (or equivalent)
+
+**Acceptance:** Eligible characters see and can use the metatask panel; ineligible characters see nothing; applying a metatask updates the displayed score.
+
+---
+
+## 🐛 SESSION B — Small Bug Fixes
+
+> Five independent fixes identified 2026-04-15. Each is self-contained.
+> **Read before starting:** `CLAUDE.md`. No spec file required for these.
+
+### TASK B.1 ✅ 2026-04-17 — Fix praxis hide/fail buttons in PraxisCard
+
+**Problem:** `PraxisCard.tsx` reads `praxis` as a read-only prop and never updates it after a moderation action. None of the callers pass `onModerated`, so the refresh callback is always a no-op. Errors are silently swallowed.
+
+**Fix:**
+
+- Add `const [localPraxis, setLocalPraxis] = useState(praxis)` and render from `localPraxis`
+- Rewrite `handleHide` / `handleFail` with try/catch; on success call `setLocalPraxis(updated)` (API returns updated `PraxisOut`); on error show an inline error message
+
+**Files:** `frontend/src/components/PraxisCard.tsx`
+
+**Acceptance:** Clicking hide/fail on a praxis card updates the card badge instantly without a page reload; errors surface visibly.
+
+---
+
+### TASK B.2 ✅ 2026-04-17 — Level selector: extend from 5 to 8
+
+**Problem:** `ProposeTask.tsx:12` has `const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5]`. Tasks in era_1 go up to `level_required=7` and the era has 9 level thresholds (0–8).
+
+**Fix:** Change to `[0, 1, 2, 3, 4, 5, 6, 7, 8]`.
+
+**Files:** `frontend/src/pages/ProposeTask.tsx` line 12
+
+**Acceptance:** Level selector on Propose Task shows 0–8.
+
+---
+
+### TASK B.3 ✅ 2026-04-17 — Rename era to "TestEra"
+
+**Problem:** `backend/eras/era_1.py:488` has `name="Era 1"`. Should be `"TestEra"`.
+
+**Fix:** Change `name="Era 1"` → `name="TestEra"`.
+
+**Files:** `backend/eras/era_1.py` line 488
+
+**Acceptance:** `GET /game-config` returns `"era_name": "TestEra"`.
+
+---
+
+### TASK B.4 ✅ 2026-04-17 — Admin can edit fields on pending/retired tasks
+
+**Problem:** No admin endpoint or UI exists to edit task title, description, point_value, or level_required after a task is created. `PUT /tasks/{id}` rejects everyone except the original proposer on pending-only tasks.
+
+**Backend:**
+
+1. Add `AdminTaskPatch` schema to `backend/schemas/admin.py` — optional fields: title, description, point_value, level_required
+2. Add `admin_edit_task(task_id, data, session)` to `backend/services/admin_service.py` — loads task, rejects if status is `active`, applies non-None fields, commits
+3. Add `PATCH /admin/tasks/{task_id}` route in `backend/routers/admin.py` that calls the service and returns `TaskOut`
+
+**Frontend:** 4. Add `adminPatchTask(id, data)` to `frontend/src/api/admin.ts` calling `PATCH /admin/tasks/{id}` 5. In `frontend/src/pages/admin/TasksTab.tsx`, add an "edit" button on pending and retired task rows that toggles an inline form for title, description, point_value, level_required; on save call `adminPatchTask` then `refresh()`
+
+**Acceptance:** Admin can open the edit form on any pending/retired task, change any of the four fields, save, and see the updated values in the list. Active tasks show no edit button.
+
+---
+
+### TASK B.5 ✅ 2026-04-17 — Admin can propose tasks regardless of level
+
+**Problem:** `services/task.py` gates proposals behind `stats.level < 3`. `ProposeTask.tsx` shows a hard error page for any character below level 3. Admins should bypass both gates.
+
+**Backend:**
+
+1. Add `skip_level_check: bool = False` param to `propose_task()` in `backend/services/task.py`; gate on `not skip_level_check`
+2. In `backend/routers/tasks.py` propose route: load the current Account; if `account.is_admin`, pass `skip_level_check=True`
+
+**Frontend:** 3. In `frontend/src/pages/ProposeTask.tsx`, change the level gate from `if (characterLevel < 3)` to `if (!user?.is_admin && characterLevel < 3)`
+
+**Acceptance:** An admin character at level 0 can navigate to Propose Task without hitting the gate and successfully submit a proposal.
+
+---
+
+## 🎨 SESSION — Frontend Style Polish (remaining)
+
+> All high and medium priority items are complete. One low-priority item remains.
+>
+> **Read before starting:** `WORLD_ZERO_STYLE.md`, `frontend/src/index.css`, `frontend/src/utils/factions.ts`.
+
+- **Full inline-style → Tailwind migration.** Convert all remaining `style={{}}` to Tailwind utilities where practical. Large effort, low urgency.
+
+---
+
+## 🧱 SESSION A — Backend architecture cleanup
+
+> Triaged from a backend architecture audit on 2026-04-14. Each item is small
+> and independent — pick them off in any order. **Read
+> `docs/spec/SPEC-backend-architecture.md` first** — it is the posture these
+> tasks align the code to.
+>
+> None of these tasks are blocking a feature. Pull them in when an agent has
+> capacity between feature work.
+
+### TASK A.1 ✅ 2026-04-15 — Rename `Submission` → `Praxis` across the codebase
+
+The canonical noun is **Praxis** (the completed-task artifact). "Submit" is
+the verb — a player _submits_ a praxis. Today the code names the entity
+`Submission` everywhere (model, table, schemas, routes, services), which
+reads as noun-verb confusion to anyone coming from the spec prose. Lock in
+"Praxis" as the noun and "submit" as the verb, consistently.
+
+This is a real refactor, not a doc sweep. Break it into two phases so it
+can land safely:
+
+**Phase 1 — Docs and new code surface:**
+
+- Sweep `docs/` so every use of "Submission" as a noun for the artifact
+  becomes "Praxis". Leave verbs ("submit the praxis", "submitted") intact.
+- In `SPEC-backend-architecture.md` §6 this is already the canonical
+  direction; the other spec files need to follow.
+- Any new spec prose or route/field name added from this point forward uses
+  "Praxis" for the noun.
+
+**Phase 2 — Code rename (single PR):**
+
+- Rename model: `models/submission.py` → `models/praxis.py`; class
+  `Submission` → `Praxis`; table `submission` → `praxis`.
+- Rename child-model references: `MediaItem.submission_id` →
+  `praxis_id`; `Vote.submission_id` → `praxis_id`; `Flag.submission_id` →
+  `praxis_id`; `SubmissionMetaTask` → `PraxisMetaTask`.
+- Rename schemas: `SubmissionOut` → `PraxisOut`, `SubmissionCreate` →
+  `PraxisCreate`, etc. Route paths: `/submissions` → `/praxes`
+  (plural of praxis is "praxes").
+- Rename services and helpers: `services/submission.py` →
+  `services/praxis.py`; `build_submission_out` → `build_praxis_out`.
+- Rename router: `routers/submissions.py` → `routers/praxes.py`.
+- Add Alembic migration that renames the tables and columns. Test the
+  migration against a prod-shaped DB snapshot before merging.
+- Update frontend API clients and component names in lockstep (this phase
+  will need coordination with `frontend-feature`).
+
+**Acceptance:**
+
+- `grep -ri "Submission" backend/ frontend/src/ docs/` returns no hits
+  referring to the entity; only residual references to verbs/history
+  (if any) remain with comments.
+- All tests pass; migration is idempotent up and down.
+- `GET /praxes/{id}` replaces `GET /submissions/{id}`; a deprecation window
+  is not required since we have no external API consumers yet.
+
+### TASK A.2 ✅ 2026-04-15 — Declare SQLAlchemy `relationship()` on core models
+
+Today every join is hand-written. `models/submission.py`, `models/vote.py`,
+`models/media_item.py`, `models/character.py`, `models/account.py` have no
+`.relationship()` declarations. This forces `services/submission.py::build_submission_out`
+and `routers/tasks.py::list_task_signups` to run manual join queries for data
+the ORM could eager-load.
+
+**Do:** add `relationship()` declarations for:
+
+- `Account.characters` / `Character.account`
+- `Account.oauth_providers` / `OAuthProvider.account`
+- `Character.submissions` / `Submission.character`
+- `Submission.task` / `Task.submissions`
+- `Submission.votes` / `Vote.submission`
+- `Submission.media_items` / `MediaItem.submission`
+- `Submission.flags` / `Flag.submission`
+
+Update at least three previously hand-joined query sites to use the
+relationships (targets: `build_submission_out`, `list_task_signups`,
+`routers/characters.py::get_character_submissions`).
+
+**Acceptance:** three previously hand-joined queries become single
+relationship-loaded statements; all tests still pass (`pytest --cov=. --cov-fail-under=80`).
+
+### TASK A.3 ✅ 2026-04-15 — Fix `Submission.invite_status` type annotation
+
+`backend/models/submission.py:62` declares
+`invite_status: Mapped[Optional[str]]` but the column is
+`Enum(InviteStatus, create_type=False)`. The Python type hint lies about the
+runtime value. Services downstream (`services/submission.py::accept_invite`)
+then compare against string literals like `"pending"` where they should use
+`InviteStatus.pending`.
+
+**Do:** change the annotation to `Mapped[Optional[InviteStatus]]`. Update
+call sites that compare against string literals to use the enum. No DB
+migration needed (the column is already an Enum); this is a Python-side fix.
+
+**Acceptance:** `mypy`/runtime behavior is unchanged; all callers reference
+`InviteStatus.pending` / `.accepted` / `.declined` rather than bare strings;
+tests pass.
+
+### TASK A.4 ✅ 2026-04-15 — Break the `era` ↔ `faction_service` import cycle
+
+`backend/services/era.py:96` imports `clear_defection_history_for_era` from
+`services.faction_service` **inside a function body** to dodge a module-load
+cycle. The whole codebase has exactly one function-scoped service import, and
+this is it.
+
+**Do:** pick one:
+
+1. Move `clear_defection_history_for_era` into `services/era.py` (it only
+   clears `FactionDefectionHistory` rows; it's closer to era concerns than
+   faction concerns).
+2. Extract a third module (e.g. `services/defection_history.py`) that both
+   `era.py` and `faction_service.py` can import without a cycle.
+
+Whichever you pick, remove the function-scoped import.
+
+**Acceptance:** `services/era.py` has only module-level imports; no
+`# TODO: break cycle` comments anywhere in `services/`; all tests pass.
+
+### TASK A.5 ✅ 2026-04-15 — Slim `routers/tasks.py::list_tasks`
+
+The `GET /tasks` handler in `backend/routers/tasks.py:39–104` contains ~60
+lines of filter-building, hidden-faction lookup, exclusion subqueries, and
+inline `TaskOut` construction. It's the fattest route handler in the codebase.
+
+**Do:** move the filter/query construction into a new
+`services/task.py::list_tasks(session, *, status, level, faction, min_points,
+max_points, exclude_character_id, limit, offset) -> list[Task]`. Keep the
+route handler as a thin adapter that calls the service and serializes the
+result via a `build_task_out` helper (also in `services/task.py`).
+
+**Acceptance:** `routers/tasks.py::list_tasks` handler body is under 15
+lines; the same query shapes are still covered by
+`backend/tests/integration/test_tasks.py`; no behavior change.
+
+### TASK A.6 ✅ 2026-04-15 — Audit `admin_service.py` for era parameterization
+
+`services/admin_service.py::set_character_stats` and other functions that
+touch `CharacterStats` do not currently take `era: EraConfig = CURRENT_ERA`.
+This works for the live era but makes era-reset scenarios hard to test and
+silently hardcodes "current era" into admin operations.
+
+**Do:** add `era: EraConfig = CURRENT_ERA` to every admin function that (a)
+reads or writes `CharacterStats`, or (b) passes rules into another service.
+Thread it through any downstream calls (`recalculate_character_stats`,
+`compute_vote_budget`).
+
+**Acceptance:** no function in `admin_service.py` imports `CURRENT_ERA`
+inside its body; unit tests covering era reset can inject a custom
+`EraConfig`.
+
+### TASK A.7 ✅ 2026-04-15 — Annotate the `/auth/me` identity exception
+
+`schemas/auth.py::CurrentUser` exposes `account_id`, which is the one
+deliberate exception to the "never leak account_id publicly" rule (see
+`SPEC-backend-architecture.md` §4). Today nothing in code marks this as
+intentional, so a future agent may "fix" it.
+
+**Do:** add a one-line comment on `CurrentUser` and on `routers/auth.py::me`
+citing `SPEC-backend-architecture.md` §4 as the authorization for this
+exception.
+
+**Acceptance:** `schemas/auth.py` and `routers/auth.py` both reference the
+spec section; no behavior change.
+
+### TASK A.8 ✅ 2026-04-15 — Tighten `build_praxis_out` after A.2 lands
+
+`services/submission.py::build_submission_out` passes optional defaults
+(`""`, `None`) for joined fields (`character_display_name`,
+`task_title`, `task_point_value`, `partner_display_name`). After TASK A.2
+declares the relationships, these fields can be read directly via the
+relationship and marked required on the schema.
+
+**Do:** after A.2 is merged, tighten `SubmissionOut` so the denormalized
+fields are required (not `Optional`). Update `build_submission_out` to read
+from the relationship rather than running a separate `session.get` per join.
+
+**Acceptance:** `SubmissionOut` has no `Optional` on denormalized display
+fields; `build_submission_out` does not issue per-submission N+1 queries;
+integration tests pass.
+
+**Depends on:** A.2.
+
+### TASK A.9 ✅ 2026-04-15 — Reconcile `submission_score` formula between code and spec
+
+`SPEC-game-rules.md` §6 says:
+
+> `submission_score = mean(vote.stars for all votes on submission) × task.point_value`
+
+`backend/services/scoring.py::compute_submission_score` implements:
+
+> `return task_point_value * faction_multiplier + total_stars`
+
+These are different formulas. The code is the live truth — points are base
+value × faction multiplier, with each star added flat. The spec is stale.
+
+**Do:** update `SPEC-game-rules.md` §6 to match the real formula. Include a
+short note about what `total_stars` is (sum of raw star ratings across all
+votes, not an average). Also document that base points are awarded on
+submission creation, not on vote receipt.
+
+**Acceptance:** the scoring formula in `SPEC-game-rules.md` matches what
+`scoring.py` computes; a reader running both past each other sees no
+contradiction.
+
+---
+
+## 🧪 SESSION — Fix Integration Test Infrastructure
+
+> Added 2026-04-15 after discovering all integration tests have been silently
+> failing in CI since before the Praxis rename. Unit tests (105) pass and meet
+> the 80% coverage threshold on their own, so CI failure was masked.
+>
+> **Root cause:** `conftest.py`'s session-scoped `test_engine` creates tables
+> via `create_all`, but asyncpg connections bind to a specific event loop.
+> When function-scoped fixtures (`db_session`, `account`, etc.) try to use the
+> same engine, asyncpg raises "cannot perform operation: another operation is
+> in progress." This is a well-documented SQLAlchemy + asyncpg + pytest-asyncio
+> incompatibility when mixing fixture scopes.
+>
+> **Read before starting:** `backend/tests/integration/conftest.py`,
+> `backend/db.py`, `backend/pytest.ini`.
+
+### TASK T.1 ✅ 2026-04-15 — Rewrite conftest engine/session fixtures for asyncpg compatibility
+
+The `test_engine` fixture (session-scoped) and `db_session` fixture
+(function-scoped) share an engine across event loop boundaries. asyncpg
+connections are bound to a single event loop, so this causes
+"another operation is in progress" errors.
+
+**Do:** Rewrite the test fixtures using one of these approaches (pick one):
+
+**Option A — Function-scoped engine (simplest, slower):**
+
+- Make `test_engine` function-scoped instead of session-scoped
+- Each test gets its own engine → own connection → own event loop
+- Trade-off: `create_all` runs per test (slower), but no concurrency issues
+- Mitigate by using `scope="module"` if per-test is too slow
+
+**Option B — NullPool + begin_nested (recommended):**
+
+- Add `poolclass=NullPool` to `create_async_engine` in the test engine
+- Use `connection.begin_nested()` (SAVEPOINT) pattern:
+  ```python
+  @pytest_asyncio.fixture
+  async def db_session(test_engine):
+      async with test_engine.connect() as conn:
+          trans = await conn.begin()
+          session = AsyncSession(bind=conn, expire_on_commit=False)
+          yield session
+          await trans.rollback()
+  ```
+- Override `get_db` to yield the same bound session
+- The single connection avoids asyncpg's concurrent-operation check
+
+**Option C — Sync create_all + async tests:**
+
+- Use a synchronous engine for `create_all`/`drop_all` only
+- Use the async engine only for test sessions
+- Avoids the session-scoped async fixture loop-binding issue entirely
+
+**Also:**
+
+- Set `asyncio_default_fixture_loop_scope = "session"` in `pytest.ini` to
+  ensure all async fixtures share one event loop (requires pytest-asyncio ≥ 0.23)
+- OR pin `pytest-asyncio` and set `loop_scope="session"` on the engine fixture
+
+**Acceptance:** `pytest backend/tests/integration/ -v` passes all tests in CI
+(GitHub Actions with PostgreSQL service container). No "another operation is
+in progress" errors.
+
+### TASK T.2 ✅ 2026-04-15 — Verify full test suite passes
+
+145 tests pass (0 failures). Coverage threshold lowered from 80% → 60%
+to reflect reality. Actual coverage: 59%. The remaining gap is documented
+in tasks T.4–T.9 below.
+
+### TASK T.3 — Add CI status check enforcement
+
+Currently PRs can be merged even when CI fails (as evidenced by multiple
+merged PRs with failing tests). Consider adding branch protection rules
+requiring the Test workflow to pass before merge.
+
+**Acceptance:** GitHub branch protection on `main` requires the "Test" status
+check to pass.
+
+### TASK T.4 ⛔ SUPERSEDED by P.8 — Integration tests: praxes routes (coverage: 36%)
+
+`routers/praxes.py` is the least-tested router. Missing tests:
+
+- `GET /praxes` with query filters (`task_id`, `character_id`)
+- `GET /praxes/{id}` for hidden/withdrawn praxis (404 expected)
+- `POST /praxes/{id}/withdraw` — withdraw and verify CharacterTask reverts
+  to `in_progress`, score decreases
+- `POST /praxes/{id}/resubmit` — resubmit and verify status + score restore
+- `DELETE /praxes/{id}` — character deletes own praxis
+- Media upload (`POST /praxes/{id}/media`) — at least a smoke test
+
+**File:** `backend/tests/integration/test_submissions.py`
+**Target:** raise `routers/praxes.py` from 36% → 70%+
+
+> **Rescoped 2026-04-17** after auditing the suite against the SESSION R rules changes. Most of T.5–T.9 turned out to be largely done already. The remaining work is: (a) cover the new R rules with explicit tests, (b) rename a couple of test functions whose names now lie about what they test, and (c) fill small gaps. T.10 is new and is the highest-value item here.
+
+### TASK T.5 ✅ 2026-04-17 — Integration tests: characters routes (coverage ~57%)
+
+**Current state:** 31 tests cover CRUD, list filters (search, faction, pagination), stats exposure, avatar upload (including 403 cases), relationships, votes-received, and the second-character level gate. The gate test functions correctly check the **level 5** threshold from R.7, but their names still say "level3".
+
+**Remaining work:**
+
+1. Rename `test_second_character_blocked_below_level3` → `test_second_character_blocked_below_level5`
+2. Rename `test_second_character_allowed_at_level3` → `test_second_character_allowed_at_level5`
+3. Add `test_albescent_requires_level8_character_on_account` (R.7) — account with only a level-7 character cannot create an Albescent second character; with a level-8 character it can
+4. Add `test_albescent_character_starts_in_albescent_faction` (R.8) — newly-created Albescent character's `faction_slug == "albescent"` (not `"ua"`)
+
+**File:** `backend/tests/integration/test_characters.py`
+**Target:** raise `routers/characters.py` to 70%+
+
+---
+
+### TASK T.6 ✅ 2026-04-17 — Integration tests: tasks routes (coverage ~65%)
+
+**Current state:** 31 tests cover list filters (status, faction, level, points, exclude_character_id), propose at level-3, edit pending tasks, signup lists, hidden-faction exclusion, response field shape.
+
+**Remaining work:**
+
+1. Add `test_my_tasks_with_status_filter` — `GET /my-tasks?status=submitted` and `?status=abandoned` return the right subsets
+2. Add `test_admin_bypass_propose_level_gate` (B.5) — admin character at level 0 can propose a task
+3. Add `test_propose_metatask_requires_level6` once SESSION M lands (defer; note here as a dependency)
+
+**File:** `backend/tests/integration/test_tasks.py`
+**Target:** raise `routers/tasks.py` to 75%+
+
+---
+
+### TASK T.7 ✅ 2026-04-17 — Integration tests: auth routes (coverage ~60%)
+
+**Current state:** 15 tests cover `/auth/me` (authenticated / unauthenticated / no character / with stats / no email leak / not-admin-by-default), logout + cookie clear, and token validation (expired, malformed, wrong signature, missing Bearer prefix).
+
+**Remaining work:**
+
+1. Add `test_auth_me_exposes_votes_available` — the computed `votes_available` field from R.5 is present in the returned CharacterStats and equals `base + floor(multiplier * score) - votes_spent_this_era`
+
+**File:** `backend/tests/integration/test_auth.py`
+**Target:** raise `routers/auth.py` to 70%+
+
+---
+
+### TASK T.8 ✅ 2026-04-17 — Integration tests: admin routes (coverage ~60%, no regressions under R.5)
+
+**Current state:** 46 tests including task management, praxis moderation, character stats patching, account management, era reset, role management, and 403 coverage on every endpoint. `test_admin_patch_character_stats` still passes under R.5 because `set_character_stats` translates the `votes_available` patch into `votes_spent_this_era = max(0, cap - desired)` at the service layer.
+
+**Remaining work:**
+
+1. Add `test_admin_patch_stats_recomputes_votes_available` — PATCH with `votes_available=5`, read back, confirm the computed value matches `base + floor(multiplier * new_score) - spent` where `spent` was set to `max(0, cap - 5)`
+2. Add `test_admin_era_reset_zeros_votes_spent_this_era` (R.5) — before reset a character has `votes_spent_this_era > 0`; after reset with `reset_vote_budget=True`, it's `0`; budget recalculates from the new score
+3. Add `test_admin_era_reset_preserves_votes_spent_without_flag` — reset with `reset_vote_budget=False` carries over `votes_spent_this_era`
+
+**File:** `backend/tests/integration/test_admin.py`
+**Target:** raise `routers/admin.py` to 70%+
+
+---
+
+### TASK T.9 ✅ MOSTLY DONE — Integration tests: remaining routes
+
+factions.py (8 tests), leaderboard.py (7 tests), messages.py (10 tests), relationships.py (11 tests), votes.py (10 tests) each have solid coverage of happy paths and key error cases. collaborations.py is ⛔ superseded by P.8.
+
+**Remaining (optional, pick up only if overall coverage is below target):**
+
+- One or two tests each for leaderboard era-specific queries and message list filtering if coverage % still lags.
+
+**Target:** raise overall coverage from 59% → 80%+ after T.5 + T.7 + T.8 + T.10 land. This is the milestone where `--cov-fail-under` in `backend/pytest.ini` can be raised back from 60 → 80.
+
+---
+
+### TASK T.10 ✅ 2026-04-17 — Cover the new R rules with explicit integration tests (NEW)
+
+Each rule that shipped in PRs #105 and #106 deserves a dedicated integration test so a future regression surfaces in CI instead of prod.
+
+**File placement follows the rule's primary router.**
+
+1. **R.1 — Level gate on create_praxis** → `test_create_praxis_below_required_level_returns_403` in `test_praxes.py`. Character at level 0 attempts to create a praxis for a task with `level_required=5`; expect 403 with a message naming the required level.
+
+2. **R.3 — max_collab_participants cap (20)** → `test_collab_invite_accept_at_cap_returns_400` in `test_praxes.py`. Seed a collab praxis with 20 members; 21st invitee accepts; expect 400 and the new member is NOT added. (Use `era.max_collab_participants` — do not hardcode 20.)
+
+3. **R.4 — Account-level duel anti-self-vote** → `test_duel_vote_blocked_by_alt_character_on_same_account` in `test_votes.py`. Account A owns character A1, character A1 is a duel member; account A's other character A2 tries to cast a duel vote; expect 403. Also confirm an unrelated account's character CAN vote.
+
+4. **R.5 — Vote budget on-read** → two tests in `test_votes.py`:
+   - `test_vote_budget_increases_when_score_grows` — stats with `score=0, votes_spent=0` → budget = base. Admin patches score up by 100 → `compute_votes_available(stats, era)` reflects the new base + `floor(multiplier * 100)`.
+   - `test_vote_budget_unaffected_by_old_drift` — set `score=500` and `votes_spent_this_era=2`; confirm `votes_available = base + floor(multiplier * 500) - 2`, regardless of prior-era state.
+
+5. **R.7 + R.8 tests are already part of T.5** — do NOT duplicate them here.
+
+**Acceptance:** 5 new tests pass locally and in CI. `pytest backend/tests/integration/ -k "level_gate or collab_cap or duel_vote_blocked_by_alt or vote_budget"` returns all 5.
+
+---
+
+### Overall SESSION T finish line
+
+After T.5 + T.6 + T.7 + T.8 + T.10 merge:
+
+- Overall backend coverage should reach 80%+
+- Raise `--cov-fail-under` from 60 → 80 in `backend/pytest.ini`
+- Enable branch protection on `main` requiring the Test status check (T.3)
+
+---
+
+## 🧹 SESSION S — /simplify follow-ups (post-PR #115)
+
+> Carved out of the retroactive `/simplify` pass that merged as PR #115 on
+> 2026-04-20. The pass landed four self-contained batches (TimestampMixin,
+> moderation_status enum, layer separation, Praxis eager-load audit). These
+> tasks capture items that were **intentionally deferred** because bundling
+> them would have made #115 unreviewable, plus follow-ups surfaced by the
+> code review of #115 itself.
+>
+> **Tasks are roughly ordered by risk/effort (cheapest first).** Anything
+> marked "discussion first" should land in a separate session only after
+> Molly decides direction.
+
+---
+
+### TASK S.1 ✅ 2026-04-20 — Document the `get_praxis` cascade invariant (cheap)
+
+**Scope:** One-liner docstring / comment on `services/praxis.py::get_praxis`.
+
+**Context:** After PR #115, `services/praxis.py::delete_praxis` depends on
+`get_praxis` eagerly loading `invites` — `invites` has
+`cascade="all, delete-orphan"` but is `lazy="raise"`, so SQLAlchemy needs
+the collection loaded at delete time for the cascade to fire. Nothing in
+the code currently makes that invariant explicit; a future refactor that
+drops `selectinload(Praxis.invites)` from `get_praxis` would silently
+break praxis deletion.
+
+**Do:**
+
+1. Add a comment on `get_praxis` stating: _"Must eagerly load every
+   Praxis relationship with `cascade='all, delete-orphan'` — currently
+   just `invites` — because `delete_praxis` does `session.delete(praxis)`
+   which needs those collections in the session to cascade."_
+2. Also mention this at the top of `models/praxis.py` near the relationship
+   declarations so someone adding a new cascade thinks of it.
+
+**Files:** `backend/services/praxis.py`, `backend/models/praxis.py`
+
+**Acceptance:** Comment present. No behaviour change. Tests still green.
+
+---
+
+### TASK S.2 ✅ 2026-04-20 — Verify `cast_or_update_duel_vote` against `lazy="raise"`
+
+**Scope:** Audit + possible fix on `services/vote.py::cast_or_update_duel_vote`.
+
+**Context:** PR #115 review flagged that `services/vote.py::cast_vote_on_praxis`
+passes `praxis_id` (not the object) into `cast_or_update_duel_vote`. That
+function presumably re-fetches the Praxis. With `lazy="raise"` now on
+`votes`, `invites`, `media_items`, `flags`, any relationship access on a
+bare `session.get(Praxis, ...)` will throw. Tests pass, so either the
+function avoids those relationships or coverage has a gap.
+
+**Do:**
+
+1. Read `cast_or_update_duel_vote` end-to-end. List every `praxis.*`
+   attribute it touches (including transitive access through `members`).
+2. If it accesses a raised relationship, add `selectinload(...)` at the
+   query site (the `session.get` → `session.execute(select(...).options(...))`
+   pattern used elsewhere in the file).
+3. If it only uses selectin-loaded relationships, leave code alone but
+   write a one-line service-level test that exercises the duel-vote path
+   to lock in the invariant.
+
+**Files:** `backend/services/vote.py`, possibly `backend/tests/integration/test_votes.py`.
+
+**Acceptance:** Duel vote path has either an explicit `selectinload()` or a
+test that would catch a future regression. No `StatementError` in the test
+suite.
+
+---
+
+### TASK S.3 ✅ 2026-04-20 — Service-level test for unified anti-self-vote
+
+**Scope:** Add one test to `tests/integration/test_votes.py` (or a new
+`tests/unit/test_vote_service.py` if a DB-free variant is practical).
+
+**Context:** PR #115 moved the account-level anti-self-vote check from
+`routers/votes.py` + `routers/praxes.py` into
+`services/vote.py::cast_or_update_vote`. The service has a fallback: if
+`praxis.created_by` is not selectin-loaded, it falls back to
+`session.get(Character, praxis.created_by_id)`. Existing route-level tests
+always go through the selectin path, so the fallback is untested.
+
+**Do:**
+
+1. Construct a Praxis via `session.get(Praxis, ...)` (which does NOT load
+   `created_by`) and pass it directly into `cast_or_update_vote` with a
+   voter whose account owns the praxis.
+2. Assert it raises `HTTPException(403, "Cannot vote on your own praxis.")`.
+3. Second assertion: same setup with an unrelated voter's account → vote
+   succeeds.
+
+**Files:** `backend/tests/integration/test_votes.py`.
+
+**Acceptance:** Two new tests, both green; coverage on the fallback branch
+in `cast_or_update_vote` confirmed by coverage report.
+
+---
+
+### TASK S.4 ✅ 2026-04-20 — Adopt the new praxis/vote fixtures
+
+**Scope:** Migrate inline Praxis/PraxisMember/Vote construction in four
+integration test files to the fixtures added to conftest in PR #115.
+
+**Context:** PR #115 added `praxis_solo`, `praxis_collab`, and `vote`
+fixtures to `backend/tests/integration/conftest.py` but deliberately did
+**not** rewrite existing tests to use them (scope discipline). Left unused,
+they'll rot.
+
+**Do:**
+
+1. Grep each file below for inline Praxis/PraxisMember/Vote construction.
+2. Replace each with the corresponding fixture where the fields match.
+3. Where a test needs non-default fields, keep it inline (don't over-fit
+   the fixtures).
+
+**Files:**
+
+- `backend/tests/integration/test_praxes.py`
+- `backend/tests/integration/test_admin.py`
+- `backend/tests/integration/test_tasks.py`
+- `backend/tests/integration/test_votes.py`
+
+**Acceptance:** Every straightforward inline Praxis/Vote setup uses a
+fixture. Full suite still 345+ passing, coverage ≥ 83.94%.
+
+---
+
+### TASK S.5 ✅ 2026-04-20 — Fix N+1 in `recalculate_character_stats`
+
+**Scope:** `services/character_stats.py::recalculate_character_stats`.
+
+**Context:** PR #115 survey found `session.get(Task, praxis.task_id)` inside
+a `for praxis in ...` loop (around `character_stats.py:99`), plus similar
+per-item lookups on the collab and member loops (~lines 140, 146, 157–162).
+For a character with N scored praxes this is N+1 queries. The loop runs on
+every vote cast and on era reset for every character — a real perf wart.
+
+**Do:**
+
+1. Before each loop, collect the set of `task_id`s needed and bulk-fetch:
+   `tasks_by_id = {t.id: t for t in (await session.execute(select(Task).where(Task.id.in_(task_ids)))).scalars()}`.
+2. Replace `session.get(Task, p.task_id)` with `tasks_by_id[p.task_id]`.
+3. Same pattern for the member/character lookups.
+4. Add a test that creates a character with ≥5 scored praxes and asserts
+   the number of SQL statements emitted by `recalculate_character_stats`
+   is bounded (use `event.listens_for(engine, "before_cursor_execute")`
+   or a `Compiled` counter).
+
+**Files:** `backend/services/character_stats.py`, new test in
+`backend/tests/integration/test_votes.py` or a new
+`test_character_stats.py`.
+
+**Acceptance:** Same functional output (covered by existing tests). Query
+count for a recalculation over 5 praxes drops by ≥ 50%.
+
+---
+
+### TASK S.6 ✅ 2026-04-20 — Optimize `moderate_praxis` to skip the re-fetch
+
+**Scope:** `services/admin_service.py::moderate_praxis`.
+
+**Context:** The function currently does two `select(Praxis).options(
+selectinload(invites), selectinload(media_items)).where(id==...)` queries —
+one before the mutation, one after the commit. The second exists because
+`session.refresh(praxis)` expires relationships and would trip
+`lazy="raise"` on the subsequent `build_praxis_out`.
+
+**Do:**
+
+1. Replace the post-commit re-fetch with
+   `await session.refresh(praxis, attribute_names=["moderation_status",
+"admin_note", "flagged_at"])` — this refreshes scalar columns only and
+   leaves the initially-loaded relationships in place.
+2. Verify via the test suite (test_admin.py moderation tests).
+
+**Files:** `backend/services/admin_service.py`.
+
+**Acceptance:** One SELECT instead of two on the moderate path. All
+existing moderation tests pass.
+
+---
+
+### TASK S.7 ✅ 2026-04-20 — Fix pre-existing nullability drift (contact/message/vote)
+
+**Scope:** `backend/alembic/versions/00XX_nullability_alignment.py` (new)
+
+- possibly model tweaks.
+
+**Context:** `alembic revision --autogenerate` on PR #115 surfaced
+pre-existing drift: `contact_messages.created_at`, `message.created_at`,
+`vote.created_at`, and `vote.updated_at` are declared `nullable=False` in
+the models (or via `TimestampMixin`) but lack the NOT NULL constraint in
+the DB. There's also a `uq_vote_solo` / `uq_vote_duel` constraint naming
+mismatch. Not caused by #115 but blocks a future clean autogenerate.
+
+**Do:**
+
+1. Decide per column whether the model or the DB is authoritative.
+2. For columns where the model is right: write a migration that sets
+   `ALTER COLUMN ... SET NOT NULL` after backfilling any NULLs with
+   `COALESCE(created_at, NOW())`.
+3. For the constraint name mismatch: rename the DB constraints to match
+   the model, or add `name=` kwargs to the model `UniqueConstraint` to
+   match the DB — either is fine, be consistent.
+4. After the migration, `alembic revision --autogenerate` should produce
+   a completely empty migration.
+
+**Files:** `backend/alembic/versions/0009_*.py`, possibly `backend/models/vote.py`.
+
+**Acceptance:** Autogenerate emits zero ops. Round-trip works. Existing
+tests pass.
+
+---
+
+### TASK S.8 ✅ 2026-04-20 — Extract media service (router-level image processing)
+
+**Scope:** Move file-I/O / image-processing out of
+`routers/characters.py::upload_avatar` (60 lines) and
+`routers/praxes.py::upload_media_route` (57 lines).
+
+**Context:** Both handlers mix PIL image resizing, MIME detection, filename
+sanitization, and filesystem writes with HTTP request handling. Spec rule
+is handlers ≤ 15 lines. These were deferred from PR #115's Batch 3 because
+the right home is a new service module and the move has non-trivial
+test implications.
+
+**Do:**
+
+1. Create `backend/services/media.py`. Define:
+   - `process_and_save_avatar(upload: UploadFile, character_id: int) -> str`
+     — returns the saved relative path.
+   - `process_and_save_media(upload: UploadFile, praxis_id: int) -> MediaItem`
+     — returns the created ORM row (service adds it to the session; router
+     commits).
+2. Move the PIL pipeline (convert, thumbnail, JPEG quality), regex
+   filename sanitization, and filesystem I/O into these helpers.
+3. Shrink both handlers to ≤ 15 lines — validation + service call +
+   response.
+4. Check the existing upload tests still exercise the full path.
+
+**Files:** new `backend/services/media.py`, `backend/routers/characters.py`,
+`backend/routers/praxes.py`.
+
+**Acceptance:** Both handlers ≤ 15 lines. Upload tests in
+`test_characters.py` and `test_praxes.py` still green. Image-processing
+code has a unit-style test that doesn't go through HTTP.
+
+---
+
+### TASK S.9 ✅ 2026-04-20 — Shorten long functions in `services/praxis.py`
+
+**Scope:** `services/praxis.py` specifically; four named functions.
+
+**Context:** `invite_to_praxis` (~99 lines), `apply_metatask` (~90),
+`create_praxis` (~84), `recalculate_character_stats` (~162 lines, in
+`services/character_stats.py`). Each is dense but consists of linear
+eligibility checks that would read more clearly as named helpers.
+
+**Do:**
+
+1. For `invite_to_praxis`: extract `_check_duel_invite_eligibility(...)`
+   and `_check_collab_invite_eligibility(...)` helpers.
+2. For `apply_metatask`: extract `_check_metatask_eligibility(...)` that
+   folds the level + faction + task_type gates into one returning a
+   reason-string or `None`.
+3. For `create_praxis`: extract `_check_create_preconditions(...)`.
+4. For `recalculate_character_stats`: split into `_score_solo_praxes`,
+   `_score_collab_praxes`, `_score_duel_praxes` — three async helpers,
+   each takes character + session + era and returns a partial score.
+
+**Files:** `backend/services/praxis.py`, `backend/services/character_stats.py`.
+
+**Acceptance:** No function in these files >= 80 lines. All existing tests
+pass. No behaviour change. Each extracted helper has a module-level
+docstring one-liner.
+
+---
+
+### TASK S.10 ✅ 2026-04-20 — Decide hardcoded game-rule numbers (all era-variable)
+
+**Scope:** Discussion → potentially moving constants into `EraConfig`.
+
+**Context:** These live as module-level constants in services today:
+
+- `services/praxis.py`: `DUEL_LEVEL_REQUIRED=2`, `COLLABORATION_LEVEL_REQUIRED=1`,
+  `METATASK_APPLY_LEVEL=7`, `FLAG_LEVEL_REQUIRED=4`.
+- `services/character.py`: `SECOND_CHARACTER_LEVEL_REQUIRED=5`,
+  `ALBESCENT_LEVEL_REQUIRED=8`.
+- `services/faction_service.py`: `FACTION_GRADUATION_LEVEL=3`,
+  `INVITATION_POINT_THRESHOLD=20`.
+
+CLAUDE.md says "don't hardcode values _that live in `EraConfig`_". These
+don't currently. The question is whether they should — if a future era
+needs different level gates, they're easier to tune via `EraConfig`. If
+they're truly era-independent (e.g., cross-faction rules built into the
+game model), they can stay as domain constants.
+
+**Do (discussion step only):**
+
+1. For each constant, Molly to decide: era-variable or era-invariant.
+2. For era-variable ones: add to `EraConfig` and `eras/era_1.py`, thread
+   through the services that read them.
+3. For era-invariant ones: leave as-is but document why in a comment.
+
+**Files:** `backend/game_config.py`, `backend/eras/era_1.py`, three service
+files.
+
+**Acceptance:** Every hardcoded game-rule number in services is either
+sourced from `era.*` or carries a comment explaining why it's invariant.
+
+---
+
+### TASK S.11 ✅ 2026-04-20 — Discussion: `HTTPException` in services (documented as acceptable)
+
+**Scope:** Codebase-wide posture call.
+
+**Context:** PR #115's survey flagged 100+ `HTTPException` raises inside
+service functions. `docs/spec/SPEC-backend-architecture.md` arguably
+forbids this as a "layer leak" (services should raise domain exceptions;
+routers translate to HTTP). CLAUDE.md doesn't explicitly forbid it. The
+codebase uses it everywhere. Fixing it would require a big bang refactor.
+
+**Do (discussion):**
+
+1. Molly to decide: is the current pattern an acceptable pragmatic choice
+   or a real violation that needs fixing?
+2. If "acceptable": update `docs/spec/SPEC-backend-architecture.md` to
+   explicitly permit it, so future reviewers don't re-flag it.
+3. If "fix it": follow up with S.12 to design domain exception types
+   (`NotFoundError`, `ForbiddenError`, `ValidationError`) and a router-side
+   translation layer, then do a mechanical rewrite.
+
+**Files:** `docs/spec/SPEC-backend-architecture.md` (either outcome).
+
+**Acceptance:** A clear, documented position on HTTPException-in-services.
+
+---
+
+### TASK S.12 ✅ 2026-04-20 — Move commit() out of services (big refactor)
+
+**Scope:** 50+ call sites. Every service file except `character_capabilities.py`,
+`scoring.py`, `taunt_service.py`, `meta_task.py`.
+
+**Context:** Spec: services use `session.flush()`; the router's
+dependency (`get_db`) owns the commit. Currently every write-path service
+calls `await session.commit()` mid-function (some multiple times). Moving
+commit-ownership is a transactional refactor — it changes what "successful
+response" means (now: dependency commits after handler returns; currently:
+service commits as a side effect).
+
+**Do:**
+
+1. Update `backend/db.py::get_db` to commit on successful return from the
+   dependent route and rollback on exception (or use a transactional
+   dependency wrapper).
+2. Mechanical pass: replace every `await session.commit()` in services
+   with `await session.flush()`. Grep-driven — every service file.
+3. Any service that needs a read-your-writes guarantee mid-function
+   already has `flush()` where needed.
+4. Any integration test that committed explicitly via fixtures needs
+   review — the SAVEPOINT pattern in `conftest.py` should absorb the
+   commit because the router-level commit is now the only commit per
+   request.
+
+**Files:** `backend/db.py`, every file under `backend/services/`,
+possibly `backend/tests/integration/conftest.py`.
+
+**Acceptance:** Grep `services/ -r "session.commit()"` returns zero hits.
+Full integration suite green. At least one new test that verifies the
+transaction rolls back on an exception raised inside the service.
+
+---
+
+### TASK S.13 ✅ 2026-04-20 — Rewrite `activity_feed.py` to return dataclasses
+
+**Scope:** `services/activity_feed.py` (~925 lines); schema types stay
+under `schemas/activity_feed.py` but are constructed by the router.
+
+**Context:** Every `_fetch_*` helper in `services/activity_feed.py` builds
+and returns Pydantic `ActivityFeedItem` / `FeedCounts` /
+`ActivityFeedResponse` objects. Per spec, services should return ORM
+objects or dataclasses; routers own Pydantic.
+
+**Do:**
+
+1. Define a frozen dataclass mirror of each Pydantic class (e.g.
+   `ActivityFeedItemDC`, `FeedCountsDC`, `ActivityFeedResponseDC`) in
+   `services/activity_feed.py` (or a new internal module).
+2. Rewrite every `_fetch_*` helper to return the dataclass form.
+3. Keep the composed `get_activity_feed(...)` returning the dataclass
+   composite.
+4. Update `routers/activity_feed.py` to build the Pydantic
+   `ActivityFeedResponse` from the dataclass via a single adapter.
+5. Tests in `test_activity_feed.py` should continue to hit the route; no
+   service-level changes needed.
+
+**Files:** `backend/services/activity_feed.py`,
+`backend/routers/activity_feed.py`, possibly
+`backend/schemas/activity_feed.py` (no changes expected).
+
+**Acceptance:** Service functions return dataclasses. Router still returns
+identical JSON. Existing activity-feed integration test passes.
+
+---
+
+### TASK S.14 — Migration squash 0002–0004 (only after 0006+ is stable)
+
+**Scope:** New `0001_squashed_v2.py` (or similar) that folds
+`0002_collab_member_content` through `0006_metatask_unification` + `0007`
+
+- `0008` into a single baseline.
+
+**Context:** Migrations 0002–0004 are an evolutionary artifact — 0002
+adds columns that 0003 removes, and 0003 is superseded by 0004. Anyone
+doing a downgrade past 0005 hits a known enum-duplication bug inside
+`0003_submission_unified`. Eventually worth cleaning up.
+
+**⚠️ Do NOT start this task until:**
+
+- 0007 and 0008 have been deployed to production for at least 30 days,
+- No developer machine/CI still relies on downgrading below 0006.
+
+**Do (when the time comes):**
+
+1. Spin up a fresh Postgres.
+2. Run `alembic upgrade head` against current chain, then
+   `pg_dump --schema-only` to capture the canonical schema.
+3. Create a new squashed baseline migration that `CREATE`s everything to
+   match the dump.
+4. Delete migrations 0002–0008.
+5. Mark the new baseline as `down_revision = None`.
+6. Coordinate a deploy window; production DB stays untouched — Alembic's
+   `alembic_version` table just needs to be updated to the new baseline's
+   revision id.
+
+**Files:** `backend/alembic/versions/` — delete 0002–0008, add new squashed
+baseline.
+
+**Acceptance:** `alembic upgrade head` from fresh DB produces a schema
+identical to pre-squash `alembic upgrade head`. CI green. Documented
+production rollout plan.
+
+---
+
+## 🔴 SESSION V — Visual System Redesign ← START HERE
+
+> **Highest priority. Complete all V tasks before any other pending work.**
+>
+> Source: design handoff in `World Zero Design System/design_handoff_world_zero/`. Where the handoff disagrees with the current codebase, the handoff wins. Rule: never hardcode hex values — only CSS variables change.
+
+### V.1 — Update `WORLD_ZERO_STYLE.md` ✅ DONE
+
+Updated typography table with all 7 per-faction headline fonts, updated faction archetype table with rainbow primaries and new headline fonts, updated vote color description, updated pennant behavior note.
+
+### V.2 — Replace CSS tokens in `frontend/src/index.css` ✅ DONE 2026-04-27
+
+Faction primaries are now a rainbow (purple/yellow/magenta/green/teal/blue/orange). All derived vars (tints, borders, card-bg, card-text, card-accent, card-muted) update to match. Add `--faction-*-card-font` vars + `--font-faction-*` family vars. Update vote colors, Singularity border, Journeymen hazard stripes, Gestalt collage scraps. Update dark mode block.
+
+Source of truth for all values: `World Zero Design System/design_handoff_world_zero/colors_and_type.css`
+
+**New primaries:**
+
+| Faction     | Old                | New               |
+| ----------- | ------------------ | ----------------- |
+| UA          | `#6b6a7a` slate    | `#7c3aed` purple  |
+| Analog      | `#15803d` green    | `#ca8a04` yellow  |
+| Gestalt     | `#14532d` forest   | `#be185d` magenta |
+| S.N.I.D.E.  | `#8a6a20` ochre    | `#16a34a` green   |
+| Journeymen  | `#c49a3a` amber    | `#0e7490` teal    |
+| Singularity | `#7c3aed` violet   | `#2563eb` blue    |
+| UA Masters  | `#555555` graphite | `#c2410c` orange  |
+
+**New vote colors:** `--vote-1: #c2410c`, `--vote-2: #ca8a04`, `--vote-3: #16a34a`, `--vote-4: #2563eb`, `--vote-5: #be185d`
+
+**Files:** `frontend/src/index.css`
+
+### V.3 — Add new Google Fonts to `frontend/index.html` ✅ DONE 2026-04-27
+
+Add to the existing `<link>` import: `Permanent Marker`, `Cutive Mono`, `UnifrakturCook` (wght 700), `Caveat`, `IM Fell English` (italic).
+
+**Files:** `frontend/index.html`
+
+### V.4 — Update `frontend/tailwind.config.ts` ✅ DONE 2026-04-27
+
+Update all 7 faction color values to rainbow primaries. Add new font-family entries for the 5 new faction fonts (Caveat, Permanent Marker, Cutive Mono, IM Fell English, UnifrakturCook).
+
+**Files:** `frontend/tailwind.config.ts`
+
+### V.5 — Update `frontend/src/utils/factions.ts` fallbacks ✅ DONE 2026-04-27
+
+`FACTION_FALLBACKS` color strings must mirror `index.css` primaries exactly. Update all 7 active factions.
+
+**Files:** `frontend/src/utils/factions.ts`
+
+### V.6 — Update faction card components to use `--faction-*-card-font` ✅ DONE 2026-04-27
+
+Replace any hardcoded `fontFamily` strings in card components with `factionCssVar(slug, 'card-font')`. Confirmed locations: `TaskCardAnalog.tsx`, `TaskCardSNIDE.tsx`, `TaskCardUAMasters.tsx`, `FactionCard.tsx`. Audit all other card files for additional hardcoded fonts.
+
+**Files:** `frontend/src/components/cards/`
+
+### V.7 — Remove trailing `+` from level labels ✅ DONE 2026-04-27
+
+"lvl 2+" → "lvl 2" across 6 files.
+
+**Files:**
+
+- `frontend/src/components/ui/LevelPill.tsx`
+- `frontend/src/components/cards/TaskCardSingularity.tsx`
+- `frontend/src/components/feed/FeedCardCollabInvite.tsx`
+- `frontend/src/components/feed/FeedCardGlobalTask.tsx`
+- `frontend/src/pages/admin/TasksTab.tsx`
+- `frontend/src/pages/ProposeTask.tsx`
+
+### V.8 — Fix inactive faction pennants ✅ DONE 2026-04-27 (no code change — `FilterFactionTabs.tsx:43-44` already reads `opacity: active ? 1 : 0.85, filter: "none"`)
+
+Remove desaturate filter from inactive state. `opacity: 0.42 + saturate(0.3)` → `opacity: 0.85, filter: none`.
+
+**Files:** `frontend/src/components/ui/FilterFactionTabs.tsx`
+
+---
+
+## 🟣 SESSION 5+ — Ambitious Frontend (post-launch)
+
+> Do not start until the site is live on worldzero.org and the MVP frontend is stable.
+
+**Vision:** Faction-specific UI themes — each faction gets its own color palette, typography, background textures, and layout variations driven by a `data-faction` attribute on `<body>` + CSS custom properties.
+
+**Planned features:**
+
+- Per-faction design tokens (colors, fonts, borders) toggled when a logged-in character's faction changes
+- Easter eggs: invisible clickable elements scattered through pages that trigger hidden messages, sounds, or lore
+- Secrets: hidden routes or interactions unlocked by specific player levels (level 5 and 8 already have UX secrets in the game spec)
+- Full design system (tokens, component library) built before this phase begins
+- Sunyata and Terminal faction UI (currently hidden factions) revealed when those factions go live
+
+---
+
+## 🚀 Deployment
+
+- **Render deploy config** — not started
+- **GoDaddy DNS config** (external — worldzero.org) — not started
+
+---
+
+## ✅ Completed
+
+### 🎨 Frontend Style Polish — 2026-04-15
+
+- ✅ **Migrate remaining inline styles to Tailwind / CSS classes.** NavBar, Sidebar, FilterStamps, FilterFactionTabs, FilterLevelNodes, Tasks page, Layout.
+- ✅ **Add responsive breakpoints.** Sidebar hidden below `lg` breakpoint; card container already uses `flex-wrap`.
+- ✅ **Audit non-card components for hardcoded hex.** NavBar, Sidebar, Leaderboard, CharacterProfile, all feed card components cleaned up; new CSS vars added to index.css.
+- ✅ **Switch frontend to consume faction colors from API.** `factionRegistry` in `utils/factions.ts` now populated from `GET /game-config` via `useGameConfig`; hardcoded values remain as initial fallback only.
+- ✅ **Consolidate dark mode in non-card components.** All `dark ? x : y` color ternaries replaced with CSS variable cascades in Updates, TaskDetail, SubmitProof, ProposeTask, CharacterProfile, Leaderboard, and filter components.


### PR DESCRIPTION
## What

Salvages the **documentation** developed in the `db-config-cleanup` working tree but never committed. That tree is being retired; this preserves the docs the GitHub issues depend on.

- **11 ADRs** — 0006-comment-system, 0008-0016, and 0017-praxis-read-page (renumbered from a duplicate 0006 to resolve a number collision with 0006-comment-system).
- **CONTEXT.md** — the domain glossary grows 85 → 297 lines (the full ubiquitous language: praxis/duel/collab/relationship + this-session's Vote/Vote tally/Contribution/Merit/Metatask + the Content-slot law).
- **docs/agents** — domain, issue-tracker, triage-labels guides.

**No code changes** — the working-tree code is being triaged/discarded separately (its intent is captured in the issues below).

## Why

These ADRs are referenced by open issues (#183, #185, #186, #187, #192, #194, #196, #204) but existed only as uncommitted files. Without this, those issues reference documents that don't exist.

## Note
- `0006-praxis-read-page` → `0017` to resolve the duplicate ADR number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)