### PR TITLE
Collapse praxis scoring into one deep module (ADR-0014)

### DIFF
--- a/backend/alembic/versions/0007_rename_vote_stars_to_value.py
+++ b/backend/alembic/versions/0007_rename_vote_stars_to_value.py
@@ -1,0 +1,46 @@
+"""Rename vote.stars → vote.value (ADR-0014 vocabulary).
+
+The DB column ``stars`` becomes ``value`` to match the new vote vocabulary:
+a voter casts a 1–5 *value* (not a star rating). All application code that
+referenced ``Vote.stars`` / ``vote.stars`` is updated in the same commit.
+
+Idempotent: the rename is guarded with ``IF EXISTS`` / ``IF NOT EXISTS`` so
+running it twice on the same DB is safe.
+
+Revision ID: 0007_rename_vote_stars_to_value
+Revises: 0006_duel_two_linked_praxes
+Create Date: 2026-06-26
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007_rename_vote_stars_to_value"
+down_revision: Union[str, None] = "0006_duel_two_linked_praxes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    has_stars = conn.execute(
+        sa.text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name='vote' AND column_name='stars'"
+        )
+    ).fetchone()
+    if has_stars:
+        op.alter_column("vote", "stars", new_column_name="value")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    has_value = conn.execute(
+        sa.text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name='vote' AND column_name='value'"
+        )
+    ).fetchone()
+    if has_value:
+        op.alter_column("vote", "value", new_column_name="stars")

--- a/backend/models/vote.py
+++ b/backend/models/vote.py
@@ -26,7 +26,7 @@ class Vote(Base):
     voter_account_id: Mapped[int] = mapped_column(
         ForeignKey("account.id"), nullable=False
     )
-    stars: Mapped[int] = mapped_column(Integer, nullable=False)
+    value: Mapped[int] = mapped_column(Integer, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -374,7 +374,7 @@ async def cast_vote_route(
     session: AsyncSession = Depends(get_db),
 ):
     vote = await cast_vote_on_praxis(
-        character, praxis_id, data.stars, session, era=CURRENT_ERA,
+        character, praxis_id, data.value, session, era=CURRENT_ERA,
     )
     return VoteOut.model_validate(vote)
 

--- a/backend/routers/votes.py
+++ b/backend/routers/votes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
@@ -8,8 +8,8 @@ from models.character import Character
 from models.praxis import Praxis
 from models.vote import Vote
 from schemas.vote import VoterDetail, VoteIn, VoteOut, VoteSummary
-from services.praxis import compute_praxis_score_from_db
 from services.vote import cast_or_update_vote
+from services.vote_tally import tally_votes
 
 router = APIRouter()
 
@@ -24,7 +24,7 @@ async def cast_vote(
     praxis = await session.get(Praxis, praxis_id)
     if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
-    vote = await cast_or_update_vote(voter, praxis, data.stars, session)
+    vote = await cast_or_update_vote(voter, praxis, data.value, session)
     return VoteOut.model_validate(vote)
 
 
@@ -37,21 +37,20 @@ async def get_vote_summary(
     if praxis is None:
         raise HTTPException(status_code=404, detail="Praxis not found.")
 
-    count_result = await session.execute(
-        select(func.count()).select_from(Vote).where(Vote.praxis_id == praxis_id)
+    tallies = await tally_votes([praxis_id], session)
+    tally = tallies.get(praxis_id)
+    total_votes = tally.voter_count if tally else 0
+    average_value = (
+        tally.points_from_votes / tally.voter_count
+        if tally and tally.voter_count > 0
+        else 0.0
     )
-    total_votes = count_result.scalar_one()
-
-    avg_result = await session.execute(
-        select(func.avg(Vote.stars)).where(Vote.praxis_id == praxis_id)
-    )
-    avg_stars = float(avg_result.scalar_one_or_none() or 0.0)
-    total_score = await compute_praxis_score_from_db(praxis, session)
+    total_score = float(tally.points_from_votes) if tally else 0.0
 
     return VoteSummary(
         praxis_id=praxis_id,
         total_votes=total_votes,
-        average_stars=avg_stars,
+        average_value=average_value,
         total_score=total_score,
     )
 
@@ -77,7 +76,7 @@ async def list_voters(
             display_name=character.display_name,
             avatar_url=character.avatar_url,
             faction_slug=character.faction_slug,
-            stars=vote.stars,
+            value=vote.value,
         )
         for vote, character in result.all()
     ]

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -63,7 +63,8 @@ class PraxisOut(BaseModel):
     members: List[PraxisMemberOut]
     invites: List[PraxisInviteOut]
     media_items: List[MediaItemOut]
-    score: float                # populated by build_praxis_out
+    score: float                # populated by build_praxis_out; = Merit (ADR-0014)
+    voter_count: int = 0        # populated by build_praxis_out via vote_tally
     # duel_id is set when this praxis is a side of a duel (ADR-0011).
     duel_id: Optional[int] = None
     applied_metatasks: List[TaskOut] = []
@@ -90,8 +91,8 @@ class PraxisCardOut(BaseModel):
     submitted_at: Optional[datetime] = None
     member_count: int
     score: float
-    average_stars: Optional[float] = None
-    total_votes: int = 0
+    average_value: Optional[float] = None
+    voter_count: int = 0
     task_faction_slug: Optional[str] = None
 
     model_config = {"from_attributes": True}
@@ -114,4 +115,4 @@ class PraxisInviteCreate(BaseModel):
 
 
 class PraxisVoteIn(BaseModel):
-    stars: int
+    value: int

--- a/backend/schemas/vote.py
+++ b/backend/schemas/vote.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class VoteIn(BaseModel):
-    stars: int = Field(..., ge=1, le=5)
+    value: int = Field(..., ge=1, le=5)
 
 
 class VoteOut(BaseModel):
@@ -14,7 +14,7 @@ class VoteOut(BaseModel):
     id: int
     praxis_id: int
     voter_character_id: int
-    stars: int
+    value: int
     created_at: datetime
     updated_at: datetime
 
@@ -22,7 +22,7 @@ class VoteOut(BaseModel):
 class VoteSummary(BaseModel):
     praxis_id: int
     total_votes: int
-    average_stars: float
+    average_value: float
     total_score: float
 
 
@@ -33,4 +33,4 @@ class VoterDetail(BaseModel):
     display_name: str
     avatar_url: str
     faction_slug: str
-    stars: int
+    value: int

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -150,7 +150,7 @@ async def _fetch_votes_on_mine(
     query = (
         select(
             Vote.id,
-            Vote.stars,
+            Vote.value,
             Vote.created_at,
             Vote.praxis_id,
             Praxis.title.label("praxis_title"),
@@ -179,11 +179,11 @@ async def _fetch_votes_on_mine(
             actor_avatar_url=row.voter_avatar_url,
             payload={
                 "vote_id": row.id,
-                "stars": row.stars,
+                "value": row.value,
                 "praxis_id": row.praxis_id,
                 "praxis_title": row.praxis_title,
                 "task_point_value": row.task_point_value,
-                "points_earned": row.stars * row.task_point_value,
+                "points_earned": row.value * row.task_point_value,
             },
         ))
     return items

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -1,13 +1,11 @@
 """Service for recomputing and persisting CharacterStats from current vote data."""
 
-from typing import Optional
-
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
-from models.duel import Duel, DuelStatus
+from models.era import Era
 from models.praxis import (
     ModerationStatus,
     Praxis,
@@ -15,325 +13,9 @@ from models.praxis import (
     PraxisStatus,
     PraxisType,
 )
-from models.task import Task
-from models.vote import Vote
-from models.era import Era
 from services.era import get_current_era_row, get_or_create_stats
-from services.meta_task import get_meta_task_points_bulk
-from services.scoring import (
-    COLLABORATION_MODE_COLLAB,
-    COLLABORATION_MODE_SOLO,
-    compute_duel_multiplier,
-    compute_faction_multiplier,
-    compute_level,
-    compute_praxis_score,
-)
-
-
-async def _score_solo_praxes(
-    character_id: int,
-    character_faction_slug: str,
-    author_level: int,
-    session: AsyncSession,
-    era: EraConfig,
-    excluded_praxis_ids: Optional[set[int]] = None,
-) -> float:
-    """Sum the score contribution of all visible submitted solo praxes this character authored.
-
-    Pass ``excluded_praxis_ids`` (duel sides) to skip them — they are scored by
-    ``_score_duel_praxes`` with the appropriate duel multiplier instead.
-    """
-    solo_result = await session.execute(
-        select(Praxis).where(
-            Praxis.type == PraxisType.solo,
-            Praxis.created_by_id == character_id,
-            Praxis.moderation_status != ModerationStatus.hidden,
-            Praxis.status == PraxisStatus.submitted,
-        )
-    )
-    all_solo = solo_result.scalars().all()
-    solo_praxes = (
-        [p for p in all_solo if p.id not in excluded_praxis_ids]
-        if excluded_praxis_ids
-        else list(all_solo)
-    )
-
-    # Bulk-fetch tasks and per-praxis vote sums to avoid N+1 queries in the loop.
-    solo_task_ids = {praxis.task_id for praxis in solo_praxes}
-    tasks_by_id: dict[int, Task] = {}
-    if solo_task_ids:
-        tasks_result = await session.execute(
-            select(Task).where(Task.id.in_(solo_task_ids))
-        )
-        tasks_by_id = {task.id: task for task in tasks_result.scalars()}
-
-    solo_praxis_ids = [praxis.id for praxis in solo_praxes]
-    solo_stars_by_praxis: dict[int, int] = {}
-    if solo_praxis_ids:
-        stars_result = await session.execute(
-            select(Vote.praxis_id, func.sum(Vote.stars))
-            .where(Vote.praxis_id.in_(solo_praxis_ids))
-            .group_by(Vote.praxis_id)
-        )
-        solo_stars_by_praxis = {
-            praxis_id: int(stars or 0) for praxis_id, stars in stars_result.all()
-        }
-
-    solo_meta_points_by_praxis = await get_meta_task_points_bulk(
-        solo_praxis_ids, author_level, session
-    )
-
-    subtotal = 0.0
-    for praxis in solo_praxes:
-        task = tasks_by_id.get(praxis.task_id)
-        if task is None:
-            continue
-        task_faction_slug = task.primary_faction_slug or "na"
-        faction_multiplier = compute_faction_multiplier(
-            character_faction_slug,
-            task_faction_slug,
-            era,
-            collaboration_mode=COLLABORATION_MODE_SOLO,
-        )
-        meta_task_points = solo_meta_points_by_praxis.get(praxis.id, 0)
-        total_stars = solo_stars_by_praxis.get(praxis.id, 0)
-        subtotal += compute_praxis_score(
-            task.point_value,
-            faction_multiplier,
-            total_stars,
-            meta_task_points=meta_task_points,
-            duel_multiplier=1.0,
-        )
-    return subtotal
-
-
-async def _score_collab_praxes(
-    character_id: int,
-    character_faction_slug: str,
-    eligible_praxes: list[Praxis],
-    member_tasks_by_id: dict[int, Task],
-    session: AsyncSession,
-    era: EraConfig,
-) -> float:
-    """Sum the score contribution of this character's submitted collaboration memberships."""
-    collab_praxes = [p for p in eligible_praxes if p.type == PraxisType.collab]
-    collab_praxis_ids = [p.id for p in collab_praxes]
-
-    collab_stars_by_praxis: dict[int, int] = {}
-    if collab_praxis_ids:
-        collab_votes_result = await session.execute(
-            select(Vote.praxis_id, func.sum(Vote.stars))
-            .where(Vote.praxis_id.in_(collab_praxis_ids))
-            .group_by(Vote.praxis_id)
-        )
-        collab_stars_by_praxis = {
-            praxis_id: int(stars or 0) for praxis_id, stars in collab_votes_result.all()
-        }
-
-    subtotal = 0.0
-    for praxis in collab_praxes:
-        task = member_tasks_by_id.get(praxis.task_id)
-        if task is None:
-            continue
-        task_faction_slug = task.primary_faction_slug or "na"
-        faction_multiplier = compute_faction_multiplier(
-            character_faction_slug,
-            task_faction_slug,
-            era,
-            collaboration_mode=COLLABORATION_MODE_COLLAB,
-        )
-        total_stars = collab_stars_by_praxis.get(praxis.id, 0)
-        subtotal += compute_praxis_score(
-            task.point_value,
-            faction_multiplier,
-            total_stars,
-            meta_task_points=0,
-            duel_multiplier=1.0,
-        )
-    return subtotal
-
-
-async def _score_duel_praxes(
-    character_id: int,
-    character_faction_slug: str,
-    session: AsyncSession,
-    era: EraConfig,
-) -> tuple[float, set[int]]:
-    """Score duel sides for a character (ADR-0011).
-
-    Returns ``(score, own_duel_praxis_ids)`` so the caller can exclude those IDs
-    from the plain solo scoring pass.
-
-    Each duel side is a standalone ``type=solo`` praxis linked via the Duel table.
-    Votes go directly to the praxis; no per-member routing.
-    """
-    # Submitted solo praxes by this character
-    own_praxes_result = await session.execute(
-        select(Praxis).where(
-            Praxis.type == PraxisType.solo,
-            Praxis.created_by_id == character_id,
-            Praxis.status == PraxisStatus.submitted,
-            Praxis.moderation_status != ModerationStatus.hidden,
-        )
-    )
-    own_praxes_by_id: dict[int, Praxis] = {
-        p.id: p for p in own_praxes_result.scalars().all()
-    }
-    if not own_praxes_by_id:
-        return 0.0, set()
-
-    own_praxis_ids = list(own_praxes_by_id.keys())
-
-    # Duel rows where this character's praxis is a side (active/settled)
-    duel_result = await session.execute(
-        select(Duel).where(
-            (Duel.challenger_praxis_id.in_(own_praxis_ids))
-            | (Duel.opponent_praxis_id.in_(own_praxis_ids)),
-            Duel.status.in_([DuelStatus.active, DuelStatus.settled]),
-        )
-    )
-    duels = list(duel_result.scalars().all())
-    if not duels:
-        return 0.0, set()
-
-    # Separate own duel praxis IDs from opponent praxis IDs
-    own_duel_praxis_ids: set[int] = set()
-    opponent_praxis_ids: set[int] = set()
-    for duel in duels:
-        if duel.challenger_praxis_id in own_praxes_by_id:
-            own_duel_praxis_ids.add(duel.challenger_praxis_id)
-            if duel.opponent_praxis_id is not None:
-                opponent_praxis_ids.add(duel.opponent_praxis_id)
-        if duel.opponent_praxis_id in own_praxes_by_id:
-            own_duel_praxis_ids.add(duel.opponent_praxis_id)
-            opponent_praxis_ids.add(duel.challenger_praxis_id)
-
-    # Bulk-fetch vote totals for all involved praxes
-    all_vote_praxis_ids = own_duel_praxis_ids | opponent_praxis_ids
-    stars_result = await session.execute(
-        select(Vote.praxis_id, func.sum(Vote.stars))
-        .where(Vote.praxis_id.in_(all_vote_praxis_ids))
-        .group_by(Vote.praxis_id)
-    )
-    stars_by_praxis: dict[int, int] = {
-        praxis_id: int(stars or 0) for praxis_id, stars in stars_result.all()
-    }
-
-    # Bulk-fetch tasks for own duel praxes
-    task_ids = {own_praxes_by_id[pid].task_id for pid in own_duel_praxis_ids}
-    tasks_by_id: dict[int, Task] = {}
-    if task_ids:
-        tasks_result = await session.execute(
-            select(Task).where(Task.id.in_(task_ids))
-        )
-        tasks_by_id = {task.id: task for task in tasks_result.scalars()}
-
-    # Opponent praxis → opponent character → faction slug
-    opp_praxes_by_id: dict[int, Praxis] = {}
-    if opponent_praxis_ids:
-        opp_praxes_result = await session.execute(
-            select(Praxis).where(Praxis.id.in_(opponent_praxis_ids))
-        )
-        opp_praxes_by_id = {p.id: p for p in opp_praxes_result.scalars()}
-
-    opp_character_ids = {p.created_by_id for p in opp_praxes_by_id.values()}
-    opp_characters_by_id: dict[int, Character] = {}
-    if opp_character_ids:
-        opp_chars_result = await session.execute(
-            select(Character).where(Character.id.in_(opp_character_ids))
-        )
-        opp_characters_by_id = {c.id: c for c in opp_chars_result.scalars()}
-
-    subtotal = 0.0
-    for duel in duels:
-        if duel.challenger_praxis_id in own_praxes_by_id:
-            own_id: Optional[int] = duel.challenger_praxis_id
-            opp_id: Optional[int] = duel.opponent_praxis_id
-        else:
-            own_id = duel.opponent_praxis_id
-            opp_id = duel.challenger_praxis_id
-
-        if own_id is None:
-            continue
-        own_praxis = own_praxes_by_id.get(own_id)
-        if own_praxis is None:
-            continue
-
-        task = tasks_by_id.get(own_praxis.task_id)
-        if task is None:
-            continue
-
-        own_stars = stars_by_praxis.get(own_id, 0)
-        opp_stars = stars_by_praxis.get(opp_id, 0) if opp_id is not None else 0
-
-        opponent_faction_slug = "na"
-        if opp_id is not None:
-            opp_praxis = opp_praxes_by_id.get(opp_id)
-            if opp_praxis is not None:
-                opp_char = opp_characters_by_id.get(opp_praxis.created_by_id)
-                if opp_char is not None:
-                    opponent_faction_slug = opp_char.faction_slug
-
-        faction_multiplier = compute_faction_multiplier(
-            character_faction_slug,
-            task.primary_faction_slug or "na",
-            era,
-            collaboration_mode=COLLABORATION_MODE_SOLO,
-        )
-        duel_multiplier = compute_duel_multiplier(
-            character_faction_slug,
-            opponent_faction_slug,
-            is_winner=own_stars > opp_stars,
-            is_tied=own_stars == opp_stars,
-            era=era,
-        )
-        subtotal += compute_praxis_score(
-            task.point_value,
-            faction_multiplier,
-            own_stars,
-            meta_task_points=0,
-            duel_multiplier=duel_multiplier,
-        )
-
-    return subtotal, own_duel_praxis_ids
-
-
-async def _fetch_membership_context(
-    character_id: int,
-    session: AsyncSession,
-) -> tuple[list[PraxisMember], list[Praxis], dict[int, Praxis], dict[int, Task]]:
-    """Bulk-fetch memberships, their praxes, and eligible praxis tasks for a character."""
-    member_result = await session.execute(
-        select(PraxisMember).where(
-            PraxisMember.character_id == character_id,
-        )
-    )
-    members = list(member_result.scalars().all())
-
-    member_praxis_ids = {member.praxis_id for member in members}
-    praxes_by_id: dict[int, Praxis] = {}
-    if member_praxis_ids:
-        praxes_result = await session.execute(
-            select(Praxis).where(Praxis.id.in_(member_praxis_ids))
-        )
-        praxes_by_id = {praxis.id: praxis for praxis in praxes_result.scalars()}
-
-    eligible_praxes = [
-        praxes_by_id[member.praxis_id]
-        for member in members
-        if member.praxis_id in praxes_by_id
-        and praxes_by_id[member.praxis_id].status == PraxisStatus.submitted
-    ]
-
-    member_task_ids = {praxis.task_id for praxis in eligible_praxes}
-    member_tasks_by_id: dict[int, Task] = {}
-    if member_task_ids:
-        tasks_result = await session.execute(
-            select(Task).where(Task.id.in_(member_task_ids))
-        )
-        member_tasks_by_id = {task.id: task for task in tasks_result.scalars()}
-
-    return members, eligible_praxes, praxes_by_id, member_tasks_by_id
+from services.praxis_scoring import compute_contributions
+from services.scoring import compute_level
 
 
 async def recalculate_character_stats(
@@ -344,11 +26,12 @@ async def recalculate_character_stats(
 ) -> None:
     """Recompute and persist score, level, and vote budget for a character.
 
-    Sums scores across:
-    - All solo praxis records (formula: (base + meta) × faction × duel_multiplier + stars)
-    - All submitted collaborations/duels the character is a member of
+    Gathers all submitted praxes the character has a stake in — solo/duel praxes
+    they authored, plus collab praxes they are a member of — then delegates all
+    scoring arithmetic to ``compute_contributions`` (ADR-0014).
 
-    Safe to call on praxis creation (0 votes → base points only) or after any vote change.
+    Safe to call on praxis creation (0 votes → base points only) or after any
+    vote change.
 
     Pass ``era_row`` when calling in a loop to avoid an extra query per iteration.
     """
@@ -356,44 +39,47 @@ async def recalculate_character_stats(
         era_row = await get_current_era_row(session)
 
     author = await session.get(Character, character_id)
-    character_faction_slug = author.faction_slug if author else "na"
+    if author is None:
+        return
 
-    # Pre-fetch current stats to get author level for meta task lookups.
-    # This is the *current* level before recalculation; it's used only for
-    # meta-task eligibility checks, where slight staleness is acceptable.
-    current_stats = await get_or_create_stats(session, character_id, era_row.id)
-    author_level = current_stats.level
+    # Pre-fetch current stats to get the author's level for meta-task eligibility.
+    # Slight staleness here is acceptable — the level is used only as a gate on
+    # bonus points, not as the value being computed.
+    stats = await get_or_create_stats(session, character_id, era_row.id)
+    author_level = stats.level
 
-    # Score duel sides first to get IDs to exclude from plain solo scoring.
-    duel_score, duel_praxis_ids = await _score_duel_praxes(
-        character_id, character_faction_slug, session, era
+    # Gather solo praxes (including duel sides) authored by this character.
+    solo_result = await session.execute(
+        select(Praxis).where(
+            Praxis.created_by_id == character_id,
+            Praxis.type == PraxisType.solo,
+            Praxis.status == PraxisStatus.submitted,
+            Praxis.moderation_status != ModerationStatus.hidden,
+        )
     )
-    total_score = await _score_solo_praxes(
-        character_id, character_faction_slug, author_level, session, era,
-        excluded_praxis_ids=duel_praxis_ids,
-    )
-    total_score += duel_score
+    solo_praxes = list(solo_result.scalars().all())
 
-    members, eligible_praxes, praxes_by_id, member_tasks_by_id = (
-        await _fetch_membership_context(character_id, session)
+    # Gather collab praxes this character is a member of.
+    collab_result = await session.execute(
+        select(Praxis)
+        .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
+        .where(
+            PraxisMember.character_id == character_id,
+            Praxis.type == PraxisType.collab,
+            Praxis.status == PraxisStatus.submitted,
+            Praxis.moderation_status != ModerationStatus.hidden,
+        )
     )
+    collab_praxes = list(collab_result.scalars().all())
 
-    total_score += await _score_collab_praxes(
-        character_id,
-        character_faction_slug,
-        eligible_praxes,
-        member_tasks_by_id,
-        session,
-        era,
+    all_praxes = solo_praxes + collab_praxes
+    contributions = await compute_contributions(
+        all_praxes, author, era, session, character_level=author_level
     )
-
-    new_score = int(total_score)
-    stats = current_stats
+    total_score = int(sum(c.total for c in contributions.values()))
 
     # Vote budget is computed on read (services.scoring.compute_votes_available)
-    # from stats.score and stats.votes_spent_this_era, so no bookkeeping is
-    # needed here when score changes.
-    stats.score = new_score
-    stats.all_time_score = max(stats.all_time_score, new_score)
-    stats.level = compute_level(new_score, era)
-
+    # from stats.score and stats.votes_spent_this_era, so no bookkeeping needed here.
+    stats.score = total_score
+    stats.all_time_score = max(stats.all_time_score, total_score)
+    stats.level = compute_level(total_score, era)

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -27,7 +27,6 @@ from models.praxis import (
     PraxisType,
 )
 from models.task import Task, TaskStatus, TaskType
-from models.vote import Vote
 from schemas.task import TaskOut
 from schemas.praxis import (
     MediaItemOut,
@@ -40,15 +39,7 @@ from schemas.praxis import (
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
 from models.duel import Duel, DuelStatus
-from services.meta_task import get_meta_task_points
-from services.scoring import (
-    COLLABORATION_MODE_COLLAB,
-    COLLABORATION_MODE_DUEL,
-    COLLABORATION_MODE_SOLO,
-    compute_duel_multiplier,
-    compute_faction_multiplier,
-    compute_praxis_score,
-)
+from services.vote_tally import get_tally, tally_votes
 
 
 EVERYMEN_FACTION_SLUG = "everymen"
@@ -99,116 +90,6 @@ async def _count_in_progress_praxes(character_id: int, session: AsyncSession) ->
 
 
 # ---------------------------------------------------------------------------
-# Score computation
-# ---------------------------------------------------------------------------
-
-
-async def compute_praxis_score_from_db(
-    praxis: Praxis,
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-) -> float:
-    """Compute the current score for a praxis from its votes."""
-    task = praxis.task
-    if task is None:
-        return 0.0
-
-    sum_result = await session.execute(
-        select(func.sum(Vote.stars)).where(Vote.praxis_id == praxis.id)
-    )
-    total_stars = int(sum_result.scalar_one_or_none() or 0)
-
-    if praxis.type == PraxisType.solo:
-        creator = praxis.created_by
-        character_faction_slug = creator.faction_slug if creator else "na"
-        task_faction_slug = task.primary_faction_slug or "na"
-        faction_multiplier = compute_faction_multiplier(
-            character_faction_slug,
-            task_faction_slug,
-            era,
-            collaboration_mode=COLLABORATION_MODE_SOLO,
-        )
-        if creator:
-            era_row = await get_current_era_row(session)
-            creator_stats = await get_or_create_stats(session, creator.id, era_row.id)
-            creator_level = creator_stats.level
-        else:
-            creator_level = 0
-        meta_task_points = await get_meta_task_points(praxis.id, creator_level, session)
-        return compute_praxis_score(task.point_value, faction_multiplier, total_stars, meta_task_points)
-
-    elif praxis.type == PraxisType.collab:
-        # For a collab, return the sum for the praxis as a whole (not per-member)
-        task_faction_slug = task.primary_faction_slug or "na"
-        # Use first member's faction for simplicity (caller should use per-member)
-        if praxis.members:
-            first_member = praxis.members[0]
-            character_faction_slug = first_member.character.faction_slug if first_member.character else "na"
-        else:
-            character_faction_slug = "na"
-        faction_multiplier = compute_faction_multiplier(
-            character_faction_slug,
-            task_faction_slug,
-            era,
-            collaboration_mode=COLLABORATION_MODE_COLLAB,
-        )
-        return compute_praxis_score(task.point_value, faction_multiplier, total_stars)
-
-    # Check if this praxis is a duel side (ADR-0011). If so, apply the duel
-    # win/loss multiplier using the live vote tallies of both sides.
-    duel_result = await session.execute(
-        select(Duel).where(
-            (Duel.challenger_praxis_id == praxis.id) | (Duel.opponent_praxis_id == praxis.id),
-            Duel.status.in_([DuelStatus.active, DuelStatus.settled]),
-        )
-    )
-    duel = duel_result.scalar_one_or_none()
-    if duel is not None:
-        opponent_praxis_id = (
-            duel.opponent_praxis_id
-            if duel.challenger_praxis_id == praxis.id
-            else duel.challenger_praxis_id
-        )
-        opponent_stars_result = await session.execute(
-            select(func.sum(Vote.stars)).where(Vote.praxis_id == opponent_praxis_id)
-        )
-        opponent_stars = int(opponent_stars_result.scalar_one_or_none() or 0)
-        creator = praxis.created_by
-        character_faction_slug = creator.faction_slug if creator else "na"
-        opponent_praxis = await session.get(Praxis, opponent_praxis_id)
-        opponent_faction_slug = (
-            opponent_praxis.created_by.faction_slug
-            if opponent_praxis and opponent_praxis.created_by
-            else "na"
-        )
-        task_faction_slug = task.primary_faction_slug or "na"
-        faction_multiplier = compute_faction_multiplier(
-            character_faction_slug, task_faction_slug, era,
-            collaboration_mode=COLLABORATION_MODE_SOLO,
-        )
-        duel_multiplier = compute_duel_multiplier(
-            character_faction_slug,
-            opponent_faction_slug,
-            is_winner=total_stars > opponent_stars,
-            is_tied=total_stars == opponent_stars,
-            era=era,
-        )
-        if creator:
-            era_row = await get_current_era_row(session)
-            creator_stats = await get_or_create_stats(session, creator.id, era_row.id)
-            creator_level = creator_stats.level
-        else:
-            creator_level = 0
-        meta_task_points = await get_meta_task_points(praxis.id, creator_level, session)
-        return compute_praxis_score(
-            task.point_value, faction_multiplier, total_stars,
-            meta_task_points, duel_multiplier,
-        )
-
-    return 0.0
-
-
-# ---------------------------------------------------------------------------
 # Build output objects
 # ---------------------------------------------------------------------------
 
@@ -237,7 +118,11 @@ async def build_praxis_out(
 
     media_items = [MediaItemOut.model_validate(item) for item in praxis.media_items]
 
-    score = await compute_praxis_score_from_db(praxis, session, era)
+    # Merit = task base + points_from_votes (viewer-independent; ADR-0014).
+    tally_map = await tally_votes([praxis.id], session)
+    tally = get_tally(tally_map, praxis.id)
+    task_base = praxis.task.point_value if praxis.task else 0
+    score = float(task_base + tally.points_from_votes)
 
     # Look up the Duel row if this praxis is a duel side (ADR-0011).
     duel_result = await session.execute(
@@ -289,6 +174,7 @@ async def build_praxis_out(
         invites=invites,
         media_items=media_items,
         score=score,
+        voter_count=tally.voter_count,
         duel_id=duel_id,
         can_flag=can_flag,
         applied_metatasks=applied_metatasks,
@@ -300,21 +186,22 @@ async def build_praxis_card_out(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> PraxisCardOut:
-    """Lightweight card for list views."""
+    """Lightweight card for list views.
+
+    score = Merit = task base + points_from_votes (viewer-independent; ADR-0014).
+    """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
     task_level_required = praxis.task.level_required if praxis.task else 0
-
-    score = await compute_praxis_score_from_db(praxis, session, era)
     created_by_display_name = praxis.created_by.display_name if praxis.created_by else ""
 
-    vote_stats_result = await session.execute(
-        select(func.avg(Vote.stars), func.count(Vote.id))
-        .where(Vote.praxis_id == praxis.id)
+    tally_map = await tally_votes([praxis.id], session)
+    tally = get_tally(tally_map, praxis.id)
+    score = float(task_point_value + tally.points_from_votes)
+    average_value = (
+        tally.points_from_votes / tally.voter_count
+        if tally.voter_count > 0 else None
     )
-    average_stars_raw, total_votes_raw = vote_stats_result.one()
-    average_stars = float(average_stars_raw) if average_stars_raw is not None else None
-    total_votes = int(total_votes_raw) if total_votes_raw is not None else 0
 
     return PraxisCardOut(
         id=praxis.id,
@@ -333,8 +220,8 @@ async def build_praxis_card_out(
         submitted_at=praxis.submitted_at,
         member_count=len(praxis.members),
         score=score,
-        average_stars=average_stars,
-        total_votes=total_votes,
+        average_value=average_value,
+        voter_count=tally.voter_count,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
     )
 
@@ -1160,7 +1047,6 @@ __all__ = [
     "build_praxis_card_out",
     "can_flag_praxis",
     "can_submit_praxis_for_task",
-    "compute_praxis_score_from_db",
     "create_praxis",
     "delete_praxis",
     "flag_praxis",

--- a/backend/services/praxis_scoring.py
+++ b/backend/services/praxis_scoring.py
@@ -1,0 +1,215 @@
+"""Praxis scoring — single interface for both read and recalc paths (ADR-0014).
+
+``compute_contributions`` is the one function that produces a
+``Contribution`` breakdown for each (character, praxis) pair.
+It replaces the scattered ``compute_praxis_score_from_db`` read path and the
+``_score_*`` / ``_fetch_*`` helpers in ``character_stats.py``.
+
+The pure arithmetic lives in ``services.scoring``; this module is the async
+gather-and-assemble layer on top of it.
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import EraConfig
+from models.character import Character
+from models.duel import Duel, DuelStatus
+from models.praxis import ModerationStatus, Praxis, PraxisType
+from models.task import Task
+from services.meta_task import get_meta_task_points_bulk
+from services.scoring import (
+    COLLABORATION_MODE_COLLAB,
+    COLLABORATION_MODE_SOLO,
+    compute_duel_multiplier,
+    compute_faction_multiplier,
+    compute_praxis_score,
+)
+from services.vote_tally import VoteTally, get_tally, tally_votes
+
+
+@dataclass(frozen=True)
+class Contribution:
+    """Points one character earns from one praxis — a frozen breakdown.
+
+    total = (base_points + metatask_points) × faction_multiplier
+            × duel_multiplier + points_from_votes
+    """
+
+    base_points: int
+    metatask_points: int
+    faction_multiplier: float
+    duel_multiplier: float
+    points_from_votes: int
+    total: float
+
+
+async def compute_contributions(
+    praxes: list[Praxis],
+    character: Character,
+    era: EraConfig,
+    session: AsyncSession,
+    *,
+    character_level: int = 0,
+) -> dict[int, Contribution]:
+    """Return a ``Contribution`` for each praxis id in ``praxes``.
+
+    ``praxes`` must be the submitted, non-hidden praxes this character has a
+    stake in: solo/duel praxes they authored, plus collab praxes they are
+    a member of. The caller is responsible for gathering them; this function
+    is pure scoring arithmetic over that set.
+
+    Uses bulk queries: one task fetch, one vote tally, one duel query, one
+    opponent fetch — no N+1 in the praxis count.
+    """
+    if not praxes:
+        return {}
+
+    praxis_ids = [p.id for p in praxes]
+
+    # ── bulk-fetch tasks ────────────────────────────────────────────────────
+    task_ids = {p.task_id for p in praxes}
+    tasks_result = await session.execute(
+        select(Task).where(Task.id.in_(task_ids))
+    )
+    tasks_by_id: dict[int, Task] = {t.id: t for t in tasks_result.scalars()}
+
+    # ── vote tallies for all praxes ─────────────────────────────────────────
+    tallies = await tally_votes(praxis_ids, session)
+
+    # ── duel info for solo praxes ────────────────────────────────────────────
+    # A solo praxis may be a duel side (ADR-0011). Fetch all active/settled
+    # duels that reference any of our praxes in one query.
+    duel_result = await session.execute(
+        select(Duel).where(
+            (Duel.challenger_praxis_id.in_(praxis_ids))
+            | (Duel.opponent_praxis_id.in_(praxis_ids)),
+            Duel.status.in_([DuelStatus.active, DuelStatus.settled]),
+        )
+    )
+    duels = list(duel_result.scalars().all())
+
+    # Map own praxis id → duel row
+    duel_by_own_praxis: dict[int, Duel] = {}
+    opponent_praxis_ids: set[int] = set()
+    for duel in duels:
+        if duel.challenger_praxis_id in praxis_ids:
+            duel_by_own_praxis[duel.challenger_praxis_id] = duel
+            if duel.opponent_praxis_id is not None:
+                opponent_praxis_ids.add(duel.opponent_praxis_id)
+        if duel.opponent_praxis_id in praxis_ids:
+            duel_by_own_praxis[duel.opponent_praxis_id] = duel
+            opponent_praxis_ids.add(duel.challenger_praxis_id)
+
+    # Fetch opponent praxes and their characters for faction slug
+    opp_praxes_by_id: dict[int, Praxis] = {}
+    opp_characters_by_id: dict[int, Character] = {}
+    if opponent_praxis_ids:
+        opp_praxis_result = await session.execute(
+            select(Praxis).where(Praxis.id.in_(opponent_praxis_ids))
+        )
+        opp_praxes_by_id = {p.id: p for p in opp_praxis_result.scalars()}
+
+        opp_character_ids = {p.created_by_id for p in opp_praxes_by_id.values()}
+        if opp_character_ids:
+            opp_char_result = await session.execute(
+                select(Character).where(Character.id.in_(opp_character_ids))
+            )
+            opp_characters_by_id = {c.id: c for c in opp_char_result.scalars()}
+
+    # Fetch opponent vote tallies (needed for duel win/loss determination)
+    opp_tallies: dict[int, VoteTally] = {}
+    if opponent_praxis_ids:
+        opp_tallies = await tally_votes(list(opponent_praxis_ids), session)
+
+    # ── meta task points for non-duel solo praxes ───────────────────────────
+    # Collab and duel praxes get 0 metatask points (preserving current behaviour).
+    solo_non_duel_ids = [
+        p.id for p in praxes
+        if p.type == PraxisType.solo and p.id not in duel_by_own_praxis
+    ]
+    meta_points = await get_meta_task_points_bulk(
+        solo_non_duel_ids, character_level=character_level, session=session
+    )
+
+    # ── assemble contributions ───────────────────────────────────────────────
+    contributions: dict[int, Contribution] = {}
+    character_faction = character.faction_slug or "na"
+
+    for praxis in praxes:
+        task = tasks_by_id.get(praxis.task_id)
+        if task is None:
+            continue
+
+        task_faction = task.primary_faction_slug or "na"
+        own_tally = get_tally(tallies, praxis.id)
+        base_points = task.point_value
+        metatask_points = 0
+
+        if praxis.type == PraxisType.collab:
+            faction_multiplier = compute_faction_multiplier(
+                character_faction, task_faction, era,
+                collaboration_mode=COLLABORATION_MODE_COLLAB,
+            )
+            duel_multiplier = 1.0
+
+        elif praxis.id in duel_by_own_praxis:
+            # Duel side: compare own votes vs opponent's
+            duel = duel_by_own_praxis[praxis.id]
+            if duel.challenger_praxis_id == praxis.id:
+                opp_id: Optional[int] = duel.opponent_praxis_id
+            else:
+                opp_id = duel.challenger_praxis_id
+
+            opp_tally = get_tally(opp_tallies, opp_id) if opp_id is not None else VoteTally(0, 0)
+
+            opp_praxis = opp_praxes_by_id.get(opp_id) if opp_id is not None else None
+            opponent_faction = "na"
+            if opp_praxis is not None:
+                opp_char = opp_characters_by_id.get(opp_praxis.created_by_id)
+                if opp_char is not None:
+                    opponent_faction = opp_char.faction_slug or "na"
+
+            faction_multiplier = compute_faction_multiplier(
+                character_faction, task_faction, era,
+                collaboration_mode=COLLABORATION_MODE_SOLO,
+            )
+            own_pts = own_tally.points_from_votes
+            opp_pts = opp_tally.points_from_votes
+            duel_multiplier = compute_duel_multiplier(
+                character_faction,
+                opponent_faction,
+                is_winner=own_pts > opp_pts,
+                is_tied=own_pts == opp_pts,
+                era=era,
+            )
+
+        else:
+            # Plain solo praxis
+            faction_multiplier = compute_faction_multiplier(
+                character_faction, task_faction, era,
+                collaboration_mode=COLLABORATION_MODE_SOLO,
+            )
+            duel_multiplier = 1.0
+            metatask_points = meta_points.get(praxis.id, 0)
+
+        total = compute_praxis_score(
+            base_points,
+            faction_multiplier,
+            own_tally.points_from_votes,
+            meta_task_points=metatask_points,
+            duel_multiplier=duel_multiplier,
+        )
+
+        contributions[praxis.id] = Contribution(
+            base_points=base_points,
+            metatask_points=metatask_points,
+            faction_multiplier=faction_multiplier,
+            duel_multiplier=duel_multiplier,
+            points_from_votes=own_tally.points_from_votes,
+            total=total,
+        )
+
+    return contributions

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -14,7 +14,7 @@ from services.scoring import compute_votes_available
 async def cast_vote_on_praxis(
     voter: Character,
     praxis_id: int,
-    stars: int,
+    value: int,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> Vote:
@@ -26,13 +26,13 @@ async def cast_vote_on_praxis(
     praxis = await session.get(Praxis, praxis_id)
     if praxis is None or praxis.moderation_status == ModerationStatus.hidden:
         raise HTTPException(status_code=404, detail="Praxis not found.")
-    return await cast_or_update_vote(voter, praxis, stars, session, era)
+    return await cast_or_update_vote(voter, praxis, value, session, era)
 
 
 async def cast_or_update_vote(
     voter: Character,
     praxis: Praxis,
-    stars: int,
+    value: int,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> Vote:
@@ -41,8 +41,8 @@ async def cast_or_update_vote(
     Enforces account-level anti-self-vote so alt characters on the same account
     cannot vote on each other's praxes.
     """
-    if not 1 <= stars <= 5:
-        raise HTTPException(status_code=422, detail="Stars must be between 1 and 5.")
+    if not 1 <= value <= 5:
+        raise HTTPException(status_code=422, detail="Vote value must be between 1 and 5.")
 
     # Account-level anti-self-vote. Praxis.created_by is selectin-loaded,
     # but fall back to an explicit lookup if it isn't populated.
@@ -62,7 +62,7 @@ async def cast_or_update_vote(
 
     if existing is not None:
         # Update is free — no budget deduction
-        existing.stars = stars
+        existing.value = value
         await session.flush()
         await recalculate_character_stats(praxis.created_by_id, session, era)
         await session.flush()
@@ -80,7 +80,7 @@ async def cast_or_update_vote(
         praxis_id=praxis.id,
         voter_character_id=voter.id,
         voter_account_id=voter.account_id,
-        stars=stars,
+        value=value,
     )
     stats.votes_spent_this_era += 1
     session.add(vote)

--- a/backend/services/vote_tally.py
+++ b/backend/services/vote_tally.py
@@ -1,0 +1,94 @@
+"""Single source for vote aggregation (ADR-0014).
+
+``tally_votes`` is the one place in the codebase that runs
+``func.sum(Vote.value)`` / ``func.count`` / per-voter breakdown queries.
+All scoring code and display code consume it; scattered per-query vote sums
+are deleted.
+"""
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.vote import Vote
+
+
+@dataclass(frozen=True)
+class PerVoterEntry:
+    character_id: int
+    display_name: str
+    value: int
+
+
+@dataclass(frozen=True)
+class VoteTally:
+    """Aggregated vote data for one praxis."""
+
+    points_from_votes: int
+    voter_count: int
+    per_voter: tuple[PerVoterEntry, ...] = field(default_factory=tuple)
+
+
+_EMPTY_TALLY = VoteTally(points_from_votes=0, voter_count=0, per_voter=())
+
+
+async def tally_votes(
+    praxis_ids: list[int],
+    session: AsyncSession,
+    *,
+    include_per_voter: bool = False,
+) -> dict[int, VoteTally]:
+    """Return a ``VoteTally`` for each requested praxis id.
+
+    Praxes with no votes are not included in the result; callers should use
+    ``.get(praxis_id, EMPTY_TALLY)`` or the helper :func:`get_tally`.
+
+    ``include_per_voter=True`` populates each tally's ``per_voter`` list with
+    (character_id, display_name, value) entries sorted by vote creation time.
+    Leave it False (the default) for scoring paths that only need the sum.
+    """
+    if not praxis_ids:
+        return {}
+
+    agg_result = await session.execute(
+        select(Vote.praxis_id, func.sum(Vote.value), func.count(Vote.id))
+        .where(Vote.praxis_id.in_(praxis_ids))
+        .group_by(Vote.praxis_id)
+    )
+    tallies: dict[int, VoteTally] = {
+        pid: VoteTally(
+            points_from_votes=int(total or 0),
+            voter_count=int(count or 0),
+        )
+        for pid, total, count in agg_result.all()
+    }
+
+    if include_per_voter and tallies:
+        voter_result = await session.execute(
+            select(Vote.praxis_id, Vote.voter_character_id, Vote.value, Character.display_name)
+            .join(Character, Character.id == Vote.voter_character_id)
+            .where(Vote.praxis_id.in_(list(tallies.keys())))
+            .order_by(Vote.praxis_id, Vote.created_at)
+        )
+        per_voter_map: dict[int, list[PerVoterEntry]] = {}
+        for pid, char_id, val, name in voter_result.all():
+            per_voter_map.setdefault(pid, []).append(
+                PerVoterEntry(character_id=char_id, display_name=name, value=val)
+            )
+        tallies = {
+            pid: VoteTally(
+                points_from_votes=t.points_from_votes,
+                voter_count=t.voter_count,
+                per_voter=tuple(per_voter_map.get(pid, [])),
+            )
+            for pid, t in tallies.items()
+        }
+
+    return tallies
+
+
+def get_tally(tallies: dict[int, VoteTally], praxis_id: int) -> VoteTally:
+    """Return the tally for ``praxis_id``, falling back to an empty tally."""
+    return tallies.get(praxis_id, _EMPTY_TALLY)

--- a/backend/services/vote_tally.py
+++ b/backend/services/vote_tally.py
@@ -1,25 +1,15 @@
 """Single source for vote aggregation (ADR-0014).
 
 ``tally_votes`` is the one place in the codebase that runs
-``func.sum(Vote.value)`` / ``func.count`` / per-voter breakdown queries.
-All scoring code and display code consume it; scattered per-query vote sums
-are deleted.
+``func.sum(Vote.value)`` / ``func.count``. All scoring code and display code
+consume it; scattered per-query vote sums are deleted.
 """
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import dataclass
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.character import Character
 from models.vote import Vote
-
-
-@dataclass(frozen=True)
-class PerVoterEntry:
-    character_id: int
-    display_name: str
-    value: int
 
 
 @dataclass(frozen=True)
@@ -28,26 +18,19 @@ class VoteTally:
 
     points_from_votes: int
     voter_count: int
-    per_voter: tuple[PerVoterEntry, ...] = field(default_factory=tuple)
 
 
-_EMPTY_TALLY = VoteTally(points_from_votes=0, voter_count=0, per_voter=())
+_EMPTY_TALLY = VoteTally(points_from_votes=0, voter_count=0)
 
 
 async def tally_votes(
     praxis_ids: list[int],
     session: AsyncSession,
-    *,
-    include_per_voter: bool = False,
 ) -> dict[int, VoteTally]:
     """Return a ``VoteTally`` for each requested praxis id.
 
     Praxes with no votes are not included in the result; callers should use
-    ``.get(praxis_id, EMPTY_TALLY)`` or the helper :func:`get_tally`.
-
-    ``include_per_voter=True`` populates each tally's ``per_voter`` list with
-    (character_id, display_name, value) entries sorted by vote creation time.
-    Leave it False (the default) for scoring paths that only need the sum.
+    the helper :func:`get_tally`.
     """
     if not praxis_ids:
         return {}
@@ -57,36 +40,13 @@ async def tally_votes(
         .where(Vote.praxis_id.in_(praxis_ids))
         .group_by(Vote.praxis_id)
     )
-    tallies: dict[int, VoteTally] = {
+    return {
         pid: VoteTally(
             points_from_votes=int(total or 0),
             voter_count=int(count or 0),
         )
         for pid, total, count in agg_result.all()
     }
-
-    if include_per_voter and tallies:
-        voter_result = await session.execute(
-            select(Vote.praxis_id, Vote.voter_character_id, Vote.value, Character.display_name)
-            .join(Character, Character.id == Vote.voter_character_id)
-            .where(Vote.praxis_id.in_(list(tallies.keys())))
-            .order_by(Vote.praxis_id, Vote.created_at)
-        )
-        per_voter_map: dict[int, list[PerVoterEntry]] = {}
-        for pid, char_id, val, name in voter_result.all():
-            per_voter_map.setdefault(pid, []).append(
-                PerVoterEntry(character_id=char_id, display_name=name, value=val)
-            )
-        tallies = {
-            pid: VoteTally(
-                points_from_votes=t.points_from_votes,
-                voter_count=t.voter_count,
-                per_voter=tuple(per_voter_map.get(pid, [])),
-            )
-            for pid, t in tallies.items()
-        }
-
-    return tallies
 
 
 def get_tally(tallies: dict[int, VoteTally], praxis_id: int) -> VoteTally:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -373,7 +373,7 @@ async def vote(
         praxis_id=praxis_solo.id,
         voter_character_id=character2.id,
         voter_account_id=character2.account_id,
-        stars=4,
+        value=4,
     )
     db_session.add(vote_row)
     await db_session.commit()

--- a/backend/tests/integration/test_activity_feed.py
+++ b/backend/tests/integration/test_activity_feed.py
@@ -35,7 +35,7 @@ async def test_activity_feed_shows_votes_on_mine(
     # character2 votes on it (voter != praxis owner, distinct accounts)
     vote_resp = await client.post(
         f"/praxes/{praxis_id}/vote",
-        json={"stars": 4},
+        json={"value": 4},
         headers=auth_headers2,
     )
     assert vote_resp.status_code == 200
@@ -53,5 +53,5 @@ async def test_activity_feed_shows_votes_on_mine(
     assert len(vote_items) == 1, f"Expected one vote_on_mine item, got: {data['items']}"
     entry = vote_items[0]
     assert entry["payload"]["praxis_id"] == praxis_id
-    assert entry["payload"]["stars"] == 4
+    assert entry["payload"]["value"] == 4
     assert entry["actor_display_name"] == character2.display_name

--- a/backend/tests/integration/test_character_stats.py
+++ b/backend/tests/integration/test_character_stats.py
@@ -76,7 +76,7 @@ async def _seed_solo_praxes_with_votes(
                 praxis_id=praxis.id,
                 voter_character_id=voter_character.id,
                 voter_account_id=voter_account.id,
-                stars=3,
+                value=3,
             )
         )
         praxes.append(praxis)

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -845,7 +845,7 @@ async def test_votes_received_with_votes(
         praxis_id=praxis.id,
         voter_character_id=character2.id,
         voter_account_id=character2.account_id,
-        stars=4,
+        value=4,
     )
     db_session.add(vote)
     await db_session.commit()

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1207,7 +1207,7 @@ async def test_create_praxis_retired_task_allowed_for_ephemerists(
 
 
 # ---------------------------------------------------------------------------
-# PraxisCardOut new fields: task_level_required, average_stars, total_votes,
+# PraxisCardOut new fields: task_level_required, average_value, voter_count,
 # submitted_at (issue #159)
 # ---------------------------------------------------------------------------
 
@@ -1219,7 +1219,7 @@ async def test_praxis_card_includes_new_fields(
     active_task: Task,
     auth_headers: dict,
 ):
-    """GET /praxes list returns task_level_required, average_stars (null), total_votes (0),
+    """GET /praxes list returns task_level_required, average_value (null), voter_count (0),
     and submitted_at (null) for a newly-created in_progress praxis."""
     create_resp = await client.post(
         "/praxes",
@@ -1239,8 +1239,8 @@ async def test_praxis_card_includes_new_fields(
     assert isinstance(card["task_level_required"], int)
     assert card["task_level_required"] == active_task.level_required
 
-    assert card["average_stars"] is None
-    assert card["total_votes"] == 0
+    assert card["average_value"] is None
+    assert card["voter_count"] == 0
     assert card["submitted_at"] is None
 
 
@@ -1274,7 +1274,7 @@ async def test_submitted_at_set_on_submit(
 
 
 @pytest.mark.asyncio
-async def test_average_stars_and_total_votes_after_vote(
+async def test_average_value_and_voter_count_after_vote(
     client: AsyncClient,
     character: Character,
     character2: Character,
@@ -1282,7 +1282,7 @@ async def test_average_stars_and_total_votes_after_vote(
     auth_headers: dict,
     auth_headers2: dict,
 ):
-    """average_stars and total_votes reflect votes cast on the praxis."""
+    """average_value and voter_count reflect votes cast on the praxis."""
     # character2 creates a praxis
     create_resp = await client.post(
         "/praxes",
@@ -1292,10 +1292,10 @@ async def test_average_stars_and_total_votes_after_vote(
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
 
-    # character votes 4 stars
+    # character votes 4
     vote_resp = await client.post(
         f"/praxes/{praxis_id}/vote",
-        json={"stars": 4},
+        json={"value": 4},
         headers=auth_headers,
     )
     assert vote_resp.status_code == 200
@@ -1303,9 +1303,9 @@ async def test_average_stars_and_total_votes_after_vote(
     list_resp = await client.get("/praxes")
     card = next(c for c in list_resp.json() if c["id"] == praxis_id)
 
-    assert card["total_votes"] == 1
-    assert card["average_stars"] is not None
-    assert abs(card["average_stars"] - 4.0) < 0.01
+    assert card["voter_count"] == 1
+    assert card["average_value"] is not None
+    assert abs(card["average_value"] - 4.0) < 0.01
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_praxis_scoring.py
+++ b/backend/tests/integration/test_praxis_scoring.py
@@ -1,0 +1,213 @@
+"""Integration tests for services.praxis_scoring.compute_contributions (ADR-0014).
+
+Verifies that the Contribution formula is correct for solo, collab, and duel
+praxis types, and that recalculate_character_stats delegates to it correctly.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task
+from models.vote import Vote
+from services.praxis_scoring import Contribution, compute_contributions
+from services.character_stats import recalculate_character_stats
+
+
+async def _submit(praxis: Praxis, db_session: AsyncSession) -> None:
+    """Transition a praxis to submitted status in-session."""
+    praxis.status = PraxisStatus.submitted
+    await db_session.flush()
+
+
+async def _cast_vote(
+    praxis: Praxis,
+    voter: Character,
+    value: int,
+    db_session: AsyncSession,
+) -> None:
+    """Direct Vote insert — bypasses service layer budget check."""
+    db_session.add(
+        Vote(
+            praxis_id=praxis.id,
+            voter_character_id=voter.id,
+            voter_account_id=voter.account_id,
+            value=value,
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_contribution_solo_no_votes(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+):
+    """Solo praxis with no votes → total equals base_points × faction_multiplier."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        title="Solo no votes",
+        body_text="proof",
+        status=PraxisStatus.submitted,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+
+    contributions = await compute_contributions(
+        [praxis], character, CURRENT_ERA, db_session
+    )
+
+    assert praxis.id in contributions
+    contrib = contributions[praxis.id]
+    assert contrib.base_points == active_task.point_value
+    assert contrib.points_from_votes == 0
+    assert contrib.duel_multiplier == 1.0
+    # total = (base + 0) × faction_multiplier × 1.0 + 0
+    assert contrib.total == pytest.approx(
+        active_task.point_value * contrib.faction_multiplier
+    )
+
+
+@pytest.mark.asyncio
+async def test_contribution_solo_with_vote(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+):
+    """Solo praxis with one 4-point vote → points_from_votes == 4."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        title="Solo with vote",
+        body_text="proof",
+        status=PraxisStatus.submitted,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    await _cast_vote(praxis, character2, 4, db_session)
+
+    contributions = await compute_contributions(
+        [praxis], character, CURRENT_ERA, db_session
+    )
+
+    contrib = contributions[praxis.id]
+    assert contrib.points_from_votes == 4
+    assert contrib.total == pytest.approx(
+        active_task.point_value * contrib.faction_multiplier + 4
+    )
+
+
+@pytest.mark.asyncio
+async def test_contribution_collab_member(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+):
+    """Collab praxis member gets a contribution with COLLAB faction multiplier."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.collab,
+        title="Collab praxis",
+        body_text="proof",
+        status=PraxisStatus.submitted,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=praxis.id, character_id=character.id))
+    await db_session.flush()
+
+    contributions = await compute_contributions(
+        [praxis], character, CURRENT_ERA, db_session
+    )
+
+    assert praxis.id in contributions
+    contrib = contributions[praxis.id]
+    assert contrib.base_points == active_task.point_value
+    # Collab multiplier is a separate config value from solo — just assert non-zero
+    assert contrib.faction_multiplier > 0
+    assert contrib.duel_multiplier == 1.0
+
+
+@pytest.mark.asyncio
+async def test_recalculate_character_stats_reflects_vote(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+):
+    """recalculate_character_stats scores a solo praxis + its vote contribution."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        title="Score praxis",
+        body_text="proof",
+        status=PraxisStatus.submitted,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    await _cast_vote(praxis, character2, 3, db_session)
+    await db_session.commit()
+
+    await recalculate_character_stats(character.id, db_session, CURRENT_ERA)
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    # At minimum, score ≥ base task points (faction_multiplier ≥ 1 for same-faction)
+    assert stats.score >= active_task.point_value
+
+
+@pytest.mark.asyncio
+async def test_merit_formula_equals_base_plus_votes(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+):
+    """Merit = task_base + points_from_votes — viewer-independent (ADR-0014 §Merit).
+
+    For a same-faction solo praxis the faction_multiplier is the SOLO config value.
+    This test verifies the points_from_votes component is added correctly.
+    """
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        title="Merit formula check",
+        body_text="proof",
+        status=PraxisStatus.submitted,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    await _cast_vote(praxis, character2, 5, db_session)
+
+    contributions = await compute_contributions(
+        [praxis], character, CURRENT_ERA, db_session
+    )
+    contrib = contributions[praxis.id]
+
+    # points_from_votes should equal the single vote value
+    assert contrib.points_from_votes == 5
+    # Merit (viewer-independent read path) = base + points_from_votes
+    merit = active_task.point_value + contrib.points_from_votes
+    assert merit == active_task.point_value + 5

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -39,12 +39,12 @@ async def test_cast_vote_on_solo_praxis(
     # character votes
     vote_resp = await client.post(
         f"/praxes/{praxis_id}/vote",
-        json={"stars": 4},
+        json={"value": 4},
         headers=auth_headers,
     )
     assert vote_resp.status_code == 200
     data = vote_resp.json()
-    assert data["stars"] == 4
+    assert data["value"] == 4
     assert data["praxis_id"] == praxis_id
     assert data["voter_character_id"] == character.id
 
@@ -67,7 +67,7 @@ async def test_cast_vote_self_blocked(
 
     vote_resp = await client.post(
         f"/praxes/{praxis_id}/vote",
-        json={"stars": 5},
+        json={"value": 5},
         headers=auth_headers,
     )
     assert vote_resp.status_code == 403
@@ -107,7 +107,7 @@ async def test_update_vote_is_free(
 
     # Initial vote
     resp1 = await client.post(
-        f"/praxes/{praxis_id}/vote", json={"stars": 3}, headers=auth_headers
+        f"/praxes/{praxis_id}/vote", json={"value": 3}, headers=auth_headers
     )
     assert resp1.status_code == 200
 
@@ -117,10 +117,10 @@ async def test_update_vote_is_free(
 
     # Update vote (no additional cost)
     resp2 = await client.post(
-        f"/praxes/{praxis_id}/vote", json={"stars": 5}, headers=auth_headers
+        f"/praxes/{praxis_id}/vote", json={"value": 5}, headers=auth_headers
     )
     assert resp2.status_code == 200
-    assert resp2.json()["stars"] == 5
+    assert resp2.json()["value"] == 5
 
     await db_session.refresh(stats)
     assert compute_votes_available(stats) == budget_after_first  # unchanged
@@ -145,7 +145,7 @@ async def test_invalid_stars_returns_422(
     praxis_id = create_resp.json()["id"]
 
     resp = await client.post(
-        f"/praxes/{praxis_id}/vote", json={"stars": 6}, headers=auth_headers
+        f"/praxes/{praxis_id}/vote", json={"value": 6}, headers=auth_headers
     )
     assert resp.status_code == 422
 
@@ -179,10 +179,10 @@ async def test_vote_updates_author_stats(
     submit_resp = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
     assert submit_resp.status_code == 200
 
-    # character votes 4 stars — triggers recalculate_character_stats for character2
+    # character votes 4 — triggers recalculate_character_stats for character2
     vote_resp = await client.post(
         f"/praxes/{praxis_id}/vote",
-        json={"stars": 4},
+        json={"value": 4},
         headers=auth_headers,
     )
     assert vote_resp.status_code == 200
@@ -382,19 +382,19 @@ async def test_vote_on_duel_side_praxis(
     # Vote on each side praxis — no praxis_member_id needed
     vote1 = await client.post(
         f"/praxes/{challenger_praxis_id}/vote",
-        json={"stars": 4},
+        json={"value": 4},
         headers=c_headers,
     )
     assert vote1.status_code == 200
-    assert vote1.json()["stars"] == 4
+    assert vote1.json()["value"] == 4
 
     vote2 = await client.post(
         f"/praxes/{opponent_praxis_id}/vote",
-        json={"stars": 3},
+        json={"value": 3},
         headers=c_headers,
     )
     assert vote2.status_code == 200
-    assert vote2.json()["stars"] == 3
+    assert vote2.json()["value"] == 3
 
 
 @pytest.mark.asyncio
@@ -538,6 +538,6 @@ async def test_anti_self_vote_fallback_allows_unrelated_voter(
 
     # character2 (different account) casts a vote — must succeed
     vote = await cast_or_update_vote(character2, praxis_unloaded, 3, db_session)
-    assert vote.stars == 3
+    assert vote.value == 3
     assert vote.voter_character_id == character2.id
     assert vote.praxis_id == praxis_solo.id

--- a/backend/tests/unit/test_vote_tally.py
+++ b/backend/tests/unit/test_vote_tally.py
@@ -1,0 +1,39 @@
+"""Unit tests for services.vote_tally — pure helpers only."""
+
+from services.vote_tally import PerVoterEntry, VoteTally, get_tally
+
+
+def test_get_tally_returns_empty_when_missing():
+    assert get_tally({}, 99) == VoteTally(0, 0)
+
+
+def test_get_tally_returns_entry_when_present():
+    entry = VoteTally(points_from_votes=12, voter_count=3)
+    result = get_tally({42: entry}, 42)
+    assert result is entry
+
+
+def test_vote_tally_defaults():
+    tally = VoteTally(points_from_votes=0, voter_count=0)
+    assert tally.per_voter == ()
+
+
+def test_vote_tally_with_per_voter():
+    voters = (
+        PerVoterEntry(character_id=1, display_name="Alice", value=4),
+        PerVoterEntry(character_id=2, display_name="Bob", value=5),
+    )
+    tally = VoteTally(points_from_votes=9, voter_count=2, per_voter=voters)
+    assert len(tally.per_voter) == 2
+    assert tally.points_from_votes == 9
+
+
+def test_vote_tally_is_frozen():
+    import dataclasses
+    assert dataclasses.fields(VoteTally)  # confirms it's a dataclass
+    tally = VoteTally(points_from_votes=5, voter_count=1)
+    try:
+        tally.voter_count = 99  # type: ignore[misc]
+        assert False, "Expected FrozenInstanceError"
+    except Exception:
+        pass  # frozen dataclasses raise FrozenInstanceError on mutation

--- a/backend/tests/unit/test_vote_tally.py
+++ b/backend/tests/unit/test_vote_tally.py
@@ -1,6 +1,6 @@
 """Unit tests for services.vote_tally — pure helpers only."""
 
-from services.vote_tally import PerVoterEntry, VoteTally, get_tally
+from services.vote_tally import VoteTally, get_tally
 
 
 def test_get_tally_returns_empty_when_missing():
@@ -11,21 +11,6 @@ def test_get_tally_returns_entry_when_present():
     entry = VoteTally(points_from_votes=12, voter_count=3)
     result = get_tally({42: entry}, 42)
     assert result is entry
-
-
-def test_vote_tally_defaults():
-    tally = VoteTally(points_from_votes=0, voter_count=0)
-    assert tally.per_voter == ()
-
-
-def test_vote_tally_with_per_voter():
-    voters = (
-        PerVoterEntry(character_id=1, display_name="Alice", value=4),
-        PerVoterEntry(character_id=2, display_name="Bob", value=5),
-    )
-    tally = VoteTally(points_from_votes=9, voter_count=2, per_voter=voters)
-    assert len(tally.per_voter) == 2
-    assert tally.points_from_votes == 9
 
 
 def test_vote_tally_is_frozen():

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -87,8 +87,8 @@ export interface PraxisCardOut {
   submitted_at: string | null
   member_count: number
   score: number
-  average_stars: number | null
-  total_votes: number
+  average_value: number | null
+  voter_count: number
   task_faction_slug: string | null
 }
 
@@ -105,7 +105,7 @@ export interface PraxisUpdate {
 }
 
 export interface PraxisVoteIn {
-  stars: number
+  value: number
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/votes.ts
+++ b/frontend/src/api/votes.ts
@@ -3,9 +3,8 @@ import api from './axios'
 export interface VoteOut {
   id: number
   praxis_id: number
-  praxis_member_id: number | null
   voter_character_id: number
-  stars: number
+  value: number
   created_at: string
   updated_at: string
 }
@@ -13,12 +12,12 @@ export interface VoteOut {
 export interface VoteSummary {
   praxis_id: number
   total_votes: number
-  average_stars: number
+  average_value: number
   total_score: number
 }
 
-export async function castVote(praxisId: number, stars: number): Promise<VoteOut> {
-  const { data } = await api.post<VoteOut>(`/praxes/${praxisId}/vote`, { stars })
+export async function castVote(praxisId: number, value: number): Promise<VoteOut> {
+  const { data } = await api.post<VoteOut>(`/praxes/${praxisId}/vote`, { value })
   return data
 }
 

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -59,7 +59,7 @@ function PlaceholderPraxisBody({
   titleStyle?: CSSProperties;
 }) {
   const hero =
-    praxis.average_stars !== null && praxis.average_stars !== undefined ? (
+    praxis.average_value !== null && praxis.average_value !== undefined ? (
       <VoteUISummary praxis={praxis} color={tint} border={tint} />
     ) : (
       <PraxisSeal praxis={praxis} color={tint} border={tint} label={sealLabel} />

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -50,8 +50,8 @@ const PRAXIS: PraxisCardOut = {
   submitted_at: "2026-01-02T00:00:00Z",
   member_count: 1,
   score: 4.2,
-  average_stars: null,
-  total_votes: 0,
+  average_value: null,
+  voter_count: 0,
   task_faction_slug: "ua",
 };
 

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -157,7 +157,7 @@ export function PraxisSeal({
 
 /**
  * Slot: compact read-only vote summary — the card hero once the praxis has been
- * rated. Replaces PraxisSeal when average_stars is present.
+ * rated. Replaces PraxisSeal when average_value is present.
  *
  * Shows the average star rating (1–5) + vote count in a compact badge. Per-faction
  * reframe labels (Concordance, Signal, etc.) are wired per archetype when their
@@ -172,7 +172,7 @@ export function VoteUISummary({
   color?: string;
   border?: string;
 }) {
-  if (praxis.average_stars === null || praxis.average_stars === undefined) return null;
+  if (praxis.average_value === null || praxis.average_value === undefined) return null;
   return (
     <div
       style={{
@@ -192,7 +192,7 @@ export function VoteUISummary({
       }}
     >
       <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)" }}>
-        {praxis.average_stars.toFixed(1)}
+        {praxis.average_value.toFixed(1)}
       </span>
       <span
         style={{
@@ -204,9 +204,9 @@ export function VoteUISummary({
       >
         ★ avg
       </span>
-      {praxis.total_votes > 0 && (
+      {praxis.voter_count > 0 && (
         <span style={{ fontSize: 7, opacity: 0.6 }}>
-          {praxis.total_votes}v
+          {praxis.voter_count}v
         </span>
       )}
     </div>

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -71,7 +71,7 @@ export default function DefaultPraxisDetail({
         {votes && votes.total_votes > 0 && (
           <div className="text-right shrink-0">
             <div className="font-display italic" style={{ fontSize: 22, color: 'var(--color-text-primary)' }}>
-              {votes.average_stars.toFixed(1)}
+              {votes.average_value.toFixed(1)}
             </div>
             <span className="eyebrow">{votes.total_votes} votes</span>
           </div>
@@ -150,7 +150,7 @@ export default function DefaultPraxisDetail({
         <VoteUI
           factionSlug={praxis.task_faction_slug}
           praxisId={praxis.id}
-          averageStars={votes?.average_stars}
+          averageStars={votes?.average_value}
           totalVotes={votes?.total_votes}
         />
       </div>

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -359,7 +359,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
           </div>
           <EphemeristsVote
             praxisId={praxis.id}
-            averageStars={votes?.average_stars}
+            averageStars={votes?.average_value}
             totalVotes={votes?.total_votes}
             mode="caster"
           />


### PR DESCRIPTION
## Summary

Closes #192. Implements ADR-0014: collapses two divergent praxis scoring paths into a single, authoritative module.

**The problem:** `PraxisOut.score` was computed by two formulas that could disagree — the read path (`compute_praxis_score_from_db`) used the first member's faction for collab and ignored duel multipliers; the recalc path (`_score_*` helpers in `character_stats.py`) computed per-member contributions correctly.

**The fix:**
- **`services/vote_tally.py`** (new): single source for all vote aggregation. `tally_votes()` fetches sum+count in one batch query; `get_tally()` provides a safe zero-returning helper.
- **`services/praxis_scoring.py`** (new): `compute_contributions()` replaces both the old read path and the four `_score_*` / `_fetch_*` helpers. Handles solo (plain), solo-as-duel-side (with duel multiplier), and collab praxes with bulk queries — no N+1 per praxis.
- **`services/character_stats.py`**: `recalculate_character_stats` now gathers praxes → calls `compute_contributions` → sums totals. Four helper functions deleted.
- **`services/praxis.py`**: `build_praxis_out` and `build_praxis_card_out` now compute Merit = `task_base + points_from_votes` via `vote_tally`. `compute_praxis_score_from_db` deleted.
- **Vote vocabulary rename** (`stars` → `value`): model, Alembic migration 0007, schemas, services, routers, activity feed, frontend API types, components, tests.
- **`PraxisCardOut`**: `average_stars` → `average_value`, `total_votes` → `voter_count`.

## Test plan

- [ ] `pytest backend/tests/unit/test_vote_tally.py` — VoteTally helpers
- [ ] `pytest backend/tests/integration/test_praxis_scoring.py` — compute_contributions for solo/collab; Merit formula regression
- [ ] `pytest backend/tests/integration/test_votes.py` — cast/update vote, duel side voting, budget accounting (all updated to `value` field)
- [ ] `pytest backend/tests/integration/test_character_stats.py` — N+1 regression guard still passes with new code path
- [ ] `pytest backend/tests/integration/test_praxes.py` — PraxisCardOut field names (average_value, voter_count)
- [ ] `alembic upgrade head` — migration 0007 renames `vote.stars` → `vote.value` idempotently
- [ ] Frontend: cast a vote, confirm card shows `average_value`; praxis detail shows correct vote score

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158XWKKpZzH8zBvHANBgMQA

---
_Generated by [Claude Code](https://claude.ai/code/session_0158XWKKpZzH8zBvHANBgMQA)_