### PR TITLE
feat(#163): build praxis read / detail page with per-faction archetype dispatch

### DIFF
--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -53,6 +53,7 @@ class PraxisOut(BaseModel):
     task_id: int
     task_title: str             # populated by build_praxis_out
     task_point_value: int       # populated by build_praxis_out
+    task_level_required: int = 0  # populated by build_praxis_out; ADR-0017 §6
     task_faction_slug: Optional[str] = None  # populated by build_praxis_out; drives per-faction vote UI
     type: PraxisType
     status: PraxisStatus
@@ -61,8 +62,10 @@ class PraxisOut(BaseModel):
     moderation_status: ModerationStatus
     admin_note: Optional[str]
     flagged_at: Optional[datetime]
+    submitted_at: Optional[datetime] = None  # set on in_progress→submitted; ADR-0017 §6
     created_by_id: int
     created_by_display_name: str  # populated by build_praxis_out
+    created_by_faction_slug: Optional[str] = None  # author's member faction; actor-scoped byline; ADR-0017 §6
     created_at: datetime
     updated_at: datetime
     members: List[PraxisMemberOut]

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -201,6 +201,7 @@ async def build_praxis_out(
     can_flag = await can_flag_praxis(viewer, praxis, session, era)
 
     created_by_display_name = praxis.created_by.display_name if praxis.created_by else ""
+    created_by_faction_slug = praxis.created_by.faction_slug if praxis.created_by else None
 
     # Query applied metatasks
     applied_metatasks: list[TaskOut] = []
@@ -218,6 +219,7 @@ async def build_praxis_out(
         task_id=praxis.task_id,
         task_title=task_title,
         task_point_value=task_point_value,
+        task_level_required=praxis.task.level_required if praxis.task else 0,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
         type=praxis.type,
         status=praxis.status,
@@ -226,8 +228,10 @@ async def build_praxis_out(
         moderation_status=praxis.moderation_status,
         admin_note=praxis.admin_note,
         flagged_at=praxis.flagged_at,
+        submitted_at=praxis.submitted_at,
         created_by_id=praxis.created_by_id,
         created_by_display_name=created_by_display_name,
+        created_by_faction_slug=created_by_faction_slug,
         created_at=praxis.created_at,
         updated_at=praxis.updated_at,
         members=members,

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -53,6 +53,7 @@ export interface PraxisOut {
   task_id: number
   task_title: string
   task_point_value: number
+  task_level_required: number
   task_faction_slug: string | null
   type: PraxisType
   status: PraxisStatus
@@ -61,8 +62,10 @@ export interface PraxisOut {
   moderation_status: ModerationStatus
   admin_note: string | null
   flagged_at: string | null
+  submitted_at: string | null
   created_by_id: number
   created_by_display_name: string
+  created_by_faction_slug: string | null
   created_at: string
   updated_at: string
   members: PraxisMemberOut[]

--- a/frontend/src/components/MediaGallery.tsx
+++ b/frontend/src/components/MediaGallery.tsx
@@ -4,16 +4,24 @@ const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
 
 interface Props {
   media: MediaItemOut[]
+  /** 'column' (default) stacks items; 'grid' uses a responsive minmax(150px,1fr) grid for image specimens. */
+  layout?: 'column' | 'grid'
 }
 
 /** Media gallery with rounded images and clean borders (Style Guide §12.5). */
-export default function MediaGallery({ media }: Props) {
+export default function MediaGallery({ media, layout = 'column' }: Props) {
   if (media.length === 0) return null
 
   const sorted = [...media].sort((a, b) => a.display_order - b.display_order)
 
   return (
-    <div className="flex flex-col gap-3">
+    <div
+      style={
+        layout === 'grid'
+          ? { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: 10 }
+          : { display: 'flex', flexDirection: 'column', gap: 12 }
+      }
+    >
       {sorted.map((item) => {
         const src = `${BASE_URL}/media/${item.file_path}`
         if (item.type === 'image') {
@@ -26,7 +34,7 @@ export default function MediaGallery({ media }: Props) {
                 width: '100%',
                 borderRadius: 8,
                 objectFit: 'cover',
-                maxHeight: 384,
+                maxHeight: layout === 'grid' ? 140 : 384,
                 border: '1px solid var(--color-border)',
               }}
             />

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -7,12 +7,22 @@
  * Mirrors the TaskDetail / EditPraxis dispatchers. The loading / error /
  * not-found guards live here so archetypes can assume a non-null praxis.
  */
+import type { ComponentType } from 'react'
 import { useParams } from 'react-router-dom'
 import { usePraxisDetail } from './praxisDetail/usePraxisDetail'
+import type { PraxisDetailState } from './praxisDetail/usePraxisDetail'
+import { pickVariant } from '../utils/factionDispatch'
 import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
+import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
 
-// ponytail: no faction has a bespoke archetype yet — everyone renders
-// DefaultPraxisDetail. Add a pickVariant dispatch here when one does.
+/**
+ * Per-faction praxis-read archetype map. Keyed by task faction slug.
+ * Add one row per faction as its read-page design lands (ADR-0017, gap tracker).
+ */
+const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDetailState }>> = {
+  ephemerists: EphemeristsPraxisDetail,
+}
+
 export default function PraxisDetail() {
   const { id } = useParams<{ id: string }>()
   const state = usePraxisDetail(id)
@@ -28,5 +38,6 @@ export default function PraxisDetail() {
   )
   if (!state.praxis) return <div className="py-8 font-body text-muted">Not found.</div>
 
-  return <DefaultPraxisDetail state={state} />
+  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, state.praxis.task_faction_slug, DefaultPraxisDetail)
+  return <Archetype state={state} />
 }

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -5,6 +5,7 @@ import { formatTimestamp } from '../../../utils/dates'
 import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import type { PraxisDetailState } from '../usePraxisDetail'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
 
 /** Style Guide §12.3 */
 const RAINBOW_COLORS = ['var(--underline-1)', 'var(--underline-2)', 'var(--underline-3)', 'var(--underline-4)', 'var(--underline-5)', 'var(--underline-6)', 'var(--underline-1)', 'var(--underline-2)']
@@ -20,34 +21,7 @@ export default function DefaultPraxisDetail({
 }: {
   state: PraxisDetailState
 }) {
-  const {
-    praxis,
-    votes,
-    isOwner,
-    showAdminBar,
-    withdrawing,
-    showWithdrawConfirm,
-    setShowWithdrawConfirm,
-    withdrawError,
-    adminFailNote,
-    setAdminFailNote,
-    showFailInput,
-    setShowFailInput,
-    moderating,
-    moderateError,
-    showFlagForm,
-    setShowFlagForm,
-    flagReason,
-    setFlagReason,
-    flagging,
-    flagError,
-    setFlagError,
-    flagSubmitted,
-    handleModerate,
-    handleWithdraw,
-    handleResubmit,
-    handleFlag,
-  } = state
+  const { praxis, votes } = state
 
   // Guarded non-null by the dispatcher.
   if (!praxis) return null
@@ -65,161 +39,8 @@ export default function DefaultPraxisDetail({
         <span style={{ color: 'var(--color-text-primary)' }}>Praxis</span>
       </nav>
 
-      {/* Editing banner */}
-      {praxis.status === 'in_progress' && (
-        <div
-          style={{
-            background: 'rgba(245,158,11,0.1)', border: '2px solid rgba(245,158,11,0.3)',
-            borderRadius: 8, padding: '8px 14px', marginBottom: 12,
-            display: 'flex', alignItems: 'center', gap: 8,
-          }}
-        >
-          <span className="eyebrow">IN EDITING</span>
-          <span className="font-body" style={{ fontSize: 11, color: 'var(--color-warning)', fontWeight: 700 }}>
-            This praxis is in editing mode. Points and votes are paused until submitted.
-          </span>
-        </div>
-      )}
-
-      {/* Failed banner (visible to author) */}
-      {praxis.moderation_status === 'failed' && praxis.admin_note && (
-        <div
-          style={{
-            background: 'rgba(220,38,38,0.05)', border: '2px solid rgba(220,38,38,0.3)',
-            borderRadius: 8, padding: '8px 14px', marginBottom: 12,
-            display: 'flex', alignItems: 'center', gap: 8,
-          }}
-        >
-          <span style={{ fontSize: 16 }}>&#10007;</span>
-          <div>
-            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-danger)', fontWeight: 700, display: 'block' }}>
-              This praxis was marked as failed.
-            </span>
-            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-warning)' }}>
-              {praxis.admin_note}
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* Admin moderation bar */}
-      {showAdminBar && (
-        <div
-          className="sidebar-card mb-4"
-          style={{ padding: '10px 14px' }}
-        >
-          <div className="flex items-center gap-3 flex-wrap">
-            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', fontSize: 8 }}>
-              ADMIN &middot; Status:
-            </span>
-            <span
-              className="eyebrow"
-              style={{
-                fontSize: 8, padding: '1px 6px',
-                border: '1px solid var(--color-border)',
-                color: praxis.moderation_status === 'flagged' ? 'var(--color-danger)'
-                  : praxis.moderation_status === 'hidden' ? 'var(--color-text-tertiary)'
-                  : praxis.moderation_status === 'failed' ? 'var(--color-warning)'
-                  : 'var(--color-success)',
-              }}
-            >
-              {praxis.moderation_status}
-            </span>
-            <div className="flex items-center gap-2 ml-auto">
-              {praxis.moderation_status === 'flagged' && (
-                <>
-                  <button
-                    onClick={() => void handleModerate('visible')}
-                    disabled={moderating}
-                    className="btn-primary text-xs"
-                    style={{ padding: '2px 10px', fontSize: 9 }}
-                  >
-                    approve
-                  </button>
-                  <button
-                    onClick={() => void handleModerate('hidden')}
-                    disabled={moderating}
-                    className="btn-outline text-xs"
-                    style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }}
-                  >
-                    hide
-                  </button>
-                  <button
-                    onClick={() => setShowFailInput(!showFailInput)}
-                    disabled={moderating}
-                    className="btn-outline text-xs"
-                    style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(245,158,11,0.5)', color: 'var(--color-warning)' }}
-                  >
-                    fail
-                  </button>
-                </>
-              )}
-              {praxis.moderation_status === 'visible' && (
-                <>
-                  <button
-                    onClick={() => void handleModerate('hidden')}
-                    disabled={moderating}
-                    className="btn-outline text-xs"
-                    style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }}
-                  >
-                    hide
-                  </button>
-                  <button
-                    onClick={() => setShowFailInput(!showFailInput)}
-                    disabled={moderating}
-                    className="btn-outline text-xs"
-                    style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(245,158,11,0.5)', color: 'var(--color-warning)' }}
-                  >
-                    fail
-                  </button>
-                </>
-              )}
-              {(praxis.moderation_status === 'hidden' || praxis.moderation_status === 'failed') && (
-                <>
-                  <button
-                    onClick={() => void handleModerate('visible')}
-                    disabled={moderating}
-                    className="btn-primary text-xs"
-                    style={{ padding: '2px 10px', fontSize: 9 }}
-                  >
-                    restore
-                  </button>
-                  <button
-                    onClick={() => setShowFailInput(!showFailInput)}
-                    disabled={moderating}
-                    className="btn-outline text-xs"
-                    style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(245,158,11,0.5)', color: 'var(--color-warning)' }}
-                  >
-                    fail
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-          {showFailInput && (
-            <div className="mt-2 flex gap-2 items-end">
-              <textarea
-                className="border-2 border-border bg-card px-3 py-1 font-body text-sm focus:outline-none focus:border-ink flex-1 resize-none"
-                rows={2}
-                placeholder="Reason for failure (visible to player)..."
-                value={adminFailNote}
-                onChange={(e) => setAdminFailNote(e.target.value)}
-              />
-              <button
-                onClick={() => void handleModerate('failed', adminFailNote)}
-                disabled={moderating}
-                className="btn-primary text-xs"
-                style={{ background: 'var(--color-warning)', borderColor: 'var(--color-warning)', fontSize: 9 }}
-              >
-                confirm
-              </button>
-            </div>
-          )}
-          {moderateError && (
-            <p className="font-body text-xs mt-1" style={{ color: 'var(--color-danger)' }}>{moderateError}</p>
-          )}
-        </div>
-      )}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
 
       {/* ── Byline Block (§12.2) ── */}
       <div
@@ -271,65 +92,7 @@ export default function DefaultPraxisDetail({
         ))}
       </div>
 
-      {/* Author actions */}
-      {isOwner && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
-          <Link
-            to={`/praxes/${praxis.id}/edit`}
-            className="font-body eyebrow hover:underline"
-            style={{ color: 'var(--color-text-tertiary)' }}
-          >
-            edit this praxis
-          </Link>
-          {praxis.status === 'in_progress' ? (
-            <button
-              onClick={handleResubmit}
-              disabled={withdrawing}
-              style={{
-                background: 'var(--color-success)', color: 'var(--color-text-on-accent)',
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.08em',
-                padding: '4px 12px', border: 'none', cursor: 'pointer', borderRadius: 0,
-                opacity: withdrawing ? 0.5 : 1,
-              }}
-            >
-              {withdrawing ? '...' : 'Submit'}
-            </button>
-          ) : !showWithdrawConfirm ? (
-            <button
-              onClick={() => setShowWithdrawConfirm(true)}
-              className="font-body eyebrow"
-              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}
-            >
-              unsubmit
-            </button>
-          ) : (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Sure? Points & votes will pause.</span>
-              <button
-                onClick={handleWithdraw}
-                disabled={withdrawing}
-                style={{
-                  background: 'rgba(220,38,38,0.1)', border: '1.5px solid var(--color-danger)', color: 'var(--color-danger)',
-                  fontFamily: "'Courier Prime', monospace", fontSize: 9, textTransform: 'uppercase',
-                  padding: '3px 10px', cursor: 'pointer', borderRadius: 0,
-                }}
-              >
-                {withdrawing ? '...' : 'Yes, unsubmit'}
-              </button>
-              <button
-                onClick={() => setShowWithdrawConfirm(false)}
-                className="btn-outline" style={{ fontSize: 9, padding: '3px 10px' }}
-              >
-                Cancel
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-      {withdrawError && (
-        <p className="font-body text-xs mb-3" style={{ color: 'var(--color-danger)' }}>{withdrawError}</p>
-      )}
+      <PraxisOwnerActions state={state} />
 
       {/* ── Task Context Strip (§12.4) ── */}
       <div
@@ -402,129 +165,7 @@ export default function DefaultPraxisDetail({
         )}
       </div>
 
-      {/* ── Flag Block (§13.3) ──
-          Hidden entirely when the viewer can't flag (not level 4+, own praxis,
-          anonymous) or after the viewer successfully flagged it this session. */}
-      {flagSubmitted ? (
-        <div
-          className="sidebar-card flex items-center gap-3"
-          style={{ padding: '10px 14px' }}
-        >
-          <div
-            style={{
-              width: 32,
-              height: 32,
-              borderRadius: '50%',
-              border: '1.5px solid var(--color-success)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              flexShrink: 0,
-            }}
-          >
-            <span className="eyebrow" style={{ color: 'var(--color-success)' }}>OK</span>
-          </div>
-          <div className="flex-1">
-            <p className="font-body" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-secondary)' }}>
-              Flagged for admin review
-            </p>
-            <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-              Thanks — an admin will take a look shortly.
-            </p>
-          </div>
-        </div>
-      ) : praxis.can_flag && praxis.moderation_status !== 'flagged' && (
-        <div
-          className="sidebar-card"
-          style={{ padding: '10px 14px' }}
-        >
-          <div className="flex items-center gap-3">
-            <div
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: '50%',
-                border: '1.5px solid rgba(220,38,38,0.25)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-              }}
-            >
-              <span className="eyebrow">FLAG</span>
-            </div>
-            <div className="flex-1">
-              <p className="font-body" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-secondary)' }}>
-                Flag this praxis
-              </p>
-              <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-                If this content is inappropriate or violates the rules, flag it for admin review.
-              </p>
-            </div>
-            {!showFlagForm && (
-              <button
-                onClick={() => {
-                  setShowFlagForm(true)
-                  setFlagError(null)
-                }}
-                className="btn-outline"
-                style={{
-                  fontSize: 9,
-                  padding: '4px 12px',
-                  borderColor: 'rgba(220,38,38,0.5)',
-                  color: 'var(--color-danger)',
-                }}
-              >
-                Flag
-              </button>
-            )}
-          </div>
-          {showFlagForm && (
-            <div style={{ marginTop: 10 }}>
-              <textarea
-                className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink w-full resize-none"
-                rows={3}
-                placeholder="Describe the issue (at least 10 characters)..."
-                value={flagReason}
-                onChange={(e) => setFlagReason(e.target.value)}
-                disabled={flagging}
-              />
-              <div className="flex items-center gap-2" style={{ marginTop: 6 }}>
-                <button
-                  onClick={() => void handleFlag()}
-                  disabled={flagging}
-                  className="btn-primary"
-                  style={{
-                    fontSize: 9,
-                    padding: '4px 12px',
-                    background: 'var(--color-danger)',
-                    borderColor: 'var(--color-danger)',
-                  }}
-                >
-                  {flagging ? '...' : 'Submit flag'}
-                </button>
-                <button
-                  onClick={() => {
-                    setShowFlagForm(false)
-                    setFlagReason('')
-                    setFlagError(null)
-                  }}
-                  disabled={flagging}
-                  className="btn-outline"
-                  style={{ fontSize: 9, padding: '4px 12px' }}
-                >
-                  Cancel
-                </button>
-              </div>
-              {flagError && (
-                <p className="font-body text-xs" style={{ color: 'var(--color-danger)', marginTop: 6 }}>
-                  {flagError}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+      <PraxisFlagBlock state={state} />
 
       {/* -- Metatask Panel -- */}
       {(() => {

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -1,0 +1,377 @@
+/**
+ * The Ephemerists praxis-read page archetype.
+ *
+ * Built from the Ephemerists canon: vellum stock, iron-gall ink, foxing stains,
+ * Cinzel headings, Cormorant Garamond body, the wax-seal Concordance caster.
+ * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
+ * the shared module — this archetype owns only presentation.
+ *
+ * All colors via --eph-* and --faction-ephemerists-* CSS vars (index.css).
+ * Actor-scoped byline themes to the AUTHOR's faction, not the task's.
+ */
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import MediaGallery from '../../../components/MediaGallery'
+import EphemeristsVote from '../../../components/vote/EphemeristsVote'
+import { EphMark, EphEyebrow, Foxing, LapisLastWord, toRoman } from '../../../components/cards/ephemeristsAtoms'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const grade = praxis.task_level_required > 0 ? toRoman(praxis.task_level_required) : '—'
+
+  return (
+    <div
+      className="py-8 max-w-2xl"
+      style={{
+        position: 'relative',
+        background: 'var(--eph-vellum)',
+        border: '1px solid color-mix(in srgb, var(--eph-ink) 12%, transparent)',
+        padding: '28px 32px',
+      }}
+    >
+      {/* Age-foxing overlay — multiply-blended, pointer-events: none */}
+      <Foxing opacity={0.45} />
+
+      {/* All content sits above the foxing */}
+      <div style={{ position: 'relative', zIndex: 2 }}>
+
+        {/* ── Masthead ── */}
+        <div style={{ textAlign: 'center', marginBottom: 20 }}>
+          <EphEyebrow motto="finding · testament · codex" />
+        </div>
+
+        {/* ── Behavior slots (invariant — from shared module) ── */}
+        <PraxisAdminBar state={state} />
+        <PraxisStatusBanners state={state} />
+
+        {/* ── Status strip ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            marginBottom: 10,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Link
+            to={`/tasks/${praxis.task_id}`}
+            style={{
+              fontFamily: 'var(--eph-display)',
+              fontSize: 8,
+              letterSpacing: '0.18em',
+              color: 'var(--eph-muted)',
+              textDecoration: 'none',
+              textTransform: 'uppercase',
+            }}
+          >
+            re: {praxis.task_title}
+          </Link>
+          <span style={{ color: 'color-mix(in srgb, var(--eph-ink) 25%, transparent)', fontSize: 8 }}>·</span>
+          <span
+            style={{
+              fontFamily: 'var(--eph-display)',
+              fontSize: 8,
+              letterSpacing: '0.12em',
+              color: 'var(--eph-muted)',
+            }}
+          >
+            Grade {grade}
+          </span>
+          <span style={{ color: 'color-mix(in srgb, var(--eph-ink) 25%, transparent)', fontSize: 8 }}>·</span>
+          <span
+            style={{
+              fontFamily: 'var(--eph-serif)',
+              fontSize: 8,
+              fontStyle: 'italic',
+              color: 'var(--eph-muted)',
+            }}
+          >
+            sealed {formatTimestamp(sealedDate)}
+          </span>
+          {praxis.moderation_status === 'flagged' && (
+            <>
+              <span style={{ color: 'color-mix(in srgb, var(--eph-ink) 25%, transparent)', fontSize: 8 }}>·</span>
+              <span
+                style={{
+                  fontFamily: 'var(--eph-display)',
+                  fontSize: 7,
+                  letterSpacing: '0.1em',
+                  color: 'var(--eph-rubric)',
+                  border: '1px solid var(--eph-rubric)',
+                  padding: '1px 5px',
+                }}
+              >
+                flagged
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* ── Finding headline ── */}
+        <h1
+          style={{
+            fontFamily: 'var(--eph-display)',
+            fontSize: 26,
+            fontWeight: 700,
+            lineHeight: 1.15,
+            color: 'var(--eph-ink)',
+            marginBottom: 4,
+            letterSpacing: '0.01em',
+          }}
+        >
+          <LapisLastWord text={praxis.title ?? 'Untitled filing'} footnote />
+        </h1>
+
+        {/* Ink rule */}
+        <div
+          style={{
+            height: 1,
+            background: `linear-gradient(90deg, var(--eph-rubric), color-mix(in srgb, var(--eph-ink) 18%, transparent))`,
+            marginBottom: 16,
+          }}
+        />
+
+        {/* ── Owner actions ── */}
+        <PraxisOwnerActions state={state} />
+
+        {/* ── Actor-scoped byline ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            marginBottom: 20,
+            paddingBottom: 14,
+            borderBottom: '1px dashed color-mix(in srgb, var(--eph-ink) 18%, transparent)',
+          }}
+        >
+          <Link to={`/characters/${praxis.created_by_id}`}>
+            <div
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: '50%',
+                flexShrink: 0,
+                background: `linear-gradient(135deg, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}, ${factionCssVar(praxis.created_by_faction_slug, 'card-bg')})`,
+                border: '1.5px solid color-mix(in srgb, var(--eph-ink) 20%, transparent)',
+              }}
+            />
+          </Link>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Link
+              to={`/characters/${praxis.created_by_id}`}
+              style={{
+                fontFamily: 'var(--eph-serif)',
+                fontStyle: 'italic',
+                fontSize: 13,
+                color: 'var(--eph-lapis)',
+                textDecoration: 'none',
+                display: 'block',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
+            </Link>
+            <span
+              style={{
+                fontFamily: 'var(--eph-display)',
+                fontSize: 7.5,
+                letterSpacing: '0.1em',
+                color: 'var(--eph-muted)',
+              }}
+            >
+              {praxis.type === 'solo' ? 'sole filing' : praxis.type === 'collab' ? 'collaborative filing' : 'dueling filing'}
+            </span>
+          </div>
+          {/* Point value from task */}
+          <div style={{ textAlign: 'right', flexShrink: 0 }}>
+            <div
+              style={{
+                fontFamily: 'var(--eph-display)',
+                fontSize: 18,
+                color: 'var(--eph-ink)',
+                lineHeight: 1,
+              }}
+            >
+              {praxis.task_point_value}
+            </div>
+            <span
+              style={{
+                fontFamily: 'var(--eph-display)',
+                fontSize: 7,
+                letterSpacing: '0.14em',
+                color: 'var(--eph-muted)',
+              }}
+            >
+              BASE PTS
+            </span>
+          </div>
+        </div>
+
+        {/* ── The account ── */}
+        {praxis.body_text && (
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                marginBottom: 10,
+              }}
+            >
+              <EphMark size={10} color="var(--eph-rubric)" />
+              <span
+                style={{
+                  fontFamily: 'var(--eph-display)',
+                  fontSize: 8,
+                  letterSpacing: '0.2em',
+                  color: 'var(--eph-rubric)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                The account
+              </span>
+            </div>
+            <div
+              className="markdown-preview"
+              style={{
+                fontFamily: 'var(--eph-script)',
+                fontStyle: 'italic',
+                fontSize: 15,
+                lineHeight: 1.8,
+                color: 'var(--eph-vellum-text)',
+              }}
+            >
+              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* ── The evidence ── */}
+        {praxis.media_items.length > 0 && (
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                marginBottom: 10,
+              }}
+            >
+              <EphMark size={10} color="var(--eph-rubric)" />
+              <span
+                style={{
+                  fontFamily: 'var(--eph-display)',
+                  fontSize: 8,
+                  letterSpacing: '0.2em',
+                  color: 'var(--eph-rubric)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                The evidence · {praxis.media_items.length} {praxis.media_items.length === 1 ? 'specimen' : 'specimens'}
+              </span>
+            </div>
+            <div
+              style={{
+                border: '1px solid color-mix(in srgb, var(--eph-ink) 14%, transparent)',
+                padding: 10,
+              }}
+            >
+              <MediaGallery media={praxis.media_items} layout="grid" />
+            </div>
+          </div>
+        )}
+
+        {/* ── Ornamental divider ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 20,
+          }}
+        >
+          <div style={{ flex: 1, height: 1, background: 'color-mix(in srgb, var(--eph-ink) 14%, transparent)' }} />
+          <EphMark size={12} color="var(--eph-gold)" />
+          <div style={{ flex: 1, height: 1, background: 'color-mix(in srgb, var(--eph-ink) 14%, transparent)' }} />
+        </div>
+
+        {/* ── The concordance (vote caster) ── */}
+        <div style={{ marginBottom: 20 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginBottom: 12,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <EphMark size={10} color="var(--eph-rubric)" />
+              <span
+                style={{
+                  fontFamily: 'var(--eph-display)',
+                  fontSize: 8,
+                  letterSpacing: '0.2em',
+                  color: 'var(--eph-rubric)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                The concordance
+              </span>
+            </div>
+            {/* Points from votes */}
+            {votes && votes.total_votes > 0 && (
+              <div style={{ textAlign: 'right' }}>
+                <span
+                  style={{
+                    fontFamily: 'var(--eph-display)',
+                    fontSize: 18,
+                    color: 'var(--eph-ink)',
+                    lineHeight: 1,
+                  }}
+                >
+                  +{votes.total_score}
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--eph-display)',
+                    fontSize: 7,
+                    letterSpacing: '0.14em',
+                    color: 'var(--eph-muted)',
+                    marginLeft: 4,
+                  }}
+                >
+                  PTS FROM VOTES
+                </span>
+              </div>
+            )}
+          </div>
+          <EphemeristsVote
+            praxisId={praxis.id}
+            averageStars={votes?.average_stars}
+            totalVotes={votes?.total_votes}
+            mode="caster"
+          />
+        </div>
+
+        {/* ── Flag block ── */}
+        <PraxisFlagBlock state={state} />
+
+        {/* Backer ledger slot — per-voter breakdown; filled by #195 */}
+        {/* Comments slot — actor-scoped surface, see CONTEXT.md; built separately (#167) */}
+
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -1,0 +1,225 @@
+/**
+ * Shared behavior module for praxis-detail archetypes (ADR-0017 §2).
+ *
+ * These slots are faction-agnostic and must be rendered identically by
+ * every archetype. They are extracted here so no archetype re-implements
+ * the guards, handlers, or chrome — only the presentational slots differ.
+ *
+ * Invariant slots owned here:
+ *   - Admin moderation bar
+ *   - Withdrawn / failed banners (IN EDITING + failed note)
+ *   - Owner actions (edit / withdraw / resubmit)
+ *   - Flag block
+ */
+import { Link } from 'react-router-dom'
+import type { PraxisDetailState } from './usePraxisDetail'
+
+// ── Admin moderation bar ─────────────────────────────────────────────────────
+
+export function PraxisAdminBar({ state }: { state: PraxisDetailState }) {
+  const { praxis, showAdminBar, adminFailNote, setAdminFailNote, showFailInput, setShowFailInput, moderating, moderateError, handleModerate } = state
+  if (!showAdminBar || !praxis) return null
+
+  return (
+    <div className="sidebar-card mb-4" style={{ padding: '10px 14px' }}>
+      <div className="flex items-center gap-3 flex-wrap">
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', fontSize: 8 }}>
+          ADMIN &middot; Status:
+        </span>
+        <span
+          className="eyebrow"
+          style={{
+            fontSize: 8, padding: '1px 6px',
+            border: '1px solid var(--color-border)',
+            color: praxis.moderation_status === 'flagged' ? 'var(--color-danger)'
+              : praxis.moderation_status === 'hidden' ? 'var(--color-text-tertiary)'
+              : praxis.moderation_status === 'failed' ? 'var(--color-warning)'
+              : 'var(--color-success)',
+          }}
+        >
+          {praxis.moderation_status}
+        </span>
+        <div className="flex items-center gap-2 ml-auto">
+          {praxis.moderation_status === 'flagged' && (
+            <>
+              <button onClick={() => void handleModerate('visible')} disabled={moderating} className="btn-primary text-xs" style={{ padding: '2px 10px', fontSize: 9 }}>approve</button>
+              <button onClick={() => void handleModerate('hidden')} disabled={moderating} className="btn-outline text-xs" style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }}>hide</button>
+              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline text-xs" style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(245,158,11,0.5)', color: 'var(--color-warning)' }}>fail</button>
+            </>
+          )}
+          {praxis.moderation_status === 'visible' && (
+            <>
+              <button onClick={() => void handleModerate('hidden')} disabled={moderating} className="btn-outline text-xs" style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }}>hide</button>
+              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline text-xs" style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(245,158,11,0.5)', color: 'var(--color-warning)' }}>fail</button>
+            </>
+          )}
+          {(praxis.moderation_status === 'hidden' || praxis.moderation_status === 'failed') && (
+            <>
+              <button onClick={() => void handleModerate('visible')} disabled={moderating} className="btn-primary text-xs" style={{ padding: '2px 10px', fontSize: 9 }}>restore</button>
+              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline text-xs" style={{ padding: '2px 10px', fontSize: 9, borderColor: 'rgba(245,158,11,0.5)', color: 'var(--color-warning)' }}>fail</button>
+            </>
+          )}
+        </div>
+      </div>
+      {showFailInput && (
+        <div className="mt-2 flex gap-2 items-end">
+          <textarea
+            className="border-2 border-border bg-card px-3 py-1 font-body text-sm focus:outline-none focus:border-ink flex-1 resize-none"
+            rows={2}
+            placeholder="Reason for failure (visible to player)..."
+            value={adminFailNote}
+            onChange={(e) => setAdminFailNote(e.target.value)}
+          />
+          <button
+            onClick={() => void handleModerate('failed', adminFailNote)}
+            disabled={moderating}
+            className="btn-primary text-xs"
+            style={{ background: 'var(--color-warning)', borderColor: 'var(--color-warning)', fontSize: 9 }}
+          >
+            confirm
+          </button>
+        </div>
+      )}
+      {moderateError && <p className="font-body text-xs mt-1" style={{ color: 'var(--color-danger)' }}>{moderateError}</p>}
+    </div>
+  )
+}
+
+// ── Status banners ────────────────────────────────────────────────────────────
+
+export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
+  const { praxis } = state
+  if (!praxis) return null
+
+  return (
+    <>
+      {praxis.status === 'in_progress' && (
+        <div style={{ background: 'rgba(245,158,11,0.1)', border: '2px solid rgba(245,158,11,0.3)', borderRadius: 8, padding: '8px 14px', marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span className="eyebrow">IN EDITING</span>
+          <span className="font-body" style={{ fontSize: 11, color: 'var(--color-warning)', fontWeight: 700 }}>
+            This praxis is in editing mode. Points and votes are paused until submitted.
+          </span>
+        </div>
+      )}
+      {praxis.moderation_status === 'failed' && praxis.admin_note && (
+        <div style={{ background: 'rgba(220,38,38,0.05)', border: '2px solid rgba(220,38,38,0.3)', borderRadius: 8, padding: '8px 14px', marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 16 }}>&#10007;</span>
+          <div>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-danger)', fontWeight: 700, display: 'block' }}>
+              This praxis was marked as failed.
+            </span>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-warning)' }}>
+              {praxis.admin_note}
+            </span>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+// ── Owner actions ─────────────────────────────────────────────────────────────
+
+export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
+  const { praxis, isOwner, withdrawing, showWithdrawConfirm, setShowWithdrawConfirm, withdrawError, handleWithdraw, handleResubmit } = state
+  if (!praxis || !isOwner) return null
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+        <Link to={`/praxes/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
+          edit this praxis
+        </Link>
+        {praxis.status === 'in_progress' ? (
+          <button
+            onClick={handleResubmit}
+            disabled={withdrawing}
+            style={{ background: 'var(--color-success)', color: 'var(--color-text-on-accent)', fontFamily: "'Courier Prime', monospace", fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.08em', padding: '4px 12px', border: 'none', cursor: 'pointer', borderRadius: 0, opacity: withdrawing ? 0.5 : 1 }}
+          >
+            {withdrawing ? '...' : 'Submit'}
+          </button>
+        ) : !showWithdrawConfirm ? (
+          <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
+            unsubmit
+          </button>
+        ) : (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Sure? Points & votes will pause.</span>
+            <button
+              onClick={handleWithdraw}
+              disabled={withdrawing}
+              style={{ background: 'rgba(220,38,38,0.1)', border: '1.5px solid var(--color-danger)', color: 'var(--color-danger)', fontFamily: "'Courier Prime', monospace", fontSize: 9, textTransform: 'uppercase', padding: '3px 10px', cursor: 'pointer', borderRadius: 0 }}
+            >
+              {withdrawing ? '...' : 'Yes, unsubmit'}
+            </button>
+            <button onClick={() => setShowWithdrawConfirm(false)} className="btn-outline" style={{ fontSize: 9, padding: '3px 10px' }}>Cancel</button>
+          </div>
+        )}
+      </div>
+      {withdrawError && <p className="font-body text-xs mb-3" style={{ color: 'var(--color-danger)' }}>{withdrawError}</p>}
+    </div>
+  )
+}
+
+// ── Flag block ────────────────────────────────────────────────────────────────
+
+export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
+  const { praxis, showFlagForm, setShowFlagForm, flagReason, setFlagReason, flagging, flagError, setFlagError, flagSubmitted, handleFlag } = state
+  if (!praxis) return null
+
+  if (flagSubmitted) {
+    return (
+      <div className="sidebar-card flex items-center gap-3" style={{ padding: '10px 14px' }}>
+        <div style={{ width: 32, height: 32, borderRadius: '50%', border: '1.5px solid var(--color-success)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          <span className="eyebrow" style={{ color: 'var(--color-success)' }}>OK</span>
+        </div>
+        <div className="flex-1">
+          <p className="font-body" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-secondary)' }}>Flagged for admin review</p>
+          <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>Thanks — an admin will take a look shortly.</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!praxis.can_flag || praxis.moderation_status === 'flagged') return null
+
+  return (
+    <div className="sidebar-card" style={{ padding: '10px 14px' }}>
+      <div className="flex items-center gap-3">
+        <div style={{ width: 32, height: 32, borderRadius: '50%', border: '1.5px solid rgba(220,38,38,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          <span className="eyebrow">FLAG</span>
+        </div>
+        <div className="flex-1">
+          <p className="font-body" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-secondary)' }}>Flag this praxis</p>
+          <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>If this content is inappropriate or violates the rules, flag it for admin review.</p>
+        </div>
+        {!showFlagForm && (
+          <button onClick={() => { setShowFlagForm(true); setFlagError(null) }} className="btn-outline" style={{ fontSize: 9, padding: '4px 12px', borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }}>
+            Flag
+          </button>
+        )}
+      </div>
+      {showFlagForm && (
+        <div style={{ marginTop: 10 }}>
+          <textarea
+            className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink w-full resize-none"
+            rows={3}
+            placeholder="Describe the issue (at least 10 characters)..."
+            value={flagReason}
+            onChange={(e) => setFlagReason(e.target.value)}
+            disabled={flagging}
+          />
+          <div className="flex items-center gap-2" style={{ marginTop: 6 }}>
+            <button onClick={() => void handleFlag()} disabled={flagging} className="btn-primary" style={{ fontSize: 9, padding: '4px 12px', background: 'var(--color-danger)', borderColor: 'var(--color-danger)' }}>
+              {flagging ? '...' : 'Submit flag'}
+            </button>
+            <button onClick={() => { setShowFlagForm(false); setFlagReason(''); setFlagError(null) }} disabled={flagging} className="btn-outline" style={{ fontSize: 9, padding: '4px 12px' }}>
+              Cancel
+            </button>
+          </div>
+          {flagError && <p className="font-body text-xs" style={{ color: 'var(--color-danger)', marginTop: 6 }}>{flagError}</p>}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #163

## What this does

Implements the praxis read / detail page (ADR-0017) with faction-specific archetype dispatch. Ephemerists are the first bespoke archetype; all other factions fall through to the default layout.

## Changes

### Backend — `PraxisOut` delta (ADR-0017 §6)
- `submitted_at` — timestamp when a praxis moved from `in_progress` → `submitted`
- `task_level_required` — grade display (converted to Roman numerals in the Ephemerists archetype)
- `created_by_faction_slug` — author's faction for actor-scoped byline theming

All three are populated in `build_praxis_out` via the existing author / task joins.

### Frontend

| File | Change |
|---|---|
| `api/praxis.ts` | Mirror the 3 new fields on `PraxisOut` interface |
| `components/MediaGallery.tsx` | Add `layout` prop (`'column'` default / `'grid'` for image specimen grids) |
| `pages/praxisDetail/shared.tsx` | **New** — extract `PraxisAdminBar`, `PraxisStatusBanners`, `PraxisOwnerActions`, `PraxisFlagBlock` from `DefaultPraxisDetail` |
| `pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx` | **New** — Ephemerists archetype: vellum/foxing/Cinzel/Cormorant, actor-scoped byline, wax-seal concordance caster |
| `pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx` | Consume shared module; remove inlined duplicates |
| `pages/PraxisDetail.tsx` | Add `pickVariant` dispatch with `ARCHETYPE_BY_SLUG` |

## Out of scope (per ADR-0017 §8 + grilling comment)
- Metatask panel: DefaultPraxisDetail only; omitted from faction archetypes
- Backer ledger: reserved slot comment → #195
- Comments surface: reserved slot comment → #167

## Test plan
- [ ] Visit a praxis belonging to an Ephemerists task → Ephemerists archetype renders (vellum bg, Foxing overlay, Cinzel title, concordance caster)
- [ ] Visit a praxis belonging to any other faction → DefaultPraxisDetail renders (unchanged visually)
- [ ] Admin bar shows approve/hide/fail controls for admin users
- [ ] Owner sees edit + submit/withdraw controls
- [ ] Flag block shows / hides based on eligibility; submits flag
- [ ] Media grid layout renders in Ephemerists archetype; column layout in default
- [ ] `submitted_at` shows in Ephemerists status strip; falls back to `created_at` when null

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01592pAW2u5svVgmKmAyr7GY

---
_Generated by [Claude Code](https://claude.ai/code/session_01592pAW2u5svVgmKmAyr7GY)_