### PR TITLE
docs(character-creation): redesign ADRs 0019-0022 + glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -306,3 +306,45 @@ One-sided Foe, Secret Admirer, Targeted, **Blocked**, Unknown. Not stored; deriv
   it — and is a *designed* state: one side feels friend, the other foe.
 _Avoid_: treating One-sided Foe / Targeted as duplicates to reconcile; storing the label;
 hiding a block from the blocked party; calling it "relationship".
+
+### Account & Character
+
+**Account**:
+The login identity — one Google OAuth2 → JWT principal, one email. Owns one or more
+**Characters** and never appears on public game surfaces (`account_id` and `email` are
+private). The Account is the unit of all *cross-character* rules: the multi-character cap,
+the account-pooled invite gate (see **Faction invite**), the account-collective
+Albescent unlock, and account-scoped anti-self-voting (a character cannot vote on a praxis
+authored by any character sharing its account).
+_Avoid_: user, player (the *player* is the human; the *account* is their credential record).
+
+**Character**:
+A single in-game persona under an **Account** — the unit that does tasks, earns
+score/level, holds a faction, casts votes, and is publicly identified (`username`,
+`display_name`). One Account → many Characters. Public surfaces show the Character, never
+the Account.
+_Avoid_: profile, user, player.
+
+**Unaffiliated** *(`na`)*:
+A character belonging to **no faction** — the **universal starting state** for every new
+character. (The old "everyone starts in UA" rule is retired: ADR-0019. UA is now an
+ordinary, invite-able faction with no starter privilege.) Scoring: full **1.0×** through
+level `era.unaffiliated_penalty_level − 1`; from that level on (the **grace cliff**),
+faction-owned tasks score `era.unaffiliated_task_modifier` (0.8×) while neutral (`na`)
+tasks stay 1.0×. `na` is also the sentinel for tasks with no faction and the state era-reset
+returns characters to. See ADR-0020.
+_Avoid_: "UA" as a synonym for "new/starting"; "none" as a faction name.
+
+**Faction invite** *(`InvitationLetter`)*:
+The single gate on faction membership. A character may **join, switch to, or be born into**
+faction X iff the **account** holds an `InvitationLetter` for X (current era) on *any* of its
+characters — one account-scoped predicate applied identically at creation and mid-life
+(ADR-0019). The lone first character "waits" only as the degenerate case: the sole invite an
+account can hold is one it earns itself. An invite is **earned per-character**: a character
+earns its *own* invite to X by completing **2 tasks for X and 50 points from X's tasks**
+(current era) — the pledge-allegiance praxis condition is dropped (ADR-0022). Invites are
+**era-scoped** (reset each era). Level is *not* a join gate — a level-1
+character can be born into a faction a sibling already holds an invite for.
+_Avoid_: treating "completed ≥1 task" as a separate join gate (it is *how* an invite is
+earned, not a parallel rule); per-character invite scoping at creation (the gate is
+account-pooled).

--- a/docs/adr/0019-characters-start-unaffiliated-invite-gated-factions.md
+++ b/docs/adr/0019-characters-start-unaffiliated-invite-gated-factions.md
@@ -1,0 +1,29 @@
+# Characters start unaffiliated; faction membership is gated by account-pooled invitation
+
+New characters are no longer forced into UA. Every character is **born unaffiliated**
+(`faction_slug = "na"`), and UA is demoted to an ordinary, invite-able faction with no
+starter privilege. A character may **join, switch to, or be born into** faction X iff the
+**account** holds an `InvitationLetter` for X in the current era on *any* of its characters —
+one account-scoped predicate applied identically at character creation and mid-life, with
+**level decoupled from joining** (a level-1 character can be born into a faction a sibling
+already holds an invite for). The lone first character's "wait" is just the degenerate case:
+the only invite an account can hold is one it earns itself, via task work.
+
+## Considered Options
+
+- **Forced UA start + per-character level-3 graduation** (the prior design): kept UA as a
+  privileged starter and gated faction choice at level 3 per character. Retired — it
+  conflated *eligibility* (have you earned a faction?) with *incentive* (should you commit?),
+  and forced a starter faction nobody chose.
+- **Task-completion as the join gate** (sibling has done ≥1 faction task): considered, but a
+  lower, fuzzier bar than the invite it would replace. Rejected in favour of reusing the
+  existing `InvitationLetter` as the single source of truth — task completion is *how* an
+  invite is earned, not a parallel gate.
+
+## Consequences
+
+- Joining is one account-scoped `EXISTS` query against `InvitationLetter` joined to the
+  account's characters — no new model, no creation-vs-switch special-casing.
+- Invites are era-scoped, so the account-pooled start resets each era.
+- "Everyone starts in UA" and the `aged_out` forced-graduation mechanic are fully retired.
+- Incentive to ever leave unaffiliated now comes from scoring, not force — see ADR-0020.

--- a/docs/adr/0020-unaffiliated-scoring-grace-cliff.md
+++ b/docs/adr/0020-unaffiliated-scoring-grace-cliff.md
@@ -1,0 +1,28 @@
+# Unaffiliated characters score full until a level-3 grace cliff
+
+Because characters now start unaffiliated and are never *forced* to join a faction
+(ADR-0019), the incentive to commit comes from scoring. An unaffiliated (`na`) character
+scores full **1.0×** through level `era.unaffiliated_penalty_level − 1` (a frictionless
+onboarding grace period). From `era.unaffiliated_penalty_level` (3 in Era 1) on, **faction-
+owned tasks** score `era.unaffiliated_task_modifier` (0.8× in Era 1) while neutral (`na`)
+tasks stay 1.0×. The penalty is a **persistent state** — applied whenever the character is
+both at/above the cliff level and unaffiliated — not a one-time deduction (points recompute
+from votes continuously).
+
+## Considered Options
+
+- **Full 1.0× forever while unaffiliated**: simplest, but makes "never join a faction" the
+  optimal scoring strategy and guts the faction system. Rejected.
+- **Penalty from level 1**: punishes onboarding before a player has any realistic path to an
+  invite. Rejected in favour of the grace period.
+
+## Consequences
+
+- Two new `EraConfig` fields: `unaffiliated_task_modifier` (0.8) and
+  `unaffiliated_penalty_level` (3). Kept separate from `faction_graduation_level` so the
+  "invites start arriving" and "you're taxed for not committing" levers tune independently,
+  even though both default to 3.
+- `compute_faction_multiplier` must take the character's **level** (today it takes only
+  slugs) to apply the cliff.
+- Neutral (`na`) tasks remain full-points for everyone, so frictionless work is always
+  available regardless of faction state.

--- a/docs/adr/0021-albescent-unlock-is-account-collective.md
+++ b/docs/adr/0021-albescent-unlock-is-account-collective.md
@@ -1,0 +1,29 @@
+# Albescent unlock is account-collective, with level and coverage decoupled
+
+Albescent becomes a selectable starting/joining faction for an account when **two
+independent conditions** both hold across the account (not on a single character):
+
+1. **Level** — *some* character on the account is at level ≥ `era.albescent_level_required`
+   (8 in Era 1). Any one character; need not be the one that did the coverage.
+2. **Coverage** — pooled across *all* the account's characters combined, there is **≥1
+   completed task** (submitted, non-hidden praxis) for **every** non-sentinel faction
+   (`na`, `aged_out`, `albescent` excluded; **UA included**, since UA is now an ordinary
+   faction per ADR-0019).
+
+Coverage is measured by **task-completion**, deliberately *not* the invite-possession gate
+used for ordinary faction joins (ADR-0019) — Albescent is the one place the bar is "the
+account has actually done the work in every faction."
+
+## Considered Options
+
+- **Both conditions on the same character** (the prior `can_start_as_albescent`): required
+  one character to be both level-8 *and* personally cover every faction. Rejected — too
+  punishing and conflated two unrelated achievements; the account is the natural unit.
+- **Coverage via invite-possession**: would have unified with the join gate, but invites are
+  a lower bar than completed work and would cheapen Albescent's "done everything" meaning.
+
+## Consequences
+
+- The level check and the coverage check become two separate account-scoped queries; the
+  same-character coupling in today's code is removed.
+- Including UA in coverage means the demotion of UA (ADR-0019) flows through here too.

--- a/docs/adr/0022-faction-invite-trigger-drops-pledge.md
+++ b/docs/adr/0022-faction-invite-trigger-drops-pledge.md
@@ -1,0 +1,24 @@
+# Faction invite is earned by 2 tasks + 50 points; pledge-allegiance gate dropped
+
+A character earns its own `InvitationLetter` for faction X (current era) by completing
+**2 tasks for X** and **50 points from X's tasks** — both faction-scoped and measured
+per-character. The prior third condition — a *"Pledge allegiance to X"* praxis with ≥2 votes
+and no flags — is **dropped**. This resolves a long-standing drift between the
+`InvitationLetter` docstring (level ≥ 3, score ≥ 20) and `SPEC-game-rules.md` (2 tasks +
+50 pts + pledge); both are superseded by this rule.
+
+## Why
+
+The invite is now *the* gate on faction membership (ADR-0019). Gating it behind a praxis that
+needs ≥2 community votes makes onboarding depend on other players showing up to vote —
+fragile, and expensive to build. A purely mechanical, self-contained, per-character trigger
+(2 tasks + 50 points) is predictable and removes the community-availability dependency.
+
+## Consequences
+
+- Invite delivery becomes a per-character count/sum check against the character's completed
+  X-tasks — no vote-state or praxis-type coupling.
+- The `InvitationLetter` docstring and the `SPEC-game-rules.md` invitation section both need
+  updating to this rule (kill the level≥3/score≥20 and the pledge variants).
+- Earning stays **per-character**; account-pooling applies only later, at the *join* gate
+  (ADR-0019).


### PR DESCRIPTION
Records the outcome of a `/grill-with-docs` session on **character creation**. Docs only — no code changes.

## Decisions
- **ADR-0019** — characters are born **unaffiliated** (`na`); UA demoted to an ordinary invite-able faction. One account-scoped predicate gates joining: the account holds an `InvitationLetter` for the faction. Level decoupled from joining.
- **ADR-0020** — unaffiliated **scoring grace cliff**: 1.0× through level 2, then `unaffiliated_task_modifier` (0.8×) on faction tasks; neutral (`na`) tasks stay full.
- **ADR-0021** — **Albescent** unlock is account-collective: level-8 on any one character AND pooled ≥1 task per faction (UA counts); level and coverage decoupled.
- **ADR-0022** — faction invite earned by **2 tasks + 50 points**; pledge-allegiance gate dropped (resolves docstring vs spec drift).
- **CONTEXT.md** — adds Account, Character, Unaffiliated, Faction invite.

## Follow-ups (not in this PR)
- Implementation: era fields (`unaffiliated_task_modifier`, `unaffiliated_penalty_level`), thread level into `compute_faction_multiplier`, rewrite `create_character` / `can_start_as_albescent`, add `account_holds_invite`.
- Update `InvitationLetter` docstring + `SPEC-game-rules.md` to ADR-0022.
- Design issues #243 (invitation pop-ups), #244 (level-up messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)