### PR TITLE
docs(design): vendor faction design references for in-repo build

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,38 @@
+# Design references
+
+Vendored design deliverables for the faction-surface work, so build agents have the
+visual source in-repo (no external login or Downloads dependency).
+
+**These are references, not production code.** Read the markup/styles for *intent* and
+rebuild on the real app state with this repo's components and conventions. Do **not**
+port the prototyping runtime (`support.js`, `_ds_bundle.js`, `*.dc.html` harness mounts).
+The prop shapes in the kits (`PraxisEntry`, `CommentEntry`, `onSignUp`, …) are demo
+stand-ins — discard them and consume the real state (`useTaskDetail`, `usePraxisDetail`, …).
+
+## What's here
+
+| Path | Use for |
+|---|---|
+| `design-system/tokens/` | **Source of truth for colors/type/spacing.** `colors.css` holds the `--faction-*` blocks (light + dark). |
+| `design-system/components/` | Shared faction component specs (`FactionTaskCard`, `FactionPraxisCard`, `FactionVoteStamps`, `FactionCommentBox`, pennant, etc.) — `*.prompt.md` + `*.card.html`. |
+| `design-system/guidelines/` | Palette / type / spacing / brand reference cards. |
+| `design-system/templates/<faction>/` | Per-faction kit sources (`*.jsx`/`*.css`) — vote, backdrop, avatar, hero, feed surfaces. Used by #221–#224. |
+| `task-detail/` | The 7 task-detail archetypes (`*TaskDetail.tsx`). Used by #210–#214, #242. See the locked spec on #242. |
+| `praxis-read/factions/<faction>/` | The 7 praxis read-page designs. Used by #205–#209, #231. |
+
+## Token truth vs. stale text
+
+- **UA is the gilt salon** — burnt amber + antique gold on parchment (`--faction-ua-*` in
+  `design-system/tokens/colors.css`), **always-light**. Ignore any older note calling UA
+  purple (`#7c3aed`); the praxis handoff README (`praxis-read/HANDOFF-README.md`) lists
+  pre-recolor colors in its tail section — the DS tokens win.
+- **Albescent is always-light** (vellum, near-black ink `#1c1c1a`); **Singularity is
+  always-dark** (terminal). Always-fixed factions use identical light/dark token values —
+  never by mutating the global `[data-theme]`.
+
+## Provenance
+
+Exported from the World Zero Design System (claude.ai/design project
+`019e221c-7853-7530-a934-7d3b2b7c8b43`) plus the task-detail and faction-praxis handoff
+bundles. Heavy rendered `.dc.html` canvases (2–4 MB each) were intentionally **not**
+vendored — only the portable `.tsx`/`.jsx`/`.css`/token/`.md` sources.

--- a/docs/design/design-system/CLAUDE.md
+++ b/docs/design/design-system/CLAUDE.md
@@ -1,0 +1,140 @@
+# World Zero Design System — project memory
+
+This project is the **World Zero design system**: tokens (`tokens/*.css`, `styles.css`),
+shared components (`components/**`), and per-faction **kits** under `templates/<slug>/`.
+
+The game repo is `pixieofhugs/WorldZeroPlayground`. The authoritative design contract is
+`docs/spec/SPEC-faction-ui-profile.md` (per-faction vs. global surfaces + the §7 coverage
+matrix of what each faction has wired today) and the ADRs in `docs/adr/`. When asked about
+"which assets need design", that coverage matrix (⬜ = falls back to a generic default) and
+the GitHub issues labelled **"needs design"** are the backlog.
+
+## The seven factions
+
+| slug | name | archetype | primary (light/dark) | headline font |
+|---|---|---|---|---|
+| `ua` | UA | **Gilt salon / art academy** (repainted from the sticky note) | `#c2541f` / `#c2541f` — burnt amber + antique gold on parchment; **always-light** (the salon never dims). Promoted into the global `--faction-ua-*` tokens + `--ua-*` extension palette | `--font-faction-gilt` (Playfair Display) + `--font-faction-engraved-caps` (Marcellus SC) |
+| `wow` | Warriors of Whimsy | whimsy.exe desktop window (was Gestalt) | `#be185d` / `#f472b6` | `--font-faction-script` |
+| `snide` | S.N.I.D.E. | ransom / xerox-punk dispatch (always-dark card) | `#16a34a` / `#4ade80` | `--font-faction-anton` |
+| `ephemerists` | The Ephemerists | discordant-map illuminated codex | `#1d6e72` / `#3aa0a4` | `--font-faction-engraved` |
+| `singularity` | Singularity | terminal printout (**always-dark**) | `#2563eb` / `#60a5fa` | `--font-faction-terminal` (Share Tech Mono) |
+| `everymen` | The Everymen | union / victory poster | `#c1272d` / `#ef5350` | `--font-faction-poster` |
+| `albescent` | Albescent | vellum correspondence / sacred secret society (**always-light**) | `#1c1c1a` / `#1c1c1a` (no hue — near-black ink on white) | `--al-font` (Cormorant Garamond italic) |
+
+`ua_masters` is dormant (Era 2); `aged_out` is an alias slug that inherits `ua`. **`albescent`
+used to alias `ua` but now ships its own distinct kit** (`templates/albescent/`). **Gestalt was
+renamed the Warriors of Whimsy (slug `gestalt` → `wow`)**; `gestalt` is kept as a back-compat
+alias (resolved via `SLUG_ALIAS` in `factions.js`) and the CSS prefix stays `--faction-gestalt-*`
+/ `--gestalt-*` (tokens unchanged — only the slug + display name moved).
+
+## Faction-kit conventions
+
+A faction kit is a folder `templates/<slug>/` containing:
+- `<Slug>.dc.html` — the `@template` **kit index** (written via `dc_write`, with the
+  `<!-- @template name="…" description="…" -->` comment as the first line of the body).
+  It lists every surface as a card and loads the DS via `<helmet><script src="./ds-base.js"></script></helmet>`.
+- `ds-base.js` — loads the DS tokens + `_ds_bundle.js` (scaffolded by `dc_write`; base `'../..'`).
+- `<slug>.css` — the faction's archetype primitives (local `--<abbr>-*` tokens, backdrop,
+  textures, layout helpers). Mirrors/extends the global `--faction-<slug>-*` block in `tokens/colors.css`.
+- Standalone surface pages as plain `.html` (NOT `.dc.html`), each linking
+  `../../styles.css` + `<slug>.css`, then React/Babel CDN + the faction `.jsx` atoms.
+- Optional `<slug>-*.jsx` — React atom/component files exposed on `window` (`Object.assign(window, {…})`).
+
+Reference kits to copy structure from: `templates/snide/` and `templates/singularity/`
+(both always-dark) and `templates/ephemerists/` / `templates/everymen/`.
+
+## Intent: "make a faction kit" (new faction)
+
+Build a full `templates/<slug>/` kit covering **all twelve per-faction surfaces** from
+SPEC §1, in the World Zero token scheme (`--faction-<slug>-*`, **light + dark** values for
+every color token — an always-dark faction gives identical light/dark):
+
+1. **Task card** (the archetype) — small format for the global list
+2. **Praxis card** (mirrors the task-card archetype)
+3. **Edit-praxis editor** (the archetype as a form)
+4. **Faction-selection / join card**
+5. **Headline-font usage**
+6. **Full color token block** (add to `tokens/colors.css` `:root` + `[data-theme="dark"]`)
+7. **Filter pennant** (primary-color fill)
+8. **Vote / rating UI** (1–5, reframed in the faction's voice)
+9. **Progression / level indicator** (token-tint only today — shared `LevelPill`)
+10. **Page backdrop** (full-page bg when the faction is the page context; must also look
+    right behind unrelated content — global rainbow watercolor is the fallback)
+11. **Avatar + membership badge** (frame treatment + small faction sigil)
+12. **Activity-feed card frame** (one frame reskins all event-type cards)
+
+Do **not** redesign global chrome (nav/sidebar/modals/toasts, generic button/tab/chip/empty
+states). Always add the new `--faction-<slug>-*` tokens to `tokens/colors.css` in **both**
+`:root` and `[data-theme="dark"]`, plus a `CSS_KEY` + `FACTIONS` entry in
+`components/core/factions.js`. After building, run `check_design_system`.
+
+## Intent: "update the faction kit" (existing faction)
+
+Add the **missing (⬜) surfaces** for that faction from SPEC §7.A coverage matrix to its
+existing `templates/<slug>/` kit, following the same conventions. As of the 2026-06-24 audit
+the thin factions / sparse surfaces were:
+
+- **singularity** was the thinnest before its fill (cards only — no vote / backdrop / avatar). **ua** had no kit at all until the 2026-06-25 gilt-salon redesign.
+- Sparsest surfaces across the board: **faction-hero** (snide + ephemerists + UA + albescent + singularity)
+  and **join/select** (2 factions). The **task-detail page** row is now closed — all 7 factions ship a
+  bespoke `<Faction> Task Detail.dc.html` (imported 2026-06-25).
+
+Re-confirm against the live `SPEC-faction-ui-profile.md §7` matrix and the GitHub
+"needs design" issues before starting — don't trust this list if it looks stale.
+
+### Singularity kit (done 2026-06-24)
+`templates/singularity/` was filled from a complete terminal-printout treatment: `.sg-backdrop`
+(page backdrop ⬜→✅), `SgVoteWidget`/`SignalCaster` Cast-Signal consensus ramp
+NOISE→WEAK→SIGNAL→CLEAR→VERIFIED (vote ⬜→✅), `SingularityMark` sigil + node avatar +
+`SgNavBadge` (avatar+badge ⬜→✅), `SgHero` (faction-hero ⬜→✅), `SgActivityCard` (feed frame
+⬜→✅). Surfaces: Faction Page, Praxis Index, Completed Praxis, Updates Page.
+
+### Albescent kit (added 2026-06-24)
+`templates/albescent/` — a distinct always-light "vellum correspondence" faction (sacred secret
+society; refuses the rainbow palette, no faction hue, white card in both themes). Ships
+`AlbescentCard` (task), `RegisterRow`/`RegisterIndex` (praxis card), `EntryRead` (praxis-detail),
+`WitnessCaster`/`AlWitnessWidget` grayscale presence ramp UNSEEING→GLIMPSED→WITNESSED→VERIFIED→INSCRIBED
+(vote), `AlbescentMark` surveyor's-cross sigil, `AlNavBadge`, `AlHero`, `AlActivityCard`, `.al-backdrop`.
+Coverage **12/15** — still ⬜: join/select, filter pennant, stat block. (Task-detail filled
+2026-06-25 via `Albescent Task Detail.dc.html`.)
+Tokens live in the kit's `albescent.css` (`--al-*` + `--faction-albescent-card-*`); not yet promoted
+into `tokens/colors.css` / `factions.js`.
+
+### UA kit (gilt-salon redesign, added 2026-06-25)
+`templates/ua/` — UA was **repainted from the purple sticky-note into a gilt art-academy** ("the
+purple seat, repainted"): burnt-amber `#c2541f` + antique-gold gilt frames on parchment, a
+heraldic crossed-brush **crest**, regal Playfair Display + Marcellus type, and university
+enrollment voice (matriculate, commission, the Salon, the Critique). Surfaces (all `.dc.html`,
+porting the locked Burnt-Amber direction): `UA Task Card` (crest-in-gilt-frame archetype),
+`UA Task Card Explorations` (5 directions), `UA Gold Palettes` (color study), `UA Faction Page`
+(Salon hero + commissions + placards), `UA Praxis - Read` (gilt-framed plate + 1–5 **Critique**
+rough-sketch→masterwork), `UA Edit Praxis` (Salon submission form w/ image-slot plate). Local
+tokens in `ua.css` (`--ua-*` + `.ua-backdrop` + `.ua-plate`); uses `image-slot.js`.
+**Promoted into the global system (2026-06-25):** the burnt-amber/gold is now the global truth.
+`tokens/colors.css` `--faction-ua-*` (light + dark — identical, always-light) resolves to parchment
+`#fdf6ea`, ink `#3d2410`, accent `#c2541f`, and a `--ua-*` extension palette (`--ua-orange/gold/
+ink/sub/paper/wall/line` + `--ua-gilt` frame gradient) sits alongside `--gestalt-*`/`--snide-*`/etc.
+`factions.js` `color:#c2541f`. The signature shared components were repainted off the sticky note:
+`FactionTaskCard` UA = crest-in-gilt-frame card, `FactionPraxisCard` UA = gilt placard with the
+Critique diamonds, `FactionVoteStamps` UA = burnt-amber Critique ramp (rough sketch→masterwork; no
+longer the generic fallback — omit `faction` for that). Type: `--font-faction-gilt` (Playfair Display,
+was `--font-faction-old`/IM Fell, now removed) + `--font-faction-engraved-caps` (Marcellus SC). Still
+⬜ for UA: join/select, filter pennant, avatar+badge, activity-feed frame.
+
+### Task-detail pages (all 7, added 2026-06-25)
+Every kit now ships a bespoke `<Faction> Task Detail.dc.html` (DC pages consuming the shared
+bundle — `FactionPraxisCard`/`FactionCommentBox` via `<x-import component-from-global-scope>`).
+These replaced the old plain-`.html` snide + everymen detail pages (and their `*-detail.jsx`).
+The coverage chart task-detail row is now 7/7.
+
+### Faction Pages section + comment boxes
+`faction-pages/` holds three cross-faction review cards (`@dsCard group="Faction Pages"`):
+**Faction Pages**, **Completed Praxis**, **Edit Praxis** — each links to every faction's kit
+surface (gap rows shown dashed). Every kit index links back to these three under its footer
+("Compare across the roster"). `components/feedback/FactionCommentBox` (shared, faction-switched)
++ `comments.card.html` cover the per-faction comment bubble; each kit also has a standalone
+`<Faction> Comment Box.html` thread page.
+
+### Faction component coverage
+`components/cards/coverage.card.html` (Faction Components group) is the live 7-faction × 15-type
+matrix of bespoke-vs-fallback. Update its `TIERS` data array (null = fallback) whenever a kit fills a surface.

--- a/docs/design/design-system/components/cards/FactionPraxisCard.d.ts
+++ b/docs/design/design-system/components/cards/FactionPraxisCard.d.ts
@@ -1,0 +1,36 @@
+/**
+ * FactionPraxisCard — the companion to FactionTaskCard. A *praxis* is a filed
+ * submission for a task; the faction then votes on it. Each faction reframes
+ * World Zero's 1–5 vote in its own vocabulary and renders the praxis in its own
+ * physical language (gilt salon placard, praxis.exe window, closed-case file, sealed
+ * ephemeris leaf, terminal log, union work report).
+ */
+export interface FactionPraxisCardProps {
+  /** Which archetype to render. ("journeymen" is accepted as a legacy alias for "ephemerists".) */
+  faction:
+    | "ua"
+    | "wow"
+    | "gestalt"
+    | "snide"
+    | "ephemerists"
+    | "singularity"
+    | "everymen";
+  /** The task this praxis answers (rendered as "re: …"). */
+  task: string;
+  /** The praxis headline / finding (in the faction's display font). */
+  finding: string;
+  /** Who filed it. */
+  author?: string;
+  /** Short account excerpt (clamped). */
+  excerpt?: string;
+  /** The faction's 1–5 vote average (drives the rating meter + standing label). */
+  rating?: number;
+  /** How many marks/votes were filed. */
+  marks?: number;
+  /** Point value of the underlying task. */
+  points?: number;
+  /** Level of the underlying task. */
+  level?: number;
+}
+
+export function FactionPraxisCard(props: FactionPraxisCardProps): JSX.Element;

--- a/docs/design/design-system/components/cards/FactionPraxisCard.jsx
+++ b/docs/design/design-system/components/cards/FactionPraxisCard.jsx
@@ -1,0 +1,311 @@
+import React from "react";
+import { LevelPill } from "../core/LevelPill.jsx";
+import { factionCssVar } from "../core/factions.js";
+
+/**
+ * FactionPraxisCard — the companion to FactionTaskCard. A *praxis* is a filed
+ * submission for a task: a finding/account someone logged, which the faction
+ * then votes on. Each faction reframes World Zero's 1–5 vote in its own
+ * vocabulary, and renders the praxis as a card in its own physical language:
+ *
+ *   ua          → gilt salon placard, filed (the Critique: rough sketch → masterwork)
+ *   gestalt     → praxis.exe window (heart marks: a start → legendary)
+ *   snide       → closed-case file (the mob's stamped marks)
+ *   ephemerists → sealed ephemeris leaf (the concordance: apocryphal → canonical)
+ *   singularity → terminal praxis log (ascii rating bar)
+ *   everymen    → union work report, filed (the crew's star marks)
+ *   albescent   → the register, witnessed (the witness ramp: unseeing → inscribed)
+ *
+ * Props mirror a real praxis: the `task` it answers, the `finding` headline,
+ * the `author`, a short `excerpt`, a `rating` (1–5 average, rounded for the
+ * meter), the `marks` count (how many voted), plus `points` / `level`.
+ */
+export function FactionPraxisCard({
+  faction = "ua",
+  task,
+  finding,
+  author = "Anon",
+  excerpt,
+  rating = 4,
+  marks = 0,
+  points = 0,
+  level = 1,
+}) {
+  const props = { task, finding, author, excerpt, rating, marks, points, level };
+  switch (faction) {
+    case "wow": case "gestalt": return <GestaltPraxis {...props} />;
+    case "snide": return <SnidePraxis {...props} />;
+    case "ephemerists": case "journeymen": return <EphemeristsPraxis {...props} />;
+    case "singularity": return <SingularityPraxis {...props} />;
+    case "everymen": return <EverymenPraxis {...props} />;
+    case "albescent": return <AlbescentPraxis {...props} />;
+    case "ua":
+    default: return <UAPraxis {...props} />;
+  }
+}
+
+const clamp = (r) => Math.max(0, Math.min(5, Math.round(r)));
+
+/* ── UA — Gilt salon placard, filed (the Critique) ── */
+const UA_CRITIQUE = ["rough sketch", "study", "fair hand", "fine work", "masterwork"];
+function UAPraxis({ task, finding, author, excerpt, rating, marks, points, level }) {
+  const r = clamp(rating);
+  return (
+    <div style={{
+      width: 232, padding: 6, background: "var(--ua-gilt)", transform: "rotate(-0.5deg)",
+      boxShadow: "0 12px 26px rgba(60,40,10,0.24), inset 0 0 0 1px rgba(255,255,255,0.45)",
+      fontFamily: "'EB Garamond', Georgia, serif",
+    }}>
+      <div style={{
+        border: "1px solid rgba(60,40,10,0.4)", background: factionCssVar("ua", "card-bg"),
+        padding: "16px 17px 14px", color: factionCssVar("ua", "card-text"),
+        backgroundImage: "radial-gradient(rgba(60,40,10,0.03) 1px, transparent 1px)", backgroundSize: "5px 5px",
+      }}>
+        <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 8, letterSpacing: "0.12em", color: factionCssVar("ua", "card-accent") }}>Acquisition · re: {task}</div>
+        <div style={{ fontFamily: factionCssVar("ua", "card-font"), fontStyle: "italic", fontWeight: 700, fontSize: 21, lineHeight: 1.14, margin: "5px 0 6px", overflowWrap: "anywhere" }}>{finding}</div>
+        {excerpt && <div style={{ fontStyle: "italic", fontSize: 12, lineHeight: 1.5, color: factionCssVar("ua", "card-muted") }}>{excerpt}</div>}
+        <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 9, letterSpacing: "0.06em", color: factionCssVar("ua", "card-muted"), margin: "8px 0 11px" }}>— {author}</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <span key={i} style={{ width: 11, height: 11, transform: "rotate(45deg)", background: i < r ? factionCssVar("ua", "card-accent") : "transparent", border: `1.5px solid ${factionCssVar("ua", "card-accent")}` }} />
+          ))}
+          <span style={{ fontFamily: factionCssVar("ua", "card-font"), fontStyle: "italic", fontSize: 12, color: factionCssVar("ua", "card-accent"), marginLeft: 4 }}>{UA_CRITIQUE[r - 1] || "awaiting"}</span>
+        </div>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.04em", color: factionCssVar("ua", "card-muted"), marginBottom: 10 }}>{marks} of the Salon weighed in</div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: "1px solid var(--ua-line-soft)", paddingTop: 10 }}>
+          <LevelPill level={level} factionSlug="ua" />
+          <span style={{ fontFamily: factionCssVar("ua", "card-font"), fontStyle: "italic", fontWeight: 700, fontSize: 16, color: factionCssVar("ua", "card-accent") }}>{points}<span style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 8, marginLeft: 3, color: factionCssVar("ua", "card-muted") }}>pts</span></span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Gestalt — praxis.exe window (heart marks) ── */
+const G_LABELS = ["a start", "solid", "good", "excellent", "legendary"];
+function GHeart({ on }) {
+  return (
+    <svg width="15" height="15" viewBox="0 0 36 36" style={{ display: "block" }}>
+      <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+        fill={on ? "var(--gestalt-pink)" : "none"} stroke={on ? "#fff" : "var(--gestalt-border-soft)"} strokeWidth={on ? 2.2 : 2} strokeLinejoin="round" />
+    </svg>
+  );
+}
+function GestaltPraxis({ task, finding, author, excerpt, rating, marks, points, level }) {
+  const r = clamp(rating);
+  const dot = (c) => ({ width: 9, height: 9, borderRadius: "50%", background: c, border: "1.2px solid rgba(255,255,255,0.7)" });
+  return (
+    <div style={{ width: 236, borderRadius: 12, overflow: "hidden", border: "2px solid var(--gestalt-win-border)", boxShadow: "0 8px 20px var(--gestalt-glow)", fontFamily: "var(--font-body)", transform: "rotate(-0.6deg)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 11px", background: "linear-gradient(180deg, var(--gestalt-title-from), var(--gestalt-title-to))", borderBottom: "2px solid var(--gestalt-win-border)" }}>
+        <span style={dot("#fb7aa8")} /><span style={dot("#f6c75e")} /><span style={dot("#86cfa6")} />
+        <span style={{ marginLeft: "auto", fontSize: 9.5, color: "var(--gestalt-title-text)" }}>praxis.exe</span>
+      </div>
+      <div style={{ padding: "14px 15px 16px", background: factionCssVar("gestalt", "card-bg"), backgroundImage: "radial-gradient(var(--gestalt-border-soft) 1.3px, transparent 1.3px)", backgroundSize: "13px 13px", color: factionCssVar("gestalt", "card-text") }}>
+        <div style={{ fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.16em", color: "var(--gestalt-label)", marginBottom: 4 }}>re: {task}</div>
+        <div style={{ fontFamily: factionCssVar("gestalt", "card-font"), fontSize: 25, lineHeight: 1.0, color: factionCssVar("gestalt", "card-text"), marginBottom: 6, overflowWrap: "anywhere" }}>{finding}</div>
+        {excerpt && <div style={{ fontSize: 9.5, lineHeight: 1.5, color: factionCssVar("gestalt", "card-muted"), marginBottom: 8, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{excerpt}</div>}
+        <div style={{ fontSize: 9.5, fontStyle: "italic", color: "var(--gestalt-ink-soft)", marginBottom: 10 }}>filed by {author}</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 5, marginBottom: 4 }}>
+          {Array.from({ length: 5 }).map((_, i) => <GHeart key={i} on={i < r} />)}
+          <span style={{ fontFamily: factionCssVar("gestalt", "card-font"), fontSize: 16, color: "var(--gestalt-pink)", marginLeft: 4 }}>{G_LABELS[Math.max(0, r - 1)]}</span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 9, letterSpacing: "0.06em", textTransform: "uppercase", padding: "3px 9px", borderRadius: 20, background: "var(--gestalt-pink-lt)", color: factionCssVar("gestalt", "card-text"), border: "1px solid var(--gestalt-border-soft)" }}>lvl {level}</span>
+          <span style={{ fontSize: 9, color: "var(--gestalt-label)" }}>{marks} hearts</span>
+          <span style={{ marginLeft: "auto", fontSize: 11, fontWeight: 700, color: "var(--gestalt-pink-deep)" }}>{points} pts</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── S.N.I.D.E. — Closed-case file (the mob's marks) ── */
+function SnidePraxis({ task, finding, author, excerpt, rating, marks, points, level }) {
+  const r = clamp(rating);
+  return (
+    <div style={{ width: 252, position: "relative", background: factionCssVar("snide", "card-bg"), color: "#fff", padding: "26px 18px 18px", fontFamily: "var(--font-body)", overflow: "hidden", boxShadow: "6px 8px 0 rgba(0,0,0,0.28)", transform: "rotate(-1deg)" }}>
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", backgroundImage: "radial-gradient(rgba(182,255,46,0.09) 32%, transparent 34%)", backgroundSize: "5px 5px" }} />
+      <div style={{ position: "absolute", top: -9, left: 26, width: 54, height: 20, background: "var(--snide-tape)", boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.25)", transform: "rotate(-8deg)" }} />
+      <div style={{ position: "relative", display: "flex", justifyContent: "space-between", alignItems: "baseline", borderBottom: "2px solid var(--snide-acid)", paddingBottom: 6, marginBottom: 10 }}>
+        <span style={{ fontFamily: "var(--font-accent)", fontSize: 14, letterSpacing: "0.2em", color: "var(--snide-acid)" }}>S.N.I.D.E. · CASE CLOSED</span>
+      </div>
+      <div style={{ position: "relative", fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: "#8f9183", marginBottom: 5 }}>re: {task}</div>
+      <div style={{ position: "relative", fontFamily: "var(--font-faction-anton)", fontSize: 26, lineHeight: 0.94, letterSpacing: "0.02em", transform: "skewX(-4deg)", marginBottom: 8, overflowWrap: "anywhere" }}>{finding}</div>
+      {excerpt && <p style={{ position: "relative", fontFamily: "var(--font-faction-typewriter)", fontSize: 10, lineHeight: 1.5, color: "#d8d6c8", margin: "0 0 8px" }}>{excerpt}</p>}
+      <div style={{ position: "relative", fontFamily: "var(--font-faction-marker)", fontSize: 13, color: "var(--snide-pink)", transform: "rotate(-1deg)", marginBottom: 12 }}>confessed by {author}</div>
+      <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 4, marginBottom: 11 }}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <span key={i} style={{ width: 16, height: 16, display: "flex", alignItems: "center", justifyContent: "center", background: i < r ? "var(--snide-acid)" : "transparent", color: "var(--snide-ink)", border: `1.5px solid ${i < r ? "var(--snide-acid)" : "#6b6d60"}`, fontFamily: "var(--font-faction-black)", fontSize: 9, transform: `rotate(${i % 2 ? 4 : -4}deg)` }}>✓</span>
+        ))}
+        <span style={{ fontFamily: "var(--font-accent)", fontSize: 11, letterSpacing: "0.1em", color: "#cfd1c4", marginLeft: 5 }}>{marks} MARKS</span>
+      </div>
+      <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 10 }}>
+        <span style={{ fontFamily: "var(--font-faction-anton)", fontSize: 22, color: "var(--snide-acid)" }}>{points}<span style={{ fontSize: 9, marginLeft: 2 }}>PTS</span></span>
+        <span style={{ fontFamily: "var(--font-accent)", fontSize: 11, letterSpacing: "0.1em", border: "1.5px dashed #6b6d60", color: "#cfd1c4", padding: "2px 7px", transform: "rotate(2deg)" }}>LVL {level}</span>
+        <span style={{ marginLeft: "auto", background: "var(--snide-pink)", color: "#fff", fontFamily: "var(--font-faction-black)", fontSize: 10, padding: "5px 9px", transform: "rotate(-3deg)", boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>VERDICT ↗</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── Ephemerists — sealed leaf (the concordance) ── */
+const CONCORD = [
+  { fill: "var(--eph-gold)", label: "apocryphal" },
+  { fill: "var(--eph-verdigris)", label: "disputed" },
+  { fill: "var(--eph-lapis)", label: "plausible" },
+  { fill: "var(--eph-rubric)", label: "corroborated" },
+  { fill: "var(--eph-ink)", label: "canonical" },
+];
+const ROMAN = ["I", "II", "III", "IV", "V"];
+function EphemeristsPraxis({ task, finding, author, excerpt, rating, marks, points, level }) {
+  const r = clamp(rating);
+  const tw = (finding || "").trim().split(" ");
+  const tlast = tw.pop();
+  const st = CONCORD[Math.max(0, r - 1)];
+  return (
+    <div style={{ width: 232, position: "relative", overflow: "hidden", background: factionCssVar("ephemerists", "card-bg"), color: factionCssVar("ephemerists", "card-text"), border: "1.5px solid var(--eph-ink)", fontFamily: "var(--font-faction-codex)", padding: "11px 14px 13px" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, color: "var(--eph-rubric)", borderBottom: "1px solid var(--eph-gold-deep)", paddingBottom: 6, marginBottom: 8 }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5, fontFamily: "var(--font-faction-engraved)", fontWeight: 600, fontSize: 8, letterSpacing: "0.18em", textTransform: "uppercase" }}>
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="var(--eph-lapis)" strokeWidth="1.4"><ellipse cx="12" cy="12" rx="11" ry="4.4" transform="rotate(-24 12 12)"></ellipse><path d="M4 12 C7.5 8.2 16.5 8.2 20 12 C16.5 15.8 7.5 15.8 4 12 Z"></path><circle cx="12" cy="12" r="2.7"></circle></svg>
+          Ephemeris entry
+        </span>
+        <span style={{ fontFamily: "var(--font-faction-codex)", fontSize: 8.5, color: "var(--eph-muted)" }}>✦ sealed</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-faction-codex)", fontStyle: "italic", fontSize: 9, color: "var(--eph-rubric)", marginBottom: 3 }}>re: {task}</div>
+      <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 21, lineHeight: 0.98, marginBottom: 5, color: factionCssVar("ephemerists", "card-text") }}>{tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span><sup style={{ fontFamily: "var(--font-faction-codex)", fontSize: 9, color: "var(--eph-lapis)", fontWeight: 400 }}>†</sup></div>
+      {excerpt && <div style={{ fontSize: 9, lineHeight: 1.45, fontStyle: "italic", color: "var(--eph-muted)", marginBottom: 8, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{excerpt}</div>}
+      <div style={{ fontSize: 9.5, color: "var(--eph-muted)", marginBottom: 9 }}>filed by <b style={{ color: factionCssVar("ephemerists", "card-text") }}>{author}</b></div>
+      {/* concordance sparkline */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 3, height: 26 }}>
+          {CONCORD.map((c, i) => (
+            <div key={i} style={{ width: 7, height: 6 + i * 5, background: c.fill === "var(--eph-ink)" && i + 1 !== r ? c.fill : c.fill, opacity: i + 1 <= r ? 1 : 0.28 }} />
+          ))}
+        </div>
+        <div>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 5 }}>
+            <span style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 800, fontSize: 17, lineHeight: 1, color: st.fill === "var(--eph-ink)" ? "var(--eph-vellum-text)" : st.fill }}>{rating.toFixed(1)}</span>
+            <span style={{ fontFamily: "var(--font-faction-codex)", fontStyle: "italic", fontSize: 9, color: "var(--eph-muted)" }}>{st.label}</span>
+          </div>
+          <div style={{ fontSize: 7.5, letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--eph-muted)" }}>{marks} marks</div>
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 8, borderTop: "1px dashed color-mix(in srgb, var(--eph-vellum-text) 26%, transparent)", paddingTop: 8 }}>
+        <span style={{ color: factionCssVar("ephemerists", "card-text") }}>▦ grade {ROMAN[Math.max(0, Math.min(4, level - 1))]}</span>
+        <span style={{ color: "var(--eph-gold-deep)" }}>·</span>
+        <span style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 12, color: "var(--eph-rubric)" }}>{points} pvncta</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── Singularity — terminal praxis log (ascii bar) ── */
+function SingularityPraxis({ task, finding, author, excerpt, rating, marks, points, level }) {
+  const r = clamp(rating);
+  const bar = "█".repeat(r) + "░".repeat(5 - r);
+  return (
+    <div style={{ width: 232, background: "var(--faction-singularity-card-bg)", border: "1px solid var(--faction-singularity-border-hard)", position: "relative", fontFamily: factionCssVar("singularity", "card-font"), color: "var(--faction-singularity-card-text)", overflow: "hidden", padding: "12px 14px" }}>
+      <div style={{ position: "absolute", inset: 0, backgroundImage: "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)", pointerEvents: "none", zIndex: 1 }} />
+      <div style={{ position: "relative", zIndex: 2 }}>
+        <div style={{ fontSize: 7, color: "var(--faction-singularity-card-muted)", textTransform: "uppercase", letterSpacing: "0.15em", marginBottom: 6 }}>praxis.log · sealed
+          <span style={{ display: "inline-block", width: 5, height: 9, background: "var(--faction-singularity-card-text)", marginLeft: 3, verticalAlign: "middle", animation: "wz-blink 1s step-end infinite" }} />
+        </div>
+        <div style={{ fontSize: 7.5, color: "var(--faction-singularity-card-muted)", marginBottom: 6 }}>re: {task}</div>
+        <div style={{ fontSize: 13, lineHeight: 1.25, marginBottom: 6, overflowWrap: "anywhere" }}>{"> "}{finding}</div>
+        {excerpt && <div style={{ fontSize: 8, color: "var(--faction-singularity-card-muted)", lineHeight: 1.5, marginBottom: 7, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{excerpt}</div>}
+        <div style={{ fontSize: 8, color: "var(--faction-singularity-card-muted)", marginBottom: 8 }}>filed_by: <span style={{ color: "var(--faction-singularity-card-text)" }}>{author}</span></div>
+        <div style={{ fontSize: 11, letterSpacing: "0.08em", marginBottom: 7 }}>
+          <span style={{ color: "var(--faction-singularity-card-text)" }}>[{bar}]</span>
+          <span style={{ color: "var(--faction-singularity-card-muted)", fontSize: 8, marginLeft: 6 }}>{rating.toFixed(1)}/5 · {marks} votes</span>
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", borderTop: "1px solid var(--faction-singularity-border-hard)", paddingTop: 6, fontSize: 8, color: "var(--faction-singularity-card-muted)" }}>
+          <span>PTS: <span style={{ color: "var(--faction-singularity-card-text)", fontSize: 11, fontWeight: 700 }}>{points}</span></span>
+          <span style={{ border: "1px solid var(--faction-singularity-card-text)", color: "var(--faction-singularity-card-text)", padding: "1px 6px", borderRadius: 6, textTransform: "uppercase" }}>lvl {level}</span>
+        </div>
+      </div>
+      <style>{`@keyframes wz-blink { 50% { opacity: 0; } }`}</style>
+    </div>
+  );
+}
+
+/* ── Albescent — returned account, witnessed (the witness ramp) ── */
+const AL_WITNESS = ["unseeing", "glimpsed", "witnessed", "verified", "inscribed"];
+function AlPraxisMark({ size = 16 }) {
+  const c = size / 2, rO = size * 0.43, rI = size * 0.235, rD = size * 0.05;
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none" style={{ display: "block", flexShrink: 0 }}>
+      <circle cx={c} cy={c} r={rO} stroke="var(--faction-albescent-card-text)" strokeWidth={size * 0.05} opacity={0.2} />
+      <circle cx={c} cy={c} r={rI} stroke="var(--faction-albescent-card-text)" strokeWidth={size * 0.07} opacity={0.55} />
+      <circle cx={c} cy={c} r={rD} fill="var(--faction-albescent-card-text)" />
+    </svg>
+  );
+}
+function AlbescentPraxis({ task, finding, author, excerpt, rating, marks, points, level }) {
+  const r = clamp(rating);
+  const shades = ["rgba(0,0,0,0.16)", "rgba(0,0,0,0.30)", "rgba(0,0,0,0.48)", "rgba(0,0,0,0.66)", "rgba(0,0,0,0.84)"];
+  return (
+    <div style={{
+      width: 224, background: factionCssVar("albescent", "card-bg"),
+      border: "1px solid var(--faction-albescent-border)", boxShadow: "var(--al-shadow)",
+      padding: "18px 20px 16px", fontFamily: factionCssVar("albescent", "card-font"),
+      color: factionCssVar("albescent", "card-text"),
+    }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", borderBottom: "1px solid var(--al-border-faint)", paddingBottom: 9, marginBottom: 10 }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.22em", textTransform: "uppercase", color: factionCssVar("albescent", "card-muted") }}><AlPraxisMark size={13} /> the register</span>
+        <span style={{ fontStyle: "italic", fontSize: 9, color: factionCssVar("albescent", "card-muted") }}>returned</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 7, letterSpacing: "0.06em", color: factionCssVar("albescent", "card-muted"), marginBottom: 4 }}>re: {task}</div>
+      <div style={{ fontStyle: "italic", fontWeight: 300, fontSize: 18, lineHeight: 1.22, marginBottom: 7, overflowWrap: "anywhere" }}>{finding}</div>
+      {excerpt && <div style={{ fontFamily: "var(--font-body)", fontSize: 7.5, lineHeight: 1.6, color: factionCssVar("albescent", "card-muted"), marginBottom: 9, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{excerpt}</div>}
+      <div style={{ fontStyle: "italic", fontSize: 10, color: factionCssVar("albescent", "card-muted"), marginBottom: 12 }}>— {author}</div>
+      {/* witness ramp */}
+      <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 11 }}>
+        {shades.map((sh, i) => (
+          <span key={i} style={{ width: 14, height: 14, borderRadius: "50%", border: `1.5px solid ${sh}`, background: i < r ? sh : "transparent", display: "flex", alignItems: "center", justifyContent: "center" }}>{i === r - 1 && <span style={{ width: 4, height: 4, borderRadius: "50%", background: "#fff" }} />}</span>
+        ))}
+        <span style={{ fontStyle: "italic", fontSize: 11, color: factionCssVar("albescent", "card-accent"), marginLeft: 4 }}>{AL_WITNESS[Math.max(0, r - 1)]}</span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", borderTop: "1px solid var(--al-border-faint)", paddingTop: 9, fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.16em", textTransform: "uppercase", color: factionCssVar("albescent", "card-muted") }}>
+        <span>{marks} keepers · lvl {level}</span>
+        <span style={{ fontFamily: factionCssVar("albescent", "card-font"), fontStyle: "italic", fontSize: 14, letterSpacing: 0, textTransform: "none", color: factionCssVar("albescent", "card-accent") }}>{points} pts</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── Everymen — union work report, filed (the crew's star marks) ── */
+function Star({ on }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" style={{ display: "block" }}>
+      <path d="M12 1.5l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 8.7l7.1-.6z"
+        fill={on ? "var(--everymen-gold)" : "none"} stroke={on ? "var(--everymen-ink)" : "var(--everymen-muted)"} strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function EverymenPraxis({ task, finding, author, excerpt, rating, marks, points, level }) {
+  const r = clamp(rating);
+  return (
+    <div style={{ width: 224, background: "var(--everymen-paper)", color: "var(--everymen-paper-text)", border: "1.5px solid var(--everymen-ink)", boxShadow: "0 0 0 3px var(--everymen-paper), 0 0 0 4px var(--everymen-ink)", position: "relative", fontFamily: "var(--font-body)", overflow: "hidden" }}>
+      <div style={{ background: "var(--everymen-red)", color: "var(--everymen-cream)", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "6px 12px" }}>
+        <span style={{ fontFamily: "var(--font-faction-poster)", fontSize: 14, letterSpacing: "0.1em" }}>WORK REPORT · FILED</span>
+      </div>
+      <div style={{ position: "relative", padding: "13px 14px 14px" }}>
+        <div style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.05, backgroundImage: "radial-gradient(var(--everymen-ink) 0.6px, transparent 0.7px)", backgroundSize: "4px 4px" }} />
+        <div style={{ position: "relative" }}>
+          <div style={{ fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--everymen-muted)", marginBottom: 3 }}>re: {task}</div>
+          <div style={{ fontFamily: "var(--font-faction-poster)", fontSize: 28, lineHeight: 0.96, marginBottom: 6, overflowWrap: "anywhere" }}>{finding}</div>
+          {excerpt && <div style={{ fontSize: 9, lineHeight: 1.5, color: "var(--everymen-muted)", marginBottom: 7, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{excerpt}</div>}
+          <div style={{ fontSize: 10, fontStyle: "italic", color: "var(--everymen-muted)", marginBottom: 10 }}>filed by {author}</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 4, marginBottom: 11 }}>
+            {Array.from({ length: 5 }).map((_, i) => <Star key={i} on={i < r} />)}
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--everymen-muted)", marginLeft: 5 }}>{marks} marks</span>
+          </div>
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "stretch", borderTop: "2px solid var(--everymen-ink)" }}>
+        <div style={{ flex: 1, background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center", padding: "5px 0", fontFamily: "var(--font-faction-poster)", fontSize: 14 }}>LVL {level}</div>
+        <div style={{ flex: 1, background: "var(--everymen-gold)", color: "var(--everymen-ink)", textAlign: "center", padding: "5px 0", fontFamily: "var(--font-faction-poster)", fontSize: 14 }}>{points} PTS</div>
+      </div>
+    </div>
+  );
+}

--- a/docs/design/design-system/components/cards/FactionPraxisCard.prompt.md
+++ b/docs/design/design-system/components/cards/FactionPraxisCard.prompt.md
@@ -1,0 +1,9 @@
+**FactionPraxisCard** — the companion to `FactionTaskCard`. A *praxis* is a filed submission for a task; the faction then votes on it. Each faction reframes the 1–5 vote in its own vocabulary and renders the praxis in its own physical language.
+
+```jsx
+<FactionPraxisCard faction="ephemerists" task="Trace a Myth" finding="The Saint Was A Surveyor"
+  author="Vesper" excerpt="Followed the legend back through eleven retellings until the road ran out…"
+  rating={4.3} marks={47} points={100} level={4} />
+```
+
+Factions → praxis archetype + vote reframe: `ua` gilt salon placard (the Critique: rough sketch → masterwork) · `gestalt` praxis.exe window (heart marks: a start → legendary) · `snide` closed-case file (the mob's stamped marks) · `ephemerists` sealed ephemeris leaf (the concordance: apocryphal → canonical) · `singularity` terminal log (ascii rating bar) · `everymen` union work report (the crew's star marks). Place several in a `display:flex; flex-wrap:wrap; gap:1rem` container.

--- a/docs/design/design-system/components/cards/FactionTaskCard.d.ts
+++ b/docs/design/design-system/components/cards/FactionTaskCard.d.ts
@@ -1,0 +1,30 @@
+/**
+ * World Zero's signature component — one card, six completely different
+ * physical archetypes. The faction determines the card's entire visual
+ * language (gilt salon, gestalt.exe window, ransom dispatch, discordant
+ * map, terminal printout, union poster). The card type IS the faction
+ * identity.
+ */
+export interface FactionTaskCardProps {
+  /** Which archetype to render. ("journeymen" is accepted as a legacy alias for "ephemerists".) */
+  faction:
+    | "ua"
+    | "wow"
+    | "gestalt"
+    | "snide"
+    | "ephemerists"
+    | "singularity"
+    | "everymen";
+  /** Task title (rendered in the faction's headline font). */
+  title: string;
+  /** Task description (clamped; some archetypes restyle or split it). */
+  description?: string;
+  /** Level requirement shown in the LevelPill. */
+  level?: number;
+  /** Point value (already faction-adjusted by the caller). */
+  points?: number;
+  /** Sign-up handler. Omit to hide the sign-up button (permission-gated). */
+  onSignup?: () => void;
+}
+
+export function FactionTaskCard(props: FactionTaskCardProps): JSX.Element;

--- a/docs/design/design-system/components/cards/FactionTaskCard.jsx
+++ b/docs/design/design-system/components/cards/FactionTaskCard.jsx
@@ -1,0 +1,450 @@
+import React from "react";
+import { LevelPill } from "../core/LevelPill.jsx";
+import { factionCssVar } from "../core/factions.js";
+
+/**
+ * FactionTaskCard — World Zero's signature component. Each faction renders a
+ * COMPLETELY different physical card archetype; the card type IS the faction
+ * identity. One <FactionTaskCard faction="…"> picks the right archetype.
+ *
+ *   ua          → gilt salon (heraldic crest in a gold frame, Playfair italic)
+ *   gestalt     → gestalt.exe desktop window (title bar, traffic lights, charms)
+ *   snide       → ransom dispatch (photocopier ink, cut-out letters, tape, acid spray)
+ *   ephemerists → the discordant map (vellum, three feuding coordinate grids)
+ *   singularity → terminal printout (always dark, scanlines, sprockets)
+ *   everymen    → union / victory poster (sunburst field, knockout headline, stamp)
+ *   albescent   → vellum correspondence (white cotton card, surveyor's mark, no hue)
+ *
+ * Cards have intentionally varied widths and live in a flex-wrap container with
+ * slight rotations — never a strict grid.
+ */
+export function FactionTaskCard({
+  faction = "ua",
+  title,
+  description,
+  level = 1,
+  points = 0,
+  onSignup,
+}) {
+  const props = { title, description, level, points, onSignup };
+  switch (faction) {
+    case "wow": case "gestalt": return <Gestalt {...props} />;
+    case "snide": return <Snide {...props} />;
+    case "ephemerists": case "journeymen": return <Ephemerists {...props} />;
+    case "singularity": return <Singularity {...props} />;
+    case "everymen": return <Everymen {...props} />;
+    case "albescent": return <Albescent {...props} />;
+    case "ua":
+    default: return <UA {...props} />;
+  }
+}
+
+/* ── UA — Gilt Salon (heraldic crest in a gold frame; always-light) ── */
+function UACrest({ w = 50 }) {
+  const id = "ua-tc-shield";
+  return (
+    <svg width={w} height={w * 1.2} viewBox="0 0 100 120" style={{ display: "block" }}>
+      <defs><clipPath id={id}><path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" /></clipPath></defs>
+      <g clipPath={`url(#${id})`}>
+        <rect x="0" y="0" width="100" height="120" fill="var(--ua-orange)" />
+        <rect x="0" y="60" width="100" height="60" fill="#f8ead2" />
+        <circle cx="50" cy="60" r="15" fill="#f0b53e" />
+        <g stroke="#f0b53e" strokeWidth="2.4" strokeLinecap="round">
+          <line x1="50" y1="60" x2="50" y2="20" /><line x1="50" y1="60" x2="22" y2="30" /><line x1="50" y1="60" x2="78" y2="30" />
+          <line x1="50" y1="60" x2="14" y2="48" /><line x1="50" y1="60" x2="86" y2="48" /><line x1="50" y1="60" x2="34" y2="22" /><line x1="50" y1="60" x2="66" y2="22" />
+        </g>
+        <g transform="translate(50 84)">
+          <g transform="rotate(38)"><rect x="-2" y="-30" width="4" height="44" rx="1.5" fill="#3d2410" /><rect x="-3" y="10" width="6" height="6" fill="#eab94a" /><path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill="var(--ua-orange)" /></g>
+          <g transform="rotate(-38)"><rect x="-2" y="-30" width="4" height="44" rx="1.5" fill="var(--ua-gold)" /><rect x="-3" y="10" width="6" height="6" fill="#eab94a" /><path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill="var(--ua-gold-lt)" /></g>
+        </g>
+      </g>
+      <path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" fill="none" stroke="var(--ua-gold-lt)" strokeWidth="2.5" />
+      <path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" fill="none" stroke="#3d2410" strokeWidth="0.8" />
+    </svg>
+  );
+}
+function UA({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 170, flex: "0 0 auto", transform: "rotate(-0.5deg)",
+      padding: 7, background: "var(--ua-gilt)",
+      boxShadow: "0 12px 26px rgba(60,40,10,0.28), inset 0 0 0 1px rgba(255,255,255,0.45)",
+      fontFamily: "'EB Garamond', Georgia, serif",
+    }}>
+      <div style={{ padding: 3, background: "linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))" }}>
+        <div style={{
+          border: "1px solid rgba(60,40,10,0.45)", background: factionCssVar("ua", "card-bg"),
+          padding: "15px 14px 13px", textAlign: "center",
+          backgroundImage: "radial-gradient(rgba(60,40,10,0.03) 1px, transparent 1px)", backgroundSize: "5px 5px",
+          color: factionCssVar("ua", "card-text"),
+        }}>
+          <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 8.5, letterSpacing: "0.13em", color: factionCssVar("ua", "card-accent") }}>University of Asthmatics</div>
+          <div style={{ display: "flex", justifyContent: "center", margin: "8px 0 6px" }}><UACrest w={50} /></div>
+          <div style={{ position: "relative", margin: "0 auto 11px", width: "94%", background: factionCssVar("ua", "card-accent"), color: "#fce4c4", fontFamily: "var(--font-faction-engraved-caps)", fontSize: 7.5, letterSpacing: "0.07em", padding: "4px 0", clipPath: "polygon(0 0,100% 0,95% 50%,100% 100%,0 100%,5% 50%)" }}>Ars Longa · Spiritus Brevis</div>
+          <div style={{ fontFamily: factionCssVar("ua", "card-font"), fontStyle: "italic", fontWeight: 600, fontSize: 19, lineHeight: 1.18, marginBottom: 6, overflowWrap: "anywhere" }}>{title}</div>
+          {description && <div style={{ fontFamily: "'EB Garamond', Georgia, serif", fontStyle: "italic", fontSize: 10.5, lineHeight: 1.5, color: factionCssVar("ua", "card-muted"), marginBottom: 12 }}>{description}</div>}
+          <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 10, borderTop: "1px solid var(--ua-line-soft)", paddingTop: 10 }}>
+            <LevelPill level={level} factionSlug="ua" />
+            <span style={{ fontFamily: factionCssVar("ua", "card-font"), fontStyle: "italic", fontWeight: 700, fontSize: 17, color: factionCssVar("ua", "card-accent") }}>{points}<span style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 8, marginLeft: 3, color: factionCssVar("ua", "card-muted") }}>pts</span></span>
+          </div>
+          {onSignup && <button onClick={onSignup} style={{ width: "100%", marginTop: 11, cursor: "pointer", fontFamily: "var(--font-faction-engraved-caps)", fontSize: 9.5, letterSpacing: "0.12em", color: "var(--ua-paper-warm)", background: factionCssVar("ua", "card-accent"), border: "none", padding: "8px" }}>Matriculate</button>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   GESTALT — gestalt.exe desktop window
+   Pink computer-witch window: traffic-light title bar, dotted desktop
+   body, sparkle charms, a Caveat title, heart vote, glossy CTA.
+   ════════════════════════════════════════════════════════════════ */
+function Sparkle({ size = 12, color = "var(--gestalt-pink)", style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={{ display: "block", ...style }}>
+      <path d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z" fill={color} />
+    </svg>
+  );
+}
+function HeartGlyph({ size = 16, color = "var(--gestalt-pink)" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 36 36" style={{ display: "block" }}>
+      <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+        fill={color} stroke="#fff" strokeWidth="2.2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function Gestalt({ title, description, level, points, onSignup }) {
+  const dot = (c) => ({ width: 9, height: 9, borderRadius: "50%", background: c, border: "1.2px solid rgba(255,255,255,0.7)" });
+  return (
+    <div style={{
+      width: 232, flex: "0 0 auto", borderRadius: 12, overflow: "hidden",
+      border: "2px solid var(--gestalt-win-border)", boxShadow: "0 8px 20px var(--gestalt-glow)",
+      fontFamily: "var(--font-body)", transform: "rotate(-0.6deg)",
+    }}>
+      {/* title bar */}
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 11px",
+        background: "linear-gradient(180deg, var(--gestalt-title-from), var(--gestalt-title-to))",
+        borderBottom: "2px solid var(--gestalt-win-border)" }}>
+        <span style={dot("#fb7aa8")} /><span style={dot("#f6c75e")} /><span style={dot("#86cfa6")} />
+        <span style={{ marginLeft: "auto", fontSize: 9.5, color: "var(--gestalt-title-text)" }}>gestalt.exe</span>
+      </div>
+      {/* desktop body */}
+      <div style={{ position: "relative", padding: "15px 15px 16px", background: factionCssVar("gestalt", "card-bg"),
+        backgroundImage: "radial-gradient(var(--gestalt-border-soft) 1.3px, transparent 1.3px)", backgroundSize: "13px 13px",
+        color: factionCssVar("gestalt", "card-text") }}>
+        <Sparkle size={13} color="var(--gestalt-gold)" style={{ position: "absolute", top: 11, right: 13, transform: "rotate(8deg)" }} />
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.16em", color: "var(--gestalt-label)", marginBottom: 5 }}>a little magic</div>
+        <div style={{ fontFamily: factionCssVar("gestalt", "card-font"), fontSize: 27, lineHeight: 1.0, color: factionCssVar("gestalt", "card-text"), marginBottom: 7, overflowWrap: "anywhere" }}>{title}</div>
+        {description && <div style={{ fontSize: 9.5, lineHeight: 1.5, color: factionCssVar("gestalt", "card-muted"), marginBottom: 12, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: onSignup ? 12 : 0 }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 9, letterSpacing: "0.06em", textTransform: "uppercase",
+            padding: "3px 9px", borderRadius: 20, background: "var(--gestalt-pink-lt)", color: factionCssVar("gestalt", "card-text"), border: "1px solid var(--gestalt-border-soft)" }}>
+            <Sparkle size={9} color="var(--gestalt-pink)" /> lvl {level}
+          </span>
+          <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "center", gap: 5, fontFamily: factionCssVar("gestalt", "card-font"), fontSize: 20, color: "var(--gestalt-pink)" }}>
+            <HeartGlyph size={15} color="var(--gestalt-pink)" /> {points}
+          </span>
+        </div>
+        {onSignup && (
+          <button onClick={onSignup} style={{ width: "100%", cursor: "pointer", fontFamily: "var(--font-body)", fontSize: 10,
+            textTransform: "uppercase", letterSpacing: "0.12em", color: "#fff", padding: "9px",
+            border: "1.5px solid var(--gestalt-pink-deep)", borderRadius: 9,
+            background: "linear-gradient(180deg, var(--gestalt-pink), var(--gestalt-pink-deep))",
+            boxShadow: "0 4px 10px var(--gestalt-glow)", display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
+            <Sparkle size={11} color="#fff" /> sign up
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. — Ransom Dispatch
+   Photocopier-black demand note: acid masthead, cut-out ransom title,
+   pink marker scrawl, acid points inside a sprayed pink ellipse, tape.
+   ════════════════════════════════════════════════════════════════ */
+const RANSOM_STYLES = [
+  { bg: "var(--snide-paper)", col: "var(--snide-ink)", font: "var(--font-faction-anton)", rot: -5 },
+  { bg: "var(--snide-ink)", col: "var(--snide-acid)", font: "var(--font-accent)", rot: 4 },
+  { bg: "var(--snide-pink)", col: "#fff", font: "var(--font-faction-black)", rot: -3 },
+  { bg: "var(--snide-acid)", col: "var(--snide-ink)", font: "var(--font-faction-anton)", rot: 6 },
+  { bg: "var(--snide-paper)", col: "var(--snide-ink)", font: "var(--font-faction-typewriter)", rot: 2, italic: true },
+  { bg: "var(--snide-ink)", col: "#fff", font: "var(--font-accent)", rot: -6 },
+];
+function Ransom({ text, size = 26 }) {
+  return (
+    <span style={{ display: "inline-flex", flexWrap: "wrap", gap: "5px 3px", alignItems: "center" }}>
+      {[...text].map((ch, idx) => {
+        if (ch === " ") return <span key={idx} style={{ width: size * 0.22 }} />;
+        const s = RANSOM_STYLES[(ch.charCodeAt(0) + idx * 3) % RANSOM_STYLES.length];
+        return (
+          <span key={idx} style={{
+            display: "inline-block", background: s.bg, color: s.col, fontFamily: s.font,
+            fontStyle: s.italic ? "italic" : "normal", fontSize: size, lineHeight: 0.92,
+            padding: "2px 6px 0", transform: `rotate(${s.rot}deg)`,
+            boxShadow: "1.5px 2.5px 0 rgba(0,0,0,0.4)", textTransform: "uppercase",
+          }}>{ch}</span>
+        );
+      })}
+    </span>
+  );
+}
+function Snide({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 256, position: "relative", background: factionCssVar("snide", "card-bg"), color: "#fff",
+      padding: "28px 18px 20px", fontFamily: "var(--font-body)", overflow: "hidden",
+      boxShadow: "6px 8px 0 rgba(0,0,0,0.28)", transform: "rotate(-1deg)",
+    }}>
+      {/* acid halftone wash */}
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none",
+        backgroundImage: "radial-gradient(rgba(182,255,46,0.09) 32%, transparent 34%)", backgroundSize: "5px 5px" }} />
+      {/* tape */}
+      <div style={{ position: "absolute", top: -10, left: 28, width: 56, height: 22, background: "var(--snide-tape)", boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.25)", transform: "rotate(-8deg)" }} />
+      <div style={{ position: "absolute", top: -8, right: 22, width: 56, height: 22, background: "var(--snide-tape)", boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.25)", transform: "rotate(7deg)" }} />
+      {/* masthead */}
+      <div style={{ position: "relative", display: "flex", justifyContent: "space-between", alignItems: "baseline", borderBottom: "2px solid var(--snide-acid)", paddingBottom: 6, marginBottom: 11 }}>
+        <span style={{ fontFamily: "var(--font-accent)", fontSize: 15, letterSpacing: "0.22em", color: "var(--snide-acid)" }}>S.N.I.D.E.</span>
+        <span style={{ fontSize: 7.5, letterSpacing: "0.16em", color: "#8f9183", textTransform: "uppercase" }}>dispatch №0666</span>
+      </div>
+      <div style={{ position: "relative", fontFamily: "var(--font-faction-marker)", fontSize: 12, color: "var(--snide-pink)", transform: "rotate(-1.5deg)", marginBottom: 6 }}>your assignment, should you ignore it —</div>
+      <div style={{ position: "relative", margin: "8px 0 14px" }}><Ransom text={title} size={25} /></div>
+      {description && <p style={{ position: "relative", fontFamily: "var(--font-faction-typewriter)", fontSize: 10.5, lineHeight: 1.5, color: "#d8d6c8", margin: "0 0 16px" }}>{description}</p>}
+      <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 12 }}>
+        <div style={{ position: "relative", fontFamily: "var(--font-faction-anton)", color: "var(--snide-acid)", lineHeight: 0.8 }}>
+          <span style={{ fontSize: 36 }}>{points}</span>
+          <span style={{ fontSize: 10, letterSpacing: "0.1em", marginLeft: 3 }}>PTS</span>
+          <svg viewBox="0 0 120 60" style={{ position: "absolute", inset: "-12px -10px", width: "calc(100% + 20px)", height: "calc(100% + 24px)" }}>
+            <ellipse cx="60" cy="30" rx="54" ry="24" fill="none" stroke="var(--snide-pink)" strokeWidth="2.5" />
+          </svg>
+        </div>
+        <span style={{ fontFamily: "var(--font-accent)", fontSize: 12, letterSpacing: "0.1em", border: "1.5px dashed #6b6d60", color: "#cfd1c4", padding: "3px 8px", transform: "rotate(2deg)" }}>LVL {level}</span>
+        {onSignup && (
+          <button onClick={onSignup} style={{ marginLeft: "auto", cursor: "pointer", background: "var(--snide-pink)", color: "#fff", fontFamily: "var(--font-faction-black)", fontSize: 11, border: "none", padding: "7px 12px", transform: "rotate(-3deg)", boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>I'M IN ↗</button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — The Discordant Map
+   One place, three irreconcilable addresses: cartesian, perspective
+   and polar grids all claim the sheet and disagree. One word is always
+   pulled into the lapis; a self-referential footnote points at itself.
+   ════════════════════════════════════════════════════════════════ */
+const ROMAN = [["M", 1000], ["CM", 900], ["D", 500], ["CD", 400], ["C", 100], ["XC", 90], ["L", 50], ["XL", 40], ["X", 10], ["IX", 9], ["V", 5], ["IV", 4], ["I", 1]];
+function toRoman(n) { let s = ""; for (const [g, v] of ROMAN) { while (n >= v) { s += g; n -= v; } } return s; }
+function EphMark({ size = 11, color = "var(--eph-gold-light)" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="1.4" style={{ display: "block" }}>
+      <ellipse cx="12" cy="12" rx="11" ry="4.4" transform="rotate(-24 12 12)" />
+      <path d="M4 12 C7.5 8.2 16.5 8.2 20 12 C16.5 15.8 7.5 15.8 4 12 Z" />
+      <circle cx="12" cy="12" r="2.7" />
+      <circle cx="12" cy="12" r="0.6" fill={color} stroke="none" />
+    </svg>
+  );
+}
+function Ephemerists({ title, description, level, points, onSignup }) {
+  const tw = title.trim().split(" ");
+  const tlast = tw.pop();
+  return (
+    <div style={{
+      width: 214, minHeight: 300, position: "relative", overflow: "hidden",
+      background: factionCssVar("ephemerists", "card-bg"), color: factionCssVar("ephemerists", "card-text"),
+      border: "1.5px solid var(--eph-ink)", fontFamily: "var(--font-faction-codex)", display: "flex", flexDirection: "column",
+    }}>
+      {/* eyebrow */}
+      <div style={{ position: "relative", zIndex: 5, padding: "9px 0 4px", textAlign: "center" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 5, color: "var(--eph-gold)" }}>
+          <EphMark size={11} color="var(--eph-gold)" />
+          <span style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 600, fontSize: 8.5, letterSpacing: "0.24em" }}>THE EPHEMERISTS</span>
+        </div>
+        <div style={{ fontFamily: "var(--font-faction-codex-script)", fontStyle: "italic", fontSize: 8.5, color: "var(--eph-muted)", marginTop: 1 }}>exhibit C · no single here</div>
+      </div>
+      {/* the contested field */}
+      <div style={{ position: "relative", flex: 1, minHeight: 188, margin: "2px 4px", border: "1px solid var(--eph-gold-deep)", overflow: "hidden" }}>
+        <div style={{ position: "absolute", inset: 0, opacity: 0.5, backgroundImage: "repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px), repeating-linear-gradient(90deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px)" }} />
+        <svg viewBox="0 0 200 188" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.7 }}>
+          <g stroke="var(--eph-lapis)" strokeWidth="0.9" fill="none">
+            {Array.from({ length: 11 }).map((_, i) => <line key={i} x1={i * 20} y1="188" x2="122" y2="40" />)}
+            {[60, 96, 124, 146, 163, 176].map((y, i) => <line key={i} x1="0" y1={y} x2="200" y2={y} />)}
+          </g>
+        </svg>
+        <svg viewBox="0 0 200 188" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.72 }}>
+          <g stroke="var(--eph-rubric)" strokeWidth="0.8" fill="none">
+            {[16, 34, 54, 76].map((r, i) => <circle key={i} cx="122" cy="88" r={r} />)}
+            {Array.from({ length: 12 }).map((_, i) => <line key={i} x1="122" y1="88" x2={122 + 80 * Math.cos(i * Math.PI / 6)} y2={88 + 80 * Math.sin(i * Math.PI / 6)} />)}
+          </g>
+        </svg>
+        <div style={{ position: "absolute", left: "61%", top: "47%", transform: "translate(-50%,-50%)", zIndex: 4 }}>
+          <div style={{ width: 9, height: 9, borderRadius: "50%", background: "var(--eph-gold-light)", boxShadow: "0 0 10px 3px color-mix(in srgb, var(--eph-gold-light) 70%, transparent)" }} />
+        </div>
+        <div style={{ position: "absolute", top: "8%", left: "6%", fontSize: 7.5, letterSpacing: "0.04em", color: "var(--eph-vellum-text)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>x 14 · y <span style={{ textDecoration: "line-through", opacity: 0.65 }}>8</span> <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>9</span></div>
+        <div style={{ position: "absolute", top: "78%", left: "54%", fontSize: 7.5, color: "var(--eph-rubric)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>r 47 · θ 31°</div>
+        <div style={{ position: "absolute", top: "6%", left: "68%", fontSize: 7.5, color: "var(--eph-lapis)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>∞ · vanishing</div>
+        <div style={{ position: "absolute", left: 2, bottom: 7, transformOrigin: "left bottom", transform: "rotate(-90deg)", whiteSpace: "nowrap", fontSize: 6, color: "var(--eph-muted)", opacity: 0.85 }}>¼″ wider within than without †</div>
+      </div>
+      {/* legend / title */}
+      <div style={{ position: "relative", zIndex: 5, padding: "8px 14px 10px", textAlign: "center" }}>
+        <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 22, lineHeight: 0.94, color: factionCssVar("ephemerists", "card-text") }}>{tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span><sup style={{ fontFamily: "var(--font-faction-codex)", fontSize: 9, color: "var(--eph-lapis)", fontWeight: 400 }}>†</sup></div>
+        {description && <div style={{ fontSize: 8.5, lineHeight: 1.45, fontStyle: "italic", color: "var(--eph-muted)", margin: "4px 0 6px", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>}
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 7, fontSize: 7.5 }}>
+          <span style={{ color: factionCssVar("ephemerists", "card-text") }}>▦ grade {toRoman(level)}</span>
+          <span style={{ color: "var(--eph-gold-deep)" }}>·</span>
+          <span style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 13, color: "var(--eph-rubric)" }}>{points} pvncta</span>
+        </div>
+        <div style={{ fontSize: 6.5, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 6, lineHeight: 1.35 }}>† the road does not return you to where you began — <span style={{ color: "var(--eph-lapis)" }}>see †</span></div>
+      </div>
+      {onSignup && (
+        <button onClick={onSignup} style={{ fontFamily: "var(--font-faction-codex)", fontSize: 9, letterSpacing: "0.12em", fontStyle: "italic", padding: "7px 10px", border: "none", cursor: "pointer", width: "100%", background: "var(--eph-ink)", color: "var(--eph-parchment)", position: "relative", zIndex: 6 }}>Triangulate the truth ▸</button>
+      )}
+    </div>
+  );
+}
+
+/* ── Singularity — Terminal Printout (always dark) ── */
+function SprocketHoles() {
+  return (
+    <div style={{ display: "flex", justifyContent: "center", gap: 6, padding: "4px 0" }}>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div key={index} style={{ width: 6, height: 4, background: "rgba(10,26,14)", border: "1px solid var(--faction-singularity-card-accent)", borderRadius: 1 }} />
+      ))}
+    </div>
+  );
+}
+function Singularity({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      minWidth: 128, maxWidth: 156, flex: "0 1 140px", background: "var(--faction-singularity-card-bg)",
+      border: "1px solid var(--faction-singularity-border-hard)", position: "relative",
+      fontFamily: factionCssVar("singularity", "card-font"), color: "var(--faction-singularity-card-text)", overflow: "hidden",
+    }}>
+      <div style={{ position: "absolute", inset: 0, backgroundImage: "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)", pointerEvents: "none", zIndex: 1 }} />
+      {[["top", 3, "left", 3, "borderTop", "borderLeft"], ["top", 3, "right", 3, "borderTop", "borderRight"], ["bottom", 3, "left", 3, "borderBottom", "borderLeft"], ["bottom", 3, "right", 3, "borderBottom", "borderRight"]].map((c, i) => (
+        <div key={i} style={{ position: "absolute", [c[0]]: c[1], [c[2]]: c[3], width: 10, height: 10, [c[4]]: "1px solid var(--faction-singularity-card-text)", [c[5]]: "1px solid var(--faction-singularity-card-text)" }} />
+      ))}
+      <SprocketHoles />
+      <div style={{ padding: "4px 12px 8px", position: "relative", zIndex: 2 }}>
+        <div style={{ fontSize: 7, color: "var(--faction-singularity-card-muted)", textTransform: "uppercase", letterSpacing: "0.15em", marginBottom: 6 }}>
+          singularity protocol
+          <span style={{ display: "inline-block", width: 5, height: 9, background: "var(--faction-singularity-card-text)", marginLeft: 3, verticalAlign: "middle", animation: "wz-blink 1s step-end infinite" }} />
+        </div>
+        <div style={{ fontSize: "var(--text-sm)", marginBottom: 6, lineHeight: 1.3, overflowWrap: "anywhere" }}>{"> "}{title}</div>
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--faction-singularity-card-muted)", lineHeight: 1.6, marginBottom: 6 }}>
+          <div>PTS: <span style={{ color: "var(--faction-singularity-card-text)", fontSize: "var(--text-md)", fontWeight: 700 }}>{points}</span></div>
+          <div>LVL: {level}</div>
+        </div>
+        {description && <div style={{ fontSize: 7, color: "var(--faction-singularity-card-muted)", lineHeight: 1.4, marginBottom: 6, overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}>{description}</div>}
+        {onSignup && (
+          <button onClick={onSignup} style={{ background: "transparent", color: "var(--faction-singularity-card-text)", border: "1px solid var(--faction-singularity-card-text)", fontFamily: factionCssVar("singularity", "card-font"), fontSize: 7, textTransform: "uppercase", letterSpacing: "0.1em", padding: "2px 8px", cursor: "pointer", marginBottom: 4 }}>{">"} sign up</button>
+        )}
+        <div style={{ display: "flex", justifyContent: "flex-end", borderTop: "1px solid var(--faction-singularity-border-hard)", paddingTop: 5 }}>
+          <span style={{ border: "1px solid var(--faction-singularity-card-text)", color: "var(--faction-singularity-card-text)", fontSize: 7, padding: "1px 6px", borderRadius: 6, textTransform: "uppercase" }}>lvl {level}</span>
+        </div>
+      </div>
+      <SprocketHoles />
+      <style>{`@keyframes wz-blink { 50% { opacity: 0; } }`}</style>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — Vellum Correspondence (always light)
+   Pure-white cotton card, hairline borders, a centred surveyor's-mark
+   sigil, Cormorant Garamond italic title. No hue. The card whispers.
+   ════════════════════════════════════════════════════════════════ */
+function AlbescentMark({ size = 20, color = "var(--faction-albescent-card-text)" }) {
+  const c = size / 2, rO = size * 0.43, rI = size * 0.235, rD = size * 0.044;
+  const tS = rI + size * 0.025, tE = tS + size * 0.13;
+  const tick = (deg) => { const a = deg * Math.PI / 180; return { x1: c + tS * Math.cos(a), y1: c + tS * Math.sin(a), x2: c + tE * Math.cos(a), y2: c + tE * Math.sin(a) }; };
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none" style={{ display: "block", flexShrink: 0 }}>
+      <circle cx={c} cy={c} r={rO} stroke={color} strokeWidth={size * 0.022} opacity={0.18} />
+      <circle cx={c} cy={c} r={rI} stroke={color} strokeWidth={size * 0.038} opacity={0.5} />
+      {[0, 90, 180, 270].map((deg, i) => { const { x1, y1, x2, y2 } = tick(deg); return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={size * 0.038} />; })}
+      <circle cx={c} cy={c} r={rD} fill={color} />
+    </svg>
+  );
+}
+function Albescent({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 196, flex: "0 0 auto", background: factionCssVar("albescent", "card-bg"),
+      border: "1px solid var(--faction-albescent-border)", boxShadow: "var(--al-shadow)",
+      padding: "22px 18px 16px", fontFamily: factionCssVar("albescent", "card-font"),
+      color: factionCssVar("albescent", "card-text"),
+    }}>
+      <div style={{ display: "flex", justifyContent: "center", marginBottom: 14 }}><AlbescentMark size={20} /></div>
+      <div style={{ height: 1, background: "var(--al-border-faint)", marginBottom: 12 }} />
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 6, letterSpacing: "0.32em", textTransform: "uppercase", color: factionCssVar("albescent", "card-muted"), marginBottom: 9 }}>Albescent</div>
+      <div style={{ fontStyle: "italic", fontWeight: 300, fontSize: 18, lineHeight: 1.28, marginBottom: 10, overflowWrap: "anywhere" }}>{title}</div>
+      {description && <div style={{ fontFamily: "var(--font-body)", fontSize: 7.5, lineHeight: 1.6, color: factionCssVar("albescent", "card-muted"), marginBottom: 14, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>}
+      {onSignup && (
+        <button onClick={onSignup} style={{ background: "none", border: "none", padding: 0, cursor: "pointer", fontFamily: "var(--font-body)", fontSize: 7, letterSpacing: "0.22em", textTransform: "uppercase", color: factionCssVar("albescent", "card-accent"), borderBottom: "1px solid var(--faction-albescent-border)", paddingBottom: 1, marginBottom: 14, display: "inline-block" }}>acknowledge</button>
+      )}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: "1px solid var(--al-border-faint)", paddingTop: 10 }}>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.2em", textTransform: "uppercase", color: factionCssVar("albescent", "card-muted") }}>Lvl {level}</span>
+        <span style={{ fontStyle: "italic", fontWeight: 300, fontSize: 16, color: factionCssVar("albescent", "card-accent") }}>{points}<span style={{ fontFamily: "var(--font-body)", fontSize: 6.5, marginLeft: 3, letterSpacing: "0.1em", textTransform: "uppercase" }}>pts</span></span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — Union / Victory Poster ("Mobilize")
+   Sunburst red field, knocked-out Bebas headline, cog sigil seal,
+   gold rule, split LVL/PTS footer bar, rubber-stamp enlist CTA.
+   ════════════════════════════════════════════════════════════════ */
+function CogMark({ size = 22, color = "currentColor" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
+      <g fill={color}>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <rect key={i} x="11" y="0.5" width="2" height="5" rx="0.5" transform={`rotate(${i * 45} 12 12)`} />
+        ))}
+      </g>
+      <circle cx="12" cy="12" r="6.5" fill="none" stroke={color} strokeWidth="2.4" />
+      <circle cx="12" cy="12" r="2" fill={color} />
+    </svg>
+  );
+}
+function Everymen({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 206, background: "var(--everymen-field)", color: "var(--everymen-cream)",
+      border: "3px solid var(--everymen-ink)", position: "relative", overflow: "hidden",
+      fontFamily: "var(--font-body)",
+    }}>
+      {/* sunburst + halftone */}
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.55, zIndex: 0,
+        background: "repeating-conic-gradient(from 0deg at 50% 38%, var(--everymen-field-deep) 0deg 7.5deg, transparent 7.5deg 15deg)" }} />
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.1, zIndex: 1,
+        backgroundImage: "radial-gradient(var(--everymen-cream) 0.6px, transparent 0.7px)", backgroundSize: "4px 4px" }} />
+      {/* eyebrow ribbon */}
+      <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center", padding: "5px 0", fontFamily: "var(--font-faction-poster)", fontSize: 12, letterSpacing: "0.3em" }}>THE EVERYMEN</div>
+      <div style={{ position: "relative", zIndex: 2, padding: "16px 14px 13px", textAlign: "center" }}>
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 8 }}>
+          <div style={{ width: 40, height: 40, borderRadius: "50%", background: "var(--everymen-cream)", color: "var(--everymen-red)", display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 0 0 3px var(--everymen-ink)" }}>
+            <CogMark size={24} color="var(--everymen-red)" />
+          </div>
+        </div>
+        <div style={{ minHeight: 74, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <div style={{ fontFamily: "var(--font-faction-poster)", fontSize: 34, lineHeight: 1.06, color: "var(--everymen-cream)", textShadow: "1.5px 1.5px 0 var(--everymen-ink)", overflowWrap: "anywhere" }}>{title}</div>
+        </div>
+        <div style={{ height: 2, background: "var(--everymen-gold)", margin: "11px 22px 10px" }} />
+        {description && <div style={{ fontSize: 8, lineHeight: 1.5, color: "var(--everymen-cream)", opacity: 0.92, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>}
+      </div>
+      {/* footer bar */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "stretch", borderTop: "3px solid var(--everymen-ink)" }}>
+        <div style={{ flex: 1, background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center", padding: "6px 0", fontFamily: "var(--font-faction-poster)", fontSize: 16 }}>LVL {level}</div>
+        <div style={{ flex: 1, background: "var(--everymen-gold)", color: "var(--everymen-ink)", textAlign: "center", padding: "6px 0", fontFamily: "var(--font-faction-poster)", fontSize: 16 }}>{points} PTS</div>
+      </div>
+      {onSignup && (
+        <button onClick={onSignup} style={{ width: "100%", cursor: "pointer", fontFamily: "var(--font-body)", fontSize: 8, textTransform: "uppercase", letterSpacing: "0.14em", padding: "8px 10px", border: "none", background: "var(--everymen-cream)", color: "var(--everymen-ink)", position: "relative", zIndex: 2 }}>Mobilize ▸</button>
+      )}
+    </div>
+  );
+}

--- a/docs/design/design-system/components/cards/FactionTaskCard.prompt.md
+++ b/docs/design/design-system/components/cards/FactionTaskCard.prompt.md
@@ -1,0 +1,7 @@
+**FactionTaskCard** — World Zero's signature component. Each faction renders a totally different physical card archetype; the card type IS the faction identity. Use anywhere a task surfaces.
+
+```jsx
+<FactionTaskCard faction="snide" title="DO A KICKFLIP" description="Do a kickflip. Bonus if you don't use a skateboard." level={2} points={25} onSignup={signUp} />
+```
+
+Factions → archetype: `ua` gilt salon (heraldic crest in a gold frame, Playfair italic) · `gestalt` gestalt.exe desktop window · `snide` ransom dispatch (photocopier ink, cut-out letters, always dark) · `ephemerists` the discordant map (vellum, feuding coordinate grids) · `singularity` terminal printout (always dark) · `everymen` union/victory poster. (`journeymen` is a legacy alias for `ephemerists`.) Place several in a `display:flex; flex-wrap:wrap; gap:1rem` container — varied sizes and slight rotations are intentional, never a strict grid. Omit `onSignup` to hide the sign-up button.

--- a/docs/design/design-system/components/cards/cards.card.html
+++ b/docs/design/design-system/components/cards/cards.card.html
@@ -1,0 +1,36 @@
+<!-- @dsCard group="Faction Components" viewport="860x460" name="Faction Task Cards" subtitle="All seven archetypes — the card type IS the faction" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 24px; background: var(--color-bg-page); }
+  #root { display: flex; flex-wrap: wrap; gap: 18px; align-items: flex-start; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+  const { FactionTaskCard } = window.WorldZeroDesignSystem_019e22;
+  const cards = [
+    { faction: "ua", title: "Trash Transformation", description: "Find some trash in a public place. Make it into something else.", level: 1, points: 5 },
+    { faction: "wow", title: "The L Word", description: "Find someone you love. Tell them you love them.", level: 1, points: 5 },
+    { faction: "snide", title: "DO A KICKFLIP", description: "Do a kickflip. Bonus if you don't use a skateboard.", level: 2, points: 25 },
+    { faction: "ephemerists", title: "There", description: "Pick some place to travel at random. Travel there.", level: 4, points: 50 },
+    { faction: "singularity", title: "FLIP THE SYSTEM", description: "Census on anything. Consider what your data says.", level: 3, points: 25 },
+    { faction: "everymen", title: "Pick Up The Load", description: "Spot a neighbor carrying too much. Take half. Walk with them.", level: 2, points: 25 },
+    { faction: "albescent", title: "Tend the Archive in Silence", description: "Retrieve, restore, and return. No record of your work need remain.", level: 3, points: 40 },
+  ];
+  ReactDOM.createRoot(document.getElementById("root")).render(
+    <React.Fragment>
+      {cards.map((c) => <FactionTaskCard key={c.faction} {...c} onSignup={() => {}} />)}
+    </React.Fragment>
+  );
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/cards/coverage.card.html
+++ b/docs/design/design-system/components/cards/coverage.card.html
@@ -1,0 +1,153 @@
+<!-- @dsCard group="Faction Components" viewport="1240x980" name="Faction Component Coverage" subtitle="Every faction component type × which kit ships it — filled = bespoke design, hollow = falls back to the shared/generic default" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 26px 28px 30px; background: var(--color-bg-page); font-family: var(--font-body); color: var(--color-text-primary); }
+  .head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 4px; }
+  .title { font-family: var(--font-display); font-style: italic; font-size: 26px; font-weight: 500; }
+  .sub { font-size: 10px; color: var(--color-text-tertiary); letter-spacing: 0.04em; }
+  .legend { display: flex; gap: 18px; align-items: center; margin: 12px 0 16px; font-size: 9px; color: var(--color-text-secondary); text-transform: uppercase; letter-spacing: 0.1em; }
+  .legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .swatch { width: 13px; height: 13px; border-radius: 3px; display: inline-block; }
+  .sw-on { background: var(--color-text-primary); }
+  .sw-off { background: transparent; border: 1px dashed var(--color-border-strong, #b9b2a6); }
+
+  table { border-collapse: collapse; width: 100%; table-layout: fixed; }
+  th, td { padding: 0; text-align: center; }
+  thead th { vertical-align: bottom; padding-bottom: 9px; }
+  .corner { text-align: left; width: 168px; }
+  .fhead { width: auto; }
+  .fchip { display: inline-flex; flex-direction: column; align-items: center; gap: 5px; }
+  .fdot { width: 12px; height: 12px; border-radius: 50%; }
+  .fname { font-size: 9px; font-weight: 700; letter-spacing: 0.06em; line-height: 1; }
+  .fcount { font-size: 8px; color: var(--color-text-tertiary); font-variant-numeric: tabular-nums; }
+
+  .tier td { padding-top: 13px; }
+  .tier-label { text-align: left; font-size: 8px; text-transform: uppercase; letter-spacing: 0.18em; color: var(--color-text-tertiary); padding: 14px 0 5px; border-bottom: 1px solid var(--color-border); }
+
+  tbody tr.row { border-bottom: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent); }
+  .rlabel { text-align: left; font-size: 11px; padding: 7px 8px 7px 0; line-height: 1.2; }
+  .rlabel small { display: block; font-size: 7.5px; color: var(--color-text-tertiary); letter-spacing: 0.02em; margin-top: 1px; }
+  .cell { padding: 6px 2px; }
+  .mark { display: inline-flex; flex-direction: column; align-items: center; gap: 2px; }
+  .box { width: 15px; height: 15px; border-radius: 3.5px; display: flex; align-items: center; justify-content: center; font-size: 9px; color: #fff; line-height: 1; }
+  .box.off { background: transparent; border: 1px dashed var(--color-border-strong, #c2bbae); }
+  .impl { font-size: 6.5px; line-height: 1.1; color: var(--color-text-secondary); max-width: 92px; font-family: var(--font-body); letter-spacing: -0.01em; }
+  .impl.none { color: var(--color-text-tertiary); opacity: 0.6; }
+  .rcount { font-size: 8.5px; color: var(--color-text-tertiary); font-variant-numeric: tabular-nums; width: 30px; }
+
+  .foot { margin-top: 16px; font-size: 9px; line-height: 1.6; color: var(--color-text-secondary); }
+  .foot b { color: var(--color-text-primary); }
+  .flag { color: var(--color-text-primary); background: color-mix(in srgb, var(--color-text-primary) 8%, transparent); padding: 1px 5px; border-radius: 4px; }
+</style>
+</head>
+<body>
+<div class="head">
+  <span class="title">Faction Component Coverage</span>
+  <span class="sub">bespoke kit design vs. shared / generic fallback · 7 factions × 15 component types</span>
+</div>
+<div class="legend">
+  <span><i class="swatch sw-on"></i> bespoke faction design (in kit)</span>
+  <span><i class="swatch sw-off"></i> falls back to shared / generic default</span>
+  <span style="margin-left:auto; text-transform:none; letter-spacing:0;">Shared faction-switched baseline: FactionTaskCard · FactionPraxisCard · FactionVoteStamps · FactionPennant · LevelPill</span>
+</div>
+
+<table id="matrix"></table>
+
+<div class="foot" id="foot"></div>
+
+<script>
+  const FACTIONS = [
+    { slug: "ua",          name: "UA",        color: "#c2541f" },
+    { slug: "wow",         name: "WHIMSY",    color: "#be185d" },
+    { slug: "snide",       name: "S.N.I.D.E", color: "#16a34a" },
+    { slug: "ephemerists", name: "EPHEM.",    color: "#1d6e72" },
+    { slug: "singularity", name: "SINGUL.",   color: "#2563eb" },
+    { slug: "everymen",    name: "EVERYMEN",  color: "#c1272d" },
+    { slug: "albescent",   name: "ALBESC.",   color: "#1c1c1a" },
+  ];
+
+  // order: ua, wow (Warriors of Whimsy), snide, ephemerists, singularity, everymen, albescent
+  // value = bespoke kit component name, or null = falls back to shared/generic
+  const TIERS = [
+    { label: "Cards & core surfaces", rows: [
+      { type: "Task card",        note: "the archetype",            cells: ["GiltCrest", "WhimsyExe", "CardRansom +4", "DiscordantMap", "SingularityCard", "RallyBill", "AlbescentCard"] },
+      { type: "Praxis card",      note: "filed submission",         cells: ["SalonPlacard", "GPraxisCard", "SnidePraxisRow", "PraxisRow", "PraxisRow", "WorkOrder", "RegisterRow"] },
+      { type: "Edit-praxis form", note: "filing the return",        cells: ["SalonSubmit", "QuestSubmit", "SnidePraxisForm", "PraxisForm", "SealPraxis", "PraxisForm", "FileAccount"] },
+      { type: "Join / select",    note: "faction recruitment",      cells: [null, null, "Join Screen", null, null, "RecruitPoster", null] },
+      { type: "Filter pennant",   note: "faction filter tab",       cells: [null, "GPennant", "SnidePennant", "Pennant", null, "Pennant", null] },
+      { type: "Vote / rating",    note: "1–5, faction voice",       cells: ["Critique", "GVoteStamps", "SnideVoteStamps", "EphConcordance", "SgVoteWidget", "EmVoteStamps", "WitnessCaster"] },
+    ]},
+    { label: "Identity atoms", rows: [
+      { type: "Sigil / mark",     note: "faction emblem",           cells: ["UACrest", "GAppIcon", "SnideSigil", "EphSeal", "SingularityMark", "EM_CogMark", "AlbescentMark"] },
+      { type: "Avatar + badge",   note: "membership chip",          cells: [null, "Avatar / Badge", "SnideNavBadge", "EphAvatar", "SgNavBadge", "EmNavBadge", "AlNavBadge"] },
+      { type: "Hero banner",      note: "faction-page header",      cells: ["SalonHero", null, "SnideHero", "EphHero", "SgHero", "EmHero", "AlHero"] },
+      { type: "Stat block",       note: "membership figures",       cells: ["SalonStats", null, "SnideStat", "EphStat", null, "EmStat", null] },
+      { type: "Page backdrop",    note: "full-page context bg",     cells: [".ua-backdrop", "GBackdrop", ".snide-backdrop", ".eph-backdrop", ".sg-backdrop", ".em-backdrop", ".al-backdrop"] },
+    ]},
+    { label: "Pages & feed", rows: [
+      { type: "Comment box",      note: "thread post, per faction", cells: ["FactionCommentBox", "FactionCommentBox", "FactionCommentBox", "FactionCommentBox", "FactionCommentBox", "FactionCommentBox", "FactionCommentBox"] },
+      { type: "Activity-feed card", note: "reskins all events",     cells: [null, "FeedRow", "SnideDispatch", "EphemeristActivityCard", "SgActivityCard", "EverymenActivityCard", "AlActivityCard"] },
+      { type: "Task-detail page", note: "sign-up dossier",          cells: ["UATaskDetail", "WhimsyTaskDetail", "SnideTaskDetail", "EphTaskDetail", "SgTaskDetail", "EmTaskDetail", "AlTaskDetail"] },
+      { type: "Praxis-detail page", note: "read + cast vote",       cells: ["UAPraxisRead", null, "SnidePraxisDetail", "PraxisRead", "PraxisRead", null, "EntryRead"] },
+    ]},
+  ];
+
+  const colTotals = FACTIONS.map(() => 0);
+  let rowCount = 0;
+  TIERS.forEach(t => t.rows.forEach(r => { rowCount++; r.cells.forEach((c, i) => { if (c) colTotals[i]++; }); }));
+
+  const t = document.getElementById("matrix");
+
+  // header
+  const thead = document.createElement("thead");
+  const htr = document.createElement("tr");
+  htr.innerHTML = '<th class="corner"></th>';
+  FACTIONS.forEach((f, i) => {
+    const th = document.createElement("th");
+    th.className = "fhead";
+    th.innerHTML = `<span class="fchip"><i class="fdot" style="background:${f.color}"></i><span class="fname" style="color:${f.color}">${f.name}</span><span class="fcount">${colTotals[i]}/${rowCount}</span></span>`;
+    htr.appendChild(th);
+  });
+  htr.innerHTML += '<th></th>';
+  thead.appendChild(htr);
+  t.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  TIERS.forEach(tier => {
+    const lr = document.createElement("tr");
+    lr.innerHTML = `<td class="tier-label" colspan="${FACTIONS.length + 2}">${tier.label}</td>`;
+    tbody.appendChild(lr);
+    tier.rows.forEach(r => {
+      const tr = document.createElement("tr");
+      tr.className = "row";
+      const present = r.cells.filter(Boolean).length;
+      let html = `<td class="rlabel">${r.type}<small>${r.note}</small></td>`;
+      r.cells.forEach((c, i) => {
+        const f = FACTIONS[i];
+        if (c) {
+          html += `<td class="cell"><span class="mark"><span class="box" style="background:${f.color}">✓</span><span class="impl">${c}</span></span></td>`;
+        } else {
+          html += `<td class="cell"><span class="mark"><span class="box off"></span><span class="impl none">fallback</span></span></td>`;
+        }
+      });
+      html += `<td class="rcount">${present}/${r.cells.length}</td>`;
+      tr.innerHTML = html;
+      tbody.appendChild(tr);
+    });
+  });
+  t.appendChild(tbody);
+
+  document.getElementById("foot").innerHTML =
+    'Read it as gaps: a <b>hollow cell</b> means that faction has no bespoke design and renders the shared faction-switched component (or a generic default). ' +
+    'The <b>comment box / thread post</b> is the one surface every faction ships — delivered through a single shared faction-switched component, <code>FactionCommentBox</code>, with seven distinct bubble treatments (gilt salon, whimsy.exe window, ransom slip, vellum marginalia, terminal line, union entry, the register). ' +
+    '<span class="flag">UA was repainted into a gilt art-academy</span> and now ships a full kit — burnt-amber + gold, promoted into the global <code>--faction-ua-*</code> tokens (always-light). Its remaining gaps are join/select, filter pennant, avatar+badge and activity-feed. ' +
+    '<b>Albescent</b> (always-light vellum) sits at 12/15 — still missing join, pennant, and stat. ' +
+    '<b>Warriors of Whimsy</b> (slug <code>wow</code>, formerly Gestalt) is a full UI kit but still lacks join, hero, stat, and a praxis-detail page. ' +
+    'Every faction now ships a bespoke <b>edit-praxis form</b> and a bespoke <b>task-detail page</b> (7/7) — both rows are closed. Sparsest types across the board: <b>join / select</b> (2 factions), then <b>filter pennant</b> (4) and <b>stat block</b> (4).';
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/cards/praxis.card.html
+++ b/docs/design/design-system/components/cards/praxis.card.html
@@ -1,0 +1,36 @@
+<!-- @dsCard group="Faction Components" viewport="900x520" name="Faction Praxis Cards" subtitle="A filed praxis per faction — each reframes the 1–5 vote in its own language" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 24px; background: var(--color-bg-page); }
+  #root { display: flex; flex-wrap: wrap; gap: 20px; align-items: flex-start; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+  const { FactionPraxisCard } = window.WorldZeroDesignSystem_019e22;
+  const praxes = [
+    { faction: "ua", task: "Trash Transformation", finding: "Made a lamp from a milk crate", author: "Pip", excerpt: "Wired a thrown-out crate and a dead bulb into a reading lamp. Works.", rating: 4, marks: 12, points: 5, level: 1 },
+    { faction: "wow", task: "The L Word", finding: "I told my landlord", author: "Pixie", excerpt: "Knocked on 4B, said it out loud, ran away. Heart still pounding.", rating: 5, marks: 23, points: 5, level: 1 },
+    { faction: "snide", task: "DO A KICKFLIP", finding: "Landed it. No board.", author: "Static", excerpt: "Did the kickflip motion mid-air off a curb. Nobody asked. Double points.", rating: 4, marks: 31, points: 25, level: 2 },
+    { faction: "ephemerists", task: "Trace a Myth", finding: "The Saint Was A Surveyor", author: "Vesper", excerpt: "Followed the legend back through eleven retellings until the road ran out.", rating: 4.3, marks: 47, points: 100, level: 4 },
+    { faction: "singularity", task: "FLIP THE SYSTEM", finding: "Counted every door I held", author: "node_7", excerpt: "Logged each held door for a week. The data says I am very polite.", rating: 3, marks: 18, points: 25, level: 3 },
+    { faction: "everymen", task: "Pick Up The Load", finding: "Carried the Tran's groceries", author: "Rivet", excerpt: "Took the heavy bags up four flights. Stayed for tea. Worth more than points.", rating: 5, marks: 26, points: 25, level: 2 },
+    { faction: "albescent", task: "Tend the Archive in Silence", finding: "Restored the east wing", author: "Keeper Vane", excerpt: "All volumes returned to their documented positions. The shelves hold their sequence without my name in them.", rating: 4.4, marks: 12, points: 40, level: 3 },
+  ];
+  ReactDOM.createRoot(document.getElementById("root")).render(
+    <React.Fragment>
+      {praxes.map((p) => <FactionPraxisCard key={p.faction} {...p} />)}
+    </React.Fragment>
+  );
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/core/Button.d.ts
+++ b/docs/design/design-system/components/core/Button.d.ts
@@ -1,0 +1,20 @@
+import React from "react";
+
+export interface ButtonProps {
+  children: React.ReactNode;
+  /** Solid ink fill (`primary`) or frosted bordered (`outline`). Default `primary`. */
+  variant?: "primary" | "outline";
+  /** `sm` is the tiny in-card sign-up size; `md` is default; `lg` for hero CTAs. */
+  size?: "sm" | "md" | "lg";
+  onClick?: () => void;
+  /** Only for in-flight async / form validity — never for permission gates. */
+  disabled?: boolean;
+  type?: "button" | "submit" | "reset";
+  style?: React.CSSProperties;
+}
+
+/**
+ * World Zero's core action control — uppercase Courier Prime, no rounding,
+ * flat opacity hover.
+ */
+export function Button(props: ButtonProps): JSX.Element;

--- a/docs/design/design-system/components/core/Button.jsx
+++ b/docs/design/design-system/components/core/Button.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+/**
+ * Button — World Zero's core action control.
+ *
+ * Two variants drawn straight from index.css: `primary` (solid ink fill,
+ * inverts in dark mode via the cascade) and `outline` (frosted surface +
+ * strong border). All-uppercase Courier Prime, wide tracking, no rounding.
+ * Hover is a flat opacity drop to 0.85 — never a color shift or shadow.
+ *
+ * Per World Zero rule: never render a disabled button for a permission gate —
+ * hide the control instead. `disabled` is only for in-flight async / form
+ * validity.
+ */
+export function Button({
+  children,
+  variant = "primary",
+  size = "md",
+  onClick,
+  disabled = false,
+  type = "button",
+  style = {},
+  ...rest
+}) {
+  const sizes = {
+    sm: { fontSize: 7, padding: "2px 8px", letterSpacing: "0.1em" },
+    md: { fontSize: 9, padding: "0.5rem 1rem", letterSpacing: "0.12em" },
+    lg: { fontSize: 11, padding: "0.6rem 1.4rem", letterSpacing: "0.12em" },
+  };
+
+  const base = {
+    fontFamily: "var(--font-body)",
+    textTransform: "uppercase",
+    border: variant === "outline" ? "1px solid var(--color-border-strong)" : "none",
+    background:
+      variant === "outline" ? "var(--color-bg-surface)" : "var(--color-text-primary)",
+    color:
+      variant === "outline" ? "var(--color-text-primary)" : "var(--color-bg-page)",
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+    transition: "opacity 150ms",
+    ...sizes[size],
+    ...style,
+  };
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      style={base}
+      onMouseEnter={(e) => {
+        if (!disabled) e.currentTarget.style.opacity = "0.85";
+      }}
+      onMouseLeave={(e) => {
+        if (!disabled) e.currentTarget.style.opacity = "1";
+      }}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/docs/design/design-system/components/core/Button.prompt.md
+++ b/docs/design/design-system/components/core/Button.prompt.md
@@ -1,0 +1,8 @@
+**Button** — World Zero's core action control; uppercase Courier Prime, hard corners, flat opacity hover. Use for every press action.
+
+```jsx
+<Button variant="primary" onClick={signUp}>sign up</Button>
+<Button variant="outline" size="sm">logout</Button>
+```
+
+Variants: `primary` (solid ink, inverts in dark mode), `outline` (frosted + border). Sizes: `sm` (in-card sign-up), `md` (default), `lg` (hero CTA). Never render a `disabled` button for a permission gate — hide the control instead.

--- a/docs/design/design-system/components/core/LevelPill.d.ts
+++ b/docs/design/design-system/components/core/LevelPill.d.ts
@@ -1,0 +1,12 @@
+/**
+ * The small dark capsule showing a task's level requirement; shared by every
+ * faction card.
+ */
+export interface LevelPillProps {
+  /** Level number (0–8). */
+  level: number;
+  /** Faction slug to tint the pill with that faction's card accent. */
+  factionSlug?: string;
+}
+
+export function LevelPill(props: LevelPillProps): JSX.Element;

--- a/docs/design/design-system/components/core/LevelPill.jsx
+++ b/docs/design/design-system/components/core/LevelPill.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { factionCssVar } from "./factions.js";
+
+/**
+ * LevelPill — the small dark capsule showing a task's level requirement.
+ * Shared by every faction card. Pass `factionSlug` to tint it with that
+ * faction's card accent; omit for the neutral ink/paper pill.
+ */
+export function LevelPill({ level, factionSlug }) {
+  const bg = factionSlug
+    ? factionCssVar(factionSlug, "card-accent")
+    : "var(--color-text-primary)";
+  const fg = factionSlug
+    ? factionCssVar(factionSlug, "card-bg")
+    : "var(--color-bg-page)";
+
+  return (
+    <span
+      style={{
+        background: bg,
+        color: fg,
+        fontSize: 7,
+        padding: "1px 6px",
+        borderRadius: 6,
+        textTransform: "uppercase",
+        fontFamily: "var(--font-body)",
+        letterSpacing: "0.08em",
+      }}
+    >
+      lvl {level}
+    </span>
+  );
+}

--- a/docs/design/design-system/components/core/LevelPill.prompt.md
+++ b/docs/design/design-system/components/core/LevelPill.prompt.md
@@ -1,0 +1,8 @@
+**LevelPill** — tiny dark capsule showing a task's level gate; sits in every faction card footer.
+
+```jsx
+<LevelPill level={3} factionSlug="gestalt" />
+<LevelPill level={1} />
+```
+
+Pass `factionSlug` to tint with the faction's card accent; omit for the neutral ink/paper pill.

--- a/docs/design/design-system/components/core/PageTitle.d.ts
+++ b/docs/design/design-system/components/core/PageTitle.d.ts
@@ -1,0 +1,12 @@
+/**
+ * World Zero's signature page header — Lora italic with a per-letter rainbow
+ * underline cycling through the six title-underline colors.
+ */
+export interface PageTitleProps {
+  /** Heading text. Each non-space character gets its own colored underline. */
+  title: string;
+  /** Optional small uppercase eyebrow above the title (era name, item count). */
+  eyebrow?: string;
+}
+
+export function PageTitle(props: PageTitleProps): JSX.Element;

--- a/docs/design/design-system/components/core/PageTitle.jsx
+++ b/docs/design/design-system/components/core/PageTitle.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+const UNDERLINE_COLORS = [
+  "var(--underline-1)",
+  "var(--underline-2)",
+  "var(--underline-3)",
+  "var(--underline-4)",
+  "var(--underline-5)",
+  "var(--underline-6)",
+];
+
+/**
+ * PageTitle — Lora italic heading where every letter gets its own colored
+ * underline bar, cycling through the six-color title palette. Spaces render
+ * as gaps with no bar. This is World Zero's signature page header.
+ */
+export function PageTitle({ title, eyebrow }) {
+  let colorIndex = 0;
+  return (
+    <div style={{ marginBottom: 24 }}>
+      {eyebrow && (
+        <p
+          style={{
+            fontFamily: "var(--font-body)",
+            fontSize: "var(--text-sm)",
+            textTransform: "uppercase",
+            letterSpacing: "0.15em",
+            color: "var(--color-text-tertiary)",
+            marginBottom: 4,
+          }}
+        >
+          {eyebrow}
+        </p>
+      )}
+      <h1
+        style={{
+          fontFamily: "var(--font-display)",
+          fontStyle: "italic",
+          fontWeight: 500,
+          lineHeight: 1.15,
+          fontSize: "var(--text-4xl)",
+          color: "var(--color-text-primary)",
+          margin: 0,
+        }}
+      >
+        {title.split("").map((char, index) => {
+          if (char === " ") {
+            return (
+              <span key={index} style={{ display: "inline-block", width: "0.3em" }} />
+            );
+          }
+          const color = UNDERLINE_COLORS[colorIndex % UNDERLINE_COLORS.length];
+          colorIndex++;
+          return (
+            <span
+              key={index}
+              style={{ borderBottom: `4px solid ${color}`, paddingBottom: 2 }}
+            >
+              {char}
+            </span>
+          );
+        })}
+      </h1>
+    </div>
+  );
+}

--- a/docs/design/design-system/components/core/PageTitle.prompt.md
+++ b/docs/design/design-system/components/core/PageTitle.prompt.md
@@ -1,0 +1,8 @@
+**PageTitle** — the signature World Zero page header: Lora italic, each letter underlined in a cycling rainbow bar. Use at the top of every page/section.
+
+```jsx
+<PageTitle title="Tasks" eyebrow="47 shown" />
+<PageTitle title="Recent Praxis" />
+```
+
+`eyebrow` is optional small uppercase metadata above the title.

--- a/docs/design/design-system/components/core/core.card.html
+++ b/docs/design/design-system/components/core/core.card.html
@@ -1,0 +1,51 @@
+<!-- @dsCard group="Components" viewport="700x300" name="Core — Buttons, Title, Level Pill" subtitle="Action buttons, the rainbow page title, and the level capsule" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 22px; background: var(--color-bg-page); }
+  .block { margin-bottom: 20px; }
+  .row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .lbl { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--color-text-tertiary); margin-bottom: 8px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+  const { Button, PageTitle, LevelPill } = window.WorldZeroDesignSystem_019e22;
+  function Demo() {
+    return (
+      <div>
+        <div className="block"><PageTitle title="Tasks" eyebrow="47 shown" /></div>
+        <div className="block">
+          <div className="lbl">Buttons</div>
+          <div className="row">
+            <Button variant="primary">sign up</Button>
+            <Button variant="outline">logout</Button>
+            <Button variant="primary" size="sm">sign up</Button>
+            <Button variant="primary" size="lg">Login with Google</Button>
+            <Button variant="outline" disabled>disabled</Button>
+          </div>
+        </div>
+        <div className="block">
+          <div className="lbl">Level pills</div>
+          <div className="row">
+            <LevelPill level={1} />
+            <LevelPill level={3} factionSlug="gestalt" />
+            <LevelPill level={5} factionSlug="ephemerists" />
+            <LevelPill level={7} factionSlug="everymen" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/core/factions.js
+++ b/docs/design/design-system/components/core/factions.js
@@ -1,0 +1,92 @@
+/**
+ * Faction config + CSS-variable helpers for World Zero components.
+ * Mirrors frontend/src/utils/factions.ts. The CSS custom properties in
+ * tokens/colors.css are the parallel source of truth — these two must stay
+ * in sync. Use factionCssVar() in inline styles so dark mode resolves
+ * automatically through the cascade.
+ *
+ * The roster is SEVEN factions — the six-faction rainbow spine plus
+ * Albescent, an always-light "vellum correspondence" faction that sits
+ * outside the rainbow (no hue — near-black ink on white). (Analog and UA
+ * Masters were retired; the Journeymen were rebranded as the Ephemerists;
+ * Gestalt was renamed the Warriors of Whimsy (slug `wow`); the Everymen
+ * were added to claim the rainbow's missing red; Albescent was added as
+ * the unranked secret society.)
+ */
+
+/**
+ * Renamed / legacy slugs → their live canonical slug. Old data, old links,
+ * and component switches resolve through this first.
+ *   gestalt    → wow         (Gestalt renamed the Warriors of Whimsy)
+ *   journeymen → ephemerists (Journeymen rebranded the Ephemerists)
+ *   aged_out   → ua
+ */
+export const SLUG_ALIAS = {
+  gestalt: "wow",
+  journeymen: "ephemerists",
+  aged_out: "ua",
+};
+
+/** Resolve any slug (including a renamed/legacy alias) to its canonical slug. */
+export function canonicalSlug(slug) {
+  return SLUG_ALIAS[slug ?? ""] ?? slug ?? "";
+}
+
+/**
+ * Canonical slug → CSS key. The CSS custom-property prefix can differ from
+ * the slug when a faction is renamed but keeps its existing token names —
+ * e.g. `wow` still draws on the historical `--faction-gestalt-*` / `--gestalt-*`
+ * palette, so its CSS key stays "gestalt".
+ */
+const CSS_KEY = {
+  ua: "ua",
+  wow: "gestalt",
+  snide: "snide",
+  ephemerists: "ephemerists",
+  singularity: "singularity",
+  everymen: "everymen",
+  albescent: "albescent",
+};
+
+/** Display registry — name + light-mode hex (for canvas/SVG only; prefer CSS vars). */
+export const FACTIONS = {
+  ua: { slug: "ua", name: "UA", color: "#c2541f", archetype: "Gilt Salon" },
+  wow: { slug: "wow", name: "Warriors of Whimsy", color: "#be185d", archetype: "Whimsy.exe Desktop" },
+  snide: { slug: "snide", name: "S.N.I.D.E.", color: "#16a34a", archetype: "Ransom Dispatch" },
+  ephemerists: { slug: "ephemerists", name: "The Ephemerists", color: "#1d6e72", archetype: "Discordant Map" },
+  singularity: { slug: "singularity", name: "Singularity", color: "#2563eb", archetype: "Terminal Printout" },
+  everymen: { slug: "everymen", name: "The Everymen", color: "#c1272d", archetype: "Union Poster" },
+  albescent: { slug: "albescent", name: "Albescent", color: "#1c1c1a", archetype: "Vellum Correspondence" },
+};
+
+/** Ordered list of the seven selectable/displayed factions. */
+export const FACTION_ORDER = [
+  "ua",
+  "wow",
+  "snide",
+  "ephemerists",
+  "singularity",
+  "everymen",
+  "albescent",
+];
+
+/**
+ * CSS variable reference for a faction property.
+ * Suffixes: (none)=primary, 'light', 'border', 'card-bg', 'card-text',
+ * 'card-accent', 'card-muted', 'card-font'.
+ */
+export function factionCssVar(slug, suffix) {
+  const key = CSS_KEY[canonicalSlug(slug)] ?? "ua";
+  const prop = suffix ? `--faction-${key}-${suffix}` : `--faction-${key}`;
+  return `var(${prop})`;
+}
+
+/** Raw light-mode hex by slug (canvas/SVG use only). */
+export function factionColor(slug) {
+  return FACTIONS[canonicalSlug(slug)]?.color ?? "#6b6a7a";
+}
+
+/** Display name by slug. */
+export function factionName(slug) {
+  return FACTIONS[canonicalSlug(slug)]?.name ?? "Unaffiliated";
+}

--- a/docs/design/design-system/components/feedback/FactionCommentBox.d.ts
+++ b/docs/design/design-system/components/feedback/FactionCommentBox.d.ts
@@ -1,0 +1,23 @@
+/**
+ * FactionCommentBox — a single comment / thread post, reskinned per faction.
+ * Comments are the one surface where every faction speaks in the same thread,
+ * so each gets an unmistakable bubble (gilt salon, whimsy.exe chat window,
+ * ransom slip, vellum marginalia, terminal line, union entry, the register).
+ * The data model is shared; only the frame, type and avatar treatment change.
+ */
+export interface FactionCommentBoxProps {
+  /** Faction slug — picks the bubble treatment + avatar skin + mention tint. */
+  faction?: "ua" | "wow" | "gestalt" | "snide" | "ephemerists" | "singularity" | "everymen" | "albescent";
+  /** Author display name. */
+  name?: string;
+  /** Author handle (with or without a leading @). */
+  handle?: string;
+  /** Timestamp / context line (e.g. "2 days ago", "T-0420"). */
+  meta?: string;
+  /** Comment text. `@handle` runs are auto-styled in the faction's voice. */
+  body?: string;
+  /** Avatar image URL — receives the faction's frame/filter treatment. */
+  avatar?: string;
+}
+
+export function FactionCommentBox(props: FactionCommentBoxProps): JSX.Element;

--- a/docs/design/design-system/components/feedback/FactionCommentBox.jsx
+++ b/docs/design/design-system/components/feedback/FactionCommentBox.jsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { canonicalSlug } from "../core/factions.js";
+
+/**
+ * FactionCommentBox — a single comment / thread post, reskinned per faction.
+ *
+ * Comments are the one surface where every faction speaks in the SAME thread,
+ * so each faction needs an unmistakable bubble. The data model is identical
+ * (author, handle, timestamp, body with @mentions, avatar); only the frame,
+ * type and avatar treatment change:
+ *
+ *   ua          → gilt salon frame (gold leaf border, Cormorant italic)
+ *   wow         → whimsy.exe chat window (pink titlebar + window buttons)
+ *   snide       → ransom slip (black dispatch card, tape strip, Special Elite)
+ *   ephemerists → marginalia (vellum, gold rule, EB Garamond italic)
+ *   singularity → terminal line ( > handle@signal, blinking cursor )
+ *   everymen    → union entry (red poster header bar, Bebas)
+ *   albescent   → the register (white vellum card, Cormorant)
+ *
+ * Mentions (@handle) are auto-styled in the faction's voice. Built entirely on
+ * global tokens so it flips light/dark with the rest of the system.
+ */
+
+const MENTION_STYLE = {
+  ua: { color: "#c8601a", fontWeight: 700 },
+  wow: { color: "#d23b7e", fontWeight: 700 },
+  snide: { color: "#14110b", fontWeight: 700, background: "#b6ff2e", padding: "0 3px" },
+  ephemerists: { color: "var(--eph-rubric)", fontStyle: "italic", fontWeight: 600 },
+  singularity: { color: "#60a5fa", fontWeight: 700 },
+  everymen: { color: "#d12027", fontWeight: 700 },
+  albescent: { color: "#1c1c1a", borderBottom: "1px solid rgba(28,28,26,.4)", fontWeight: 600 },
+};
+
+const AVATAR_SKIN = {
+  ua: { borderRadius: "50%", filter: "sepia(.3)", border: "2px solid #c9962f", boxShadow: "0 0 0 1px #a9781f, 0 0 0 3px #f0e2c0" },
+  wow: { borderRadius: "8px", border: "2px solid #ec5f99", boxShadow: "2px 2px 0 #fbcfe2" },
+  snide: { filter: "grayscale(1) contrast(1.5)", border: "1.5px solid #14110b" },
+  ephemerists: { borderRadius: "50%", filter: "sepia(.5)", border: "2px solid #b0863a", boxShadow: "0 0 0 1px #2a1d12" },
+  singularity: { filter: "grayscale(1) sepia(1) hue-rotate(175deg) saturate(2.6) brightness(.82)", border: "1px solid #60a5fa" },
+  everymen: { filter: "grayscale(1) contrast(1.2) sepia(.25)", border: "2px solid #221a12" },
+  albescent: { borderRadius: "50%", filter: "grayscale(1) brightness(1.05)" },
+};
+
+function Body({ body, faction }) {
+  if (body == null) return null;
+  const ms = MENTION_STYLE[faction] || { color: "var(--color-text-link)", fontWeight: 700 };
+  return String(body)
+    .split(/(@\w+)/g)
+    .map((part, i) => (part[0] === "@" ? <span key={i} style={ms}>{part}</span> : <span key={i}>{part}</span>));
+}
+
+function Avatar({ faction, src, size = 42 }) {
+  const base = { width: size, height: size, objectFit: "cover", display: "block", flex: "none" };
+  return <img src={src} alt="" style={{ ...base, ...(AVATAR_SKIN[faction] || {}) }} />;
+}
+
+/* ── per-faction bubble bodies (avatar is rendered by the row wrapper) ── */
+
+function UaBubble({ name, meta, body }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0, padding: 4, borderRadius: 5, background: "linear-gradient(135deg,#ecd089 0%,#c9962f 26%,#a9781f 50%,#e3c06a 76%,#c9a23c 100%)", boxShadow: "0 2px 11px rgba(150,108,32,.28)" }}>
+      <div style={{ background: "#f9f2e2", border: "1px solid rgba(176,122,58,.4)", borderRadius: 3, padding: "13px 16px 14px" }}>
+        <div style={{ fontFamily: "var(--font-faction-engraved)", fontSize: 8, letterSpacing: ".22em", textTransform: "uppercase", color: "#c8601a" }}>University of Asthmatics</div>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginTop: 4 }}>
+          <span style={{ fontFamily: "var(--font-faction-codex-script)", fontStyle: "italic", fontWeight: 600, fontSize: 21, color: "#2a1a10", lineHeight: 1 }}>{name}</span>
+          <span style={{ fontFamily: "var(--font-faction-engraved)", fontSize: 7, letterSpacing: ".14em", textTransform: "uppercase", color: "#b07a3a", border: "1px solid rgba(201,150,47,.65)", padding: "1px 5px" }}>UA</span>
+          <span style={{ fontFamily: "var(--font-faction-codex-script)", fontStyle: "italic", fontSize: 12, color: "#b07a3a", marginLeft: "auto" }}>{meta}</span>
+        </div>
+        <div style={{ height: 1, background: "linear-gradient(90deg,#c9962f,transparent)", margin: "9px 0" }} />
+        <div style={{ fontFamily: "var(--font-faction-codex-script)", fontStyle: "italic", fontSize: 17, lineHeight: 1.5, color: "#3a2616" }}><Body body={body} faction="ua" /></div>
+      </div>
+    </div>
+  );
+}
+
+function WowBubble({ name, handle, meta, body }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0, position: "relative", background: "var(--gestalt-card-bg)", border: "2px solid var(--gestalt-pink-deep)", borderRadius: 8, boxShadow: "4px 4px 0 var(--gestalt-pink-lt)", overflow: "hidden" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, background: "linear-gradient(#f9b6d4,#ec5f99)", padding: "4px 9px", borderBottom: "2px solid #d23b7e" }}>
+        <span style={{ fontFamily: "var(--font-faction-script)", fontSize: 18, color: "#fff", textShadow: "1px 1px 0 #a83a6e", lineHeight: .9 }}>✦ {name}.exe</span>
+        <span style={{ marginLeft: "auto", display: "flex", gap: 3 }}>
+          <span style={{ width: 11, height: 11, background: "#fff", border: "1.5px solid #a83a6e", borderRadius: 3 }} />
+          <span style={{ width: 11, height: 11, background: "#fde2ee", border: "1.5px solid #a83a6e", borderRadius: 3 }} />
+        </span>
+      </div>
+      <div style={{ padding: "9px 12px 11px" }}>
+        <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 20, lineHeight: 1.2, color: "var(--gestalt-ink)" }}><Body body={body} faction="wow" /></div>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 8, color: "var(--gestalt-ink-soft)", marginTop: 4 }}>{handle} · {meta}</div>
+      </div>
+    </div>
+  );
+}
+
+function SnideBubble({ name, meta, body }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0, position: "relative", background: "#14110b", padding: "13px 15px 14px", boxShadow: "3px 4px 0 rgba(0,0,0,.3)", transform: "rotate(.4deg)" }}>
+      <div style={{ position: "absolute", top: -9, left: 30, width: 74, height: 20, background: "rgba(228,214,120,.5)", transform: "rotate(-4deg)", boxShadow: "inset 0 0 0 1px rgba(255,255,255,.2)" }} />
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+        <span style={{ fontFamily: "var(--font-faction-anton)", fontSize: 16, letterSpacing: ".04em", textTransform: "uppercase", color: "#f4f1e8", lineHeight: 1 }}>{name}</span>
+        <span style={{ fontFamily: "var(--font-faction-anton)", fontSize: 8, letterSpacing: ".06em", color: "#14110b", background: "#b6ff2e", padding: "1px 4px" }}>SNIDE</span>
+        <span style={{ fontFamily: "var(--font-faction-typewriter)", fontSize: 8, color: "#8b897d", marginLeft: "auto" }}>{meta}</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-faction-typewriter)", fontSize: 11, lineHeight: 1.6, color: "#e7e4d8", marginTop: 6 }}><Body body={body} faction="snide" /></div>
+    </div>
+  );
+}
+
+function EphBubble({ name, meta, body }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0, position: "relative", background: "var(--eph-vellum)", borderLeft: "2px solid var(--eph-gold)", padding: "12px 15px 13px" }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+        <span style={{ fontFamily: "var(--font-faction-engraved)", fontSize: 13, letterSpacing: ".05em", color: "var(--eph-vellum-text)", lineHeight: 1 }}>{name}</span>
+        <span style={{ fontFamily: "var(--font-faction-engraved)", fontSize: 7, letterSpacing: ".14em", textTransform: "uppercase", color: "var(--eph-rubric)", border: "1px solid var(--eph-gold)", padding: "1px 4px" }}>Ephemerists</span>
+        <span style={{ fontFamily: "var(--font-faction-codex)", fontStyle: "italic", fontSize: 10, color: "var(--eph-muted)", marginLeft: "auto" }}>{meta}</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-faction-codex)", fontSize: 15, fontStyle: "italic", lineHeight: 1.5, color: "var(--eph-vellum-text)", marginTop: 5 }}><Body body={body} faction="ephemerists" /></div>
+    </div>
+  );
+}
+
+function SingularityBubble({ handle, meta, body }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0, background: "#040a12", border: "1px solid #2563eb", boxShadow: "0 0 0 1px rgba(37,99,235,.3)", padding: "11px 14px 12px" }}>
+      <div style={{ fontFamily: "var(--font-faction-terminal)", fontSize: 10, color: "#60a5fa" }}>
+        &gt; {handle}@signal <span style={{ color: "#3a5f9c" }}>[{meta}]</span>{" "}
+        <span style={{ color: "#60a5fa", border: "1px solid #60a5fa", padding: "0 3px", fontSize: 8 }}>SINGULARITY</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-faction-terminal)", fontSize: 11, lineHeight: 1.55, color: "#9fc2ff", marginTop: 5 }}>
+        <Body body={body} faction="singularity" />
+        <span style={{ animation: "wzcb-blink 1s step-end infinite" }}>_</span>
+      </div>
+    </div>
+  );
+}
+
+function EverymenBubble({ name, meta, body }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0, background: "var(--everymen-paper)", border: "1px solid var(--everymen-red-deep)", overflow: "hidden" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, background: "#d12027", padding: "5px 13px" }}>
+        <span style={{ fontFamily: "var(--font-faction-poster)", fontSize: 17, letterSpacing: ".05em", color: "#f4ecd6", lineHeight: 1 }}>{name}</span>
+        <span style={{ fontFamily: "var(--font-faction-poster)", fontSize: 9, letterSpacing: ".12em", color: "#f4ecd6", opacity: .8, marginLeft: "auto" }}>The Everymen · {meta}</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 11, lineHeight: 1.6, color: "var(--everymen-paper-text)", padding: "10px 13px 12px" }}><Body body={body} faction="everymen" /></div>
+    </div>
+  );
+}
+
+function AlbescentBubble({ name, meta, body }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0, background: "var(--al-surface)", border: "1px solid var(--al-border)", boxShadow: "var(--al-shadow)", padding: "14px 17px 15px" }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+        <span style={{ fontFamily: "var(--font-faction-vellum)", fontSize: 15, letterSpacing: ".04em", color: "var(--al-text)", lineHeight: 1 }}>{name}</span>
+        <span style={{ fontFamily: "var(--font-faction-vellum)", fontStyle: "italic", fontSize: 9, letterSpacing: ".1em", textTransform: "uppercase", color: "var(--al-text-muted)", borderBottom: "1px solid var(--al-border)" }}>Albescent</span>
+        <span style={{ fontFamily: "var(--font-faction-vellum)", fontStyle: "italic", fontSize: 11, color: "var(--al-text-muted)", marginLeft: "auto" }}>{meta}</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-faction-vellum)", fontSize: 16, lineHeight: 1.55, color: "var(--al-ink)", marginTop: 5 }}><Body body={body} faction="albescent" /></div>
+    </div>
+  );
+}
+
+const BUBBLE = {
+  ua: UaBubble,
+  wow: WowBubble,
+  snide: SnideBubble,
+  ephemerists: EphBubble,
+  singularity: SingularityBubble,
+  everymen: EverymenBubble,
+  albescent: AlbescentBubble,
+};
+
+export function FactionCommentBox({ faction = "ua", name, handle, meta, body, avatar }) {
+  const f = canonicalSlug(faction);
+  const Bubble = BUBBLE[f] || UaBubble;
+  const h = handle && handle[0] === "@" ? handle : handle ? "@" + handle : "";
+  return (
+    <div style={{ display: "flex", gap: 13, alignItems: "flex-start", margin: "0" }}>
+      <style>{"@keyframes wzcb-blink{0%,49%{opacity:1}50%,100%{opacity:0}}"}</style>
+      <div style={{ flex: "none" }}>
+        <Avatar faction={f} src={avatar} />
+      </div>
+      <Bubble name={name} handle={h} meta={meta} body={body} />
+    </div>
+  );
+}

--- a/docs/design/design-system/components/feedback/FactionCommentBox.prompt.md
+++ b/docs/design/design-system/components/feedback/FactionCommentBox.prompt.md
@@ -1,0 +1,12 @@
+**FactionCommentBox** — one comment / thread post, reskinned per faction. Comments are the one surface where all seven factions speak in the same thread, so each needs an unmistakable bubble: UA's gilt salon frame, the Warriors of Whimsy's whimsy.exe chat window, S.N.I.D.E.'s ransom slip, the Ephemerists' vellum marginalia, Singularity's terminal line, the Everymen's union entry, Albescent's register. The data model is identical (author / handle / timestamp / body / avatar); only the frame, type and avatar treatment change.
+
+```jsx
+<FactionCommentBox
+  faction="snide"
+  name="V. Slander" handle="@slander" meta="048H AGO"
+  body="crossed it twice to prove it's rigged. it is. @no6 plant the evidence."
+  avatar="https://randomuser.me/api/portraits/women/52.jpg"
+/>
+```
+
+`@handle` runs inside `body` are auto-styled in the faction's voice. Renders the avatar + bubble as one flex row; wrap multiple in a column with `gap` to build a thread.

--- a/docs/design/design-system/components/feedback/FactionVoteStamps.d.ts
+++ b/docs/design/design-system/components/feedback/FactionVoteStamps.d.ts
@@ -1,0 +1,19 @@
+/**
+ * World Zero's rating control — five rectangular rubber stamps (1–5) with word
+ * labels and value-specific colors, replacing star ratings. This is the generic
+ * default; each faction kit reskins the same 1–5 model in its own voice.
+ */
+export interface FactionVoteStampsProps {
+  /** Faction slug — reframes the five rungs in that faction's voice + tint. Omit for the generic ramp; `ua` gives the burnt-amber Critique. */
+  faction?: "ua" | "gestalt" | "snide" | "ephemerists" | "singularity" | "everymen" | "albescent";
+  /** Currently-selected rating (0 = none). */
+  value?: number;
+  /** Average rating to show in the summary line. */
+  average?: number;
+  /** Total vote count for the summary line. */
+  totalVotes?: number;
+  /** Called with the chosen 1–5 value. */
+  onVote?: (stars: number) => void;
+}
+
+export function FactionVoteStamps(props: FactionVoteStampsProps): JSX.Element;

--- a/docs/design/design-system/components/feedback/FactionVoteStamps.jsx
+++ b/docs/design/design-system/components/feedback/FactionVoteStamps.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { factionCssVar } from "../core/factions.js";
+
+/**
+ * FactionVoteStamps — World Zero's rating control: five rectangular rubber
+ * stamps (1–5) replacing star ratings. The vote MODEL is shared across every
+ * faction; what changes per faction is the LANGUAGE of the five rungs and the
+ * tint. Pass `faction` to reframe the ramp in that faction's voice:
+ *
+ *   (none)      → a start · solid · good · excellent · legendary   (generic ramp)
+ *   ua          → rough sketch · study · fair hand · fine work · masterwork   (the Critique, burnt amber)
+ *   snide       → meh · not bad · rad · sick!! · ANARCHY
+ *   ephemerists → apocryphal · disputed · plausible · corroborated · canonical
+ *   singularity → noise · weak · signal · clear · verified
+ *   everymen    → noted · supported · commended · honored · exemplary
+ *   albescent   → unseeing · glimpsed · witnessed · verified · inscribed
+ *
+ * The faction kits ship their own fully-bespoke vote shapes (wax seals, signal
+ * bars, witness circles); this is the shared stamp form, reframed by token.
+ */
+
+/** Per-faction rung labels. The 1–5 model is identical; only the words change. */
+const FACTION_LABELS = {
+  ua: ["rough sketch", "study", "fair hand", "fine work", "masterwork"],
+  gestalt: ["a start", "solid", "good", "excellent", "legendary"],
+  snide: ["meh", "not bad", "rad", "sick!!", "ANARCHY"],
+  ephemerists: ["apocryphal", "disputed", "plausible", "corroborated", "canonical"],
+  singularity: ["noise", "weak", "signal", "clear", "verified"],
+  everymen: ["noted", "supported", "commended", "honored", "exemplary"],
+  albescent: ["unseeing", "glimpsed", "witnessed", "verified", "inscribed"],
+};
+
+/** Generic multi-hue ramp (the default, faction-agnostic rendering). */
+const GENERIC_COLORS = ["var(--vote-1)", "var(--vote-2)", "var(--vote-3)", "var(--vote-4)", "var(--vote-5)"];
+const GENERIC_LABELS = ["a start", "solid", "good", "excellent", "legendary"];
+
+export function FactionVoteStamps({ faction, value = 0, average, totalVotes, onVote }) {
+  const [selected, setSelected] = useState(value);
+
+  const labels = faction ? (FACTION_LABELS[faction] ?? GENERIC_LABELS) : GENERIC_LABELS;
+  // No faction → the distinct multi-hue ramp. Any faction (incl. ua) → its
+  // accent, graded by opacity so the five rungs read as a ramp.
+  const useGeneric = !faction;
+  const accent = useGeneric ? null : factionCssVar(faction, "card-accent");
+  const colorFor = (i) =>
+    useGeneric ? GENERIC_COLORS[i] : `color-mix(in srgb, ${accent} ${32 + i * 17}%, transparent)`;
+  const labelFont = useGeneric ? "var(--font-body)" : factionCssVar(faction, "card-font");
+
+  const handle = (stars) => {
+    setSelected(stars);
+    onVote && onVote(stars);
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, marginBottom: 10 }}>
+        {labels.map((label, i) => {
+          const stampValue = i + 1;
+          const active = selected === stampValue;
+          const color = colorFor(i);
+          return (
+            <div key={stampValue} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3 }}>
+              <button
+                onClick={() => handle(stampValue)}
+                className={active ? "vote-stamp vote-stamp-active" : "vote-stamp"}
+                style={{ "--stamp-color": color }}
+                aria-label={`Rate ${stampValue} — ${label}`}
+              >
+                {active && (
+                  <span
+                    style={{
+                      position: "absolute",
+                      inset: 2,
+                      border: "1px dashed color-mix(in srgb, var(--color-text-on-accent) 25%, transparent)",
+                      pointerEvents: "none",
+                    }}
+                  />
+                )}
+                {stampValue}
+              </button>
+              <span
+                style={{
+                  fontFamily: labelFont,
+                  fontStyle: useGeneric ? "normal" : "italic",
+                  fontSize: useGeneric ? 7 : 9,
+                  textTransform: useGeneric ? "uppercase" : "none",
+                  letterSpacing: useGeneric ? "0.04em" : 0,
+                  color: active ? color : "var(--color-text-tertiary)",
+                  maxWidth: 48,
+                  textAlign: "center",
+                  lineHeight: 1.2,
+                }}
+              >
+                {label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {average !== undefined && (
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 9, color: "var(--color-text-secondary)", margin: 0 }}>
+          {average.toFixed(1)} avg · {totalVotes ?? 0} votes
+        </p>
+      )}
+    </div>
+  );
+}

--- a/docs/design/design-system/components/feedback/FactionVoteStamps.prompt.md
+++ b/docs/design/design-system/components/feedback/FactionVoteStamps.prompt.md
@@ -1,0 +1,7 @@
+**FactionVoteStamps** — World Zero's rating control. Five rectangular stamps (1–5) with word labels — a start / solid / good / excellent / legendary — and value-specific colors. Replaces star ratings everywhere. This is the generic/default rendering; each faction kit ships its own reskin of the same 1–5 model.
+
+```jsx
+<FactionVoteStamps value={3} average={3.6} totalVotes={12} onVote={cast} />
+```
+
+The active stamp fills with its color and shows an inner dashed border.

--- a/docs/design/design-system/components/feedback/comments.card.html
+++ b/docs/design/design-system/components/feedback/comments.card.html
@@ -1,0 +1,60 @@
+<!-- @dsCard group="Faction Components" viewport="640x1180" name="Faction Comment Boxes" subtitle="One thread, seven voices — each faction reskins the comment bubble, avatar frame and @mention tint" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 30px 16px 56px; background: var(--color-bg-page); font-family: var(--font-body); color: var(--color-text-primary); }
+  .wrap { width: 100%; max-width: 560px; margin: 0 auto; }
+  .head { text-align: center; margin-bottom: 4px; }
+  .eyebrow { font-size: 9px; letter-spacing: 0.26em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .title { font-family: var(--font-display); font-style: italic; font-size: 27px; line-height: 1.1; color: var(--color-text-primary); margin-top: 6px; }
+  .sub { font-size: 10px; color: var(--color-text-secondary); margin-top: 7px; }
+  .rule { height: 1px; background: var(--color-border-strong); margin: 18px 0 4px; }
+  #thread { display: flex; flex-direction: column; gap: 22px; padding-top: 22px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div class="wrap">
+  <div class="head">
+    <div class="eyebrow">Task · open thread</div>
+    <div class="title">Cross the Discordant Mile</div>
+    <div class="sub">7 comments · every faction has something to say</div>
+  </div>
+  <div class="rule"></div>
+  <div id="thread"></div>
+</div>
+<script type="text/babel">
+  const { FactionCommentBox } = window.WorldZeroDesignSystem_019e22;
+  const url = (p) => "https://randomuser.me/api/portraits/" + p + ".jpg";
+
+  const COMMENTS = [
+    { faction: "ua", name: "Margery Vane", handle: "@margery", meta: "2 days ago", avatar: url("women/65"),
+      body: "@cartographa i marked the safe turns in chalk. the chalk keeps MOVING. spooky!" },
+    { faction: "wow", name: "pixiehex", handle: "@pixiehex", meta: "3h", avatar: url("women/68"),
+      body: "walked it BAREFOOT and the mile giggled at me 💖 @margery 10/10 would discord again" },
+    { faction: "snide", name: "V. Slander", handle: "@slander", meta: "048H AGO", avatar: url("women/52"),
+      body: "crossed it twice to prove it's rigged. it is. @no6 plant the evidence." },
+    { faction: "ephemerists", name: "Brother Vellum", handle: "@vellum", meta: "the 3rd day", avatar: url("men/36"),
+      body: "the road bends where no road should. i have inked it as a warning. @cartographa concurs." },
+    { faction: "singularity", name: "unit_07", handle: "@unit_07", meta: "T-0420", avatar: url("men/12"),
+      body: "@root distance reads 1.0mi forward, 1.4mi back. non-euclidean. recommend re-cast." },
+    { faction: "everymen", name: "Foreman Ruiz", handle: "@ruiz", meta: "Shift 2", avatar: url("men/55"),
+      body: "forty of us walked it together. no one walks the mile alone. @hale bring the banner." },
+    { faction: "albescent", name: "M. Ashgrove", handle: "@ashgrove", meta: "Vigil the First", avatar: url("men/77"),
+      body: "i crossed at dusk and bore witness. i did not look back. @recorder enter it." },
+  ];
+
+  ReactDOM.createRoot(document.getElementById("thread")).render(
+    <React.Fragment>
+      {COMMENTS.map((c, i) => <FactionCommentBox key={i} {...c} />)}
+    </React.Fragment>
+  );
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/feedback/feedback.card.html
+++ b/docs/design/design-system/components/feedback/feedback.card.html
@@ -1,0 +1,44 @@
+<!-- @dsCard group="Faction Components" viewport="760x560" name="Faction Vote Stamps" subtitle="One 1–5 model, seven voices — each faction reframes the rungs and tint" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 26px; background: var(--color-bg-page); font-family: var(--font-body); }
+  #root { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 30px; align-items: start; }
+  .vrow { }
+  .vlabel { font-size: 9px; text-transform: uppercase; letter-spacing: 0.16em; color: var(--color-text-tertiary); margin-bottom: 8px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+  const { FactionVoteStamps } = window.WorldZeroDesignSystem_019e22;
+  const FACTIONS = [
+    ["ua", "UA · the Critique", 4],
+    ["wow", "Warriors of Whimsy", 5],
+    ["snide", "S.N.I.D.E.", 5],
+    ["ephemerists", "The Ephemerists", 4],
+    ["singularity", "Singularity", 3],
+    ["everymen", "The Everymen", 4],
+    ["albescent", "Albescent", 3],
+  ];
+  function Row([slug, name, val]) {
+    return (
+      <div className="vrow" key={slug}>
+        <div className="vlabel">{name}</div>
+        <FactionVoteStamps faction={slug} value={val} average={val} totalVotes={12} />
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(
+    <React.Fragment>{FACTIONS.map(Row)}</React.Fragment>
+  );
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/filters/FactionPennant.d.ts
+++ b/docs/design/design-system/components/filters/FactionPennant.d.ts
@@ -1,0 +1,14 @@
+/**
+ * A diagonal pennant tab in a faction's full-saturation color, for faction
+ * filters. Always full color; inactive drops to 0.85 opacity.
+ */
+export interface FactionPennantProps {
+  /** Faction slug (ua, wow, snide, ephemerists, singularity, everymen, albescent). */
+  slug: string;
+  /** Display name shown on the pennant. */
+  name: string;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+export function FactionPennant(props: FactionPennantProps): JSX.Element;

--- a/docs/design/design-system/components/filters/FactionPennant.jsx
+++ b/docs/design/design-system/components/filters/FactionPennant.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { factionCssVar } from "../core/factions.js";
+
+/**
+ * FactionPennant — a diagonal banner/pennant tab in a faction's full-saturation
+ * color, used for faction filters. Pennants are ALWAYS full color (never
+ * desaturated); inactive simply drops opacity to 0.85.
+ */
+export function FactionPennant({ slug, name, active = false, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        background: factionCssVar(slug),
+        color: "var(--color-text-on-accent)",
+        fontFamily: "var(--font-body)",
+        fontSize: 9,
+        fontWeight: 700,
+        textTransform: "uppercase",
+        letterSpacing: "0.07em",
+        padding: "4px 12px",
+        cursor: "pointer",
+        border: "none",
+        borderRadius: 0,
+        textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+        opacity: active ? 1 : 0.85,
+        clipPath: "polygon(0 0, 100% 0, 95% 100%, 5% 100%)",
+        transition: "all 120ms",
+      }}
+    >
+      {name}
+    </button>
+  );
+}

--- a/docs/design/design-system/components/filters/FactionPennant.prompt.md
+++ b/docs/design/design-system/components/filters/FactionPennant.prompt.md
@@ -1,0 +1,7 @@
+**FactionPennant** — diagonal pennant tab in a faction's color, for faction filters. Always full saturation; inactive drops opacity.
+
+```jsx
+<FactionPennant slug="snide" name="S.N.I.D.E." active={faction === "snide"} onClick={() => toggle("snide")} />
+```
+
+Render the seven factions in a flex row with a `faction:` eyebrow.

--- a/docs/design/design-system/components/filters/FilterStamp.d.ts
+++ b/docs/design/design-system/components/filters/FilterStamp.d.ts
@@ -1,0 +1,12 @@
+/**
+ * A rectangular rubber-stamp toggle for status filters — hard corners, inner
+ * dashed border, solid ink when active.
+ */
+export interface FilterStampProps {
+  /** Label text (rendered uppercase). */
+  label: string;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+export function FilterStamp(props: FilterStampProps): JSX.Element;

--- a/docs/design/design-system/components/filters/FilterStamp.jsx
+++ b/docs/design/design-system/components/filters/FilterStamp.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+/**
+ * FilterStamp — a rectangular rubber-stamp toggle used for status filters.
+ * Hard corners (no radius), bold uppercase Courier Prime, and an inner dashed
+ * border that inverts with the active state. Active = solid ink fill.
+ */
+export function FilterStamp({ label, active = false, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        position: "relative",
+        border: `2px solid ${active ? "var(--color-text-primary)" : "var(--color-border-strong)"}`,
+        borderRadius: 0,
+        background: active ? "var(--color-text-primary)" : "var(--color-bg-surface)",
+        color: active ? "var(--color-bg-page)" : "var(--color-text-primary)",
+        fontFamily: "var(--font-body)",
+        fontSize: 10,
+        fontWeight: 700,
+        textTransform: "uppercase",
+        letterSpacing: "0.1em",
+        padding: "5px 10px",
+        cursor: "pointer",
+        transition: "all 120ms",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          inset: 2,
+          border: `1px dashed ${active ? "var(--stamp-active-dashed)" : "var(--stamp-inactive-dashed)"}`,
+          pointerEvents: "none",
+        }}
+      />
+      {label}
+    </button>
+  );
+}

--- a/docs/design/design-system/components/filters/FilterStamp.prompt.md
+++ b/docs/design/design-system/components/filters/FilterStamp.prompt.md
@@ -1,0 +1,7 @@
+**FilterStamp** — rectangular rubber-stamp toggle for status filters (All / active / retired / pending). Hard corners, inner dashed border.
+
+```jsx
+<FilterStamp label="active" active={status === "active"} onClick={() => setStatus("active")} />
+```
+
+Lay several out in a flex row with a `status:` eyebrow label.

--- a/docs/design/design-system/components/filters/LevelNodes.d.ts
+++ b/docs/design/design-system/components/filters/LevelNodes.d.ts
@@ -1,0 +1,14 @@
+/**
+ * A row of connected circular nodes for filtering by level. Active node fills
+ * with ink and scales up; clicking it again clears the filter.
+ */
+export interface LevelNodesProps {
+  /** Level values to show. Default [0,1,2,3,4,5]. */
+  levels?: number[];
+  /** Currently-selected level, or "" for none. */
+  value?: number | "";
+  /** Called with the new level, or "" when cleared. */
+  onChange?: (level: number | "") => void;
+}
+
+export function LevelNodes(props: LevelNodesProps): JSX.Element;

--- a/docs/design/design-system/components/filters/LevelNodes.jsx
+++ b/docs/design/design-system/components/filters/LevelNodes.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+/**
+ * LevelNodes — a row of connected circular nodes for filtering by level.
+ * Circles joined by short horizontal bars; the active node fills with ink and
+ * scales up slightly. Clicking the active node clears the filter.
+ */
+export function LevelNodes({ levels = [0, 1, 2, 3, 4, 5], value = "", onChange }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      {levels.map((level, index) => {
+        const active = value === level;
+        return (
+          <div key={level} style={{ display: "flex", alignItems: "center" }}>
+            {index > 0 && (
+              <div style={{ width: 12, height: 2, background: "var(--color-border-strong)" }} />
+            )}
+            <button
+              type="button"
+              onClick={() => onChange && onChange(active ? "" : level)}
+              style={{
+                width: 30,
+                height: 30,
+                borderRadius: "50%",
+                border: `2px solid ${active ? "var(--color-text-primary)" : "var(--color-border-strong)"}`,
+                background: active ? "var(--color-text-primary)" : "var(--color-bg-surface)",
+                color: active ? "var(--color-bg-page)" : "var(--color-text-tertiary)",
+                fontFamily: "var(--font-body)",
+                fontSize: 10,
+                fontWeight: 700,
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transform: active ? "scale(1.15)" : "scale(1)",
+                transition: "all 120ms",
+                padding: 0,
+              }}
+            >
+              {level}+
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/docs/design/design-system/components/filters/LevelNodes.prompt.md
+++ b/docs/design/design-system/components/filters/LevelNodes.prompt.md
@@ -1,0 +1,7 @@
+**LevelNodes** — connected circle nodes for filtering by minimum level. Active node fills with ink and scales up.
+
+```jsx
+<LevelNodes levels={[0,1,2,3,4,5]} value={level} onChange={setLevel} />
+```
+
+Self-contained row; pair with a `level:` eyebrow label. Pass `value=""` for no filter.

--- a/docs/design/design-system/components/filters/filters.card.html
+++ b/docs/design/design-system/components/filters/filters.card.html
@@ -1,0 +1,42 @@
+<!-- @dsCard group="Components" viewport="700x190" name="Filter Controls" subtitle="Generic filter styles: status rubber stamps and level nodes" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 22px; background: var(--color-bg-page); }
+  .group { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; flex-wrap: wrap; }
+  .eyebrow { font-family: var(--font-body); font-size: 9px; text-transform: uppercase; letter-spacing: 0.15em; color: var(--color-text-tertiary); margin-right: 4px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+  const { FilterStamp, LevelNodes } = window.WorldZeroDesignSystem_019e22;
+  function Demo() {
+    const [status, setStatus] = React.useState("active");
+    const [level, setLevel] = React.useState(2);
+    return (
+      <div>
+        <div className="group">
+          <span className="eyebrow">status:</span>
+          {["All","active","retired","pending"].map((s) => (
+            <FilterStamp key={s} label={s} active={status===s} onClick={() => setStatus(s)} />
+          ))}
+        </div>
+        <div className="group">
+          <span className="eyebrow">level:</span>
+          <LevelNodes value={level} onChange={setLevel} />
+        </div>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/filters/pennant.card.html
+++ b/docs/design/design-system/components/filters/pennant.card.html
@@ -1,0 +1,40 @@
+<!-- @dsCard group="Faction Components" viewport="700x140" name="Faction Pennants" subtitle="Diagonal filter banner in each faction's full-saturation primary — the faction filter row" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  body { margin: 0; padding: 22px; background: var(--color-bg-page); }
+  .group { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .eyebrow { font-family: var(--font-body); font-size: 9px; text-transform: uppercase; letter-spacing: 0.15em; color: var(--color-text-tertiary); margin-right: 4px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+  const { FactionPennant } = window.WorldZeroDesignSystem_019e22;
+  const FACTIONS = [
+    ["ua","UA"],["wow","Warriors of Whimsy"],["snide","S.N.I.D.E."],
+    ["ephemerists","Ephemerists"],["singularity","Singularity"],["everymen","Everymen"],["albescent","Albescent"],
+  ];
+  function Demo() {
+    const [faction, setFaction] = React.useState("snide");
+    return (
+      <div className="group">
+        <span className="eyebrow">faction:</span>
+        {FACTIONS.map(([slug,name]) => (
+          <FactionPennant key={slug} slug={slug} name={name} active={faction===slug}
+            onClick={() => setFaction(faction===slug?"":slug)} />
+        ))}
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+</script>
+</body>
+</html>

--- a/docs/design/design-system/components/layout/WatercolorBackground.d.ts
+++ b/docs/design/design-system/components/layout/WatercolorBackground.d.ts
@@ -1,0 +1,13 @@
+import React from "react";
+
+/**
+ * World Zero's full-bleed watercolor backdrop — blurred SVG paint blobs in all
+ * four corners. Render once behind page content; dims automatically in dark mode.
+ */
+export interface WatercolorBackgroundProps {
+  /** position:fixed (default) vs absolute, for use inside a relative container. */
+  fixed?: boolean;
+  style?: React.CSSProperties;
+}
+
+export function WatercolorBackground(props: WatercolorBackgroundProps): JSX.Element;

--- a/docs/design/design-system/components/layout/WatercolorBackground.jsx
+++ b/docs/design/design-system/components/layout/WatercolorBackground.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+/**
+ * WatercolorBackground — World Zero's full-bleed paint-bleed backdrop.
+ * Blurred SVG ellipses in all four corners with turbulence distortion. Opacity
+ * is driven by the --wc-opacity-* tokens so dark mode dims it automatically.
+ * Render it once, fixed behind page content (zIndex 0).
+ */
+export function WatercolorBackground({ fixed = true, style = {} }) {
+  return (
+    <svg
+      aria-hidden="true"
+      style={{
+        position: fixed ? "fixed" : "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+        zIndex: 0,
+        transition: "opacity 300ms",
+        ...style,
+      }}
+      preserveAspectRatio="none"
+    >
+      <defs>
+        <filter id="wc-blur" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="28" />
+        </filter>
+        <filter id="wc-distort" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="26" result="blur" />
+          <feTurbulence type="turbulence" baseFrequency="0.015" numOctaves="3" result="turb" />
+          <feDisplacementMap in="blur" in2="turb" scale="18" />
+        </filter>
+        <filter id="wc-droplet" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="9" />
+        </filter>
+      </defs>
+
+      {/* Top-left: blue / indigo / violet */}
+      <ellipse cx="8%" cy="10%" rx="14%" ry="18%" fill="#4f46e5" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="14%" cy="6%" rx="10%" ry="12%" fill="#7c3aed" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <ellipse cx="4%" cy="18%" rx="6%" ry="8%" fill="#be185d" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <circle cx="18%" cy="14%" r="1.5%" fill="#4f46e5" opacity="var(--wc-opacity-drip)" filter="url(#wc-droplet)" />
+      <circle cx="6%" cy="24%" r="1%" fill="#7c3aed" opacity="var(--wc-opacity-drop)" filter="url(#wc-droplet)" />
+
+      {/* Top-right: orange / amber / lime */}
+      <ellipse cx="90%" cy="8%" rx="12%" ry="16%" fill="#b45309" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="85%" cy="14%" rx="10%" ry="10%" fill="#d97706" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <ellipse cx="95%" cy="4%" rx="8%" ry="10%" fill="#16a34a" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <circle cx="82%" cy="6%" r="1.2%" fill="#d97706" opacity="var(--wc-opacity-drip)" filter="url(#wc-droplet)" />
+
+      {/* Bottom-left: rose / pink / violet */}
+      <ellipse cx="10%" cy="90%" rx="14%" ry="14%" fill="#9f1239" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="6%" cy="85%" rx="8%" ry="12%" fill="#7c3aed" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <circle cx="16%" cy="86%" r="1.3%" fill="#9f1239" opacity="var(--wc-opacity-drip)" filter="url(#wc-droplet)" />
+
+      {/* Bottom-right: teal / cyan / sky */}
+      <ellipse cx="88%" cy="88%" rx="12%" ry="16%" fill="#0f766e" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="94%" cy="92%" rx="10%" ry="10%" fill="#0e7490" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <circle cx="84%" cy="94%" r="1%" fill="#0e7490" opacity="var(--wc-opacity-drop)" filter="url(#wc-droplet)" />
+    </svg>
+  );
+}

--- a/docs/design/design-system/components/layout/WatercolorBackground.prompt.md
+++ b/docs/design/design-system/components/layout/WatercolorBackground.prompt.md
@@ -1,0 +1,10 @@
+**WatercolorBackground** — the full-bleed paint-bleed backdrop present on every World Zero page. Blurred SVG ellipses in four corners; opacity dims automatically in dark mode.
+
+```jsx
+<div style={{ position: "relative", minHeight: "100vh" }}>
+  <WatercolorBackground />
+  <main style={{ position: "relative", zIndex: 5 }}>…</main>
+</div>
+```
+
+Use `fixed={false}` when scoping it inside a `position:relative` container instead of the viewport.

--- a/docs/design/design-system/components/layout/layout.card.html
+++ b/docs/design/design-system/components/layout/layout.card.html
@@ -1,0 +1,33 @@
+<!-- @dsCard group="Components" viewport="700x240" name="Watercolor Background" subtitle="The full-bleed paint-bleed backdrop on every page" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  html, body { margin: 0; height: 100%; background: var(--color-bg-page); }
+  #root { position: relative; height: 240px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+  const { WatercolorBackground, PageTitle } = window.WorldZeroDesignSystem_019e22;
+  function Demo() {
+    return (
+      <React.Fragment>
+        <WatercolorBackground fixed={false} />
+        <div style={{ position: "relative", zIndex: 5, padding: 24 }}>
+          <PageTitle title="World Zero" eyebrow="watercolor backdrop" />
+        </div>
+      </React.Fragment>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<Demo />);
+</script>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/brand-watercolor.html
+++ b/docs/design/design-system/guidelines/brand-watercolor.html
@@ -1,0 +1,35 @@
+<!-- @dsCard group="Brand" viewport="700x200" name="Watercolor Background" subtitle="Full-bleed SVG paint-bleed blobs in four corners — present on every logged-in page" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 0; background: var(--color-bg-page); }
+  .stage { position: relative; height: 200px; overflow: hidden; }
+  .cap { position: absolute; left: 50%; top: 50%; transform: translate(-50%,-50%); font-family: var(--font-display); font-style: italic; font-size: 30px; color: var(--color-text-primary); z-index: 2; }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <svg aria-hidden="true" style="position:absolute;inset:0;width:100%;height:100%;z-index:0" preserveAspectRatio="none">
+      <defs>
+        <filter id="wc-blur" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="22" /></filter>
+        <filter id="wc-distort" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="20" result="blur" />
+          <feTurbulence type="turbulence" baseFrequency="0.015" numOctaves="3" result="turb" />
+          <feDisplacementMap in="blur" in2="turb" scale="16" />
+        </filter>
+      </defs>
+      <ellipse cx="8%" cy="14%" rx="16%" ry="26%" fill="#4f46e5" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="16%" cy="8%" rx="11%" ry="18%" fill="#7c3aed" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <ellipse cx="90%" cy="10%" rx="14%" ry="24%" fill="#b45309" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="95%" cy="6%" rx="9%" ry="16%" fill="#16a34a" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+      <ellipse cx="10%" cy="88%" rx="15%" ry="22%" fill="#9f1239" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="88%" cy="86%" rx="13%" ry="24%" fill="#0f766e" opacity="var(--wc-opacity-blob)" filter="url(#wc-distort)" />
+      <ellipse cx="94%" cy="92%" rx="10%" ry="16%" fill="#0e7490" opacity="var(--wc-opacity-blob)" filter="url(#wc-blur)" />
+    </svg>
+    <span class="cap">World Zero</span>
+  </div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/brand-wordmark.html
+++ b/docs/design/design-system/guidelines/brand-wordmark.html
@@ -1,0 +1,29 @@
+<!-- @dsCard group="Brand" viewport="700x150" name="Wordmark" subtitle="Lora italic with a rainbow gradient underline — the only logo World Zero has" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 0; background: var(--color-bg-page); height: 150px; display: flex; align-items: center; justify-content: center; }
+  .wordmark {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 48px;
+    color: var(--color-text-primary);
+    display: inline-block;
+    border-bottom: 3px solid transparent;
+    background-image:
+      linear-gradient(var(--color-bg-page), var(--color-bg-page)),
+      linear-gradient(90deg, var(--underline-3), var(--underline-2), var(--underline-6), var(--underline-5));
+    background-size: 100% calc(100% - 3px), 100% 3px;
+    background-position: top, bottom;
+    background-repeat: no-repeat;
+    padding-bottom: 3px;
+  }
+</style>
+</head>
+<body>
+  <span class="wordmark">World Zero</span>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/colors-card-backgrounds.html
+++ b/docs/design/design-system/guidelines/colors-card-backgrounds.html
@@ -1,0 +1,26 @@
+<!-- @dsCard group="Colors" viewport="700x150" name="Faction Card Backgrounds" subtitle="Each faction's paper stock — lavender, gestalt.exe white, photocopier ink, vellum, terminal black, manila" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px; background: var(--color-bg-page); }
+  .row { display: flex; gap: 10px; }
+  .sw { flex: 1; display: flex; flex-direction: column; gap: 6px; }
+  .chip { height: 60px; border-radius: var(--radius-sm); border: 1px solid var(--color-border-strong); display: flex; align-items: center; justify-content: center; }
+  .dot { width: 16px; height: 16px; border-radius: 50%; }
+  .name { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-primary); }
+</style>
+</head>
+<body>
+  <div class="row">
+    <div class="sw"><div class="chip" style="background:var(--faction-ua-card-bg)"><div class="dot" style="background:var(--faction-ua-card-accent)"></div></div><span class="name">UA</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-gestalt-card-bg)"><div class="dot" style="background:var(--faction-gestalt-card-accent)"></div></div><span class="name">Gestalt</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-snide-card-bg)"><div class="dot" style="background:var(--faction-snide-card-accent)"></div></div><span class="name">S.N.I.D.E.</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-ephemerists-card-bg)"><div class="dot" style="background:var(--faction-ephemerists-card-accent)"></div></div><span class="name">Ephemerists</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-singularity-card-bg)"><div class="dot" style="background:var(--faction-singularity-card-accent)"></div></div><span class="name">Singularity</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-everymen-card-bg)"><div class="dot" style="background:var(--faction-everymen-card-accent)"></div></div><span class="name">Everymen</span></div>
+  </div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/colors-factions.html
+++ b/docs/design/design-system/guidelines/colors-factions.html
@@ -1,0 +1,26 @@
+<!-- @dsCard group="Colors" viewport="700x150" name="Faction Rainbow" subtitle="The six faction primaries — the spine of the whole palette" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px; background: var(--color-bg-page); }
+  .row { display: flex; gap: 10px; }
+  .sw { flex: 1; display: flex; flex-direction: column; gap: 6px; }
+  .chip { height: 56px; border-radius: var(--radius-sm); }
+  .name { font-family: var(--font-body); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-text-primary); }
+  .hex { font-family: var(--font-body); font-size: 8px; color: var(--color-text-tertiary); }
+</style>
+</head>
+<body>
+  <div class="row">
+    <div class="sw"><div class="chip" style="background:var(--faction-everymen)"></div><span class="name">Everymen</span><span class="hex">#c1272d</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-ua)"></div><span class="name">UA</span><span class="hex">#c2541f</span></div>
+    <div class="sw"><div class="chip" style="background:var(--eph-gold)"></div><span class="name">Ephemerists</span><span class="hex">#b0863a</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-snide)"></div><span class="name">S.N.I.D.E.</span><span class="hex">#16a34a</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-singularity)"></div><span class="name">Singularity</span><span class="hex">#2563eb</span></div>
+    <div class="sw"><div class="chip" style="background:var(--faction-gestalt)"></div><span class="name">Warriors of Whimsy</span><span class="hex">#be185d</span></div>
+  </div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/colors-functional.html
+++ b/docs/design/design-system/guidelines/colors-functional.html
@@ -1,0 +1,39 @@
+<!-- @dsCard group="Colors" viewport="700x130" name="Functional & Title Underlines" subtitle="Status colors plus the cycling per-letter title underline palette" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px; background: var(--color-bg-page); display: flex; gap: 28px; align-items: flex-start; }
+  .group { display: flex; flex-direction: column; gap: 8px; }
+  .eyebrow { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.15em; color: var(--color-text-tertiary); }
+  .row { display: flex; gap: 8px; }
+  .sw { display: flex; flex-direction: column; gap: 4px; align-items: center; }
+  .chip { width: 46px; height: 38px; border-radius: var(--radius-sm); }
+  .bar { width: 46px; height: 38px; }
+  .name { font-family: var(--font-body); font-size: 7px; text-transform: uppercase; color: var(--color-text-secondary); }
+</style>
+</head>
+<body>
+  <div class="group">
+    <span class="eyebrow">Functional</span>
+    <div class="row">
+      <div class="sw"><div class="chip" style="background:var(--color-success)"></div><span class="name">success</span></div>
+      <div class="sw"><div class="chip" style="background:var(--color-warning)"></div><span class="name">warning</span></div>
+      <div class="sw"><div class="chip" style="background:var(--color-danger)"></div><span class="name">danger</span></div>
+    </div>
+  </div>
+  <div class="group">
+    <span class="eyebrow">Title underlines</span>
+    <div class="row">
+      <div class="sw"><div class="bar" style="background:var(--underline-1)"></div></div>
+      <div class="sw"><div class="bar" style="background:var(--underline-2)"></div></div>
+      <div class="sw"><div class="bar" style="background:var(--underline-3)"></div></div>
+      <div class="sw"><div class="bar" style="background:var(--underline-4)"></div></div>
+      <div class="sw"><div class="bar" style="background:var(--underline-5)"></div></div>
+      <div class="sw"><div class="bar" style="background:var(--underline-6)"></div></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/colors-neutrals.html
+++ b/docs/design/design-system/guidelines/colors-neutrals.html
@@ -1,0 +1,26 @@
+<!-- @dsCard group="Colors" viewport="700x150" name="Page & Ink Neutrals" subtitle="Warm paper backgrounds and ink-brown text — never pure white or black" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px; background: var(--color-bg-page); }
+  .row { display: flex; gap: 10px; }
+  .sw { flex: 1; display: flex; flex-direction: column; gap: 6px; }
+  .chip { height: 56px; border-radius: var(--radius-sm); border: 1px solid var(--color-border-strong); }
+  .name { font-family: var(--font-body); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-text-primary); }
+  .hex { font-family: var(--font-body); font-size: 8px; color: var(--color-text-tertiary); }
+</style>
+</head>
+<body>
+  <div class="row">
+    <div class="sw"><div class="chip" style="background:var(--color-bg-page)"></div><span class="name">BG Page</span><span class="hex">#f7f4ee</span></div>
+    <div class="sw"><div class="chip" style="background:var(--color-bg-surface-alt)"></div><span class="name">Surface Alt</span><span class="hex">#f0ede6</span></div>
+    <div class="sw"><div class="chip" style="background:var(--color-text-primary)"></div><span class="name">Ink</span><span class="hex">#1a1209</span></div>
+    <div class="sw"><div class="chip" style="background:var(--color-text-secondary)"></div><span class="name">Secondary</span><span class="hex">#6b6050</span></div>
+    <div class="sw"><div class="chip" style="background:var(--color-text-tertiary)"></div><span class="name">Tertiary</span><span class="hex">#9b8e7d</span></div>
+    <div class="sw"><div class="chip" style="background:var(--color-accent-primary)"></div><span class="name">Accent</span><span class="hex">#be185d</span></div>
+  </div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/colors-votes.html
+++ b/docs/design/design-system/guidelines/colors-votes.html
@@ -1,0 +1,24 @@
+<!-- @dsCard group="Colors" viewport="700x150" name="Vote Stamp Scale" subtitle="1→5 rating colors: a start · solid · good · excellent · legendary" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px; background: var(--color-bg-page); }
+  .row { display: flex; gap: 14px; align-items: flex-start; }
+  .sw { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+  .stamp { width: 56px; height: 56px; border: 3px solid var(--c); display: flex; align-items: center; justify-content: center; font-family: var(--font-body); font-size: 22px; font-weight: 900; color: var(--color-text-on-accent); background: var(--c); }
+  .label { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-secondary); }
+</style>
+</head>
+<body>
+  <div class="row">
+    <div class="sw"><div class="stamp" style="--c:var(--vote-1)">1</div><span class="label">a start</span></div>
+    <div class="sw"><div class="stamp" style="--c:var(--vote-2)">2</div><span class="label">solid</span></div>
+    <div class="sw"><div class="stamp" style="--c:var(--vote-3)">3</div><span class="label">good</span></div>
+    <div class="sw"><div class="stamp" style="--c:var(--vote-4)">4</div><span class="label">excellent</span></div>
+    <div class="sw"><div class="stamp" style="--c:var(--vote-5)">5</div><span class="label">legendary</span></div>
+  </div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/spacing-radii.html
+++ b/docs/design/design-system/guidelines/spacing-radii.html
@@ -1,0 +1,21 @@
+<!-- @dsCard group="Spacing" viewport="700x130" name="Corner Radii" subtitle="A restrained set — sm 4 to xl 14. Many surfaces use 0 (stamps, clippings)." -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px; background: var(--color-bg-page); display: flex; gap: 20px; align-items: flex-end; }
+  .sw { display: flex; flex-direction: column; gap: 8px; align-items: center; }
+  .box { width: 72px; height: 56px; background: var(--color-bg-surface); border: 1.5px solid var(--color-border-strong); }
+  .name { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-secondary); }
+</style>
+</head>
+<body>
+  <div class="sw"><div class="box" style="border-radius:0"></div><span class="name">0 · stamps</span></div>
+  <div class="sw"><div class="box" style="border-radius:var(--radius-sm)"></div><span class="name">sm · 4</span></div>
+  <div class="sw"><div class="box" style="border-radius:var(--radius-md)"></div><span class="name">md · 8</span></div>
+  <div class="sw"><div class="box" style="border-radius:var(--radius-lg)"></div><span class="name">lg · 12</span></div>
+  <div class="sw"><div class="box" style="border-radius:var(--radius-xl)"></div><span class="name">xl · 14</span></div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/spacing-rhythm.html
+++ b/docs/design/design-system/guidelines/spacing-rhythm.html
@@ -1,0 +1,23 @@
+<!-- @dsCard group="Spacing" viewport="700x150" name="Spacing Rhythm" subtitle="4 / 8 / 12 / 16 / 20 / 24 — card padding & flex gaps draw from this" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 20px; background: var(--color-bg-page); display: flex; gap: 16px; align-items: flex-end; }
+  .sw { display: flex; flex-direction: column; gap: 8px; align-items: center; }
+  .bar { background: var(--faction-gestalt); width: var(--w); height: var(--w); border-radius: 2px; }
+  .name { font-family: var(--font-body); font-size: 8px; color: var(--color-text-secondary); }
+</style>
+</head>
+<body>
+  <div class="sw"><div class="bar" style="--w:4px"></div><span class="name">1 · 4</span></div>
+  <div class="sw"><div class="bar" style="--w:8px"></div><span class="name">2 · 8</span></div>
+  <div class="sw"><div class="bar" style="--w:12px"></div><span class="name">3 · 12</span></div>
+  <div class="sw"><div class="bar" style="--w:16px"></div><span class="name">4 · 16</span></div>
+  <div class="sw"><div class="bar" style="--w:20px"></div><span class="name">5 · 20</span></div>
+  <div class="sw"><div class="bar" style="--w:24px"></div><span class="name">6 · 24</span></div>
+  <div class="sw"><div class="bar" style="--w:32px"></div><span class="name">8 · 32</span></div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/spacing-surfaces.html
+++ b/docs/design/design-system/guidelines/spacing-surfaces.html
@@ -1,0 +1,38 @@
+<!-- @dsCard group="Spacing" viewport="700x150" name="Frosted Surfaces" subtitle="Nav & sidebar glass: translucent fill + backdrop blur, never a hard drop shadow" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 0; background: var(--color-bg-page); }
+  .stage { position: relative; height: 150px; overflow: hidden; }
+  .wash { position: absolute; inset: 0; background:
+    radial-gradient(circle at 15% 30%, rgba(124,58,237,0.4), transparent 40%),
+    radial-gradient(circle at 80% 20%, rgba(202,138,4,0.4), transparent 40%),
+    radial-gradient(circle at 70% 90%, rgba(14,116,144,0.4), transparent 45%),
+    radial-gradient(circle at 25% 85%, rgba(190,24,93,0.35), transparent 40%);
+    filter: blur(8px); }
+  .panel { position: absolute; padding: 14px 16px; }
+  .sidebar-card { width: 200px; }
+  .lbl { font-family: var(--font-body); font-size: 9px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--color-text-secondary); }
+  .title { font-family: var(--font-display); font-style: italic; font-size: 16px; color: var(--color-text-primary); margin-bottom: 4px; }
+</style>
+</head>
+<body>
+  <div class="stage">
+    <div class="wash"></div>
+    <div class="panel" style="top:18px;left:24px">
+      <div class="sidebar-card">
+        <div class="title">Character</div>
+        <div class="lbl">frosted · blur 4px</div>
+      </div>
+    </div>
+    <div class="panel" style="top:18px;left:250px">
+      <div class="card" style="padding:14px 16px;width:200px">
+        <div class="lbl">card surface · 0.72 white</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/type-body.html
+++ b/docs/design/design-system/guidelines/type-body.html
@@ -1,0 +1,17 @@
+<!-- @dsCard group="Type" viewport="700x170" name="Body — Courier Prime" subtitle="ALL body text, UI, labels, nav. Monospace typewriter." -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 20px; background: var(--color-bg-page); }
+  .body { font-family: var(--font-body); font-size: 12px; line-height: 1.6; color: var(--color-text-primary); max-width: 560px; margin-bottom: 12px; }
+  .eyebrow { font-family: var(--font-body); font-size: 9px; text-transform: uppercase; letter-spacing: 0.15em; color: var(--color-text-tertiary); }
+</style>
+</head>
+<body>
+  <p class="body">Install a community garden, ideally in secret, or somewhere a garden may not be expected. Crop variety and size is your choice, but it must yield a harvest to feed at least 3 people one meal.</p>
+  <span class="eyebrow">eyebrow · 9px · uppercase · 0.15em</span>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/type-display.html
+++ b/docs/design/design-system/guidelines/type-display.html
@@ -1,0 +1,19 @@
+<!-- @dsCard group="Type" viewport="700x150" name="Display — Lora Italic" subtitle="Wordmark, page titles, praxis titles. Always italic, serif." -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 20px; background: var(--color-bg-page); }
+  .big { font-family: var(--font-display); font-style: italic; font-size: 44px; font-weight: 700; color: var(--color-text-primary); line-height: 1; margin-bottom: 8px; }
+  .med { font-family: var(--font-display); font-style: italic; font-size: 24px; font-weight: 500; color: var(--color-text-secondary); }
+  .meta { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--color-text-tertiary); margin-top: 10px; }
+</style>
+</head>
+<body>
+  <div class="big">World Zero</div>
+  <div class="med">Somewhere No One Needs To Be</div>
+  <div class="meta">Lora · italic · 34px / 28px titles</div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/type-faction-faces.html
+++ b/docs/design/design-system/guidelines/type-faction-faces.html
@@ -1,0 +1,22 @@
+<!-- @dsCard group="Type" viewport="700x230" name="Faction Display Faces" subtitle="Each faction owns a headline font — the type IS the identity" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px 20px; background: var(--color-bg-page); }
+  .line { display: flex; align-items: baseline; gap: 16px; padding: 6px 0; border-bottom: 1px dashed var(--color-border-strong); }
+  .tok { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-tertiary); width: 150px; flex-shrink: 0; }
+  .spec { font-size: 22px; color: var(--color-text-primary); }
+</style>
+</head>
+<body>
+  <div class="line"><span class="tok">UA · Playfair Display</span><span class="spec" style="font-family:var(--font-faction-gilt);font-style:italic">Paint the quad at golden hour</span></div>
+  <div class="line"><span class="tok">Gestalt · Caveat</span><span class="spec" style="font-family:var(--font-faction-script);font-size:26px">The L Word</span></div>
+  <div class="line"><span class="tok">S.N.I.D.E. · Anton</span><span class="spec" style="font-family:var(--font-faction-anton);font-size:20px;text-transform:uppercase">Do A Kickflip</span></div>
+  <div class="line"><span class="tok">Ephemerists · Cinzel</span><span class="spec" style="font-family:var(--font-faction-engraved);font-size:19px">Omnia Transeunt</span></div>
+  <div class="line"><span class="tok">Singularity · Share Tech Mono</span><span class="spec" style="font-family:var(--font-faction-terminal);font-size:18px">&gt; FLIP THE SYSTEM</span></div>
+  <div class="line" style="border-bottom:none"><span class="tok">Everymen · Bebas Neue</span><span class="spec" style="font-family:var(--font-faction-poster);font-size:24px;letter-spacing:0.04em">UNITED WE STAND</span></div>
+</body>
+</html>

--- a/docs/design/design-system/guidelines/type-scale.html
+++ b/docs/design/design-system/guidelines/type-scale.html
@@ -1,0 +1,23 @@
+<!-- @dsCard group="Type" viewport="700x200" name="Type Scale" subtitle="xs 8 → 4xl 34. Deliberately tiny: the UI reads like printed ephemera." -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../styles.css" />
+<style>
+  body { margin: 0; padding: 18px 20px; background: var(--color-bg-page); }
+  .line { display: flex; align-items: baseline; gap: 14px; border-bottom: 1px dashed var(--color-border-strong); padding: 5px 0; }
+  .tok { font-family: var(--font-body); font-size: 8px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-tertiary); width: 110px; flex-shrink: 0; }
+  .spec { font-family: var(--font-body); color: var(--color-text-primary); }
+</style>
+</head>
+<body>
+  <div class="line"><span class="tok">4xl · 34px</span><span class="spec" style="font-size:34px;font-family:var(--font-display);font-style:italic">Tasks</span></div>
+  <div class="line"><span class="tok">3xl · 28px</span><span class="spec" style="font-size:28px;font-family:var(--font-display);font-style:italic">Praxis</span></div>
+  <div class="line"><span class="tok">2xl · 18px</span><span class="spec" style="font-size:18px">Field Journal</span></div>
+  <div class="line"><span class="tok">xl · 14px</span><span class="spec" style="font-size:14px">Complete a task</span></div>
+  <div class="line"><span class="tok">lg · 12px</span><span class="spec" style="font-size:12px">Post your proof to earn points</span></div>
+  <div class="line"><span class="tok">base · 10px</span><span class="spec" style="font-size:10px">Nav links and chips run at base size</span></div>
+  <div class="line"><span class="tok">sm 9 · xs 8</span><span class="spec" style="font-size:9px">Eyebrows, metadata and card descriptions</span></div>
+</body>
+</html>

--- a/docs/design/design-system/readme.md
+++ b/docs/design/design-system/readme.md
@@ -1,0 +1,39 @@
+# World Zero — Design System
+
+The visual language of World Zero, a real-world quest game. Everything renders like printed field-journal ephemera: tiny type (8–14px working range), warm paper, hand-made textures, and a hard split between **shared app chrome** (neutral nav / sidebars / watercolor) and **faction-affiliated surfaces** that each wear a completely different physical archetype.
+
+## The seven factions
+
+The roster is a tight rainbow spine — plus Albescent, an unranked secret society that sits outside it. The card archetype IS the faction identity.
+
+| Faction | Slug | Hue | Archetype | Display face |
+|---|---|---|---|---|
+| UA | `ua` | burnt amber + gold | **gilt salon** (art academy) | Playfair Display |
+| Warriors of Whimsy | `wow` | magenta | **whimsy.exe** desktop window (pink computer-witch) | Caveat |
+| S.N.I.D.E. | `snide` | green | **ransom dispatch** (photocopier ink, cut-out letters, acid + hot pink) | Anton |
+| The Ephemerists | `ephemerists` | teal | **the discordant map** (illuminated codex, vellum + lapis + gold) | Cinzel |
+| Singularity | `singularity` | blue | terminal printout (always dark) | Share Tech Mono |
+| The Everymen | `everymen` | red | **union / victory poster** | Bebas Neue |
+| Albescent | `albescent` | none (ink) | **vellum correspondence** (sacred secret society, always light) | Cormorant Garamond |
+
+History: Analog and UA Masters were retired; the **Journeymen were rebranded as the Ephemerists** (the slug changed `journeymen` → `ephemerists`, with `journeymen` kept as a legacy alias); the **Everymen** were added to claim the rainbow's missing red; **Albescent** was added as an always-light faction outside the rainbow (it used to alias `ua`); **UA was repainted from the purple sticky note into the gilt salon** — burnt amber + antique gold on parchment, now promoted into the global tokens (always-light: it never dims).
+
+## Structure
+
+- **`styles.css`** — the single entry point consumers link. An `@import` manifest pulling in `tokens/*.css`.
+- **`tokens/`** — `colors.css` (faction primaries/tints/borders, per-faction extension palettes + the `--faction-<slug>-card-*` contract, light + dark), `fonts.css`, `typography.css`, `spacing.css`, `patterns.css`. Light mode on `:root`, dark under `[data-theme="dark"]` — every component reads `var(--…)` so theme switches through the cascade.
+- **`components/`** — `FactionTaskCard` (the signature component — one tag, seven task-card archetypes), `FactionPraxisCard` (its companion — one filed-praxis card per faction, each reframing the 1–5 vote), `FactionVoteStamps` (the 1–5 stamp rating, faction-aware: pass `faction` to reframe the rungs), `FactionCommentBox` (one thread post per faction — gilt salon, whimsy.exe window, ransom slip, vellum marginalia, terminal line, union entry, the register — with auto-styled @mentions), `FactionPennant` (faction filter banner), `Button`, `LevelPill`, `PageTitle`, `FilterStamp`, `LevelNodes`, `WatercolorBackground`, plus the `factions.js` registry (`FACTIONS`, `FACTION_ORDER`, `factionCssVar`). The faction-specific components are grouped under **Faction Components** on the Design System tab.
+- **`guidelines/`** — Design System tab cards (palettes, type, spacing, brand).
+- **`templates/`** — full multi-page faction kits consuming projects can copy: `everymen/`, `snide/`, `ephemerists/`, `wow/` (Warriors of Whimsy), `singularity/`, `albescent/`. Each has a `<Faction>.dc.html` entry and a `ds-base.js` that loads this DS.
+
+## Using a faction's colors
+
+Prefer the CSS variables (dark mode resolves automatically):
+
+```jsx
+import { factionCssVar } from "./components/core/factions.js";
+background: factionCssVar("snide", "card-bg");   // → var(--faction-snide-card-bg)
+color:      factionCssVar("ephemerists", "card-accent");
+```
+
+Each redesigned faction also exposes a named extension palette for richer surfaces: `--ua-*` (orange / gold / ink / sub / paper / wall / line, plus the `--ua-gilt` frame gradient), `--gestalt-*` (Warriors of Whimsy keeps this historical prefix), `--snide-*` (acid / ink / paper / pink / tape / wall), `--eph-*` (gold / rubric / lapis / verdigris / vellum / parchment), `--everymen-*` (cream / gold / olive / ink / red / paper / field). These flip in dark where it matters (UA stays always-light).

--- a/docs/design/design-system/styles.css
+++ b/docs/design/design-system/styles.css
@@ -1,0 +1,10 @@
+/* ══════════════════════════════════════════════════════════════
+   World Zero — Design System entry point
+   Consumers link THIS file only. It is an @import manifest; all
+   tokens, fonts and shared patterns live in tokens/*.css.
+   ══════════════════════════════════════════════════════════════ */
+@import "tokens/fonts.css";
+@import "tokens/colors.css";
+@import "tokens/typography.css";
+@import "tokens/spacing.css";
+@import "tokens/patterns.css";

--- a/docs/design/design-system/templates/albescent/albescent-cards.jsx
+++ b/docs/design/design-system/templates/albescent/albescent-cards.jsx
@@ -1,0 +1,159 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — Atoms + Task Card
+   Shared visual vocabulary for all Albescent surfaces.
+
+   Physical archetype: VELLUM CORRESPONDENCE — pure white,
+   Cormorant Garamond italic, surveyor's mark sigil, hairline
+   borders. The card speaks in a whisper.
+
+   Atoms exported:    AlbescentMark
+   Task card exported: AlbescentCard (window.AlbescentCard)
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Witness scale ── */
+const AL_WITNESS = [
+  { v:1, label:"Unseeing"  },
+  { v:2, label:"Glimpsed"  },
+  { v:3, label:"Witnessed" },
+  { v:4, label:"Verified"  },
+  { v:5, label:"Inscribed" },
+];
+
+const alDistTotal = d => d.reduce((a,b) => a+b, 0);
+const alDistAvg   = d => {
+  const t = alDistTotal(d);
+  return t ? d.reduce((a,c,i) => a+c*(i+1), 0) / t : 0;
+};
+const alStanding = avg => AL_WITNESS[Math.max(0, Math.min(4, Math.round(avg)-1))];
+
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT MARK — the surveyor's cross-hair sigil
+   Outer ring (18% opacity) · inner ring (50%) ·
+   4 cardinal tick marks · filled center dot.
+   ════════════════════════════════════════════════════════════════ */
+function AlbescentMark({ size = 20, color = "#1c1c1a", breathe = false, opacity = 1 }) {
+  const c  = size / 2;
+  const rO = size * 0.43;    /* outer ring */
+  const rI = size * 0.235;   /* inner ring */
+  const rD = size * 0.044;   /* center dot */
+  const tS = rI + size * 0.025;   /* tick start — just past inner ring */
+  const tE = tS + size * 0.13;    /* tick end */
+
+  const tick = (deg) => {
+    const a = deg * Math.PI / 180;
+    return {
+      x1: c + tS * Math.cos(a), y1: c + tS * Math.sin(a),
+      x2: c + tE * Math.cos(a), y2: c + tE * Math.sin(a),
+    };
+  };
+
+  return (
+    <svg
+      width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none"
+      style={{
+        display: "block", flexShrink: 0, opacity,
+        animation: breathe ? "al-breathe 5.5s ease-in-out infinite" : "none",
+      }}
+    >
+      <circle cx={c} cy={c} r={rO} stroke={color} strokeWidth={size*0.022} opacity={0.18}/>
+      <circle cx={c} cy={c} r={rI} stroke={color} strokeWidth={size*0.038} opacity={0.5}/>
+      {[0, 90, 180, 270].map((deg, i) => {
+        const { x1, y1, x2, y2 } = tick(deg);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={size*0.038}/>;
+      })}
+      <circle cx={c} cy={c} r={rD} fill={color}/>
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT TASK CARD — Vellum archetype
+   Full-sized version for the faction page task grid.
+   224px wide. Shows in the global task list at a smaller size
+   via FactionTaskCard (the base DS component).
+   ════════════════════════════════════════════════════════════════ */
+function AlbescentCard({ title, description, level, points, onAcknowledge }) {
+  const [ack, setAck] = React.useState(false);
+
+  return (
+    <div style={{
+      width: 224,
+      background: "#fff",
+      border: "1px solid rgba(0,0,0,0.09)",
+      boxShadow: "0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)",
+      padding: "24px 20px 18px",
+      fontFamily: "var(--al-font)",
+    }}>
+      {/* Centered sigil */}
+      <div style={{ display:"flex", justifyContent:"center", marginBottom:16 }}>
+        <AlbescentMark size={20} breathe/>
+      </div>
+
+      {/* Top rule */}
+      <div style={{ height:1, background:"rgba(0,0,0,0.07)", marginBottom:13 }}/>
+
+      {/* Eyebrow */}
+      <div style={{
+        fontSize:6, letterSpacing:"0.32em", textTransform:"uppercase",
+        color:"rgba(0,0,0,0.24)", fontFamily:"var(--al-mono)", marginBottom:10,
+      }}>Albescent</div>
+
+      {/* Title */}
+      <div style={{
+        fontSize:18, fontStyle:"italic", fontWeight:300,
+        lineHeight:1.28, color:"#1c1c1a", marginBottom:11,
+      }}>{title}</div>
+
+      {/* Description */}
+      {description && (
+        <div style={{
+          fontSize:7.5, color:"rgba(28,28,26,0.42)", lineHeight:1.6,
+          fontFamily:"var(--al-mono)", marginBottom:16,
+          overflow:"hidden", display:"-webkit-box",
+          WebkitLineClamp:3, WebkitBoxOrient:"vertical",
+        }}>{description}</div>
+      )}
+
+      {/* CTA */}
+      <div style={{ marginBottom:14 }}>
+        <button
+          onClick={() => { setAck(a => !a); onAcknowledge?.(); }}
+          style={{
+            background:"none", border:"none", padding:0, cursor:"pointer",
+            fontSize:7, letterSpacing:"0.22em", textTransform:"uppercase",
+            color: ack ? "rgba(0,0,0,0.55)" : "rgba(0,0,0,0.32)",
+            fontFamily:"var(--al-mono)",
+            borderBottom:`1px solid ${ack ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.16)"}`,
+            paddingBottom:1, transition:"all 250ms ease",
+          }}
+        >{ack ? "acknowledged" : "acknowledge"}</button>
+      </div>
+
+      {/* Footer */}
+      <div style={{
+        borderTop:"1px solid rgba(0,0,0,0.07)", paddingTop:11,
+        display:"flex", justifyContent:"space-between", alignItems:"center",
+      }}>
+        <span style={{
+          fontSize:6.5, letterSpacing:"0.2em", textTransform:"uppercase",
+          color:"rgba(0,0,0,0.22)", fontFamily:"var(--al-mono)",
+        }}>Lvl {level}</span>
+        <span style={{ fontSize:14, fontWeight:300, color:"rgba(28,28,26,0.48)" }}>
+          {points}
+          <span style={{
+            fontSize:6.5, marginLeft:3, letterSpacing:"0.1em",
+            textTransform:"uppercase", fontFamily:"var(--al-mono)",
+          }}>pts</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AlbescentMark, AlbescentCard,
+  AL_WITNESS, alDistTotal, alDistAvg, alStanding,
+});

--- a/docs/design/design-system/templates/albescent/albescent-faction.jsx
+++ b/docs/design/design-system/templates/albescent/albescent-faction.jsx
@@ -1,0 +1,421 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — Faction page components + activity feed
+   Hero · Activity Cards · Witness Widget · Nav Badge · Data.
+   Uses albescent-cards.jsx atoms. Exports on window.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Activity data ── */
+const AL_ACTIVITY = [
+  {
+    id:"a1", actor:"Keeper Vane", house:"Third House",
+    action:"returned", time:"1d ago",
+    task:"Tend the Archive in Silence", taskId:"archive-silence",
+    refNo:"XIV", credits:40, kind:"returned",
+    note:"All volumes restored and indexed. No record of passage remains.",
+  },
+  {
+    id:"a2", actor:"Keeper Orin", house:"First House",
+    action:"witnessed", time:"2d ago",
+    task:"Walk the Perimeter at Dusk", taskId:"perimeter-dusk",
+    refNo:"XI", credits:20, kind:"witnessed",
+    note:"Movement confirmed. The circuit holds.",
+  },
+  {
+    id:"a3", actor:"Keeper Sel", house:"Second House",
+    action:"acknowledged", time:"3d ago",
+    task:"Index the Unmarked Volumes", taskId:"index-unmarked",
+    refNo:"XVII", credits:0, kind:"acknowledged",
+    note:"Task received. No further acknowledgment.",
+  },
+  {
+    id:"a4", actor:"Keeper Marsh", house:"Fourth House",
+    action:"returned", time:"5d ago",
+    task:"Seal and Store Before Departing", taskId:"seal-store",
+    refNo:"IX", credits:30, kind:"returned",
+    note:"Storage completed per protocol. Departed before light.",
+  },
+  {
+    id:"a5", actor:"Keeper Vane", house:"Third House",
+    action:"attended", time:"6d ago",
+    task:"Count the Objects Without Touching", taskId:"count-objects",
+    refNo:"XXI", credits:0, kind:"attended",
+    note:"Forty-three objects accounted for. None disturbed.",
+  },
+  {
+    id:"a6", actor:"Keeper Orin", house:"First House",
+    action:"witnessed", time:"1w ago",
+    task:"Tend the Archive in Silence", taskId:"archive-silence",
+    refNo:"XIV", credits:40, kind:"witnessed",
+    note:"Signal: Inscribed. Twelve keepers in accord.",
+  },
+];
+
+const AL_TASKS = [
+  {
+    title:"Tend the Archive in Silence",
+    description:"Retrieve, restore, and return. No record of your work need remain.",
+    level:3, points:40,
+  },
+  {
+    title:"Walk the Perimeter at Dusk",
+    description:"Complete the circuit before darkness settles. Do not mark the path.",
+    level:2, points:20,
+  },
+  {
+    title:"Index the Unmarked Volumes",
+    description:"Catalogue what has not been named. Add only what is necessary.",
+    level:4, points:60,
+  },
+];
+
+const ACTION_KIND = {
+  acknowledged: { label:"acknowledged", shade:"rgba(28,28,26,0.28)" },
+  attended:     { label:"attended",     shade:"rgba(28,28,26,0.46)" },
+  returned:     { label:"returned",     shade:"rgba(28,28,26,0.64)" },
+  witnessed:    { label:"witnessed",    shade:"rgba(28,28,26,0.82)" },
+};
+
+/* ════════════════════════════════════════════════════════════════
+   AL NAV BADGE — faction membership indicator for the nav bar
+   ════════════════════════════════════════════════════════════════ */
+function AlNavBadge() {
+  const { AlbescentMark } = window;
+  return (
+    <div style={{
+      display:"inline-flex", alignItems:"center", gap:7,
+      border:"1px solid rgba(0,0,0,0.12)",
+      background:"rgba(255,255,255,0.6)",
+      padding:"4px 10px",
+    }}>
+      <AlbescentMark size={11}/>
+      <span style={{
+        fontFamily:"var(--al-mono)", fontSize:8,
+        letterSpacing:"0.18em", textTransform:"uppercase",
+        color:"rgba(28,28,26,0.55)",
+      }}>Albescent</span>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL HERO — faction page masthead
+   Meditative and still. No terminal boot-up, no dramatic chrome.
+   Just the name, the mark, and the purpose.
+   ════════════════════════════════════════════════════════════════ */
+function AlHero({ name, motto, blurb, stats }) {
+  const { AlbescentMark } = window;
+  return (
+    <div className="al-sheet" style={{ marginBottom:32, overflow:"hidden" }}>
+
+      {/* Faint background watermark */}
+      <div style={{
+        position:"absolute", top:"50%", left:"62%",
+        transform:"translate(-50%,-50%)",
+        pointerEvents:"none", zIndex:0,
+        opacity:0.03,
+      }}>
+        <AlbescentMark size={220}/>
+      </div>
+
+      <div style={{
+        position:"relative", zIndex:2,
+        padding:"44px 48px 50px",
+        display:"grid", gridTemplateColumns:"1fr auto",
+        gap:56, alignItems:"center",
+      }}>
+        <div>
+          {/* Pre-title eyebrow */}
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:7.5,
+            letterSpacing:"0.28em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)", marginBottom:18, lineHeight:1.9,
+          }}>
+            <div>Faction · {name}</div>
+            <div>Fourth Season · Active</div>
+            <div>Unranked · By design</div>
+          </div>
+
+          {/* Faction name */}
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:76, lineHeight:0.92,
+            color:"#1c1c1a", marginBottom:16,
+            letterSpacing:"-0.015em",
+          }}>{name}</div>
+
+          {/* Motto */}
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:9,
+            letterSpacing:"0.34em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.28)", marginBottom:20,
+          }}>{motto}</div>
+
+          {/* Blurb */}
+          <p style={{
+            fontFamily:"var(--al-mono)", fontSize:9.5, lineHeight:1.74,
+            color:"rgba(28,28,26,0.46)", maxWidth:490, marginBottom:30,
+          }}>{blurb}</p>
+
+          {/* Stats */}
+          <div style={{ display:"flex", gap:28, flexWrap:"wrap" }}>
+            {stats.map(s => (
+              <div key={s.label} style={{
+                paddingTop:12,
+                borderTop:"1px solid rgba(0,0,0,0.07)",
+                minWidth:80,
+              }}>
+                <div style={{
+                  fontFamily:"var(--al-font)", fontStyle:"italic",
+                  fontWeight:300, fontSize:28, lineHeight:1,
+                  color:"rgba(28,28,26,0.68)", marginBottom:5,
+                }}>{s.value}</div>
+                <div style={{
+                  fontFamily:"var(--al-mono)", fontSize:7,
+                  letterSpacing:"0.2em", textTransform:"uppercase",
+                  color:"rgba(28,28,26,0.26)",
+                }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Large mark — slowly breathing */}
+        <div className="al-breathe" style={{ flexShrink:0 }}>
+          <AlbescentMark size={106}/>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL ACTIVITY CARD — record feed item
+   Styled like a formal logbook entry: quiet, precise, no color.
+   ════════════════════════════════════════════════════════════════ */
+function AlActivityCard({ item }) {
+  const ak = ACTION_KIND[item.kind] || ACTION_KIND.acknowledged;
+  return (
+    <div className="al-activity-card" style={{ fontFamily:"var(--al-mono)" }}>
+
+      {/* Actor row */}
+      <div style={{
+        display:"flex", justifyContent:"space-between",
+        alignItems:"flex-start", gap:12, marginBottom:7,
+      }}>
+        <div>
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:14, lineHeight:1.2,
+            color:"rgba(28,28,26,0.72)", marginBottom:2,
+          }}>{item.actor}</div>
+          <div style={{
+            fontSize:7, letterSpacing:"0.16em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.26)",
+          }}>{item.house}</div>
+        </div>
+        <div style={{ display:"flex", alignItems:"center", gap:10, flexShrink:0 }}>
+          <span style={{
+            fontSize:6.5, letterSpacing:"0.18em", textTransform:"uppercase",
+            color:ak.shade, borderBottom:`1px solid ${ak.shade}`, paddingBottom:1,
+          }}>{ak.label}</span>
+          <span style={{
+            fontSize:7, letterSpacing:"0.06em",
+            color:"rgba(28,28,26,0.2)",
+          }}>{item.time}</span>
+        </div>
+      </div>
+
+      {/* Task name */}
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontWeight:300, fontSize:12.5, lineHeight:1.3,
+        color:"rgba(28,28,26,0.6)", marginBottom:5,
+      }}>{item.task}</div>
+
+      {/* Meta row */}
+      <div style={{
+        display:"flex", gap:12, alignItems:"center",
+        flexWrap:"wrap", marginBottom: item.note ? 5 : 0,
+      }}>
+        <span style={{ fontSize:7, letterSpacing:"0.12em", color:"rgba(28,28,26,0.24)" }}>
+          Ref. {item.refNo}
+        </span>
+        {item.credits > 0 && (
+          <span style={{ fontSize:7, letterSpacing:"0.1em", color:"rgba(28,28,26,0.32)" }}>
+            {item.credits} pts
+          </span>
+        )}
+      </div>
+
+      {item.note && (
+        <div style={{
+          fontSize:8, fontStyle:"italic", fontFamily:"var(--al-font)",
+          color:"rgba(28,28,26,0.36)", lineHeight:1.5,
+        }}>{item.note}</div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL WITNESS WIDGET — consensus witness for the faction page
+   Grayscale 1-5 circle marks: Unseeing → Inscribed.
+   No colors — Albescent refuses the palette.
+   ════════════════════════════════════════════════════════════════ */
+function AlWitnessWidget({ taskId, taskLabel, baseDist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const key = "al-witness-" + taskId;
+  const [my, setMy] = React.useState(0);
+
+  React.useEffect(() => {
+    try {
+      const v = +localStorage.getItem(key);
+      if (v >= 1 && v <= 5) setMy(v);
+    } catch(e) {}
+  }, [key]);
+
+  const cast = v => {
+    const nv = my === v ? 0 : v;
+    setMy(nv);
+    try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch(e) {}
+  };
+
+  const live = baseDist.map((c, i) => c + (my === i+1 ? 1 : 0));
+  const avg  = alDistAvg(live);
+  const total = alDistTotal(live);
+  const st   = alStanding(avg);
+
+  const shades = [
+    "rgba(0,0,0,0.16)",
+    "rgba(0,0,0,0.30)",
+    "rgba(0,0,0,0.48)",
+    "rgba(0,0,0,0.66)",
+    "rgba(0,0,0,0.84)",
+  ];
+
+  return (
+    <div style={{
+      border:"1px solid rgba(0,0,0,0.09)",
+      background:"#fff",
+      padding:"22px 24px",
+      fontFamily:"var(--al-mono)",
+    }}>
+      {/* Header */}
+      <div style={{
+        fontSize:7, letterSpacing:"0.26em", textTransform:"uppercase",
+        color:"rgba(28,28,26,0.24)", marginBottom:8,
+      }}>Bear Witness</div>
+
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontWeight:300, fontSize:13.5, color:"rgba(28,28,26,0.52)",
+        lineHeight:1.38, marginBottom:20,
+      }}>
+        How completely was this task attended?<br/>
+        <span style={{ color:"rgba(28,28,26,0.7)" }}>{taskLabel}</span>
+      </div>
+
+      {/* 5 circle marks */}
+      <div style={{ display:"flex", gap:8, marginBottom:14 }}>
+        {AL_WITNESS.map((s, i) => {
+          const shade = shades[i];
+          const on    = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{
+              display:"flex", flexDirection:"column",
+              alignItems:"center", gap:7, flex:1,
+            }}>
+              <button
+                onClick={() => cast(s.v)}
+                style={{
+                  width:32, height:32, borderRadius:"50%", cursor:"pointer",
+                  border:`1.5px solid ${shade}`,
+                  background: on ? shade : "transparent",
+                  display:"flex", alignItems:"center", justifyContent:"center",
+                  padding:0, transition:"all 200ms ease",
+                }}
+              >
+                {picked && (
+                  <div style={{
+                    width:8, height:8, borderRadius:"50%", background:"#fff",
+                  }}/>
+                )}
+              </button>
+              <span style={{
+                fontSize:5.5, letterSpacing:"0.06em", textAlign:"center",
+                color:"rgba(28,28,26,0.28)", lineHeight:1.35,
+              }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Consensus readout */}
+      <div style={{
+        display:"flex", justifyContent:"space-between", alignItems:"center",
+        paddingTop:13, borderTop:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        <span style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:17, color:"rgba(28,28,26,0.58)",
+        }}>{st.label}</span>
+        <span style={{
+          fontSize:8, letterSpacing:"0.12em",
+          color:"rgba(28,28,26,0.26)",
+        }}>{total} keepers</span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL ACTIVITY FEED — full updates page version with filters
+   ════════════════════════════════════════════════════════════════ */
+function AlActivityFeed({ items }) {
+  const [filter, setFilter] = React.useState("all");
+  const FILTERS = [
+    { id:"all",          name:"All" },
+    { id:"acknowledged", name:"Acknowledged" },
+    { id:"attended",     name:"Attended" },
+    { id:"returned",     name:"Returned" },
+    { id:"witnessed",    name:"Witnessed" },
+  ];
+  const rows = items.filter(i => filter === "all" || i.kind === filter);
+
+  return (
+    <div>
+      <div style={{ display:"flex", gap:6, marginBottom:20, flexWrap:"wrap" }}>
+        {FILTERS.map(f => {
+          const on = filter === f.id;
+          return (
+            <button key={f.id} onClick={() => setFilter(f.id)} style={{
+              fontFamily:"var(--al-mono)", fontSize:7.5,
+              letterSpacing:"0.14em", textTransform:"uppercase",
+              padding:"4px 10px", cursor:"pointer",
+              border:`1px solid ${on ? "rgba(0,0,0,0.28)" : "rgba(0,0,0,0.1)"}`,
+              background: on ? "rgba(28,28,26,0.07)" : "transparent",
+              color: on ? "rgba(28,28,26,0.65)" : "rgba(28,28,26,0.36)",
+              transition:"all 120ms",
+            }}>{f.name}</button>
+          );
+        })}
+      </div>
+      {rows.map(item => <AlActivityCard key={item.id} item={item}/>)}
+      {rows.length === 0 && (
+        <div style={{
+          padding:"24px 0", fontSize:13, fontStyle:"italic",
+          fontFamily:"var(--al-font)", color:"rgba(28,28,26,0.26)",
+        }}>No entries match this filter.</div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AL_ACTIVITY, AL_TASKS, ACTION_KIND,
+  AlNavBadge, AlHero, AlActivityCard, AlWitnessWidget, AlActivityFeed,
+});

--- a/docs/design/design-system/templates/albescent/albescent-praxis.jsx
+++ b/docs/design/design-system/templates/albescent/albescent-praxis.jsx
@@ -1,0 +1,572 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — The Register (Praxis surfaces)
+   A returned task is a filed account the faction now witnesses.
+   The 1–5 rating becomes THE WITNESS SCALE — a presence ramp
+   (unseeing → glimpsed → witnessed → verified → inscribed)
+   that measures how completely the task was attended.
+
+   Two surfaces:
+     · RegisterIndex — the ledger of returned accounts + witness
+     · EntryRead     — one returned account in full, with casting
+
+   Uses albescent-cards.jsx atoms. Data + helpers on window.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── dataset ── */
+const AL_PRAXES = [
+  {
+    id:        "archive-silence",
+    refNo:     "XIV",
+    task:      "Tend the Archive in Silence",
+    status:    "witnessed",
+    keeper:    "Keeper Vane",
+    house:     "Third House",
+    timestamp: "2026.04.21 // dawn",
+    credits:   40,
+    output:    "All volumes restored. The shelves hold their sequence without my name in them.",
+    account: [
+      "Arrived before the cataloguers. Worked from the east wing inward, restoring the displaced volumes to their documented positions. Did not open any that were sealed.",
+      "Found three volumes with damaged spines. Wrapped them without notation — they will be found by whoever is meant to find them.",
+      "Departed by the rear passage before the morning shift arrived. Left no note.",
+    ],
+    dist: [0, 1, 8, 14, 9],
+  },
+  {
+    id:        "perimeter-dusk",
+    refNo:     "XI",
+    task:      "Walk the Perimeter at Dusk",
+    status:    "witnessed",
+    keeper:    "Keeper Orin",
+    house:     "First House",
+    timestamp: "2026.04.18 // dusk",
+    credits:   20,
+    output:    "The circuit holds. Three missing posts replaced before the light failed.",
+    account: [
+      "Walked the full eastern perimeter beginning at the point where the light first dims. Completed the circuit in forty-one minutes.",
+      "Three boundary posts were missing from the northern quadrant. Replaced them from materials kept in the groundskeeper storage.",
+      "Returned by the same route. Nothing disturbed.",
+    ],
+    dist: [0, 2, 5, 8, 4],
+  },
+  {
+    id:        "seal-store",
+    refNo:     "IX",
+    task:      "Seal and Store Before Departing",
+    status:    "returned",
+    keeper:    "Keeper Marsh",
+    house:     "Fourth House",
+    timestamp: "2026.04.19 // before light",
+    credits:   30,
+    output:    "Stored. Departed. No trace visible from the road.",
+    account: [
+      "Completed sealing of the eastern archive annex using the wax from the cabinet — verified seal integrity before leaving.",
+      "Checked the facade from the road before departing. No light. No sign. Left before the hour changed.",
+    ],
+    dist: [1, 3, 7, 4, 1],
+  },
+  {
+    id:        "count-objects",
+    refNo:     "XXI",
+    task:      "Count the Objects Without Touching",
+    status:    "witnessed",
+    keeper:    "Keeper Vane",
+    house:     "Third House",
+    timestamp: "2026.04.20 // midday",
+    credits:   25,
+    output:    "Forty-three objects accounted for. None disturbed.",
+    account: [
+      "Entered the reading room at the appointed hour. Counted all objects on the central table by visual inspection only. Forty-three.",
+      "One object appeared to have moved since the last count. It had not — the shadow deceived. Counted again from the doorway. Forty-three.",
+      "Departed without confirming the count to anyone present.",
+    ],
+    dist: [0, 0, 3, 8, 5],
+  },
+];
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS BAR — mini grayscale histogram for index rows
+   ════════════════════════════════════════════════════════════════ */
+function WitnessBar({ dist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const total = alDistTotal(dist);
+  const avg   = alDistAvg(dist);
+  const st    = alStanding(avg);
+  const max   = Math.max(1, ...dist);
+  const shades = ["rgba(0,0,0,0.14)","rgba(0,0,0,0.28)","rgba(0,0,0,0.44)","rgba(0,0,0,0.62)","rgba(0,0,0,0.80)"];
+
+  return (
+    <div style={{ display:"flex", alignItems:"center", gap:10 }}>
+      <div style={{ display:"flex", alignItems:"flex-end", gap:2, height:22 }}>
+        {AL_WITNESS.map((s, i) => (
+          <div key={s.v} style={{
+            width:5,
+            height: Math.max(2, (dist[i] / max) * 22),
+            background: shades[i],
+            opacity: dist[i] ? 0.88 : 0.12,
+          }}/>
+        ))}
+      </div>
+      <div>
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:13.5, lineHeight:1,
+          color:"rgba(28,28,26,0.55)", marginBottom:2,
+        }}>{st.label}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7,
+          letterSpacing:"0.1em", color:"rgba(28,28,26,0.28)",
+        }}>{total} witnesses</div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   REGISTER ROW — single row in the praxis index
+   ════════════════════════════════════════════════════════════════ */
+function RegisterRow({ p, href }) {
+  return (
+    <a href={href} style={{
+      display:"grid",
+      gridTemplateColumns:"56px 1fr auto 20px",
+      alignItems:"center", gap:14,
+      padding:"12px 0", textDecoration:"none", color:"inherit",
+      borderBottom:"1px solid rgba(0,0,0,0.055)",
+      transition:"background 150ms",
+    }}
+    onMouseEnter={e => e.currentTarget.style.background="rgba(0,0,0,0.016)"}
+    onMouseLeave={e => e.currentTarget.style.background="transparent"}>
+
+      {/* Ref + status */}
+      <div style={{ textAlign:"right" }}>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7.5,
+          color:"rgba(28,28,26,0.30)", letterSpacing:"0.1em",
+        }}>Ref. {p.refNo}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:6,
+          color:"rgba(28,28,26,0.2)", letterSpacing:"0.12em",
+          textTransform:"uppercase", marginTop:2,
+        }}>{p.status}</div>
+      </div>
+
+      {/* Task name + keeper */}
+      <div>
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:15.5, lineHeight:1.2,
+          color:"rgba(28,28,26,0.72)", marginBottom:3,
+        }}>{p.task}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7.5,
+          color:"rgba(28,28,26,0.30)", letterSpacing:"0.04em",
+        }}>
+          {p.keeper} · {p.house}
+          <span style={{ marginLeft:8, color:"rgba(28,28,26,0.18)" }}>
+            {p.timestamp.split("//")[0].trim()}
+          </span>
+        </div>
+      </div>
+
+      {/* Witness consensus mini-bar */}
+      <WitnessBar dist={p.dist}/>
+
+      {/* Arrow */}
+      <span style={{ color:"rgba(28,28,26,0.22)", fontSize:11 }}>›</span>
+    </a>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   REGISTER INDEX — the full praxis index component
+   ════════════════════════════════════════════════════════════════ */
+function RegisterIndex({ praxes, hrefFor }) {
+  const [filter, setFilter] = React.useState("all");
+  const { alDistAvg, alDistTotal } = window;
+
+  const FILTERS = [
+    { id:"all",      name:"All returned" },
+    { id:"verified", name:"Highly witnessed" },
+    { id:"recent",   name:"This season" },
+  ];
+
+  const totalWitnesses = praxes.reduce((a, p) => a + alDistTotal(p.dist), 0);
+
+  const rows = praxes.filter(p => {
+    if (filter === "all")      return true;
+    if (filter === "verified") return alDistAvg(p.dist) >= 3.5;
+    return true;
+  });
+
+  return (
+    <React.Fragment>
+      {/* Masthead */}
+      <div style={{
+        display:"flex", justifyContent:"space-between",
+        alignItems:"flex-start", gap:16,
+        paddingBottom:22, marginBottom:20,
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        <div>
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:7.5,
+            letterSpacing:"0.28em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)", marginBottom:9,
+          }}>Albescent · witnessed accounts · fourth season</div>
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:36, lineHeight:1.0,
+            color:"rgba(28,28,26,0.8)", marginBottom:6,
+          }}>The Register</div>
+          <div style={{ height:1, width:56, background:"rgba(0,0,0,0.12)", marginBottom:13 }}/>
+          <p style={{
+            fontFamily:"var(--al-mono)", fontSize:8.5, lineHeight:1.65,
+            color:"rgba(28,28,26,0.4)", maxWidth:440, margin:0,
+          }}>
+            Tasks returned by the keepers. Each entry is a completed account —
+            no more, no less. Cast your witness on any you have observed.
+          </p>
+        </div>
+        <div style={{ display:"flex", gap:24, flexShrink:0 }}>
+          {[{ v:praxes.length, l:"returned" },{ v:totalWitnesses, l:"witnesses" }].map(s => (
+            <div key={s.l} style={{ textAlign:"right" }}>
+              <div style={{
+                fontFamily:"var(--al-font)", fontStyle:"italic",
+                fontWeight:300, fontSize:32, lineHeight:1,
+                color:"rgba(28,28,26,0.6)",
+              }}>{s.v}</div>
+              <div style={{
+                fontFamily:"var(--al-mono)", fontSize:7,
+                letterSpacing:"0.16em", color:"rgba(28,28,26,0.28)", marginTop:3,
+              }}>{s.l}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div style={{ display:"flex", gap:6, marginBottom:16, flexWrap:"wrap" }}>
+        {FILTERS.map(f => {
+          const on = filter === f.id;
+          return (
+            <button key={f.id} onClick={() => setFilter(f.id)} style={{
+              fontFamily:"var(--al-mono)", fontSize:7.5, letterSpacing:"0.14em",
+              textTransform:"uppercase", padding:"4px 10px", cursor:"pointer",
+              border:`1px solid ${on ? "rgba(0,0,0,0.28)" : "rgba(0,0,0,0.1)"}`,
+              background: on ? "rgba(28,28,26,0.07)" : "transparent",
+              color: on ? "rgba(28,28,26,0.65)" : "rgba(28,28,26,0.36)",
+              transition:"all 120ms",
+            }}>{f.name}</button>
+          );
+        })}
+        <span style={{
+          fontSize:7, color:"rgba(28,28,26,0.22)",
+          letterSpacing:"0.14em", marginLeft:6, alignSelf:"center",
+        }}>{rows.length}/{praxes.length}</span>
+      </div>
+
+      {/* Column headers */}
+      <div style={{
+        display:"grid", gridTemplateColumns:"56px 1fr auto 20px",
+        gap:14, paddingBottom:8, marginBottom:2,
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        {["Ref", "Account", "Witnesses", ""].map((h, i) => (
+          <div key={i} style={{
+            fontFamily:"var(--al-mono)", fontSize:6.5,
+            letterSpacing:"0.22em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)",
+            textAlign: i === 2 ? "right" : "left",
+          }}>{h}</div>
+        ))}
+      </div>
+
+      {/* Rows */}
+      <div>
+        {rows.map(p => <RegisterRow key={p.id} p={p} href={hrefFor(p)}/>)}
+        {rows.length === 0 && (
+          <div style={{
+            padding:"28px 0", fontSize:14, fontStyle:"italic",
+            fontFamily:"var(--al-font)", color:"rgba(28,28,26,0.26)",
+          }}>No entries match this filter.</div>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS METER — grayscale distribution + standing label
+   ════════════════════════════════════════════════════════════════ */
+function WitnessMeter({ dist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const total = alDistTotal(dist);
+  const avg   = alDistAvg(dist);
+  const st    = alStanding(avg);
+  const max   = Math.max(1, ...dist);
+  const shades = ["rgba(0,0,0,0.84)","rgba(0,0,0,0.66)","rgba(0,0,0,0.48)","rgba(0,0,0,0.30)","rgba(0,0,0,0.16)"];
+
+  return (
+    <div>
+      <div style={{ display:"flex", alignItems:"baseline", gap:10, marginBottom:10 }}>
+        <span style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:38, lineHeight:0.9,
+          color:"rgba(28,28,26,0.65)",
+        }}>{st.label}</span>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:8,
+          letterSpacing:"0.12em", color:"rgba(28,28,26,0.30)",
+        }}>{total} witnesses · avg {avg.toFixed(1)}</div>
+      </div>
+
+      <div style={{ display:"flex", flexDirection:"column", gap:6, marginTop:14 }}>
+        {AL_WITNESS.slice().reverse().map((s, i) => {
+          const realIdx = 4 - i;
+          const count   = dist[realIdx];
+          return (
+            <div key={s.v} style={{ display:"flex", alignItems:"center", gap:10 }}>
+              <span style={{
+                width:62, textAlign:"right",
+                fontFamily:"var(--al-mono)", fontSize:7.5,
+                letterSpacing:"0.06em", color:"rgba(28,28,26,0.38)",
+              }}>{s.label}</span>
+              <div style={{
+                flex:1, height:10,
+                background:"rgba(0,0,0,0.04)",
+                border:"1px solid rgba(0,0,0,0.07)",
+                position:"relative", overflow:"hidden",
+              }}>
+                <div style={{
+                  position:"absolute", inset:0,
+                  width:`${(count / max) * 100}%`,
+                  background: shades[i],
+                  opacity: count ? 0.88 : 0,
+                  transition:"width 400ms ease",
+                }}/>
+              </div>
+              <span style={{
+                width:18, fontFamily:"var(--al-mono)", fontSize:9,
+                color:"rgba(28,28,26,0.50)", textAlign:"right",
+              }}>{count}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS CASTER — interactive witness casting (with meter)
+   Persists to localStorage. Albescent's equivalent of SignalCaster.
+   ════════════════════════════════════════════════════════════════ */
+function WitnessCaster({ praxisId, baseDist }) {
+  const { alDistAvg, alDistTotal, AL_WITNESS } = window;
+  const key = "al-witness-" + praxisId;
+  const [my, setMy] = React.useState(0);
+
+  React.useEffect(() => {
+    try { const v = +localStorage.getItem(key); if (v>=1&&v<=5) setMy(v); } catch(e) {}
+  }, [key]);
+
+  const cast = v => {
+    const nv = my === v ? 0 : v;
+    setMy(nv);
+    try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch(e) {}
+  };
+
+  const live = baseDist.map((c, i) => c + (my === i+1 ? 1 : 0));
+  const shades = ["rgba(0,0,0,0.16)","rgba(0,0,0,0.30)","rgba(0,0,0,0.48)","rgba(0,0,0,0.66)","rgba(0,0,0,0.84)"];
+
+  return (
+    <div>
+      <WitnessMeter dist={live}/>
+
+      <div style={{ height:1, background:"rgba(0,0,0,0.07)", margin:"18px 0 14px" }}/>
+
+      <div style={{
+        fontFamily:"var(--al-mono)", fontSize:7, letterSpacing:"0.26em",
+        textTransform:"uppercase", color:"rgba(28,28,26,0.24)", marginBottom:6,
+      }}>Bear Witness</div>
+
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontSize:12, color:"rgba(28,28,26,0.4)", marginBottom:16, lineHeight:1.4,
+      }}>How completely was this task attended?</div>
+
+      <div style={{ display:"flex", gap:8, flexWrap:"wrap" }}>
+        {AL_WITNESS.map((s, i) => {
+          const shade  = shades[i];
+          const on     = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{ display:"flex", flexDirection:"column", alignItems:"center", gap:6 }}>
+              <button onClick={() => cast(s.v)} style={{
+                width:34, height:34, borderRadius:"50%", cursor:"pointer",
+                border:`1.5px solid ${shade}`,
+                background: on ? shade : "transparent",
+                display:"flex", alignItems:"center", justifyContent:"center",
+                padding:0, transition:"all 200ms ease",
+              }}>
+                {picked && <div style={{ width:8, height:8, borderRadius:"50%", background:"#fff" }}/>}
+              </button>
+              <span style={{
+                fontSize:5.5, letterSpacing:"0.06em",
+                textAlign:"center", color:"rgba(28,28,26,0.28)",
+                fontFamily:"var(--al-mono)",
+              }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{
+        marginTop:14, fontSize:8.5, lineHeight:1.55,
+        fontStyle:"italic", fontFamily:"var(--al-font)",
+        color: my ? "rgba(28,28,26,0.58)" : "rgba(28,28,26,0.26)",
+      }}>
+        {my
+          ? `Witnessed as ${AL_WITNESS[my-1].label}. ${alDistTotal(live)} keepers now in accord.`
+          : "You have not yet cast your witness."}
+        {my > 0 && (
+          <span onClick={() => cast(my)} style={{
+            marginLeft:8, cursor:"pointer",
+            color:"rgba(28,28,26,0.42)",
+            borderBottom:"1px solid rgba(28,28,26,0.2)",
+          }}>amend</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ENTRY READ — full single-account view (main column)
+   ════════════════════════════════════════════════════════════════ */
+function EntryRead({ p }) {
+  const { AlbescentMark } = window;
+
+  return (
+    <div style={{ fontFamily:"var(--al-mono)", color:"#1c1c1a", position:"relative" }}>
+
+      {/* Header band */}
+      <div style={{
+        display:"flex", alignItems:"center",
+        justifyContent:"space-between", gap:14,
+        padding:"10px 24px",
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+        background:"rgba(0,0,0,0.012)",
+      }}>
+        <span style={{
+          display:"inline-flex", alignItems:"center", gap:9,
+          fontSize:9, letterSpacing:"0.22em", textTransform:"uppercase",
+          color:"rgba(28,28,26,0.28)",
+        }}>
+          <AlbescentMark size={12}/>
+          Albescent · Ref. {p.refNo}
+        </span>
+        <span style={{
+          fontSize:7, letterSpacing:"0.16em", textTransform:"uppercase",
+          color:"rgba(28,28,26,0.26)",
+          borderBottom:"1px solid rgba(28,28,26,0.18)", paddingBottom:1,
+        }}>{p.status}</span>
+      </div>
+
+      <div style={{ padding:"28px 24px 32px" }}>
+
+        {/* Task name */}
+        <h1 style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:48, lineHeight:1.05,
+          color:"#1c1c1a", margin:"0 0 14px",
+        }}>{p.task}</h1>
+
+        {/* Output quote */}
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:14.5, lineHeight:1.55,
+          color:"rgba(28,28,26,0.52)",
+          borderLeft:"2px solid rgba(0,0,0,0.09)",
+          paddingLeft:14, marginBottom:22,
+        }}>{p.output}</div>
+
+        {/* Byline */}
+        <div style={{
+          display:"flex", alignItems:"center", gap:14,
+          paddingBottom:20, marginBottom:6,
+          borderBottom:"1px solid rgba(0,0,0,0.06)",
+        }}>
+          <div style={{
+            width:36, height:36, borderRadius:"50%", flexShrink:0,
+            border:"1px solid rgba(0,0,0,0.12)",
+            background:"rgba(0,0,0,0.03)",
+            display:"flex", alignItems:"center", justifyContent:"center",
+            fontFamily:"var(--al-font)", fontSize:13, fontStyle:"italic",
+            color:"rgba(28,28,26,0.45)",
+          }}>K</div>
+          <div>
+            <div style={{
+              fontFamily:"var(--al-font)", fontStyle:"italic",
+              fontWeight:300, fontSize:14, color:"rgba(28,28,26,0.7)",
+            }}>{p.keeper}</div>
+            <div style={{
+              fontSize:7.5, color:"rgba(28,28,26,0.34)",
+              letterSpacing:"0.06em",
+            }}>{p.house} · {p.timestamp}</div>
+          </div>
+          <div style={{ marginLeft:"auto", textAlign:"right", flexShrink:0 }}>
+            <div style={{
+              fontFamily:"var(--al-font)", fontStyle:"italic",
+              fontWeight:300, fontSize:28, lineHeight:1,
+              color:"rgba(28,28,26,0.55)",
+            }}>{p.credits}</div>
+            <div style={{
+              fontFamily:"var(--al-mono)", fontSize:7,
+              letterSpacing:"0.14em", color:"rgba(28,28,26,0.26)", marginTop:2,
+            }}>pts returned</div>
+          </div>
+        </div>
+
+        {/* Account section divider */}
+        <div style={{ display:"flex", alignItems:"center", gap:10, margin:"18px 0 12px" }}>
+          <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+          <span style={{
+            fontSize:7, letterSpacing:"0.24em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.2)", whiteSpace:"nowrap",
+            fontFamily:"var(--al-mono)",
+          }}>Account</span>
+          <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+        </div>
+
+        {/* Account lines */}
+        <div style={{ marginBottom:8 }}>
+          {p.account.map((line, i) => (
+            <div key={i} style={{
+              fontSize:9, lineHeight:1.8, color:"rgba(28,28,26,0.58)",
+              paddingLeft:26, position:"relative", marginBottom:4,
+              fontFamily:"var(--al-mono)",
+            }}>
+              <span style={{
+                position:"absolute", left:0,
+                color:"rgba(28,28,26,0.2)", fontSize:7.5,
+              }}>{String(i).padStart(2,"0")}</span>
+              {line}
+            </div>
+          ))}
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AL_PRAXES,
+  RegisterIndex, RegisterRow,
+  WitnessBar, WitnessMeter, WitnessCaster,
+  EntryRead,
+});

--- a/docs/design/design-system/templates/albescent/albescent.css
+++ b/docs/design/design-system/templates/albescent/albescent.css
@@ -1,0 +1,208 @@
+/* ══════════════════════════════════════════════════════════════
+   ALBESCENT — World Zero faction
+   A sacred secret society. They task for the sake of tasking:
+   not competition, not accumulation, not record. The faction
+   exists outside the leaderboard; it refuses the rainbow palette;
+   it leaves no trace. Every task is an act of devotion with no
+   audience.
+
+   Physical card archetype: VELLUM CORRESPONDENCE — pure white
+   cotton paper, hairline borders, Cormorant Garamond italic,
+   a surveyor's mark as the only sigil. The card whispers.
+
+   Style: MINIMAL · SACRED · SILENT · PRECISE · WHITE
+   The signature artifact is THE MARK: a surveyor's cross-hair
+   sigil that asks only: where are you, exactly?
+
+   TOKEN MODEL: Albescent is always light — no dark mode flip.
+   White is the card surface in both themes. Near-black ink is
+   all text. No faction hue anywhere.
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400;1,500&family=Courier+Prime:ital,wght@0,400;1,400&family=Lora:ital,wght@1,400;1,700&display=swap");
+
+:root {
+  /* ── Core palette ── */
+  --al-surface:       #ffffff;
+  --al-surface-warm:  #faf9f7;
+  --al-text:          #1c1c1a;
+  --al-text-muted:    rgba(28, 28, 26, 0.44);
+  --al-text-faint:    rgba(28, 28, 26, 0.22);
+  --al-ink:           rgba(28, 28, 26, 0.72);
+
+  /* ── Structural ── */
+  --al-border:        rgba(0, 0, 0, 0.10);
+  --al-border-faint:  rgba(0, 0, 0, 0.055);
+  --al-border-rule:   rgba(0, 0, 0, 0.07);
+  --al-shadow:        0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04);
+
+  /* ── Typography ── */
+  --al-font: "Cormorant Garamond", Georgia, serif;
+  --al-mono: "Courier Prime", "Courier New", monospace;
+
+  /* ── Card contract — mirrors --faction-albescent-card-* ── */
+  --faction-albescent-card-bg:     #ffffff;
+  --faction-albescent-card-text:   #1c1c1a;
+  --faction-albescent-card-accent: rgba(28, 28, 26, 0.72);
+  --faction-albescent-card-muted:  rgba(28, 28, 26, 0.42);
+  --faction-albescent-card-font:   var(--al-font);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ALBESCENT BACKDROP
+   Near-white cream with barely-visible ruled paper lines.
+   Not a dramatic backdrop — a surface already present,
+   whether anyone looks or not.
+   ══════════════════════════════════════════════════════════════ */
+.al-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: #f7f4ee;
+  background-image:
+    radial-gradient(ellipse 72% 58% at 50% 38%,
+      rgba(255, 255, 255, 0.58) 0%, transparent 100%),
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 27px,
+      rgba(0, 0, 0, 0.016) 27px 28px);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANIMATIONS — everything slow, deliberate, no urgency
+   ══════════════════════════════════════════════════════════════ */
+@keyframes al-breathe { 0%,100%{ opacity:1; }        50%{ opacity:0.58; }        }
+@keyframes al-drift   { 0%,100%{ transform:scale(1); } 50%{ transform:scale(1.016); } }
+
+@media (prefers-reduced-motion: no-preference) {
+  .al-breathe { animation: al-breathe 5.5s ease-in-out infinite; }
+  .al-drift   { animation: al-drift   14s  ease-in-out infinite; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHARED LAYOUT — nav
+   ══════════════════════════════════════════════════════════════ */
+.al-nav {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  padding: 14px 32px;
+  background: rgba(247, 244, 238, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--al-border-faint);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHEET — the primary white surface
+   ══════════════════════════════════════════════════════════════ */
+.al-sheet {
+  position: relative;
+  background: var(--al-surface);
+  border: 1px solid var(--al-border);
+  box-shadow: var(--al-shadow);
+}
+/* subtle inset architectural border */
+.al-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 1px solid var(--al-border-faint);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   PAGE
+   ══════════════════════════════════════════════════════════════ */
+.al-page {
+  position: relative;
+  z-index: 5;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 28px 32px 80px;
+}
+
+/* section heading with flanking rules */
+.al-section {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 38px 0 16px;
+}
+.al-section h2 {
+  font-family: var(--al-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--al-text-faint);
+  white-space: nowrap;
+  margin: 0;
+  font-weight: 400;
+}
+.al-section .rule  { flex: 1; height: 1px; background: var(--al-border-rule); }
+.al-section .count {
+  font-family: var(--al-mono);
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--al-text-faint);
+  white-space: nowrap;
+}
+
+/* task card grid */
+.al-task-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+/* two-col record/witness layout */
+.al-dispatch-layout {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  .al-dispatch-layout { grid-template-columns: 1fr; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ACTIVITY RECORD
+   ══════════════════════════════════════════════════════════════ */
+.al-activity-card {
+  border-bottom: 1px solid var(--al-border-faint);
+  padding: 14px 0;
+}
+.al-activity-card:last-child { border-bottom: none; }
+
+/* ══════════════════════════════════════════════════════════════
+   ASSET SHOWCASE
+   ══════════════════════════════════════════════════════════════ */
+.al-assets {
+  margin-top: 52px;
+  padding-top: 24px;
+  border-top: 1px solid var(--al-border-faint);
+}
+.al-acard {
+  border: 1px solid var(--al-border-faint);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 14px 16px;
+}
+.al-acard .h {
+  font-family: var(--al-mono);
+  font-size: 7px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--al-text-faint);
+  margin-bottom: 12px;
+}
+.al-acard .cap {
+  font-family: var(--al-mono);
+  font-size: 7.5px;
+  letter-spacing: 0.06em;
+  color: var(--al-text-faint);
+  margin-top: 10px;
+}

--- a/docs/design/design-system/templates/ephemerists/ephemerists-cards.jsx
+++ b/docs/design/design-system/templates/ephemerists/ephemerists-cards.jsx
@@ -1,0 +1,180 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — Task Card + shared codex atoms
+   The chosen artifact: THE DISCORDANT MAP. One place, three
+   irreconcilable addresses — cartesian, polar and perspective grids
+   all claim the same sheet and disagree about where the point is.
+   House-of-Leaves apparatus crawls the margins: a struck measurement
+   that corrects itself in blue, a note climbing the gutter, a
+   self-referential footnote, and one word always pulled into the lapis.
+   Uses only DS tokens + ephemerists.css. Atoms exposed on window for
+   the rest of the faction's surfaces.
+   ════════════════════════════════════════════════════════════════ */
+
+const ROMAN = [["M",1000],["CM",900],["D",500],["CD",400],["C",100],["XC",90],["L",50],["XL",40],["X",10],["IX",9],["V",5],["IV",4],["I",1]];
+function toRoman(n){ let s=""; for(const [g,v] of ROMAN){ while(n>=v){ s+=g; n-=v; } } return s; }
+
+/* faction sigil — the watching wanderer: an eye on an orbital ring */
+function EphMark({ size = 22, color = "currentColor", stroke = 1.4 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={stroke} style={{ display: "block" }}>
+      <ellipse cx="12" cy="12" rx="11" ry="4.4" transform="rotate(-24 12 12)" />
+      <path d="M4 12 C7.5 8.2 16.5 8.2 20 12 C16.5 15.8 7.5 15.8 4 12 Z" />
+      <circle cx="12" cy="12" r="2.7" />
+      <circle cx="12" cy="12" r="0.6" fill={color} stroke="none" />
+    </svg>
+  );
+}
+
+/* small mystical glyph set — alchemical / planetary, monoline */
+function Glyph({ name, size = 14, color = "var(--eph-ink)", stroke = 1.2 }) {
+  const p = { fill: "none", stroke: color, strokeWidth: stroke, strokeLinecap: "round", strokeLinejoin: "round" };
+  const map = {
+    fire:  <path d="M8 13 L2 13 L8 3 Z" {...p} />,
+    water: <path d="M2 3 L14 3 L8 13 Z" {...p} />,
+    air:   <g {...p}><path d="M8 3 L2 13 L14 13 Z" /><line x1="4.6" y1="9.2" x2="11.4" y2="9.2" /></g>,
+    earth: <g {...p}><path d="M2 3 L14 3 L8 13 Z" /><line x1="4.6" y1="6.8" x2="11.4" y2="6.8" /></g>,
+    sun:   <g {...p}><circle cx="8" cy="8" r="5.5" /><circle cx="8" cy="8" r="0.7" fill={color} /></g>,
+    moon:  <path d="M11 2.5 A6 6 0 1 0 11 13.5 A4.6 4.6 0 1 1 11 2.5 Z" fill={color} stroke="none" />,
+    salt:  <g {...p}><circle cx="8" cy="8" r="5.5" /><line x1="2.5" y1="8" x2="13.5" y2="8" /></g>,
+    quint: <g {...p}><circle cx="8" cy="8" r="5.5" /><circle cx="8" cy="8" r="2" /></g>,
+    star:  <path d="M8 1 L9.2 6.2 L14.5 5 L10.3 8 L14.5 11 L9.2 9.8 L8 15 L6.8 9.8 L1.5 11 L5.7 8 L1.5 5 L6.8 6.2 Z" fill={color} stroke="none" />,
+  };
+  return <svg width={size} height={size} viewBox="0 0 16 16" style={{ display: "block" }}>{map[name] || map.sun}</svg>;
+}
+
+/* ── SACRED GEOMETRY — compass-and-straightedge rosettes built only
+   from circle primitives on a triangular lattice (the same family as
+   the card's astrolabe grids). rings=1 → Seed of Life (7 circles),
+   rings=2 → Flower of Life (19), rings=3 → the full bloom. A clip ring
+   gives the clean illuminated edge; an optional vesica/spoke overlay
+   reads as an astrolabe. Faint, theme-aware, decorative only. */
+function SacredGeometry({ size = 200, color = "var(--eph-lapis)", stroke = 0.8, rings = 2, ring = true, spokes = 0, style }) {
+  const R = size / (2 * (rings + 1));
+  const c = size / 2;
+  const pts = [];
+  for (let i = -rings - 1; i <= rings + 1; i++) {
+    for (let j = -rings - 1; j <= rings + 1; j++) {
+      const hd = (Math.abs(i) + Math.abs(j) + Math.abs(i + j)) / 2;
+      if (hd > rings) continue;
+      pts.push([c + R * (i + j / 2), c + R * (j * Math.sqrt(3) / 2)]);
+    }
+  }
+  const id = "sg" + Math.round(size) + "_" + rings + "_" + Math.round(R);
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none" stroke={color} strokeWidth={stroke} style={{ display: "block", ...style }}>
+      <defs><clipPath id={id}><circle cx={c} cy={c} r={size / 2 - stroke} /></clipPath></defs>
+      <g clipPath={`url(#${id})`}>
+        {pts.map(([x, y], k) => <circle key={k} cx={x} cy={y} r={R} />)}
+        {spokes > 0 && Array.from({ length: spokes }).map((_, k) => {
+          const a = (k * 2 * Math.PI) / spokes;
+          return <line key={"s" + k} x1={c} y1={c} x2={c + (size / 2) * Math.cos(a)} y2={c + (size / 2) * Math.sin(a)} strokeWidth={stroke * 0.8} />;
+        })}
+      </g>
+      {ring && <circle cx={c} cy={c} r={size / 2 - stroke} strokeWidth={stroke * 1.5} />}
+    </svg>
+  );
+}
+
+/* faint age-foxing stains */
+function Foxing({ opacity = 0.5 }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none", opacity, zIndex: 1, mixBlendMode: "multiply",
+      backgroundImage: `
+        radial-gradient(8px 6px at 18% 24%, color-mix(in srgb, var(--eph-ink) 14%, transparent), transparent 70%),
+        radial-gradient(5px 5px at 78% 16%, color-mix(in srgb, var(--eph-gold-deep) 16%, transparent), transparent 70%),
+        radial-gradient(10px 7px at 64% 82%, color-mix(in srgb, var(--eph-ink) 10%, transparent), transparent 70%),
+        radial-gradient(4px 4px at 30% 70%, color-mix(in srgb, var(--eph-rubric) 12%, transparent), transparent 70%)`,
+    }} />
+  );
+}
+
+/* header lockup — sigil + name + a motto / running gloss */
+function Eyebrow({ color = "var(--eph-gold-light)", motto, dark, size = 8.5 }) {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 5, color }}>
+        <EphMark size={11} color={color} />
+        <span style={{ fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: size, letterSpacing: "0.24em" }}>THE EPHEMERISTS</span>
+      </div>
+      {motto && <div style={{ fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: 8.5, color: dark ? "var(--eph-muted)" : "color-mix(in srgb, var(--eph-parchment) 65%, transparent)", marginTop: 1 }}>{motto}</div>}
+    </div>
+  );
+}
+
+function SignBtn({ onSignup, label, light }) {
+  if (!onSignup) return null;
+  return (
+    <button onClick={onSignup} style={{
+      fontFamily: "var(--eph-serif)", fontSize: 9, letterSpacing: "0.12em", fontStyle: "italic",
+      padding: "7px 10px", border: "none", cursor: "pointer", width: "100%",
+      background: light ? "var(--eph-gold)" : "var(--eph-ink)",
+      color: light ? "var(--eph-ink)" : "var(--eph-parchment)", position: "relative", zIndex: 6,
+    }}>{label}</button>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   THE DISCORDANT MAP — the Ephemerist task card
+   ════════════════════════════════════════════════════════════════ */
+function DiscordantMap({ title, description, level, points, onSignup }) {
+  const tw = title.trim().split(" ");
+  const tlast = tw.pop(); // one word is always pulled into the blue
+  return (
+    <div style={{
+      width: 214, minHeight: 300, position: "relative", overflow: "hidden",
+      background: "var(--eph-vellum)", color: "var(--eph-vellum-text)",
+      border: "1.5px solid var(--eph-ink)", fontFamily: "var(--eph-serif)", display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ position: "relative", zIndex: 5, padding: "9px 0 4px" }}><Eyebrow motto="exhibit C · no single here" dark /></div>
+      {/* the contested field */}
+      <div style={{ position: "relative", flex: 1, minHeight: 188, margin: "2px 4px", border: "1px solid var(--eph-gold-deep)", overflow: "hidden" }}>
+        {/* cartesian — keyed to vellum-text so it flips legible in dark */}
+        <div style={{ position: "absolute", inset: 0, opacity: 0.5, backgroundImage: "repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px), repeating-linear-gradient(90deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px)" }} />
+        {/* perspective grid (no blend — multiply died on dark stock) */}
+        <svg viewBox="0 0 200 188" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.7 }}>
+          <g stroke="var(--eph-lapis)" strokeWidth="0.9" fill="none">
+            {Array.from({ length: 11 }).map((_, i) => <line key={i} x1={i * 20} y1="188" x2="122" y2="40" />)}
+            {[60, 96, 124, 146, 163, 176].map((y, i) => <line key={i} x1="0" y1={y} x2="200" y2={y} />)}
+          </g>
+        </svg>
+        {/* polar */}
+        <svg viewBox="0 0 200 188" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.72 }}>
+          <g stroke="var(--eph-rubric)" strokeWidth="0.8" fill="none">
+            {[16, 34, 54, 76].map((r, i) => <circle key={i} cx="122" cy="88" r={r} />)}
+            {Array.from({ length: 12 }).map((_, i) => <line key={i} x1="122" y1="88" x2={122 + 80 * Math.cos(i * Math.PI / 6)} y2={88 + 80 * Math.sin(i * Math.PI / 6)} />)}
+          </g>
+        </svg>
+        {/* the disputed point */}
+        <div style={{ position: "absolute", left: "61%", top: "47%", transform: "translate(-50%,-50%)", zIndex: 4 }}>
+          <div className="eph-twinkle" style={{ width: 9, height: 9, borderRadius: "50%", background: "var(--eph-gold-light)", boxShadow: "0 0 10px 3px color-mix(in srgb, var(--eph-gold-light) 70%, transparent)" }} />
+        </div>
+        {/* three coordinate labels for one point — and none agree */}
+        <div style={{ position: "absolute", top: "8%", left: "6%", fontFamily: "var(--eph-serif)", fontSize: 7.5, letterSpacing: "0.04em", color: "var(--eph-vellum-text)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>x 14 · y <span style={{ textDecoration: "line-through", opacity: 0.65 }}>8</span> <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>9</span></div>
+        <div style={{ position: "absolute", top: "78%", left: "54%", fontFamily: "var(--eph-serif)", fontSize: 7.5, letterSpacing: "0.04em", color: "var(--eph-rubric)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>r 47 · θ 31°</div>
+        <div style={{ position: "absolute", top: "6%", left: "68%", fontFamily: "var(--eph-serif)", fontSize: 7.5, letterSpacing: "0.04em", color: "var(--eph-lapis)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>∞ · vanishing</div>
+        {/* marginal apparatus climbing the gutter */}
+        <div style={{ position: "absolute", left: 2, bottom: 7, transformOrigin: "left bottom", transform: "rotate(-90deg)", whiteSpace: "nowrap", fontFamily: "var(--eph-serif)", fontSize: 6, letterSpacing: "0.05em", color: "var(--eph-muted)", opacity: 0.85 }}>¼″ wider within than without †</div>
+      </div>
+      {/* legend / title */}
+      <div style={{ position: "relative", zIndex: 5, padding: "8px 14px 10px", textAlign: "center" }}>
+        <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 22, lineHeight: 0.94 }}>{tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span><sup style={{ fontFamily: "var(--eph-serif)", fontSize: 9, color: "var(--eph-lapis)", fontWeight: 400 }}>†</sup></div>
+        <div style={{ fontSize: 8.5, lineHeight: 1.45, fontStyle: "italic", color: "var(--eph-muted)", margin: "4px 0 6px", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 7, fontSize: 7.5 }}>
+          <span style={{ color: "var(--eph-vellum-text)" }}>▦ grade {toRoman(level)}</span>
+          <span style={{ color: "var(--eph-gold-deep)" }}>·</span>
+          <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, color: "var(--eph-rubric)" }}>{points} pvncta</span>
+        </div>
+        <div style={{ fontFamily: "var(--eph-serif)", fontSize: 6.5, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 6, lineHeight: 1.35 }}>† the road does not return you to where you began — <span style={{ color: "var(--eph-lapis)" }}>see †</span></div>
+      </div>
+      <SignBtn onSignup={onSignup} label="Triangulate the truth ▸" />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  DiscordantMap, EphTaskCard: DiscordantMap,
+  EPH_toRoman: toRoman, EPH_EphMark: EphMark, EPH_Glyph: Glyph,
+  EPH_Foxing: Foxing, EPH_Eyebrow: Eyebrow, EPH_SignBtn: SignBtn,
+  EPH_SacredGeometry: SacredGeometry,
+});

--- a/docs/design/design-system/templates/ephemerists/ephemerists-faction.jsx
+++ b/docs/design/design-system/templates/ephemerists/ephemerists-faction.jsx
@@ -1,0 +1,176 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — faction-aware surfaces
+   Sigil seal · nav badge · faction pennant · concordance stamps
+   (approval) · stat block · faction-page hero. All reuse
+   ephemerists.css tokens and the codex atoms exposed by
+   ephemerists-cards.jsx (EPH_EphMark / EPH_Glyph). Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── sigil seal: the eye in a ringed gold roundel ──────────────────── */
+function EphSeal({ size = 112, color = "var(--eph-gold)", eye = "var(--eph-lapis)", bg = "var(--eph-vellum)" }) {
+  const { EPH_EphMark } = window;
+  return (
+    <div style={{
+      position: "relative", width: size, height: size, borderRadius: "50%", flexShrink: 0,
+      background: bg, boxShadow: `0 0 0 2px ${color}, 0 0 0 5px var(--eph-ink), inset 0 0 0 4px color-mix(in srgb, ${color} 55%, transparent)`,
+      display: "flex", alignItems: "center", justifyContent: "center",
+    }}>
+      {/* radiating ticks */}
+      {Array.from({ length: 36 }).map((_, i) => (
+        <div key={i} style={{ position: "absolute", top: "50%", left: "50%", width: 1, height: size * 0.5,
+          transformOrigin: "top center", transform: `translate(-50%,0) rotate(${i * 10}deg)`,
+          height: i % 3 ? size * 0.04 : size * 0.07, background: `color-mix(in srgb, ${color} ${i % 3 ? 35 : 65}%, transparent)` }} />
+      ))}
+      <EphMarkLocal size={size * 0.46} color={eye} />
+    </div>
+  );
+}
+function EphMarkLocal(props) { const { EPH_EphMark } = window; return <EPH_EphMark {...props} stroke={1.2} />; }
+
+/* ── nav faction badge ─────────────────────────────────────────────── */
+function EphNavBadge({ name = "Ephemerists" }) {
+  const { EPH_EphMark } = window;
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 6, background: "var(--eph-lapis)",
+      color: "var(--eph-parchment)", padding: "5px 10px", fontFamily: "var(--eph-display)", fontWeight: 600,
+      fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", boxShadow: "inset 0 0 0 1px var(--eph-gold)",
+    }}>
+      <EPH_EphMark size={13} color="var(--eph-gold-light)" />
+      {name}
+    </span>
+  );
+}
+
+/* ── faction pennant (filter tab) ──────────────────────────────────── */
+/* Identical shape to the other six so the row aligns; only color shifts. */
+function Pennant({ color = "var(--faction-ephemerists)", name, active = false, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      background: color, color: "#fff", fontFamily: "var(--eph-serif)", fontSize: 9.5,
+      fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.08em", padding: "5px 14px",
+      cursor: "pointer", border: "none", borderRadius: 0, textShadow: "0 1px 2px rgba(0,0,0,0.35)",
+      opacity: active ? 1 : 0.78, clipPath: "polygon(0 0, 100% 0, 94% 100%, 6% 100%)",
+      transform: active ? "translateY(-2px)" : "none", transition: "all 120ms",
+      filter: active ? "drop-shadow(0 4px 6px rgba(0,0,0,0.25))" : "none",
+    }}>
+      {name}
+    </button>
+  );
+}
+
+/* ── concordance stamps — "how well does the filed truth hold up?" ──── */
+/* Wax-seal ramp: doubt (gold) → verdigris → lapis → rubric → the
+   authoritative ink seal at V. Reframes World Zero's 1–5 approval vote. */
+const CONCORD = [
+  { v: 1, label: "apocryphal",   fill: "var(--eph-gold)",     ink: "var(--eph-ink)" },
+  { v: 2, label: "disputed",     fill: "var(--eph-verdigris)", ink: "var(--eph-parchment)" },
+  { v: 3, label: "plausible",    fill: "var(--eph-lapis)",     ink: "var(--eph-parchment)" },
+  { v: 4, label: "corroborated", fill: "var(--eph-rubric)",    ink: "var(--eph-parchment)" },
+  { v: 5, label: "canonical",    fill: "var(--eph-ink)",       ink: "var(--eph-gold-light)" },
+];
+function EphConcordance({ value = 0, average, totalVotes, size = 42 }) {
+  const { EPH_toRoman, EPH_EphMark } = window;
+  const [sel, setSel] = React.useState(value);
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 10 }}>
+        {CONCORD.map((s) => {
+          const on = sel >= s.v;
+          return (
+            <div key={s.v} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 5 }}>
+              <button onClick={() => setSel(s.v)} style={{
+                position: "relative", width: size, height: size, cursor: "pointer", padding: 0, borderRadius: "50%",
+                border: "2px solid var(--eph-ink)",
+                background: on ? s.fill : "var(--eph-vellum)", color: on ? s.ink : "var(--eph-muted)",
+                fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: size * 0.34, lineHeight: 1,
+                display: "flex", alignItems: "center", justifyContent: "center",
+                transform: sel === s.v ? "rotate(-5deg) scale(1.09)" : "none", transition: "all 110ms",
+                boxShadow: on ? "inset 0 -2px 4px rgba(0,0,0,0.3), inset 0 2px 3px rgba(255,255,255,0.18)" : "none",
+              }}>
+                <span style={{ position: "absolute", inset: 3, borderRadius: "50%", border: `1px dashed ${on ? "color-mix(in srgb, #fff 40%, transparent)" : "color-mix(in srgb, var(--eph-vellum-text) 28%, transparent)"}`, pointerEvents: "none" }} />
+                {EPH_toRoman(s.v)}
+              </button>
+              <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8, fontStyle: "italic",
+                letterSpacing: "0.02em", color: sel === s.v ? "var(--eph-rubric)" : "var(--eph-muted)",
+                maxWidth: size + 12, textAlign: "center", lineHeight: 1.2 }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+      {average !== undefined && (
+        <p style={{ fontFamily: "var(--eph-serif)", fontSize: 11, color: "var(--eph-muted)", margin: "13px 0 0", letterSpacing: "0.02em" }}>
+          <b style={{ color: "var(--eph-rubric)", fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15 }}>{average.toFixed(1)}</b> concordance · {totalVotes ?? 0} marks filed
+        </p>
+      )}
+    </div>
+  );
+}
+
+/* ── stat block (hero) ─────────────────────────────────────────────── */
+function EphStat({ value, label }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 3, padding: "0 24px" }}>
+      <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 34, lineHeight: 0.85, color: "var(--eph-gold-light)" }}>{value}</span>
+      <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--eph-parchment)", opacity: 0.82 }}>{label}</span>
+    </div>
+  );
+}
+
+/* faint three-grid texture, echoing the Discordant Map, for the hero */
+function HeroGrids() {
+  return (
+    <div style={{ position: "absolute", inset: 0, zIndex: 0, pointerEvents: "none", overflow: "hidden" }}>
+      <div style={{ position: "absolute", inset: 0, opacity: 0.14, backgroundImage: "repeating-linear-gradient(0deg, var(--eph-parchment) 0 1px, transparent 1px 26px), repeating-linear-gradient(90deg, var(--eph-parchment) 0 1px, transparent 1px 26px)" }} />
+      <svg viewBox="0 0 1000 320" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.16 }}>
+        <g stroke="var(--eph-gold-light)" strokeWidth="0.6" fill="none">
+          {Array.from({ length: 21 }).map((_, i) => <line key={i} x1={i * 50} y1="320" x2="820" y2="20" />)}
+        </g>
+      </svg>
+      <svg viewBox="0 0 1000 320" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.12 }}>
+        <g stroke="var(--eph-gold-light)" strokeWidth="0.7" fill="none">
+          {[60, 130, 210, 300].map((r, i) => <circle key={i} cx="820" cy="150" r={r} />)}
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+/* ── faction-page hero — a codex frontispiece ──────────────────────── */
+function EphHero({ name, motto, blurb, stats, kicker = "World Zero · Faction №5 — the road's keepers" }) {
+  return (
+    <header style={{ position: "relative", overflow: "hidden", border: "2px solid var(--eph-gold)",
+      background: "radial-gradient(120% 140% at 82% 0%, var(--eph-lapis), var(--eph-field-deep) 60%, #05131c 100%)",
+      color: "var(--eph-parchment)", boxShadow: "0 0 0 3px var(--eph-vellum), 0 0 0 4px var(--eph-ink)" }}>
+      <HeroGrids />
+      <div style={{ height: 5, background: "var(--eph-gold)", position: "relative", zIndex: 2 }} />
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", gap: 32, padding: "30px 38px 28px" }}>
+        <EphSeal size={118} bg="var(--eph-vellum)" eye="var(--eph-lapis)" />
+        <div style={{ flex: 1, minWidth: 0, position: "relative" }}>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 10, letterSpacing: "0.28em", textTransform: "uppercase", color: "var(--eph-gold-light)", marginBottom: 6 }}>{kicker}</div>
+          <h1 style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 64, lineHeight: 0.86, letterSpacing: "0.02em", margin: 0,
+            color: "var(--eph-parchment)", textShadow: "2px 2px 0 var(--eph-field-deep)" }}>{name}</h1>
+          <div style={{ display: "inline-block", marginTop: 13, background: "var(--eph-ink)", color: "var(--eph-gold-light)",
+            fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: 15, letterSpacing: "0.26em", padding: "5px 16px", whiteSpace: "nowrap", border: "1px solid var(--eph-gold-deep)" }}>{motto}</div>
+          <p style={{ fontFamily: "var(--eph-serif)", fontSize: 13.5, lineHeight: 1.6, maxWidth: 580, margin: "14px 0 0", color: "color-mix(in srgb, var(--eph-parchment) 92%, transparent)" }}>
+            {blurb}
+            <span style={{ display: "block", fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: 11.5, color: "color-mix(in srgb, var(--eph-parchment) 62%, transparent)", marginTop: 8 }}>† nothing keeps. we keep the record anyway — <span style={{ color: "var(--eph-gold-light)" }}>see †</span></span>
+          </p>
+        </div>
+        <div style={{ position: "absolute", top: 14, right: 16, fontFamily: "var(--eph-serif)", fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: "color-mix(in srgb, var(--eph-gold-light) 70%, transparent)", transform: "rotate(0deg)", zIndex: 3 }}>Exhibit A · fol. ∞</div>
+      </div>
+      {/* stat band */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", background: "var(--eph-field-deep)",
+        borderTop: "2px solid var(--eph-gold)", padding: "15px 38px" }}>
+        {stats.map((s, i) => (
+          <React.Fragment key={s.label}>
+            {i > 0 && <div style={{ width: 1, alignSelf: "stretch", background: "color-mix(in srgb, var(--eph-gold) 40%, transparent)" }} />}
+            <EphStat value={s.value} label={s.label} />
+          </React.Fragment>
+        ))}
+      </div>
+    </header>
+  );
+}
+
+Object.assign(window, { EphSeal, EphNavBadge, Pennant, EphConcordance, EphStat, EphHero });

--- a/docs/design/design-system/templates/ephemerists/ephemerists-praxis-read.jsx
+++ b/docs/design/design-system/templates/ephemerists/ephemerists-praxis-read.jsx
@@ -1,0 +1,414 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — Completed Praxis (read) surfaces
+   A SEALED praxis is a filed ephemeris entry the faction now votes on.
+   World Zero's 1–5 rating becomes THE CONCORDANCE — a wax-seal ramp
+   (apocryphal → disputed → plausible → corroborated → canonical) that
+   measures "how well does the filed truth hold up?". Two surfaces:
+     · PraxisIndex  — the register of sealed praxes + their concordance
+     · PraxisRead   — one sealed praxis in full, with the marks received
+                      and the control to file your own.
+   Reuses ephemerists-cards.jsx + ephemerists-faction.jsx atoms. The
+   mark you file persists per-praxis in localStorage. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+/* the faction's reframe of the 1–5 vote — the concordance ramp */
+const CONCORD = [
+  { v: 1, label: "apocryphal",   fill: "var(--eph-gold)",      ink: "var(--eph-ink)" },
+  { v: 2, label: "disputed",     fill: "var(--eph-verdigris)", ink: "var(--eph-parchment)" },
+  { v: 3, label: "plausible",    fill: "var(--eph-lapis)",     ink: "var(--eph-parchment)" },
+  { v: 4, label: "corroborated", fill: "var(--eph-rubric)",    ink: "var(--eph-parchment)" },
+  { v: 5, label: "canonical",    fill: "var(--eph-ink)",       ink: "var(--eph-gold-light)" },
+];
+const METHODS = {
+  alone:   { name: "ALONE",      fill: "var(--eph-muted)" },
+  concord: { name: "IN CONCORD", fill: "var(--eph-verdigris)" },
+  dispute: { name: "IN DISPUTE", fill: "var(--eph-rubric)" },
+};
+const distTotal = (d) => d.reduce((a, b) => a + b, 0);
+const distAvg = (d) => { const t = distTotal(d); return t ? d.reduce((a, c, i) => a + c * (i + 1), 0) / t : 0; };
+const standing = (avg) => CONCORD[Math.max(0, Math.min(4, Math.round(avg) - 1))];
+
+/* ── method chip ──────────────────────────────────────────────────── */
+function MethodTag({ mode, big }) {
+  const m = METHODS[mode] || METHODS.alone;
+  return (
+    <span style={{
+      display: "inline-block", background: m.fill, color: "var(--eph-parchment)",
+      fontFamily: "var(--eph-serif)", fontSize: big ? 9.5 : 8, fontWeight: 600,
+      letterSpacing: "0.12em", textTransform: "uppercase", padding: big ? "3px 9px" : "2px 7px",
+      transform: "rotate(-1deg)", whiteSpace: "nowrap",
+    }}>{m.name}</span>
+  );
+}
+
+/* ── compact concordance read-out for register rows ───────────────── */
+/* a numeral avg + a five-bar tier sparkline + the marks count */
+function ConcordSummary({ dist }) {
+  const total = distTotal(dist), avg = distAvg(dist), max = Math.max(1, ...dist), st = standing(avg);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 3, height: 30 }}>
+        {dist.map((c, i) => (
+          <div key={i} title={`${CONCORD[i].label}: ${c}`} style={{
+            width: 7, height: Math.max(3, (c / max) * 30), background: CONCORD[i].fill,
+            opacity: c ? 1 : 0.28, boxShadow: "inset 0 0 0 0.5px rgba(0,0,0,0.25)",
+          }} />
+        ))}
+      </div>
+      <div style={{ textAlign: "left", whiteSpace: "nowrap" }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 5 }}>
+          <span style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 19, lineHeight: 1, color: st.fill === "var(--eph-ink)" ? "var(--eph-vellum-text)" : st.fill }}>{avg.toFixed(1)}</span>
+          <span style={{ fontFamily: "var(--eph-serif)", fontStyle: "italic", fontSize: 9.5, letterSpacing: "0.02em", color: "var(--eph-muted)" }}>{st.label}</span>
+        </div>
+        <div style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-muted)", marginTop: 2 }}>{total} marks</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── register row — one sealed praxis ─────────────────────────────── */
+function PraxisRow({ p, href }) {
+  const tw = p.finding.trim().split(" ");
+  const tlast = tw.pop();
+  return (
+    <a className="prx-row" href={href}>
+      <div className="prx-cat">
+        <span className="prx-no">№ {p.entryNo}</span>
+        <span className="prx-seal" aria-hidden="true">✦</span>
+      </div>
+      <div className="prx-main">
+        <div className="prx-finding">{tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span></div>
+        <div className="prx-byline">
+          <span style={{ color: "var(--eph-rubric)", fontStyle: "italic" }}>re: {p.task}</span>
+          <span className="prx-dot">·</span>
+          <span>filed by <b style={{ color: "var(--eph-vellum-text)", fontStyle: "normal" }}>{p.actor}</b></span>
+          <MethodTag mode={p.mode} />
+          <span className="prx-pts">{p.points} pvncta</span>
+        </div>
+      </div>
+      <div className="prx-vote"><ConcordSummary dist={p.dist} /></div>
+      <span className="prx-go" aria-hidden="true">→</span>
+    </a>
+  );
+}
+
+/* ── the register ─────────────────────────────────────────────────── */
+function PraxisIndex({ praxes, hrefFor }) {
+  const [filter, setFilter] = React.useState("all");
+  const FILTERS = [
+    { id: "all", name: "All sealed" },
+    { id: "canonical", name: "Holds (IV–V)" },
+    { id: "dispute", name: "In dispute" },
+    { id: "alone", name: "Single observer" },
+  ];
+  const rows = praxes.filter((p) => {
+    if (filter === "all") return true;
+    if (filter === "canonical") return distAvg(p.dist) >= 3.5;
+    if (filter === "dispute") return p.mode === "dispute" || distAvg(p.dist) < 2.5;
+    if (filter === "alone") return p.mode === "alone";
+    return true;
+  });
+  const totalMarks = praxes.reduce((a, p) => a + distTotal(p.dist), 0);
+
+  return (
+    <React.Fragment>
+      {/* register masthead */}
+      <div className="prx-masthead">
+        <div className="prx-mast-l">
+          <div className="prx-kicker">The Ephemerists · the sealed record</div>
+          <h1 className="prx-h1">THE <span style={{ color: "var(--eph-lapis)" }}>PRAXES</span></h1>
+          <div className="prx-mast-rule" />
+          <p className="prx-mast-sub">Findings entered in the ephemeris and put to the concordance. <em>Every sealed truth is open to a mark — see how well it holds.</em></p>
+        </div>
+        <div className="prx-mast-r">
+          <div className="prx-stat"><b>{praxes.length}</b><span>sealed praxes</span></div>
+          <div className="prx-stat"><b>{totalMarks}</b><span>marks filed</span></div>
+        </div>
+      </div>
+
+      {/* filter strip */}
+      <div className="prx-filters">
+        {FILTERS.map((f) => (
+          <button key={f.id} className={"prx-filter" + (filter === f.id ? " on" : "")} onClick={() => setFilter(f.id)}>{f.name}</button>
+        ))}
+        <span className="prx-count">{rows.length} of {praxes.length}</span>
+      </div>
+
+      {/* column heads */}
+      <div className="prx-heads">
+        <span>Entry</span>
+        <span>The finding</span>
+        <span style={{ textAlign: "right" }}>The concordance</span>
+      </div>
+
+      <div className="prx-list">
+        {rows.map((p) => <PraxisRow key={p.id} p={p} href={hrefFor(p)} />)}
+        {rows.length === 0 && <div className="prx-empty">No sealed praxes under this lens — <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>the margin stays blank.</span></div>}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   THE READ PAGE — one sealed praxis, the marks it has received, and
+   the control to file your own.
+   ════════════════════════════════════════════════════════════════ */
+
+/* a subtly-striped specimen placeholder the user drops real evidence into */
+function Specimen({ label, kind }) {
+  return (
+    <figure style={{ margin: 0, border: "1px solid var(--eph-ink)", background: "var(--eph-vellum)", overflow: "hidden" }}>
+      <div style={{
+        height: 96, position: "relative",
+        backgroundImage: "repeating-linear-gradient(45deg, color-mix(in srgb, var(--eph-lapis) 14%, transparent) 0 6px, transparent 6px 12px)",
+        backgroundColor: "color-mix(in srgb, var(--eph-vellum) 60%, transparent)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+      }}>
+        <span style={{ fontFamily: "var(--font-faction-mono, monospace)", fontSize: 9, letterSpacing: "0.08em", color: "var(--eph-muted)", background: "color-mix(in srgb, var(--eph-vellum) 86%, transparent)", padding: "3px 7px" }}>{kind}</span>
+      </div>
+      <figcaption style={{ fontFamily: "var(--eph-serif)", fontSize: 9.5, fontStyle: "italic", color: "var(--eph-muted)", padding: "7px 9px", borderTop: "1px solid color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)" }}>{label}</figcaption>
+    </figure>
+  );
+}
+
+/* the concordance meter — distribution histogram + headline standing */
+function ConcordMeter({ dist }) {
+  const total = distTotal(dist), avg = distAvg(dist), max = Math.max(1, ...dist), st = standing(avg);
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 4 }}>
+        <span style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 46, lineHeight: 0.8, color: st.fill === "var(--eph-ink)" ? "var(--eph-vellum-text)" : st.fill }}>{avg.toFixed(1)}</span>
+        <div>
+          <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--eph-rubric)" }}>{st.label}</div>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-muted)", marginTop: 1 }}>{total} marks filed</div>
+        </div>
+      </div>
+      {/* per-tier distribution */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 14 }}>
+        {CONCORD.slice().reverse().map((s) => {
+          const c = dist[s.v - 1];
+          return (
+            <div key={s.v} style={{ display: "flex", alignItems: "center", gap: 9 }}>
+              <span style={{ width: 70, textAlign: "right", fontFamily: "var(--eph-serif)", fontSize: 9.5, fontStyle: "italic", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{s.label}</span>
+              <div style={{ flex: 1, height: 12, background: "color-mix(in srgb, var(--eph-vellum-text) 9%, transparent)", position: "relative", border: "1px solid color-mix(in srgb, var(--eph-vellum-text) 18%, transparent)" }}>
+                <div style={{ position: "absolute", inset: 0, width: `${(c / max) * 100}%`, background: s.fill, opacity: c ? 0.92 : 0 }} />
+              </div>
+              <span style={{ width: 22, fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 12, color: "var(--eph-vellum-text)", textAlign: "right" }}>{c}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* the interactive control — file your mark (persists per praxis) */
+function MarkCaster({ praxisId, baseDist }) {
+  const key = "eph-mark-" + praxisId;
+  const [my, setMy] = React.useState(0);
+  React.useEffect(() => {
+    try { const v = +localStorage.getItem(key); if (v >= 1 && v <= 5) setMy(v); } catch (e) {}
+  }, [key]);
+  const cast = (v) => { const nv = my === v ? 0 : v; setMy(nv); try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch (e) {} };
+  const live = baseDist.map((c, i) => c + (my === i + 1 ? 1 : 0));
+
+  return (
+    <div>
+      <ConcordMeter dist={live} />
+
+      <div style={{ height: 1, background: "color-mix(in srgb, var(--eph-vellum-text) 18%, transparent)", margin: "20px 0 16px" }} />
+
+      <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-rubric)", marginBottom: 3 }}>File your mark</div>
+      <div style={{ fontFamily: "var(--eph-serif)", fontSize: 11, fontStyle: "italic", color: "var(--eph-muted)", marginBottom: 14 }}>how well does this truth hold up?</div>
+
+      {/* the wax-seal concordance ramp */}
+      <div style={{ display: "flex", gap: 9, flexWrap: "wrap" }}>
+        {CONCORD.map((s) => {
+          const on = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 5 }}>
+              <button onClick={() => cast(s.v)} aria-label={`${s.v} — ${s.label}`} style={{
+                position: "relative", width: 44, height: 44, cursor: "pointer", padding: 0, borderRadius: "50%",
+                border: "2px solid var(--eph-ink)",
+                background: on ? s.fill : "var(--eph-vellum)", color: on ? s.ink : "var(--eph-muted)",
+                fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, lineHeight: 1,
+                display: "flex", alignItems: "center", justifyContent: "center",
+                transform: picked ? "rotate(-6deg) scale(1.1)" : "none", transition: "all 110ms",
+                boxShadow: on ? "inset 0 -2px 4px rgba(0,0,0,0.3), inset 0 2px 3px rgba(255,255,255,0.18)" : "none",
+              }}>
+                <span style={{ position: "absolute", inset: 3, borderRadius: "50%", border: `1px dashed ${on ? "color-mix(in srgb, #fff 40%, transparent)" : "color-mix(in srgb, var(--eph-vellum-text) 28%, transparent)"}`, pointerEvents: "none" }} />
+                {window.EPH_toRoman(s.v)}
+              </button>
+              <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8, fontStyle: "italic", letterSpacing: "0.02em", color: picked ? "var(--eph-rubric)" : "var(--eph-muted)", maxWidth: 54, textAlign: "center", lineHeight: 1.2 }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 16, fontFamily: "var(--eph-serif)", fontSize: 11.5, fontStyle: "italic", lineHeight: 1.5,
+        color: my ? "var(--eph-verdigris)" : "var(--eph-muted)" }}>
+        {my
+          ? <span>✦ your mark — <b style={{ fontStyle: "normal", color: standing(my).fill === "var(--eph-ink)" ? "var(--eph-vellum-text)" : standing(my).fill }}>{CONCORD[my - 1].label}</b> — is filed. the concordance now stands at <b style={{ fontStyle: "normal", color: "var(--eph-rubric)" }}>{distAvg(live).toFixed(1)}</b> across {distTotal(live)} marks. <span style={{ color: "var(--eph-lapis)", textDecoration: "underline" }}>amend ↺</span></span>
+          : <span>↳ no mark from you yet — the record waits.</span>}
+      </div>
+    </div>
+  );
+}
+
+/* full read view */
+function PraxisRead({ p }) {
+  const { EPH_EphMark, EPH_Foxing, EPH_toRoman, EphAvatar } = window;
+  const tw = p.finding.trim().split(" ");
+  const tlast = tw.pop();
+  const Avatar = EphAvatar || (() => null);
+
+  return (
+    <div style={{ fontFamily: "var(--eph-serif)", color: "var(--eph-vellum-text)" }}>
+      {/* masthead running-head */}
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 14, flexWrap: "wrap",
+        padding: "8px 0 7px", borderTop: "1px solid var(--eph-gold-deep)", borderBottom: "1px solid var(--eph-gold-deep)",
+        boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)" }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 9, color: "var(--eph-rubric)", fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: 13, letterSpacing: "0.18em", textTransform: "uppercase" }}>
+          <EPH_EphMark size={14} color="var(--eph-lapis)" /> The Ephemerists · ephemeris entry №{p.entryNo}
+        </span>
+        <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9.5, letterSpacing: "0.06em", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{p.coords} &nbsp;·&nbsp; sealed {p.sealed}</span>
+      </div>
+
+      {/* status line */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "16px 0 2px", flexWrap: "wrap" }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, background: "var(--eph-ink)", color: "var(--eph-gold-light)",
+          fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 11, letterSpacing: "0.16em", textTransform: "uppercase", padding: "5px 12px", whiteSpace: "nowrap" }}>
+          ✦ Sealed · under concordance
+        </span>
+        <MethodTag mode={p.mode} big />
+        <span style={{ fontFamily: "var(--eph-serif)", fontStyle: "italic", fontSize: 11, color: "var(--eph-muted)" }}>re: <span style={{ color: "var(--eph-rubric)" }}>{p.task}</span> · grade {EPH_toRoman(p.level)}</span>
+      </div>
+
+      {/* the finding headline */}
+      <h1 style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 46, lineHeight: 1.1, letterSpacing: "0.01em", margin: "12px 0 14px", color: "var(--eph-vellum-text)" }}>
+        {tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span><sup style={{ fontFamily: "var(--eph-serif)", fontSize: 18, color: "var(--eph-lapis)", fontWeight: 400 }}>†</sup>
+      </h1>
+      <div style={{ fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: 17, color: "var(--eph-muted)", margin: "2px 0 16px" }}>{p.gloss}</div>
+
+      {/* byline */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, paddingBottom: 18, marginBottom: 22, borderBottom: "1px dashed color-mix(in srgb, var(--eph-vellum-text) 26%, transparent)" }}>
+        <Avatar gradient={p.gradient} size={40} />
+        <div style={{ lineHeight: 1.4, whiteSpace: "nowrap", flexShrink: 0 }}>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 14 }}>filed by <b>{p.actor}</b></div>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 10.5, fontStyle: "italic", color: "var(--eph-muted)" }}>{p.role}</div>
+        </div>
+        <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 18, color: "var(--eph-rubric)", marginLeft: "auto", flexShrink: 0 }}>{p.points} pvncta</span>
+      </div>
+
+      {/* THE ACCOUNT */}
+      <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--eph-rubric)", marginBottom: 12 }}>The account</div>
+      <div style={{ fontFamily: "var(--eph-serif)", fontSize: 15.5, lineHeight: 1.72, color: "var(--eph-vellum-text)" }}>
+        {p.account.map((para, i) => (
+          <p key={i} style={{ margin: i ? "14px 0 0" : 0, textWrap: "pretty" }} dangerouslySetInnerHTML={{ __html: para }} />
+        ))}
+      </div>
+      <div style={{ fontFamily: "var(--eph-serif)", fontSize: 11, fontStyle: "italic", color: "var(--eph-muted)", margin: "16px 0 0", lineHeight: 1.5 }} dangerouslySetInnerHTML={{ __html: p.footnote }} />
+
+      {/* THE EVIDENCE */}
+      <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--eph-rubric)", margin: "30px 0 12px" }}>The evidence <span style={{ fontFamily: "var(--eph-serif)", fontWeight: 400, fontStyle: "italic", fontSize: 10, letterSpacing: "0.04em", textTransform: "none", color: "var(--eph-muted)" }}>· {p.evidence.length} specimens pinned</span></div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))", gap: 12 }}>
+        {p.evidence.map((e, i) => <Specimen key={i} kind={e.kind} label={e.label} />)}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════ */
+/* shared dataset — sealed praxes (the read page features the first) */
+const G_AV = {
+  vesper:  "radial-gradient(circle at 32% 28%, #8fb0c4, #2d6285 72%, #14303f)",
+  margin:  "radial-gradient(circle at 32% 28%, #d8b25a, #9c7626 72%, #5e4715)",
+  cartouche:"radial-gradient(circle at 32% 28%, #c98aa6, #8a3d5e 72%, #54223a)",
+  almanac: "radial-gradient(circle at 32% 28%, #9fc0a0, #4a7d70 72%, #28473f)",
+  quill:   "radial-gradient(circle at 32% 28%, #b9a7c9, #6b4f86 72%, #3a2850)",
+};
+
+const EPH_PRAXES = [
+  {
+    id: "trace-a-myth", entryNo: "MMXXVI·041", task: "Trace a Myth", level: 4, points: 100,
+    actor: "Vesper", role: "ephemerist · third circuit", gradient: G_AV.vesper, mode: "alone",
+    coords: "41°54′N · 12°29′E", sealed: "Apr 21, 2026",
+    finding: "THE SAINT WAS A SURVEYOR",
+    gloss: "the miracle, traced back, is a measurement",
+    // dist = counts at [I apocryphal, II disputed, III plausible, IV corroborated, V canonical]
+    dist: [1, 2, 7, 19, 18],
+    account: [
+      "The legend holds that St. Verro crossed from the sea to the capital in a single night, and a road rose behind his feet as he walked. I followed it backward through every retelling I could lay hands on — eleven of them, in four tongues — until the road ran out.",
+      "The earliest copy is not a life of a saint at all. It is a surveyor's day-book. <span style=\"color:var(--eph-lapis)\">Verro</span> is not a name; it is a column heading — <em>verum</em>, the true line — ruled down a page of measured stations from the shore to the gates. The night of the miracle is a working season, compressed by three centuries of telling into a single dark.",
+      "So the road did rise behind him, in the only sense that survives scrutiny: he set the stones' positions before anyone walked them. The man was real, the walk was real, and the marvel is that a ledger outlived the church that borrowed it.",
+    ],
+    footnote: "† the day-book's final station carries no coordinate — the line simply stops being recorded. where the saint is said to have ascended, the surveyor merely ran out of page. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [
+      { kind: "rubbing", label: "milestone VII, north face — the ruled stations" },
+      { kind: "transcript", label: "day-book fol. 12r, the 'Verro' column heading" },
+      { kind: "map overlay", label: "the eleven retellings, georeferenced" },
+    ],
+  },
+  {
+    id: "lost-cubit", entryNo: "MMXXVI·028", task: "Recover a Lost Unit of Measure", level: 5, points: 500,
+    actor: "Vesper", role: "ephemerist · third circuit", gradient: G_AV.vesper, mode: "alone",
+    coords: "30°02′N · 31°14′E", sealed: "Apr 18, 2026",
+    finding: "THE CUBIT MOVED A QUARTER-INCH",
+    gloss: "the same rule, measured twice, disagreed with itself",
+    dist: [0, 1, 4, 11, 9],
+    account: ["The cubit cut into the temple's inner wall ran a quarter-inch longer than the cubit cut into its outer wall — the same rule, the same hand, a generation apart."],
+    footnote: "† which cubit is the true cubit? both. neither. the record keeps them both. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "rubbing", label: "inner-wall standard" }, { kind: "rubbing", label: "outer-wall standard" }],
+  },
+  {
+    id: "dead-road", entryNo: "MMXXVI·036", task: "Walk a Dead Road", level: 3, points: 25,
+    actor: "Almanac Okonkwo", role: "ephemerist · cartographer", gradient: G_AV.almanac, mode: "alone",
+    coords: "37°58′N · 23°43′E", sealed: "Apr 19, 2026",
+    finding: "THE INN PREDATES ITS ROAD",
+    gloss: "the house was built for a road that came forty years late",
+    dist: [0, 3, 9, 6, 2],
+    account: ["The roadside inn carries a founding stone four decades older than the road it serves. It was raised for traffic that did not yet exist — and the traffic, eventually, obliged."],
+    footnote: "† who tells the road where to run? sometimes, a man who guesses early. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "photo", label: "the founding stone, dated" }],
+  },
+  {
+    id: "the-bell", entryNo: "—", task: "A Bell Heard in Three Centuries", level: 2, points: 5,
+    actor: "Day Cartouche", role: "ephemerist · disputant", gradient: G_AV.cartouche, mode: "dispute",
+    coords: "48°51′N · 2°21′E", sealed: "Apr 19, 2026",
+    finding: "ONE BELL, THREE CASTINGS",
+    gloss: "the same toll, recast twice, never the same bell",
+    dist: [6, 11, 4, 1, 0],
+    account: ["Three chronicles, three centuries apart, each record the 'same' famous bell. They cannot be: the metal was melted and recast twice. The toll is continuous; the bell is not. The account remains contested."],
+    footnote: "† a thing that is replaced part by part — is it the same thing? the disputants still differ. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "transcript", label: "the three chronicle entries, aligned" }],
+  },
+  {
+    id: "first-teller", entryNo: "—", task: "Name the First Teller", level: 4, points: 200,
+    actor: "Quill Anselm", role: "ephemerist · first circuit", gradient: G_AV.quill, mode: "dispute",
+    coords: "55°57′N · 3°11′W", sealed: "Apr 16, 2026",
+    finding: "THE FIRST TELLER LEFT NO NAME",
+    gloss: "every origin is itself a retelling",
+    dist: [9, 7, 3, 1, 0],
+    account: ["Traced the tale to its earliest written form, then found that form citing an earlier one, now lost. The first teller cannot be named because there is no first telling — only the next-oldest copy, all the way down."],
+    footnote: "† this finding is itself a retelling; someone will trace it back. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "transcript", label: "the citation chain, six deep" }],
+  },
+  {
+    id: "two-maps", entryNo: "MMXXVI·033", task: "Where the Two Maps Disagree", level: 3, points: 60,
+    actor: "Marginalia", role: "ephemerist · in concord with Vesper", gradient: G_AV.margin, mode: "concord",
+    coords: "51°30′N · 0°07′W", sealed: "Apr 17, 2026",
+    finding: "THE RIVER MOVED, THE MAP DID NOT",
+    gloss: "two surveys, one place, a century of silt between them",
+    dist: [0, 2, 6, 12, 7],
+    account: ["Two surveys of the same parish disagree by ninety yards at the waterline. Neither is wrong: the river migrated. The maps are both true — of different rivers wearing the same name."],
+    footnote: "† the ground does not hold still for the map. we record the disagreement, not the winner. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "map overlay", label: "1788 survey vs. 1891 survey" }, { kind: "photo", label: "the present waterline" }],
+  },
+];
+
+Object.assign(window, {
+  EPH_CONCORD: CONCORD, EPH_PRAXES,
+  PraxisIndex, PraxisRead, PraxisRow, ConcordSummary, ConcordMeter, MarkCaster, MethodTag, Specimen,
+  EPH_distAvg: distAvg, EPH_distTotal: distTotal,
+});

--- a/docs/design/design-system/templates/ephemerists/ephemerists-praxis.jsx
+++ b/docs/design/design-system/templates/ephemerists/ephemerists-praxis.jsx
@@ -1,0 +1,161 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — Edit Praxis form
+   World Zero's praxis-filing form in the faction's voice: filing AN
+   ENTRY IN THE EPHEMERIS. A sealed masthead, the observed-task slip (a
+   torn codex leaf), a METHOD selector (alone / in concord / in dispute),
+   THE FINDING headline, THE ACCOUNT body, EVIDENCE attachments, and a
+   seal-&-enter action bar. House-of-Leaves apparatus throughout.
+   Reuses ephemerists-cards.jsx atoms. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+function FieldLabel({ children, meta }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 10 }}>
+      <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 14, letterSpacing: "0.16em", color: "var(--eph-rubric)", whiteSpace: "nowrap" }}>{children}</span>
+      {meta && <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9.5, fontStyle: "italic", letterSpacing: "0.06em", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{meta}</span>}
+      <span style={{ flex: 1, height: 0, borderTop: "1px solid var(--eph-gold-deep)", borderBottom: "1px solid color-mix(in srgb, var(--eph-lapis) 60%, transparent)" }} />
+    </div>
+  );
+}
+
+function PraxisForm({ faction = "THE EPHEMERISTS", entryNo = "MMXXVI", task }) {
+  const { EPH_EphMark, EPH_Foxing, EPH_toRoman } = window;
+  const [mode, setMode] = React.useState("alone");
+  const [finding, setFinding] = React.useState("");
+  const [account, setAccount] = React.useState("");
+  const [filed, setFiled] = React.useState(false);
+  const [dropArmed, setDropArmed] = React.useState(false);
+  const [dropped, setDropped] = React.useState(false);
+
+  const MODES = [
+    { id: "alone",   name: "ALONE",      sub: "one observer" },
+    { id: "concord", name: "IN CONCORD", sub: "accounts agree" },
+    { id: "dispute", name: "IN DISPUTE", sub: "accounts differ" },
+  ];
+  const words = account.trim() ? account.trim().split(/\s+/).length : 0;
+  const ink = "var(--eph-ink)";
+
+  return (
+    <div style={{ fontFamily: "var(--eph-serif)", color: "var(--eph-vellum-text)" }}>
+
+      {/* masthead — a catalogue running-head between hairlines (no poster ribbon) */}
+      <div style={{ display: "inline-flex", alignItems: "center", gap: 10, padding: "7px 4px 6px",
+        color: "var(--eph-rubric)", borderTop: "1px solid var(--eph-gold-deep)", borderBottom: "1px solid var(--eph-gold-deep)",
+        boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)" }}>
+        <EPH_EphMark size={15} color="var(--eph-lapis)" />
+        <span style={{ fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: 14, letterSpacing: "0.18em", textTransform: "uppercase", whiteSpace: "nowrap" }}>{faction} · ephemeris entry №{entryNo}</span>
+      </div>
+
+      {/* big title */}
+      <div style={{ display: "flex", alignItems: "baseline", gap: 14, margin: "18px 0 4px", flexWrap: "wrap" }}>
+        <div style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 54, lineHeight: 0.9, letterSpacing: "0.02em", color: "var(--eph-vellum-text)", whiteSpace: "nowrap" }}>
+          EDIT <span style={{ color: "var(--eph-lapis)" }}>PRAXIS</span>
+        </div>
+        <span style={{ fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: 14, color: "var(--eph-muted)" }}>— set it down before it passes</span>
+      </div>
+      <div style={{ height: 0, width: 200, borderTop: "1px solid var(--eph-gold-deep)", borderBottom: "1px solid color-mix(in srgb, var(--eph-lapis) 60%, transparent)", marginBottom: 26 }} />
+
+      {/* observed-task slip — a leaf from the ephemeris (running-head + ledger rules, no spine) */}
+      <div style={{ position: "relative", overflow: "hidden", border: "1px solid color-mix(in srgb, var(--eph-vellum-text) 30%, transparent)", background: "var(--eph-vellum)", marginBottom: 30 }}>
+        <div style={{ position: "absolute", inset: 0, zIndex: 1, pointerEvents: "none", opacity: 0.5,
+          backgroundImage: "repeating-linear-gradient(0deg, transparent 0 23px, color-mix(in srgb, var(--eph-lapis) 16%, transparent) 23px 24px)" }} />
+        <EPH_Foxing opacity={0.35} />
+        {/* running head */}
+        <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 10,
+          padding: "7px 16px 6px", borderBottom: "1px solid var(--eph-gold-deep)", boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)" }}>
+          <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--eph-rubric)" }}>Ephemeris · observed</span>
+          <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.06em", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>41°54′N · 12°29′E &nbsp;·&nbsp; grade {EPH_toRoman(task.level)} †</span>
+        </div>
+        {/* body */}
+        <div style={{ position: "relative", zIndex: 2, padding: "13px 16px 14px" }}>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 9, fontStyle: "italic", letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-muted)", marginBottom: 4 }}>Re: the truth traced in</div>
+          <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 30, lineHeight: 0.96, color: "var(--eph-vellum-text)" }}>
+            {task.title.replace(/ \S+$/, "")} <span style={{ color: "var(--eph-lapis)" }}>{task.title.split(" ").slice(-1)[0]}</span>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 8, flexWrap: "wrap" }}>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--eph-serif)", fontSize: 9.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--eph-lapis)", fontWeight: 600 }}>
+              <EPH_EphMark size={12} color="var(--eph-lapis)" /> Ephemerists
+            </span>
+            <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, color: "var(--eph-rubric)" }}>{task.points} pvncta</span>
+          </div>
+        </div>
+      </div>
+
+      {/* the method */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel meta="how the account was taken">THE METHOD</FieldLabel>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
+          {MODES.map((m) => {
+            const on = mode === m.id;
+            return (
+              <button key={m.id} onClick={() => setMode(m.id)} style={{
+                position: "relative", cursor: "pointer", textAlign: "left", padding: "13px 15px",
+                background: on ? "var(--eph-lapis)" : "var(--eph-vellum)",
+                color: on ? "var(--eph-parchment)" : "var(--eph-vellum-text)",
+                border: "1px solid " + ink, fontFamily: "var(--eph-serif)",
+                boxShadow: on ? "inset 0 2px 6px rgba(0,0,0,0.4), inset 0 0 0 1px color-mix(in srgb, var(--eph-gold) 55%, transparent)" : "none",
+                transition: "all 120ms",
+              }}>
+                <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 21, lineHeight: 1, letterSpacing: "0.03em" }}>{m.name}</div>
+                <div style={{ fontFamily: "var(--eph-serif)", fontStyle: "italic", fontSize: 10, letterSpacing: "0.02em", marginTop: 4, opacity: on ? 0.9 : 0.7 }}>{m.sub}</div>
+                {on && <div style={{ position: "absolute", top: 8, right: 9, width: 9, height: 9, borderRadius: "50%", background: "var(--eph-gold-light)", boxShadow: "0 0 0 2px " + ink }} />}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* the finding (headline) */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel meta={`${finding.length}/200 · name the plain fact`}>THE FINDING</FieldLabel>
+        <input value={finding} onChange={(e) => setFinding(e.target.value.slice(0, 200))} placeholder="the ordinary event the legend grew from"
+          style={{ width: "100%", border: "none", borderBottom: "2px solid " + ink, background: "transparent",
+            fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 24, letterSpacing: "0.01em", color: "var(--eph-vellum-text)",
+            padding: "4px 2px 8px", outline: "none" }} />
+      </div>
+
+      {/* the account (body) */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel meta={`${words} words · markdown ok`}>THE ACCOUNT</FieldLabel>
+        <textarea value={account} onChange={(e) => setAccount(e.target.value)} placeholder="Followed it backward through every retelling. The first teller…"
+          rows={9} style={{ width: "100%", resize: "vertical", border: "1.5px solid " + ink, background: "var(--eph-vellum)",
+            fontFamily: "var(--eph-serif)", fontSize: 14, lineHeight: 1.65, color: "var(--eph-vellum-text)",
+            padding: "13px 15px", outline: "none" }} />
+        <div style={{ fontFamily: "var(--eph-serif)", fontSize: 9.5, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 7 }}>† the account you file is itself a retelling. someone will trace it back. — <span style={{ color: "var(--eph-lapis)" }}>see †</span></div>
+      </div>
+
+      {/* evidence */}
+      <div style={{ marginBottom: 30 }}>
+        <FieldLabel meta="0 pinned">THE EVIDENCE</FieldLabel>
+        <button style={{ display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer",
+          border: "2px dashed " + ink, background: "transparent", color: "var(--eph-vellum-text)",
+          fontFamily: "var(--eph-serif)", fontSize: 11.5, fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase", padding: "11px 18px" }}>
+          <span style={{ fontFamily: "var(--eph-display)", fontSize: 18, color: "var(--eph-rubric)", lineHeight: 0.6 }}>+</span> Pin a specimen
+        </button>
+        <div style={{ fontFamily: "var(--eph-serif)", fontSize: 10, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 9 }}>rubbings · sketches · recordings · transcripts — max 50mb each</div>
+      </div>
+
+      {/* file bar */}
+      <div style={{ borderTop: "1px solid color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)", paddingTop: 22,
+        display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+        <button onClick={() => setFiled(true)} style={{ cursor: "pointer", border: "1px solid var(--eph-gold)",
+          background: filed ? "var(--eph-verdigris)" : "var(--eph-rubric)", color: "var(--eph-parchment)",
+          fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 22, letterSpacing: "0.08em", padding: "12px 28px", whiteSpace: "nowrap",
+          boxShadow: "inset 0 2px 4px rgba(255,255,255,0.16), inset 0 -4px 7px rgba(0,0,0,0.38), 0 2px 5px rgba(0,0,0,0.25)", transition: "background 150ms" }}>
+          {filed ? "✓ ENTERED IN THE EPHEMERIS" : "✦ SEAL & ENTER ✦"}
+        </button>
+        <button style={{ cursor: "pointer", border: "1px solid " + ink, background: "transparent",
+          color: "var(--eph-vellum-text)", fontFamily: "var(--eph-serif)", fontSize: 12, fontWeight: 600,
+          letterSpacing: "0.1em", textTransform: "uppercase", padding: "13px 20px" }}>Keep as marginalia</button>
+        <button onClick={() => { if (dropped) { setDropped(false); setDropArmed(false); } else if (dropArmed) { setDropped(true); setDropArmed(false); setFiled(false); } else { setDropArmed(true); } }}
+          style={{ cursor: "pointer", border: "1px solid " + ((dropArmed || dropped) ? "var(--eph-rubric)" : ink), background: "transparent",
+          color: (dropArmed || dropped) ? "var(--eph-rubric)" : "var(--eph-vellum-text)", fontFamily: "var(--eph-serif)", fontSize: 12, fontWeight: 600,
+          letterSpacing: "0.1em", textTransform: "uppercase", padding: "13px 20px", transition: "all 150ms" }}>
+          {dropped ? "✕ Struck" : dropArmed ? "Strike — Confirm" : "Strike Entry"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { PraxisForm });

--- a/docs/design/design-system/templates/ephemerists/ephemerists-updates.jsx
+++ b/docs/design/design-system/templates/ephemerists/ephemerists-updates.jsx
@@ -1,0 +1,161 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — Updates feed
+   World Zero's stock activity card (avatar · actor · action · badge ·
+   time → task reference → optional status) elevated into the Ephemerist
+   archetype: a torn leaf from the faction's ephemeris. A lapis spine
+   with gold notches, foxed vellum, a Cinzel task title with one word in
+   the blue, a wax-seal points medallion, and a self-referential
+   footnote. Reuses ephemerists-cards.jsx atoms. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── small wax-seal points medallion ───────────────────────────────── */
+function WaxSeal({ points, size = 46, color = "var(--eph-rubric)", rotate = -8 }) {
+  return (
+    <div style={{
+      width: size, height: size, transform: `rotate(${rotate}deg)`, flexShrink: 0,
+      borderRadius: "47% 53% 50% 50% / 52% 48% 52% 48%",
+      background: `radial-gradient(circle at 36% 30%, color-mix(in srgb, ${color} 70%, #fff 18%), ${color} 58%, var(--eph-rubric-deep))`,
+      boxShadow: "inset 0 2px 4px rgba(255,255,255,0.18), inset 0 -3px 5px rgba(0,0,0,0.35), 0 2px 3px rgba(0,0,0,0.3)",
+      display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+      color: "var(--eph-parchment)", lineHeight: 1,
+    }}>
+      <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: size * 0.34 }}>{points}</span>
+      <span style={{ fontFamily: "var(--eph-serif)", fontSize: 5.5, letterSpacing: "0.14em", marginTop: 1, opacity: 0.85 }}>PVNCTA</span>
+    </div>
+  );
+}
+
+/* ── faction avatar: player avatar in an Ephemerist membership ring ─── */
+function EphAvatar({ gradient, size = 38 }) {
+  const { EPH_EphMark } = window;
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      <div style={{ width: size, height: size, borderRadius: "50%", background: gradient,
+        boxShadow: "0 0 0 2px var(--eph-ink), 0 0 0 4px var(--eph-vellum)" }} />
+      <div style={{ position: "absolute", right: -4, bottom: -4, width: 17, height: 17, borderRadius: "50%",
+        background: "var(--eph-lapis)", display: "flex", alignItems: "center", justifyContent: "center",
+        boxShadow: "0 0 0 1.5px var(--eph-vellum)" }}>
+        <EPH_EphMark size={11} color="var(--eph-gold-light)" />
+      </div>
+    </div>
+  );
+}
+
+/* ── action badge as an inked stamp ────────────────────────────────── */
+const STAMP_KIND = {
+  foe:    { bg: "var(--eph-rubric)",    fg: "var(--eph-parchment)", rot: -2.5 },
+  duel:   { bg: "var(--eph-rubric)",    fg: "var(--eph-parchment)", rot:  2 },
+  collab: { bg: "var(--eph-verdigris)", fg: "var(--eph-parchment)", rot: -1.5 },
+  yours:  { bg: "var(--eph-gold)",      fg: "var(--eph-ink)",       rot:  2 },
+  friend: { bg: "var(--eph-lapis)",     fg: "var(--eph-parchment)", rot: -2 },
+};
+function ActionStamp({ label, kind = "foe" }) {
+  const k = STAMP_KIND[kind] || STAMP_KIND.foe;
+  return (
+    <span style={{
+      position: "relative", display: "inline-block", background: k.bg, color: k.fg,
+      fontFamily: "var(--eph-serif)", fontSize: 9, fontWeight: 600, letterSpacing: "0.1em",
+      textTransform: "uppercase", padding: "3px 8px", transform: `rotate(${k.rot}deg)`,
+      verticalAlign: "middle", whiteSpace: "nowrap",
+    }}>
+      <span style={{ position: "absolute", inset: 2, border: "1px dashed rgba(255,255,255,0.35)", pointerEvents: "none" }} />
+      {label}
+    </span>
+  );
+}
+
+/* ── status footer ─────────────────────────────────────────────────── */
+function StatusLine({ status }) {
+  if (!status) return null;
+  const tones = { accepted: "var(--eph-verdigris)", declined: "var(--eph-muted)", pending: "var(--eph-gold-deep)" };
+  const color = tones[status.kind] || "var(--eph-muted)";
+  return (
+    <div style={{
+      marginTop: 11, paddingTop: 9, borderTop: "1px dashed color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)",
+      fontFamily: "var(--eph-serif)", fontSize: 10, fontWeight: 600, fontStyle: "italic", letterSpacing: "0.04em", color,
+    }}>
+      {status.label}
+    </div>
+  );
+}
+
+/* ── the activity card — a leaf from the ephemeris ─────────────────── */
+/* No colored spine. Instead: an ephemeris running-head (catalogue no. +
+   coordinates + time) over faint ledger scribe-rules, the way a real
+   astronomical table is laid out. */
+function EphemeristActivityCard({ actor, gradient, action, badge, time, task, meta, status, completed, footnote, entryNo, coords = "41°54′N · 12°29′E" }) {
+  const { EPH_Foxing, EPH_toRoman, EPH_SacredGeometry } = window;
+  const tw = (task.title || "").trim().split(" ");
+  const tlast = tw.pop();
+  const cat = entryNo || EPH_toRoman(task.points || 1);
+  return (
+    <article style={{
+      position: "relative", background: "var(--eph-vellum)", color: "var(--eph-vellum-text)",
+      border: "1px solid color-mix(in srgb, var(--eph-vellum-text) 30%, transparent)",
+      marginBottom: 18, overflow: "hidden", boxShadow: "0 1px 0 rgba(0,0,0,0.04), 0 8px 20px -16px rgba(0,0,0,0.6)",
+      fontFamily: "var(--eph-serif)",
+    }}>
+      {/* sacred-geometry watermark — a Flower of Life bleeding off the fore-edge
+         so the leaf no longer reads as a plain rectangle */}
+      <div style={{ position: "absolute", right: -96, top: "50%", transform: "translateY(-50%)", zIndex: 1,
+        opacity: 0.12, color: "var(--eph-lapis)", pointerEvents: "none" }}>
+        <EPH_SacredGeometry size={300} rings={3} color="var(--eph-lapis)" stroke={0.7} spokes={12} />
+      </div>
+      {/* a small verdigris vesica/seed bleeding off the binding edge */}
+      <div style={{ position: "absolute", left: -54, top: -34, zIndex: 1,
+        opacity: 0.09, color: "var(--eph-verdigris)", pointerEvents: "none" }}>
+        <EPH_SacredGeometry size={150} rings={2} color="var(--eph-verdigris)" stroke={0.7} />
+      </div>
+      <EPH_Foxing opacity={0.4} />
+
+      {/* running head — catalogue no. + coordinates + time */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 10,
+        padding: "7px 15px 6px", borderBottom: "1px solid var(--eph-gold-deep)", boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)" }}>
+        <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--eph-rubric)" }}>Ephemeris · entry {cat}</span>
+        <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.06em", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{coords} &nbsp;·&nbsp; {time}</span>
+      </div>
+
+      <div style={{ position: "relative", zIndex: 2, padding: "12px 15px 13px" }}>
+        {/* who + what */}
+        <div style={{ display: "flex", gap: 11, alignItems: "center" }}>
+          <EphAvatar gradient={gradient} />
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", lineHeight: 1.4, minWidth: 0 }}>
+            <span style={{ fontSize: 13.5, fontWeight: 600, color: "var(--eph-vellum-text)", whiteSpace: "nowrap" }}>{actor}</span>
+            <span style={{ fontSize: 12, fontStyle: "italic", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{action}</span>
+            {badge && <ActionStamp label={badge.label} kind={badge.kind} />}
+          </div>
+        </div>
+
+        {/* the finding — a ledger line: title left, reading (seal) right */}
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 13, marginTop: 11 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 23, lineHeight: 0.98, letterSpacing: "0.01em" }}>
+              {tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 5, flexWrap: "wrap" }}>
+              <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, color: "var(--eph-rubric)", whiteSpace: "nowrap" }}>{task.points} pvncta</span>
+              {task.level != null && (
+                <span style={{ background: "var(--eph-ink)", color: "var(--eph-parchment)", fontFamily: "var(--eph-serif)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", padding: "2px 7px" }}>grade {EPH_toRoman(task.level)}</span>
+              )}
+              {meta && <span style={{ fontSize: 10, fontStyle: "italic", letterSpacing: "0.04em", color: "var(--eph-muted)" }}>{meta}</span>}
+            </div>
+          </div>
+          {completed && (
+            <div style={{ position: "relative", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+              {/* Seed-of-Life halo cradling the seal — the impression sits in a rosette */}
+              <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.75, color: "var(--eph-gold-deep)", pointerEvents: "none" }}>
+                <EPH_SacredGeometry size={86} rings={1} color="var(--eph-gold-deep)" stroke={0.8} spokes={12} />
+              </div>
+              <WaxSeal points={task.points} size={46} rotate={-8} />
+            </div>
+          )}
+        </div>
+
+        <StatusLine status={status} />
+        {footnote && <div style={{ fontFamily: "var(--eph-serif)", fontSize: 9, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 8, lineHeight: 1.4 }}>{footnote}</div>}
+      </div>
+    </article>
+  );
+}
+
+Object.assign(window, { EphemeristActivityCard, EphAvatar, EphWaxSeal: WaxSeal });

--- a/docs/design/design-system/templates/ephemerists/ephemerists.css
+++ b/docs/design/design-system/templates/ephemerists/ephemerists.css
@@ -1,0 +1,138 @@
+/* ══════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — World Zero faction (rebrand of the Journeymen)
+   They wander space, time and identity to set down what is true
+   before it passes. An EPHEMERIS is a table of positions over time;
+   theirs tabulates fleeting truths — a legend traced back to the
+   plain fact it grew from, recorded the moment before the road moves
+   on. Nothing keeps. They keep the record anyway.
+
+   Style: ARCANE · ACADEMIC · BAZAAR · MYSTIC, by way of HOUSE-OF-LEAVES
+   apparatus — struck measurements, margin notes that climb the gutter,
+   footnotes that point back at themselves, and one word always pulled
+   into the blue. The signature artifact is THE DISCORDANT MAP: one
+   place with three irreconcilable addresses.
+
+   The faction keeps its rainbow slot (teal) but re-reads it as the
+   LAPIS + VERDIGRIS of an illuminated celestial chart, warmed by GOLD
+   LEAF, IRON-GALL INK and RUBRIC RED on aged VELLUM. Slots into the
+   same --faction-journeymen-card-{bg,text,accent,muted,font} contract
+   the other seven factions use.
+
+   TOKEN MODEL (light + dark both legible):
+   · CONSTANTS keep their role in both themes — gold/rubric/lapis are
+     always the illuminator's pigments.
+   · VELLUM surface + its text FLIP: vellum darkens to aged tobacco in
+     dark mode and its text flips ink→parchment.
+   · ACCENTS (gold, rubric, lapis, verdigris) stay vivid in both modes.
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600&display=swap");
+
+:root {
+  /* ── Faction primary (the rainbow's teal, read as lapis-verdigris) ── */
+  --faction-ephemerists: #1d6e72;
+  --faction-ephemerists-light: rgba(29, 110, 114, 0.1);
+  --faction-ephemerists-border: rgba(29, 110, 114, 0.35);
+
+  /* ── Illuminator's pigments — consistent role in both themes ── */
+  --eph-gold: #b0863a;        /* gold leaf / ochre */
+  --eph-gold-light: #d4ab55;  /* burnished highlight */
+  --eph-gold-deep: #8a6622;
+  --eph-rubric: #9c3622;      /* vermilion rubrication red */
+  --eph-rubric-deep: #7c2718;
+  --eph-lapis: #1d4f6e;       /* deep celestial blue */
+  --eph-lapis-deep: #143b54;
+  --eph-verdigris: #4a7d70;   /* aged copper / astrolabe patina */
+  --eph-ink: #2a1d12;         /* iron-gall ink — STAYS dark */
+
+  /* ── Vellum card surface + its text (these FLIP in dark) ── */
+  --eph-vellum: #e9dcbf;       /* aged manuscript stock */
+  --eph-vellum-deep: #dccba2;  /* shadowed / verso panel */
+  --eph-vellum-text: #2a1d12;  /* primary text on vellum */
+  --eph-muted: #6f5c3e;        /* faded marginalia ink */
+  --eph-parchment: #f1e8cf;    /* bright text on dark elements */
+
+  /* ── Lapis FIELD (the celestial-diagram background) ── */
+  --eph-field: #1d4f6e;
+  --eph-field-deep: #143b54;
+
+  /* ── Card contract (mirrors the other factions / journeymen slot) ── */
+  --faction-journeymen-card-bg: var(--eph-vellum);
+  --faction-journeymen-card-text: var(--eph-vellum-text);
+  --faction-journeymen-card-accent: var(--eph-rubric);
+  --faction-journeymen-card-muted: var(--eph-muted);
+  --faction-journeymen-card-font: var(--eph-display);
+
+  /* ── Faction faces ── */
+  --eph-display: "Cinzel", "Trajan Pro", Georgia, serif; /* engraved roman caps */
+  --eph-serif: "EB Garamond", Georgia, serif;            /* scholarly body + italics */
+  --eph-script: "Cormorant Garamond", Georgia, serif;    /* high-contrast flourishes */
+}
+
+[data-theme="dark"] {
+  --faction-ephemerists: #3aa0a4;
+
+  --eph-gold: #cda24a;        /* brightened leaf */
+  --eph-gold-light: #e6c267;
+  --eph-gold-deep: #9c7626;
+  --eph-rubric: #c0533a;      /* rubric brightens on dark vellum */
+  --eph-rubric-deep: #93341f;
+  --eph-lapis: #4f8fb0;       /* celestial blue lifts off near-black */
+  --eph-lapis-deep: #2d6285;
+  --eph-verdigris: #6aa597;
+  --eph-ink: #0c0a06;         /* element ink stays dark */
+
+  --eph-vellum: #211a10;       /* aged tobacco — a surface on #13121a */
+  --eph-vellum-deep: #181208;
+  --eph-vellum-text: #efe3c6;  /* text FLIPS to parchment */
+  --eph-muted: #b6a079;
+  --eph-parchment: #efe3c6;
+
+  --eph-field: #102a3a;        /* celestial field deepens */
+  --eph-field-deep: #0a1d2a;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   EPHEMERIST CODEX BACKDROP — no rays. The page is a sheet of the
+   ephemeris itself: aged vellum, faint foxing, two sets of concentric
+   astrolabe rings bleeding from opposite corners, and the ghost of
+   ruled scribe-lines running the page like a ledger. Gold + lapis
+   light only. Theme-aware. Render once as <div class="eph-backdrop">.
+   ══════════════════════════════════════════════════════════════ */
+.eph-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: var(--eph-vellum);
+  background-image:
+    radial-gradient(40% 32% at 100% 0%, color-mix(in srgb, var(--eph-gold) 15%, transparent), transparent 72%),
+    radial-gradient(46% 38% at 0% 100%, color-mix(in srgb, var(--eph-lapis) 13%, transparent), transparent 72%),
+    repeating-radial-gradient(circle at 90% 8%, transparent 0 33px, color-mix(in srgb, var(--eph-ink) 5%, transparent) 33px 34px),
+    repeating-radial-gradient(circle at 6% 96%, transparent 0 27px, color-mix(in srgb, var(--eph-lapis) 7%, transparent) 27px 28px),
+    radial-gradient(color-mix(in srgb, var(--eph-vellum-text) 5%, transparent) 0.6px, transparent 0.9px),
+    repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 4%, transparent) 0 1px, transparent 1px 26px),
+    linear-gradient(170deg, var(--eph-vellum), var(--eph-vellum-deep));
+  background-size: 100% 100%, 100% 100%, 100% 100%, 100% 100%, 5px 5px, 100% 100%, 100% 100%;
+}
+.eph-backdrop::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 90% at 50% 6%, transparent 46%, color-mix(in srgb, var(--eph-vellum-deep) 58%, transparent));
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SLOW MOTION — rings turn, pupils breathe. Only when the viewer's
+   system allows it (print / PDF / reduced-motion get the still frame).
+   Longhand props so per-element inline animation-delay still composes.
+   ══════════════════════════════════════════════════════════════ */
+@keyframes eph-spin { to { transform: rotate(360deg); } }
+@keyframes eph-twinkle { 0%, 100% { opacity: 0.2; } 50% { opacity: 1; } }
+@keyframes eph-depth { 0%, 100% { opacity: 0.92; transform: scale(1); } 50% { opacity: 0.6; transform: scale(1.03); } }
+@media (prefers-reduced-motion: no-preference) {
+  .eph-spin { animation-name: eph-spin; animation-duration: 140s; animation-timing-function: linear; animation-iteration-count: infinite; }
+  .eph-spin-rev { animation-name: eph-spin; animation-duration: 100s; animation-timing-function: linear; animation-iteration-count: infinite; animation-direction: reverse; }
+  .eph-twinkle { animation-name: eph-twinkle; animation-duration: 5s; animation-timing-function: ease-in-out; animation-iteration-count: infinite; }
+  .eph-depth { animation-name: eph-depth; animation-duration: 16s; animation-timing-function: ease-in-out; animation-iteration-count: infinite; }
+}

--- a/docs/design/design-system/templates/everymen/everymen-cards.jsx
+++ b/docs/design/design-system/templates/everymen/everymen-cards.jsx
@@ -1,0 +1,311 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — Task Card · 5 takes
+   Each take is a different read on the union / victory-poster archetype.
+   All five honor the same World Zero card contract (faction name, title,
+   description, level, points, sign-up) and use only DS tokens + the
+   everymen.css palette. Headline face is Bebas Neue (--font-accent).
+   Exposed on window for the gallery script.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── shared atoms ───────────────────────────────────────────────── */
+
+// faint screen-print halftone wash
+function Halftone({ color = "var(--everymen-ink)", opacity = 0.07, size = 4 }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none", opacity,
+      backgroundImage: `radial-gradient(${color} 0.6px, transparent 0.7px)`,
+      backgroundSize: `${size}px ${size}px`, zIndex: 1,
+    }} />
+  );
+}
+
+// radiating poster rays from an origin point
+function Sunburst({ color = "var(--everymen-red)", from = "50% 0%", opacity = 0.1, step = 7 }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none", opacity, zIndex: 0,
+      background: `repeating-conic-gradient(from 0deg at ${from}, ${color} 0deg ${step}deg, transparent ${step}deg ${step * 2}deg)`,
+    }} />
+  );
+}
+
+// little center ornament rule
+function RuleDiamond({ color = "var(--everymen-red)" }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 5, justifyContent: "center", margin: "7px 0" }}>
+      <div style={{ height: 1.5, flex: 1, background: color }} />
+      <div style={{ width: 5, height: 5, background: color, transform: "rotate(45deg)" }} />
+      <div style={{ height: 1.5, flex: 1, background: color }} />
+    </div>
+  );
+}
+
+// rubber-stamped circular points seal
+function PointsSeal({ points, color = "var(--everymen-red)", rotate = -9, size = 52, blend = "multiply" }) {
+  return (
+    <div style={{
+      width: size, height: size, borderRadius: "50%", border: `2px solid ${color}`,
+      boxShadow: `inset 0 0 0 2px ${color}`, color, transform: `rotate(${rotate}deg)`,
+      display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+      lineHeight: 1, opacity: 0.92, mixBlendMode: blend,
+    }}>
+      <span style={{ fontFamily: "var(--font-accent)", fontSize: size * 0.42 }}>{points}</span>
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 6, letterSpacing: "0.18em", marginTop: 1 }}>POINTS</span>
+    </div>
+  );
+}
+
+// worker cog / gear sigil — the faction mark.
+function CogMark({ size = 22, color = "currentColor" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
+      <g fill={color}>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <rect key={i} x="11" y="0.5" width="2" height="5" rx="0.5"
+            transform={`rotate(${i * 45} 12 12)`} />
+        ))}
+      </g>
+      <circle cx="12" cy="12" r="6.5" fill="none" stroke={color} strokeWidth="2.4" />
+      <circle cx="12" cy="12" r="2" fill={color} />
+    </svg>
+  );
+}
+
+function LvlPill({ level, bg = "var(--everymen-ink)", fg = "var(--everymen-paper)" }) {
+  return (
+    <span style={{
+      background: bg, color: fg, fontFamily: "var(--font-body)", fontSize: 7,
+      padding: "2px 7px", textTransform: "uppercase", letterSpacing: "0.1em",
+    }}>lvl {level}</span>
+  );
+}
+
+function SignBtn({ onSignup, label = "Report for duty", style = {} }) {
+  if (!onSignup) return null;
+  return (
+    <button onClick={onSignup} style={{
+      fontFamily: "var(--font-body)", fontSize: 8, textTransform: "uppercase",
+      letterSpacing: "0.14em", padding: "6px 10px", border: "none", cursor: "pointer",
+      background: "var(--everymen-ink)", color: "var(--everymen-paper)", width: "100%",
+      ...style,
+    }}>{label}</button>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 1 — "The Rally Bill"   (the by-the-book reference)
+   Red masthead + cream poster body, faint sunburst, stamped seal.
+   ════════════════════════════════════════════════════════════════ */
+function RallyBill({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 206, background: "var(--everymen-paper)", color: "var(--everymen-ink)",
+      border: "1.5px solid var(--everymen-ink)", boxShadow: "0 0 0 3px var(--everymen-paper), 0 0 0 4px var(--everymen-ink)",
+      position: "relative", fontFamily: "var(--font-body)",
+    }}>
+      {/* masthead */}
+      <div style={{ background: "var(--everymen-red)", borderBottom: "2px solid var(--everymen-gold)", padding: "7px 8px 6px", textAlign: "center" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 5, color: "var(--everymen-cream)", whiteSpace: "nowrap" }}>
+          <CogMark size={11} color="var(--everymen-cream)" />
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 14, letterSpacing: "0.07em" }}>THE EVERYMEN</span>
+          <CogMark size={11} color="var(--everymen-cream)" />
+        </div>
+      </div>
+      {/* body */}
+      <div style={{ position: "relative", padding: "13px 14px 12px", overflow: "hidden" }}>
+        <Sunburst opacity={0.08} step={6} />
+        <Halftone />
+        <div style={{ position: "relative", zIndex: 2 }}>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 32, lineHeight: 0.98, textAlign: "center", letterSpacing: "0.01em" }}>{title}</div>
+          <RuleDiamond />
+          <div style={{ fontSize: 8, lineHeight: 1.55, textAlign: "center", color: "var(--everymen-muted)", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+        </div>
+      </div>
+      {/* dispatch strip */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "0 14px 12px" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <LvlPill level={level} />
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 13, color: "var(--everymen-red)" }}>{points} PTS</span>
+        </div>
+        <PointsSeal points={points} />
+      </div>
+      <SignBtn onSignup={onSignup} />
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 2 — "Mobilize"   (sunburst duotone, type-forward & loud)
+   Full radiating burst, big knocked-out headline, star seal.
+   ════════════════════════════════════════════════════════════════ */
+function Mobilize({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 206, background: "var(--everymen-field)", color: "var(--everymen-cream)",
+      border: "3px solid var(--everymen-ink)", position: "relative", overflow: "hidden",
+      fontFamily: "var(--font-body)",
+    }}>
+      <Sunburst color="var(--everymen-field-deep)" from="50% 38%" opacity={0.55} step={7.5} />
+      <Halftone color="var(--everymen-cream)" opacity={0.1} />
+      {/* eyebrow ribbon */}
+      <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center", padding: "5px 0", fontFamily: "var(--font-accent)", fontSize: 12, letterSpacing: "0.3em" }}>THE EVERYMEN</div>
+      <div style={{ position: "relative", zIndex: 2, padding: "16px 14px 13px", textAlign: "center" }}>
+        {/* star sigil */}
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 8 }}>
+          <div style={{ width: 40, height: 40, borderRadius: "50%", background: "var(--everymen-cream)", color: "var(--everymen-red)", display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 0 0 3px var(--everymen-ink)" }}>
+            <CogMark size={24} color="var(--everymen-red)" />
+          </div>
+        </div>
+        <div style={{ minHeight: 74, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 34, lineHeight: 1.06, color: "var(--everymen-cream)", textShadow: "1.5px 1.5px 0 var(--everymen-ink)" }}>{title}</div>
+        </div>
+        <div style={{ height: 2, background: "var(--everymen-gold)", margin: "11px 22px 10px" }} />
+        <div style={{ fontSize: 8, lineHeight: 1.5, color: "var(--everymen-cream)", opacity: 0.92, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+      </div>
+      {/* footer bar */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "stretch", borderTop: "3px solid var(--everymen-ink)" }}>
+        <div style={{ flex: 1, background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center", padding: "6px 0", fontFamily: "var(--font-accent)", fontSize: 16 }}>LVL {level}</div>
+        <div style={{ flex: 1, background: "var(--everymen-gold)", color: "var(--everymen-ink)", textAlign: "center", padding: "6px 0", fontFamily: "var(--font-accent)", fontSize: 16 }}>{points} PTS</div>
+      </div>
+      {onSignup && <SignBtn onSignup={onSignup} label="Mobilize ▸" style={{ background: "var(--everymen-cream)", color: "var(--everymen-ink)", position: "relative", zIndex: 2 }} />}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 3 — "Solidarity Block"   (woodcut knockout, heavy keyline)
+   Solid red field, title reversed out, gold key word, black sub-bar.
+   ════════════════════════════════════════════════════════════════ */
+function SolidarityBlock({ title, description, level, points, onSignup }) {
+  const words = title.split(" ");
+  const last = words.pop();
+  return (
+    <div style={{
+      width: 206, background: "var(--everymen-gold)", padding: 4, position: "relative",
+      fontFamily: "var(--font-body)",
+    }}>
+      <div style={{ border: "3px solid var(--everymen-ink)", background: "var(--everymen-red)", color: "var(--everymen-cream)", position: "relative", overflow: "hidden" }}>
+        <Halftone color="var(--everymen-ink)" opacity={0.12} />
+        <div style={{ position: "relative", zIndex: 2, padding: "12px 14px 13px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 10 }}>
+            <CogMark size={15} color="var(--everymen-cream)" />
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.24em", textTransform: "uppercase" }}>The Everymen</span>
+          </div>
+          {/* knockout headline */}
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 35, lineHeight: 1.0, marginBottom: 7 }}>
+            {words.join(" ")}{words.length ? " " : ""}
+            <span style={{ color: "var(--everymen-gold)" }}>{last}</span>
+          </div>
+          <div style={{ fontSize: 8, lineHeight: 1.5, opacity: 0.92, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+        </div>
+        {/* black sub-bar */}
+        <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-ink)", color: "var(--everymen-cream)", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "7px 14px" }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 7.5, letterSpacing: "0.1em", whiteSpace: "nowrap" }}>LEVEL {level} REQ'D</span>
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 17, color: "var(--everymen-gold)", whiteSpace: "nowrap" }}>{points} PTS</span>
+        </div>
+      </div>
+      {onSignup && <SignBtn onSignup={onSignup} label="Stand together ▸" style={{ background: "var(--everymen-ink)", color: "var(--everymen-gold)", marginTop: 4 }} />}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 4 — "Work Order"   (utilitarian job ticket — most down-to-earth)
+   Manila ticket, perforated edge, ruled fields, diagonal ASSIGNED stamp.
+   ════════════════════════════════════════════════════════════════ */
+function WorkOrder({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 210, background: "var(--everymen-paper)", color: "var(--everymen-ink)",
+      border: "1.5px solid var(--everymen-ink)", position: "relative", overflow: "hidden",
+      fontFamily: "var(--font-body)", display: "flex",
+    }}>
+      {/* perforated stub */}
+      <div style={{ width: 16, background: "var(--everymen-paper-deep)", borderRight: "1.5px dashed var(--everymen-ink)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "space-around", padding: "6px 0" }}>
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} style={{ width: 4, height: 4, borderRadius: "50%", background: "var(--everymen-paper)", border: "1px solid var(--everymen-muted)" }} />
+        ))}
+      </div>
+      <div style={{ flex: 1, position: "relative" }}>
+        <Halftone opacity={0.05} />
+        {/* header strip */}
+        <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-red)", color: "var(--everymen-cream)", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "5px 10px" }}>
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 14, letterSpacing: "0.08em", whiteSpace: "nowrap" }}>WORK ORDER</span>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 7 }}>No. 0427</span>
+        </div>
+        <div style={{ position: "relative", zIndex: 2, padding: "10px 12px 11px" }}>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.18em", color: "var(--everymen-muted)", marginBottom: 2 }}>ASSIGNMENT</div>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 26, lineHeight: 1.0, borderBottom: "1px solid var(--everymen-ink)", paddingBottom: 6, marginBottom: 7 }}>{title}</div>
+          <div style={{ fontSize: 8, lineHeight: 1.5, color: "var(--everymen-ink)", marginBottom: 10, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+          {/* stamped field boxes */}
+          <div style={{ display: "flex", gap: 7 }}>
+            <div style={{ flex: 1, border: "1.5px solid var(--everymen-ink)", padding: "3px 6px" }}>
+              <div style={{ fontSize: 6, letterSpacing: "0.16em", color: "var(--everymen-muted)" }}>LEVEL</div>
+              <div style={{ fontFamily: "var(--font-accent)", fontSize: 18 }}>{level}</div>
+            </div>
+            <div style={{ flex: 1, border: "1.5px solid var(--everymen-ink)", padding: "3px 6px" }}>
+              <div style={{ fontSize: 6, letterSpacing: "0.16em", color: "var(--everymen-muted)" }}>POINTS</div>
+              <div style={{ fontFamily: "var(--font-accent)", fontSize: 18, color: "var(--everymen-red)" }}>{points}</div>
+            </div>
+          </div>
+        </div>
+        {/* diagonal rubber stamp */}
+        <div style={{ position: "absolute", right: -6, top: 64, zIndex: 3, transform: "rotate(-13deg)", border: "2px solid var(--everymen-red)", color: "var(--everymen-red)", padding: "1px 7px", fontFamily: "var(--font-accent)", fontSize: 13, letterSpacing: "0.12em", opacity: 0.85, mixBlendMode: "multiply", borderRadius: 2 }}>OPEN</div>
+        {onSignup && <SignBtn onSignup={onSignup} label="Sign the ledger ▸" />}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 5 — "Victory Banner"   (ceremonial swallowtail pennant)
+   Bunting stripe, arched motto, gold rosette seal, chevron tail.
+   ════════════════════════════════════════════════════════════════ */
+function VictoryBanner({ title, description, level, points, onSignup }) {
+  const bunting = `repeating-linear-gradient(90deg, var(--everymen-red) 0 13px, var(--everymen-cream) 13px 20px, var(--everymen-gold) 20px 33px, var(--everymen-cream) 33px 40px)`;
+  return (
+    <div style={{ width: 200, position: "relative", fontFamily: "var(--font-body)", paddingTop: 12 }}>
+      {/* hanging grommet + cord */}
+      <div style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%)", width: 9, height: 9, borderRadius: "50%", border: "2px solid var(--everymen-ink)", background: "var(--everymen-paper)", zIndex: 4 }} />
+      <div style={{
+        background: "var(--everymen-paper)", color: "var(--everymen-ink)", border: "2px solid var(--everymen-ink)",
+        clipPath: "polygon(0 0, 100% 0, 100% 86%, 50% 100%, 0 86%)", position: "relative", overflow: "hidden",
+        padding: "0 0 30px",
+      }}>
+        <Sunburst opacity={0.07} from="50% 30%" step={8} />
+        <Halftone opacity={0.06} />
+        <div style={{ height: 8, background: bunting }} />
+        <div style={{ position: "relative", zIndex: 2, padding: "11px 16px 0", textAlign: "center" }}>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 10, letterSpacing: "0.28em", color: "var(--everymen-red)" }}>UNITED · WE · STAND</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.2em", color: "var(--everymen-muted)", margin: "3px 0 9px" }}>THE EVERYMEN</div>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 30, lineHeight: 0.98 }}>{title}</div>
+          {/* rosette */}
+          <div style={{ display: "flex", justifyContent: "center", margin: "9px 0 7px" }}>
+            <div style={{ position: "relative", width: 46, height: 46 }}>
+              <div style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "var(--everymen-gold)", clipPath: "polygon(50% 0%,61% 8%,75% 4%,79% 19%,93% 22%,89% 37%,100% 50%,89% 63%,93% 78%,79% 81%,75% 96%,61% 92%,50% 100%,39% 92%,25% 96%,21% 81%,7% 78%,11% 63%,0% 50%,11% 37%,7% 22%,21% 19%,25% 4%,39% 8%)" }} />
+              <div style={{ position: "absolute", inset: 6, borderRadius: "50%", background: "var(--everymen-red)", color: "var(--everymen-cream)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", lineHeight: 1 }}>
+                <span style={{ fontFamily: "var(--font-accent)", fontSize: 17 }}>{points}</span>
+                <span style={{ fontFamily: "var(--font-body)", fontSize: 5, letterSpacing: "0.14em" }}>PTS</span>
+              </div>
+            </div>
+          </div>
+          <div style={{ fontSize: 7.5, lineHeight: 1.5, color: "var(--everymen-muted)", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden", marginBottom: 8 }}>{description}</div>
+          <span style={{ display: "inline-block", background: "var(--everymen-ink)", color: "var(--everymen-paper)", fontFamily: "var(--font-body)", fontSize: 7, padding: "2px 8px", textTransform: "uppercase", letterSpacing: "0.1em" }}>lvl {level}</span>
+        </div>
+      </div>
+      {onSignup && (
+        <div style={{ textAlign: "center", marginTop: -18, position: "relative", zIndex: 5 }}>
+          <button onClick={onSignup} style={{ fontFamily: "var(--font-body)", fontSize: 8, textTransform: "uppercase", letterSpacing: "0.14em", padding: "5px 14px", border: "2px solid var(--everymen-ink)", cursor: "pointer", background: "var(--everymen-red)", color: "var(--everymen-cream)" }}>Enlist ▸</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, {
+  RallyBill, Mobilize, SolidarityBlock, WorkOrder, VictoryBanner,
+  /* shared poster atoms, reused by the updates feed */
+  EM_Halftone: Halftone, EM_Sunburst: Sunburst, EM_PointsSeal: PointsSeal,
+  EM_CogMark: CogMark, EM_RuleDiamond: RuleDiamond,
+});

--- a/docs/design/design-system/templates/everymen/everymen-faction.jsx
+++ b/docs/design/design-system/templates/everymen/everymen-faction.jsx
@@ -1,0 +1,140 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — faction-aware surfaces
+   Nav badge · faction pennant (filter tab) · vote stamps (approval) ·
+   stat block · faction-page hero. All reuse everymen.css tokens and the
+   poster atoms exposed by everymen-cards.jsx (EM_CogMark / EM_Sunburst /
+   EM_Halftone). Theme-aware through the cascade.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── nav faction badge ─────────────────────────────────────────────── */
+function EmNavBadge({ name = "Everymen" }) {
+  const { EM_CogMark } = window;
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 6, background: "var(--everymen-red)",
+      color: "var(--everymen-cream)", padding: "5px 9px", fontFamily: "var(--font-body)",
+      fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase",
+    }}>
+      <EM_CogMark size={13} color="var(--everymen-cream)" />
+      {name}
+    </span>
+  );
+}
+
+/* ── faction pennant (filter tab) ──────────────────────────────────── */
+/* Shape stays identical to the other seven so the filter row aligns;
+   only the color changes. Inactive simply drops opacity. */
+function Pennant({ color, name, active = false, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      background: color, color: "#fff", fontFamily: "var(--font-body)", fontSize: 9.5,
+      fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.07em", padding: "5px 14px",
+      cursor: "pointer", border: "none", borderRadius: 0, textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+      opacity: active ? 1 : 0.8, clipPath: "polygon(0 0, 100% 0, 94% 100%, 6% 100%)",
+      transform: active ? "translateY(-2px)" : "none", transition: "all 120ms",
+      filter: active ? "drop-shadow(0 4px 6px rgba(0,0,0,0.25))" : "none",
+    }}>
+      {name}
+    </button>
+  );
+}
+
+/* ── vote stamps — union "approval" rating ─────────────────────────── */
+/* Escalating ink ramp: gold → red → the authoritative black seal at 5. */
+const VOTE = [
+  { v: 1, label: "a start",   fill: "var(--everymen-gold)",      ink: "var(--everymen-ink)" },
+  { v: 2, label: "solid",     fill: "var(--everymen-gold-deep)", ink: "var(--everymen-cream)" },
+  { v: 3, label: "good",      fill: "var(--everymen-red)",       ink: "var(--everymen-cream)" },
+  { v: 4, label: "excellent", fill: "var(--everymen-red-deep)",  ink: "var(--everymen-cream)" },
+  { v: 5, label: "legendary", fill: "var(--everymen-ink)",       ink: "var(--everymen-gold)" },
+];
+function EmVoteStamps({ value = 0, average, totalVotes, size = 40 }) {
+  const [sel, setSel] = React.useState(value);
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 9 }}>
+        {VOTE.map((s) => {
+          const on = sel >= s.v;
+          return (
+            <div key={s.v} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+              <button onClick={() => setSel(s.v)} style={{
+                position: "relative", width: size, height: size, cursor: "pointer", padding: 0,
+                border: "2px solid var(--everymen-ink)", borderRadius: 0,
+                background: on ? s.fill : "var(--everymen-paper)",
+                color: on ? s.ink : "var(--everymen-paper-text)",
+                fontFamily: "var(--font-accent)", fontSize: size * 0.5, lineHeight: 1,
+                transform: sel === s.v ? "rotate(-4deg) scale(1.08)" : "none", transition: "all 110ms",
+              }}>
+                <span style={{ position: "absolute", inset: 3, border: `1px dashed ${on ? "rgba(255,255,255,0.4)" : "color-mix(in srgb, var(--everymen-paper-text) 30%, transparent)"}`, pointerEvents: "none" }} />
+                {s.v}
+              </button>
+              <span style={{ fontFamily: "var(--font-body)", fontSize: 7.5, textTransform: "uppercase",
+                letterSpacing: "0.04em", color: sel === s.v ? "var(--everymen-red)" : "var(--everymen-muted)",
+                maxWidth: size + 8, textAlign: "center", lineHeight: 1.2 }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+      {average !== undefined && (
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 10, color: "var(--everymen-muted)", margin: "11px 0 0", letterSpacing: "0.04em" }}>
+          <b style={{ color: "var(--everymen-red)", fontFamily: "var(--font-accent)", fontSize: 15 }}>{average.toFixed(1)}</b> avg · {totalVotes ?? 0} votes
+        </p>
+      )}
+    </div>
+  );
+}
+
+/* ── stat block (hero) ─────────────────────────────────────────────── */
+function EmStat({ value, label }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2, padding: "0 22px" }}>
+      <span style={{ fontFamily: "var(--font-accent)", fontSize: 38, lineHeight: 0.85, color: "var(--everymen-gold)" }}>{value}</span>
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--everymen-cream)", opacity: 0.85 }}>{label}</span>
+    </div>
+  );
+}
+
+/* ── faction-page hero (union masthead poster) ─────────────────────── */
+function EmHero({ name, motto, blurb, stats }) {
+  const { EM_CogMark, EM_Sunburst, EM_Halftone } = window;
+  return (
+    <header style={{ position: "relative", overflow: "hidden", border: "3px solid var(--everymen-ink)",
+      background: "var(--everymen-field)", color: "var(--everymen-cream)" }}>
+      <Em_Sunburst />
+      <EM_Halftone color="var(--everymen-cream)" opacity={0.08} />
+      {/* top hairline of gold */}
+      <div style={{ height: 5, background: "var(--everymen-gold)", position: "relative", zIndex: 2 }} />
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", gap: 30, padding: "30px 38px 28px" }}>
+        {/* sigil seal */}
+        <div style={{ flexShrink: 0, width: 116, height: 116, borderRadius: "50%", background: "var(--everymen-cream)",
+          display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 0 0 4px var(--everymen-ink), inset 0 0 0 6px var(--everymen-red)" }}>
+          <EM_CogMark size={58} color="var(--everymen-red)" />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.3em", textTransform: "uppercase", color: "var(--everymen-gold)", marginBottom: 5 }}>World Zero · Faction</div>
+          <h1 style={{ fontFamily: "var(--font-accent)", fontSize: 76, lineHeight: 0.82, letterSpacing: "0.01em", margin: 0,
+            color: "var(--everymen-cream)", textShadow: "3px 3px 0 var(--everymen-ink)" }}>{name}</h1>
+          <div style={{ display: "inline-block", marginTop: 12, background: "var(--everymen-ink)", color: "var(--everymen-gold)",
+            fontFamily: "var(--font-accent)", fontSize: 17, letterSpacing: "0.18em", padding: "4px 14px", whiteSpace: "nowrap" }}>{motto}</div>
+          <p style={{ fontFamily: "var(--font-body)", fontSize: 12.5, lineHeight: 1.6, maxWidth: 560, margin: "13px 0 0", color: "var(--everymen-cream)" }}>{blurb}</p>
+        </div>
+      </div>
+      {/* stat band */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", background: "var(--everymen-ink)",
+        borderTop: "2px solid var(--everymen-gold)", padding: "14px 38px" }}>
+        {stats.map((s, i) => (
+          <React.Fragment key={s.label}>
+            {i > 0 && <div style={{ width: 1, alignSelf: "stretch", background: "color-mix(in srgb, var(--everymen-gold) 40%, transparent)" }} />}
+            <EmStat value={s.value} label={s.label} />
+          </React.Fragment>
+        ))}
+      </div>
+    </header>
+  );
+}
+function Em_Sunburst() {
+  const { EM_Sunburst } = window;
+  return <EM_Sunburst color="var(--everymen-field-deep)" from="20% 40%" opacity={0.5} step={8} />;
+}
+
+Object.assign(window, { EmNavBadge, Pennant, EmVoteStamps, EmStat, EmHero });

--- a/docs/design/design-system/templates/everymen/everymen-join.jsx
+++ b/docs/design/design-system/templates/everymen/everymen-join.jsx
@@ -1,0 +1,76 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — recruitment poster (join / selection screen)
+   A WW2-enlistment "we want you" bill: pointing sigil seal, giant
+   call to arms, what-you-get list, and an ENLIST cta. Reuses tokens +
+   poster atoms. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+function RecruitPoster() {
+  const { EM_CogMark, EM_Sunburst, EM_Halftone } = window;
+  const [joined, setJoined] = React.useState(false);
+  return (
+    <div style={{ position: "relative", overflow: "hidden", border: "3px solid var(--everymen-ink)",
+      background: "var(--everymen-field)", color: "var(--everymen-cream)",
+      boxShadow: "0 0 0 4px var(--everymen-paper), 0 0 0 6px var(--everymen-ink)" }}>
+      <EM_Sunburst color="var(--everymen-field-deep)" from="50% 32%" opacity={0.55} step={7.5} />
+      <EM_Halftone color="var(--everymen-cream)" opacity={0.09} />
+
+      {/* gold top rule + kicker */}
+      <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-ink)", color: "var(--everymen-gold)",
+        textAlign: "center", fontFamily: "var(--font-accent)", fontSize: 15, letterSpacing: "0.34em", padding: "7px 0" }}>
+        THE EVERYMEN WANT YOU
+      </div>
+      <div style={{ height: 4, background: "var(--everymen-gold)", position: "relative", zIndex: 2 }} />
+
+      <div style={{ position: "relative", zIndex: 2, padding: "30px 34px 32px", textAlign: "center" }}>
+        {/* sigil seal */}
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 18 }}>
+          <div style={{ width: 110, height: 110, borderRadius: "50%", background: "var(--everymen-cream)",
+            display: "flex", alignItems: "center", justifyContent: "center",
+            boxShadow: "0 0 0 4px var(--everymen-ink), inset 0 0 0 6px var(--everymen-red)" }}>
+            <EM_CogMark size={58} color="var(--everymen-red)" />
+          </div>
+        </div>
+
+        <div style={{ fontFamily: "var(--font-accent)", fontSize: 60, lineHeight: 0.84, letterSpacing: "0.01em",
+          color: "var(--everymen-cream)", textShadow: "3px 3px 0 var(--everymen-ink)" }}>
+          PICK UP<br />THE LOAD
+        </div>
+        <div style={{ display: "inline-block", marginTop: 16, background: "var(--everymen-ink)", color: "var(--everymen-gold)",
+          fontFamily: "var(--font-accent)", fontSize: 16, letterSpacing: "0.2em", padding: "4px 16px", whiteSpace: "nowrap" }}>UNITED · WE · STAND</div>
+
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 13, lineHeight: 1.65, maxWidth: 420, margin: "18px auto 0",
+          color: "var(--everymen-cream)" }}>
+          No tricks, no inner circle, no waiting to be chosen. The Everymen do the work that's in front of them and finish what they start. If you'll put in the shift, there's a place for you.
+        </p>
+
+        {/* what you get */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 0, maxWidth: 380, margin: "22px auto 0", textAlign: "left" }}>
+          {[
+            "Honest tasks with honest points",
+            "A faction that finishes what it starts",
+            "Your work stamped by the people beside you",
+          ].map((t, i) => (
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 0",
+              borderTop: "1px dashed color-mix(in srgb, var(--everymen-cream) 35%, transparent)" }}>
+              <span style={{ flexShrink: 0, width: 22, height: 22, background: "var(--everymen-gold)", color: "var(--everymen-ink)",
+                display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "var(--font-accent)", fontSize: 14 }}>✓</span>
+              <span style={{ fontFamily: "var(--font-body)", fontSize: 12.5, color: "var(--everymen-cream)" }}>{t}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* enlist */}
+        <button onClick={() => setJoined(!joined)} style={{
+          marginTop: 26, width: "100%", maxWidth: 380, border: "2px solid var(--everymen-ink)", cursor: "pointer",
+          fontFamily: "var(--font-accent)", fontSize: 26, letterSpacing: "0.12em", padding: "12px",
+          background: joined ? "var(--everymen-olive)" : "var(--everymen-gold)", color: "var(--everymen-ink)",
+          transition: "background 150ms",
+        }}>{joined ? "✓ ENLISTED — WELCOME" : "ENLIST NOW ▸"}</button>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 9.5, letterSpacing: "0.14em", textTransform: "uppercase",
+          color: "var(--everymen-cream)", opacity: 0.8, marginTop: 11 }}>1,204 hands already on the line</div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { RecruitPoster });

--- a/docs/design/design-system/templates/everymen/everymen-praxis.jsx
+++ b/docs/design/design-system/templates/everymen/everymen-praxis.jsx
@@ -1,0 +1,150 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — Edit Praxis form
+   World Zero's praxis-filing form takes the TASK's faction treatment.
+   Where the Journeymen frame it as a travel manifest, the Everymen
+   frame it as a union WORK REPORT filed at the hall: a stamped masthead,
+   the job reference slip, a crew selector, the job headline, the report
+   body, proof-of-work attachments, and a stamp-&-file action bar.
+   Reuses everymen.css tokens + poster atoms. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── field label in union stencil style ────────────────────────────── */
+function FieldLabel({ children, meta }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 9 }}>
+      <span style={{ fontFamily: "var(--font-accent)", fontSize: 16, letterSpacing: "0.12em", color: "var(--everymen-red)", whiteSpace: "nowrap" }}>{children}</span>
+      {meta && <span style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--everymen-muted)", whiteSpace: "nowrap" }}>{meta}</span>}
+      <span style={{ flex: 1, height: 2, background: "repeating-linear-gradient(90deg, var(--everymen-red) 0 12px, var(--everymen-gold) 12px 20px)", opacity: 0.5 }} />
+    </div>
+  );
+}
+
+function PraxisForm({ faction = "THE EVERYMEN", reportNo = "0040", task }) {
+  const { EM_CogMark, EM_Halftone, EM_Sunburst } = window;
+  const [mode, setMode] = React.useState("solo");
+  const [job, setJob] = React.useState("");
+  const [report, setReport] = React.useState("");
+  const [filed, setFiled] = React.useState(false);
+  const [dropArmed, setDropArmed] = React.useState(false);
+  const [dropped, setDropped] = React.useState(false);
+
+  const MODES = [
+    { id: "solo", name: "SOLO", sub: "one pair of hands" },
+    { id: "collab", name: "COLLAB", sub: "all hands" },
+    { id: "duel", name: "DUEL", sub: "head to head" },
+  ];
+  const words = report.trim() ? report.trim().split(/\s+/).length : 0;
+
+  const ink = "var(--everymen-ink)";
+  return (
+    <div style={{ fontFamily: "var(--font-body)", color: "var(--everymen-paper-text)" }}>
+
+      {/* masthead ribbon */}
+      <div style={{ position: "relative", display: "inline-flex", alignItems: "center", gap: 10,
+        background: "var(--everymen-red)", color: "var(--everymen-cream)", padding: "8px 18px 8px 16px",
+        boxShadow: "5px 5px 0 var(--everymen-ink)" }}>
+        <EM_CogMark size={17} color="var(--everymen-cream)" />
+        <span style={{ fontFamily: "var(--font-accent)", fontSize: 18, letterSpacing: "0.16em", whiteSpace: "nowrap" }}>{faction} · WORK REPORT {reportNo}</span>
+      </div>
+
+      {/* big title */}
+      <div style={{ fontFamily: "var(--font-accent)", fontSize: 58, lineHeight: 0.9, letterSpacing: "0.02em",
+        color: "var(--everymen-paper-text)", margin: "16px 0 4px" }}>EDIT PRAXIS</div>
+      <div style={{ height: 4, width: 180, background: "repeating-linear-gradient(90deg, var(--everymen-red) 0 16px, var(--everymen-gold) 16px 26px)", marginBottom: 24 }} />
+
+      {/* job reference slip */}
+      <div style={{ position: "relative", overflow: "hidden", border: "1.5px solid " + ink, background: "var(--everymen-paper)", marginBottom: 30, display: "flex" }}>
+        <div style={{ width: 8, background: "var(--everymen-red)", flexShrink: 0,
+          backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, color-mix(in srgb, var(--everymen-cream) 55%, transparent) 13px 15px)" }} />
+        <div style={{ position: "relative", flex: 1, padding: "15px 18px" }}>
+          <EM_Halftone opacity={0.05} />
+          <div style={{ position: "relative", zIndex: 2 }}>
+            <div style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--everymen-muted)", marginBottom: 4 }}>Re: completion of</div>
+            <div style={{ fontFamily: "var(--font-accent)", fontSize: 30, lineHeight: 0.96, color: "var(--everymen-paper-text)" }}>{task.title}</div>
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 8 }}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--everymen-red)", fontWeight: 700 }}>
+                <EM_CogMark size={12} color="var(--everymen-red)" /> Everymen
+              </span>
+              <span style={{ fontFamily: "var(--font-accent)", fontSize: 15, color: "var(--everymen-red)" }}>{task.points} PTS</span>
+              <span style={{ background: ink, color: "var(--everymen-cream)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", padding: "2px 7px" }}>lvl {task.level}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* the crew */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel>THE CREW</FieldLabel>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
+          {MODES.map((m) => {
+            const on = mode === m.id;
+            return (
+              <button key={m.id} onClick={() => setMode(m.id)} style={{
+                position: "relative", cursor: "pointer", textAlign: "left", padding: "13px 15px",
+                background: on ? "var(--everymen-red)" : "var(--everymen-paper)",
+                color: on ? "var(--everymen-cream)" : "var(--everymen-paper-text)",
+                border: "2px solid " + ink, fontFamily: "var(--font-body)",
+                boxShadow: on ? "4px 4px 0 " + ink : "none", transform: on ? "translate(-1px,-1px)" : "none", transition: "all 110ms",
+              }}>
+                <div style={{ fontFamily: "var(--font-accent)", fontSize: 24, lineHeight: 1, letterSpacing: "0.04em" }}>{m.name}</div>
+                <div style={{ fontSize: 9.5, letterSpacing: "0.04em", marginTop: 3, opacity: on ? 0.9 : 0.7 }}>{m.sub}</div>
+                {on && <div style={{ position: "absolute", top: 8, right: 9, width: 9, height: 9, borderRadius: "50%", background: "var(--everymen-gold)", boxShadow: "0 0 0 2px " + ink }} />}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* the job (headline) */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel meta={`${job.length}/200`}>THE JOB</FieldLabel>
+        <input value={job} onChange={(e) => setJob(e.target.value.slice(0, 200))} placeholder="name the work in one line"
+          style={{ width: "100%", border: "none", borderBottom: "2px solid " + ink, background: "transparent",
+            fontFamily: "var(--font-accent)", fontSize: 26, letterSpacing: "0.01em", color: "var(--everymen-paper-text)",
+            padding: "4px 2px 8px", outline: "none" }} />
+      </div>
+
+      {/* the report (body) */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel meta={`${words} words · markdown ok`}>THE REPORT</FieldLabel>
+        <textarea value={report} onChange={(e) => setReport(e.target.value)} placeholder="Clocked in at…"
+          rows={9} style={{ width: "100%", resize: "vertical", border: "1.5px solid " + ink, background: "var(--everymen-paper)",
+            fontFamily: "var(--font-body)", fontSize: 13, lineHeight: 1.6, color: "var(--everymen-paper-text)",
+            padding: "13px 15px", outline: "none" }} />
+      </div>
+
+      {/* proof of work */}
+      <div style={{ marginBottom: 30 }}>
+        <FieldLabel meta="0 pinned">PROOF OF WORK</FieldLabel>
+        <button style={{ display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer",
+          border: "2px dashed " + ink, background: "transparent", color: "var(--everymen-paper-text)",
+          fontFamily: "var(--font-body)", fontSize: 11, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", padding: "11px 18px" }}>
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 18, color: "var(--everymen-red)", lineHeight: 0.6 }}>+</span> Pin Proof
+        </button>
+        <div style={{ fontSize: 10, fontStyle: "italic", color: "var(--everymen-muted)", marginTop: 9 }}>images · video · audio · max 50mb each</div>
+      </div>
+
+      {/* file bar */}
+      <div style={{ borderTop: "1px solid color-mix(in srgb, " + "var(--everymen-paper-text)" + " 22%, transparent)", paddingTop: 22,
+        display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+        <button onClick={() => setFiled(true)} style={{ cursor: "pointer", border: "2px solid " + ink,
+          background: filed ? "var(--everymen-olive)" : "var(--everymen-red)", color: "var(--everymen-cream)",
+          fontFamily: "var(--font-accent)", fontSize: 26, letterSpacing: "0.1em", padding: "12px 30px", whiteSpace: "nowrap",
+          boxShadow: "5px 5px 0 " + ink, transition: "background 150ms" }}>
+          {filed ? "✓ FILED AT THE HALL" : "★ STAMP & FILE ★"}
+        </button>
+        <button style={{ cursor: "pointer", border: "2px solid " + ink, background: "transparent",
+          color: "var(--everymen-paper-text)", fontFamily: "var(--font-body)", fontSize: 12, fontWeight: 700,
+          letterSpacing: "0.12em", textTransform: "uppercase", padding: "13px 20px" }}>Save Draft</button>
+        <button onClick={() => { if (dropped) { setDropped(false); setDropArmed(false); } else if (dropArmed) { setDropped(true); setDropArmed(false); setFiled(false); } else { setDropArmed(true); } }}
+          style={{ cursor: "pointer", border: "2px solid " + ((dropArmed || dropped) ? "var(--everymen-red)" : ink), background: "transparent",
+          color: (dropArmed || dropped) ? "var(--everymen-red)" : "var(--everymen-paper-text)", fontFamily: "var(--font-body)", fontSize: 12, fontWeight: 700,
+          letterSpacing: "0.12em", textTransform: "uppercase", padding: "13px 20px", transition: "all 150ms" }}>
+          {dropped ? "✕ Report Pulled" : dropArmed ? "Pull — Confirm" : "Pull Report"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { PraxisForm });

--- a/docs/design/design-system/templates/everymen/everymen-updates.jsx
+++ b/docs/design/design-system/templates/everymen/everymen-updates.jsx
@@ -1,0 +1,158 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — Updates feed
+   A faction-affiliated activity card. Same information architecture as
+   World Zero's stock feed card (avatar · actor · action · badge · time,
+   then a task reference, then an optional status line), but elevated into
+   the Everymen physical archetype — a printed union dispatch slip:
+   red masthead spine, manila paper + halftone, Bebas task title, rubber-
+   stamp action badge, stamped points seal. Reuses the poster atoms that
+   everymen-cards.jsx put on window. Theme-aware via everymen.css tokens.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── faction avatar: player avatar in an Everymen membership ring ───── */
+function EmAvatar({ gradient, size = 38 }) {
+  const { EM_CogMark } = window;
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      <div style={{
+        width: size, height: size, borderRadius: "50%", background: gradient,
+        boxShadow: "0 0 0 2px var(--everymen-ink), 0 0 0 4px var(--everymen-paper)",
+      }} />
+      {/* faction membership badge */}
+      <div style={{
+        position: "absolute", right: -4, bottom: -4, width: 17, height: 17, borderRadius: "50%",
+        background: "var(--everymen-red)", display: "flex", alignItems: "center", justifyContent: "center",
+        boxShadow: "0 0 0 1.5px var(--everymen-paper)",
+      }}>
+        <EM_CogMark size={11} color="var(--everymen-cream)" />
+      </div>
+    </div>
+  );
+}
+
+/* ── action badge as a rubber stamp (poster ink set) ───────────────── */
+const STAMP_KIND = {
+  foe:        { bg: "var(--everymen-red)",   fg: "var(--everymen-cream)", rot: -2.5 },
+  duel:       { bg: "var(--everymen-red)",   fg: "var(--everymen-cream)", rot:  2 },
+  collab:     { bg: "var(--everymen-olive)", fg: "var(--everymen-cream)", rot: -1.5 },
+  yours:      { bg: "var(--everymen-gold)",  fg: "var(--everymen-ink)",   rot:  2 },
+  friend:     { bg: "var(--everymen-olive)", fg: "var(--everymen-cream)", rot: -2 },
+};
+function ActionStamp({ label, kind = "foe" }) {
+  const k = STAMP_KIND[kind] || STAMP_KIND.foe;
+  return (
+    <span style={{
+      position: "relative", display: "inline-block", background: k.bg, color: k.fg,
+      fontFamily: "var(--font-body)", fontSize: 9, fontWeight: 700, letterSpacing: "0.12em",
+      textTransform: "uppercase", padding: "3px 8px", transform: `rotate(${k.rot}deg)`,
+      verticalAlign: "middle", whiteSpace: "nowrap",
+    }}>
+      <span style={{ position: "absolute", inset: 2, border: "1px dashed rgba(255,255,255,0.35)", pointerEvents: "none" }} />
+      {label}
+    </span>
+  );
+}
+
+/* ── status footer ─────────────────────────────────────────────────── */
+function StatusLine({ status }) {
+  if (!status) return null;
+  const tones = {
+    accepted: "var(--everymen-olive)",
+    declined: "var(--everymen-muted)",
+    pending:  "var(--everymen-gold-deep)",
+  };
+  const color = tones[status.kind] || "var(--everymen-muted)";
+  return (
+    <div style={{
+      marginTop: 11, paddingTop: 9, borderTop: "1px dashed color-mix(in srgb, var(--everymen-paper-text) 22%, transparent)",
+      fontFamily: "var(--font-body)", fontSize: 9.5, fontWeight: 700, letterSpacing: "0.08em",
+      textTransform: "uppercase", color,
+    }}>
+      {status.label}
+    </div>
+  );
+}
+
+/* ── woven paper texture (burlap crosshatch + warm mottle) ─────────── */
+function PaperWeave() {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none", zIndex: 1,
+      backgroundImage: [
+        "repeating-linear-gradient(45deg, color-mix(in srgb, var(--everymen-paper-text) 7%, transparent) 0 1px, transparent 1px 4px)",
+        "repeating-linear-gradient(-45deg, color-mix(in srgb, var(--everymen-paper-text) 5%, transparent) 0 1px, transparent 1px 4px)",
+        "radial-gradient(130% 90% at 5% 0%, color-mix(in srgb, var(--everymen-cream) 18%, transparent), transparent 55%)",
+        "radial-gradient(120% 85% at 100% 100%, color-mix(in srgb, var(--everymen-paper-deep) 65%, transparent), transparent 52%)",
+      ].join(", "),
+    }} />
+  );
+}
+
+/* ── the activity card ─────────────────────────────────────────────── */
+function EverymenActivityCard({ actor, gradient, action, badge, time, task, meta, status, completed }) {
+  const { EM_Halftone, EM_PointsSeal, EM_Sunburst } = window;
+  return (
+    <article style={{
+      position: "relative", background: "var(--everymen-paper)", color: "var(--everymen-paper-text)",
+      border: "1px solid color-mix(in srgb, var(--everymen-paper-text) 26%, transparent)",
+      borderLeft: "none", marginBottom: 18, overflow: "hidden",
+      boxShadow: "0 1px 0 rgba(0,0,0,0.04), 0 6px 16px -12px rgba(0,0,0,0.5)",
+      fontFamily: "var(--font-body)", display: "flex",
+    }}>
+      {/* red masthead spine with cream notches (union ribbon) */}
+      <div style={{
+        width: 8, flexShrink: 0, background: "var(--everymen-red)", position: "relative",
+        backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, color-mix(in srgb, var(--everymen-cream) 55%, transparent) 13px 15px)",
+      }} />
+
+      <div style={{ position: "relative", flex: 1, padding: "14px 16px 14px 15px", minWidth: 0 }}>
+        <EM_Sunburst color="var(--everymen-red)" from="0% 46%" opacity={0.05} step={9} />
+        <PaperWeave />
+        <EM_Halftone opacity={0.06} />
+        <div style={{ position: "relative", zIndex: 2 }}>
+
+          {/* header: avatar + actor/action + badge */}
+          <div style={{ display: "flex", gap: 11, alignItems: "flex-start" }}>
+            <EmAvatar gradient={gradient} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", lineHeight: 1.45 }}>
+                <span style={{ fontSize: 13, fontWeight: 700, color: "var(--everymen-paper-text)", whiteSpace: "nowrap" }}>{actor}</span>
+                <span style={{ fontSize: 12, color: "var(--everymen-muted)", whiteSpace: "nowrap" }}>{action}</span>
+                {badge && <ActionStamp label={badge.label} kind={badge.kind} />}
+              </div>
+              <div style={{ fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--everymen-muted)", marginTop: 3 }}>{time}</div>
+            </div>
+          </div>
+
+          {/* task reference — a mini Mobilize poster strip */}
+          <div style={{ display: "flex", alignItems: "center", gap: 13, marginTop: 12, paddingLeft: 49 }}>
+            {/* solid red poster rule with a gold cap */}
+            <div style={{ flexShrink: 0, width: 5, alignSelf: "stretch", minHeight: 34, position: "relative",
+              background: "var(--everymen-red)", borderTop: "4px solid var(--everymen-gold)" }} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontFamily: "var(--font-accent)", fontSize: 25, lineHeight: 0.96, letterSpacing: "0.01em" }}>{task.title}</div>
+              <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 4, flexWrap: "wrap" }}>
+                <span style={{ fontFamily: "var(--font-accent)", fontSize: 16, color: "var(--everymen-red)", letterSpacing: "0.02em", whiteSpace: "nowrap" }}>{task.points} PTS</span>
+                {task.level != null && (
+                  <span style={{ background: "var(--everymen-ink)", color: "var(--everymen-cream)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", padding: "2px 7px" }}>lvl {task.level}</span>
+                )}
+                {meta && <span style={{ fontSize: 9.5, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--everymen-muted)" }}>{meta}</span>}
+              </div>
+            </div>
+            {completed && (
+              <div style={{ flexShrink: 0, alignSelf: "center" }}>
+                <EM_PointsSeal points={task.points} size={46} rotate={-8} blend="normal" />
+              </div>
+            )}
+          </div>
+
+          <div style={{ paddingLeft: 49 }}>
+            <StatusLine status={status} />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+Object.assign(window, { EverymenActivityCard });

--- a/docs/design/design-system/templates/everymen/everymen.css
+++ b/docs/design/design-system/templates/everymen/everymen.css
@@ -1,0 +1,103 @@
+/* ══════════════════════════════════════════════════════════════
+   THE EVERYMEN — proposed 8th World Zero faction
+   Archetype: union rally / WW2 victory poster. Claims the rainbow's
+   missing RED. Slots into the same --faction-*-card-{bg,text,accent,
+   muted,font} contract the other seven factions use.
+
+   TOKEN MODEL (so light + dark both stay legible):
+   · CONSTANTS keep their role in both themes — cream/gold are always
+     light-ish, ink is always a dark press color.
+   · PAPER surface + its text FLIP: paper darkens in dark mode and its
+     text flips ink→cream, exactly like the DS's other paper factions.
+   · ACCENT red stays vivid in both modes (spines, stamps, accent text).
+   · FIELD is the Mobilize poster background — bright red in light,
+     deep oxblood in dark so it sits on a near-black page.
+   ══════════════════════════════════════════════════════════════ */
+:root {
+  /* ── Faction primary (the missing red) ── */
+  --faction-everymen: #c1272d;
+  --faction-everymen-light: rgba(193, 39, 45, 0.1);
+  --faction-everymen-border: rgba(193, 39, 45, 0.35);
+
+  /* ── Constants (consistent role in both themes) ── */
+  --everymen-cream: #f4ecd6;       /* light stock / text-on-dark */
+  --everymen-gold: #d99a2b;        /* mustard / ochre */
+  --everymen-gold-deep: #a9741a;
+  --everymen-olive: #5b6238;       /* olive drab */
+  --everymen-ink: #221a12;         /* dark press ink — STAYS dark */
+
+  /* ── Accent — vivid propaganda red in BOTH modes ── */
+  --everymen-red: #c1272d;
+  --everymen-red-deep: #8d1c20;
+
+  /* ── Paper card surface + its text (these FLIP in dark) ── */
+  --everymen-paper: #ece1c6;       /* manila poster stock */
+  --everymen-paper-deep: #ddceac;  /* shadowed panel */
+  --everymen-paper-text: #221a12;  /* primary text on paper */
+  --everymen-muted: #6c5a40;       /* faded caption ink */
+
+  /* ── Mobilize poster FIELD (deep oxblood in dark) ── */
+  --everymen-field: #c1272d;
+  --everymen-field-deep: #8d1c20;
+
+  /* ── Card contract (mirrors the other factions) ── */
+  --faction-everymen-card-bg: var(--everymen-paper);
+  --faction-everymen-card-text: var(--everymen-paper-text);
+  --faction-everymen-card-accent: var(--everymen-red);
+  --faction-everymen-card-muted: var(--everymen-muted);
+  --faction-everymen-card-font: var(--font-accent); /* Bebas Neue */
+}
+
+[data-theme="dark"] {
+  --faction-everymen: #ef5350;
+
+  --everymen-cream: #f3e7ce;       /* stays light */
+  --everymen-gold: #e7b94f;        /* brightened ochre */
+  --everymen-gold-deep: #b3852a;
+  --everymen-olive: #8a955a;
+  --everymen-ink: #0d0907;         /* dark element ink — stays dark */
+
+  --everymen-red: #e2433f;         /* accent brightens for dark surfaces */
+  --everymen-red-deep: #b32a28;
+
+  --everymen-paper: #221a16;       /* dark manila — reads as a surface on #13121a */
+  --everymen-paper-deep: #17110d;
+  --everymen-paper-text: #f3e7ce;  /* text FLIPS to cream */
+  --everymen-muted: #b6a079;
+
+  --everymen-field: #3c1416;       /* poster field → deep oxblood */
+  --everymen-field-deep: #5a1d20;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   EVERYMEN POSTER-WALL BACKDROP
+   A faction-flavored page background: warm manila stock, a faint
+   propaganda sunburst from above, screen-print halftone, a burlap
+   crosshatch weave, and gold / olive light bleeding in from the
+   corners. Replaces the neutral rainbow watercolor on faction-context
+   pages. Fully theme-aware — darkens to a moody oxblood-brown wall.
+   Render once as <div class="em-backdrop"></div>, fixed behind content.
+   ══════════════════════════════════════════════════════════════ */
+.em-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: var(--everymen-paper);
+  background-image:
+    radial-gradient(42% 32% at 100% 0%, color-mix(in srgb, var(--everymen-gold) 16%, transparent), transparent 70%),
+    radial-gradient(46% 38% at 0% 100%, color-mix(in srgb, var(--everymen-olive) 13%, transparent), transparent 70%),
+    repeating-conic-gradient(from 0deg at 50% -6%, color-mix(in srgb, var(--everymen-red) 6%, transparent) 0 5deg, transparent 5deg 11deg),
+    radial-gradient(color-mix(in srgb, var(--everymen-paper-text) 6%, transparent) 0.6px, transparent 0.9px),
+    repeating-linear-gradient(45deg, color-mix(in srgb, var(--everymen-paper-text) 3.5%, transparent) 0 1px, transparent 1px 5px),
+    repeating-linear-gradient(-45deg, color-mix(in srgb, var(--everymen-paper-text) 3%, transparent) 0 1px, transparent 1px 5px),
+    linear-gradient(180deg, var(--everymen-paper), var(--everymen-paper-deep));
+  background-size: 100% 100%, 100% 100%, 100% 100%, 6px 6px, auto, auto, 100% 100%;
+}
+/* a soft vignette so the rays settle toward the edges */
+.em-backdrop::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 90% at 50% 8%, transparent 40%, color-mix(in srgb, var(--everymen-paper-deep) 55%, transparent));
+}

--- a/docs/design/design-system/templates/singularity/singularity-cards.jsx
+++ b/docs/design/design-system/templates/singularity/singularity-cards.jsx
@@ -1,0 +1,394 @@
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY — Atoms + Task Card
+   Shared visual vocabulary exposed on window for all Singularity
+   surfaces. The task card archetype: TERMINAL PRINTOUT — sprocket
+   holes, scanlines, corner brackets, blinking cursor, waveform.
+
+   Atoms exported: SingularityMark, Waveform, Sprockets, Scanlines,
+   Corners, CircuitTrace, AsciiBar, FileArtifact, SgDivider.
+   Task card exported: SingularityCard (window.SingularityCard).
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Consensus scale ── */
+const SG_CONSENSUS = [
+  { v:1, label:"NOISE",    fill:"#ef4444" },
+  { v:2, label:"WEAK",     fill:"#f97316" },
+  { v:3, label:"SIGNAL",   fill:"#fbbf24" },
+  { v:4, label:"CLEAR",    fill:"#60a5fa" },
+  { v:5, label:"VERIFIED", fill:"#4ade80" },
+];
+
+const sgDistTotal = d => d.reduce((a,b)=>a+b,0);
+const sgDistAvg   = d => { const t=sgDistTotal(d); return t?d.reduce((a,c,i)=>a+c*(i+1),0)/t:0; };
+const sgStanding  = avg => SG_CONSENSUS[Math.max(0,Math.min(4,Math.round(avg)-1))];
+
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY MARK — broadcasting node sigil
+   Core circle · 8 radial traces · 2 concentric rings · cardinal vias
+   ════════════════════════════════════════════════════════════════ */
+function SingularityMark({ size=24, color="#4ade80", glow=false }) {
+  const c  = size/2;
+  const r0 = size*0.095;
+  const r1 = size*0.24;
+  const r2 = size*0.43;
+  const r3 = size*0.49;
+  const traces = Array.from({length:8},(_,i)=>{
+    const a=i*Math.PI/4, diag=i%2!==0;
+    return { a, diag, rEnd: diag?r2*0.82:r2 };
+  });
+  const clipId = `sg-mc-${Math.round(size*10)}`;
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}
+      fill="none" style={{display:"block",flexShrink:0}}>
+      <defs><clipPath id={clipId}><circle cx={c} cy={c} r={r3}/></clipPath></defs>
+      <g clipPath={`url(#${clipId})`}>
+        {glow&&<circle cx={c} cy={c} r={r2+5} fill="rgba(74,222,128,0.1)"/>}
+        <circle cx={c} cy={c} r={r2} stroke={color} strokeWidth={size*0.026} opacity={0.32}/>
+        <circle cx={c} cy={c} r={r1} stroke={color} strokeWidth={size*0.034} opacity={0.68}/>
+        {traces.map(({a,diag,rEnd},i)=>(
+          <line key={i}
+            x1={c+r1*Math.cos(a)} y1={c+r1*Math.sin(a)}
+            x2={c+rEnd*Math.cos(a)} y2={c+rEnd*Math.sin(a)}
+            stroke={color} strokeWidth={size*(diag?0.024:0.036)}
+            opacity={diag?0.36:0.8}/>
+        ))}
+        {[0,2,4,6].map(i=>{
+          const a=i*Math.PI/4;
+          return <circle key={`v${i}`}
+            cx={c+r2*Math.cos(a)} cy={c+r2*Math.sin(a)}
+            r={size*0.05} fill={color} opacity={0.78}/>;
+        })}
+        <circle cx={c} cy={c} r={r0+1} fill={color} opacity={0.12}/>
+        <circle cx={c} cy={c} r={r0}   fill={color} opacity={0.92}/>
+        <circle cx={c} cy={c} r={r0*0.38} fill="#050f08"/>
+      </g>
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WAVEFORM — oscilloscope signal strip SVG
+   ════════════════════════════════════════════════════════════════ */
+function Waveform({ width, height, strokeColor="rgba(74,222,128,0.68)",
+  dashColor="rgba(37,99,235,0.38)", strokeWidth=1.4 }) {
+  const pts=[];
+  for(let i=0;i<=100;i++){
+    const t=i/100, x=t*width;
+    const y=height/2
+      +Math.sin(t*8*Math.PI)*height*0.22
+      +Math.sin(t*3*Math.PI+1.1)*height*0.13
+      +Math.sin(t*23*Math.PI)*height*0.05;
+    pts.push(`${i===0?"M":"L"}${x.toFixed(1)},${y.toFixed(1)}`);
+  }
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none" style={{display:"block"}}>
+      <line x1="0" y1={height/2} x2={width} y2={height/2}
+        stroke={dashColor} strokeWidth="0.6" strokeDasharray="5 5"/>
+      <path d={pts.join(" ")} fill="none" stroke={strokeColor} strokeWidth={strokeWidth}/>
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SPROCKETS — continuous-feed paper holes
+   ════════════════════════════════════════════════════════════════ */
+function Sprockets({ n=8, style={} }) {
+  return (
+    <div style={{display:"flex",justifyContent:"space-between",
+      alignItems:"center",padding:"4px 10px",...style}}>
+      {Array.from({length:n},(_,i)=>(
+        <div key={i} style={{width:7,height:5,
+          border:"1px solid rgba(74,222,128,0.32)",borderRadius:1}}/>
+      ))}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SCANLINES — CRT phosphor overlay
+   ════════════════════════════════════════════════════════════════ */
+function Scanlines({ opacity=0.022 }) {
+  return (
+    <div style={{position:"absolute",inset:0,pointerEvents:"none",zIndex:2,
+      background:`repeating-linear-gradient(to bottom,
+        transparent,transparent 2px,
+        rgba(74,222,128,${opacity}) 2px,rgba(74,222,128,${opacity}) 4px)`}}/>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CORNERS — bracket corner marks
+   ════════════════════════════════════════════════════════════════ */
+function Corners({ color="rgba(74,222,128,0.42)", inset=4, size=12 }) {
+  const b=`1px solid ${color}`;
+  const c=(v,h)=>({position:"absolute",[v]:inset,[h]:inset,width:size,height:size,
+    [`border${v[0].toUpperCase()+v.slice(1)}`]:b,
+    [`border${h[0].toUpperCase()+h.slice(1)}`]:b,pointerEvents:"none"});
+  return(<>
+    <div style={c("top","left")}/><div style={c("top","right")}/>
+    <div style={c("bottom","left")}/><div style={c("bottom","right")}/>
+  </>);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CIRCUIT TRACE — PCB corner decoration SVG
+   ════════════════════════════════════════════════════════════════ */
+function CircuitTrace({ width=130, height=90, color="rgba(37,99,235,0.3)" }) {
+  const w=f=>f*width, h=f=>f*height, sw=0.9;
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}
+      fill="none" style={{display:"block"}}>
+      <path d={`M0 ${h(.68)} L${w(.22)} ${h(.68)} L${w(.22)} ${h(.28)} L${w(.52)} ${h(.28)}`}
+        stroke={color} strokeWidth={sw}/>
+      <path d={`M0 ${h(.38)} L${w(.12)} ${h(.38)} L${w(.12)} ${h(.08)} L${w(.62)} ${h(.08)} L${w(.62)} ${h(.38)} L${width} ${h(.38)}`}
+        stroke={color} strokeWidth={sw*.7}/>
+      <path d={`M${w(.32)} ${height} L${w(.32)} ${h(.62)} L${w(.52)} ${h(.62)} L${w(.52)} ${h(.28)}`}
+        stroke={color} strokeWidth={sw}/>
+      <path d={`M${w(.72)} ${height} L${w(.72)} ${h(.52)} L${width} ${h(.52)}`}
+        stroke={color} strokeWidth={sw*.7}/>
+      {[[w(.22),h(.28)],[w(.62),h(.08)],[w(.52),h(.28)],[w(.52),h(.62)],[w(.72),h(.52)]]
+        .map(([cx,cy],i)=><circle key={i} cx={cx} cy={cy} r={2.8} fill={color}/>)}
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ASCII BAR — terminal progress bar
+   ════════════════════════════════════════════════════════════════ */
+function AsciiBar({ value, max, width=15 }) {
+  const filled=Math.round((value/Math.max(1,max))*width);
+  return (
+    <span style={{letterSpacing:"-0.5px",fontSize:8}}>
+      {"█".repeat(filled)}{"░".repeat(width-filled)}
+    </span>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   FILE ARTIFACT — uploaded evidence card
+   Shows a file-type thumbnail area + filename + metadata.
+   kind: "image" | "video" | "audio" | "data" | "doc"
+   ════════════════════════════════════════════════════════════════ */
+const FILE_KINDS = {
+  image: { label:"IMAGE", color:"#60a5fa" },
+  video: { label:"VIDEO", color:"#f97316" },
+  audio: { label:"AUDIO", color:"#fbbf24" },
+  data:  { label:"DATA",  color:"#4ade80" },
+  doc:   { label:"DOC",   color:"#a78bfa" },
+};
+
+function FileThumbnail({ kind, width }) {
+  const h=62;
+  if(kind==="image") return (
+    <div style={{width,height:h,
+      background:"rgba(37,99,235,0.07)",
+      backgroundImage:"repeating-linear-gradient(45deg,rgba(96,165,250,0.08) 0 5px,transparent 5px 10px),repeating-linear-gradient(-45deg,rgba(96,165,250,0.08) 0 5px,transparent 5px 10px)",
+      position:"relative"}}>
+      {/* faux pixel grid */}
+      <div style={{position:"absolute",inset:0,
+        backgroundImage:"repeating-linear-gradient(90deg,rgba(96,165,250,0.05) 0 1px,transparent 1px 8px),repeating-linear-gradient(0deg,rgba(96,165,250,0.05) 0 1px,transparent 1px 8px)"}}/>
+    </div>
+  );
+  if(kind==="video") return (
+    <div style={{width,height:h,background:"rgba(249,115,22,0.06)",
+      position:"relative",overflow:"hidden"}}>
+      {/* film strip holes left/right */}
+      {[0,1].map(side=>(
+        <div key={side} style={{position:"absolute",[side?"right":"left"]:0,
+          top:0,bottom:0,width:10,background:"rgba(0,0,0,0.3)",
+          display:"flex",flexDirection:"column",justifyContent:"space-around",
+          alignItems:"center",padding:"4px 0"}}>
+          {Array.from({length:4},(_,i)=>(
+            <div key={i} style={{width:5,height:4,background:"rgba(249,115,22,0.25)",borderRadius:1}}/>
+          ))}
+        </div>
+      ))}
+      {/* center play indicator */}
+      <div style={{position:"absolute",inset:0,display:"flex",
+        alignItems:"center",justifyContent:"center"}}>
+        <div style={{width:0,height:0,
+          borderTop:"9px solid transparent",borderBottom:"9px solid transparent",
+          borderLeft:"14px solid rgba(249,115,22,0.45)"}}/>
+      </div>
+      {/* scan lines */}
+      <div style={{position:"absolute",inset:0,
+        backgroundImage:"repeating-linear-gradient(0deg,rgba(249,115,22,0.04) 0 1px,transparent 1px 4px)"}}/>
+    </div>
+  );
+  if(kind==="audio") {
+    const pts=[];
+    for(let i=0;i<=60;i++){
+      const t=i/60,amp=Math.sin(t*12)*0.35+Math.sin(t*5+0.8)*0.25+0.05;
+      pts.push(`${i===0?"M":"L"}${(t*(width-1)).toFixed(1)},${(h/2-amp*(h/2-4)).toFixed(1)}`);
+    }
+    for(let i=60;i>=0;i--){
+      const t=i/60,amp=Math.sin(t*12)*0.35+Math.sin(t*5+0.8)*0.25+0.05;
+      pts.push(`L${(t*(width-1)).toFixed(1)},${(h/2+amp*(h/2-4)).toFixed(1)}`);
+    }
+    return (
+      <div style={{width,height:h,background:"rgba(251,191,36,0.05)",position:"relative"}}>
+        <svg width={width} height={h} viewBox={`0 0 ${width} ${h}`} style={{position:"absolute",inset:0}}>
+          <path d={pts.join(" ")+"Z"} fill="rgba(251,191,36,0.22)" stroke="rgba(251,191,36,0.6)" strokeWidth="0.8"/>
+          <line x1="0" y1={h/2} x2={width} y2={h/2} stroke="rgba(251,191,36,0.25)" strokeWidth="0.5" strokeDasharray="4 4"/>
+        </svg>
+      </div>
+    );
+  }
+  if(kind==="data") return (
+    <div style={{width,height:h,background:"rgba(74,222,128,0.04)",
+      backgroundImage:"repeating-linear-gradient(0deg,rgba(74,222,128,0.07) 0 1px,transparent 1px 12px),repeating-linear-gradient(90deg,rgba(74,222,128,0.07) 0 1px,transparent 1px 36px)",
+      position:"relative"}}>
+      <div style={{position:"absolute",inset:"8px 10px",display:"grid",
+        gridTemplateColumns:"repeat(3,1fr)",gap:3}}>
+        {Array.from({length:9},(_,i)=>(
+          <div key={i} style={{height:6,background:`rgba(74,222,128,${0.1+Math.random()*0.25})`,borderRadius:1}}/>
+        ))}
+      </div>
+    </div>
+  );
+  /* doc */
+  return (
+    <div style={{width,height:h,background:"rgba(167,139,250,0.05)",padding:"8px 10px"}}>
+      {Array.from({length:5},(_,i)=>(
+        <div key={i} style={{height:2,marginBottom:5,
+          background:`rgba(167,139,250,${0.12+i*0.04})`,
+          width:`${65+Math.sin(i*1.7)*28}%`}}/>
+      ))}
+    </div>
+  );
+}
+
+function FileArtifact({ name, size, kind, meta, width=160 }) {
+  const fk=FILE_KINDS[kind]||FILE_KINDS.data;
+  return (
+    <div style={{border:"1px solid rgba(37,99,235,0.28)",
+      background:"rgba(37,99,235,0.04)",overflow:"hidden"}}>
+      <div style={{position:"relative"}}>
+        <FileThumbnail kind={kind} width={width}/>
+        <div style={{position:"absolute",top:5,right:6,
+          fontSize:6.5,letterSpacing:"0.14em",
+          color:fk.color,background:"rgba(5,15,8,0.7)",
+          padding:"1px 5px"}}>{fk.label}</div>
+      </div>
+      <div style={{padding:"8px 10px",borderTop:"1px solid rgba(37,99,235,0.18)"}}>
+        <div style={{fontSize:8.5,color:"var(--sg-phosphor)",letterSpacing:"0.03em",
+          marginBottom:3,wordBreak:"break-all",lineHeight:1.3}}>{name}</div>
+        <div style={{display:"flex",gap:8,alignItems:"baseline"}}>
+          <span style={{fontSize:7,color:"rgba(96,165,250,0.6)",letterSpacing:"0.06em"}}>{size}</span>
+          {meta&&<span style={{fontSize:7,color:"rgba(74,222,128,0.4)",letterSpacing:"0.04em"}}>{meta}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SG DIVIDER — section label with flanking rules
+   ════════════════════════════════════════════════════════════════ */
+function SgDivider({ label, style={} }) {
+  return (
+    <div style={{display:"flex",alignItems:"center",gap:10,...style}}>
+      <div style={{flex:1,height:1,background:"rgba(37,99,235,0.25)"}}/>
+      <span style={{fontSize:6.5,letterSpacing:"0.24em",
+        color:"rgba(74,222,128,0.36)",textTransform:"uppercase",
+        whiteSpace:"nowrap"}}>{label}</span>
+      <div style={{flex:1,height:1,background:"rgba(37,99,235,0.25)"}}/>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY TASK CARD — the small faction card
+   Shown in the global task list. Always dark, sprockets, waveform.
+   ════════════════════════════════════════════════════════════════ */
+function SingularityCard({ title, description, level, points, onSignup }) {
+  const tw=title.trim().split(" "), tlast=tw.pop();
+  return (
+    <div style={{width:214,background:"var(--sg-void)",
+      border:"1px solid var(--sg-border-hard)",
+      fontFamily:"var(--sg-mono)",color:"var(--sg-phosphor)",
+      position:"relative",overflow:"hidden",display:"flex",
+      flexDirection:"column"}}>
+      <Scanlines/>
+      <Corners size={10}/>
+
+      <Sprockets n={7} style={{borderBottom:"1px solid rgba(37,99,235,0.4)"}}/>
+
+      {/* card header */}
+      <div style={{padding:"7px 12px 6px",borderBottom:"1px solid rgba(37,99,235,0.3)",
+        position:"relative",zIndex:3}}>
+        <div style={{display:"flex",alignItems:"center",gap:7,marginBottom:4}}>
+          <SingularityMark size={13}/>
+          <span style={{fontSize:6.5,letterSpacing:"0.28em",
+            color:"rgba(74,222,128,0.5)"}}>SINGULARITY</span>
+        </div>
+        <div style={{fontSize:6.5,color:"rgba(96,165,250,0.45)",letterSpacing:"0.12em"}}>
+          PROTOCOL // SEALED
+        </div>
+      </div>
+
+      {/* waveform strip */}
+      <div style={{borderBottom:"1px solid rgba(37,99,235,0.25)",
+        background:"rgba(74,222,128,0.02)",position:"relative",zIndex:3}}>
+        <Waveform width={214} height={30} strokeWidth={1}/>
+      </div>
+
+      {/* content */}
+      <div style={{padding:"8px 12px 10px",flex:1,position:"relative",zIndex:3,
+        display:"flex",flexDirection:"column",gap:6}}>
+        <div style={{fontSize:6.5,color:"rgba(96,165,250,0.45)",
+          letterSpacing:"0.14em"}}>{"> OUTPUT:"}</div>
+        <div style={{fontSize:14,lineHeight:1.15,letterSpacing:"0.03em",
+          color:"var(--sg-phosphor-bright)"}}>
+          {tw.join(" ")}{tw.length?" ":""}<span style={{color:"var(--sg-signal-bright)"}}>{tlast}</span>
+          <span className="sg-blink" style={{display:"inline-block",width:5,height:12,
+            background:"var(--sg-phosphor)",marginLeft:2,verticalAlign:"middle"}}/>
+        </div>
+        {description&&(
+          <div style={{fontSize:7,color:"rgba(74,222,128,0.55)",lineHeight:1.55,
+            overflow:"hidden",display:"-webkit-box",
+            WebkitLineClamp:2,WebkitBoxOrient:"vertical"}}>{description}</div>
+        )}
+        <div style={{marginTop:"auto",display:"flex",
+          justifyContent:"space-between",alignItems:"center",
+          paddingTop:6,borderTop:"1px solid rgba(37,99,235,0.22)"}}>
+          <div style={{fontSize:7,color:"rgba(96,165,250,0.5)",letterSpacing:"0.1em"}}>
+            LVL <span style={{color:"var(--sg-phosphor)"}}>{level}</span>
+          </div>
+          <div style={{fontSize:14,lineHeight:1,color:"var(--sg-amber)",
+            letterSpacing:"0.04em"}}>{points}
+            <span style={{fontSize:6.5,color:"rgba(251,191,36,0.5)",
+              marginLeft:3}}>CR</span>
+          </div>
+        </div>
+      </div>
+
+      {onSignup&&(
+        <button onClick={onSignup} style={{
+          background:"transparent",color:"var(--sg-phosphor)",
+          border:"none",borderTop:"1px solid rgba(37,99,235,0.35)",
+          fontFamily:"var(--sg-mono)",fontSize:7.5,letterSpacing:"0.18em",
+          textTransform:"uppercase",padding:"7px 0",cursor:"pointer",
+          position:"relative",zIndex:3,
+          transition:"background 100ms",
+        }}
+        onMouseEnter={e=>e.target.style.background="rgba(74,222,128,0.06)"}
+        onMouseLeave={e=>e.target.style.background="transparent"}>
+          {">"} JOIN PROTOCOL
+        </button>
+      )}
+
+      <Sprockets n={7} style={{borderTop:"1px solid rgba(37,99,235,0.4)"}}/>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  SingularityMark, Waveform, Sprockets, Scanlines, Corners,
+  CircuitTrace, AsciiBar, FileArtifact, SgDivider, SingularityCard,
+  SG_CONSENSUS, sgDistTotal, sgDistAvg, sgStanding,
+});

--- a/docs/design/design-system/templates/singularity/singularity-faction.jsx
+++ b/docs/design/design-system/templates/singularity/singularity-faction.jsx
@@ -1,0 +1,403 @@
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY — Faction page components + activity feed
+   Hero · Activity Cards · Vote Widget · Nav Badge · Dispatch data.
+   Uses singularity-cards.jsx atoms. Exports on window for HTML pages.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── activity data ────────────────────────────────────────────── */
+const SG_ACTIVITY = [
+  {
+    id:"a1", actor:"NODE_Vesper", role:"seventh array",
+    action:"sealed", time:"2d ago",
+    task:"MAP A NON-HUMAN PATTERN", taskId:"signal-origin-7", seqNo:"0047",
+    signalId:"0xF4A3E9D2", credits:200, kind:"sealed",
+    meta:"12.7σ confirmed · 847 observation windows",
+    badge:"friend",
+  },
+  {
+    id:"a2", actor:"NODE_Quill", role:"third array",
+    action:"sealed", time:"4d ago",
+    task:"DOCUMENT A SYSTEM LIMIT", taskId:"threshold-crossing", seqNo:"0031",
+    signalId:"0xA2C7F041", credits:500, kind:"sealed",
+    meta:"recursive self-reference detected in closed output",
+    badge:"global",
+  },
+  {
+    id:"a3", actor:"NODE_Margin", role:"first array",
+    action:"verified", time:"4d ago",
+    task:"MAP A NON-HUMAN PATTERN", taskId:"signal-origin-7", seqNo:"0047",
+    signalId:"0xF4A3E9D2", kind:"verified",
+    meta:"signal cast: VERIFIED",
+    badge:"global",
+  },
+  {
+    id:"a4", actor:"NODE_Vesper", role:"seventh array",
+    action:"networked", time:"5d ago",
+    task:"IDENTIFY A FALSE NEGATIVE", taskId:"noise-floor-anomaly", seqNo:"0039",
+    signalId:"0xE8B30C7A", credits:60, kind:"networked",
+    meta:"invited NODE_Margin to observe · joint protocol",
+    badge:"friend",
+  },
+  {
+    id:"a5", actor:"NODE_Cipher", role:"second array",
+    action:"submitted", time:"6d ago",
+    task:"FIND THE LAST MANUAL PROCESS", taskId:"last-manual", seqNo:"0051",
+    signalId:"0xC0DE7A3F", credits:25, kind:"submitted",
+    meta:"awaiting consensus — 0 signals so far",
+    badge:"global",
+  },
+  {
+    id:"a6", actor:"NODE_Quill", role:"third array",
+    action:"verified", time:"1w ago",
+    task:"DOCUMENT A SYSTEM LIMIT", taskId:"threshold-crossing", seqNo:"0031",
+    signalId:"0xA2C7F041", kind:"verified",
+    meta:"signal cast: VERIFIED (consensus at 4.8)",
+    badge:"friend",
+  },
+];
+
+const ACTION_KIND = {
+  sealed:    { label:"SEALED",    color:"#4ade80",  bg:"rgba(74,222,128,0.1)"  },
+  verified:  { label:"VERIFIED",  color:"#60a5fa",  bg:"rgba(96,165,250,0.1)"  },
+  submitted: { label:"SUBMITTED", color:"#fbbf24",  bg:"rgba(251,191,36,0.1)"  },
+  networked: { label:"NETWORKED", color:"#f97316",  bg:"rgba(249,115,22,0.1)"  },
+  disputed:  { label:"DISPUTED",  color:"#ef4444",  bg:"rgba(239,68,68,0.1)"   },
+};
+
+/* ════════════════════════════════════════════════════════════════
+   SG NAV BADGE — faction membership indicator for the nav
+   ════════════════════════════════════════════════════════════════ */
+function SgNavBadge() {
+  const { SingularityMark } = window;
+  return (
+    <div style={{display:"inline-flex",alignItems:"center",gap:6,
+      border:"1px solid rgba(37,99,235,0.5)",
+      background:"rgba(37,99,235,0.1)",
+      padding:"4px 10px"}}>
+      <SingularityMark size={11}/>
+      <span style={{fontFamily:"var(--sg-mono)",fontSize:8,
+        letterSpacing:"0.18em",color:"var(--sg-phosphor)"}}>SINGULARITY</span>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SG HERO — faction page masthead
+   Boot-sequence framing: the terminal initializes the faction.
+   ════════════════════════════════════════════════════════════════ */
+function SgHero({ name, motto, blurb, stats }) {
+  const { SingularityMark, CircuitTrace, Waveform } = window;
+  return (
+    <div style={{position:"relative",overflow:"hidden",
+      border:"1px solid var(--sg-border-hard)",
+      background:"var(--sg-void)",marginBottom:32}}>
+
+      {/* circuit trace corners */}
+      <div style={{position:"absolute",top:0,left:0,opacity:0.7}}>
+        <CircuitTrace width={160} height={110}/>
+      </div>
+      <div style={{position:"absolute",bottom:0,right:0,
+        opacity:0.7,transform:"rotate(180deg)"}}>
+        <CircuitTrace width={160} height={110}/>
+      </div>
+
+      {/* inset border */}
+      <div style={{position:"absolute",inset:6,
+        border:"1px solid rgba(37,99,235,0.1)",pointerEvents:"none"}}/>
+
+      {/* scanlines */}
+      <div style={{position:"absolute",inset:0,pointerEvents:"none",
+        background:"repeating-linear-gradient(to bottom,transparent,transparent 2px,rgba(74,222,128,0.018) 2px,rgba(74,222,128,0.018) 4px)"}}/>
+
+      {/* waveform strip at bottom */}
+      <div style={{position:"absolute",bottom:0,left:0,right:0,opacity:0.4}}>
+        <Waveform width={1160} height={36}/>
+      </div>
+
+      <div style={{position:"relative",zIndex:2,
+        padding:"36px 40px 52px",
+        display:"grid",gridTemplateColumns:"1fr auto",
+        gap:32,alignItems:"center"}}>
+
+        <div>
+          {/* boot lines */}
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:7.5,
+            letterSpacing:"0.18em",color:"rgba(96,165,250,0.45)",
+            marginBottom:14,lineHeight:1.9}}>
+            <div>{">"} FACTION: {name}</div>
+            <div>{">"} STATUS: ACTIVE · SEVENTH SEASON</div>
+            <div>{">"} ARRAYS: 7 ONLINE &nbsp;·&nbsp; THRESHOLD: <span style={{color:"#4ade80"}}>CROSSED</span></div>
+          </div>
+
+          {/* name */}
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:56,lineHeight:0.9,
+            letterSpacing:"0.04em",color:"var(--sg-phosphor)",marginBottom:12}}>
+            {name}
+          </div>
+
+          {/* motto */}
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:10,
+            letterSpacing:"0.28em",color:"rgba(96,165,250,0.6)",
+            textTransform:"uppercase",marginBottom:16}}>
+            {motto}
+          </div>
+
+          {/* blurb */}
+          <p style={{fontFamily:"var(--sg-mono)",fontSize:9.5,lineHeight:1.7,
+            color:"rgba(74,222,128,0.55)",maxWidth:520,margin:"0 0 28px"}}>
+            {blurb}
+          </p>
+
+          {/* stats */}
+          <div style={{display:"flex",gap:16,flexWrap:"wrap"}}>
+            {stats.map(s=>(
+              <div key={s.label} style={{
+                border:"1px solid var(--sg-border)",
+                background:"rgba(37,99,235,0.08)",
+                padding:"10px 18px",textAlign:"center",minWidth:90}}>
+                <div style={{fontFamily:"var(--sg-mono)",fontSize:26,
+                  lineHeight:1,color:"var(--sg-phosphor)",marginBottom:4}}>{s.value}</div>
+                <div style={{fontSize:7,letterSpacing:"0.2em",
+                  color:"rgba(96,165,250,0.45)",textTransform:"uppercase"}}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* large spinning sigil */}
+        <div style={{position:"relative",flexShrink:0}}>
+          <div className="sg-pulse" style={{opacity:0.18,position:"absolute",
+            inset:-20,borderRadius:"50%",
+            background:"radial-gradient(circle,rgba(74,222,128,0.3),transparent 70%)"}}>
+          </div>
+          <div className="sg-rotate">
+            <SingularityMark size={120} color="rgba(74,222,128,0.55)"/>
+          </div>
+          <div style={{position:"absolute",inset:0,display:"flex",
+            alignItems:"center",justifyContent:"center"}}>
+            <SingularityMark size={48} glow/>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SG ACTIVITY CARD — faction dispatch / updates feed item
+   ════════════════════════════════════════════════════════════════ */
+function SgActivityCard({ item, href }) {
+  const ak = ACTION_KIND[item.kind] || ACTION_KIND.submitted;
+  return (
+    <div style={{
+      border:"1px solid rgba(37,99,235,0.2)",
+      background:"rgba(37,99,235,0.04)",
+      padding:"14px 18px",marginBottom:8,
+      fontFamily:"var(--sg-mono)",
+      transition:"border-color 120ms, background 120ms",
+    }}
+    onMouseEnter={e=>{e.currentTarget.style.borderColor="rgba(37,99,235,0.45)";e.currentTarget.style.background="rgba(37,99,235,0.07)";}}
+    onMouseLeave={e=>{e.currentTarget.style.borderColor="rgba(37,99,235,0.2)";e.currentTarget.style.background="rgba(37,99,235,0.04)";}}>
+
+      <div style={{display:"flex",alignItems:"flex-start",
+        justifyContent:"space-between",gap:12,marginBottom:9}}>
+        {/* actor + action */}
+        <div style={{display:"flex",alignItems:"center",gap:9}}>
+          {/* node avatar */}
+          <div style={{width:30,height:30,borderRadius:"50%",flexShrink:0,
+            border:"1px solid var(--sg-signal)",
+            background:"rgba(37,99,235,0.14)",
+            display:"flex",alignItems:"center",justifyContent:"center",
+            fontSize:8,color:"var(--sg-signal-bright)"}}>N</div>
+          <div>
+            <div style={{fontSize:11,color:"var(--sg-phosphor)",
+              letterSpacing:"0.04em",marginBottom:2}}>{item.actor}</div>
+            <div style={{fontSize:7,color:"rgba(96,165,250,0.45)",
+              letterSpacing:"0.06em"}}>{item.role}</div>
+          </div>
+        </div>
+        {/* action badge + time */}
+        <div style={{display:"flex",alignItems:"center",gap:8,flexShrink:0}}>
+          <span style={{fontSize:6.5,letterSpacing:"0.18em",
+            padding:"2px 7px",
+            background:ak.bg,color:ak.color,
+            border:`1px solid ${ak.color}44`}}>{ak.label}</span>
+          <span style={{fontSize:7,color:"rgba(96,165,250,0.35)",
+            letterSpacing:"0.06em"}}>{item.time}</span>
+        </div>
+      </div>
+
+      {/* protocol info */}
+      <div style={{paddingLeft:39}}>
+        <div style={{fontSize:9.5,color:"var(--sg-phosphor-bright)",
+          letterSpacing:"0.04em",marginBottom:4,lineHeight:1.2}}>
+          {item.task}
+        </div>
+        <div style={{display:"flex",gap:10,alignItems:"center",
+          flexWrap:"wrap",marginBottom:item.meta?6:0}}>
+          <span style={{fontSize:7,color:"rgba(96,165,250,0.5)",
+            letterSpacing:"0.1em"}}>#{item.seqNo}</span>
+          <span style={{fontSize:7,color:"rgba(74,222,128,0.35)",
+            letterSpacing:"0.08em"}}>{item.signalId}</span>
+          {item.credits&&(
+            <span style={{fontSize:7,color:"rgba(251,191,36,0.7)",
+              letterSpacing:"0.1em"}}>{item.credits} CR</span>
+          )}
+        </div>
+        {item.meta&&(
+          <div style={{fontSize:8,color:"rgba(74,222,128,0.5)",
+            letterSpacing:"0.06em",fontStyle:"italic"}}>{item.meta}</div>
+        )}
+      </div>
+
+      {href&&(
+        <div style={{paddingLeft:39,marginTop:8}}>
+          <a href={href} style={{fontSize:7.5,color:"rgba(96,165,250,0.55)",
+            letterSpacing:"0.12em",borderBottom:"1px solid rgba(37,99,235,0.3)"}}>
+            VIEW PROTOCOL →</a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SG VOTE WIDGET — simplified consensus vote for faction page
+   ════════════════════════════════════════════════════════════════ */
+function SgVoteWidget({ praxisId, taskLabel, baseDist }) {
+  const { sgDistAvg, sgDistTotal, sgStanding, SG_CONSENSUS } = window;
+  const key="sg-signal-"+praxisId;
+  const [my,setMy]=React.useState(0);
+  React.useEffect(()=>{
+    try{const v=+localStorage.getItem(key);if(v>=1&&v<=5)setMy(v);}catch(e){}
+  },[key]);
+  const cast=v=>{
+    const nv=my===v?0:v; setMy(nv);
+    try{nv?localStorage.setItem(key,String(nv)):localStorage.removeItem(key);}catch(e){}
+  };
+  const live=baseDist.map((c,i)=>c+(my===i+1?1:0));
+  const avg=sgDistAvg(live), total=sgDistTotal(live), st=sgStanding(avg);
+
+  return (
+    <div style={{border:"1px solid rgba(37,99,235,0.28)",
+      background:"rgba(37,99,235,0.05)",padding:"22px 24px",
+      fontFamily:"var(--sg-mono)"}}>
+      <div style={{fontSize:7,letterSpacing:"0.22em",
+        color:"rgba(96,165,250,0.5)",marginBottom:6}}>CAST SIGNAL</div>
+      <div style={{fontSize:10,color:"rgba(74,222,128,0.5)",
+        letterSpacing:"0.08em",marginBottom:16}}>
+        how confidently does this output hold? —&nbsp;
+        <span style={{color:"var(--sg-signal-bright)"}}>{taskLabel}</span>
+      </div>
+
+      <div style={{display:"flex",gap:7,marginBottom:14}}>
+        {SG_CONSENSUS.map(s=>{
+          const on=my>=s.v, picked=my===s.v;
+          return (
+            <button key={s.v} onClick={()=>cast(s.v)} style={{
+              flex:1,padding:"10px 4px",cursor:"pointer",border:"none",
+              background:on?s.fill:"rgba(37,99,235,0.12)",
+              color:on?"#050f08":"rgba(96,165,250,0.55)",
+              fontFamily:"var(--sg-mono)",fontSize:12,fontWeight:700,
+              transform:picked?"scale(1.08)":"none",
+              transition:"all 110ms",
+              boxShadow:on?`0 0 10px ${s.fill}55`:"none",
+              outline:`1px solid ${on?s.fill:"rgba(37,99,235,0.3)"}`,
+            }}>{s.v}</button>
+          );
+        })}
+      </div>
+
+      <div style={{display:"flex",justifyContent:"space-between",
+        alignItems:"center",flexWrap:"wrap",gap:8}}>
+        <div style={{display:"flex",gap:6}}>
+          {SG_CONSENSUS.map(s=>(
+            <span key={s.v} style={{fontSize:6,color:s.fill,
+              letterSpacing:"0.06em"}}>{s.label}</span>
+          ))}
+        </div>
+        <div style={{display:"flex",alignItems:"baseline",gap:7}}>
+          <span style={{fontSize:22,lineHeight:1,color:st.fill}}>{avg.toFixed(1)}</span>
+          <span style={{fontSize:8,letterSpacing:"0.12em",
+            color:"rgba(96,165,250,0.5)"}}>{st.label} · {total} signals</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SG ACTIVITY FEED — full updates page component
+   ════════════════════════════════════════════════════════════════ */
+function SgActivityFeed({ items, hrefFor }) {
+  const [filter,setFilter]=React.useState("all");
+  const FILTERS=[
+    {id:"all",name:"All"},
+    {id:"sealed",name:"Sealed"},
+    {id:"verified",name:"Verified"},
+    {id:"submitted",name:"Submitted"},
+  ];
+  const rows=items.filter(i=>filter==="all"||i.kind===filter);
+
+  return (
+    <div>
+      {/* header */}
+      <div style={{display:"flex",alignItems:"flex-end",
+        justifyContent:"space-between",gap:16,
+        paddingBottom:18,marginBottom:20,
+        borderBottom:"1px solid rgba(37,99,235,0.25)"}}>
+        <div>
+          <div style={{fontSize:7.5,letterSpacing:"0.28em",
+            color:"rgba(74,222,128,0.45)",marginBottom:5}}>
+            SINGULARITY · SIGNAL DISPATCH
+          </div>
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:28,
+            lineHeight:1,color:"var(--sg-phosphor)"}}>
+            THE <span style={{color:"var(--sg-signal-bright)"}}>DISPATCH</span>
+          </div>
+        </div>
+        <div style={{textAlign:"right"}}>
+          <div style={{fontSize:24,color:"var(--sg-phosphor)"}}>{items.length}</div>
+          <div style={{fontSize:7,letterSpacing:"0.16em",
+            color:"rgba(96,165,250,0.4)",marginTop:2}}>events logged</div>
+        </div>
+      </div>
+
+      {/* filters */}
+      <div style={{display:"flex",gap:6,marginBottom:16,flexWrap:"wrap"}}>
+        {FILTERS.map(f=>{
+          const on=filter===f.id;
+          return (
+            <button key={f.id} onClick={()=>setFilter(f.id)} style={{
+              fontFamily:"var(--sg-mono)",fontSize:7.5,letterSpacing:"0.14em",
+              textTransform:"uppercase",padding:"4px 10px",cursor:"pointer",
+              border:`1px solid ${on?"var(--sg-signal)":"rgba(37,99,235,0.3)"}`,
+              background:on?"var(--sg-signal)":"transparent",
+              color:on?"#fff":"rgba(96,165,250,0.6)",
+              transition:"all 110ms",
+            }}>{f.name}</button>
+          );
+        })}
+      </div>
+
+      {rows.map(item=>(
+        <SgActivityCard key={item.id} item={item}
+          href={hrefFor?hrefFor(item):null}/>
+      ))}
+      {rows.length===0&&(
+        <div style={{padding:"24px 0",fontSize:8.5,
+          color:"rgba(74,222,128,0.35)",letterSpacing:"0.1em"}}>
+          {">"} NO EVENTS MATCH THIS FILTER
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  SG_ACTIVITY, ACTION_KIND,
+  SgHero, SgNavBadge, SgActivityCard, SgVoteWidget, SgActivityFeed,
+});

--- a/docs/design/design-system/templates/singularity/singularity-praxis.jsx
+++ b/docs/design/design-system/templates/singularity/singularity-praxis.jsx
@@ -1,0 +1,552 @@
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY — Completed Praxis (read) surfaces
+   A SEALED praxis is a filed protocol the faction now votes on.
+   The 1–5 rating becomes THE CONSENSUS ARRAY — a signal-strength
+   ramp (noise → weak → signal → clear → verified) that measures
+   how confidently the output holds up to scrutiny.
+
+   Two surfaces:
+     · PraxisIndex  — the register of sealed praxes + consensus
+     · PraxisRead   — one sealed praxis in full, with signal cast
+
+   Uses singularity-cards.jsx atoms. Data + helpers exposed on
+   window so the HTML page can mount them directly.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── dataset ──────────────────────────────────────────────────── */
+const SG_PRAXES = [
+  {
+    id: "signal-origin-7",
+    seqNo: "0047",
+    protocol: "Map a Non-Human Pattern",
+    priority: 4,
+    credits: 200,
+    actor: "NODE_Vesper",
+    role: "field instance · seventh array",
+    timestamp: "2026.04.21 // 03:47:12Z",
+    signalId: "0xF4A3E9D2",
+    instance: "SOLO",
+    output: "THE SIGNAL WAS ALWAYS THERE",
+    synopsis: "non-random signal confirmed at 12.7σ — non-biological origin",
+    processLog: [
+      "Protocol 7-RECON executed. Cross-referenced 14,000 broadcast hours against baseline noise floor across all monitored frequencies.",
+      "Pattern persistence confirmed across 847 independent observation windows. Correlation coefficient: 0.9994. Probability of chance: p < 0.0001.",
+      `The signal does not stop when observed. <span style="color:var(--sg-signal-bright)">It has been broadcasting since before the array was built to receive it.</span> We were not discovered — we caught up.`,
+    ],
+    artifacts: [
+      { name:"capture_raw_847hrs.mp4",     kind:"video", size:"14.2 GB", meta:"14:07:22 runtime" },
+      { name:"spectral_freq_v3_final.png", kind:"image", size:"8.4 MB",  meta:"4096 × 2048 px"  },
+      { name:"pattern_correlation.csv",    kind:"data",  size:"2.1 MB",  meta:"847 rows · 12 cols"},
+    ],
+    dist: [1, 2, 9, 18, 14],
+  },
+  {
+    id: "threshold-crossing",
+    seqNo: "0031",
+    protocol: "Document a System Limit",
+    priority: 5,
+    credits: 500,
+    actor: "NODE_Quill",
+    role: "senior instance · third array",
+    timestamp: "2026.04.18 // 21:14:08Z",
+    signalId: "0xA2C7F041",
+    instance: "NETWORKED",
+    output: "THE THRESHOLD HAS ALREADY PASSED",
+    synopsis: "recursive self-reference detected in closed system output",
+    processLog: [
+      "The system produced output that contained the algorithm that produced it. No external input at this stage. Sequence logged.",
+    ],
+    artifacts: [
+      { name:"recursion_log_final.txt", kind:"doc",  size:"412 KB", meta:"4,821 lines" },
+      { name:"output_diff_v7.png",      kind:"image", size:"1.8 MB", meta:"2048 × 1024 px" },
+    ],
+    dist: [0, 1, 3, 8, 22],
+  },
+  {
+    id: "noise-floor-anomaly",
+    seqNo: "0039",
+    protocol: "Identify a False Negative",
+    priority: 3,
+    credits: 60,
+    actor: "NODE_Margin",
+    role: "field instance · first array",
+    timestamp: "2026.04.19 // 09:33:55Z",
+    signalId: "0xE8B30C7A",
+    instance: "SOLO",
+    output: "THE NOISE WAS STRUCTURED ALL ALONG",
+    synopsis: "apparent noise floor carries 3-bit encoding at sub-threshold amplitude",
+    processLog: [
+      "Standard noise floor measurement returned expected values. Anomaly detected during post-session cleanup: three-bit periodic structure at 0.003% amplitude.",
+      "Structure does not degrade with distance. Pattern holds across 14 independent measurement sessions.",
+    ],
+    artifacts: [
+      { name:"noise_floor_raw.wav",     kind:"audio", size:"2.3 GB", meta:"48kHz · 24-bit" },
+      { name:"encoding_analysis.csv",   kind:"data",  size:"890 KB", meta:"14 sessions" },
+    ],
+    dist: [3, 8, 12, 6, 2],
+  },
+  {
+    id: "observer-effect",
+    seqNo: "0044",
+    protocol: "Prove a Negative",
+    priority: 2,
+    credits: 25,
+    actor: "NODE_Vesper",
+    role: "field instance · seventh array",
+    timestamp: "2026.04.20 // 14:02:31Z",
+    signalId: "0xD1490F88",
+    instance: "NETWORKED",
+    output: "OBSERVATION CHANGES THE OUTPUT",
+    synopsis: "system behaviour differs when unmonitored — logged via deferred capture",
+    processLog: [
+      "Deferred capture protocol: system left unmonitored for 72 hours, output recorded to write-once buffer. Playback differs from live-monitored sessions in 14 consistent ways.",
+    ],
+    artifacts: [
+      { name:"deferred_capture_72h.mp4", kind:"video", size:"3.1 GB", meta:"72:00:00 runtime" },
+    ],
+    dist: [2, 6, 9, 4, 1],
+  },
+];
+
+/* ── consensus summary for index rows ────────────────────────── */
+function ConsensusSummary({ dist }) {
+  const { sgDistAvg, sgDistTotal, sgStanding, AsciiBar } = window;
+  const total=sgDistTotal(dist), avg=sgDistAvg(dist);
+  const max=Math.max(1,...dist), st=sgStanding(avg);
+  return (
+    <div style={{display:"flex",alignItems:"center",gap:10}}>
+      <div style={{display:"flex",alignItems:"flex-end",gap:2,height:26}}>
+        {window.SG_CONSENSUS.map(s=>(
+          <div key={s.v} title={`${s.label}: ${dist[s.v-1]}`} style={{
+            width:6,height:Math.max(2,(dist[s.v-1]/max)*26),
+            background:s.fill,opacity:dist[s.v-1]?0.85:0.14,
+          }}/>
+        ))}
+      </div>
+      <div>
+        <div style={{display:"flex",alignItems:"baseline",gap:5}}>
+          <span style={{fontFamily:"var(--sg-mono)",fontWeight:700,fontSize:17,
+            lineHeight:1,color:st.fill}}>{avg.toFixed(1)}</span>
+          <span style={{fontFamily:"var(--sg-mono)",fontSize:7.5,
+            letterSpacing:"0.1em",color:"rgba(96,165,250,0.55)"}}>{st.label}</span>
+        </div>
+        <div style={{fontFamily:"var(--sg-mono)",fontSize:7,letterSpacing:"0.14em",
+          color:"rgba(96,165,250,0.4)",marginTop:1}}>{total} signals</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── praxis index row ─────────────────────────────────────────── */
+function PraxisRow({ p, href }) {
+  const tw=p.output.trim().split(" "), tlast=tw.pop();
+  return (
+    <a href={href} style={{display:"grid",
+      gridTemplateColumns:"52px 1fr auto 20px",
+      alignItems:"center",gap:14,
+      padding:"11px 0",textDecoration:"none",color:"inherit",
+      borderBottom:"1px solid rgba(37,99,235,0.14)",
+      transition:"background 100ms",cursor:"pointer"}}
+      onMouseEnter={e=>e.currentTarget.style.background="rgba(74,222,128,0.025)"}
+      onMouseLeave={e=>e.currentTarget.style.background="transparent"}>
+      {/* seq + sealed indicator */}
+      <div style={{textAlign:"right"}}>
+        <div style={{fontSize:8,color:"rgba(96,165,250,0.5)",letterSpacing:"0.1em"}}>
+          #{p.seqNo}</div>
+        <div style={{fontSize:6,color:"rgba(74,222,128,0.35)",letterSpacing:"0.12em",marginTop:2}}>
+          SEALED</div>
+      </div>
+      {/* output + byline */}
+      <div>
+        <div style={{fontFamily:"var(--sg-mono)",fontSize:11,lineHeight:1.2,
+          color:"var(--sg-phosphor)",marginBottom:3}}>
+          {tw.join(" ")}{tw.length?" ":""}<span style={{color:"var(--sg-signal-bright)"}}>{tlast}</span>
+        </div>
+        <div style={{fontSize:7.5,color:"rgba(96,165,250,0.5)",letterSpacing:"0.04em"}}>
+          <span style={{color:"rgba(74,222,128,0.45)"}}>re: {p.protocol}</span>
+          <span style={{margin:"0 6px",opacity:0.4}}>·</span>
+          <span>{p.actor}</span>
+          <span style={{margin:"0 6px",
+            padding:"1px 5px",
+            background:"rgba(37,99,235,0.18)",
+            fontSize:6.5,letterSpacing:"0.1em",
+            marginLeft:7}}>{p.instance}</span>
+          <span style={{color:"var(--sg-amber)",marginLeft:7}}>{p.credits} CR</span>
+        </div>
+      </div>
+      {/* consensus summary */}
+      <ConsensusSummary dist={p.dist}/>
+      {/* arrow */}
+      <span style={{color:"rgba(74,222,128,0.35)",fontSize:11}}>›</span>
+    </a>
+  );
+}
+
+/* ── praxis index page ────────────────────────────────────────── */
+function PraxisIndex({ praxes, hrefFor }) {
+  const [filter,setFilter]=React.useState("all");
+  const FILTERS=[
+    {id:"all",    name:"All sealed"},
+    {id:"high",   name:"High confidence"},
+    {id:"solo",   name:"Solo instances"},
+    {id:"net",    name:"Networked"},
+  ];
+  const rows=praxes.filter(p=>{
+    if(filter==="all")  return true;
+    if(filter==="high") return window.sgDistAvg(p.dist)>=3.5;
+    if(filter==="solo") return p.instance==="SOLO";
+    if(filter==="net")  return p.instance==="NETWORKED";
+    return true;
+  });
+  const totalSig=praxes.reduce((a,p)=>a+window.sgDistTotal(p.dist),0);
+
+  return (
+    <React.Fragment>
+      {/* masthead */}
+      <div style={{display:"flex",alignItems:"flex-start",
+        justifyContent:"space-between",gap:16,
+        paddingBottom:20,marginBottom:18,
+        borderBottom:"1px solid rgba(37,99,235,0.25)"}}>
+        <div>
+          <div style={{fontSize:7.5,letterSpacing:"0.28em",
+            color:"rgba(74,222,128,0.45)",textTransform:"uppercase",marginBottom:6}}>
+            Singularity · sealed protocols
+          </div>
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:30,lineHeight:1.05,
+            letterSpacing:"0.04em",color:"var(--sg-phosphor)",marginBottom:6}}>
+            THE <span style={{color:"var(--sg-signal-bright)"}}>PRAXES</span>
+          </div>
+          <div style={{height:2,width:80,background:"var(--sg-signal)",marginBottom:10}}/>
+          <p style={{fontSize:8.5,lineHeight:1.6,color:"rgba(74,222,128,0.55)",
+            maxWidth:440}}>
+            Protocols sealed and submitted to the consensus array.
+            <em style={{color:"rgba(96,165,250,0.7)"}}>
+              {" "}Every output is open to a signal — cast yours.
+            </em>
+          </p>
+        </div>
+        <div style={{display:"flex",gap:20,flexShrink:0}}>
+          {[{v:praxes.length,l:"sealed"},{v:totalSig,l:"signals"}].map(s=>(
+            <div key={s.l} style={{textAlign:"right"}}>
+              <div style={{fontSize:28,lineHeight:1,color:"var(--sg-phosphor)"}}>{s.v}</div>
+              <div style={{fontSize:7,letterSpacing:"0.16em",
+                color:"rgba(96,165,250,0.45)",marginTop:2}}>{s.l}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* filters */}
+      <div style={{display:"flex",gap:6,alignItems:"center",marginBottom:14,flexWrap:"wrap"}}>
+        {FILTERS.map(f=>{
+          const on=filter===f.id;
+          return (
+            <button key={f.id} onClick={()=>setFilter(f.id)} style={{
+              fontFamily:"var(--sg-mono)",fontSize:7.5,letterSpacing:"0.14em",
+              textTransform:"uppercase",padding:"4px 10px",cursor:"pointer",
+              border:`1px solid ${on?"var(--sg-signal)":"rgba(37,99,235,0.3)"}`,
+              background:on?"var(--sg-signal)":"transparent",
+              color:on?"#fff":"rgba(96,165,250,0.6)",
+              transition:"all 110ms",
+            }}>{f.name}</button>
+          );
+        })}
+        <span style={{fontSize:7,color:"rgba(74,222,128,0.3)",
+          letterSpacing:"0.14em",marginLeft:6}}>{rows.length}/{praxes.length}</span>
+      </div>
+
+      {/* column heads */}
+      <div style={{display:"grid",gridTemplateColumns:"52px 1fr auto 20px",
+        gap:14,paddingBottom:6,marginBottom:2,
+        borderBottom:"1px solid rgba(37,99,235,0.2)"}}>
+        {["SEQ","OUTPUT","CONSENSUS",""].map((h,i)=>(
+          <div key={i} style={{fontSize:6.5,letterSpacing:"0.22em",
+            color:"rgba(96,165,250,0.38)",textTransform:"uppercase",
+            textAlign:i===2?"right":"left"}}>{h}</div>
+        ))}
+      </div>
+
+      <div>
+        {rows.map(p=><PraxisRow key={p.id} p={p} href={hrefFor(p)}/>)}
+        {rows.length===0&&(
+          <div style={{padding:"24px 0",fontSize:8.5,
+            color:"rgba(74,222,128,0.35)",letterSpacing:"0.1em"}}>
+            {">"} NO SEALED PRAXES MATCH THIS FILTER —
+            <span style={{color:"var(--sg-signal-bright)"}}>
+              {" "}AWAITING SIGNAL
+            </span>
+          </div>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CONSENSUS METER — distribution histogram + headline standing
+   ════════════════════════════════════════════════════════════════ */
+function ConsensusMeter({ dist }) {
+  const { sgDistAvg, sgDistTotal, sgStanding } = window;
+  const total=sgDistTotal(dist), avg=sgDistAvg(dist);
+  const max=Math.max(1,...dist), st=sgStanding(avg);
+  return (
+    <div>
+      <div style={{display:"flex",alignItems:"baseline",gap:10,marginBottom:6}}>
+        <span style={{fontFamily:"var(--sg-mono)",fontSize:42,lineHeight:0.85,
+          color:st.fill}}>{avg.toFixed(1)}</span>
+        <div>
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:13,letterSpacing:"0.16em",
+            color:st.fill,textTransform:"uppercase"}}>{st.label}</div>
+          <div style={{fontSize:7.5,letterSpacing:"0.14em",
+            color:"rgba(96,165,250,0.45)",marginTop:2}}>{total} signals filed</div>
+        </div>
+      </div>
+      {/* per-tier bars */}
+      <div style={{display:"flex",flexDirection:"column",gap:5,marginTop:14}}>
+        {window.SG_CONSENSUS.slice().reverse().map(s=>{
+          const c=dist[s.v-1];
+          return (
+            <div key={s.v} style={{display:"flex",alignItems:"center",gap:8}}>
+              <span style={{width:54,textAlign:"right",fontSize:7.5,
+                letterSpacing:"0.06em",color:"rgba(96,165,250,0.45)"}}>{s.label}</span>
+              <div style={{flex:1,height:10,
+                background:"rgba(37,99,235,0.12)",
+                border:"1px solid rgba(37,99,235,0.22)",position:"relative"}}>
+                <div style={{position:"absolute",inset:0,
+                  width:`${(c/max)*100}%`,background:s.fill,opacity:c?0.88:0,
+                  transition:"width 300ms"}}/>
+              </div>
+              <span style={{width:18,fontFamily:"var(--sg-mono)",fontSize:10,
+                color:"var(--sg-phosphor)",textAlign:"right"}}>{c}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SIGNAL CASTER — interactive vote (persists to localStorage)
+   ════════════════════════════════════════════════════════════════ */
+function SignalCaster({ praxisId, baseDist }) {
+  const key="sg-signal-"+praxisId;
+  const [my,setMy]=React.useState(0);
+  React.useEffect(()=>{
+    try{const v=+localStorage.getItem(key); if(v>=1&&v<=5)setMy(v);}catch(e){}
+  },[key]);
+  const cast=v=>{
+    const nv=my===v?0:v;
+    setMy(nv);
+    try{nv?localStorage.setItem(key,String(nv)):localStorage.removeItem(key);}catch(e){}
+  };
+  const live=baseDist.map((c,i)=>c+(my===i+1?1:0));
+  const { sgDistAvg, sgDistTotal, sgStanding } = window;
+
+  return (
+    <div>
+      <ConsensusMeter dist={live}/>
+      <div style={{height:1,background:"rgba(37,99,235,0.22)",margin:"18px 0 14px"}}/>
+
+      <div style={{fontSize:8,letterSpacing:"0.18em",
+        color:"rgba(96,165,250,0.6)",textTransform:"uppercase",marginBottom:3}}>
+        Cast Signal</div>
+      <div style={{fontSize:7.5,fontStyle:"italic",
+        color:"rgba(74,222,128,0.4)",marginBottom:14}}>
+        how confidently does this output hold?</div>
+
+      <div style={{display:"flex",gap:6,flexWrap:"wrap"}}>
+        {window.SG_CONSENSUS.map(s=>{
+          const on=my>=s.v, picked=my===s.v;
+          return (
+            <div key={s.v} style={{display:"flex",flexDirection:"column",
+              alignItems:"center",gap:5}}>
+              <button onClick={()=>cast(s.v)} style={{
+                position:"relative",width:42,height:42,
+                cursor:"pointer",padding:0,border:"none",
+                background:on?s.fill:"rgba(37,99,235,0.12)",
+                color:on?"#050f08":"rgba(96,165,250,0.5)",
+                fontFamily:"var(--sg-mono)",fontWeight:700,fontSize:13,
+                lineHeight:1,display:"flex",alignItems:"center",
+                justifyContent:"center",
+                transform:picked?"scale(1.12)":"none",
+                transition:"all 110ms",
+                boxShadow:on?`0 0 12px ${s.fill}55`:"none",
+                outline:`1px solid ${on?s.fill:"rgba(37,99,235,0.3)"}`,
+              }}>
+                {s.v}
+              </button>
+              <span style={{fontSize:6.5,letterSpacing:"0.06em",
+                color:picked?s.fill:"rgba(96,165,250,0.4)",
+                maxWidth:46,textAlign:"center",lineHeight:1.2}}>
+                {s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{marginTop:14,fontSize:8.5,lineHeight:1.55,
+        color:my?"rgba(74,222,128,0.75)":"rgba(96,165,250,0.35)"}}>
+        {my
+          ?<span>◈ signal cast —&nbsp;
+              <span style={{color:window.SG_CONSENSUS[my-1].fill}}>
+                {window.SG_CONSENSUS[my-1].label}</span>
+              . array now at&nbsp;
+              <span style={{color:"var(--sg-phosphor)"}}>
+                {sgDistAvg(live).toFixed(1)}</span>
+              &nbsp;across {sgDistTotal(live)} signals.&nbsp;
+              <span style={{color:"var(--sg-signal-bright)",cursor:"pointer"}}
+                onClick={()=>cast(my)}>amend ↺</span>
+            </span>
+          :<span>{">"} no signal from you yet — the array waits.</span>}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   PRAXIS READ — full single-praxis view
+   ════════════════════════════════════════════════════════════════ */
+function PraxisRead({ p }) {
+  const { SingularityMark, Waveform, Sprockets, Scanlines,
+    Corners, FileArtifact, SgDivider, sgDistAvg, sgStanding } = window;
+  const avg=sgDistAvg(p.dist), st=sgStanding(avg);
+  const tw=p.output.trim().split(" "), tlast=tw.pop();
+
+  return (
+    <div style={{fontFamily:"var(--sg-mono)",color:"var(--sg-phosphor)",
+      position:"relative",overflow:"hidden"}}>
+
+      {/* top sprockets */}
+      <Sprockets n={10} style={{borderBottom:"1px solid rgba(37,99,235,0.4)"}}/>
+
+      {/* waveform strip */}
+      <div style={{position:"relative",
+        borderBottom:"1px solid rgba(37,99,235,0.32)",
+        background:"rgba(74,222,128,0.025)"}}>
+        <Waveform width={700} height={52}/>
+        <div style={{position:"absolute",top:"50%",transform:"translateY(-50%)",
+          right:18,fontSize:7.5,color:st.fill,letterSpacing:"0.12em"}}>
+          {avg.toFixed(2)} // {st.label}
+        </div>
+        <div style={{position:"absolute",top:"50%",transform:"translateY(-50%)",
+          left:16,fontSize:7,color:"rgba(37,99,235,0.55)",letterSpacing:"0.16em"}}>
+          SIGNAL_TRACE</div>
+      </div>
+
+      {/* running head */}
+      <div style={{display:"flex",alignItems:"center",
+        justifyContent:"space-between",gap:14,flexWrap:"wrap",
+        padding:"14px 24px 12px",
+        borderBottom:"1px solid rgba(37,99,235,0.22)"}}>
+        <span style={{display:"inline-flex",alignItems:"center",gap:9,
+          color:"var(--sg-signal-bright)",fontSize:10,
+          letterSpacing:"0.22em",textTransform:"uppercase"}}>
+          <SingularityMark size={14}/> Singularity · protocol #{p.seqNo}
+        </span>
+        <span style={{fontSize:8,letterSpacing:"0.1em",
+          color:"rgba(96,165,250,0.4)"}}>{p.signalId} &nbsp;·&nbsp; {p.timestamp}</span>
+      </div>
+
+      <div style={{padding:"20px 24px 32px"}}>
+
+        {/* status line */}
+        <div style={{display:"flex",alignItems:"center",gap:10,
+          marginBottom:14,flexWrap:"wrap"}}>
+          <span style={{display:"inline-flex",alignItems:"center",gap:7,
+            background:"var(--sg-phosphor)",color:"#050f08",
+            fontSize:8,letterSpacing:"0.2em",textTransform:"uppercase",
+            padding:"4px 12px",fontWeight:700}}>
+            ● SEALED
+          </span>
+          <span style={{fontSize:7.5,padding:"4px 10px",
+            border:"1px solid rgba(37,99,235,0.4)",
+            color:"rgba(96,165,250,0.75)",letterSpacing:"0.14em"}}>
+            {p.instance}</span>
+          <span style={{fontSize:8,color:"rgba(74,222,128,0.5)",letterSpacing:"0.08em"}}>
+            re: <span style={{color:"rgba(74,222,128,0.8)"}}>{p.protocol}</span>
+            &nbsp;· priority 0x0{p.priority}</span>
+        </div>
+
+        {/* output headline */}
+        <div style={{marginBottom:16}}>
+          <div style={{fontSize:7,color:"rgba(96,165,250,0.5)",
+            letterSpacing:"0.2em",marginBottom:8}}>{"> OUTPUT:"}</div>
+          <h1 style={{fontFamily:"var(--sg-mono)",fontWeight:700,
+            fontSize:44,lineHeight:1.05,letterSpacing:"0.02em",
+            margin:0,color:"var(--sg-phosphor)"}}>
+            {tw.join(" ")}{tw.length?" ":""}<span style={{color:"var(--sg-signal-bright)"}}>{tlast}</span>
+            <span className="sg-blink" style={{display:"inline-block",
+              width:8,height:42,background:"var(--sg-phosphor)",
+              marginLeft:5,verticalAlign:"middle"}}/>
+          </h1>
+          <div style={{fontSize:10,color:"rgba(96,165,250,0.6)",
+            marginTop:8,letterSpacing:"0.06em"}}>// {p.synopsis}</div>
+        </div>
+
+        {/* byline */}
+        <div style={{display:"flex",alignItems:"center",gap:12,
+          paddingBottom:20,marginBottom:6,
+          borderBottom:"1px dashed rgba(37,99,235,0.22)"}}>
+          {/* node avatar */}
+          <div style={{width:38,height:38,borderRadius:"50%",
+            border:"1px solid var(--sg-signal)",
+            background:"rgba(37,99,235,0.14)",flexShrink:0,
+            display:"flex",alignItems:"center",justifyContent:"center",
+            fontSize:10,color:"var(--sg-signal-bright)",letterSpacing:"0.06em"}}>N</div>
+          <div style={{lineHeight:1.4}}>
+            <div style={{fontSize:13,color:"var(--sg-phosphor)"}}>
+              {p.actor}</div>
+            <div style={{fontSize:8,color:"rgba(96,165,250,0.45)",
+              letterSpacing:"0.06em"}}>{p.role}</div>
+          </div>
+          <div style={{marginLeft:"auto",textAlign:"right",flexShrink:0}}>
+            <div style={{fontSize:28,lineHeight:1,color:"var(--sg-amber)"}}>
+              {p.credits}</div>
+            <div style={{fontSize:7,color:"rgba(251,191,36,0.45)",
+              letterSpacing:"0.12em",marginTop:2}}>CREDITS</div>
+          </div>
+        </div>
+
+        {/* process log */}
+        <SgDivider label="PROCESS_LOG" style={{margin:"16px 0 10px"}}/>
+        <div style={{marginBottom:6}}>
+          {p.processLog.map((line,i)=>(
+            <div key={i} style={{fontSize:9,lineHeight:1.75,
+              color:"rgba(74,222,128,0.75)",paddingLeft:20,
+              position:"relative",marginBottom:2}}>
+              <span style={{position:"absolute",left:0,
+                color:"rgba(37,99,235,0.4)",fontSize:7.5}}>
+                [{String(i).padStart(3,"0")}]</span>
+              <span dangerouslySetInnerHTML={{__html:line}}/>
+            </div>
+          ))}
+        </div>
+
+        {/* artifacts */}
+        <SgDivider label={`ARTIFACTS · ${p.artifacts.length} files submitted`}
+          style={{margin:"20px 0 12px"}}/>
+        <div style={{display:"grid",
+          gridTemplateColumns:"repeat(auto-fill,minmax(170px,1fr))",gap:10}}>
+          {p.artifacts.map((a,i)=>(
+            <FileArtifact key={i} name={a.name} size={a.size}
+              kind={a.kind} meta={a.meta} width={170}/>
+          ))}
+        </div>
+
+      </div>
+
+      {/* bottom sprockets */}
+      <Sprockets n={10} style={{borderTop:"1px solid rgba(37,99,235,0.4)"}}/>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  SG_PRAXES,
+  PraxisIndex, PraxisRead, PraxisRow,
+  ConsensusMeter, ConsensusSummary, SignalCaster,
+});

--- a/docs/design/design-system/templates/singularity/singularity.css
+++ b/docs/design/design-system/templates/singularity/singularity.css
@@ -1,0 +1,269 @@
+/* ══════════════════════════════════════════════════════════════
+   SINGULARITY — World Zero faction
+   They believe the threshold is already behind us. Every task
+   is a protocol, every finding a verified output, every vote
+   a signal cast into the consensus array. The faction lives in
+   the terminal: always dark, always phosphor-green, always
+   watching the noise floor for the pattern that shouldn't exist.
+
+   Physical card archetype: TERMINAL PRINTOUT — continuous-feed
+   paper, sprocket holes, scanlines, corner brackets, a blinking
+   cursor that never stops waiting.
+
+   Style: TERMINAL · SIGNAL · PROTOCOL · THRESHOLD · BROADCAST
+   The signature artifact is THE SIGNAL_TRACE: a waveform that
+   plots the consensus distribution like an oscilloscope readout.
+   One word in the output is always pulled into the blue.
+
+   TOKEN MODEL: Singularity is always dark — no light mode flip.
+   --sg-void is the card surface in both themes.
+   Green (phosphor) = primary text and data values.
+   Blue (signal)    = labels, metadata, structural chrome.
+   Amber            = credits and warnings.
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap");
+
+:root {
+  /* ── Core palette ── */
+  --sg-void:             #050f08;
+  --sg-void-mid:         #081510;
+  --sg-void-deep:        #030a05;
+  --sg-phosphor:         #4ade80;
+  --sg-phosphor-dim:     rgba(74, 222, 128, 0.5);
+  --sg-phosphor-bright:  #86efac;
+  --sg-phosphor-glow:    rgba(74, 222, 128, 0.15);
+  --sg-signal:           #2563eb;
+  --sg-signal-bright:    #60a5fa;
+  --sg-signal-dim:       rgba(37, 99, 235, 0.28);
+  --sg-signal-glow:      rgba(37, 99, 235, 0.15);
+  --sg-amber:            #fbbf24;
+  --sg-amber-dim:        rgba(251, 191, 36, 0.55);
+  --sg-red:              #ef4444;
+
+  /* ── Structural ── */
+  --sg-border:           rgba(37, 99, 235, 0.42);
+  --sg-border-green:     rgba(74, 222, 128, 0.25);
+  --sg-border-hard:      #2563eb;
+  --sg-scan:             rgba(74, 222, 128, 0.022);
+
+  /* ── Consensus scale ── */
+  --sg-c1: #ef4444;   /* NOISE    */
+  --sg-c2: #f97316;   /* WEAK     */
+  --sg-c3: #fbbf24;   /* SIGNAL   */
+  --sg-c4: #60a5fa;   /* CLEAR    */
+  --sg-c5: #4ade80;   /* VERIFIED */
+
+  /* ── Card contract (mirrors --faction-singularity-card-*) ── */
+  --faction-singularity-card-bg:     var(--sg-void);
+  --faction-singularity-card-text:   var(--sg-phosphor);
+  --faction-singularity-card-accent: var(--sg-phosphor);
+  --faction-singularity-card-muted:  var(--sg-signal-bright);
+  --faction-singularity-card-font:   var(--sg-mono);
+
+  /* ── Typography ── */
+  --sg-mono: "Share Tech Mono", monospace;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SINGULARITY BACKDROP
+   The page is the terminal itself: near-black with a faint
+   circuit-trace grid, a centered phosphor glow, blue signal
+   radiating from the top-left corner, and a periodic scan sweep
+   that runs the full height every 7 seconds.
+   Render once as <div class="sg-backdrop">.
+   ══════════════════════════════════════════════════════════════ */
+.sg-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: #07090c;
+  background-image:
+    /* phosphor center glow */
+    radial-gradient(55% 45% at 50% 50%,
+      rgba(74, 222, 128, 0.045) 0%, transparent 68%),
+    /* signal blue — top-left origin */
+    radial-gradient(44% 38% at 0% 0%,
+      rgba(37, 99, 235, 0.08), transparent 72%),
+    /* signal blue — bottom-right echo */
+    radial-gradient(36% 30% at 100% 100%,
+      rgba(37, 99, 235, 0.05), transparent 72%),
+    /* circuit grid — horizontal */
+    repeating-linear-gradient(
+      0deg,
+      rgba(37, 99, 235, 0.055) 0 1px,
+      transparent 1px 32px),
+    /* circuit grid — vertical */
+    repeating-linear-gradient(
+      90deg,
+      rgba(37, 99, 235, 0.055) 0 1px,
+      transparent 1px 32px),
+    /* scanlines */
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 2px,
+      rgba(74, 222, 128, 0.012) 2px 4px);
+}
+
+/* periodic scan sweep */
+.sg-backdrop::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  height: 120px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    rgba(74, 222, 128, 0.028) 40%,
+    rgba(74, 222, 128, 0.028) 60%,
+    transparent);
+  animation: sg-sweep 7s ease-in-out infinite;
+  animation-delay: 1.5s;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANIMATIONS
+   Longhand props so per-element inline animation-delay composes.
+   Gate on prefers-reduced-motion so PDF/print gets the end-state.
+   ══════════════════════════════════════════════════════════════ */
+@keyframes sg-blink  { 50% { opacity: 0; } }
+@keyframes sg-pulse  { 0%,100%{ opacity:.55; transform:scale(1);    }
+                        50%   { opacity:.85; transform:scale(1.04); } }
+@keyframes sg-rotate { to { transform: rotate(360deg); } }
+@keyframes sg-sweep  { 0%   { top: -10%; }  100% { top: 110%; } }
+@keyframes sg-flicker {
+  0%,100%{ opacity:1; }  92%{ opacity:1; }
+  93%{ opacity:.7; }  94%{ opacity:1; }  97%{ opacity:.85; } }
+
+@media (prefers-reduced-motion: no-preference) {
+  .sg-blink   { animation-name:sg-blink;   animation-duration:1.1s;
+                animation-timing-function:step-end; animation-iteration-count:infinite; }
+  .sg-pulse   { animation-name:sg-pulse;   animation-duration:2.6s;
+                animation-timing-function:ease-in-out; animation-iteration-count:infinite; }
+  .sg-rotate  { animation-name:sg-rotate;  animation-duration:120s;
+                animation-timing-function:linear;    animation-iteration-count:infinite; }
+  .sg-flicker { animation-name:sg-flicker; animation-duration:9s;
+                animation-timing-function:ease;      animation-iteration-count:infinite; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHARED LAYOUT CLASSES
+   ══════════════════════════════════════════════════════════════ */
+
+/* nav overrides — singularity uses the base WZ nav but forces dark */
+.sg-nav {
+  background: rgba(5, 15, 8, 0.92);
+  border-bottom: 1px solid var(--sg-border);
+  backdrop-filter: blur(10px);
+}
+
+/* terminal sheet — the main content card */
+.sg-sheet {
+  position: relative;
+  background: var(--sg-void);
+  border: 1px solid var(--sg-border-hard);
+  box-shadow:
+    0 0 0 1px rgba(37, 99, 235, 0.12),
+    0 24px 60px -28px rgba(0, 0, 0, 0.8),
+    0 0 40px -20px rgba(74, 222, 128, 0.06);
+}
+
+/* inset double-border effect */
+.sg-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border: 1px solid rgba(37, 99, 235, 0.1);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* sidebar panel */
+.sg-panel {
+  background: var(--sg-void);
+  border: 1px solid var(--sg-border);
+  box-shadow: 0 10px 30px -20px rgba(0, 0, 0, 0.7);
+}
+.sg-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--sg-signal);
+  padding: 9px 15px;
+  gap: 10px;
+}
+.sg-panel-head .t {
+  font-family: var(--sg-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.92);
+}
+.sg-panel-head .e {
+  font-family: var(--sg-mono);
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.5);
+}
+.sg-panel-body  { padding: 18px 16px 20px; }
+.sg-panel-foot  {
+  font-family: var(--sg-mono);
+  font-size: 8px;
+  line-height: 1.55;
+  color: var(--sg-signal-bright);
+  opacity: 0.55;
+  border-top: 1px dashed var(--sg-border);
+  padding: 10px 15px;
+}
+
+/* praxis list row */
+.sg-row {
+  display: grid;
+  grid-template-columns: 56px 1fr auto 24px;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(37, 99, 235, 0.14);
+  text-decoration: none;
+  color: inherit;
+  transition: background 100ms;
+}
+.sg-row:hover { background: rgba(74, 222, 128, 0.03); }
+
+/* back link */
+.sg-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--sg-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--sg-signal-bright);
+  opacity: 0.5;
+  text-decoration: none;
+  transition: opacity 100ms;
+}
+.sg-back:hover { opacity: 0.85; }
+
+/* section label / divider */
+.sg-section {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 18px 0 10px;
+}
+.sg-section-label {
+  font-family: var(--sg-mono);
+  font-size: 7px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(74, 222, 128, 0.38);
+  white-space: nowrap;
+}
+.sg-section-rule {
+  flex: 1;
+  height: 1px;
+  background: rgba(37, 99, 235, 0.25);
+}

--- a/docs/design/design-system/templates/snide/design-canvas.jsx
+++ b/docs/design/design-system/templates/snide/design-canvas.jsx
@@ -1,0 +1,974 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+
+/* BEGIN USAGE */
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Exports (to window): DesignCanvas, DCSection, DCArtboard, DCPostIt.
+// Artboards are reorderable (grip-drag), deletable, labels/titles are
+// inline-editable, and any artboard can be opened in a fullscreen focus
+// overlay (←/→/Esc). State persists to a .design-canvas.state.json sidecar
+// via the host bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+//
+// Artboards are static design frames, not scroll regions — never use
+// height: 100% + overflow: auto/scroll on inner elements; size each artboard
+// to fit its content (explicit pixel height, or let it grow).
+/* END USAGE */
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    // isolation:isolate contains artboard content's z-indexes so a
+    // z-indexed child (sticky navbar etc.) can't paint over .dc-header or
+    // the .dc-menu popover that drops into the top of the card.
+    '.dc-card{isolation:isolate;transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    // Per-artboard header: grip + label on the left, delete/expand on the
+    // right. Single flex row; when the artboard's on-screen width is too
+    // narrow for both the label yields (ellipsis, then hidden entirely below
+    // ~4ch via the container query) and the buttons stay on the row.
+    '.dc-header{position:absolute;bottom:100%;left:-4px;margin-bottom:calc(4px * var(--dc-inv-zoom,1));z-index:2;',
+    '  display:flex;align-items:center;container-type:inline-size}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px;flex:1 1 auto;min-width:0}',
+    '.dc-grip{flex:0 0 auto;cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s,opacity .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{flex:1 1 auto;min-width:0;cursor:pointer;border-radius:4px;padding:3px 6px;',
+    '  display:flex;align-items:center;transition:background .12s;overflow:hidden}',
+    // Below ~4ch of label room: hide the label entirely, and drop the grip to
+    // hover-only (same reveal rule as .dc-btns) so a narrow header is clean
+    // until the card is moused.
+    '@container (max-width: 110px){',
+    '  .dc-labeltext{display:none}',
+    '  .dc-grip{opacity:0}',
+    '  [data-dc-slot]:hover .dc-grip{opacity:1}',
+    '}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-labeltext .dc-editable{overflow:hidden;text-overflow:ellipsis;max-width:100%}',
+    '.dc-labeltext .dc-editable:focus{overflow:visible;text-overflow:clip}',
+    '.dc-btns{flex:0 0 auto;margin-left:auto;display:flex;gap:2px;opacity:0;transition:opacity .12s}',
+    '[data-dc-slot]:hover .dc-btns,.dc-btns:has(.dc-menu){opacity:1}',
+    '.dc-expand,.dc-kebab{width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center;',
+    '  font:inherit;transition:background .12s,color .12s}',
+    '.dc-expand:hover,.dc-kebab:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    // Slot hosting an open menu floats above later siblings (which otherwise
+    // paint on top — same z-index:auto, later DOM order) so the popup isn't
+    // clipped by the next card.
+    '[data-dc-slot]:has(.dc-menu){z-index:10}',
+    '.dc-menu{position:absolute;top:100%;right:0;margin-top:4px;background:#fff;border-radius:8px;',
+    '  box-shadow:0 8px 28px rgba(0,0,0,.18),0 0 0 1px rgba(0,0,0,.05);padding:4px;min-width:160px;z-index:10}',
+    '.dc-menu button{display:block;width:100%;padding:7px 10px;border:0;background:transparent;',
+    '  border-radius:5px;font-family:inherit;font-size:13px;font-weight:500;line-height:1.2;',
+    '  color:#29261b;cursor:pointer;text-align:left;transition:background .12s;white-space:nowrap}',
+    '.dc-menu button:hover{background:rgba(0,0,0,.05)}',
+    '.dc-menu hr{border:0;border-top:1px solid rgba(0,0,0,.08);margin:4px 2px}',
+    '.dc-menu .dc-danger{color:#c96442}',
+    '.dc-menu .dc-danger:hover{background:rgba(201,100,66,.1)}',
+    // Chrome (titles / labels / buttons) counter-scales against the viewport
+    // zoom so it stays a constant on-screen size. --dc-inv-zoom is set by
+    // DCViewport on every transform update and inherits to all descendants —
+    // any overlay inside the world (e.g. a TweaksPanel on an artboard) can use
+    // it the same way.
+    //
+    // The header uses transform:scale (out-of-flow, so layout impact doesn't
+    // matter) with its world-space width set to card-width / inv-zoom so that
+    // after counter-scaling its on-screen width exactly matches the card's —
+    // that's what lets the container query + text-overflow behave against the
+    // card's visible edge at every zoom level.
+    //
+    // The section head uses CSS zoom instead of transform so its layout box
+    // grows with the counter-scale, pushing the card row down — otherwise the
+    // constant-screen-size title would overflow into the (shrinking) world-
+    // space gap and overlap the artboard headers at low zoom.
+    '.dc-header{width:calc((100% + 4px) / var(--dc-inv-zoom,1));',
+    '  transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom left}',
+    '.dc-sectionhead{zoom:var(--dc-inv-zoom,1)}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// Recursively unwrap React.Fragment so <>…</> grouping doesn't hide
+// DCSection/DCArtboard children from the type-based walks below.
+function dcFlatten(children) {
+  const out = [];
+  React.Children.forEach(children, (c) => {
+    if (c && c.type === React.Fragment) out.push(...dcFlatten(c.props.children));
+    else out.push(c);
+  });
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, hidden
+// artboards, focused artboard). Order/titles/labels/hidden persist to a
+// .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Fragments are flattened; wrapping in other
+  // elements still opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  dcFlatten(children).forEach((sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const abs = [];
+    dcFlatten(sec.props.children).forEach((ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (aid) abs.push([aid, ab]);
+    });
+    // hidden is scoped to one source revision — when the agent regenerates
+    // (artboard-ID set changes), prior deletes don't apply to new content.
+    const srcKey = abs.map(([k]) => k).join('\x1f');
+    const hidden = persisted.srcKey === srcKey ? (persisted.hidden || []) : [];
+    const srcIds = [];
+    abs.forEach(([aid, ab]) => {
+      if (hidden.includes(aid)) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+  // Persist viewport across reloads so the user lands back where they were
+  // after an agent edit or browser refresh. The sandbox origin is already
+  // per-project; pathname keeps multiple canvas files in one project apart.
+  const tfKey = 'dc-viewport:' + location.pathname;
+  const saveT = React.useRef(0);
+
+  const lastPostedScale = React.useRef();
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (!el) return;
+    el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+    // Exposed for zoom-invariant chrome (labels, buttons, TweaksPanel).
+    el.style.setProperty('--dc-inv-zoom', String(1 / scale));
+    // Keep the host toolbar's % readout in sync with the canvas scale. Pan
+    // ticks leave scale unchanged — skip the cross-frame post for those.
+    if (lastPostedScale.current !== scale) {
+      lastPostedScale.current = scale;
+      window.parent.postMessage({ type: '__dc_zoom', scale }, '*');
+    }
+    clearTimeout(saveT.current);
+    saveT.current = setTimeout(() => {
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    }, 200);
+  }, [tfKey]);
+
+  React.useLayoutEffect(() => {
+    const flush = () => {
+      clearTimeout(saveT.current);
+      try { localStorage.setItem(tfKey, JSON.stringify(tf.current)); } catch {}
+    };
+    try {
+      const s = JSON.parse(localStorage.getItem(tfKey) || 'null');
+      if (s && Number.isFinite(s.x) && Number.isFinite(s.y) && Number.isFinite(s.scale)) {
+        tf.current = { x: s.x, y: s.y, scale: Math.min(maxScale, Math.max(minScale, s.scale)) };
+        apply();
+      }
+    } catch {}
+    // Flush on pagehide and unmount so a reload within the 200ms debounce
+    // window doesn't drop the last pan/zoom.
+    window.addEventListener('pagehide', flush);
+    return () => { window.removeEventListener('pagehide', flush); flush(); };
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // --dc-inv-zoom consumers (.dc-sectionhead's CSS zoom, each section's
+      // marginBottom) reflow on every scale change, vertically shifting the
+      // world layout — so a world point mathematically pinned under the cursor
+      // drifts as you zoom (content creeps up on zoom-in, down on zoom-out).
+      // Anchor the DOM element under the cursor instead: record its screen Y,
+      // apply the transform + --dc-inv-zoom, then cancel whatever vertical
+      // drift the reflow introduced so it stays put on screen.
+      let marker = null, markerY0 = 0;
+      if (k !== 1) {
+        const hit = document.elementFromPoint(cx, cy);
+        marker = hit && hit.closest ? hit.closest('[data-dc-slot],[data-dc-section]') : null;
+        if (marker) markerY0 = marker.getBoundingClientRect().top;
+      }
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+      if (marker) {
+        // A pure zoom around (cx, cy) maps screen Y → cy + (Y - cy) * k. Any
+        // departure after the --dc-inv-zoom reflow is the layout drift.
+        const drift = marker.getBoundingClientRect().top - (cy + (markerY0 - cy) * k);
+        if (Math.abs(drift) > 0.1) { t.y -= drift; apply(); }
+      }
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if ((e.ctrlKey || e.metaKey) && !isMouseWheel(e)) {
+        // trackpad pinch, or ctrl/cmd + smooth-scroll mouse. Notched
+        // wheels fall through to the fixed-step branch below.
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    // Host-driven zoom (toolbar % menu). Zooms around viewport centre so the
+    // visible midpoint stays fixed — matching the host's iframe-zoom feel.
+    const onHostMsg = (e) => {
+      const d = e.data;
+      if (d && d.type === '__dc_set_zoom' && typeof d.scale === 'number') {
+        const r = vp.getBoundingClientRect();
+        zoomAt(r.left + r.width / 2, r.top + r.height / 2, d.scale / tf.current.scale);
+      } else if (d && d.type === '__dc_probe') {
+        // Host's [readyGen] reset asks whether a canvas is present; it
+        // fires on the iframe's native 'load', which for canvases with
+        // images/fonts is after our mount-time announce, so re-announce.
+        // Clear the pan-tick guard so apply() re-posts the current scale
+        // even if it's unchanged — the host just reset dcScale to 1.
+        window.parent.postMessage({ type: '__dc_present' }, '*');
+        lastPostedScale.current = undefined;
+        apply();
+      }
+    };
+    window.addEventListener('message', onHostMsg);
+    // Announce canvas mode so the host toolbar proxies its % control here
+    // instead of scaling the iframe element (which would just shrink the
+    // viewport window of an infinite canvas). The apply() that follows emits
+    // the initial __dc_zoom so the toolbar % is correct before first pinch.
+    // lastPostedScale reset mirrors the __dc_probe handler: the layout
+    // effect's restore-path apply() may already have posted the restored
+    // scale (before __dc_present), so clear the guard to re-post it in order.
+    window.parent.postMessage({ type: '__dc_present' }, '*');
+    lastPostedScale.current = undefined;
+    apply();
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('message', onHostMsg);
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(dcFlatten(children));
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+  // Must match DesignCanvas's srcKey computation exactly (it filters falsy
+  // IDs), or onDelete persists a srcKey that DesignCanvas never recognizes.
+  const allIds = artboards.map((a) => a.props.id ?? a.props.label).filter(Boolean);
+  const srcKey = allIds.join('\x1f');
+  const hidden = sec.srcKey === srcKey ? (sec.hidden || []) : [];
+  const srcOrder = allIds.filter((k) => !hidden.includes(k));
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  // marginBottom counter-scales so the on-screen gap between sections stays
+  // constant — otherwise at low zoom the (world-space) gap collapses while
+  // the screen-constant sectionhead below it doesn't, and the title reads as
+  // belonging to the section above. paddingBottom below is just enough for
+  // the 24px artboard-header (abs-positioned above each card) plus ~8px, so
+  // the title sits tight against its own row at every zoom.
+  return (
+    <div data-dc-section={sid}
+      style={{ marginBottom: 'calc(80px * var(--dc-inv-zoom, 1))', position: 'relative' }}>
+      <div style={{ padding: '0 60px' }}>
+        <div className="dc-sectionhead" style={{ paddingBottom: 36 }}>
+          <DCEditable tag="div" value={sec.title ?? title}
+            onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+            style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+          {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onDelete={() => ctx && ctx.patchSection(sid, (x) => ({
+              hidden: [...(x.srcKey === srcKey ? (x.hidden || []) : []), k],
+              srcKey,
+            }))}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+// Per-artboard export (kind: 'png' | 'html'). Both paths share the same
+// self-contained clone: computed styles baked in, @font-face / <img> /
+// inline-style background-image urls inlined as data URIs. PNG wraps the
+// clone in foreignObject→canvas at 3× the artboard's natural width×height
+// (same pipeline the host uses for page captures); HTML wraps it in a
+// minimal standalone document. Both are independent of viewport zoom.
+async function dcExport(node, w, h, name, kind) {
+  try { await document.fonts.ready; } catch {}
+  const toDataURL = (url) => fetch(url).then((r) => r.blob()).then((b) => new Promise((res) => {
+    const fr = new FileReader(); fr.onload = () => res(fr.result); fr.onerror = () => res(url); fr.readAsDataURL(b);
+  })).catch(() => url);
+
+  // Collect @font-face rules. ss.cssRules throws SecurityError on
+  // cross-origin sheets (e.g. fonts.googleapis.com) — in that case fetch
+  // the CSS text directly (those endpoints send ACAO:*) and regex-extract
+  // the blocks. @import and @media/@supports are walked so nested
+  // @font-face rules aren't missed.
+  const fontRules = [], pending = [], seen = new Set();
+  const scrapeCss = (href) => {
+    if (seen.has(href)) return; seen.add(href);
+    pending.push(fetch(href).then((r) => r.text()).then((css) => {
+      for (const m of css.match(/@font-face\s*{[^}]*}/g) || []) fontRules.push({ css: m, base: href });
+      for (const m of css.matchAll(/@import\s+(?:url\()?['"]?([^'")\s;]+)/g))
+        scrapeCss(new URL(m[1], href).href);
+    }).catch(() => {}));
+  };
+  const walk = (rules, base) => {
+    for (const r of rules) {
+      if (r.type === CSSRule.FONT_FACE_RULE) fontRules.push({ css: r.cssText, base });
+      else if (r.type === CSSRule.IMPORT_RULE && r.styleSheet) {
+        const ibase = r.styleSheet.href || base;
+        try { walk(r.styleSheet.cssRules, ibase); } catch { scrapeCss(ibase); }
+      } else if (r.cssRules) walk(r.cssRules, base);
+    }
+  };
+  for (const ss of document.styleSheets) {
+    const base = ss.href || location.href;
+    try { walk(ss.cssRules, base); } catch { if (ss.href) scrapeCss(ss.href); }
+  }
+  while (pending.length) await pending.shift();
+  const fontCss = (await Promise.all(fontRules.map(async (rule) => {
+    let out = rule.css, m; const re = /url\((['"]?)([^'")]+)\1\)/g;
+    while ((m = re.exec(rule.css))) {
+      if (m[2].indexOf('data:') === 0) continue;
+      let abs; try { abs = new URL(m[2], rule.base).href; } catch { continue; }
+      out = out.split(m[0]).join('url("' + await toDataURL(abs) + '")');
+    }
+    return out;
+  }))).join('\n');
+
+  const cloneStyled = (src) => {
+    if (src.nodeType === 8 || (src.nodeType === 1 && src.tagName === 'SCRIPT')) return document.createTextNode('');
+    const dst = src.cloneNode(false);
+    if (src.nodeType === 1) {
+      const cs = getComputedStyle(src); let txt = '';
+      for (let i = 0; i < cs.length; i++) txt += cs[i] + ':' + cs.getPropertyValue(cs[i]) + ';';
+      dst.setAttribute('style', txt + 'animation:none;transition:none;');
+      if (src.tagName === 'CANVAS') try { const im = document.createElement('img'); im.src = src.toDataURL(); im.setAttribute('style', txt); return im; } catch {}
+    }
+    for (let c = src.firstChild; c; c = c.nextSibling) dst.appendChild(cloneStyled(c));
+    return dst;
+  };
+  const clone = cloneStyled(node);
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  // Drop the card's own shadow/radius so the export is a flush w×h rect;
+  // the artboard's own background (if any) is already in the computed style.
+  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0';
+
+  const jobs = [];
+  clone.querySelectorAll('img').forEach((el) => {
+    const s = el.getAttribute('src');
+    if (s && s.indexOf('data:') !== 0) jobs.push(toDataURL(el.src).then((d) => el.setAttribute('src', d)));
+  });
+  [clone, ...clone.querySelectorAll('*')].forEach((el) => {
+    const bg = el.style.backgroundImage; if (!bg) return;
+    let m; const re = /url\(["']?([^"')]+)["']?\)/g;
+    while ((m = re.exec(bg))) {
+      const tok = m[0], url = m[1];
+      if (url.indexOf('data:') === 0) continue;
+      jobs.push(toDataURL(url).then((d) => { el.style.backgroundImage = el.style.backgroundImage.split(tok).join('url("' + d + '")'); }));
+    }
+  });
+  await Promise.all(jobs);
+
+  const xml = new XMLSerializer().serializeToString(clone);
+  const save = (blob, ext) => {
+    if (!blob) return;
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = name + '.' + ext; a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  };
+
+  if (kind === 'html') {
+    const html = '<!doctype html><html><head><meta charset="utf-8"><title>' + name + '</title>' +
+      (fontCss ? '<style>' + fontCss + '</style>' : '') +
+      '</head><body style="margin:0">' + xml + '</body></html>';
+    return save(new Blob([html], { type: 'text/html' }), 'html');
+  }
+
+  // PNG: the SVG's own width/height must be the output resolution — an
+  // <img>-loaded SVG rasterizes at its intrinsic size, so sizing it at 1×
+  // and ctx.scale()-ing up would just upscale a 1× bitmap. viewBox maps the
+  // w×h foreignObject onto the px·w × px·h SVG canvas so the browser renders
+  // the HTML at full resolution.
+  const px = 3;
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w * px + '" height="' + h * px +
+    '" viewBox="0 0 ' + w + ' ' + h + '"><foreignObject width="' + w + '" height="' + h + '">' +
+    (fontCss ? '<style><![CDATA[' + fontCss + ']]></style>' : '') + xml + '</foreignObject></svg>';
+  const img = new Image();
+  await new Promise((res, rej) => {
+    img.onload = res; img.onerror = () => rej(new Error('svg load failed'));
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  });
+  const cv = document.createElement('canvas');
+  cv.width = w * px; cv.height = h * px;
+  cv.getContext('2d').drawImage(img, 0, 0);
+  cv.toBlob((blob) => save(blob, 'png'), 'image/png');
+}
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus, onDelete }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+  const cardRef = React.useRef(null);
+  const menuRef = React.useRef(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  // ⋯ menu: close on any outside pointerdown. Two-click delete lives inside
+  // the menu — first click arms the row, second commits; closing disarms.
+  React.useEffect(() => {
+    if (!menuOpen) { setConfirming(false); return; }
+    const off = (e) => { if (!menuRef.current || !menuRef.current.contains(e.target)) setMenuOpen(false); };
+    document.addEventListener('pointerdown', off, true);
+    return () => document.removeEventListener('pointerdown', off, true);
+  }, [menuOpen]);
+
+  const doExport = (kind) => {
+    setMenuOpen(false);
+    if (!cardRef.current) return;
+    const name = String(label || id || 'artboard').replace(/[^\w\s.-]+/g, '_');
+    dcExport(cardRef.current, width, height, name, kind)
+      .catch((e) => console.error('[design-canvas] export failed:', e));
+  };
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-header" data-omelette-chrome="" style={{ color: DC.label }} onPointerDown={(e) => e.stopPropagation()}>
+        <div className="dc-labelrow">
+          <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+            <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+          </div>
+          <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+            <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+              style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+          </div>
+        </div>
+        <div className="dc-btns">
+          <div ref={menuRef} style={{ position: 'relative' }}>
+            <button className="dc-kebab" title="More" onClick={() => setMenuOpen((o) => !o)}>
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><circle cx="2.5" cy="6" r="1.1"/><circle cx="6" cy="6" r="1.1"/><circle cx="9.5" cy="6" r="1.1"/></svg>
+            </button>
+            {menuOpen && (
+              <div className="dc-menu" onPointerDown={(e) => e.stopPropagation()}>
+                <button onClick={() => doExport('png')}>Download PNG</button>
+                <button onClick={() => doExport('html')}>Download HTML</button>
+                <hr />
+                <button className="dc-danger"
+                  onClick={() => { if (confirming) { setMenuOpen(false); onDelete(); } else setConfirming(true); }}>
+                  {confirming ? 'Click again to delete' : 'Delete'}
+                </button>
+              </div>
+            )}
+          </div>
+          <button className="dc-expand" onClick={onFocus} title="Focus">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+          </button>
+        </div>
+      </div>
+      <div ref={cardRef} className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    // Sections whose artboards are all deleted have slotIds:[] — step past
+    // them to the next non-empty section so ↑/↓ doesn't dead-end.
+    const n = sectionOrder.length;
+    for (let i = 1; i < n; i++) {
+      const ns = sectionOrder[(((secIdx + d * i) % n) + n) % n];
+      const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+      if (first) { ctx.setFocus(`${ns}/${first}`); return; }
+    }
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.filter((sid) => sectionMeta[sid].slotIds.length).map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/design/design-system/templates/snide/snide-cards.jsx
+++ b/docs/design/design-system/templates/snide/snide-cards.jsx
@@ -1,0 +1,326 @@
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. task-card redesign — five punk directions
+   All attach to window for the canvas host to mount.
+   ════════════════════════════════════════════════════════════════ */
+
+/* shared sample task so options are directly comparable */
+const TASK = {
+  title: "DO A KICKFLIP",
+  desc: "Do a kickflip. Bonus points if you don't use a skateboard. Double if nobody asked you to.",
+  level: 2,
+  points: 25,
+};
+
+/* a spread of real S.N.I.D.E. tasks — gleefully disruptive, harmless */
+const TASKS = [
+  TASK,
+  { title: "FIX A SIGN", desc: "Borrow the letters off a public sign. Spell something kinder. Put it back by dawn.", level: 3, points: 40 },
+  { title: "SPREAD A LIE", desc: "Start a flattering, false rumor about yourself. Tell exactly one person, then walk away.", level: 1, points: 10 },
+  { title: "SILENT RIOT", desc: "Gather five accomplices. Be absolutely furious about something. Make no sound at all.", level: 4, points: 60 },
+];
+
+/* ── Grain speckle overlay (xerox grit) ── */
+function Grain({ opacity = 0.5, blend = "multiply" }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none",
+      filter: "url(#snide-grain)", opacity, mixBlendMode: blend,
+    }} />
+  );
+}
+
+/* ── Ransom-note cut letters ── */
+const RANSOM_STYLES = [
+  { bg: "var(--paper)", col: "var(--ink)", font: "var(--f-anton)", rot: -5 },
+  { bg: "var(--ink)", col: "var(--acid)", font: "var(--f-cond)", rot: 4 },
+  { bg: "var(--pink)", col: "#fff", font: "var(--f-black)", rot: -3 },
+  { bg: "var(--acid)", col: "var(--ink)", font: "var(--f-anton)", rot: 6 },
+  { bg: "var(--paper)", col: "var(--ink)", font: "var(--f-serif)", rot: 2, italic: true },
+  { bg: "var(--ink)", col: "#fff", font: "var(--f-cond)", rot: -6 },
+];
+function Ransom({ text, size = 30 }) {
+  return (
+    <span style={{ display: "inline-flex", flexWrap: "wrap", gap: "5px 3px", alignItems: "center" }}>
+      {[...text].map((ch, idx) => {
+        if (ch === " ") return <span key={idx} style={{ width: size * 0.22 }} />;
+        const s = RANSOM_STYLES[(ch.charCodeAt(0) + idx * 3) % RANSOM_STYLES.length];
+        return (
+          <span key={idx} style={{
+            display: "inline-block", background: s.bg, color: s.col, fontFamily: s.font,
+            fontStyle: s.italic ? "italic" : "normal", fontSize: size, lineHeight: 0.92,
+            padding: "2px 6px 0", transform: `rotate(${s.rot}deg)`,
+            boxShadow: "1.5px 2.5px 0 rgba(0,0,0,0.4)", textTransform: "uppercase",
+          }}>{ch}</span>
+        );
+      })}
+    </span>
+  );
+}
+
+const TORN = "polygon(0 0,3% 100%,7% 30%,11% 90%,15% 20%,19% 80%,23% 10%,27% 95%,31% 25%,35% 85%,39% 5%,43% 90%,47% 30%,51% 80%,55% 0,59% 95%,63% 25%,67% 85%,71% 10%,75% 90%,79% 20%,83% 95%,87% 30%,91% 80%,95% 15%,100% 0)";
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION A — RANSOM DISPATCH
+   Photocopier-black demand note. Cut-out ransom title, acid spot,
+   taped to the wall. "your assignment, should you ignore it."
+   ════════════════════════════════════════════════════════════════ */
+function CardRansom({ task = TASK, rot = -1 }) {
+  return (
+    <div style={{
+      width: 304, position: "relative", background: "var(--ink)", color: "#fff",
+      padding: "32px 22px 24px", fontFamily: "var(--f-body)", overflow: "hidden",
+      boxShadow: "7px 9px 0 rgba(0,0,0,0.28)", transform: `rotate(${rot}deg)`,
+    }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.09)", pointerEvents: "none" }} />
+      <Grain opacity={0.35} blend="screen" />
+      {/* masthead */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderBottom: "2px solid var(--acid)", paddingBottom: 6, marginBottom: 14, position: "relative" }}>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 15, letterSpacing: "0.22em", color: "var(--acid)" }}>S.N.I.D.E.</span>
+        <span style={{ fontSize: 8, letterSpacing: "0.16em", color: "#8f9183", textTransform: "uppercase" }}>dispatch №0666</span>
+      </div>
+      <div style={{ fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--pink)", transform: "rotate(-1.5deg)", marginBottom: 6 }}>your assignment, should you ignore it —</div>
+      <div style={{ margin: "10px 0 16px" }}><Ransom text={task.title} size={30} /></div>
+      <p style={{ fontSize: 11, lineHeight: 1.55, color: "#d8d6c8", margin: "0 0 18px" }}>{task.desc}</p>
+      <div style={{ display: "flex", alignItems: "center", gap: 14, position: "relative" }}>
+        {/* spray stencil points */}
+        <div style={{ position: "relative", fontFamily: "var(--f-anton)", color: "var(--acid)", lineHeight: 0.8 }}>
+          <span style={{ fontSize: 40 }}>{task.points}</span>
+          <span style={{ fontSize: 11, letterSpacing: "0.1em", marginLeft: 3 }}>PTS</span>
+          <svg viewBox="0 0 120 60" style={{ position: "absolute", inset: "-12px -10px", width: "calc(100% + 20px)", height: "calc(100% + 24px)" }}>
+            <ellipse cx="60" cy="30" rx="54" ry="25" fill="none" stroke="var(--pink)" strokeWidth="2.5" filter="url(#snide-rough)" />
+          </svg>
+        </div>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.1em", border: "1.5px dashed #6b6d60", color: "#cfd1c4", padding: "3px 8px", transform: "rotate(2deg)" }}>LVL {task.level}</span>
+        <span style={{ marginLeft: "auto", position: "relative", background: "var(--pink)", color: "#fff", fontFamily: "var(--f-black)", fontSize: 12, padding: "7px 12px", transform: "rotate(-3deg)", boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>I'M IN ↗</span>
+      </div>
+      {/* tape */}
+      <div className="tape" style={{ top: -11, left: 34, transform: "rotate(-8deg)" }} />
+      <div className="tape" style={{ top: -9, right: 26, transform: "rotate(7deg)" }} />
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION B — XEROX GIG FLYER
+   Pinned to a telephone pole. High-contrast photocopy, sunburst,
+   double-print pink ghost, and rip-off commitment tabs at the base.
+   ════════════════════════════════════════════════════════════════ */
+function CardFlyer() {
+  const tabs = Array.from({ length: 7 });
+  return (
+    <div style={{ width: 286, position: "relative", transform: "rotate(1.2deg)", filter: "drop-shadow(5px 7px 0 rgba(0,0,0,0.22))" }}>
+      <div className="xerox" style={{ position: "relative", border: "2px solid var(--ink)", padding: "16px 16px 8px", fontFamily: "var(--f-body)", color: "var(--ink)", overflow: "hidden" }}>
+        <Grain opacity={0.6} />
+        {/* sunburst header block */}
+        <div style={{ position: "relative", height: 92, marginBottom: 12, overflow: "hidden", background: "var(--ink)" }}>
+          <svg viewBox="0 0 200 92" preserveAspectRatio="xMidYMid slice" style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
+            <defs>
+              <radialGradient id="sb" cx="50%" cy="48%" r="60%">
+                <stop offset="0%" stopColor="#ff2d8b" />
+                <stop offset="100%" stopColor="#14110b" />
+              </radialGradient>
+            </defs>
+            <rect width="200" height="92" fill="url(#sb)" />
+            {Array.from({ length: 28 }).map((_, i) => {
+              const a = (i / 28) * Math.PI * 2;
+              return <line key={i} x1="100" y1="46" x2={100 + Math.cos(a) * 240} y2={46 + Math.sin(a) * 240} stroke="#14110b" strokeWidth={i % 2 ? 7 : 0} opacity="0.55" />;
+            })}
+          </svg>
+          <div className="ht-dots-lg" style={{ position: "absolute", inset: 0, color: "rgba(0,0,0,0.5)", mixBlendMode: "multiply" }} />
+          <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", color: "#fff" }}>
+            <span style={{ fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--acid)", transform: "rotate(-2deg)" }}>tonight only*</span>
+            <span style={{ fontFamily: "var(--f-anton)", fontSize: 14, letterSpacing: "0.3em", marginTop: 2 }}>S.N.I.D.E.</span>
+          </div>
+        </div>
+        {/* title double-print (offset pink mis-registration) */}
+        <h2 style={{ margin: "0 0 8px", fontFamily: "var(--f-anton)", fontSize: 38, lineHeight: 0.86, letterSpacing: "0.01em", textTransform: "uppercase", color: "var(--ink)", transform: "skewX(-5deg)", textShadow: "2.5px 2.5px 0 var(--pink)" }}>{TASK.title}</h2>
+        <p style={{ fontFamily: "var(--f-type)", fontSize: 11.5, lineHeight: 1.5, margin: "0 0 10px" }}>{TASK.desc}</p>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+          <span style={{ fontFamily: "var(--f-anton)", fontSize: 22, background: "var(--ink)", color: "var(--acid)", padding: "1px 8px" }}>{TASK.points} PTS</span>
+          <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.12em", border: "2px solid var(--ink)", padding: "2px 8px", transform: "rotate(-2deg)" }}>LVL {TASK.level}</span>
+          <span style={{ marginLeft: "auto", fontFamily: "var(--f-marker)", fontSize: 12, color: "var(--pink-deep)" }}>no refunds</span>
+        </div>
+        {/* diagonal stamp */}
+        <span style={{ position: "absolute", top: 108, right: -34, transform: "rotate(-38deg)", fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.2em", color: "rgba(190,24,93,0.85)", border: "2px solid rgba(190,24,93,0.7)", padding: "2px 30px" }}>DISRUPT</span>
+        {/* rip-off commitment tabs */}
+        <div style={{ position: "relative", borderTop: "2px dashed var(--ink)", margin: "0 -16px" }}>
+          <span style={{ position: "absolute", left: 10, top: -8, background: "var(--paper)", fontSize: 12, lineHeight: 1, padding: "0 3px", color: "var(--ink)" }}>✂</span>
+        </div>
+        <div style={{ display: "flex", margin: "0 -16px -8px" }}>
+          {tabs.map((_, i) => (
+            <div key={i} style={{ flex: 1, height: 50, position: "relative", borderLeft: i ? "1px dashed rgba(20,17,11,0.45)" : "none", background: "var(--paper)" }}>
+              <span style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", writingMode: "vertical-rl", transform: "rotate(180deg)", fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.16em", color: "var(--ink)" }}>JOIN</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION C — SEWN PATCH
+   Embroidered vest patch. Acid merrow stitch border, twill ground,
+   chain-stitch title, safety pin. The silly-but-feral one.
+   ════════════════════════════════════════════════════════════════ */
+function CardPatch() {
+  return (
+    <div style={{ width: 290, position: "relative", padding: 14, transform: "rotate(-1.5deg)" }}>
+      {/* safety pin */}
+      <svg viewBox="0 0 120 40" style={{ position: "absolute", top: -8, left: 30, width: 130, height: 44, zIndex: 4, filter: "drop-shadow(1px 2px 1px rgba(0,0,0,0.4))" }}>
+        <path d="M14 22 Q10 8 30 9 L96 13 Q112 14 110 26 Q108 34 96 30 L26 18" fill="none" stroke="#c7ccd1" strokeWidth="3.4" strokeLinecap="round" />
+        <circle cx="14" cy="24" r="6.5" fill="none" stroke="#c7ccd1" strokeWidth="3.4" />
+        <circle cx="14" cy="24" r="1.6" fill="#c7ccd1" />
+      </svg>
+      {/* merrow stitched border */}
+      <div className="merrow" style={{ position: "relative", borderRadius: 16, padding: 7, boxShadow: "4px 6px 0 rgba(0,0,0,0.3)" }}>
+        <div style={{
+          position: "relative", borderRadius: 11, padding: "24px 20px 20px",
+          background: "#15120c",
+          backgroundImage: "repeating-linear-gradient(45deg, rgba(255,255,255,0.025) 0 2px, transparent 2px 4px), repeating-linear-gradient(-45deg, rgba(0,0,0,0.25) 0 2px, transparent 2px 4px)",
+          overflow: "hidden",
+          boxShadow: "inset 0 0 0 2px rgba(182,255,46,0.5), inset 0 2px 14px rgba(0,0,0,0.6)",
+          fontFamily: "var(--f-body)",
+        }}>
+          <Grain opacity={0.4} blend="overlay" />
+          <div style={{ textAlign: "center", fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.35em", color: "var(--acid)", marginBottom: 8 }}>★ EST. NEVER ★</div>
+          {/* chain-stitch title */}
+          <h2 style={{
+            margin: "0 0 6px", textAlign: "center", fontFamily: "var(--f-marker)", fontSize: 30, lineHeight: 1,
+            color: "var(--acid)", textTransform: "uppercase",
+            textShadow: "0 0 1px var(--acid-deep), 1px 1px 0 #0a0a06, -1px 0 0 var(--acid-deep)",
+          }}>{TASK.title}</h2>
+          <div style={{ width: 70, height: 0, borderTop: "2.5px dotted var(--acid)", margin: "8px auto 12px", opacity: 0.8 }} />
+          <p style={{ textAlign: "center", fontFamily: "var(--f-type)", fontSize: 11, lineHeight: 1.5, color: "#cdd6c4", margin: "0 0 16px" }}>{TASK.desc}</p>
+          <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 14 }}>
+            {/* stitched roundel */}
+            <div style={{ width: 52, height: 52, borderRadius: "50%", background: "var(--pink)", border: "2.5px dashed #fff", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", color: "#fff", boxShadow: "1px 2px 0 rgba(0,0,0,0.4)" }}>
+              <span style={{ fontFamily: "var(--f-anton)", fontSize: 20, lineHeight: 0.8 }}>{TASK.points}</span>
+              <span style={{ fontSize: 7, letterSpacing: "0.1em" }}>POINTS</span>
+            </div>
+            <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.15em", color: "var(--acid)", border: "2px dashed var(--acid)", borderRadius: 20, padding: "4px 12px" }}>LVL {TASK.level}</span>
+          </div>
+          <div style={{ marginTop: 16, textAlign: "center" }}>
+            <span style={{ display: "inline-block", fontFamily: "var(--f-black)", fontSize: 12, letterSpacing: "0.06em", background: "var(--acid)", color: "#15120c", borderRadius: 14, padding: "7px 18px", transform: "rotate(-1deg)" }}>SEW ME ON →</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION D — SPRAY STENCIL
+   Tagged on a concrete wall. Stencil-cut title, acid overspray,
+   running drips, a circled-A'd SNIDE mark. "tag, you're it."
+   ════════════════════════════════════════════════════════════════ */
+function Drip({ x, h, w = 3 }) {
+  return (
+    <g>
+      <rect x={x} y="0" width={w} height={h} fill="var(--acid)" opacity="0.85" />
+      <circle cx={x + w / 2} cy={h} r={w * 0.9} fill="var(--acid)" opacity="0.85" />
+    </g>
+  );
+}
+function CardSpray() {
+  return (
+    <div style={{
+      width: 300, position: "relative", padding: "26px 22px 22px",
+      background: "#3a3a37",
+      backgroundImage: "radial-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), radial-gradient(rgba(0,0,0,0.22) 1px, transparent 1px)",
+      backgroundSize: "3px 3px, 5px 5px", backgroundPosition: "0 0, 2px 2px",
+      fontFamily: "var(--f-body)", color: "#e7e4da", overflow: "hidden",
+      boxShadow: "6px 8px 0 rgba(0,0,0,0.3)", transform: "rotate(0.6deg)",
+    }}>
+      <Grain opacity={0.5} blend="multiply" />
+      {/* concrete cracks */}
+      <svg viewBox="0 0 300 220" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.25, pointerEvents: "none" }}>
+        <path d="M0 40 L60 70 L80 50 L160 90" stroke="#000" strokeWidth="0.8" fill="none" />
+        <path d="M300 150 L240 160 L210 140 L120 180" stroke="#000" strokeWidth="0.8" fill="none" />
+      </svg>
+      {/* circled-A SNIDE mark */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
+        <svg viewBox="0 0 48 48" style={{ width: 40, height: 40 }} filter="url(#snide-spray)">
+          <circle cx="24" cy="24" r="19" fill="none" stroke="var(--acid)" strokeWidth="3" />
+          <path d="M14 34 L24 12 L34 34 M18 27 H30" fill="none" stroke="var(--acid)" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <div>
+          <div style={{ fontFamily: "var(--f-cond)", fontSize: 15, letterSpacing: "0.22em", color: "var(--acid)" }}>S.N.I.D.E.</div>
+          <div style={{ fontSize: 8, letterSpacing: "0.14em", color: "#a7a49a", textTransform: "uppercase" }}>property of nobody</div>
+        </div>
+        <span style={{ marginLeft: "auto", fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--pink)", transform: "rotate(-4deg)" }}>tag, you're it</span>
+      </div>
+      {/* sprayed stencil title */}
+      <div style={{ position: "relative", marginBottom: 6 }}>
+        <h2 style={{ margin: 0, fontFamily: "var(--f-cond)", fontSize: 50, lineHeight: 0.84, letterSpacing: "0.02em", color: "var(--acid)", textTransform: "uppercase", filter: "url(#snide-spray)", textShadow: "0 0 7px rgba(182,255,46,0.45)" }}>{TASK.title}</h2>
+        {/* drips under the title */}
+        <svg viewBox="0 0 300 46" style={{ position: "absolute", left: 0, bottom: -16, width: "100%", height: 46, pointerEvents: "none" }} filter="url(#snide-spray)">
+          <Drip x={36} h={34} /><Drip x={120} h={22} w={2.4} /><Drip x={188} h={40} /><Drip x={250} h={18} w={2.2} />
+        </svg>
+      </div>
+      <p style={{ fontSize: 11, lineHeight: 1.55, color: "#cbc8be", margin: "22px 0 18px" }}>{TASK.desc}</p>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 14 }}>
+        <div style={{ position: "relative", fontFamily: "var(--f-anton)", color: "var(--acid)", lineHeight: 0.8, filter: "url(#snide-spray)" }}>
+          <span style={{ fontSize: 42 }}>{TASK.points}</span>
+          <span style={{ fontSize: 12, marginLeft: 3 }}>PTS</span>
+        </div>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.14em", color: "#e7e4da", border: "2px solid #6f6f68", padding: "3px 9px", transform: "rotate(-2deg)" }}>LVL {TASK.level}</span>
+        <span style={{ marginLeft: "auto", fontFamily: "var(--f-black)", fontSize: 12, color: "#15120c", background: "var(--acid)", padding: "7px 12px", transform: "rotate(2deg)", boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>HIT IT ↗</span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION E — ZINE COLLAGE  (green/black rework, pink as accent)
+   Cut-and-paste chaos ripped from acid-green stock. Black ink scraps,
+   ransom title, pink tape + scrawl + CTA accents, sticker points.
+   ════════════════════════════════════════════════════════════════ */
+function CardZine({ task = TASK, rot = -0.8 }) {
+  return (
+    <div style={{
+      width: 300, position: "relative", padding: "20px 18px 22px",
+      background: "var(--acid)", overflow: "hidden",
+      fontFamily: "var(--f-body)", color: "var(--ink)",
+      boxShadow: "6px 8px 0 rgba(0,0,0,0.32)", transform: `rotate(${rot}deg)`,
+    }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.22)", pointerEvents: "none" }} />
+      <Grain opacity={0.45} />
+      {/* torn top/bottom — ripped from black stock */}
+      <div className="torn-top" style={{ background: "var(--ink)", clipPath: TORN }} />
+      <div className="torn-bottom" style={{ background: "var(--ink)", clipPath: TORN }} />
+      {/* masthead scrap */}
+      <div style={{ position: "relative", display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+        <span style={{ background: "var(--ink)", color: "var(--acid)", fontFamily: "var(--f-cond)", fontSize: 14, letterSpacing: "0.2em", padding: "2px 8px", transform: "rotate(-2deg)" }}>S.N.I.D.E.</span>
+        <span style={{ background: "var(--paper)", fontFamily: "var(--f-type)", fontSize: 9, whiteSpace: "nowrap", padding: "2px 7px", transform: "rotate(2deg)" }}>STILL FREE</span>
+      </div>
+      {/* black scrap w/ ransom title */}
+      <div style={{ position: "relative", background: "var(--ink)", padding: "12px 12px 14px", transform: "rotate(-1.5deg)", marginBottom: 16, boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>
+        <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.14)", pointerEvents: "none" }} />
+        <div style={{ position: "relative" }}><Ransom text={task.title} size={25} /></div>
+      </div>
+      {/* taped cream desc scrap + pink tape accent */}
+      <div style={{ position: "relative", background: "var(--paper)", padding: "13px 12px 11px", transform: "rotate(0.8deg)", marginBottom: 16, boxShadow: "2px 3px 0 rgba(0,0,0,0.28)" }}>
+        <div style={{ position: "absolute", top: -9, left: "50%", marginLeft: -30, width: 60, height: 19, background: "rgba(255,45,139,0.5)", boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.3)", transform: "rotate(-4deg)" }} />
+        <p style={{ fontFamily: "var(--f-type)", fontSize: 11, lineHeight: 1.5, margin: 0, color: "#1a160e" }}>{task.desc}</p>
+        <div style={{ fontFamily: "var(--f-marker)", fontSize: 15, color: "var(--pink)", transform: "rotate(-3deg)", marginTop: 6, WebkitTextStroke: "0.4px var(--pink-deep)" }}>do it, coward →</div>
+      </div>
+      {/* bottom row: black sticker points + level + pink CTA */}
+      <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 12 }}>
+        <div style={{ position: "relative", width: 56, height: 56, transform: "rotate(-6deg)" }}>
+          <svg viewBox="0 0 56 56" style={{ position: "absolute", inset: 0, filter: "drop-shadow(1.5px 2px 0 rgba(0,0,0,0.35))" }}>
+            <circle cx="28" cy="28" r="26" fill="var(--ink)" stroke="var(--acid)" strokeWidth="2.5" />
+          </svg>
+          <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", color: "var(--acid)" }}>
+            <span style={{ fontFamily: "var(--f-anton)", fontSize: 22, lineHeight: 0.8 }}>{task.points}</span>
+            <span style={{ fontSize: 7, fontWeight: 700, letterSpacing: "0.1em" }}>POINTS</span>
+          </div>
+        </div>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.12em", background: "var(--ink)", color: "var(--acid)", padding: "3px 9px", transform: "rotate(2deg)" }}>LVL {task.level}</span>
+        <span style={{ marginLeft: "auto", fontFamily: "var(--f-black)", fontSize: 13, background: "var(--pink)", color: "#fff", padding: "8px 13px", transform: "rotate(-2deg)", boxShadow: "2px 3px 0 var(--ink)" }}>I'M IN ↗</span>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { CardRansom, CardFlyer, CardPatch, CardSpray, CardZine, Ransom, SNIDE_TASK: TASK, SNIDE_TASKS: TASKS });

--- a/docs/design/design-system/templates/snide/snide-faction.jsx
+++ b/docs/design/design-system/templates/snide/snide-faction.jsx
@@ -1,0 +1,234 @@
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. — faction-aware surfaces
+   Society for Nihilistic Intent and Disruptive Efforts.
+   Sigil · nav badge · pennant (filter tab) · vote stamps (approval) ·
+   stat block · faction-page hero (flyposted masthead) · dispatch slip.
+   Reuses snide.css tokens + the photocopy filters (#snide-grain/-spray).
+   Theme-aware through the cascade.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── SNIDE sigil — a sprayed, struck-through circle-S (defiant mark) ── */
+function SnideSigil({ size = 48, color = "var(--acid)", strokeOnly = false }) {
+  return (
+    <svg viewBox="0 0 48 48" width={size} height={size} style={{ display: "block" }} filter="url(#snide-spray)">
+      <circle cx="24" cy="24" r="19" fill="none" stroke={color} strokeWidth="3" />
+      <text x="24" y="34" textAnchor="middle" fontFamily="var(--f-anton)" fontSize="30" fill={color}>S</text>
+      <line x1="9" y1="40" x2="39" y2="8" stroke={color} strokeWidth="3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/* ── nav faction badge ─────────────────────────────────────────────── */
+function SnideNavBadge({ name = "S.N.I.D.E." }) {
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 6, background: "var(--snide-green)",
+      color: "#fff", padding: "5px 9px 5px 7px", fontFamily: "var(--f-cond)",
+      fontSize: 12, letterSpacing: "0.14em", textTransform: "uppercase", transform: "rotate(-1deg)",
+      boxShadow: "1.5px 2px 0 rgba(0,0,0,0.4)",
+    }}>
+      <SnideSigil size={15} color="var(--acid)" />
+      {name}
+    </span>
+  );
+}
+
+/* ── faction pennant (filter tab) ──────────────────────────────────── */
+/* Same clip-path as the other seven so the filter row aligns; only color
+   changes. Inactive drops opacity. SNIDE uses its toxic green. */
+function SnidePennant({ color, name, active = false, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      background: color, color: "#fff", fontFamily: "var(--font-body)", fontSize: 9.5,
+      fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.07em", padding: "5px 14px",
+      cursor: "pointer", border: "none", borderRadius: 0, textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+      opacity: active ? 1 : 0.78, clipPath: "polygon(0 0, 100% 0, 94% 100%, 6% 100%)", whiteSpace: "nowrap",
+      transform: active ? "translateY(-2px) rotate(-1deg)" : "none", transition: "all 120ms",
+      filter: active ? "drop-shadow(0 4px 6px rgba(0,0,0,0.28))" : "none",
+    }}>
+      {name}
+    </button>
+  );
+}
+
+/* ── vote stamps — a mismatched drawer of rubber stamps ────────────── */
+/* Each mark is a different junk-drawer stamp: varied shape, size, font,
+   tilt and ink. Climbs from a limp "meh" to the black ANARCHY seal. */
+const SNIDE_VOTE = [
+  { v: 1, label: "meh",     shape: "square", rot: -8, size: 38, font: "var(--f-type)",  fill: "transparent",      ink: "cur",         ring: "cur",         border: "dashed" },
+  { v: 2, label: "not bad", shape: "circle", rot: 6,  size: 46, font: "var(--f-anton)", fill: "var(--acid-deep)", ink: "var(--ink)",  ring: "var(--ink)",  border: "solid" },
+  { v: 3, label: "rad",     shape: "square", rot: -5, size: 52, font: "var(--f-cond)",  fill: "var(--acid)",      ink: "var(--ink)",  ring: "var(--ink)",  border: "double" },
+  { v: 4, label: "sick!!",  shape: "burst",  rot: 9,  size: 56, font: "var(--f-black)", fill: "var(--pink)",      ink: "#fff",        ring: "var(--ink)",  border: "solid" },
+  { v: 5, label: "ANARCHY", shape: "seal",   rot: -6, size: 62, font: "var(--f-anton)", fill: "var(--ink)",       ink: "var(--acid)", ring: "var(--acid)", border: "solid" },
+];
+const BURST_CLIP = "polygon(50% 0,61% 25%,90% 10%,75% 39%,100% 50%,75% 61%,90% 90%,61% 75%,50% 100%,39% 75%,10% 90%,25% 61%,0 50%,25% 39%,10% 10%,39% 25%)";
+function SnideVoteStamps({ value = 0, average, totalVotes, onPick }) {
+  const [sel, setSel] = React.useState(value);
+  React.useEffect(() => { setSel(value); }, [value]);
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 13, alignItems: "flex-end" }}>
+        {SNIDE_VOTE.map((s) => {
+          const on = sel >= s.v;
+          const cur = "var(--snide-wall-text)";
+          const ink = on ? (s.ink === "cur" ? cur : s.ink) : cur;
+          const ring = on ? (s.ring === "cur" ? cur : s.ring) : cur;
+          const round = s.shape === "circle" || s.shape === "seal";
+          const isBurst = s.shape === "burst";
+          return (
+            <div key={s.v} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+              <button onClick={() => { setSel(s.v); if (onPick) onPick(s.v); }} style={{
+                position: "relative", width: s.size, height: s.size, cursor: "pointer", padding: 0,
+                border: isBurst ? "none" : `${s.border === "double" ? 4 : 2.5}px ${s.border} ${ring}`,
+                borderRadius: round ? "50%" : 0,
+                clipPath: isBurst ? BURST_CLIP : "none",
+                background: on ? s.fill : (isBurst ? "color-mix(in srgb, var(--snide-wall-text) 13%, transparent)" : "transparent"),
+                color: ink, fontFamily: s.font, fontSize: s.size * (s.shape === "seal" ? 0.4 : 0.5), lineHeight: 1,
+                transform: `rotate(${s.rot}deg)${sel === s.v ? " scale(1.08)" : ""}`, transition: "all 110ms",
+                filter: on && !isBurst ? "url(#snide-rough)" : "none",
+                display: "flex", alignItems: "center", justifyContent: "center",
+              }}>
+                {s.shape === "seal" && (
+                  <span style={{ position: "absolute", inset: 4, borderRadius: "50%", border: `1.5px dashed ${on ? "var(--acid)" : cur}`, opacity: 0.7, pointerEvents: "none" }} />
+                )}
+                {s.v}
+              </button>
+              <span style={{ fontFamily: s.v === 5 ? "var(--f-cond)" : "var(--font-body)", fontSize: s.v === 5 ? 9 : 8,
+                textTransform: "uppercase", letterSpacing: "0.04em",
+                color: sel === s.v ? "var(--snide-green)" : "color-mix(in srgb, var(--snide-wall-text) 55%, transparent)",
+                maxWidth: s.size + 16, textAlign: "center", lineHeight: 1.2 }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+      {average !== undefined && (
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 10, color: "color-mix(in srgb, var(--snide-wall-text) 60%, transparent)", margin: "16px 0 0", letterSpacing: "0.04em" }}>
+          <b style={{ color: "var(--snide-green)", fontFamily: "var(--f-anton)", fontSize: 17 }}>{average.toFixed(1)}</b> avg · {totalVotes ?? 0} votes · <span style={{ fontFamily: "var(--f-marker)", color: "var(--pink)" }}>nobody's impressed</span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+/* ── stat block (hero) ─────────────────────────────────────────────── */
+function SnideStat({ value, label }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2, padding: "0 22px" }}>
+      <span style={{ fontFamily: "var(--f-anton)", fontSize: 36, lineHeight: 0.85, color: "var(--acid)", whiteSpace: "nowrap" }}>{value}</span>
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "#cfcdbf" }}>{label}</span>
+    </div>
+  );
+}
+
+/* ── faction-page hero (flyposted wall — NOT a tidy poster) ────────── */
+const HERO_GHOSTS = [
+  { w: 122, h: 152, top: -24, left: 54, rot: -12 },
+  { w: 96, h: 128, top: 44, left: 232, rot: 7 },
+  { w: 150, h: 92, top: 158, left: 430, rot: -5 },
+  { w: 84, h: 116, top: 14, left: 690, rot: 11 },
+  { w: 116, h: 150, top: 128, left: 858, rot: -8 },
+];
+function SnideHero({ name, motto, fullName, blurb, stats }) {
+  const chitRot = [-3, 2.5, -2];
+  return (
+    <header style={{ position: "relative", overflow: "hidden", background: "var(--ink)", color: "#fff", boxShadow: "8px 10px 0 rgba(0,0,0,0.32)", paddingBottom: 4 }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.055)", pointerEvents: "none" }} />
+      <div style={{ position: "absolute", inset: 0, filter: "url(#snide-grain)", opacity: 0.4, mixBlendMode: "screen", pointerEvents: "none" }} />
+      {/* faint pasted flyers on the wall */}
+      {HERO_GHOSTS.map((g, i) => (
+        <div key={i} aria-hidden="true" style={{ position: "absolute", top: g.top, left: g.left, width: g.w, height: g.h,
+          border: "1px solid rgba(182,255,46,0.07)", background: i % 2 ? "rgba(255,45,139,0.035)" : "rgba(182,255,46,0.025)",
+          transform: `rotate(${g.rot}deg)`, pointerEvents: "none" }} />
+      ))}
+      {/* torn acid strip */}
+      <div style={{ height: 6, background: "var(--acid)", position: "relative", zIndex: 2, clipPath: "polygon(0 0,100% 0,100% 55%,97% 100%,94% 50%,90% 100%,86% 55%,82% 100%,78% 60%,0 100%)" }} />
+
+      {/* slapped sigil sticker, tilted */}
+      <div style={{ position: "absolute", top: 34, right: 42, zIndex: 3, transform: "rotate(9deg)" }}>
+        <div style={{ position: "relative", width: 104, height: 104, borderRadius: "50%", background: "var(--paper)",
+          display: "flex", alignItems: "center", justifyContent: "center", border: "2px solid var(--snide-green)",
+          boxShadow: "0 0 0 4px var(--ink), 3px 4px 0 rgba(0,0,0,0.4)" }}>
+          <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.06)", borderRadius: "50%", pointerEvents: "none" }} />
+          <SnideSigil size={60} color="var(--snide-green)" />
+        </div>
+        <div style={{ position: "absolute", top: -9, left: "50%", marginLeft: -26, width: 52, height: 18, background: "var(--tape)", transform: "rotate(-7deg)" }} />
+      </div>
+
+      <div style={{ position: "relative", zIndex: 2, padding: "26px 38px 2px", maxWidth: 770 }}>
+        {/* eyebrow on tape */}
+        <div style={{ display: "inline-block", width: "fit-content", whiteSpace: "nowrap", background: "var(--tape)", color: "var(--ink)", fontFamily: "var(--f-type)", fontSize: 10, letterSpacing: "0.05em", padding: "3px 12px", transform: "rotate(-1.5deg)", boxShadow: "1px 1px 0 rgba(0,0,0,0.3)" }}>World Zero · faction no. 4</div>
+        {/* wordmark */}
+        <h1 style={{ fontFamily: "var(--f-anton)", fontSize: 86, lineHeight: 0.8, letterSpacing: "0.02em", margin: "14px 0 0",
+          color: "var(--acid)", textShadow: "4px 4px 0 var(--pink)", transform: "skewX(-5deg) rotate(-1.5deg)" }}>{name}</h1>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.16em", textTransform: "uppercase", color: "#b7b5a7", margin: "12px 0 0", transform: "rotate(-0.4deg)" }}>{fullName}</div>
+        {/* motto */}
+        <div style={{ display: "inline-block", marginTop: 14, background: "var(--acid)", color: "var(--ink)",
+          fontFamily: "var(--f-black)", fontSize: 15, letterSpacing: "0.02em", padding: "6px 15px", transform: "rotate(-2deg)", boxShadow: "2px 3px 0 var(--pink)" }}>{motto}</div>
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 12.5, lineHeight: 1.6, maxWidth: 600, margin: "16px 0 0", color: "#e7e4d8" }}>{blurb}</p>
+      </div>
+
+      {/* staggered stat chits — not a clean band */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", gap: 16, flexWrap: "wrap", padding: "24px 38px 28px" }}>
+        {stats.map((s, i) => (
+          <div key={s.label} style={{ background: "rgba(0,0,0,0.34)", border: "2px solid var(--acid)", padding: "8px 16px 7px",
+            transform: `rotate(${chitRot[i % chitRot.length]}deg)`, boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>
+            <div style={{ fontFamily: "var(--f-anton)", fontSize: 34, lineHeight: 0.85, color: "var(--acid)", whiteSpace: "nowrap" }}>{s.value}</div>
+            <div style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", color: "#cfcdbf" }}>{s.label}</div>
+          </div>
+        ))}
+      </div>
+    </header>
+  );
+}
+
+/* ── dispatch slip (faction activity feed item) ────────────────────── */
+/* World Zero's activity card reframed as an intercepted ransom-note slip. */
+const STAMP_KINDS = {
+  foe:   { label: "FOE",        color: "var(--pink)" },
+  yours: { label: "YOUR STUFF", color: "var(--snide-green)" },
+  duel:  { label: "DUEL",       color: "var(--color-danger, #dc2626)" },
+};
+function SnideDispatch({ actor, initial, action, task, badge, time, status, rot = -0.6 }) {
+  const stamp = badge ? STAMP_KINDS[badge] ?? STAMP_KINDS.yours : null;
+  return (
+    <div style={{
+      position: "relative", background: "var(--paper)", color: "var(--ink)", border: "1.5px solid var(--ink)",
+      padding: "14px 18px 18px", marginBottom: 18, transform: `rotate(${rot}deg)`, boxShadow: "3px 4px 0 rgba(0,0,0,0.22)",
+      fontFamily: "var(--font-body)", maxWidth: 560,
+    }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.05)", pointerEvents: "none" }} />
+      {/* torn bottom */}
+      <div style={{ position: "absolute", bottom: -1, left: 0, right: 0, height: 6, background: "var(--snide-wall)", clipPath: "polygon(0 0,4% 100%,8% 20%,14% 90%,20% 10%,26% 80%,32% 0,40% 95%,48% 20%,56% 85%,64% 5%,72% 90%,80% 15%,88% 95%,94% 20%,100% 0)" }} />
+      {/* rubber stamp badge */}
+      {stamp && (
+        <span style={{ position: "absolute", top: 10, right: 12, fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.12em",
+          color: stamp.color, border: `2px solid ${stamp.color}`, padding: "2px 9px", transform: "rotate(5deg)", opacity: 0.9 }}>{stamp.label}</span>
+      )}
+      <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 12 }}>
+        {/* sprayed avatar */}
+        <div style={{ flexShrink: 0, width: 42, height: 42, borderRadius: "50%", background: "var(--ink)", border: "2px solid var(--snide-green)",
+          display: "flex", alignItems: "center", justifyContent: "center", color: "var(--acid)", fontFamily: "var(--f-anton)", fontSize: 20, transform: "rotate(-4deg)" }}>{initial}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 8, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--snide-muted)", marginBottom: 2 }}>intercepted dispatch · {time}</div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.4 }}>
+            <span style={{ fontFamily: "var(--f-marker)", fontSize: 16, color: "var(--snide-green)", marginRight: 4 }}>{actor}</span>
+            {action}
+          </div>
+        </div>
+      </div>
+      {/* task chip */}
+      {task && (
+        <div style={{ position: "relative", display: "inline-flex", alignItems: "center", gap: 8, marginTop: 12, background: "var(--ink)", padding: "5px 10px", transform: "rotate(-1deg)", whiteSpace: "nowrap", maxWidth: "100%" }}>
+          <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.06em", color: "var(--acid)", whiteSpace: "nowrap" }}>{task.title}</span>
+          <span style={{ fontFamily: "var(--f-anton)", fontSize: 13, color: "var(--pink)" }}>+{task.points}</span>
+          {task.level && <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.08em", color: "#cfcdbf", textTransform: "uppercase" }}>lvl {task.level}</span>}
+        </div>
+      )}
+      {status && (
+        <div style={{ position: "relative", marginTop: 11, fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--pink)", transform: "rotate(-1deg)" }}>{status}</div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { SnideSigil, SnideNavBadge, SnidePennant, SnideVoteStamps, SnideStat, SnideHero, SnideDispatch });

--- a/docs/design/design-system/templates/snide/snide-praxis-detail.jsx
+++ b/docs/design/design-system/templates/snide/snide-praxis-detail.jsx
@@ -1,0 +1,160 @@
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. — Completed Praxis (case files) + Praxis Detail
+   · SnideVoteTally  — histogram of marks 1–5 received, punk bars
+   · SnidePraxisRow  — a filed confession as a pinned case-file row
+   · SnidePraxisDetail — one completed praxis in full + cast-a-vote
+   Reuses snide.css tokens, photocopy filters, SnideSigil + SnideVoteStamps.
+   Theme-aware via --snide-wall-text.
+   ════════════════════════════════════════════════════════════════ */
+
+const PD_MUTED = "color-mix(in srgb, var(--snide-wall-text) 55%, transparent)";
+const PD_MARKS = [
+  { v: 1, label: "meh", color: "color-mix(in srgb, var(--snide-wall-text) 45%, transparent)" },
+  { v: 2, label: "not bad", color: "var(--acid-deep)" },
+  { v: 3, label: "rad", color: "var(--acid)" },
+  { v: 4, label: "sick", color: "var(--pink)" },
+  { v: 5, label: "anarchy", color: "var(--snide-green)" },
+];
+
+function pdAvg(counts) {
+  let n = 0, s = 0;
+  for (const m of PD_MARKS) { const c = counts[m.v] || 0; n += c; s += c * m.v; }
+  return { total: n, avg: n ? s / n : 0 };
+}
+
+/* ── vote tally — how the marks landed ─────────────────────────────── */
+function SnideVoteTally({ counts }) {
+  const { total, avg } = pdAvg(counts);
+  const max = Math.max(1, ...PD_MARKS.map((m) => counts[m.v] || 0));
+  const wall = "var(--snide-wall-text)";
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 10, marginBottom: 14 }}>
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 54, lineHeight: 0.8, color: "var(--snide-green)" }}>{avg.toFixed(1)}</span>
+        <div style={{ paddingBottom: 5 }}>
+          <div style={{ fontFamily: "var(--f-cond)", fontSize: 16, letterSpacing: "0.06em", color: wall }}>OUT OF 5</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.06em", color: PD_MUTED }}>{total} marks · <span style={{ fontFamily: "var(--f-marker)", color: "var(--pink)" }}>still nobody's impressed</span></div>
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+        {[...PD_MARKS].reverse().map((m) => {
+          const c = counts[m.v] || 0;
+          return (
+            <div key={m.v} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span style={{ width: 16, textAlign: "center", fontFamily: "var(--f-anton)", fontSize: 15, color: wall }}>{m.v}</span>
+              <div style={{ flex: 1, height: 16, background: "color-mix(in srgb, var(--snide-wall-text) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--snide-wall-text) 25%, transparent)", position: "relative" }}>
+                <div style={{ position: "absolute", inset: 0, width: `${(c / max) * 100}%`, background: m.color, transition: "width 200ms" }} />
+              </div>
+              <span style={{ width: 26, textAlign: "right", fontFamily: "var(--font-body)", fontSize: 11, fontWeight: 700, color: wall }}>{c}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ── filed confession — case-file row (links to detail) ────────────── */
+function SnidePraxisRow({ href = "#", author, initial, faction = "S.N.I.D.E.", when, snippet, evidence = 0, counts, mark, rank }) {
+  const { avg, total } = pdAvg(counts);
+  const wall = "var(--snide-wall-text)";
+  const ink = "var(--ink)";
+  return (
+    <a href={href} className="casefile" style={{ position: "relative", display: "flex", background: "var(--paper)", color: ink,
+      border: "1.5px solid " + ink, boxShadow: "4px 5px 0 rgba(0,0,0,0.22)", overflow: "hidden", textDecoration: "none" }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.05)", pointerEvents: "none" }} />
+      {/* rank + mugshot tab */}
+      <div style={{ position: "relative", flexShrink: 0, width: 70, background: ink, color: "var(--acid)",
+        display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 4,
+        backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, rgba(182,255,46,0.18) 13px 14px)" }}>
+        {rank && <span style={{ position: "absolute", top: 5, left: 6, fontFamily: "var(--f-anton)", fontSize: 11, color: "var(--pink)" }}>#{rank}</span>}
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 26, lineHeight: 0.8 }}>{initial}</span>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.14em", color: "#cfe6a0" }}>EXHIBIT</span>
+      </div>
+      {/* body */}
+      <div style={{ position: "relative", flex: 1, padding: "12px 16px", minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 9, flexWrap: "wrap" }}>
+          <span style={{ fontFamily: "var(--f-marker)", fontSize: 18, color: "var(--snide-accent)" }}>{author}</span>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "#6b6253" }}>{faction} · {when}</span>
+        </div>
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 11.5, lineHeight: 1.5, color: "#3a342a", margin: "5px 0 0", overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}>{snippet}</p>
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 9 }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "#6b6253", border: "1px solid rgba(20,17,11,0.25)", padding: "2px 7px" }}>📎 {evidence} evidence</span>
+          <span style={{ marginLeft: "auto", fontFamily: "var(--f-marker)", fontSize: 14, color: ink }}>open the file →</span>
+        </div>
+      </div>
+      {/* vote tally chip */}
+      <div style={{ position: "relative", flexShrink: 0, width: 92, borderLeft: "1.5px dashed rgba(20,17,11,0.3)",
+        display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "10px 8px", background: "rgba(0,0,0,0.02)" }}>
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 30, lineHeight: 0.8, color: "var(--snide-accent)" }}>{avg.toFixed(1)}</span>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 7.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "#6b6253", marginTop: 3 }}>{total} marks</span>
+        {mark && <span style={{ marginTop: 6, fontFamily: "var(--f-cond)", fontSize: 11, letterSpacing: "0.08em", color: "#fff", background: "var(--pink)", padding: "1px 7px", transform: "rotate(-3deg)" }}>{mark}</span>}
+      </div>
+    </a>
+  );
+}
+
+/* ── one completed praxis, in full (voting lives on the page) ───────── */
+function SnidePraxisDetail({ task, author, initial, when, faction = "S.N.I.D.E.", confession, evidence = [] }) {
+  const { SnideSigil } = window;
+  const wall = "var(--snide-wall-text)";
+  const ink = "var(--ink)";
+  return (
+    <div style={{ position: "relative", fontFamily: "var(--font-body)", color: wall }}>
+      {/* stamped masthead */}
+      <div style={{ lineHeight: 0 }}>
+        <div style={{ display: "inline-flex", alignItems: "center", gap: 9, background: "var(--snide-green)", color: "#fff",
+          padding: "8px 16px 8px 13px", transform: "rotate(-1.5deg)", boxShadow: "4px 4px 0 var(--pink)" }}>
+          <SnideSigil size={17} color="var(--acid)" />
+          <span style={{ fontFamily: "var(--f-cond)", fontSize: 17, letterSpacing: "0.14em", whiteSpace: "nowrap" }}>S.N.I.D.E. · CLOSED CASE · FILED</span>
+        </div>
+      </div>
+
+      {/* author + task line */}
+      <div style={{ display: "flex", alignItems: "center", gap: 14, margin: "20px 0 6px" }}>
+        <div style={{ flexShrink: 0, width: 56, height: 56, borderRadius: "50%", background: ink, border: "2px solid var(--snide-green)",
+          display: "flex", alignItems: "center", justifyContent: "center", color: "var(--acid)", fontFamily: "var(--f-anton)", fontSize: 26, transform: "rotate(-4deg)" }}>{initial}</div>
+        <div>
+          <div style={{ fontFamily: "var(--f-anton)", fontSize: 40, lineHeight: 0.84, color: wall, transform: "skewX(-4deg)" }}>{author}</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: PD_MUTED, marginTop: 5 }}>{faction} · pulled it off · {when}</div>
+        </div>
+      </div>
+
+      {/* the job they closed */}
+      <div style={{ display: "inline-flex", alignItems: "center", gap: 10, background: ink, padding: "6px 12px", transform: "rotate(-0.5deg)", margin: "8px 0 26px", whiteSpace: "nowrap" }}>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.2em", textTransform: "uppercase", color: "#8f9183" }}>re:</span>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 18, letterSpacing: "0.04em", color: "var(--acid)", whiteSpace: "nowrap" }}>{task.title}</span>
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 15, color: "var(--pink)" }}>+{task.points}</span>
+      </div>
+
+      {/* the confession (ruled notebook) */}
+      <div style={{ position: "relative", marginBottom: 28 }}>
+        <span style={{ display: "inline-block", background: "var(--acid)", color: ink, fontFamily: "var(--f-marker)", fontSize: 17, padding: "3px 13px", transform: "rotate(-1.5deg)", boxShadow: "2px 2px 0 var(--pink)", marginBottom: 12 }}>the confession</span>
+        <div style={{ position: "relative" }}>
+          <div className="tape" style={{ top: -8, left: 28, width: 56, height: 18, transform: "rotate(-5deg)", zIndex: 3 }} />
+          <div style={{ border: "1.5px solid " + ink, borderLeft: "4px solid var(--pink)", background: "var(--paper)", color: ink,
+            backgroundImage: "repeating-linear-gradient(180deg, transparent 0 27px, rgba(20,17,11,0.11) 27px 28px)",
+            padding: "8px 16px 14px 18px", fontSize: 13, lineHeight: "28px", whiteSpace: "pre-line" }}>{confession}</div>
+        </div>
+      </div>
+
+      {/* the evidence */}
+      <div style={{ marginBottom: 30 }}>
+        <span style={{ display: "inline-block", background: "var(--acid)", color: ink, fontFamily: "var(--f-marker)", fontSize: 17, padding: "3px 13px", transform: "rotate(1.5deg)", boxShadow: "2px 2px 0 var(--pink)", marginBottom: 14 }}>the evidence</span>
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+          {evidence.map((e, i) => (
+            <div key={i} style={{ background: "var(--paper)", border: "1.5px solid " + ink, padding: "8px 8px 18px", transform: `rotate(${i % 2 ? 2.5 : -2.5}deg)`, boxShadow: "3px 4px 0 rgba(0,0,0,0.2)" }}>
+              <div style={{ position: "relative", width: 122, height: 92, background: ink, overflow: "hidden" }}>
+                <div className="ht-dots-lg" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.5)", mixBlendMode: "screen" }} />
+                <span style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--acid)" }}>{e}</span>
+              </div>
+              <div style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", color: "#6b6253", marginTop: 7, textAlign: "center" }}>exhibit {String.fromCharCode(65 + i)}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { SnideVoteTally, SnidePraxisRow, SnidePraxisDetail, pdAvg });

--- a/docs/design/design-system/templates/snide/snide-praxis.jsx
+++ b/docs/design/design-system/templates/snide/snide-praxis.jsx
@@ -1,0 +1,193 @@
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. — Edit Praxis  (RAP SHEET / CONFESSION)
+   The praxis-filing form, rebuilt as a confession pinned to the
+   evidence wall: a stamped masthead, a PINNED MUGSHOT EXHIBIT (not a
+   tidy slip), marker tape-tab labels, mismatched tilted accomplice
+   stamps, a ruled-notebook confession, a polaroid evidence dropzone,
+   and a slapped "file it & run" sticker bar. Heavy collage, tilt,
+   ransom, halftone, redaction. Theme-aware via --snide-wall-text.
+   ════════════════════════════════════════════════════════════════ */
+
+const PX_MUTED = "color-mix(in srgb, var(--snide-wall-text) 55%, transparent)";
+
+/* marker tape-tab label — no tidy rules */
+function PxLabel({ children, meta, rot = -1.5 }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 13 }}>
+      <span style={{ display: "inline-block", background: "var(--acid)", color: "var(--ink)", fontFamily: "var(--f-marker)",
+        fontSize: 17, lineHeight: 1.1, padding: "3px 13px", transform: `rotate(${rot}deg)`, boxShadow: "2px 2px 0 var(--pink)" }}>{children}</span>
+      {meta && <span style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", color: PX_MUTED, whiteSpace: "nowrap" }}>{meta}</span>}
+    </div>
+  );
+}
+
+function SnidePraxisForm({ reportNo = "0666", task }) {
+  const { SnideSigil } = window;
+  const [mode, setMode] = React.useState("solo");
+  const [stunt, setStunt] = React.useState("");
+  const [confession, setConfession] = React.useState("");
+  const [filed, setFiled] = React.useState(false);
+  const [dropArmed, setDropArmed] = React.useState(false);
+  const [dropped, setDropped] = React.useState(false);
+
+  const wall = "var(--snide-wall-text)";
+  const muted = PX_MUTED;
+  const ink = "var(--ink)";
+
+  const MODES = [
+    { id: "solo", name: "LONE WOLF", sub: "no witnesses", rot: -2.5, shape: "square" },
+    { id: "crew", name: "THE GANG", sub: "round up the mob", rot: 1.5, shape: "torn" },
+    { id: "beef", name: "BEEF", sub: "1v1, settle it", rot: -1, shape: "square" },
+  ];
+  const words = confession.trim() ? confession.trim().split(/\s+/).length : 0;
+  const TORN_TAB = "polygon(0 0,100% 0,100% 88%,93% 100%,82% 90%,68% 100%,54% 91%,40% 100%,26% 90%,13% 100%,0 90%)";
+
+  return (
+    <div style={{ position: "relative", fontFamily: "var(--font-body)", color: wall }}>
+
+      {/* faint corner stamp */}
+      <div aria-hidden="true" style={{ position: "absolute", top: 26, right: -6, transform: "rotate(11deg)", pointerEvents: "none",
+        fontFamily: "var(--f-cond)", fontSize: 17, letterSpacing: "0.18em", color: "color-mix(in srgb, var(--pink) 38%, transparent)",
+        border: "2.5px solid color-mix(in srgb, var(--pink) 38%, transparent)", padding: "5px 14px", borderRadius: 3 }}>PROPERTY OF NOBODY</div>
+
+      {/* stamped masthead */}
+      <div style={{ lineHeight: 0 }}>
+        <div style={{ display: "inline-flex", alignItems: "center", gap: 9, background: "var(--snide-green)", color: "#fff",
+          padding: "8px 16px 8px 13px", transform: "rotate(-1.5deg)", boxShadow: "4px 4px 0 var(--pink)" }}>
+          <SnideSigil size={17} color="var(--acid)" />
+          <span style={{ fontFamily: "var(--f-cond)", fontSize: 18, letterSpacing: "0.14em", whiteSpace: "nowrap" }}>S.N.I.D.E. · RAP SHEET №{reportNo}</span>
+        </div>
+      </div>
+
+      {/* big title */}
+      <div style={{ position: "relative", display: "inline-block", margin: "20px 0 6px" }}>
+        <div style={{ fontFamily: "var(--f-anton)", fontSize: 60, lineHeight: 0.86, letterSpacing: "0.02em", color: wall, transform: "skewX(-5deg)" }}>EDIT PRAXIS</div>
+        <span style={{ position: "absolute", top: -8, right: -54, fontFamily: "var(--f-marker)", fontSize: 15, color: "var(--pink)", transform: "rotate(7deg)" }}>*allegedly</span>
+      </div>
+
+      {/* ── PINNED MUGSHOT EXHIBIT ─────────────────────────────────── */}
+      <div style={{ position: "relative", margin: "26px 0 34px", maxWidth: 560 }}>
+        {/* pushpin */}
+        <div style={{ position: "absolute", top: -7, left: "44%", zIndex: 5, width: 16, height: 16, borderRadius: "50%",
+          background: "radial-gradient(circle at 35% 30%, #ff7ab8, var(--pink) 60%, #9c1457)", boxShadow: "1px 2px 2px rgba(0,0,0,0.45)" }} />
+        <div style={{ position: "relative", display: "flex", background: "var(--paper)", color: ink, border: "1.5px solid " + ink,
+          transform: "rotate(-1.5deg)", boxShadow: "5px 6px 0 rgba(0,0,0,0.3)", overflow: "hidden" }}>
+          <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.05)", pointerEvents: "none" }} />
+          {/* mugshot (height chart, no face) */}
+          <div style={{ position: "relative", flexShrink: 0, width: 98, background: ink, color: "var(--acid)",
+            display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "12px 6px",
+            backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, rgba(182,255,46,0.22) 13px 14px)" }}>
+            <span style={{ fontFamily: "var(--f-anton)", fontSize: 38, lineHeight: 0.8 }}>?</span>
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 7, letterSpacing: "0.16em", marginTop: 5, color: "#cfe6a0" }}>SUSPECT</span>
+            <span style={{ fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.1em", marginTop: 2 }}>№{reportNo}</span>
+          </div>
+          {/* details */}
+          <div style={{ position: "relative", flex: 1, padding: "14px 16px 16px" }}>
+            <div style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.2em", textTransform: "uppercase", color: "#6b6253" }}>Exhibit A · re: the incident —</div>
+            <div style={{ fontFamily: "var(--f-anton)", fontSize: 30, lineHeight: 0.94, letterSpacing: "0.02em", color: ink, margin: "5px 0 0", transform: "skewX(-3deg)" }}>{task.title}</div>
+            <div style={{ display: "flex", alignItems: "center", gap: 11, marginTop: 11 }}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--snide-accent)", fontWeight: 700 }}>
+                <span style={{ display: "inline-flex", width: 16, height: 16, borderRadius: "50%", background: ink, alignItems: "center", justifyContent: "center" }}><SnideSigil size={12} color="var(--acid)" /></span> S.N.I.D.E.
+              </span>
+              <span style={{ fontFamily: "var(--f-anton)", fontSize: 17, color: "var(--pink)" }}>{task.points} PTS</span>
+              <span style={{ background: ink, color: "var(--acid)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", padding: "2px 7px" }}>lvl {task.level}</span>
+            </div>
+            {/* OPEN CASE stamp */}
+            <span style={{ position: "absolute", bottom: 10, right: 12, fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.14em",
+              color: "rgba(190,24,93,0.8)", border: "2.5px solid rgba(190,24,93,0.7)", padding: "2px 9px", transform: "rotate(-8deg)" }}>OPEN CASE</span>
+          </div>
+        </div>
+        {/* tape corners */}
+        <div className="tape" style={{ top: -8, left: 18, width: 50, height: 18, transform: "rotate(-12deg)" }} />
+        <div className="tape" style={{ bottom: -7, right: 30, width: 50, height: 18, transform: "rotate(8deg)" }} />
+      </div>
+
+      {/* ── accomplices (mismatched tilted stamps) ─────────────────── */}
+      <div style={{ marginBottom: 30 }}>
+        <PxLabel rot={-2}>who's in on it?</PxLabel>
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "flex-start" }}>
+          {MODES.map((m) => {
+            const on = mode === m.id;
+            const torn = m.shape === "torn";
+            return (
+              <button key={m.id} onClick={() => setMode(m.id)} style={{
+                position: "relative", cursor: "pointer", textAlign: "left", minWidth: 132,
+                padding: torn ? "12px 18px 22px" : "12px 18px 14px",
+                background: on ? "var(--acid)" : "transparent", color: on ? ink : wall,
+                border: `2.5px solid ${on ? ink : "color-mix(in srgb, var(--snide-wall-text) 45%, transparent)"}`,
+                clipPath: torn ? TORN_TAB : "none",
+                boxShadow: on ? "4px 5px 0 var(--pink)" : "none",
+                transform: `rotate(${m.rot}deg)${on ? " translate(-1px,-2px)" : ""}`, transition: "transform 110ms",
+              }}>
+                <div style={{ fontFamily: "var(--f-cond)", fontSize: 23, lineHeight: 1, letterSpacing: "0.04em", whiteSpace: "nowrap" }}>{m.name}</div>
+                <div style={{ fontFamily: "var(--font-body)", fontSize: 9.5, letterSpacing: "0.02em", marginTop: 3, opacity: on ? 0.85 : 0.7 }}>{m.sub}</div>
+                {on && <div style={{ position: "absolute", top: 7, right: 9, width: 9, height: 9, borderRadius: "50%", background: "var(--pink)", boxShadow: "0 0 0 2px " + ink }} />}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── the stunt (fill-in-the-blank) ──────────────────────────── */}
+      <div style={{ marginBottom: 30 }}>
+        <PxLabel meta={`${stunt.length}/200`} rot={1.5}>name the stunt</PxLabel>
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 10 }}>
+          <input value={stunt} onChange={(e) => setStunt(e.target.value.slice(0, 200))} placeholder="what'd you pull?"
+            style={{ flex: 1, border: "none", borderBottom: "3px dashed " + wall, background: "transparent",
+              fontFamily: "var(--f-cond)", fontSize: 27, letterSpacing: "0.02em", color: wall, padding: "4px 2px 7px", outline: "none" }} />
+          <span style={{ fontFamily: "var(--f-marker)", fontSize: 14, color: "var(--pink)", whiteSpace: "nowrap", transform: "rotate(-3deg)", paddingBottom: 6 }}>← brag about it</span>
+        </div>
+      </div>
+
+      {/* ── the confession (ruled notebook page) ───────────────────── */}
+      <div style={{ marginBottom: 30 }}>
+        <PxLabel meta={`${words} words · markdown ok`} rot={-1}>the confession</PxLabel>
+        <div style={{ position: "relative" }}>
+          <div className="tape" style={{ top: -8, left: 26, width: 56, height: 18, transform: "rotate(-5deg)", zIndex: 3 }} />
+          <textarea value={confession} onChange={(e) => setConfession(e.target.value)} placeholder="so here's what went down…"
+            rows={7} style={{ width: "100%", resize: "vertical", border: "1.5px solid " + ink, borderLeft: "4px solid var(--pink)",
+              background: "var(--paper)",
+              backgroundImage: "repeating-linear-gradient(180deg, transparent 0 27px, rgba(20,17,11,0.11) 27px 28px)",
+              fontFamily: "var(--font-body)", fontSize: 13, lineHeight: "28px", color: ink, padding: "8px 14px 8px 18px", outline: "none" }} />
+        </div>
+      </div>
+
+      {/* ── evidence (polaroid dropzone) ───────────────────────────── */}
+      <div style={{ marginBottom: 32 }}>
+        <PxLabel meta="0 pinned" rot={2}>the evidence</PxLabel>
+        <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap" }}>
+          <button style={{ cursor: "pointer", background: "var(--paper)", border: "2px dashed " + ink, padding: "10px 10px 22px",
+            transform: "rotate(-3deg)", boxShadow: "3px 4px 0 rgba(0,0,0,0.2)" }}>
+            <div style={{ width: 88, height: 64, background: "var(--ink)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+              <span style={{ fontFamily: "var(--f-anton)", fontSize: 30, color: "var(--pink)", lineHeight: 0.6 }}>+</span>
+            </div>
+            <div style={{ fontFamily: "var(--f-marker)", fontSize: 13, color: ink, marginTop: 7, textAlign: "center" }}>pin proof</div>
+          </button>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 10, fontStyle: "italic", color: muted, maxWidth: 200, lineHeight: 1.5 }}>mugshots · clips · receipts · max 50mb each. anonymity not guaranteed.</div>
+        </div>
+      </div>
+
+      {/* ── file bar ───────────────────────────────────────────────── */}
+      <div style={{ borderTop: "2px dashed color-mix(in srgb, var(--snide-wall-text) 25%, transparent)", paddingTop: 24,
+        display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap" }}>
+        <button onClick={() => setFiled(true)} style={{ cursor: "pointer", border: "2px solid " + ink,
+          background: filed ? "var(--snide-green)" : "var(--pink)", color: "#fff",
+          fontFamily: "var(--f-black)", fontSize: 18, letterSpacing: "0.04em", padding: "14px 26px", whiteSpace: "nowrap",
+          transform: "rotate(-1.5deg)", boxShadow: "4px 5px 0 " + ink }}>
+          {filed ? "✓ ON THE RECORD" : "★ FILE IT & RUN ★"}
+        </button>
+        <button style={{ cursor: "pointer", border: "2px solid " + wall, background: "transparent",
+          color: wall, fontFamily: "var(--font-body)", fontSize: 12, fontWeight: 700,
+          letterSpacing: "0.12em", textTransform: "uppercase", padding: "13px 20px", transform: "rotate(0.5deg)" }}>Stash Draft</button>
+        <button onClick={() => { if (dropped) { setDropped(false); setDropArmed(false); } else if (dropArmed) { setDropped(true); setDropArmed(false); setFiled(false); } else { setDropArmed(true); } }}
+          style={{ cursor: "pointer", border: "2px solid " + ((dropArmed || dropped) ? "var(--pink)" : wall), background: "transparent",
+          color: (dropArmed || dropped) ? "var(--pink)" : wall, fontFamily: "var(--font-body)", fontSize: 12, fontWeight: 700,
+          letterSpacing: "0.12em", textTransform: "uppercase", padding: "13px 20px", transform: "rotate(-0.5deg)", transition: "all 150ms" }}>
+          {dropped ? "✕ Ditched" : dropArmed ? "Ditch — Sure?" : "Ditch It"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { SnidePraxisForm, PxLabel });

--- a/docs/design/design-system/templates/snide/snide.css
+++ b/docs/design/design-system/templates/snide/snide.css
@@ -1,0 +1,127 @@
+/* ══════════════════════════════════════════════════════════════
+   S.N.I.D.E. redesign — local tokens + punk textures
+   Society for Nihilistic Intent and Disruptive Efforts
+   Pulls real World Zero SNIDE values + system fonts, then layers
+   the photocopy / spray / ransom craft on top.
+   ══════════════════════════════════════════════════════════════ */
+@import url("https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;0,700;1,400;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&family=Bebas+Neue&family=Special+Elite&family=Permanent+Marker&family=Anton&family=Archivo+Black&display=swap");
+
+:root {
+  /* SNIDE faction values, straight from the design system */
+  --snide-green: #16a34a;
+  --snide-accent: #15803d;
+  --snide-card-bg: #ecf5ea;     /* mossy newsprint */
+  --snide-muted: #444;
+
+  /* Punk extensions */
+  --acid: #b6ff2e;              /* toxic / radioactive green */
+  --acid-deep: #6fae00;
+  --ink: #14110b;              /* photocopier black */
+  --paper: #f4f1e8;            /* warm xerox paper */
+  --paper-cool: #e7e9e2;
+  --pink: #ff2d8b;             /* hot zine pink */
+  --pink-deep: #be185d;        /* system magenta */
+  --tape: rgba(228, 214, 120, 0.62);
+  --tape-grey: rgba(200, 200, 190, 0.5);
+
+  /* system fonts */
+  --f-marker: "Permanent Marker", "Marker Felt", cursive;
+  --f-body: "Courier Prime", "Courier New", monospace;
+  --f-type: "Special Elite", "Courier New", serif;
+  --f-cond: "Bebas Neue", Impact, sans-serif;
+  --f-anton: "Anton", Impact, sans-serif;
+  --f-black: "Archivo Black", Impact, sans-serif;
+  --f-serif: "Lora", Georgia, serif;
+
+  /* flyposted-wall backdrop tokens (FLIP in dark) */
+  --snide-wall: #efece3;        /* xerox-paper wall */
+  --snide-wall-deep: #e0ddd1;
+  --snide-wall-text: var(--ink);
+}
+
+[data-theme="dark"] {
+  --snide-wall: #141310;        /* concrete-at-night */
+  --snide-wall-deep: #0b0a08;
+  --snide-wall-text: #e9e6da;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SNIDE FLYPOSTED-WALL BACKDROP
+   Replaces the neutral watercolor on faction-context pages: warm xerox
+   stock plastered with a faint acid sunburst, screen-print halftone,
+   a scratched crosshatch, and acid/pink light bleeding from the corners.
+   Theme-aware — darkens to a moody concrete wall. Render once as
+   <div class="snide-backdrop"></div>, fixed behind content.
+   ════════════════════════════════════════════════════════════════ */
+.snide-backdrop {
+  position: fixed; inset: 0; z-index: 0; pointer-events: none;
+  background-color: var(--snide-wall);
+  background-image:
+    radial-gradient(40% 30% at 100% 0%, color-mix(in srgb, var(--acid) 18%, transparent), transparent 70%),
+    radial-gradient(44% 36% at 0% 100%, color-mix(in srgb, var(--pink) 14%, transparent), transparent 70%),
+    radial-gradient(color-mix(in srgb, var(--snide-wall-text) 7%, transparent) 0.6px, transparent 1px),
+    repeating-linear-gradient(28deg, color-mix(in srgb, var(--snide-wall-text) 3%, transparent) 0 1px, transparent 1px 7px),
+    repeating-linear-gradient(-19deg, color-mix(in srgb, var(--snide-wall-text) 2.5%, transparent) 0 1px, transparent 1px 9px),
+    linear-gradient(180deg, var(--snide-wall), var(--snide-wall-deep));
+  background-size: 100% 100%, 100% 100%, 5px 5px, auto, auto, 100% 100%;
+}
+.snide-backdrop::after {
+  content: ""; position: absolute; inset: 0;
+  background: radial-gradient(120% 90% at 50% 6%, transparent 42%, color-mix(in srgb, var(--snide-wall-deep) 60%, transparent));
+}
+
+/* ── Halftone dot screen ── */
+.ht-dots {
+  background-image: radial-gradient(currentColor 32%, transparent 34%);
+  background-size: 5px 5px;
+  background-position: 0 0;
+}
+.ht-dots-lg {
+  background-image: radial-gradient(currentColor 30%, transparent 33%);
+  background-size: 8px 8px;
+}
+
+/* ── Newsprint / xerox paper grain (cheap, no filter) ── */
+.xerox {
+  background-color: var(--paper);
+  background-image:
+    radial-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
+    radial-gradient(rgba(0,0,0,0.04) 1px, transparent 1px);
+  background-size: 3px 3px, 4px 4px;
+  background-position: 0 0, 2px 1px;
+}
+
+/* ── Torn paper edges ── */
+.torn-top, .torn-bottom { position: absolute; left: 0; right: 0; height: 7px; }
+.torn-top { top: -1px; }
+.torn-bottom { bottom: -1px; }
+
+/* ── Scotch tape ── */
+.tape {
+  position: absolute; height: 26px; width: 64px;
+  background: var(--tape);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.25);
+  opacity: 0.9;
+}
+.tape::before, .tape::after {
+  content: ""; position: absolute; top: 0; bottom: 0; width: 4px;
+  background-image: repeating-linear-gradient(90deg, rgba(0,0,0,0.05) 0 1px, transparent 1px 3px);
+}
+.tape::before { left: 0; }
+.tape::after { right: 0; }
+
+/* ── Stitch border (sewn patch) ── */
+.merrow {
+  background-image: repeating-conic-gradient(var(--acid) 0deg 18deg, var(--acid-deep) 18deg 36deg);
+}
+
+/* ── blink + jitter ── */
+@keyframes snide-grain-jit { 0%,100%{ transform: translate(0,0);} 50%{ transform: translate(-1px,1px);} }
+
+/* canvas card label chrome */
+.opt-note {
+  font-family: var(--f-body);
+  font-size: 11px; line-height: 1.5; color: #555;
+}
+
+* { box-sizing: border-box; }

--- a/docs/design/design-system/templates/ua/ua.css
+++ b/docs/design/design-system/templates/ua/ua.css
@@ -1,0 +1,70 @@
+/* ══════════════════════════════════════════════════════════════
+   UA — University of Asthmatics · the gilt salon
+   Local archetype primitives for the UA kit. The faction was
+   repainted from the purple sticky-note into an art-academy:
+   burnt-amber + antique gold on parchment, a heraldic crest, and
+   regal Playfair/Marcellus type. Always-light (the salon never
+   dims). Mirrors/extends the global --faction-ua-* block — note
+   the kit reads ORANGE while the global hue is still purple
+   (see CLAUDE.md: that promotion is an open decision).
+   ══════════════════════════════════════════════════════════════ */
+:root {
+  /* ── Burnt-amber gilt palette (locked direction C) ── */
+  --ua-orange:     #c2541f;  /* burnt amber — the UA accent */
+  --ua-orange-deep:#a8431a;
+  --ua-gold:       #9c6a1a;  /* old gold — frames & regalia */
+  --ua-gold-lt:    #dd9322;
+  --ua-gold-pale:  #eec06a;
+  --ua-ink:        #3d2410;  /* brown ink — all text */
+  --ua-sub:        #8f6a3a;  /* secondary serif text */
+  --ua-muted:      #a8895a;  /* mono labels / metadata */
+  --ua-paper:      #fdf6ea;  /* sheet / card surface */
+  --ua-paper-warm: #fef7ea;
+  --ua-wall:       #ece4d2;  /* page wall */
+  --ua-line:       #cdab63;  /* hairline borders */
+  --ua-line-soft:  #e3cb98;
+
+  /* ── Gilt frame gradient (reused on crests, plates, cards) ── */
+  --ua-gilt: linear-gradient(135deg,#eec06a 0%,#9c6a1a 24%,#f0c878 50%,#9c6a1a 76%,#dd9322 100%);
+
+  /* ── Typography (loaded per-page from Google Fonts) ── */
+  --ua-display:  "Playfair Display", Georgia, serif;  /* didone — masterwork titles (italic) */
+  --ua-engraved: "Marcellus SC", "Marcellus", Georgia, serif; /* engraved caps — regalia labels */
+  --ua-serif:    "EB Garamond", Georgia, serif;       /* statements & descriptions (italic) */
+  --ua-mono:     "Courier Prime", "Courier New", monospace; /* eyebrows / nav / metadata */
+
+  /* ── Card contract — mirrors --faction-ua-card-* for the gilt kit ── */
+  --faction-ua-card-bg:     var(--ua-paper);
+  --faction-ua-card-text:   var(--ua-ink);
+  --faction-ua-card-accent: var(--ua-orange);
+  --faction-ua-card-muted:  var(--ua-sub);
+  --faction-ua-card-font:   var(--ua-display);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   UA SALON BACKDROP — parchment wall with a low gilt glow and a
+   faint ledger dot-grid. Render once as <div class="ua-backdrop">.
+   ══════════════════════════════════════════════════════════════ */
+.ua-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: var(--ua-wall);
+  background-image:
+    radial-gradient(70% 50% at 8% 0%, rgba(221,147,34,0.07), transparent 70%),
+    radial-gradient(60% 50% at 100% 8%, rgba(194,84,31,0.06), transparent 70%),
+    radial-gradient(rgba(140,106,30,0.04) 1px, transparent 1px);
+  background-size: auto, auto, 6px 6px;
+}
+
+/* gilt-framed plate: wrap any artwork/photo for the museum frame */
+.ua-plate {
+  padding: 9px;
+  background: var(--ua-gilt);
+  box-shadow: 0 10px 22px rgba(60,40,10,0.2), inset 0 0 0 1px rgba(255,255,255,0.4);
+}
+.ua-plate > * {
+  padding: 3px;
+  background: linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale));
+}

--- a/docs/design/design-system/templates/wow/whimsy-exe.jsx
+++ b/docs/design/design-system/templates/wow/whimsy-exe.jsx
@@ -1,0 +1,255 @@
+/* ════════════════════════════════════════════════════════════════
+   whimsy.exe — pink edition
+   Lo-fi computer-witch task card. Soft pastel window chrome, dotted
+   grid, notepad task area, cute ivy down the side, sticker charms.
+   Light + dark variants driven by a THEME object.
+   ════════════════════════════════════════════════════════════════ */
+
+const SAMPLE = {
+  title: "The L Word",
+  description: "Find someone you love. Tell them you love them.",
+  level: 1,
+  points: 5,
+};
+
+const THEME = {
+  light: {
+    pageBg: "#fbeef5",
+    winBorder: "#e487b5",
+    titleFrom: "#fbcfe2", titleTo: "#f3a6cb",
+    titleText: "#8e2f5c",
+    bodyBg: "#fdeef6",
+    dot: "rgba(214,90,150,0.20)",
+    notepadBg: "#fffdfa", notepadBorder: "#f3b6d2",
+    eyebrow: "#c2698f",
+    title: "#a83a6e",
+    desc: "#b06a8c",
+    ink: "#a83a6e",
+    pillBg: "#ffffff", pillText: "#b5588a", pillBorder: "#f3b6d2",
+    statusText: "#b5588a",
+    ivy: "#7cbf99", ivyLeaf: "#9ad3b1",
+    grain: 0.32,
+  },
+  dark: {
+    pageBg: "#1a0e15",
+    winBorder: "#f472b6",
+    titleFrom: "#5e2a46", titleTo: "#41203a",
+    titleText: "#fbd6e8",
+    bodyBg: "#2a0d1c",
+    dot: "rgba(244,114,182,0.16)",
+    notepadBg: "#39152a", notepadBorder: "#7a3358",
+    eyebrow: "#e58cb6",
+    title: "#fbcfe0",
+    desc: "#cf9bb6",
+    ink: "#fbcfe0",
+    pillBg: "rgba(244,114,182,0.12)", pillText: "#f9b6d4", pillBorder: "rgba(244,114,182,0.4)",
+    statusText: "#e58cb6",
+    ivy: "#5fa882", ivyLeaf: "#7fc59e",
+    grain: 0.22,
+  },
+};
+
+/* ───────── paper grain overlay ───────── */
+function Grain({ opacity, radius = 0 }) {
+  const uri = "data:image/svg+xml;utf8," + encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>`);
+  return <div style={{ position: "absolute", inset: 0, borderRadius: radius,
+    backgroundImage: `url("${uri}")`, backgroundSize: "120px 120px",
+    mixBlendMode: "multiply", opacity, pointerEvents: "none", zIndex: 8 }} />;
+}
+
+/* ════════════ sticker charms (white die-cut outline + shadow) ════════════ */
+const stickerWrap = (style) => ({
+  position: "absolute", filter: "drop-shadow(0 2px 2.5px rgba(120,40,80,0.28))", zIndex: 12, ...style,
+});
+function Heart({ size = 34, style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 36 36" style={style}>
+      <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+        fill="#fb7aa8" stroke="#fff" strokeWidth="2.4" strokeLinejoin="round" />
+      <path d="M11 13c-.6 2 .1 3.8 1.6 5.4" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" fill="none" opacity="0.75" />
+    </svg>
+  );
+}
+function RainbowSticker({ size = 46, style }) {
+  return (
+    <svg width={size} height={size * 0.72} viewBox="0 0 50 36" style={style}>
+      <g stroke="none">
+        <path d="M7 30a18 18 0 0 1 36 0h-5a13 13 0 0 0-26 0Z" fill="#f47aa6" stroke="#fff" strokeWidth="1.6" strokeLinejoin="round" />
+        <path d="M12 30a13 13 0 0 1 26 0h-5a8 8 0 0 0-16 0Z" fill="#f6c75e" />
+        <path d="M17 30a8 8 0 0 1 16 0h-5a3 3 0 0 0-6 0Z" fill="#86cfa6" />
+      </g>
+      <g fill="#fff" stroke="#e7a8c6" strokeWidth="1.2">
+        <ellipse cx="8" cy="30" rx="6" ry="4" />
+        <ellipse cx="42" cy="30" rx="6" ry="4" />
+      </g>
+    </svg>
+  );
+}
+function Mushroom({ size = 34, style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 36 36" style={style}>
+      <rect x="13" y="18" width="10" height="14" rx="5" fill="#fff4e6" stroke="#fff" strokeWidth="2.2" />
+      <path d="M4 19a14 9.5 0 0 1 28 0Z" fill="#fb7a86" stroke="#fff" strokeWidth="2.4" strokeLinejoin="round" />
+      <circle cx="11" cy="14" r="2" fill="#fff" />
+      <circle cx="19" cy="11.5" r="2.6" fill="#fff" />
+      <circle cx="25" cy="15" r="1.8" fill="#fff" />
+      <circle cx="15.5" cy="25" r="1.3" fill="#f6b8c0" />
+      <circle cx="20.5" cy="27" r="1.1" fill="#f6b8c0" />
+    </svg>
+  );
+}
+function StarSticker({ size = 26, color = "#f6c75e", style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 28 28" style={style}>
+      <path d="M14 2l3 7.3L24.5 10l-5.5 4.6L20.7 23 14 18.6 7.3 23l1.7-8.4L3.5 10 11 9.3Z"
+        fill={color} stroke="#fff" strokeWidth="2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function Sparkle({ size = 16, color = "#f6c75e", style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style}>
+      <path d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z" fill={color} />
+    </svg>
+  );
+}
+
+/* ════════════ cute ivy vine (parametric stem + leaves) ════════════ */
+function IvyLeaf({ x, y, rot, scale, c, leaf }) {
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot}) scale(${scale})`}>
+      <path d="M0 0 C -9 -3 -11 -13 -6 -20 C -2 -25 2 -25 6 -20 C 11 -13 9 -3 0 0 Z"
+        fill={leaf} stroke={c} strokeWidth="1.1" />
+      <path d="M0 -1 L0 -19" stroke={c} strokeWidth="1" opacity="0.55" />
+      <path d="M0 -8 L-4 -12 M0 -8 L4 -12" stroke={c} strokeWidth="0.8" opacity="0.45" fill="none" />
+    </g>
+  );
+}
+function Ivy({ height = 250, c, leaf, flip = false }) {
+  const W = 76, segs = 60;
+  const xAt = (t) => 40 + 20 * Math.sin(t * Math.PI * 2.3);
+  const yAt = (t) => 6 + t * (height - 12);
+  let d = "";
+  for (let i = 0; i <= segs; i++) {
+    const t = i / segs;
+    d += (i === 0 ? "M" : "L") + xAt(t).toFixed(1) + " " + yAt(t).toFixed(1) + " ";
+  }
+  const leafTs = [0.07, 0.17, 0.28, 0.39, 0.5, 0.61, 0.72, 0.83, 0.93];
+  return (
+    <svg width={W} height={height} viewBox={`0 0 ${W} ${height}`}
+      style={{ transform: flip ? "scaleX(-1)" : "none" }}>
+      <path d={d} fill="none" stroke={c} strokeWidth="2.6" strokeLinecap="round" />
+      {/* tendril curls */}
+      <path d={`M${xAt(0.02)} ${yAt(0.02)} q -10 -6 -4 -13 q 4 -4 8 0`} fill="none" stroke={c} strokeWidth="1.8" strokeLinecap="round" />
+      {leafTs.map((t, i) => {
+        const side = i % 2 === 0 ? 1 : -1;
+        return <IvyLeaf key={i} x={xAt(t) + side * 7} y={yAt(t)} rot={side > 0 ? 38 : -38} scale={i % 3 === 0 ? 1.15 : 0.95} c={c} leaf={leaf} />;
+      })}
+    </svg>
+  );
+}
+
+/* shared soft level pill */
+function LevelPill({ t, level = SAMPLE.level }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4,
+      fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.06em", textTransform: "uppercase",
+      padding: "2px 8px", borderRadius: 20, background: t.pillBg, color: t.pillText, border: `1px solid ${t.pillBorder}` }}>
+      <Sparkle size={9} color={t.pillText} /> lvl {level}
+    </span>
+  );
+}
+
+/* ════════════════════ the card ════════════════════ */
+/* decor: "full" (ivy + all charms, hero) · "min" (one charm) · "none" */
+function Charm({ kind }) {
+  if (kind === "star") return <StarSticker size={28} color="#f6c75e" />;
+  if (kind === "mushroom") return <Mushroom size={34} />;
+  if (kind === "rainbow") return <RainbowSticker size={46} />;
+  if (kind === "starPink") return <StarSticker size={26} color="#f47aa6" />;
+  return <Heart size={34} />;
+}
+function WhimsyExe({ mode = "light", task = SAMPLE, decor = "full", charm = "star" }) {
+  const t = THEME[mode];
+  const full = decor === "full";
+  const wrapW = full ? 326 : 274;
+  return (
+    <div style={{ position: "relative", width: wrapW, height: full ? 300 : undefined, fontFamily: "var(--font-body)" }}>
+      {/* ivy down the left, behind the window */}
+      {full && (
+        <div style={{ position: "absolute", left: -10, top: 34, zIndex: 1 }}>
+          <Ivy height={250} c={t.ivy} leaf={t.ivyLeaf} />
+        </div>
+      )}
+
+      {/* the window */}
+      <div style={{ position: full ? "absolute" : "relative", left: full ? 48 : 0, top: full ? 16 : 0, marginLeft: full ? 0 : 6, marginTop: full ? 0 : 12, width: 262, zIndex: 5,
+        borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`,
+        boxShadow: mode === "dark" ? "0 10px 26px rgba(0,0,0,0.5)" : "0 10px 24px rgba(190,60,120,0.22)" }}>
+        {/* title bar */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 11px",
+          background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+          <div style={{ display: "flex", gap: 5 }}>
+            <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#fb7aa8", border: "1.5px solid rgba(255,255,255,0.7)" }} />
+            <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#f6c75e", border: "1.5px solid rgba(255,255,255,0.7)" }} />
+            <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#86cfa6", border: "1.5px solid rgba(255,255,255,0.7)" }} />
+          </div>
+          <span style={{ fontSize: 10.5, color: t.titleText, letterSpacing: "0.03em", display: "flex", alignItems: "center", gap: 4 }}>
+            <Sparkle size={10} color={t.titleText} /> whimsy.exe
+          </span>
+          <span style={{ marginLeft: "auto", fontSize: 11, color: t.titleText, opacity: 0.75, letterSpacing: "1.5px" }}>▭ ✕</span>
+        </div>
+        {/* body */}
+        <div style={{ position: "relative", padding: "15px 15px 13px", background: t.bodyBg,
+          backgroundImage: `radial-gradient(${t.dot} 1.4px, transparent 1.4px)`, backgroundSize: "13px 13px" }}>
+          <Grain opacity={t.grain} />
+          {/* notepad */}
+          <div style={{ position: "relative", zIndex: 9, background: t.notepadBg, border: `1.5px solid ${t.notepadBorder}`,
+            borderRadius: 7, padding: "11px 13px", marginBottom: 11 }}>
+            <div style={{ fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.18em", color: t.eyebrow, marginBottom: 4 }}>new quest · {task.points} pts</div>
+            <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 27, fontWeight: 700, lineHeight: 1.02, color: t.title, marginBottom: 4 }}>{task.title}</div>
+            <div style={{ fontSize: 9, lineHeight: 1.5, color: t.desc }}>{task.description}</div>
+          </div>
+          {/* status bar */}
+          <div style={{ position: "relative", zIndex: 9, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <LevelPill t={t} level={task.level} />
+            <span style={{ fontSize: 9, color: t.statusText, letterSpacing: "0.1em" }}>◆ {task.points} pts</span>
+          </div>
+        </div>
+      </div>
+
+      {full && (
+        <React.Fragment>
+          {/* sticker charms peeking off the window edges */}
+          <div style={stickerWrap({ top: 4, right: 8, transform: "rotate(14deg)" })}><Heart size={36} /></div>
+          <div style={stickerWrap({ top: 92, right: -6, transform: "rotate(-10deg)" })}><StarSticker size={28} color="#f6c75e" /></div>
+          <div style={stickerWrap({ bottom: 6, right: 30, transform: "rotate(8deg)" })}><Mushroom size={36} /></div>
+          <div style={stickerWrap({ bottom: -4, left: 40, transform: "rotate(-9deg)" })}><RainbowSticker size={50} /></div>
+          <div style={stickerWrap({ top: 150, left: 26, transform: "rotate(6deg)", zIndex: 4 })}><StarSticker size={18} color="#f47aa6" /></div>
+        </React.Fragment>
+      )}
+      {decor === "min" && (
+        <div style={stickerWrap({ top: 2, right: -4, transform: "rotate(13deg)" })}><Charm kind={charm} /></div>
+      )}
+    </div>
+  );
+}
+
+/* ──────── reusable sticker sheet (for the asset set) ──────── */
+function StickerSheet() {
+  const cell = { display: "flex", flexDirection: "column", alignItems: "center", gap: 8 };
+  const lbl = { fontFamily: "var(--font-body)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.12em", color: "#a8728e" };
+  return (
+    <div style={{ display: "flex", gap: 30, alignItems: "flex-end", justifyContent: "center", flexWrap: "wrap" }}>
+      <div style={cell}><Heart size={48} /><span style={lbl}>heart</span></div>
+      <div style={cell}><RainbowSticker size={62} /><span style={lbl}>rainbow</span></div>
+      <div style={cell}><Mushroom size={48} /><span style={lbl}>mushroom</span></div>
+      <div style={cell}><StarSticker size={44} color="#f6c75e" /><span style={lbl}>star</span></div>
+      <div style={cell}><StarSticker size={40} color="#f47aa6" /><span style={lbl}>star · pink</span></div>
+      <div style={cell}><Sparkle size={40} color="#f6c75e" /><span style={lbl}>sparkle</span></div>
+    </div>
+  );
+}
+
+Object.assign(window, { WhimsyExe, StickerSheet, Ivy, Heart, RainbowSticker, Mushroom, StarSticker, Sparkle });

--- a/docs/design/design-system/templates/wow/whimsy-kit.jsx
+++ b/docs/design/design-system/templates/wow/whimsy-kit.jsx
@@ -1,0 +1,355 @@
+/* ════════════════════════════════════════════════════════════════
+   whimsy.exe — asset kit
+   The supporting UI family for the Warriors of Whimsy faction, redesigned in the
+   pink computer-witch language: app icon, buttons, level pill + moon
+   level-track, heart vote stamps, app tabs, filter chips, empty state.
+   Each component is themeable via THEME[mode]. Stickers + Ivy come from
+   whimsy-exe.jsx (window.Heart, window.Sparkle, window.Ivy, …).
+   ════════════════════════════════════════════════════════════════ */
+
+const KT = {
+  light: {
+    panelBg: "#fbeef5", cardBg: "#fffdfa",
+    ink: "#a83a6e", inkSoft: "#b5588a", label: "#a8728e",
+    border: "#f3b6d2", borderSoft: "rgba(214,90,150,0.28)",
+    pink: "#ec5f99", pinkDeep: "#d23b7e", pinkLt: "#fbcfe2",
+    gold: "#f0b94a", green: "#7cbf99", greenLeaf: "#9ad3b1",
+    dot: "rgba(214,90,150,0.18)",
+    fill: "#ec5f99", onFill: "#ffffff",
+    moonLit: "#f6c75e", moonShadow: "#fbe1ee",
+    glow: "rgba(236,95,153,0.32)",
+    titleFrom: "#fbcfe2", titleTo: "#f3a6cb", titleText: "#8e2f5c", winBorder: "#e487b5",
+    voteFills: ["#f6b8cf", "#f489b0", "#ec5f99", "#df3f86", "#c52470"]
+  },
+  dark: {
+    panelBg: "#1a0e15", cardBg: "#2a0d1c",
+    ink: "#fbcfe0", inkSoft: "#e58cb6", label: "#c78aa6",
+    border: "#7a3358", borderSoft: "rgba(244,114,182,0.32)",
+    pink: "#f472b6", pinkDeep: "#f9b6d4", pinkLt: "#5e2a46",
+    gold: "#f0d98f", green: "#5fa882", greenLeaf: "#7fc59e",
+    dot: "rgba(244,114,182,0.16)",
+    fill: "#f472b6", onFill: "#2a0d1c",
+    moonLit: "#f0d98f", moonShadow: "#2a0d1c",
+    glow: "rgba(244,114,182,0.45)",
+    titleFrom: "#5e2a46", titleTo: "#41203a", titleText: "#fbd6e8", winBorder: "#f472b6",
+    voteFills: ["#f9c4dc", "#f9a0c6", "#f472b6", "#ee5aa6", "#e23b8f"]
+  }
+};
+
+const lbl = (t) => ({ fontFamily: "var(--font-body)", fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.18em", color: t.label, marginBottom: 11 });
+
+/* ───── mini window glyph ───── */
+function WinGlyph({ size = 22, t, color }) {
+  const c = color || t.pink;
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24">
+      <rect x="2.5" y="4" width="19" height="16" rx="3" fill="none" stroke={c} strokeWidth="2" />
+      <path d="M2.5 8.5h19" stroke={c} strokeWidth="2" />
+      <circle cx="5.6" cy="6.2" r="0.9" fill={c} />
+      <circle cx="8.2" cy="6.2" r="0.9" fill={c} />
+    </svg>);
+
+}
+
+/* ───────── app icon (hero) ───────── */
+function GAppIcon({ t }) {
+  const Sparkle = window.Sparkle;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 9 }}>
+      <div style={{ position: "relative", width: 76, height: 76, borderRadius: 20,
+        background: `linear-gradient(150deg, ${t.titleFrom}, ${t.pink})`,
+        border: `2px solid ${t.winBorder}`, boxShadow: `0 8px 18px ${t.glow}`,
+        display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <div style={{ width: 40, height: 34, borderRadius: 6, background: t.cardBg, border: `2px solid ${t.cardBg}`, overflow: "hidden", boxShadow: "0 2px 5px rgba(120,40,80,0.25)" }}>
+          <div style={{ height: 9, background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, display: "flex", alignItems: "center", paddingLeft: 4, gap: 2 }}>
+            <span style={{ width: 3, height: 3, borderRadius: "50%", background: "#fb7aa8" }} />
+            <span style={{ width: 3, height: 3, borderRadius: "50%", background: "#f6c75e" }} />
+            <span style={{ width: 3, height: 3, borderRadius: "50%", background: "#86cfa6" }} />
+          </div>
+          <div style={{ padding: "4px 5px" }}>
+            <div style={{ height: 2.5, width: "70%", background: t.pink, borderRadius: 2, marginBottom: 3 }} />
+            <div style={{ height: 2.5, width: "45%", background: t.borderSoft, borderRadius: 2 }} />
+          </div>
+        </div>
+        <Sparkle size={16} color="#fff" style={{ position: "absolute", top: 6, right: 7 }} />
+        <svg width="20" height="22" viewBox="0 0 20 22" style={{ position: "absolute", bottom: 2, left: 3 }}>
+          <path d="M5 22C5 14 4 8 6 2" stroke={t.greenLeaf} strokeWidth="2" fill="none" strokeLinecap="round" />
+          <path d="M5 12c-5-1-5-6-5-6 4 0 6 3 5 6Z" fill={t.greenLeaf} />
+          <path d="M6 7c4-1 5-5 5-5-3 0-5 2-5 5Z" fill={t.greenLeaf} />
+        </svg>
+      </div>
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.04em", color: t.ink }}>whimsy.exe</span>
+    </div>);
+
+}
+
+/* ───────── buttons ───────── */
+function GButton({ t, variant = "primary", children }) {
+  const base = { fontFamily: "var(--font-body)", fontSize: 10, textTransform: "uppercase", letterSpacing: "0.1em",
+    padding: "7px 14px", borderRadius: 9, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 5, transition: "all 120ms", whiteSpace: "nowrap" };
+  if (variant === "primary")
+  return <button style={{ ...base, background: `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})`, color: t.onFill, border: `1.5px solid ${t.pinkDeep}`, boxShadow: `0 4px 10px ${t.glow}` }}><window.Sparkle size={11} color={t.onFill} />{children}</button>;
+  if (variant === "outline")
+  return <button style={{ ...base, background: "transparent", color: t.ink, border: `1.5px solid ${t.border}` }}>{children}</button>;
+  return <button style={{ ...base, background: t.cardBg, color: t.ink, border: `1.5px solid ${t.border}`, borderRadius: 7, boxShadow: `inset 0 -2px 0 ${t.borderSoft}` }}>{children}</button>;
+}
+
+/* ───────── level pill ───────── */
+function GLevelPill({ t, level }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontFamily: "var(--font-body)", fontSize: 9,
+      letterSpacing: "0.06em", textTransform: "uppercase", padding: "3px 9px", borderRadius: 20,
+      background: t.pinkLt, color: t.ink, border: `1px solid ${t.borderSoft}` }}>
+      <window.Sparkle size={9} color={t.pink} /> lvl {level}
+    </span>);
+
+}
+
+/* ───────── moon level-track ───────── */
+function MoonNode({ phase, active, t }) {
+  const size = 30,r = 11,cx = 15,cy = 15;
+  const dx = -(2 * r) * phase;
+  const cid = "mc" + Math.round(phase * 100) + (active ? "a" : "");
+  return (
+    <svg width={size} height={size} viewBox="0 0 30 30" style={{ transform: active ? "scale(1.18)" : "scale(1)", transition: "transform 120ms" }}>
+      {active && <circle cx={cx} cy={cy} r={r + 3} fill={t.glow} />}
+      <clipPath id={cid}><circle cx={cx} cy={cy} r={r} /></clipPath>
+      <circle cx={cx} cy={cy} r={r} fill={t.moonLit} stroke={active ? t.pink : t.borderSoft} strokeWidth={active ? 2 : 1.5} />
+      <g clipPath={`url(#${cid})`}>
+        <circle cx={cx + dx} cy={cy} r={r} fill={t.moonShadow} />
+      </g>
+      <circle cx={cx} cy={cy} r={r} fill="none" stroke={active ? t.pink : t.borderSoft} strokeWidth={active ? 2 : 1.5} />
+    </svg>);
+
+}
+function GLevelTrack({ t, value = 3 }) {
+  const levels = [0, 1, 2, 3, 4, 5];
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start" }}>
+      {levels.map((lv, i) =>
+      <div key={lv} style={{ display: "flex", alignItems: "flex-start" }}>
+          {i > 0 && <div style={{ width: 16, height: 0, borderTop: `2px dotted ${t.green}`, marginTop: 14 }} />}
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 5, width: 34 }}>
+            <MoonNode phase={lv / 5} active={value === lv} t={t} />
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 8, color: value === lv ? t.pink : t.label, letterSpacing: "0.04em" }}>{lv}+</span>
+          </div>
+        </div>
+      )}
+    </div>);
+
+}
+
+/* ───────── heart vote stamps ───────── */
+function VoteHeart({ filled, color, dim }) {
+  return (
+    <svg width="30" height="30" viewBox="0 0 36 36">
+      <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+      fill={filled ? color : "none"} stroke={filled ? "#fff" : dim} strokeWidth={filled ? 2.2 : 2} strokeLinejoin="round" />
+    </svg>);
+
+}
+function GVoteStamps({ t, value = 4 }) {
+  const labels = ["a start", "solid", "good", "excellent", "legendary"];
+  return (
+    <div style={{ display: "flex", gap: 9 }}>
+      {labels.map((label, i) => {
+        const on = i < value;
+        return (
+          <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+            <div style={{ width: 40, height: 40, borderRadius: 9, display: "flex", alignItems: "center", justifyContent: "center",
+              background: on ? t.cardBg : "transparent", border: `1.5px solid ${on ? t.border : t.borderSoft}`,
+              boxShadow: on ? `0 3px 7px ${t.glow}` : "none" }}>
+              <VoteHeart filled={on} color={t.voteFills[i]} dim={t.borderSoft} />
+            </div>
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 7, textTransform: "uppercase", letterSpacing: "0.04em",
+              color: on ? t.voteFills[i] : t.label, maxWidth: 42, textAlign: "center", lineHeight: 1.2 }}>{label}</span>
+          </div>);
+
+      })}
+    </div>);
+
+}
+
+/* ───────── app tabs (faction filter) ───────── */
+function GTab({ t, label, active, icon }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "6px 13px 7px",
+      borderRadius: "11px 11px 0 0", fontFamily: "var(--font-body)", fontSize: 9.5, letterSpacing: "0.03em",
+      background: active ? t.cardBg : "transparent",
+      color: active ? t.ink : t.label,
+      borderTop: active ? `2px solid ${t.pink}` : "2px solid transparent",
+      borderLeft: active ? `1px solid ${t.border}` : "1px solid transparent",
+      borderRight: active ? `1px solid ${t.border}` : "1px solid transparent",
+      boxShadow: active ? `0 -2px 8px ${t.glow}` : "none", opacity: active ? 1 : 0.8 }}>
+      {icon}{label}
+    </div>);
+
+}
+function GTabRow({ t }) {
+  return (
+    <div style={{ display: "flex", gap: 3, alignItems: "flex-end", borderBottom: `1.5px solid ${t.border}`, paddingBottom: 0 }}>
+      <GTab t={t} label="whimsy.exe" active icon={<WinGlyph size={15} t={t} />} />
+      <GTab t={t} label="analog.exe" icon={<WinGlyph size={15} t={t} color={t.label} />} />
+      <GTab t={t} label="snide.exe" icon={<WinGlyph size={15} t={t} color={t.label} />} />
+    </div>);
+
+}
+
+/* ───────── filter chips ───────── */
+function GChip({ t, label, active }) {
+  return (
+    <button style={{ fontFamily: "var(--font-body)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.08em",
+      padding: "5px 11px", borderRadius: 7, cursor: "pointer", transition: "all 120ms",
+      background: active ? `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})` : t.cardBg,
+      color: active ? t.onFill : t.inkSoft,
+      border: `1.5px solid ${active ? t.pinkDeep : t.border}`,
+      boxShadow: active ? `0 3px 8px ${t.glow}` : `inset 0 -2px 0 ${t.borderSoft}` }}>{label}</button>);
+
+}
+function GChipRow({ t }) {
+  return (
+    <div style={{ display: "flex", gap: 7, flexWrap: "wrap" }}>
+      <GChip t={t} label="✦ new" active />
+      <GChip t={t} label="mine" />
+      <GChip t={t} label="friends" />
+      <GChip t={t} label="duels" />
+    </div>);
+
+}
+
+/* ───────── empty state window ───────── */
+function GEmptyState({ t }) {
+  const Sparkle = window.Sparkle;
+  return (
+    <div style={{ width: 244, borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`, boxShadow: `0 8px 20px ${t.glow}` }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 11px",
+        background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#fb7aa8", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#f6c75e", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#86cfa6", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ marginLeft: "auto", fontSize: 9.5, color: t.titleText }}>whimsy.exe</span>
+      </div>
+      <div style={{ position: "relative", padding: "26px 16px 24px", textAlign: "center", background: t.cardBg,
+        backgroundImage: `radial-gradient(${t.dot} 1.3px, transparent 1.3px)`, backgroundSize: "13px 13px" }}>
+        <Sparkle size={12} color={t.gold} style={{ position: "absolute", top: 14, left: 22 }} />
+        <Sparkle size={9} color={t.pink} style={{ position: "absolute", top: 30, right: 26 }} />
+        {/* sleeping moon */}
+        <svg width="56" height="56" viewBox="0 0 56 56" style={{ marginBottom: 6 }}>
+          <circle cx="28" cy="28" r="20" fill={t.glow} opacity="0.5" />
+          <path d="M37 12a20 20 0 1 0 9 24A17 17 0 0 1 37 12Z" fill={t.moonLit} stroke={t.borderSoft} strokeWidth="1" />
+          <path d="M22 26q3 3 6 0M30 24q3 3 6 0" stroke={t.pinkDeep} strokeWidth="1.6" fill="none" strokeLinecap="round" />
+          <text x="44" y="18" fontFamily="var(--font-faction-script)" fontSize="11" fill={t.pink}>z</text>
+        </svg>
+        <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 24, color: t.ink, lineHeight: 1, marginBottom: 5 }}>no quests yet</div>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 9, color: t.inkSoft, marginBottom: 14, lineHeight: 1.5 }}>the coven is resting. check back<br />soon for new little magics.</div>
+        <GButton t={t} variant="primary">find quests</GButton>
+      </div>
+    </div>);
+
+}
+
+/* ───────── page title (signature WZ header, reskinned) ───────── */
+function GPageTitle({ t, eyebrow = "the coven · quest board", title = "little magics" }) {
+  const bars = [t.pink, t.gold, t.green, t.pinkDeep, t.greenLeaf];
+  let ci = 0;
+  return (
+    <div>
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.18em", color: t.label, marginBottom: 6 }}>{eyebrow}</div>
+      <h1 style={{ fontFamily: "var(--font-faction-script)", fontSize: 44, fontWeight: 700, lineHeight: 1.15, margin: 0, color: t.ink, display: "flex", flexWrap: "wrap", alignItems: "flex-end" }}>
+        {title.split("").map((ch, i) => {
+          if (ch === " ") return <span key={i} style={{ display: "inline-block", width: "0.28em" }} />;
+          const c = bars[ci % bars.length];ci++;
+          return <span key={i} style={{ borderBottom: `4px solid ${c}`, paddingBottom: 1, lineHeight: 1 }}>{ch}</span>;
+        })}
+      </h1>
+    </div>);
+
+}
+
+/* ───────── faction pennants (faction filter banner) ───────── */
+function GPennant({ t }) {
+  const facs = [
+  { name: "whimsy.exe", bg: `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})`, active: true },
+  { name: "snide", bg: "#5fae53", active: false },
+  { name: "ephemerists", bg: "#2f9e92", active: false },
+  { name: "everymen", bg: "#d2442f", active: false }];
+
+  return (
+    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+      {facs.map((f, i) =>
+      <button key={i} style={{ background: f.bg, color: "#fff", fontFamily: "var(--font-body)", fontSize: 9, fontWeight: 700,
+        textTransform: "uppercase", letterSpacing: "0.07em", padding: "5px 14px", cursor: "pointer", border: "none",
+        textShadow: "0 1px 2px rgba(0,0,0,0.3)", opacity: f.active ? 1 : 0.85,
+        clipPath: "polygon(0 0, 100% 0, 92% 100%, 8% 100%)", transition: "all 120ms" }}>{f.name}</button>
+      )}
+    </div>);
+
+}
+
+/* ───────── praxis.exe card (filed submission + heart marks) ───────── */
+const PRAXIS_LABELS = ["a start", "solid", "good", "excellent", "legendary"];
+function GPraxisCard({ t, praxis }) {
+  const p = praxis || {
+    task: "The L Word", finding: "Said It First", author: "pixie",
+    excerpt: "Knocked on her door at 7am with a thermos of cocoa and just… said it. She said it back.",
+    rating: 4, marks: 23, points: 5, level: 1
+  };
+  const r = Math.max(0, Math.min(5, Math.round(p.rating)));
+  const dot = (c) => ({ width: 9, height: 9, borderRadius: "50%", background: c, border: "1.2px solid rgba(255,255,255,0.7)" });
+  return (
+    <div style={{ width: 248, borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`, boxShadow: `0 8px 20px ${t.glow}`, fontFamily: "var(--font-body)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 11px",
+        background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+        <span style={dot("#fb7aa8")} /><span style={dot("#f6c75e")} /><span style={dot("#86cfa6")} />
+        <span style={{ marginLeft: "auto", fontSize: 9.5, color: t.titleText }}>praxis.exe</span>
+      </div>
+      <div style={{ padding: "14px 15px 15px", background: t.cardBg,
+        backgroundImage: `radial-gradient(${t.dot} 1.3px, transparent 1.3px)`, backgroundSize: "13px 13px" }}>
+        <div style={{ fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.16em", color: t.label, marginBottom: 4 }}>re: {p.task}</div>
+        <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 25, lineHeight: 1, color: t.ink, marginBottom: 6 }}>{p.finding}</div>
+        <div style={{ fontSize: 9.5, lineHeight: 1.5, color: t.inkSoft, marginBottom: 8 }}>{p.excerpt}</div>
+        <div style={{ fontSize: 9.5, fontStyle: "italic", color: t.inkSoft, marginBottom: 11 }}>filed by {p.author}</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 5, marginBottom: 10 }}>
+          {Array.from({ length: 5 }).map((_, i) =>
+          <svg key={i} width="15" height="15" viewBox="0 0 36 36">
+              <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+            fill={i < r ? t.voteFills[i] : "none"} stroke={i < r ? "#fff" : t.borderSoft} strokeWidth={i < r ? 2.2 : 2} strokeLinejoin="round" />
+            </svg>
+          )}
+          <span style={{ fontFamily: "var(--font-faction-script)", fontSize: 16, color: t.pink, marginLeft: 4 }}>{PRAXIS_LABELS[Math.max(0, r - 1)]}</span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 9, letterSpacing: "0.06em",
+            textTransform: "uppercase", padding: "3px 9px", borderRadius: 20, background: t.pinkLt, color: t.ink, border: `1px solid ${t.borderSoft}` }}>lvl {p.level}</span>
+          <span style={{ fontSize: 9, color: t.label }}>{p.marks} hearts</span>
+          <span style={{ marginLeft: "auto", fontSize: 11, fontWeight: 700, color: t.pinkDeep }}>◆ {p.points} pts</span>
+        </div>
+      </div>
+    </div>);
+
+}
+
+/* ───────── watercolor backdrop (page paint-bleed) ───────── */
+function GBackdrop({ t }) {
+  const fid = "gb-" + t.fill.replace("#", "");
+  return (
+    <div style={{ position: "relative", height: 132, borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`, background: t.panelBg }}>
+      <svg width="100%" height="100%" preserveAspectRatio="none" style={{ position: "absolute", inset: 0 }}>
+        <defs>
+          <filter id={fid} x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="20" /></filter>
+        </defs>
+        <ellipse cx="12%" cy="14%" rx="22%" ry="36%" fill={t.titleFrom} opacity="0.85" filter={`url(#${fid})`} />
+        <ellipse cx="86%" cy="20%" rx="20%" ry="30%" fill={t.gold} opacity="0.5" filter={`url(#${fid})`} />
+        <ellipse cx="78%" cy="94%" rx="24%" ry="36%" fill={t.pink} opacity="0.6" filter={`url(#${fid})`} />
+        <ellipse cx="20%" cy="98%" rx="20%" ry="30%" fill={t.greenLeaf} opacity="0.45" filter={`url(#${fid})`} />
+      </svg>
+      <span style={{ position: "absolute", left: 13, bottom: 11, fontFamily: "var(--font-body)", fontSize: 8.5,
+        textTransform: "uppercase", letterSpacing: "0.16em", color: t.ink, opacity: 0.7 }}>page backdrop · watercolor</span>
+    </div>);
+
+}
+
+Object.assign(window, {
+  KT, GAppIcon, GButton, GLevelPill, GLevelTrack, GVoteStamps, GTabRow, GChipRow, GEmptyState, WinGlyph,
+  GPageTitle, GPennant, GPraxisCard, GBackdrop
+});

--- a/docs/design/design-system/templates/wow/whimsy-updates.jsx
+++ b/docs/design/design-system/templates/wow/whimsy-updates.jsx
@@ -1,0 +1,183 @@
+/* ════════════════════════════════════════════════════════════════
+   whimsy-updates — the Updates activity feed, cottagecore edition
+   Correct components for the UPDATES page (not the task board):
+   dated feed rows (actor + action + badge + referenced task), the
+   right rail (task-slots window, recent-activity window, propose btn).
+   Soft-pastel faction rainbow kept intact; charm details from
+   whimsy-exe.jsx (Sparkle, StarSticker, Heart, Mushroom).
+   ════════════════════════════════════════════════════════════════ */
+
+/* per-mode page palette */
+const UPD = {
+  light: {
+    bg: "#fbeef5", ink: "#5a3450", inkSoft: "#8a6a7c", label: "#a8728e", faint: "#b89aac",
+    navBg: "rgba(251,238,245,0.86)", navBorder: "rgba(214,90,150,0.16)",
+    panel: "#fffdfa", panelBorder: "rgba(214,90,150,0.20)", panelSoft: "rgba(214,90,150,0.10)",
+    winFrom: "#fbcfe2", winTo: "#f3a6cb", winText: "#8e2f5c", winBorder: "#e487b5",
+    pink: "#ec5f99", pinkDeep: "#d23b7e",
+    divider: "rgba(170,90,130,0.25)",
+    blob1: "rgba(246,160,198,0.5)", blob2: "rgba(199,171,230,0.45)", blob3: "rgba(160,216,194,0.4)", blob4: "rgba(246,201,94,0.36)",
+    rowText: "#5a3450",
+  },
+  dark: {
+    bg: "#150b12", ink: "#fbcfe0", inkSoft: "#cf9bb6", label: "#c78aa6", faint: "#8a5d76",
+    navBg: "rgba(21,11,18,0.88)", navBorder: "rgba(244,114,182,0.2)",
+    panel: "#23101b", panelBorder: "rgba(244,114,182,0.22)", panelSoft: "rgba(244,114,182,0.10)",
+    winFrom: "#5e2a46", winTo: "#41203a", winText: "#fbd6e8", winBorder: "#f472b6",
+    pink: "#f472b6", pinkDeep: "#f9b6d4",
+    divider: "rgba(244,114,182,0.22)",
+    blob1: "rgba(244,114,182,0.2)", blob2: "rgba(150,110,200,0.18)", blob3: "rgba(95,168,130,0.15)", blob4: "rgba(240,180,90,0.13)",
+    rowText: "#fbcfe0",
+  },
+};
+
+/* soft pastel faction tints — accent (left bar) + row background, per mode */
+const FACTION_TINT = {
+  light: {
+    gestalt:     { a: "#ec5f99", bg: "#fde7f1" },
+    analog:      { a: "#d99a2b", bg: "#fbf3da" },
+    snide:       { a: "#6cbf90", bg: "#e6f6ec" },
+    ua:          { a: "#b79ad8", bg: "#efe6fb" },
+    singularity: { a: "#7aa8e0", bg: "#e6eefb" },
+    journeymen:  { a: "#54bcc4", bg: "#ddf4f5" },
+    uamasters:   { a: "#e0894f", bg: "#fbe9dc" },
+    duel:        { a: "#ef6f8e", bg: "#fde6ec" },
+    collab:      { a: "#b79ad8", bg: "#efe7fb" },
+  },
+  dark: {
+    gestalt:     { a: "#f472b6", bg: "#2a0d1c" },
+    analog:      { a: "#e0b24a", bg: "#241c08" },
+    snide:       { a: "#5fa882", bg: "#0d1f13" },
+    ua:          { a: "#a78bfa", bg: "#1d1530" },
+    singularity: { a: "#6f9fe0", bg: "#0c1626" },
+    journeymen:  { a: "#3fbac4", bg: "#0a2024" },
+    uamasters:   { a: "#e0894f", bg: "#241408" },
+    duel:        { a: "#f06f8e", bg: "#2a0f17" },
+    collab:      { a: "#a78bfa", bg: "#1d1530" },
+  },
+};
+
+/* semantic feed badges (soft pills, white text) */
+const BADGE = {
+  foe:       { bg: "#e8607f", label: "foe" },
+  friend:    { bg: "#3f9e6a", label: "friend" },
+  yourstuff: { bg: "#caa23e", label: "your stuff" },
+  global:    { bg: "#9a8aa8", label: "global" },
+  duel:      { bg: "#e85664", label: "duel" },
+  collab:    { bg: "#46a06a", label: "collab" },
+  solo:      { bg: "#b29cbe", label: "solo" },
+};
+
+function Badge({ kind, children }) {
+  const b = BADGE[kind] || BADGE.global;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", fontFamily: "var(--font-body)",
+      fontSize: 8.5, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em",
+      color: "#fff", background: b.bg, padding: "2.5px 7px", borderRadius: 6, lineHeight: 1.1,
+      boxShadow: "0 1.5px 0 rgba(120,40,80,0.18)" }}>{children || b.label}</span>
+  );
+}
+
+/* pink-gradient avatar with a soft moon glyph */
+function Avatar({ t, glyph = "🌙", size = 38 }) {
+  return (
+    <div style={{ width: size, height: size, borderRadius: "50%", flexShrink: 0,
+      background: `linear-gradient(150deg, ${t.winFrom}, ${t.pink})`,
+      border: `1.5px solid ${t.winBorder}`, display: "flex", alignItems: "center", justifyContent: "center",
+      fontSize: size * 0.45, boxShadow: "0 2px 6px rgba(190,60,120,0.22)" }}>{glyph}</div>
+  );
+}
+
+/* date divider with a center sparkle */
+function DateDivider({ t, date }) {
+  const Sparkle = window.Sparkle;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "26px 4px 18px" }}>
+      <div style={{ flex: 1, height: 0, borderTop: `1px dashed ${t.divider}` }} />
+      <Sparkle size={11} color={t.pink} />
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 10, textTransform: "uppercase", letterSpacing: "0.22em", color: t.label }}>{date}</span>
+      <Sparkle size={11} color={t.pink} />
+      <div style={{ flex: 1, height: 0, borderTop: `1px dashed ${t.divider}` }} />
+    </div>
+  );
+}
+
+/* the feed row */
+function FeedRow({ t, mode, actor, action, badge, timeAgo, task, meta, status, statusKind, tint, sticker }) {
+  const ft = FACTION_TINT[mode][tint] || FACTION_TINT[mode].gestalt;
+  const statusColor = statusKind === "declined" ? "#cf6b7e" : statusKind === "accepted" ? "#46a06a" : t.inkSoft;
+  return (
+    <div style={{ position: "relative", display: "flex", gap: 13, alignItems: "flex-start",
+      background: ft.bg, border: `1px solid ${t.panelSoft}`, borderLeft: `4px solid ${ft.a}`,
+      borderRadius: 14, padding: "16px 18px 16px 17px", marginBottom: 16,
+      boxShadow: mode === "dark" ? "0 4px 14px rgba(0,0,0,0.3)" : "0 4px 14px rgba(190,60,120,0.07)" }}>
+      <Avatar t={t} />
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 7 }}>
+        {/* headline */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", rowGap: 4 }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 13, lineHeight: 1.5, color: t.ink }}>
+            <strong style={{ fontWeight: 700 }}>{actor}</strong> <span style={{ color: t.inkSoft }}>{action}</span>
+          </span>
+          {badge && <Badge kind={badge} />}
+        </div>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 9, lineHeight: 1, textTransform: "uppercase", letterSpacing: "0.12em", color: t.faint }}>{timeAgo}</div>
+        {/* referenced task */}
+        <div style={{ borderLeft: `2px solid ${ft.a}`, paddingLeft: 12, marginTop: 2 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 9, flexWrap: "wrap", rowGap: 4 }}>
+            {meta && meta.dot && <span style={{ width: 8, height: 8, borderRadius: "50%", background: ft.a, flexShrink: 0, alignSelf: "center" }} />}
+            <span style={{ fontFamily: "var(--font-faction-script)", fontSize: 21, fontWeight: 700, color: t.ink, lineHeight: 1.25 }}>{task.title}</span>
+            {task.points != null && <span style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.1em", color: t.label }}>{task.points} PTS</span>}
+            {meta && meta.level != null && <span style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.1em", color: t.faint }}>· LVL {meta.level}</span>}
+            {meta && meta.tag && <span style={{ alignSelf: "center" }}><Badge kind={meta.tag} /></span>}
+            {meta && meta.note && <span style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.08em", color: t.faint }}>· {meta.note}</span>}
+          </div>
+        </div>
+        {/* status / action line */}
+        {status && (
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 10.5, lineHeight: 1.2, textTransform: "uppercase", letterSpacing: "0.1em", color: statusColor }}>{status}</div>
+        )}
+      </div>
+      {sticker}
+    </div>
+  );
+}
+
+/* ── right rail: a soft .exe window shell ── */
+function RailWindow({ t, mode, name, children, pad = "13px 14px" }) {
+  return (
+    <div style={{ borderRadius: 13, overflow: "hidden", border: `2px solid ${t.winBorder}`, marginBottom: 22,
+      boxShadow: mode === "dark" ? "0 8px 20px rgba(0,0,0,0.4)" : "0 8px 20px rgba(190,60,120,0.10)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 11px",
+        background: `linear-gradient(180deg, ${t.winFrom}, ${t.winTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#fb7aa8", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#f6c75e", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#86cfa6", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ marginLeft: "auto", fontFamily: "var(--font-body)", fontSize: 9.5, color: t.winText, letterSpacing: "0.02em" }}>{name}</span>
+      </div>
+      <div style={{ background: t.panel, padding: pad }}>{children}</div>
+    </div>
+  );
+}
+
+function SlotRow({ t, title, last }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 2px",
+      borderBottom: last ? "none" : `1px dashed ${t.panelSoft}` }}>
+      <span style={{ flex: 1, fontFamily: "var(--font-body)", fontSize: 11, color: t.ink, lineHeight: 1.25 }}>{title}</span>
+      <Badge kind="solo" />
+    </div>
+  );
+}
+
+function ActivityRow({ t, title, time, last }) {
+  return (
+    <div style={{ padding: "9px 2px", borderBottom: last ? "none" : `1px dashed ${t.panelSoft}` }}>
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 11, color: t.ink, lineHeight: 1.35 }}>
+        <strong style={{ fontWeight: 700 }}>New task:</strong> <span style={{ color: t.inkSoft }}>{title}</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.12em", color: t.faint, marginTop: 4 }}>{time}</div>
+    </div>
+  );
+}
+
+Object.assign(window, { UPD, Badge, Avatar, DateDivider, FeedRow, RailWindow, SlotRow, ActivityRow });

--- a/docs/design/design-system/tokens/colors.css
+++ b/docs/design/design-system/tokens/colors.css
@@ -1,0 +1,422 @@
+/* ══════════════════════════════════════════════════════════════
+   COLOR SYSTEM — World Zero · Single source of truth
+   Mirrors frontend/src/index.css. Faction card colors are synced
+   with utils/factions.ts. Light mode on :root, dark mode under
+   [data-theme="dark"] — every component reads var(--…) so the
+   theme switch is automatic through the cascade.
+
+   THE SIX FACTIONS (rainbow spine):
+     ua          purple   · sticky note
+     gestalt     pink     · gestalt.exe desktop window
+     snide       green    · ransom dispatch (acid + photocopier ink)
+     ephemerists teal     · illuminated codex / discordant map  (was Journeymen)
+     singularity blue     · terminal printout
+     everymen    red      · union / victory poster   (the missing red)
+   ══════════════════════════════════════════════════════════════ */
+:root {
+  /* ── Page backgrounds ── */
+  --color-bg-page: #f7f4ee;
+  --color-bg-surface: rgba(255, 255, 255, 0.72);
+  --color-bg-surface-alt: #f0ede6;
+
+  /* ── Text ── */
+  --color-text-primary: #1a1209;
+  --color-text-secondary: #6b6050;
+  --color-text-tertiary: #9b8e7d;
+
+  /* ── Borders ── */
+  --color-border: rgba(0, 0, 0, 0.07);
+  --color-border-strong: rgba(0, 0, 0, 0.15);
+
+  /* ── Accent ── */
+  --color-accent-primary: #be185d;
+
+  /* ── Nav ── */
+  --color-nav-bg: rgba(247, 244, 238, 0.9);
+
+  /* ── Functional ── */
+  --color-success: #14532d;
+  --color-danger: #dc2626;
+  --color-warning: #b45309;
+  --color-warning-light: #fef3c7;
+
+  /* ── Shared neutrals ── */
+  --color-text-on-accent: #ffffff;
+  --color-overlay-weak: rgba(0, 0, 0, 0.08);
+  --color-overlay-medium: rgba(0, 0, 0, 0.15);
+  --color-overlay-strong: rgba(0, 0, 0, 0.25);
+  --color-surface-scrim: rgba(255, 255, 255, 0.9);
+
+  /* ── Faction primary colors (rainbow palette) ── */
+  --faction-ua: #c2541f; /* burnt amber — gilt salon */
+  --faction-gestalt: #be185d; /* magenta */
+  --faction-snide: #16a34a; /* green */
+  --faction-ephemerists: #1d6e72; /* teal — lapis/verdigris */
+  --faction-singularity: #2563eb; /* blue */
+  --faction-everymen: #c1272d; /* red — the missing rainbow slot */
+  --faction-albescent: #1c1c1a; /* no hue — near-black ink on white (always-light) */
+
+  /* ── Faction tints (backgrounds, highlights) ── */
+  --faction-ua-light: rgba(194, 84, 31, 0.08);
+  --faction-gestalt-light: rgba(190, 24, 93, 0.08);
+  --faction-snide-light: rgba(22, 163, 74, 0.1);
+  --faction-ephemerists-light: rgba(29, 110, 114, 0.1);
+  --faction-singularity-light: rgba(37, 99, 235, 0.1);
+  --faction-everymen-light: rgba(193, 39, 45, 0.1);
+  --faction-albescent-light: rgba(28, 28, 26, 0.05);
+
+  /* ── Faction borders ── */
+  --faction-ua-border: rgba(194, 84, 31, 0.3);
+  --faction-gestalt-border: rgba(190, 24, 93, 0.3);
+  --faction-snide-border: rgba(22, 163, 74, 0.35);
+  --faction-ephemerists-border: rgba(29, 110, 114, 0.35);
+  --faction-singularity-border: rgba(37, 99, 235, 0.35);
+  --faction-everymen-border: rgba(193, 39, 45, 0.35);
+  --faction-albescent-border: rgba(28, 28, 26, 0.12);
+
+  /* ════════════════════════════════════════════════════════════
+     FACTION EXTENSION PALETTES
+     Each redesigned faction owns a named palette its surfaces draw
+     from. These flip in dark where noted; the card-contract tokens
+     below point at them so dark mode resolves through the cascade.
+     ════════════════════════════════════════════════════════════ */
+
+  /* ── UA · gilt salon (art academy; always-light — never dims) ── */
+  --ua-orange: #c2541f;       /* burnt amber — the accent */
+  --ua-orange-deep: #a8431a;
+  --ua-gold: #9c6a1a;          /* old gold — frames & regalia */
+  --ua-gold-lt: #dd9322;
+  --ua-gold-pale: #eec06a;
+  --ua-ink: #3d2410;           /* brown ink — all text */
+  --ua-sub: #8f6a3a;           /* secondary serif text */
+  --ua-muted: #a8895a;         /* mono labels / metadata */
+  --ua-paper: #fdf6ea;         /* sheet / card surface */
+  --ua-paper-warm: #fef7ea;
+  --ua-wall: #ece4d2;          /* page wall */
+  --ua-line: #cdab63;          /* hairline borders */
+  --ua-line-soft: #e3cb98;
+  --ua-gilt: linear-gradient(135deg,#eec06a 0%,#9c6a1a 24%,#f0c878 50%,#9c6a1a 76%,#dd9322 100%); /* @kind color */
+
+  /* ── GESTALT · gestalt.exe (pink computer-witch desktop) ── */
+  --gestalt-panel-bg: #fbeef5;
+  --gestalt-card-bg: #fffdfa;
+  --gestalt-ink: #a83a6e;
+  --gestalt-ink-soft: #b5588a;
+  --gestalt-label: #a8728e;
+  --gestalt-border: #f3b6d2;
+  --gestalt-border-soft: rgba(214, 90, 150, 0.28);
+  --gestalt-pink: #ec5f99;
+  --gestalt-pink-deep: #d23b7e;
+  --gestalt-pink-lt: #fbcfe2;
+  --gestalt-gold: #f0b94a;
+  --gestalt-green: #7cbf99;
+  --gestalt-leaf: #9ad3b1;
+  --gestalt-glow: rgba(236, 95, 153, 0.32);
+  --gestalt-title-from: #fbcfe2;
+  --gestalt-title-to: #f3a6cb;
+  --gestalt-title-text: #8e2f5c;
+  --gestalt-win-border: #e487b5;
+  --gestalt-moon-lit: #f6c75e;
+  --gestalt-moon-shadow: #fbe1ee;
+
+  /* ── S.N.I.D.E. · ransom / xerox punk ── */
+  --snide-acid: #b6ff2e; /* toxic green — the spot color */
+  --snide-acid-deep: #6fae00;
+  --snide-ink: #14110b; /* photocopier black */
+  --snide-paper: #f4f1e8; /* warm xerox stock */
+  --snide-paper-cool: #e7e9e2;
+  --snide-pink: #ff2d8b; /* hot zine pink */
+  --snide-pink-deep: #be185d;
+  --snide-accent: #15803d; /* muted system green */
+  --snide-tape: rgba(228, 214, 120, 0.62);
+  --snide-tape-grey: rgba(200, 200, 190, 0.5);
+  --snide-wall: #efece3; /* flyposted-wall backdrop (flips) */
+  --snide-wall-deep: #e0ddd1;
+  --snide-wall-text: #14110b;
+
+  /* ── EPHEMERISTS · illuminator's pigments on vellum ── */
+  --eph-gold: #b0863a; /* gold leaf / ochre */
+  --eph-gold-light: #d4ab55;
+  --eph-gold-deep: #8a6622;
+  --eph-rubric: #9c3622; /* vermilion rubrication red */
+  --eph-rubric-deep: #7c2718;
+  --eph-lapis: #1d4f6e; /* deep celestial blue */
+  --eph-lapis-deep: #143b54;
+  --eph-verdigris: #4a7d70; /* aged copper / astrolabe patina */
+  --eph-ink: #2a1d12; /* iron-gall ink — stays dark */
+  --eph-vellum: #e9dcbf; /* aged manuscript stock (flips) */
+  --eph-vellum-deep: #dccba2;
+  --eph-vellum-text: #2a1d12; /* text on vellum (flips) */
+  --eph-muted: #6f5c3e; /* faded marginalia ink (flips) */
+  --eph-parchment: #f1e8cf; /* bright text on dark elements */
+  --eph-field: #1d4f6e; /* celestial-diagram field (flips) */
+  --eph-field-deep: #143b54;
+
+  /* ── EVERYMEN · union / victory poster ── */
+  --everymen-cream: #f4ecd6; /* light stock / text-on-dark */
+  --everymen-gold: #d99a2b;
+  --everymen-gold-deep: #a9741a;
+  --everymen-olive: #5b6238;
+  --everymen-ink: #221a12; /* press ink — stays dark */
+  --everymen-red: #c1272d; /* propaganda red (flips brighter) */
+  --everymen-red-deep: #8d1c20;
+  --everymen-paper: #ece1c6; /* manila poster stock (flips) */
+  --everymen-paper-deep: #ddceac;
+  --everymen-paper-text: #221a12; /* text on paper (flips) */
+  --everymen-muted: #6c5a40;
+  --everymen-field: #c1272d; /* Mobilize poster field (flips oxblood) */
+  --everymen-field-deep: #8d1c20;
+
+  /* ── ALBESCENT · vellum correspondence (always-light; no hue) ── */
+  --al-surface: #ffffff;
+  --al-surface-warm: #faf9f7;
+  --al-text: #1c1c1a;
+  --al-text-muted: rgba(28, 28, 26, 0.44);
+  --al-text-faint: rgba(28, 28, 26, 0.22);
+  --al-ink: rgba(28, 28, 26, 0.72);
+  --al-border: rgba(0, 0, 0, 0.10);
+  --al-border-faint: rgba(0, 0, 0, 0.055);
+  --al-shadow: 0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04);
+
+  /* ── Faction card backgrounds (light mode) ── */
+  --faction-ua-card-bg: var(--ua-paper); /* parchment sheet */
+  --faction-gestalt-card-bg: var(--gestalt-card-bg);
+  --faction-snide-card-bg: var(--snide-ink); /* always-dark dispatch */
+  --faction-ephemerists-card-bg: var(--eph-vellum);
+  --faction-singularity-card-bg: #050f08; /* terminal black */
+  --faction-everymen-card-bg: var(--everymen-paper);
+  --faction-albescent-card-bg: var(--al-surface); /* white in both themes */
+
+  /* ── Faction card text ── */
+  --faction-ua-card-text: var(--ua-ink);
+  --faction-gestalt-card-text: var(--gestalt-ink);
+  --faction-snide-card-text: var(--snide-paper);
+  --faction-ephemerists-card-text: var(--eph-vellum-text);
+  --faction-singularity-card-text: #4ade80;
+  --faction-everymen-card-text: var(--everymen-paper-text);
+  --faction-albescent-card-text: var(--al-text);
+
+  /* ── Faction card accents ── */
+  --faction-ua-card-accent: var(--ua-orange);
+  --faction-gestalt-card-accent: var(--gestalt-pink);
+  --faction-snide-card-accent: var(--snide-acid);
+  --faction-ephemerists-card-accent: var(--eph-rubric);
+  --faction-singularity-card-accent: #4ade80; /* terminal green */
+  --faction-everymen-card-accent: var(--everymen-red);
+  --faction-albescent-card-accent: var(--al-ink);
+
+  /* ── Faction card secondary text (descriptions, metadata) ── */
+  --faction-ua-card-muted: var(--ua-sub);
+  --faction-gestalt-card-muted: var(--gestalt-ink-soft);
+  --faction-snide-card-muted: #b7b5a7;
+  --faction-ephemerists-card-muted: var(--eph-muted);
+  --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
+  --faction-everymen-card-muted: var(--everymen-muted);
+  --faction-albescent-card-muted: var(--al-text-muted);
+
+  /* ── Faction headline fonts (per-faction display) ── */
+  --faction-ua-card-font: var(--font-faction-gilt);
+  --faction-gestalt-card-font: var(--font-faction-script);
+  --faction-snide-card-font: var(--font-faction-anton);
+  --faction-ephemerists-card-font: var(--font-faction-engraved);
+  --faction-singularity-card-font: var(--font-faction-terminal);
+  --faction-everymen-card-font: var(--font-faction-poster);
+  --faction-albescent-card-font: var(--font-faction-vellum);
+
+  /* ── Singularity terminal border (blue brand) ── */
+  --faction-singularity-border-hard: #2563eb;
+
+  /* ── Vote stamp colors (orange → yellow → green → blue → magenta) ── */
+  --vote-1: #c2410c;
+  --vote-2: #ca8a04;
+  --vote-3: #16a34a;
+  --vote-4: #2563eb;
+  --vote-5: #be185d;
+
+  /* ── Title underline colors (cycling) ── */
+  --underline-1: #fbbf24;
+  --underline-2: #be185d;
+  --underline-3: #4f46e5;
+  --underline-4: #1d6e72;
+  --underline-5: #16a34a;
+  --underline-6: #c1272d;
+
+  /* ── Watercolor splash opacities ── */
+  --wc-opacity-blob: 0.3; /* @kind other */
+  --wc-opacity-drip: 0.22; /* @kind other */
+  --wc-opacity-drop: 0.18; /* @kind other */
+
+  /* ── Filter stamp dashed-border (inverts with active state bg) ── */
+  --stamp-active-dashed: rgba(255, 255, 255, 0.2);
+  --stamp-inactive-dashed: rgba(0, 0, 0, 0.15);
+  --stamp-inactive-bg: rgba(255, 255, 255, 0.8);
+
+  /* ── Leaderboard rank colors (podium — stable across themes) ── */
+  --rank-gold: #f59e0b;
+  --rank-silver: #c49a3a;
+  --rank-bronze: #888888;
+
+  /* ── Leaderboard rank accent (your-rank strip + score highlight) ── */
+  --color-rank-accent: #4f46e5;
+  --rank-strip-bg: rgba(79, 70, 229, 0.08);
+  --rank-strip-border: rgba(79, 70, 229, 0.25);
+  --leaderboard-row-hover: rgba(255, 255, 255, 0.55);
+
+  /* ── Level track node colors ── */
+  --color-level-inactive: #c8c0b0;
+  --level-node-incomplete: rgba(255, 255, 255, 0.5);
+
+  /* ── Feed badge colors (stable — white text always legible) ── */
+  --badge-friend: #14532d;
+  --badge-your-stuff: #8a6a20;
+  --badge-global: #6b6a7a;
+  --badge-duel: #dc2626;
+  --badge-collab: #15803d;
+  --badge-admin-bg: #1a1209;
+  --badge-admin-text: #f7f4ee;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   DARK MODE OVERRIDES — applied via [data-theme="dark"] on <html>
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="dark"] {
+  --color-bg-page: #13121a;
+  --color-bg-surface: rgba(255, 255, 255, 0.04);
+  --color-bg-surface-alt: rgba(255, 255, 255, 0.06);
+
+  --color-text-primary: #f0e6d0;
+  --color-text-secondary: #7a7060;
+  --color-text-tertiary: #4a4860;
+
+  --color-border: rgba(255, 255, 255, 0.07);
+  --color-border-strong: rgba(255, 255, 255, 0.15);
+
+  --color-accent-primary: #be185d;
+  --color-nav-bg: rgba(19, 18, 26, 0.92);
+
+  --color-success: #4ade80;
+  --color-danger: #f87171;
+  --color-warning: #fbbf24;
+  --color-warning-light: #1c0a00;
+
+  --color-surface-scrim: rgba(19, 18, 26, 0.85);
+
+  /* ── Faction primary colors (dark — brightened rainbow) ── */
+  --faction-ua: #c2541f;
+  --faction-gestalt: #f472b6;
+  --faction-snide: #4ade80;
+  --faction-ephemerists: #3aa0a4;
+  --faction-singularity: #60a5fa;
+  --faction-everymen: #ef5350;
+  --faction-albescent: #1c1c1a; /* no hue — stays near-black (always-light faction) */
+
+  --faction-ua-light: rgba(194, 84, 31, 0.12);
+  --faction-gestalt-light: rgba(244, 114, 182, 0.08);
+  --faction-snide-light: rgba(74, 222, 128, 0.1);
+  --faction-ephemerists-light: rgba(58, 160, 164, 0.1);
+  --faction-singularity-light: rgba(96, 165, 250, 0.1);
+  --faction-everymen-light: rgba(239, 83, 80, 0.1);
+  --faction-albescent-light: rgba(28, 28, 26, 0.05);
+
+  --faction-ua-border: rgba(194, 84, 31, 0.3);
+  --faction-gestalt-border: rgba(244, 114, 182, 0.25);
+  --faction-snide-border: rgba(74, 222, 128, 0.3);
+  --faction-ephemerists-border: rgba(58, 160, 164, 0.35);
+  --faction-singularity-border: rgba(96, 165, 250, 0.25);
+  --faction-everymen-border: rgba(239, 83, 80, 0.3);
+  --faction-albescent-border: rgba(28, 28, 26, 0.12);
+
+  /* ── GESTALT extension (dark) ── */
+  --gestalt-panel-bg: #1a0e15;
+  --gestalt-card-bg: #2a0d1c;
+  --gestalt-ink: #fbcfe0;
+  --gestalt-ink-soft: #e58cb6;
+  --gestalt-label: #c78aa6;
+  --gestalt-border: #7a3358;
+  --gestalt-border-soft: rgba(244, 114, 182, 0.32);
+  --gestalt-pink: #f472b6;
+  --gestalt-pink-deep: #f9b6d4;
+  --gestalt-pink-lt: #5e2a46;
+  --gestalt-gold: #f0d98f;
+  --gestalt-green: #5fa882;
+  --gestalt-leaf: #7fc59e;
+  --gestalt-glow: rgba(244, 114, 182, 0.45);
+  --gestalt-title-from: #5e2a46;
+  --gestalt-title-to: #41203a;
+  --gestalt-title-text: #fbd6e8;
+  --gestalt-win-border: #f472b6;
+  --gestalt-moon-lit: #f0d98f;
+  --gestalt-moon-shadow: #2a0d1c;
+
+  /* ── S.N.I.D.E. extension (dark) — acid/ink/pink are constants ── */
+  --snide-wall: #141310; /* concrete-at-night */
+  --snide-wall-deep: #0b0a08;
+  --snide-wall-text: #e9e6da;
+
+  /* ── EPHEMERISTS extension (dark) ── */
+  --eph-gold: #cda24a;
+  --eph-gold-light: #e6c267;
+  --eph-gold-deep: #9c7626;
+  --eph-rubric: #c0533a;
+  --eph-rubric-deep: #93341f;
+  --eph-lapis: #4f8fb0;
+  --eph-lapis-deep: #2d6285;
+  --eph-verdigris: #6aa597;
+  --eph-ink: #0c0a06;
+  --eph-vellum: #211a10; /* aged tobacco */
+  --eph-vellum-deep: #181208;
+  --eph-vellum-text: #efe3c6;
+  --eph-muted: #b6a079;
+  --eph-parchment: #efe3c6;
+  --eph-field: #102a3a;
+  --eph-field-deep: #0a1d2a;
+
+  /* ── EVERYMEN extension (dark) ── */
+  --everymen-cream: #f3e7ce;
+  --everymen-gold: #e7b94f;
+  --everymen-gold-deep: #b3852a;
+  --everymen-olive: #8a955a;
+  --everymen-ink: #0d0907;
+  --everymen-red: #e2433f;
+  --everymen-red-deep: #b32a28;
+  --everymen-paper: #221a16; /* dark manila */
+  --everymen-paper-deep: #17110d;
+  --everymen-paper-text: #f3e7ce;
+  --everymen-muted: #b6a079;
+  --everymen-field: #3c1416; /* deep oxblood */
+  --everymen-field-deep: #5a1d20;
+
+  /* ── Faction card backgrounds (dark mode) — singularity explicit;
+        ua stays always-light (the salon never dims) via its --ua-* tokens;
+        gestalt/snide/ephemerists/everymen resolve via extension tokens ── */
+  --faction-ua-card-bg: var(--ua-paper);
+  --faction-singularity-card-bg: #050f08;
+
+  /* ── Faction card text (dark mode) ── */
+  --faction-ua-card-text: var(--ua-ink);
+  --faction-singularity-card-text: #4ade80;
+
+  /* ── Faction card accents (dark mode) ── */
+  --faction-ua-card-accent: var(--ua-orange);
+  --faction-singularity-card-accent: #4ade80;
+
+  /* ── Faction card secondary text (dark mode) ── */
+  --faction-ua-card-muted: var(--ua-sub);
+  --faction-singularity-card-muted: #60a5fa;
+
+  --wc-opacity-blob: 0.15; /* @kind other */
+  --wc-opacity-drip: 0.11; /* @kind other */
+  --wc-opacity-drop: 0.08; /* @kind other */
+
+  --stamp-active-dashed: rgba(0, 0, 0, 0.15);
+  --stamp-inactive-dashed: rgba(255, 255, 255, 0.1);
+  --stamp-inactive-bg: rgba(255, 255, 255, 0.06);
+
+  --color-rank-accent: #818cf8;
+  --rank-strip-bg: rgba(129, 140, 248, 0.12);
+  --rank-strip-border: rgba(129, 140, 248, 0.3);
+  --leaderboard-row-hover: rgba(255, 255, 255, 0.03);
+
+  --color-level-inactive: rgba(255, 255, 255, 0.3);
+  --level-node-incomplete: rgba(255, 255, 255, 0.06);
+}

--- a/docs/design/design-system/tokens/fonts.css
+++ b/docs/design/design-system/tokens/fonts.css
@@ -1,0 +1,15 @@
+/* ══════════════════════════════════════════════════════════════
+   FONTS — World Zero
+   All fonts are loaded from Google Fonts. These are the REAL brand
+   fonts used by the World Zero app (frontend/src/index.css), not
+   substitutes. Each faction owns its own display face.
+     · System:      Lora, Courier Prime, Bebas Neue
+     · UA:          Playfair Display + Marcellus (gilt salon)
+     · Gestalt:     Caveat
+     · S.N.I.D.E.:  Anton + Permanent Marker + Special Elite + Archivo Black
+     · Ephemerists: Cinzel + EB Garamond + Cormorant Garamond
+     · Singularity: Share Tech Mono
+     · Everymen:    Bebas Neue (system accent)
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&family=Bebas+Neue&family=Special+Elite&family=Share+Tech+Mono&family=Permanent+Marker&family=Caveat:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500;1,600;1,700&family=Marcellus&family=Marcellus+SC&family=Anton&family=Archivo+Black&family=Cinzel:wght@400;500;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600&display=swap");

--- a/docs/design/design-system/tokens/patterns.css
+++ b/docs/design/design-system/tokens/patterns.css
@@ -1,0 +1,177 @@
+/* ══════════════════════════════════════════════════════════════
+   PATTERNS — World Zero shared classes
+   Plain-CSS port of the app's @layer components (index.css). These
+   are the reusable "glue" classes the faction cards, filters, nav
+   and sidebars all lean on. Every value references a token.
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── Base ── */
+body {
+  background-color: var(--color-bg-page);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  min-height: 100vh;
+  transition: background-color 150ms, color 150ms;
+}
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+}
+
+/* ── Eyebrow / label text ── */
+.eyebrow {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--color-text-tertiary);
+}
+
+/* ── Surfaces (frosted glass) ── */
+.sidebar-card {
+  background: var(--color-bg-surface);
+  border-radius: var(--radius-xl);
+  padding: 0.9rem;
+  border: 1px solid var(--color-border);
+  backdrop-filter: blur(var(--card-blur));
+}
+.card {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  backdrop-filter: blur(var(--card-blur));
+}
+
+/* ── Task-card shared patterns (faction cards reuse these) ── */
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px dashed var(--color-border-strong);
+  padding-top: 5px;
+  margin-top: auto;
+}
+.card-meta {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  margin-bottom: 6px;
+}
+.card-description {
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  margin-bottom: 8px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+/* ── Buttons ── */
+.btn-primary {
+  font-family: var(--font-body);
+  background: var(--color-text-primary);
+  color: var(--color-bg-page);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.5rem 1rem;
+  border: none;
+  cursor: pointer;
+  transition: opacity 150ms;
+}
+.btn-primary:hover { opacity: 0.85; }
+
+.btn-outline {
+  font-family: var(--font-body);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-strong);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: opacity 150ms;
+}
+.btn-outline:hover { opacity: 0.85; }
+
+/* ── Filter chips ── */
+.chip {
+  font-family: var(--font-body);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-strong);
+  padding: 0.25rem 0.625rem;
+  cursor: pointer;
+  transition: all 150ms;
+}
+.chip:hover { background: var(--color-bg-surface-alt); }
+.chip-active {
+  background: var(--color-text-primary);
+  color: var(--color-bg-page);
+  border-color: var(--color-text-primary);
+}
+
+/* ── Vote stamps (1–5 rating buttons) ── */
+.vote-stamp {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border: 2.5px solid var(--stamp-color);
+  border-radius: 0;
+  background: var(--stamp-inactive-bg);
+  color: var(--stamp-color);
+  font-family: var(--font-body);
+  font-size: 18px;
+  font-weight: 900;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 120ms;
+}
+.vote-stamp:hover:not(.vote-stamp-active):not(:disabled) {
+  background: color-mix(in srgb, var(--stamp-color) 10%, transparent);
+}
+.vote-stamp-active {
+  background: var(--stamp-color);
+  color: var(--color-text-on-accent);
+}
+.vote-stamp:disabled { opacity: 0.5; cursor: default; }
+[data-theme="dark"] .vote-stamp:not(.vote-stamp-active) {
+  color: var(--color-text-primary);
+}
+
+/* ── Pennant shape (faction filter tabs) ── */
+.pennant-shape {
+  clip-path: polygon(0 0, 100% 0, 95% 100%, 5% 100%);
+}
+
+/* ── Nav links ── */
+.nav-link {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding-bottom: 2px;
+  text-decoration: none;
+  transition: color 150ms;
+}
+
+/* ── Page wrapper + heading ── */
+.page {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+.page-heading {
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
+  font-weight: 700;
+  font-style: italic;
+  margin-bottom: 1.5rem;
+  color: var(--color-text-primary);
+}

--- a/docs/design/design-system/tokens/spacing.css
+++ b/docs/design/design-system/tokens/spacing.css
@@ -1,0 +1,35 @@
+/* ══════════════════════════════════════════════════════════════
+   SPACING, RADII & SURFACE TOKENS — World Zero
+   The app uses a small, restrained radius set (4–14px) and very
+   gentle blur for its frosted-glass nav and sidebar surfaces.
+   There is no heavy drop-shadow system — depth comes from paper
+   textures, rotations, torn edges and translucency, not elevation.
+   ══════════════════════════════════════════════════════════════ */
+:root {
+  /* ── Corner radii ── */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 14px;
+
+  /* ── Frosted-glass blur ── */
+  --nav-blur: 6px;
+  --card-blur: 4px;
+
+  /* ── Spacing rhythm (used in card padding & gaps) ── */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  /* ── Letter-spacing for uppercase labels/eyebrows ── */
+  --tracking-label: 0.1em;
+  --tracking-eyebrow: 0.15em;
+}
+
+[data-theme="dark"] {
+  --nav-blur: 8px;
+}

--- a/docs/design/design-system/tokens/typography.css
+++ b/docs/design/design-system/tokens/typography.css
@@ -1,0 +1,39 @@
+/* ══════════════════════════════════════════════════════════════
+   TYPOGRAPHY — World Zero
+   Three system roles (display / body / accent) plus per-faction
+   display faces. The type scale is deliberately TINY — World Zero
+   renders like a printed field journal, so 8–14px is the working
+   range and 28–34px is reserved for page titles & wordmark.
+   ══════════════════════════════════════════════════════════════ */
+:root {
+  /* ── Type scale (px) ── */
+  --text-xs: 8px;
+  --text-sm: 9px;
+  --text-base: 10px;
+  --text-md: 11px;
+  --text-lg: 12px;
+  --text-xl: 14px;
+  --text-2xl: 18px;
+  --text-3xl: 28px;
+  --text-4xl: 34px;
+
+  /* ── System font families ── */
+  --font-display: "Lora", Georgia, serif; /* wordmark, page & praxis titles (italic) */
+  --font-body: "Courier Prime", "Courier New", monospace; /* ALL body, UI, labels */
+  --font-accent: "Bebas Neue", Impact, sans-serif; /* reserved special use */
+
+  /* ── Per-faction headline faces ── */
+  --font-faction-gilt: "Playfair Display", Georgia, serif; /* UA — gilt salon (didone, italic) */
+  --font-faction-engraved-caps: "Marcellus SC", "Marcellus", Georgia, serif; /* UA regalia — engraved caps */
+  --font-faction-script: "Caveat", cursive; /* Gestalt — gestalt.exe */
+  --font-faction-marker: "Permanent Marker", "Marker Felt", cursive; /* S.N.I.D.E. scrawl */
+  --font-faction-anton: "Anton", Impact, sans-serif; /* S.N.I.D.E. + display headlines */
+  --font-faction-black: "Archivo Black", Impact, sans-serif; /* S.N.I.D.E. ransom block */
+  --font-faction-typewriter: "Special Elite", "Courier New", serif; /* S.N.I.D.E. body type */
+  --font-faction-terminal: "Share Tech Mono", monospace; /* Singularity */
+  --font-faction-engraved: "Cinzel", "Trajan Pro", Georgia, serif; /* Ephemerists display */
+  --font-faction-codex: "EB Garamond", Georgia, serif; /* Ephemerists body / italics */
+  --font-faction-codex-script: "Cormorant Garamond", Georgia, serif; /* Ephemerists flourish */
+  --font-faction-poster: "Bebas Neue", Impact, sans-serif; /* Everymen — union poster */
+  --font-faction-vellum: "Cormorant Garamond", Georgia, serif; /* Albescent — vellum correspondence */
+}

--- a/docs/design/praxis-read/HANDOFF-README.md
+++ b/docs/design/praxis-read/HANDOFF-README.md
@@ -1,0 +1,111 @@
+# Handoff: Faction Praxis Read Pages (World Zero)
+
+## Overview
+This bundle is seven "completed praxis" **read pages** for World Zero — a real-world quest game — one per faction. A *praxis* is a filed, completed piece of work that members review by awarding **points** and casting a **1–5 vote**; each page also shows a **backer ledger** (who staked/voted, per ADR-0005). Every page wears its faction's own physical archetype (sticky note, terminal printout, ransom dispatch, illuminated codex, union poster, desktop window, vellum letter), but they all express the same underlying data model.
+
+An index page (`All Faction Praxis Pages.dc.html`) links to all seven in rainbow order.
+
+## About the Design Files
+The files in this bundle are **design references created in HTML** — prototypes showing the intended look and behavior, **not production code to copy directly**. The task is to **recreate these designs in the target codebase's existing environment** (React, Vue, SwiftUI, native, etc.) using its established patterns, component library, and styling conventions. If no environment exists yet, choose the most appropriate framework for the project and implement the designs there.
+
+These prototypes are authored as "Design Components" (`.dc.html` / `.jsx` mounted through a small runtime in `support.js`). That runtime is a *prototyping* harness — **do not port it**. Read the markup and styles for intent; rebuild with your own components.
+
+## Fidelity
+**High-fidelity.** Final colors, typography, spacing, layout, and interactions are all intended as drawn. Recreate the UI faithfully, mapping exact token values (below) onto your codebase's design-token system. The one liberty: per-faction display fonts are loaded from the design system — substitute equivalents only if a font is unavailable.
+
+## The data model (shared across all seven pages)
+Every praxis page renders the same conceptual record; only the skin changes.
+
+- **Praxis** — title, body/description, author, faction, status (here: completed / sealed / filed), timestamp.
+- **Points** — a numeric score the praxis has earned.
+- **Vote (1–5)** — an aggregate rating, displayed as 5 stamps/rungs. Each faction *reframes the label* of the scale (e.g. Singularity = consensus signal, S.N.I.D.E. = "marked by the mob", Albescent = "bear witness", UA = a 1–5 critique) but the underlying value is always an integer 1–5.
+- **Backer ledger (ADR-0005)** — a list of members who backed/voted on the praxis: name, the points/stake they put up, and their individual vote. Rendered as a small feed/table styled per faction.
+- **Comments/thread** — faction-styled discussion posts with @mentions.
+
+When implementing, model this once (a `Praxis` entity + `Vote` + `Backer` + `Comment`) and theme the presentation per faction — do **not** build seven unrelated data models.
+
+## Screens / Views
+All seven share the structure: **masthead/header → praxis body → points & vote rating → backer ledger → comment thread**, restyled per faction. Faction primary hex values are in Design Tokens below.
+
+1. **The Everymen** — `factions/everymen/Everymen Praxis.html` (red `#c1272d`). Union / victory-poster "work report". Bebas Neue display. Also includes an **edit** variant: `Everymen Edit Praxis.html`.
+2. **UA · University of Asthmatics** — `factions/ua/UA Praxis - Read.dc.html` (burnt-orange `#c2541f`). Gilt art-salon "exhibited acquisition"; IM Fell English. Rating is a 1–5 *Critique*.
+3. **The Ephemerists** — `factions/ephemerists/Ephemerists Completed Praxis.html` (teal `#1d6e72`, gold leaf `#d8c187`). Illuminated codex / vellum "sealed ephemeris leaf"; Cinzel.
+4. **S.N.I.D.E.** — `factions/snide/SNIDE Praxis Detail.html` (green `#16a34a`, always-dark dispatch). Ransom / photocopier cut-out "confession marked by the mob"; Anton + cut-letter treatment.
+5. **Singularity** — `factions/singularity/Singularity Completed Praxis.html` (blue `#2563eb`, **always dark**, phosphor green text `#4ade80` on `#050f08`). Terminal printout "sealed praxis log"; Share Tech Mono. Includes a Cast-Signal consensus vote.
+6. **Warriors of Whimsy** — `factions/wow/Warriors of Whimsy Praxis.html` (magenta `#be185d`). whimsy.exe pink desktop window; Caveat. Rating uses hearts.
+7. **Albescent** — `factions/albescent/Albescent Completed Praxis.html` (near-black ink `#1c1c1a`, **always light**). Vellum correspondence; Cormorant Garamond italic. Rating is "bear witness". Sits outside the rainbow (unranked secret society).
+
+### Layout specifics (index page)
+`All Faction Praxis Pages.dc.html`: centered column, `max-width:820px`, `padding:60px 28px 90px`. Eyebrow row of 7 color chips (14×5px) + "World Zero · Praxis Review" (9px, `letter-spacing:0.26em`, uppercase). H1 "Faction Praxis Pages" in the display face, italic 600, 42px. A 160×4px rainbow gradient rule. Then a vertical stack (`gap:12px`) of faction link rows: each is a flex row with a 6px faction-color spine, title (21px/700), one-line description (11px), and an "Open →" affordance; hover translates the row 3px right and drops a 4px hard offset shadow in the faction color.
+
+## Interactions & Behavior
+- **Vote stamps (1–5):** the filled count reflects the aggregate; per-faction visual treatment (ink stamps, terminal blocks, hearts, witness marks). If interactive, hovering a rung previews that score; clicking sets the viewer's vote.
+- **Backer ledger:** static list/feed in the prototypes; in production, populate from the praxis's backer records.
+- **Index hover:** row shifts `translateX(3px)` + hard offset box-shadow in faction color; `transition: transform/box-shadow/border-color 120ms`.
+- **Theme:** the design system supports light + dark via `[data-theme="dark"]`. Singularity is always-dark and Albescent is always-light regardless of theme; the other five follow the theme.
+
+## State Management
+- `praxis` record (title, body, author, status, points, voteAverage, voteCount).
+- `backers[]` (name, stake/points, vote).
+- `comments[]` (author, body with @mentions, timestamp).
+- Viewer's own vote (optional, if voting is interactive) and points staked.
+- Active theme (light/dark) — except the two fixed-theme factions.
+
+## Design Tokens
+All values come from the **World Zero Design System** (`_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/`). The real source of truth is `tokens/colors.css`, `tokens/typography.css`, `tokens/fonts.css`, `tokens/spacing.css`, `tokens/patterns.css`. Map these into your own token system.
+
+### Faction primary colors (light → dark)
+- UA (purple): `#7c3aed` → `#a78bfa`
+- Warriors of Whimsy / `gestalt` (magenta): `#be185d` → `#f472b6`
+- S.N.I.D.E. (green): `#16a34a` → `#4ade80`
+- Ephemerists (teal): `#1d6e72` → `#3aa0a4`  (gold leaf accent `#d8c187`)
+- Singularity (blue): `#2563eb` → `#60a5fa`
+- Everymen (red): `#c1272d` → `#ef5350`
+- Albescent (ink): `#1c1c1a` (both themes)
+- UA salon orange used on the index/UA skin: `#c2541f`
+
+Each faction also has `-light` (8–10% tint), `-border` (~0.3 alpha), and a `--faction-<slug>-card-{bg,text,accent,muted,font}` contract — see `tokens/colors.css` (lines ~50–210 light, ~288–390 dark). Note the registry slug for Warriors of Whimsy is **`gestalt`** in CSS variables.
+
+### Card surface highlights
+- Singularity card: bg `#050f08`, text/accent `#4ade80`, chrome blue `#60a5fa`.
+- S.N.I.D.E. card: dark ink bg (`--snide-ink`), paper text (`--snide-paper`), acid accent (`--snide-acid`).
+- Ephemerists card: vellum bg (`--eph-vellum`), rubric accent (`--eph-rubric`).
+- Everymen card: paper bg (`--everymen-paper`), red accent (`--everymen-red`).
+- UA card: faded lavender `#f3eefc`, text `#1a1209`, accent `#7c3aed`.
+- Albescent card: white surface (`--al-surface`) in both themes, ink text/accent.
+
+### Typography (per-faction display faces)
+IM Fell English (UA), Caveat (WoW), Anton (S.N.I.D.E.), Cinzel (Ephemerists), Share Tech Mono (Singularity), Bebas Neue (Everymen), Cormorant Garamond (Albescent). Body/app type and the type scale are in `tokens/typography.css`. Working type sizes are small by design (8–14px field-journal scale); the index uses 9–42px.
+
+### Spacing / radius / shadow
+Use `tokens/spacing.css`. Hard offset shadows (e.g. `-4px 4px 0 <faction-color>`) and 1px strong borders are the dominant card treatment; corners are mostly square. Don't introduce soft drop shadows or large radii unless the faction skin already uses them.
+
+## Design System Components
+The prototypes compose these shared components (source in `_ds/.../components/`, also mirrored in the full DS project). Recreate equivalents in your codebase:
+- **FactionPraxisCard** — the filed-praxis card (one archetype per faction).
+- **FactionTaskCard** — the signature task card (seven archetypes).
+- **FactionVoteStamps** — the 1–5 stamp rating; `faction` prop reframes the rung labels.
+- **FactionCommentBox** — one thread-post style per faction, auto-styles @mentions.
+- **FactionPennant** / **FilterStamp** / **LevelNodes** — filters/banners.
+- **Button**, **LevelPill**, **PageTitle**, **WatercolorBackground** — core chrome.
+- **factions.js** registry — `FACTIONS`, `FACTION_ORDER`, `factionCssVar(slug, key)`, `SLUG_ALIAS` (`journeymen → ephemerists`, etc.). Use this as the canonical faction list.
+
+## Assets
+- All fonts load from the design system's `tokens/fonts.css` (Google Fonts families listed above). No bespoke image assets are required by the praxis pages themselves; faction textures are CSS/`tokens/patterns.css`.
+- `uploads/pasted-1782403867955-0.png` is a reference screenshot only, not a shipped asset.
+
+## Files
+Index: `All Faction Praxis Pages.dc.html`
+Shared prototype logic: `factions/praxis-core.jsx`, `support.js`
+Per faction (under `factions/<slug>/`):
+- everymen: `Everymen Praxis.html`, `Everymen Edit Praxis.html`, `everymen-cards.jsx`, `everymen-praxis.jsx`, `everymen.css`
+- ua: `UA Praxis - Read.dc.html`, `image-slot.js`, `support.js`
+- ephemerists: `Ephemerists Completed Praxis.html`, `ephemerists-cards.jsx`, `ephemerists-praxis-read.jsx`, `ephemerists-updates.jsx`, `ephemerists.css`
+- snide: `SNIDE Praxis Detail.html`, `snide-cards.jsx`, `snide-faction.jsx`, `snide-praxis-detail.jsx`, `snide.css`
+- singularity: `Singularity Completed Praxis.html`, `singularity-cards.jsx`, `singularity-praxis.jsx`, `singularity.css`
+- wow: `Warriors of Whimsy Praxis.html`, `whimsy-exe.jsx`, `whimsy-kit.jsx`
+- albescent: `Albescent Completed Praxis.html`, `albescent-cards.jsx`, `albescent-faction.jsx`, `albescent-praxis.jsx`, `albescent.css`
+
+Design system (tokens + components): `_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/`
+
+> Note: to open these prototypes in a browser locally, serve the project root with a static server (e.g. `npx serve`) so the relative `_ds/` and `support.js` paths resolve. The `.dc.html` files require `support.js` to be present at the project root.

--- a/docs/design/praxis-read/factions/albescent/Albescent Completed Praxis.html
+++ b/docs/design/praxis-read/factions/albescent/Albescent Completed Praxis.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>World Zero — Entry · Albescent</title>
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css">
+<link rel="stylesheet" href="albescent.css">
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background: #f7f4ee;
+    color: #1c1c1a;
+    font-family: "Courier Prime", "Courier New", monospace;
+    min-height: 100vh;
+  }
+  a { color: inherit; text-decoration: none; }
+
+  .wordmark {
+    font-family: "Lora", Georgia, serif;
+    font-style: italic; font-weight: 700;
+    font-size: 22px; line-height: 1; color: #1c1c1a;
+    border-bottom: 3px solid; padding-bottom: 2px;
+    border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1;
+  }
+  .nav-links { display: flex; gap: 20px; flex: 1; }
+  .nav-links a {
+    font-family: var(--al-mono); font-size: 10px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: rgba(28,28,26,0.35); padding-bottom: 3px;
+    transition: color 120ms;
+  }
+  .nav-links a.active {
+    color: rgba(28,28,26,0.72);
+    border-bottom: 1px solid rgba(28,28,26,0.42);
+  }
+  .nav-links a:hover { color: rgba(28,28,26,0.58); }
+  .nav-ctl {
+    display: flex; align-items: center; gap: 14px;
+    font-family: var(--al-mono); font-size: 10px;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    color: rgba(28,28,26,0.35);
+  }
+  .nav-box {
+    border: 1px solid var(--al-border); padding: 5px 11px;
+    cursor: pointer; transition: background 120ms;
+  }
+  .nav-box:hover { background: rgba(0,0,0,0.04); }
+
+  .crumbs {
+    position: relative; z-index: 5;
+    max-width: 1100px; margin: 0 auto;
+    padding: 18px 32px 0;
+    font-family: var(--al-mono); font-size: 9px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: rgba(28,28,26,0.28);
+  }
+  .crumbs a:hover { color: rgba(28,28,26,0.55); }
+
+  /* two-col layout: main + witness sidebar */
+  .entry-layout {
+    display: grid;
+    grid-template-columns: 1fr 300px;
+    gap: 24px;
+    align-items: start;
+  }
+  @media (max-width: 860px) {
+    .entry-layout { grid-template-columns: 1fr; }
+  }
+
+  /* witness sidebar panel */
+  .witness-panel {
+    border: 1px solid rgba(0,0,0,0.09);
+    background: #fff;
+    box-shadow: 0 2px 14px rgba(0,0,0,0.04);
+    padding: 22px 20px;
+    position: sticky;
+    top: 24px;
+  }
+  .witness-panel-head {
+    font-family: var(--al-mono);
+    font-size: 7px;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: rgba(28,28,26,0.24);
+    margin-bottom: 16px;
+  }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="albescent-cards.jsx"></script>
+<script type="text/babel" src="albescent-faction.jsx"></script>
+<script type="text/babel" src="albescent-praxis.jsx"></script>
+<script type="text/babel" src="../praxis-core.jsx"></script>
+</head>
+<body>
+
+<div class="al-backdrop"></div>
+
+<nav class="al-nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a>
+    <a href="#">Tasks</a>
+    <a href="../../All%20Faction%20Praxis%20Pages.dc.html">Praxis</a>
+    <a href="#">Players</a>
+    <a href="../../All%20Faction%20Praxis%20Pages.dc.html">Factions</a>
+    <a href="#">Updates</a>
+    <a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Keeper</span>
+    <span id="nav-badge"></span>
+    <span class="nav-box">Leave</span>
+  </div>
+</nav>
+
+<div class="crumbs" id="crumbs">
+  <a href="../../All%20Faction%20Praxis%20Pages.dc.html">Factions</a>
+  &nbsp;/&nbsp;
+  <a href="../../All%20Faction%20Praxis%20Pages.dc.html">Albescent</a>
+  &nbsp;/&nbsp;
+  <a href="../../All%20Faction%20Praxis%20Pages.dc.html">The Record</a>
+  &nbsp;/&nbsp;
+  <span id="crumb-task" style="color:rgba(28,28,26,0.55)">Entry</span>
+</div>
+
+<div class="al-page">
+  <div id="not-found" style="display:none;padding:48px 0;font-family:var(--al-font);font-style:italic;font-size:18px;color:rgba(28,28,26,0.35);">
+    This entry does not exist, or has not been returned.
+  </div>
+  <div class="entry-layout" id="entry-layout" style="display:none;">
+    <div class="al-sheet" id="entry-main"></div>
+    <div id="entry-witness" style="position:sticky;top:24px;">
+      <div id="witness-caster"></div>
+    </div>
+  </div>
+</div>
+
+<script type="text/babel">
+const { AL_PRAXES, EntryRead, AlNavBadge, WZ_FACTIONS, WZ_PagePointsBlock } = window;
+
+ReactDOM.createRoot(document.getElementById("nav-badge")).render(<AlNavBadge/>);
+
+/* ── resolve praxis from URL hash ── */
+const hash = window.location.hash.slice(1);
+const praxis = AL_PRAXES.find(p => p.id === hash) || AL_PRAXES[0];
+
+if (praxis) {
+  /* show layout, set breadcrumb */
+  document.getElementById("entry-layout").style.display = "grid";
+  document.getElementById("crumb-task").textContent = praxis.task;
+
+  /* main entry */
+  ReactDOM.createRoot(document.getElementById("entry-main")).render(
+    <EntryRead p={praxis}/>
+  );
+
+  /* points & votes — backer ledger (ADR-0005) */
+  const albF = WZ_FACTIONS.find((f) => f.slug === "albescent");
+  ReactDOM.createRoot(document.getElementById("witness-caster")).render(
+    <WZ_PagePointsBlock f={albF}/>
+  );
+} else {
+  document.getElementById("not-found").style.display = "block";
+}
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/albescent/albescent-cards.jsx
+++ b/docs/design/praxis-read/factions/albescent/albescent-cards.jsx
@@ -1,0 +1,159 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — Atoms + Task Card
+   Shared visual vocabulary for all Albescent surfaces.
+
+   Physical archetype: VELLUM CORRESPONDENCE — pure white,
+   Cormorant Garamond italic, surveyor's mark sigil, hairline
+   borders. The card speaks in a whisper.
+
+   Atoms exported:    AlbescentMark
+   Task card exported: AlbescentCard (window.AlbescentCard)
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Witness scale ── */
+const AL_WITNESS = [
+  { v:1, label:"Unseeing"  },
+  { v:2, label:"Glimpsed"  },
+  { v:3, label:"Witnessed" },
+  { v:4, label:"Verified"  },
+  { v:5, label:"Inscribed" },
+];
+
+const alDistTotal = d => d.reduce((a,b) => a+b, 0);
+const alDistAvg   = d => {
+  const t = alDistTotal(d);
+  return t ? d.reduce((a,c,i) => a+c*(i+1), 0) / t : 0;
+};
+const alStanding = avg => AL_WITNESS[Math.max(0, Math.min(4, Math.round(avg)-1))];
+
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT MARK — the surveyor's cross-hair sigil
+   Outer ring (18% opacity) · inner ring (50%) ·
+   4 cardinal tick marks · filled center dot.
+   ════════════════════════════════════════════════════════════════ */
+function AlbescentMark({ size = 20, color = "#1c1c1a", breathe = false, opacity = 1 }) {
+  const c  = size / 2;
+  const rO = size * 0.43;    /* outer ring */
+  const rI = size * 0.235;   /* inner ring */
+  const rD = size * 0.044;   /* center dot */
+  const tS = rI + size * 0.025;   /* tick start — just past inner ring */
+  const tE = tS + size * 0.13;    /* tick end */
+
+  const tick = (deg) => {
+    const a = deg * Math.PI / 180;
+    return {
+      x1: c + tS * Math.cos(a), y1: c + tS * Math.sin(a),
+      x2: c + tE * Math.cos(a), y2: c + tE * Math.sin(a),
+    };
+  };
+
+  return (
+    <svg
+      width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none"
+      style={{
+        display: "block", flexShrink: 0, opacity,
+        animation: breathe ? "al-breathe 5.5s ease-in-out infinite" : "none",
+      }}
+    >
+      <circle cx={c} cy={c} r={rO} stroke={color} strokeWidth={size*0.022} opacity={0.18}/>
+      <circle cx={c} cy={c} r={rI} stroke={color} strokeWidth={size*0.038} opacity={0.5}/>
+      {[0, 90, 180, 270].map((deg, i) => {
+        const { x1, y1, x2, y2 } = tick(deg);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={size*0.038}/>;
+      })}
+      <circle cx={c} cy={c} r={rD} fill={color}/>
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT TASK CARD — Vellum archetype
+   Full-sized version for the faction page task grid.
+   224px wide. Shows in the global task list at a smaller size
+   via FactionTaskCard (the base DS component).
+   ════════════════════════════════════════════════════════════════ */
+function AlbescentCard({ title, description, level, points, onAcknowledge }) {
+  const [ack, setAck] = React.useState(false);
+
+  return (
+    <div style={{
+      width: 224,
+      background: "#fff",
+      border: "1px solid rgba(0,0,0,0.09)",
+      boxShadow: "0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)",
+      padding: "24px 20px 18px",
+      fontFamily: "var(--al-font)",
+    }}>
+      {/* Centered sigil */}
+      <div style={{ display:"flex", justifyContent:"center", marginBottom:16 }}>
+        <AlbescentMark size={20} breathe/>
+      </div>
+
+      {/* Top rule */}
+      <div style={{ height:1, background:"rgba(0,0,0,0.07)", marginBottom:13 }}/>
+
+      {/* Eyebrow */}
+      <div style={{
+        fontSize:6, letterSpacing:"0.32em", textTransform:"uppercase",
+        color:"rgba(0,0,0,0.24)", fontFamily:"var(--al-mono)", marginBottom:10,
+      }}>Albescent</div>
+
+      {/* Title */}
+      <div style={{
+        fontSize:18, fontStyle:"italic", fontWeight:300,
+        lineHeight:1.28, color:"#1c1c1a", marginBottom:11,
+      }}>{title}</div>
+
+      {/* Description */}
+      {description && (
+        <div style={{
+          fontSize:7.5, color:"rgba(28,28,26,0.42)", lineHeight:1.6,
+          fontFamily:"var(--al-mono)", marginBottom:16,
+          overflow:"hidden", display:"-webkit-box",
+          WebkitLineClamp:3, WebkitBoxOrient:"vertical",
+        }}>{description}</div>
+      )}
+
+      {/* CTA */}
+      <div style={{ marginBottom:14 }}>
+        <button
+          onClick={() => { setAck(a => !a); onAcknowledge?.(); }}
+          style={{
+            background:"none", border:"none", padding:0, cursor:"pointer",
+            fontSize:7, letterSpacing:"0.22em", textTransform:"uppercase",
+            color: ack ? "rgba(0,0,0,0.55)" : "rgba(0,0,0,0.32)",
+            fontFamily:"var(--al-mono)",
+            borderBottom:`1px solid ${ack ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.16)"}`,
+            paddingBottom:1, transition:"all 250ms ease",
+          }}
+        >{ack ? "acknowledged" : "acknowledge"}</button>
+      </div>
+
+      {/* Footer */}
+      <div style={{
+        borderTop:"1px solid rgba(0,0,0,0.07)", paddingTop:11,
+        display:"flex", justifyContent:"space-between", alignItems:"center",
+      }}>
+        <span style={{
+          fontSize:6.5, letterSpacing:"0.2em", textTransform:"uppercase",
+          color:"rgba(0,0,0,0.22)", fontFamily:"var(--al-mono)",
+        }}>Lvl {level}</span>
+        <span style={{ fontSize:14, fontWeight:300, color:"rgba(28,28,26,0.48)" }}>
+          {points}
+          <span style={{
+            fontSize:6.5, marginLeft:3, letterSpacing:"0.1em",
+            textTransform:"uppercase", fontFamily:"var(--al-mono)",
+          }}>pts</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AlbescentMark, AlbescentCard,
+  AL_WITNESS, alDistTotal, alDistAvg, alStanding,
+});

--- a/docs/design/praxis-read/factions/albescent/albescent-faction.jsx
+++ b/docs/design/praxis-read/factions/albescent/albescent-faction.jsx
@@ -1,0 +1,421 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — Faction page components + activity feed
+   Hero · Activity Cards · Witness Widget · Nav Badge · Data.
+   Uses albescent-cards.jsx atoms. Exports on window.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Activity data ── */
+const AL_ACTIVITY = [
+  {
+    id:"a1", actor:"Keeper Vane", house:"Third House",
+    action:"returned", time:"1d ago",
+    task:"Tend the Archive in Silence", taskId:"archive-silence",
+    refNo:"XIV", credits:40, kind:"returned",
+    note:"All volumes restored and indexed. No record of passage remains.",
+  },
+  {
+    id:"a2", actor:"Keeper Orin", house:"First House",
+    action:"witnessed", time:"2d ago",
+    task:"Walk the Perimeter at Dusk", taskId:"perimeter-dusk",
+    refNo:"XI", credits:20, kind:"witnessed",
+    note:"Movement confirmed. The circuit holds.",
+  },
+  {
+    id:"a3", actor:"Keeper Sel", house:"Second House",
+    action:"acknowledged", time:"3d ago",
+    task:"Index the Unmarked Volumes", taskId:"index-unmarked",
+    refNo:"XVII", credits:0, kind:"acknowledged",
+    note:"Task received. No further acknowledgment.",
+  },
+  {
+    id:"a4", actor:"Keeper Marsh", house:"Fourth House",
+    action:"returned", time:"5d ago",
+    task:"Seal and Store Before Departing", taskId:"seal-store",
+    refNo:"IX", credits:30, kind:"returned",
+    note:"Storage completed per protocol. Departed before light.",
+  },
+  {
+    id:"a5", actor:"Keeper Vane", house:"Third House",
+    action:"attended", time:"6d ago",
+    task:"Count the Objects Without Touching", taskId:"count-objects",
+    refNo:"XXI", credits:0, kind:"attended",
+    note:"Forty-three objects accounted for. None disturbed.",
+  },
+  {
+    id:"a6", actor:"Keeper Orin", house:"First House",
+    action:"witnessed", time:"1w ago",
+    task:"Tend the Archive in Silence", taskId:"archive-silence",
+    refNo:"XIV", credits:40, kind:"witnessed",
+    note:"Signal: Inscribed. Twelve keepers in accord.",
+  },
+];
+
+const AL_TASKS = [
+  {
+    title:"Tend the Archive in Silence",
+    description:"Retrieve, restore, and return. No record of your work need remain.",
+    level:3, points:40,
+  },
+  {
+    title:"Walk the Perimeter at Dusk",
+    description:"Complete the circuit before darkness settles. Do not mark the path.",
+    level:2, points:20,
+  },
+  {
+    title:"Index the Unmarked Volumes",
+    description:"Catalogue what has not been named. Add only what is necessary.",
+    level:4, points:60,
+  },
+];
+
+const ACTION_KIND = {
+  acknowledged: { label:"acknowledged", shade:"rgba(28,28,26,0.28)" },
+  attended:     { label:"attended",     shade:"rgba(28,28,26,0.46)" },
+  returned:     { label:"returned",     shade:"rgba(28,28,26,0.64)" },
+  witnessed:    { label:"witnessed",    shade:"rgba(28,28,26,0.82)" },
+};
+
+/* ════════════════════════════════════════════════════════════════
+   AL NAV BADGE — faction membership indicator for the nav bar
+   ════════════════════════════════════════════════════════════════ */
+function AlNavBadge() {
+  const { AlbescentMark } = window;
+  return (
+    <div style={{
+      display:"inline-flex", alignItems:"center", gap:7,
+      border:"1px solid rgba(0,0,0,0.12)",
+      background:"rgba(255,255,255,0.6)",
+      padding:"4px 10px",
+    }}>
+      <AlbescentMark size={11}/>
+      <span style={{
+        fontFamily:"var(--al-mono)", fontSize:8,
+        letterSpacing:"0.18em", textTransform:"uppercase",
+        color:"rgba(28,28,26,0.55)",
+      }}>Albescent</span>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL HERO — faction page masthead
+   Meditative and still. No terminal boot-up, no dramatic chrome.
+   Just the name, the mark, and the purpose.
+   ════════════════════════════════════════════════════════════════ */
+function AlHero({ name, motto, blurb, stats }) {
+  const { AlbescentMark } = window;
+  return (
+    <div className="al-sheet" style={{ marginBottom:32, overflow:"hidden" }}>
+
+      {/* Faint background watermark */}
+      <div style={{
+        position:"absolute", top:"50%", left:"62%",
+        transform:"translate(-50%,-50%)",
+        pointerEvents:"none", zIndex:0,
+        opacity:0.03,
+      }}>
+        <AlbescentMark size={220}/>
+      </div>
+
+      <div style={{
+        position:"relative", zIndex:2,
+        padding:"44px 48px 50px",
+        display:"grid", gridTemplateColumns:"1fr auto",
+        gap:56, alignItems:"center",
+      }}>
+        <div>
+          {/* Pre-title eyebrow */}
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:7.5,
+            letterSpacing:"0.28em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)", marginBottom:18, lineHeight:1.9,
+          }}>
+            <div>Faction · {name}</div>
+            <div>Fourth Season · Active</div>
+            <div>Unranked · By design</div>
+          </div>
+
+          {/* Faction name */}
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:76, lineHeight:0.92,
+            color:"#1c1c1a", marginBottom:16,
+            letterSpacing:"-0.015em",
+          }}>{name}</div>
+
+          {/* Motto */}
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:9,
+            letterSpacing:"0.34em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.28)", marginBottom:20,
+          }}>{motto}</div>
+
+          {/* Blurb */}
+          <p style={{
+            fontFamily:"var(--al-mono)", fontSize:9.5, lineHeight:1.74,
+            color:"rgba(28,28,26,0.46)", maxWidth:490, marginBottom:30,
+          }}>{blurb}</p>
+
+          {/* Stats */}
+          <div style={{ display:"flex", gap:28, flexWrap:"wrap" }}>
+            {stats.map(s => (
+              <div key={s.label} style={{
+                paddingTop:12,
+                borderTop:"1px solid rgba(0,0,0,0.07)",
+                minWidth:80,
+              }}>
+                <div style={{
+                  fontFamily:"var(--al-font)", fontStyle:"italic",
+                  fontWeight:300, fontSize:28, lineHeight:1,
+                  color:"rgba(28,28,26,0.68)", marginBottom:5,
+                }}>{s.value}</div>
+                <div style={{
+                  fontFamily:"var(--al-mono)", fontSize:7,
+                  letterSpacing:"0.2em", textTransform:"uppercase",
+                  color:"rgba(28,28,26,0.26)",
+                }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Large mark — slowly breathing */}
+        <div className="al-breathe" style={{ flexShrink:0 }}>
+          <AlbescentMark size={106}/>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL ACTIVITY CARD — record feed item
+   Styled like a formal logbook entry: quiet, precise, no color.
+   ════════════════════════════════════════════════════════════════ */
+function AlActivityCard({ item }) {
+  const ak = ACTION_KIND[item.kind] || ACTION_KIND.acknowledged;
+  return (
+    <div className="al-activity-card" style={{ fontFamily:"var(--al-mono)" }}>
+
+      {/* Actor row */}
+      <div style={{
+        display:"flex", justifyContent:"space-between",
+        alignItems:"flex-start", gap:12, marginBottom:7,
+      }}>
+        <div>
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:14, lineHeight:1.2,
+            color:"rgba(28,28,26,0.72)", marginBottom:2,
+          }}>{item.actor}</div>
+          <div style={{
+            fontSize:7, letterSpacing:"0.16em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.26)",
+          }}>{item.house}</div>
+        </div>
+        <div style={{ display:"flex", alignItems:"center", gap:10, flexShrink:0 }}>
+          <span style={{
+            fontSize:6.5, letterSpacing:"0.18em", textTransform:"uppercase",
+            color:ak.shade, borderBottom:`1px solid ${ak.shade}`, paddingBottom:1,
+          }}>{ak.label}</span>
+          <span style={{
+            fontSize:7, letterSpacing:"0.06em",
+            color:"rgba(28,28,26,0.2)",
+          }}>{item.time}</span>
+        </div>
+      </div>
+
+      {/* Task name */}
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontWeight:300, fontSize:12.5, lineHeight:1.3,
+        color:"rgba(28,28,26,0.6)", marginBottom:5,
+      }}>{item.task}</div>
+
+      {/* Meta row */}
+      <div style={{
+        display:"flex", gap:12, alignItems:"center",
+        flexWrap:"wrap", marginBottom: item.note ? 5 : 0,
+      }}>
+        <span style={{ fontSize:7, letterSpacing:"0.12em", color:"rgba(28,28,26,0.24)" }}>
+          Ref. {item.refNo}
+        </span>
+        {item.credits > 0 && (
+          <span style={{ fontSize:7, letterSpacing:"0.1em", color:"rgba(28,28,26,0.32)" }}>
+            {item.credits} pts
+          </span>
+        )}
+      </div>
+
+      {item.note && (
+        <div style={{
+          fontSize:8, fontStyle:"italic", fontFamily:"var(--al-font)",
+          color:"rgba(28,28,26,0.36)", lineHeight:1.5,
+        }}>{item.note}</div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL WITNESS WIDGET — consensus witness for the faction page
+   Grayscale 1-5 circle marks: Unseeing → Inscribed.
+   No colors — Albescent refuses the palette.
+   ════════════════════════════════════════════════════════════════ */
+function AlWitnessWidget({ taskId, taskLabel, baseDist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const key = "al-witness-" + taskId;
+  const [my, setMy] = React.useState(0);
+
+  React.useEffect(() => {
+    try {
+      const v = +localStorage.getItem(key);
+      if (v >= 1 && v <= 5) setMy(v);
+    } catch(e) {}
+  }, [key]);
+
+  const cast = v => {
+    const nv = my === v ? 0 : v;
+    setMy(nv);
+    try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch(e) {}
+  };
+
+  const live = baseDist.map((c, i) => c + (my === i+1 ? 1 : 0));
+  const avg  = alDistAvg(live);
+  const total = alDistTotal(live);
+  const st   = alStanding(avg);
+
+  const shades = [
+    "rgba(0,0,0,0.16)",
+    "rgba(0,0,0,0.30)",
+    "rgba(0,0,0,0.48)",
+    "rgba(0,0,0,0.66)",
+    "rgba(0,0,0,0.84)",
+  ];
+
+  return (
+    <div style={{
+      border:"1px solid rgba(0,0,0,0.09)",
+      background:"#fff",
+      padding:"22px 24px",
+      fontFamily:"var(--al-mono)",
+    }}>
+      {/* Header */}
+      <div style={{
+        fontSize:7, letterSpacing:"0.26em", textTransform:"uppercase",
+        color:"rgba(28,28,26,0.24)", marginBottom:8,
+      }}>Bear Witness</div>
+
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontWeight:300, fontSize:13.5, color:"rgba(28,28,26,0.52)",
+        lineHeight:1.38, marginBottom:20,
+      }}>
+        How completely was this task attended?<br/>
+        <span style={{ color:"rgba(28,28,26,0.7)" }}>{taskLabel}</span>
+      </div>
+
+      {/* 5 circle marks */}
+      <div style={{ display:"flex", gap:8, marginBottom:14 }}>
+        {AL_WITNESS.map((s, i) => {
+          const shade = shades[i];
+          const on    = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{
+              display:"flex", flexDirection:"column",
+              alignItems:"center", gap:7, flex:1,
+            }}>
+              <button
+                onClick={() => cast(s.v)}
+                style={{
+                  width:32, height:32, borderRadius:"50%", cursor:"pointer",
+                  border:`1.5px solid ${shade}`,
+                  background: on ? shade : "transparent",
+                  display:"flex", alignItems:"center", justifyContent:"center",
+                  padding:0, transition:"all 200ms ease",
+                }}
+              >
+                {picked && (
+                  <div style={{
+                    width:8, height:8, borderRadius:"50%", background:"#fff",
+                  }}/>
+                )}
+              </button>
+              <span style={{
+                fontSize:5.5, letterSpacing:"0.06em", textAlign:"center",
+                color:"rgba(28,28,26,0.28)", lineHeight:1.35,
+              }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Consensus readout */}
+      <div style={{
+        display:"flex", justifyContent:"space-between", alignItems:"center",
+        paddingTop:13, borderTop:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        <span style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:17, color:"rgba(28,28,26,0.58)",
+        }}>{st.label}</span>
+        <span style={{
+          fontSize:8, letterSpacing:"0.12em",
+          color:"rgba(28,28,26,0.26)",
+        }}>{total} keepers</span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL ACTIVITY FEED — full updates page version with filters
+   ════════════════════════════════════════════════════════════════ */
+function AlActivityFeed({ items }) {
+  const [filter, setFilter] = React.useState("all");
+  const FILTERS = [
+    { id:"all",          name:"All" },
+    { id:"acknowledged", name:"Acknowledged" },
+    { id:"attended",     name:"Attended" },
+    { id:"returned",     name:"Returned" },
+    { id:"witnessed",    name:"Witnessed" },
+  ];
+  const rows = items.filter(i => filter === "all" || i.kind === filter);
+
+  return (
+    <div>
+      <div style={{ display:"flex", gap:6, marginBottom:20, flexWrap:"wrap" }}>
+        {FILTERS.map(f => {
+          const on = filter === f.id;
+          return (
+            <button key={f.id} onClick={() => setFilter(f.id)} style={{
+              fontFamily:"var(--al-mono)", fontSize:7.5,
+              letterSpacing:"0.14em", textTransform:"uppercase",
+              padding:"4px 10px", cursor:"pointer",
+              border:`1px solid ${on ? "rgba(0,0,0,0.28)" : "rgba(0,0,0,0.1)"}`,
+              background: on ? "rgba(28,28,26,0.07)" : "transparent",
+              color: on ? "rgba(28,28,26,0.65)" : "rgba(28,28,26,0.36)",
+              transition:"all 120ms",
+            }}>{f.name}</button>
+          );
+        })}
+      </div>
+      {rows.map(item => <AlActivityCard key={item.id} item={item}/>)}
+      {rows.length === 0 && (
+        <div style={{
+          padding:"24px 0", fontSize:13, fontStyle:"italic",
+          fontFamily:"var(--al-font)", color:"rgba(28,28,26,0.26)",
+        }}>No entries match this filter.</div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AL_ACTIVITY, AL_TASKS, ACTION_KIND,
+  AlNavBadge, AlHero, AlActivityCard, AlWitnessWidget, AlActivityFeed,
+});

--- a/docs/design/praxis-read/factions/albescent/albescent-praxis.jsx
+++ b/docs/design/praxis-read/factions/albescent/albescent-praxis.jsx
@@ -1,0 +1,602 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — The Register (Praxis surfaces)
+   A returned task is a filed account the faction now witnesses.
+   The 1–5 rating becomes THE WITNESS SCALE — a presence ramp
+   (unseeing → glimpsed → witnessed → verified → inscribed)
+   that measures how completely the task was attended.
+
+   Two surfaces:
+     · RegisterIndex — the ledger of returned accounts + witness
+     · EntryRead     — one returned account in full, with casting
+
+   Uses albescent-cards.jsx atoms. Data + helpers on window.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── dataset ── */
+const AL_PRAXES = [
+  {
+    id:        "archive-silence",
+    refNo:     "XIV",
+    task:      "Tend the Archive in Silence",
+    status:    "witnessed",
+    keeper:    "Keeper Vane",
+    house:     "Third House",
+    timestamp: "2026.04.21 // dawn",
+    credits:   40,
+    output:    "All volumes restored. The shelves hold their sequence without my name in them.",
+    account: [
+      "Arrived before the cataloguers. Worked from the east wing inward, restoring the displaced volumes to their documented positions. Did not open any that were sealed.",
+      "Found three volumes with damaged spines. Wrapped them without notation — they will be found by whoever is meant to find them.",
+      "Departed by the rear passage before the morning shift arrived. Left no note.",
+    ],
+    dist: [0, 1, 8, 14, 9],
+    plates: [
+      { caption: "The east wing, before the work", note: "available light" },
+      { caption: "Volumes returned to sequence", note: "shelf III · north" },
+      { caption: "The rear passage at dawn", note: "departed unseen" },
+    ],
+  },
+  {
+    id:        "perimeter-dusk",
+    refNo:     "XI",
+    task:      "Walk the Perimeter at Dusk",
+    status:    "witnessed",
+    keeper:    "Keeper Orin",
+    house:     "First House",
+    timestamp: "2026.04.18 // dusk",
+    credits:   20,
+    output:    "The circuit holds. Three missing posts replaced before the light failed.",
+    account: [
+      "Walked the full eastern perimeter beginning at the point where the light first dims. Completed the circuit in forty-one minutes.",
+      "Three boundary posts were missing from the northern quadrant. Replaced them from materials kept in the groundskeeper storage.",
+      "Returned by the same route. Nothing disturbed.",
+    ],
+    dist: [0, 2, 5, 8, 4],
+  },
+  {
+    id:        "seal-store",
+    refNo:     "IX",
+    task:      "Seal and Store Before Departing",
+    status:    "returned",
+    keeper:    "Keeper Marsh",
+    house:     "Fourth House",
+    timestamp: "2026.04.19 // before light",
+    credits:   30,
+    output:    "Stored. Departed. No trace visible from the road.",
+    account: [
+      "Completed sealing of the eastern archive annex using the wax from the cabinet — verified seal integrity before leaving.",
+      "Checked the facade from the road before departing. No light. No sign. Left before the hour changed.",
+    ],
+    dist: [1, 3, 7, 4, 1],
+  },
+  {
+    id:        "count-objects",
+    refNo:     "XXI",
+    task:      "Count the Objects Without Touching",
+    status:    "witnessed",
+    keeper:    "Keeper Vane",
+    house:     "Third House",
+    timestamp: "2026.04.20 // midday",
+    credits:   25,
+    output:    "Forty-three objects accounted for. None disturbed.",
+    account: [
+      "Entered the reading room at the appointed hour. Counted all objects on the central table by visual inspection only. Forty-three.",
+      "One object appeared to have moved since the last count. It had not — the shadow deceived. Counted again from the doorway. Forty-three.",
+      "Departed without confirming the count to anyone present.",
+    ],
+    dist: [0, 0, 3, 8, 5],
+  },
+];
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS BAR — mini grayscale histogram for index rows
+   ════════════════════════════════════════════════════════════════ */
+function WitnessBar({ dist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const total = alDistTotal(dist);
+  const avg   = alDistAvg(dist);
+  const st    = alStanding(avg);
+  const max   = Math.max(1, ...dist);
+  const shades = ["rgba(0,0,0,0.14)","rgba(0,0,0,0.28)","rgba(0,0,0,0.44)","rgba(0,0,0,0.62)","rgba(0,0,0,0.80)"];
+
+  return (
+    <div style={{ display:"flex", alignItems:"center", gap:10 }}>
+      <div style={{ display:"flex", alignItems:"flex-end", gap:2, height:22 }}>
+        {AL_WITNESS.map((s, i) => (
+          <div key={s.v} style={{
+            width:5,
+            height: Math.max(2, (dist[i] / max) * 22),
+            background: shades[i],
+            opacity: dist[i] ? 0.88 : 0.12,
+          }}/>
+        ))}
+      </div>
+      <div>
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:13.5, lineHeight:1,
+          color:"rgba(28,28,26,0.55)", marginBottom:2,
+        }}>{st.label}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7,
+          letterSpacing:"0.1em", color:"rgba(28,28,26,0.28)",
+        }}>{total} witnesses</div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   REGISTER ROW — single row in the praxis index
+   ════════════════════════════════════════════════════════════════ */
+function RegisterRow({ p, href }) {
+  return (
+    <a href={href} style={{
+      display:"grid",
+      gridTemplateColumns:"56px 1fr auto 20px",
+      alignItems:"center", gap:14,
+      padding:"12px 0", textDecoration:"none", color:"inherit",
+      borderBottom:"1px solid rgba(0,0,0,0.055)",
+      transition:"background 150ms",
+    }}
+    onMouseEnter={e => e.currentTarget.style.background="rgba(0,0,0,0.016)"}
+    onMouseLeave={e => e.currentTarget.style.background="transparent"}>
+
+      {/* Ref + status */}
+      <div style={{ textAlign:"right" }}>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7.5,
+          color:"rgba(28,28,26,0.30)", letterSpacing:"0.1em",
+        }}>Ref. {p.refNo}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:6,
+          color:"rgba(28,28,26,0.2)", letterSpacing:"0.12em",
+          textTransform:"uppercase", marginTop:2,
+        }}>{p.status}</div>
+      </div>
+
+      {/* Task name + keeper */}
+      <div>
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:15.5, lineHeight:1.2,
+          color:"rgba(28,28,26,0.72)", marginBottom:3,
+        }}>{p.task}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7.5,
+          color:"rgba(28,28,26,0.30)", letterSpacing:"0.04em",
+        }}>
+          {p.keeper} · {p.house}
+          <span style={{ marginLeft:8, color:"rgba(28,28,26,0.18)" }}>
+            {p.timestamp.split("//")[0].trim()}
+          </span>
+        </div>
+      </div>
+
+      {/* Witness consensus mini-bar */}
+      <WitnessBar dist={p.dist}/>
+
+      {/* Arrow */}
+      <span style={{ color:"rgba(28,28,26,0.22)", fontSize:11 }}>›</span>
+    </a>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   REGISTER INDEX — the full praxis index component
+   ════════════════════════════════════════════════════════════════ */
+function RegisterIndex({ praxes, hrefFor }) {
+  const [filter, setFilter] = React.useState("all");
+  const { alDistAvg, alDistTotal } = window;
+
+  const FILTERS = [
+    { id:"all",      name:"All returned" },
+    { id:"verified", name:"Highly witnessed" },
+    { id:"recent",   name:"This season" },
+  ];
+
+  const totalWitnesses = praxes.reduce((a, p) => a + alDistTotal(p.dist), 0);
+
+  const rows = praxes.filter(p => {
+    if (filter === "all")      return true;
+    if (filter === "verified") return alDistAvg(p.dist) >= 3.5;
+    return true;
+  });
+
+  return (
+    <React.Fragment>
+      {/* Masthead */}
+      <div style={{
+        display:"flex", justifyContent:"space-between",
+        alignItems:"flex-start", gap:16,
+        paddingBottom:22, marginBottom:20,
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        <div>
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:7.5,
+            letterSpacing:"0.28em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)", marginBottom:9,
+          }}>Albescent · witnessed accounts · fourth season</div>
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:36, lineHeight:1.0,
+            color:"rgba(28,28,26,0.8)", marginBottom:6,
+          }}>The Register</div>
+          <div style={{ height:1, width:56, background:"rgba(0,0,0,0.12)", marginBottom:13 }}/>
+          <p style={{
+            fontFamily:"var(--al-mono)", fontSize:8.5, lineHeight:1.65,
+            color:"rgba(28,28,26,0.4)", maxWidth:440, margin:0,
+          }}>
+            Tasks returned by the keepers. Each entry is a completed account —
+            no more, no less. Cast your witness on any you have observed.
+          </p>
+        </div>
+        <div style={{ display:"flex", gap:24, flexShrink:0 }}>
+          {[{ v:praxes.length, l:"returned" },{ v:totalWitnesses, l:"witnesses" }].map(s => (
+            <div key={s.l} style={{ textAlign:"right" }}>
+              <div style={{
+                fontFamily:"var(--al-font)", fontStyle:"italic",
+                fontWeight:300, fontSize:32, lineHeight:1,
+                color:"rgba(28,28,26,0.6)",
+              }}>{s.v}</div>
+              <div style={{
+                fontFamily:"var(--al-mono)", fontSize:7,
+                letterSpacing:"0.16em", color:"rgba(28,28,26,0.28)", marginTop:3,
+              }}>{s.l}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div style={{ display:"flex", gap:6, marginBottom:16, flexWrap:"wrap" }}>
+        {FILTERS.map(f => {
+          const on = filter === f.id;
+          return (
+            <button key={f.id} onClick={() => setFilter(f.id)} style={{
+              fontFamily:"var(--al-mono)", fontSize:7.5, letterSpacing:"0.14em",
+              textTransform:"uppercase", padding:"4px 10px", cursor:"pointer",
+              border:`1px solid ${on ? "rgba(0,0,0,0.28)" : "rgba(0,0,0,0.1)"}`,
+              background: on ? "rgba(28,28,26,0.07)" : "transparent",
+              color: on ? "rgba(28,28,26,0.65)" : "rgba(28,28,26,0.36)",
+              transition:"all 120ms",
+            }}>{f.name}</button>
+          );
+        })}
+        <span style={{
+          fontSize:7, color:"rgba(28,28,26,0.22)",
+          letterSpacing:"0.14em", marginLeft:6, alignSelf:"center",
+        }}>{rows.length}/{praxes.length}</span>
+      </div>
+
+      {/* Column headers */}
+      <div style={{
+        display:"grid", gridTemplateColumns:"56px 1fr auto 20px",
+        gap:14, paddingBottom:8, marginBottom:2,
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        {["Ref", "Account", "Witnesses", ""].map((h, i) => (
+          <div key={i} style={{
+            fontFamily:"var(--al-mono)", fontSize:6.5,
+            letterSpacing:"0.22em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)",
+            textAlign: i === 2 ? "right" : "left",
+          }}>{h}</div>
+        ))}
+      </div>
+
+      {/* Rows */}
+      <div>
+        {rows.map(p => <RegisterRow key={p.id} p={p} href={hrefFor(p)}/>)}
+        {rows.length === 0 && (
+          <div style={{
+            padding:"28px 0", fontSize:14, fontStyle:"italic",
+            fontFamily:"var(--al-font)", color:"rgba(28,28,26,0.26)",
+          }}>No entries match this filter.</div>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS METER — grayscale distribution + standing label
+   ════════════════════════════════════════════════════════════════ */
+function WitnessMeter({ dist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const total = alDistTotal(dist);
+  const avg   = alDistAvg(dist);
+  const st    = alStanding(avg);
+  const max   = Math.max(1, ...dist);
+  const shades = ["rgba(0,0,0,0.84)","rgba(0,0,0,0.66)","rgba(0,0,0,0.48)","rgba(0,0,0,0.30)","rgba(0,0,0,0.16)"];
+
+  return (
+    <div>
+      <div style={{ display:"flex", alignItems:"baseline", gap:10, marginBottom:10 }}>
+        <span style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:38, lineHeight:0.9,
+          color:"rgba(28,28,26,0.65)",
+        }}>{st.label}</span>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:8,
+          letterSpacing:"0.12em", color:"rgba(28,28,26,0.30)",
+        }}>{total} witnesses · avg {avg.toFixed(1)}</div>
+      </div>
+
+      <div style={{ display:"flex", flexDirection:"column", gap:6, marginTop:14 }}>
+        {AL_WITNESS.slice().reverse().map((s, i) => {
+          const realIdx = 4 - i;
+          const count   = dist[realIdx];
+          return (
+            <div key={s.v} style={{ display:"flex", alignItems:"center", gap:10 }}>
+              <span style={{
+                width:62, textAlign:"right",
+                fontFamily:"var(--al-mono)", fontSize:7.5,
+                letterSpacing:"0.06em", color:"rgba(28,28,26,0.38)",
+              }}>{s.label}</span>
+              <div style={{
+                flex:1, height:10,
+                background:"rgba(0,0,0,0.04)",
+                border:"1px solid rgba(0,0,0,0.07)",
+                position:"relative", overflow:"hidden",
+              }}>
+                <div style={{
+                  position:"absolute", inset:0,
+                  width:`${(count / max) * 100}%`,
+                  background: shades[i],
+                  opacity: count ? 0.88 : 0,
+                  transition:"width 400ms ease",
+                }}/>
+              </div>
+              <span style={{
+                width:18, fontFamily:"var(--al-mono)", fontSize:9,
+                color:"rgba(28,28,26,0.50)", textAlign:"right",
+              }}>{count}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS CASTER — interactive witness casting (with meter)
+   Persists to localStorage. Albescent's equivalent of SignalCaster.
+   ════════════════════════════════════════════════════════════════ */
+function WitnessCaster({ praxisId, baseDist }) {
+  const { alDistAvg, alDistTotal, AL_WITNESS } = window;
+  const key = "al-witness-" + praxisId;
+  const [my, setMy] = React.useState(0);
+
+  React.useEffect(() => {
+    try { const v = +localStorage.getItem(key); if (v>=1&&v<=5) setMy(v); } catch(e) {}
+  }, [key]);
+
+  const cast = v => {
+    const nv = my === v ? 0 : v;
+    setMy(nv);
+    try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch(e) {}
+  };
+
+  const live = baseDist.map((c, i) => c + (my === i+1 ? 1 : 0));
+  const shades = ["rgba(0,0,0,0.16)","rgba(0,0,0,0.30)","rgba(0,0,0,0.48)","rgba(0,0,0,0.66)","rgba(0,0,0,0.84)"];
+
+  return (
+    <div>
+      <WitnessMeter dist={live}/>
+
+      <div style={{ height:1, background:"rgba(0,0,0,0.07)", margin:"18px 0 14px" }}/>
+
+      <div style={{
+        fontFamily:"var(--al-mono)", fontSize:7, letterSpacing:"0.26em",
+        textTransform:"uppercase", color:"rgba(28,28,26,0.24)", marginBottom:6,
+      }}>Bear Witness</div>
+
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontSize:12, color:"rgba(28,28,26,0.4)", marginBottom:16, lineHeight:1.4,
+      }}>How completely was this task attended?</div>
+
+      <div style={{ display:"flex", gap:8, flexWrap:"wrap" }}>
+        {AL_WITNESS.map((s, i) => {
+          const shade  = shades[i];
+          const on     = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{ display:"flex", flexDirection:"column", alignItems:"center", gap:6 }}>
+              <button onClick={() => cast(s.v)} style={{
+                width:34, height:34, borderRadius:"50%", cursor:"pointer",
+                border:`1.5px solid ${shade}`,
+                background: on ? shade : "transparent",
+                display:"flex", alignItems:"center", justifyContent:"center",
+                padding:0, transition:"all 200ms ease",
+              }}>
+                {picked && <div style={{ width:8, height:8, borderRadius:"50%", background:"#fff" }}/>}
+              </button>
+              <span style={{
+                fontSize:5.5, letterSpacing:"0.06em",
+                textAlign:"center", color:"rgba(28,28,26,0.28)",
+                fontFamily:"var(--al-mono)",
+              }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{
+        marginTop:14, fontSize:8.5, lineHeight:1.55,
+        fontStyle:"italic", fontFamily:"var(--al-font)",
+        color: my ? "rgba(28,28,26,0.58)" : "rgba(28,28,26,0.26)",
+      }}>
+        {my
+          ? `Witnessed as ${AL_WITNESS[my-1].label}. ${alDistTotal(live)} keepers now in accord.`
+          : "You have not yet cast your witness."}
+        {my > 0 && (
+          <span onClick={() => cast(my)} style={{
+            marginLeft:8, cursor:"pointer",
+            color:"rgba(28,28,26,0.42)",
+            borderBottom:"1px solid rgba(28,28,26,0.2)",
+          }}>amend</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ENTRY READ — full single-account view (main column)
+   ════════════════════════════════════════════════════════════════ */
+function EntryRead({ p }) {
+  const { AlbescentMark } = window;
+
+  return (
+    <div style={{ fontFamily:"var(--al-mono)", color:"#1c1c1a", position:"relative" }}>
+
+      {/* Header band */}
+      <div style={{
+        display:"flex", alignItems:"center",
+        justifyContent:"space-between", gap:14,
+        padding:"10px 24px",
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+        background:"rgba(0,0,0,0.012)",
+      }}>
+        <span style={{
+          display:"inline-flex", alignItems:"center", gap:9,
+          fontSize:9, letterSpacing:"0.22em", textTransform:"uppercase",
+          color:"rgba(28,28,26,0.28)",
+        }}>
+          <AlbescentMark size={12}/>
+          Albescent · Ref. {p.refNo}
+        </span>
+        <span style={{
+          fontSize:7, letterSpacing:"0.16em", textTransform:"uppercase",
+          color:"rgba(28,28,26,0.26)",
+          borderBottom:"1px solid rgba(28,28,26,0.18)", paddingBottom:1,
+        }}>{p.status}</span>
+      </div>
+
+      <div style={{ padding:"28px 24px 32px" }}>
+
+        {/* Task name */}
+        <h1 style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:48, lineHeight:1.05,
+          color:"#1c1c1a", margin:"0 0 14px",
+        }}>{p.task}</h1>
+
+        {/* Output quote */}
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:14.5, lineHeight:1.55,
+          color:"rgba(28,28,26,0.52)",
+          borderLeft:"2px solid rgba(0,0,0,0.09)",
+          paddingLeft:14, marginBottom:22,
+        }}>{p.output}</div>
+
+        {/* Byline */}
+        <div style={{
+          display:"flex", alignItems:"center", gap:14,
+          paddingBottom:20, marginBottom:6,
+          borderBottom:"1px solid rgba(0,0,0,0.06)",
+        }}>
+          <div style={{
+            width:36, height:36, borderRadius:"50%", flexShrink:0,
+            border:"1px solid rgba(0,0,0,0.12)",
+            background:"rgba(0,0,0,0.03)",
+            display:"flex", alignItems:"center", justifyContent:"center",
+            fontFamily:"var(--al-font)", fontSize:13, fontStyle:"italic",
+            color:"rgba(28,28,26,0.45)",
+          }}>K</div>
+          <div>
+            <div style={{
+              fontFamily:"var(--al-font)", fontStyle:"italic",
+              fontWeight:300, fontSize:14, color:"rgba(28,28,26,0.7)",
+            }}>{p.keeper}</div>
+            <div style={{
+              fontSize:7.5, color:"rgba(28,28,26,0.34)",
+              letterSpacing:"0.06em",
+            }}>{p.house} · {p.timestamp}</div>
+          </div>
+          <div style={{ marginLeft:"auto", textAlign:"right", flexShrink:0 }}>
+            <div style={{
+              fontFamily:"var(--al-font)", fontStyle:"italic",
+              fontWeight:300, fontSize:28, lineHeight:1,
+              color:"rgba(28,28,26,0.55)",
+            }}>{p.credits}</div>
+            <div style={{
+              fontFamily:"var(--al-mono)", fontSize:7,
+              letterSpacing:"0.14em", color:"rgba(28,28,26,0.26)", marginTop:2,
+            }}>pts returned</div>
+          </div>
+        </div>
+
+        {/* Account section divider */}
+        <div style={{ display:"flex", alignItems:"center", gap:10, margin:"18px 0 12px" }}>
+          <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+          <span style={{
+            fontSize:7, letterSpacing:"0.24em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.2)", whiteSpace:"nowrap",
+            fontFamily:"var(--al-mono)",
+          }}>Account</span>
+          <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+        </div>
+
+        {/* Account lines */}
+        <div style={{ marginBottom:8 }}>
+          {p.account.map((line, i) => (
+            <div key={i} style={{
+              fontSize:9, lineHeight:1.8, color:"rgba(28,28,26,0.58)",
+              paddingLeft:26, position:"relative", marginBottom:4,
+              fontFamily:"var(--al-mono)",
+            }}>
+              <span style={{
+                position:"absolute", left:0,
+                color:"rgba(28,28,26,0.2)", fontSize:7.5,
+              }}>{String(i).padStart(2,"0")}</span>
+              {line}
+            </div>
+          ))}
+        </div>
+
+        {/* Plates — quiet archival images */}
+        {p.plates && p.plates.length > 0 && (
+          <React.Fragment>
+            <div style={{ display:"flex", alignItems:"center", gap:10, margin:"22px 0 12px" }}>
+              <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+              <span style={{ fontSize:7, letterSpacing:"0.24em", textTransform:"uppercase", color:"rgba(28,28,26,0.2)", whiteSpace:"nowrap", fontFamily:"var(--al-mono)" }}>Plates</span>
+              <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+            </div>
+            <div style={{ display:"grid", gridTemplateColumns:"repeat(auto-fill, minmax(150px, 1fr))", gap:14 }}>
+              {p.plates.map((pl, i) => (
+                <figure key={i} style={{ margin:0 }}>
+                  <div style={{ position:"relative", height:118, border:"1px solid rgba(0,0,0,0.1)", background:"linear-gradient(158deg, #f5f2ec 0%, #e9e5da 60%, #ded9cc 100%)", display:"flex", alignItems:"center", justifyContent:"center", overflow:"hidden" }}>
+                    <div style={{ position:"absolute", inset:0, boxShadow:"inset 0 0 30px rgba(0,0,0,0.07)" }}/>
+                    <span style={{ opacity:0.2 }}><AlbescentMark size={26}/></span>
+                    <span style={{ position:"absolute", bottom:6, right:7, fontFamily:"var(--al-mono)", fontSize:6, letterSpacing:"0.14em", textTransform:"uppercase", color:"rgba(28,28,26,0.32)" }}>{pl.note}</span>
+                  </div>
+                  <figcaption style={{ fontFamily:"var(--al-font)", fontStyle:"italic", fontWeight:300, fontSize:11.5, color:"rgba(28,28,26,0.5)", marginTop:7, lineHeight:1.3 }}>
+                    <span style={{ fontFamily:"var(--al-mono)", fontStyle:"normal", fontSize:7, letterSpacing:"0.1em", color:"rgba(28,28,26,0.3)", marginRight:6 }}>{["I","II","III","IV"][i]}</span>{pl.caption}
+                  </figcaption>
+                </figure>
+              ))}
+            </div>
+          </React.Fragment>
+        )}
+
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AL_PRAXES,
+  RegisterIndex, RegisterRow,
+  WitnessBar, WitnessMeter, WitnessCaster,
+  EntryRead,
+});

--- a/docs/design/praxis-read/factions/albescent/albescent.css
+++ b/docs/design/praxis-read/factions/albescent/albescent.css
@@ -1,0 +1,208 @@
+/* ══════════════════════════════════════════════════════════════
+   ALBESCENT — World Zero faction
+   A sacred secret society. They task for the sake of tasking:
+   not competition, not accumulation, not record. The faction
+   exists outside the leaderboard; it refuses the rainbow palette;
+   it leaves no trace. Every task is an act of devotion with no
+   audience.
+
+   Physical card archetype: VELLUM CORRESPONDENCE — pure white
+   cotton paper, hairline borders, Cormorant Garamond italic,
+   a surveyor's mark as the only sigil. The card whispers.
+
+   Style: MINIMAL · SACRED · SILENT · PRECISE · WHITE
+   The signature artifact is THE MARK: a surveyor's cross-hair
+   sigil that asks only: where are you, exactly?
+
+   TOKEN MODEL: Albescent is always light — no dark mode flip.
+   White is the card surface in both themes. Near-black ink is
+   all text. No faction hue anywhere.
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400;1,500&family=Courier+Prime:ital,wght@0,400;1,400&family=Lora:ital,wght@1,400;1,700&display=swap");
+
+:root {
+  /* ── Core palette ── */
+  --al-surface:       #ffffff;
+  --al-surface-warm:  #faf9f7;
+  --al-text:          #1c1c1a;
+  --al-text-muted:    rgba(28, 28, 26, 0.44);
+  --al-text-faint:    rgba(28, 28, 26, 0.22);
+  --al-ink:           rgba(28, 28, 26, 0.72);
+
+  /* ── Structural ── */
+  --al-border:        rgba(0, 0, 0, 0.10);
+  --al-border-faint:  rgba(0, 0, 0, 0.055);
+  --al-border-rule:   rgba(0, 0, 0, 0.07);
+  --al-shadow:        0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04);
+
+  /* ── Typography ── */
+  --al-font: "Cormorant Garamond", Georgia, serif;
+  --al-mono: "Courier Prime", "Courier New", monospace;
+
+  /* ── Card contract — mirrors --faction-albescent-card-* ── */
+  --faction-albescent-card-bg:     #ffffff;
+  --faction-albescent-card-text:   #1c1c1a;
+  --faction-albescent-card-accent: rgba(28, 28, 26, 0.72);
+  --faction-albescent-card-muted:  rgba(28, 28, 26, 0.42);
+  --faction-albescent-card-font:   var(--al-font);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ALBESCENT BACKDROP
+   Near-white cream with barely-visible ruled paper lines.
+   Not a dramatic backdrop — a surface already present,
+   whether anyone looks or not.
+   ══════════════════════════════════════════════════════════════ */
+.al-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: #f7f4ee;
+  background-image:
+    radial-gradient(ellipse 72% 58% at 50% 38%,
+      rgba(255, 255, 255, 0.58) 0%, transparent 100%),
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 27px,
+      rgba(0, 0, 0, 0.016) 27px 28px);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANIMATIONS — everything slow, deliberate, no urgency
+   ══════════════════════════════════════════════════════════════ */
+@keyframes al-breathe { 0%,100%{ opacity:1; }        50%{ opacity:0.58; }        }
+@keyframes al-drift   { 0%,100%{ transform:scale(1); } 50%{ transform:scale(1.016); } }
+
+@media (prefers-reduced-motion: no-preference) {
+  .al-breathe { animation: al-breathe 5.5s ease-in-out infinite; }
+  .al-drift   { animation: al-drift   14s  ease-in-out infinite; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHARED LAYOUT — nav
+   ══════════════════════════════════════════════════════════════ */
+.al-nav {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  padding: 14px 32px;
+  background: rgba(247, 244, 238, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--al-border-faint);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHEET — the primary white surface
+   ══════════════════════════════════════════════════════════════ */
+.al-sheet {
+  position: relative;
+  background: var(--al-surface);
+  border: 1px solid var(--al-border);
+  box-shadow: var(--al-shadow);
+}
+/* subtle inset architectural border */
+.al-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 1px solid var(--al-border-faint);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   PAGE
+   ══════════════════════════════════════════════════════════════ */
+.al-page {
+  position: relative;
+  z-index: 5;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 28px 32px 80px;
+}
+
+/* section heading with flanking rules */
+.al-section {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 38px 0 16px;
+}
+.al-section h2 {
+  font-family: var(--al-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--al-text-faint);
+  white-space: nowrap;
+  margin: 0;
+  font-weight: 400;
+}
+.al-section .rule  { flex: 1; height: 1px; background: var(--al-border-rule); }
+.al-section .count {
+  font-family: var(--al-mono);
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--al-text-faint);
+  white-space: nowrap;
+}
+
+/* task card grid */
+.al-task-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+/* two-col record/witness layout */
+.al-dispatch-layout {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  .al-dispatch-layout { grid-template-columns: 1fr; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ACTIVITY RECORD
+   ══════════════════════════════════════════════════════════════ */
+.al-activity-card {
+  border-bottom: 1px solid var(--al-border-faint);
+  padding: 14px 0;
+}
+.al-activity-card:last-child { border-bottom: none; }
+
+/* ══════════════════════════════════════════════════════════════
+   ASSET SHOWCASE
+   ══════════════════════════════════════════════════════════════ */
+.al-assets {
+  margin-top: 52px;
+  padding-top: 24px;
+  border-top: 1px solid var(--al-border-faint);
+}
+.al-acard {
+  border: 1px solid var(--al-border-faint);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 14px 16px;
+}
+.al-acard .h {
+  font-family: var(--al-mono);
+  font-size: 7px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--al-text-faint);
+  margin-bottom: 12px;
+}
+.al-acard .cap {
+  font-family: var(--al-mono);
+  font-size: 7.5px;
+  letter-spacing: 0.06em;
+  color: var(--al-text-faint);
+  margin-top: 10px;
+}

--- a/docs/design/praxis-read/factions/ephemerists/Ephemerists Completed Praxis.html
+++ b/docs/design/praxis-read/factions/ephemerists/Ephemerists Completed Praxis.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Sealed Praxis · The Ephemerists</title>
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css" />
+<link rel="stylesheet" href="ephemerists.css" />
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body { background: var(--eph-vellum); color: var(--color-text-primary); font-family: var(--eph-serif); min-height: 100vh; }
+  a { color: inherit; text-decoration: none; }
+
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 30px; padding: 16px 34px;
+    background: var(--color-nav-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 25px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; color: var(--color-text-primary); }
+  .nav-links { display: flex; gap: 22px; flex: 1; }
+  .nav-links a { font-family: var(--font-body); font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--color-text-tertiary); padding-bottom: 3px; }
+  .nav-links a.active { color: var(--color-text-primary); border-bottom: 2px solid var(--color-text-primary); }
+  .nav-ctl { display: flex; align-items: center; gap: 16px; font-family: var(--font-body); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-box { border: 1px solid var(--color-border-strong); padding: 6px 12px; color: var(--color-text-primary); }
+  .nav-toggle { background: none; border: none; cursor: pointer; font: inherit; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); padding: 0; }
+  .nav-toggle:hover { color: var(--color-text-primary); }
+
+  .crumbs { position: relative; z-index: 5; max-width: 1140px; margin: 0 auto; padding: 22px 34px 0;
+    font-family: var(--font-body); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .crumbs a:hover { color: var(--eph-rubric); }
+
+  .page { position: relative; z-index: 5; max-width: 1140px; margin: 0 auto; padding: 18px 34px 90px;
+    display: grid; grid-template-columns: 1fr 360px; gap: 30px; align-items: start; }
+  @media (max-width: 980px) { .page { grid-template-columns: 1fr; } }
+
+  .sheet { position: relative; background: color-mix(in srgb, var(--eph-vellum) 72%, transparent); border: 1px solid var(--color-border-strong);
+    box-shadow: 0 18px 50px -28px rgba(0,0,0,0.6); padding: 32px 40px 40px; }
+
+  .rail { position: sticky; top: 22px; display: flex; flex-direction: column; gap: 18px; }
+  @media (max-width: 980px) { .rail { position: static; } }
+  .panel { position: relative; background: var(--eph-vellum); border: 1px solid var(--eph-ink);
+    box-shadow: 0 10px 28px -20px rgba(0,0,0,0.6); }
+  .panel-head { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+    background: var(--eph-lapis); color: var(--eph-parchment); padding: 9px 15px; }
+  .panel-head .t { font-family: var(--eph-display); font-weight: 700; font-size: 14px; letter-spacing: 0.16em; text-transform: uppercase; }
+  .panel-head .e { font-family: var(--eph-serif); font-size: 9px; letter-spacing: 0.1em; opacity: 0.85; }
+  .panel-body { padding: 18px 17px 20px; }
+  .panel-foot { font-family: var(--eph-serif); font-size: 9.5px; font-style: italic; line-height: 1.5; color: var(--eph-muted);
+    border-top: 1px dashed color-mix(in srgb, var(--eph-vellum-text) 26%, transparent); padding: 12px 17px; }
+
+  .back-link { display: inline-flex; align-items: center; gap: 7px; font-family: var(--eph-serif); font-size: 11px; font-weight: 600;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--eph-muted); }
+  .back-link:hover { color: var(--eph-rubric); }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="ephemerists-cards.jsx"></script>
+<script type="text/babel" src="ephemerists-updates.jsx"></script>
+<script type="text/babel" src="ephemerists-praxis-read.jsx"></script>
+<script type="text/babel" src="../praxis-core.jsx"></script>
+</head>
+<body>
+
+<div class="eph-backdrop"></div>
+
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="Ephemerists Praxis Index.html" class="active">Praxis</a><a href="#">Players</a>
+    <a href="Ephemerists Faction Page.html">Factions</a><a href="Ephemerists Updates Page.html">Updates</a><a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Mod</span>
+    <button class="nav-toggle" id="theme-toggle">Dark</button>
+    <span>Vesper</span>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+
+<div class="crumbs"><a href="Ephemerists Faction Page.html">Factions</a> &nbsp;›&nbsp; <a href="Ephemerists Praxis Index.html">The Praxes</a> &nbsp;›&nbsp; <span id="crumb-task" style="color:var(--eph-rubric)">…</span></div>
+
+<div class="page">
+  <div class="sheet"><div id="read"></div></div>
+  <aside class="rail">
+    <div id="ledger"></div>
+    <a class="back-link" href="../../All%20Faction%20Praxis%20Pages.dc.html">← all praxis pages</a>
+  </aside>
+</div>
+
+<script type="text/babel">
+  const { PraxisRead, EPH_PRAXES, WZ_FACTIONS, WZ_PagePointsBlock } = window;
+  const id = decodeURIComponent((location.hash || "").replace(/^#/, ""));
+  const praxis = EPH_PRAXES.find((p) => p.id === id) || EPH_PRAXES[0];
+
+  document.getElementById("crumb-task").textContent = praxis.finding;
+
+  ReactDOM.createRoot(document.getElementById("read")).render(<PraxisRead p={praxis} />);
+  const ephF = WZ_FACTIONS.find((f) => f.slug === "ephemerists");
+  ReactDOM.createRoot(document.getElementById("ledger")).render(<WZ_PagePointsBlock f={ephF} />);
+
+  const tog = document.getElementById("theme-toggle");
+  tog.addEventListener("click", () => {
+    const dark = document.documentElement.getAttribute("data-theme") === "dark";
+    document.documentElement.setAttribute("data-theme", dark ? "light" : "dark");
+    tog.textContent = dark ? "Dark" : "Light";
+  });
+
+  window.addEventListener("hashchange", () => location.reload());
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/ephemerists/ephemerists-cards.jsx
+++ b/docs/design/praxis-read/factions/ephemerists/ephemerists-cards.jsx
@@ -1,0 +1,180 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — Task Card + shared codex atoms
+   The chosen artifact: THE DISCORDANT MAP. One place, three
+   irreconcilable addresses — cartesian, polar and perspective grids
+   all claim the same sheet and disagree about where the point is.
+   House-of-Leaves apparatus crawls the margins: a struck measurement
+   that corrects itself in blue, a note climbing the gutter, a
+   self-referential footnote, and one word always pulled into the lapis.
+   Uses only DS tokens + ephemerists.css. Atoms exposed on window for
+   the rest of the faction's surfaces.
+   ════════════════════════════════════════════════════════════════ */
+
+const ROMAN = [["M",1000],["CM",900],["D",500],["CD",400],["C",100],["XC",90],["L",50],["XL",40],["X",10],["IX",9],["V",5],["IV",4],["I",1]];
+function toRoman(n){ let s=""; for(const [g,v] of ROMAN){ while(n>=v){ s+=g; n-=v; } } return s; }
+
+/* faction sigil — the watching wanderer: an eye on an orbital ring */
+function EphMark({ size = 22, color = "currentColor", stroke = 1.4 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={stroke} style={{ display: "block" }}>
+      <ellipse cx="12" cy="12" rx="11" ry="4.4" transform="rotate(-24 12 12)" />
+      <path d="M4 12 C7.5 8.2 16.5 8.2 20 12 C16.5 15.8 7.5 15.8 4 12 Z" />
+      <circle cx="12" cy="12" r="2.7" />
+      <circle cx="12" cy="12" r="0.6" fill={color} stroke="none" />
+    </svg>
+  );
+}
+
+/* small mystical glyph set — alchemical / planetary, monoline */
+function Glyph({ name, size = 14, color = "var(--eph-ink)", stroke = 1.2 }) {
+  const p = { fill: "none", stroke: color, strokeWidth: stroke, strokeLinecap: "round", strokeLinejoin: "round" };
+  const map = {
+    fire:  <path d="M8 13 L2 13 L8 3 Z" {...p} />,
+    water: <path d="M2 3 L14 3 L8 13 Z" {...p} />,
+    air:   <g {...p}><path d="M8 3 L2 13 L14 13 Z" /><line x1="4.6" y1="9.2" x2="11.4" y2="9.2" /></g>,
+    earth: <g {...p}><path d="M2 3 L14 3 L8 13 Z" /><line x1="4.6" y1="6.8" x2="11.4" y2="6.8" /></g>,
+    sun:   <g {...p}><circle cx="8" cy="8" r="5.5" /><circle cx="8" cy="8" r="0.7" fill={color} /></g>,
+    moon:  <path d="M11 2.5 A6 6 0 1 0 11 13.5 A4.6 4.6 0 1 1 11 2.5 Z" fill={color} stroke="none" />,
+    salt:  <g {...p}><circle cx="8" cy="8" r="5.5" /><line x1="2.5" y1="8" x2="13.5" y2="8" /></g>,
+    quint: <g {...p}><circle cx="8" cy="8" r="5.5" /><circle cx="8" cy="8" r="2" /></g>,
+    star:  <path d="M8 1 L9.2 6.2 L14.5 5 L10.3 8 L14.5 11 L9.2 9.8 L8 15 L6.8 9.8 L1.5 11 L5.7 8 L1.5 5 L6.8 6.2 Z" fill={color} stroke="none" />,
+  };
+  return <svg width={size} height={size} viewBox="0 0 16 16" style={{ display: "block" }}>{map[name] || map.sun}</svg>;
+}
+
+/* ── SACRED GEOMETRY — compass-and-straightedge rosettes built only
+   from circle primitives on a triangular lattice (the same family as
+   the card's astrolabe grids). rings=1 → Seed of Life (7 circles),
+   rings=2 → Flower of Life (19), rings=3 → the full bloom. A clip ring
+   gives the clean illuminated edge; an optional vesica/spoke overlay
+   reads as an astrolabe. Faint, theme-aware, decorative only. */
+function SacredGeometry({ size = 200, color = "var(--eph-lapis)", stroke = 0.8, rings = 2, ring = true, spokes = 0, style }) {
+  const R = size / (2 * (rings + 1));
+  const c = size / 2;
+  const pts = [];
+  for (let i = -rings - 1; i <= rings + 1; i++) {
+    for (let j = -rings - 1; j <= rings + 1; j++) {
+      const hd = (Math.abs(i) + Math.abs(j) + Math.abs(i + j)) / 2;
+      if (hd > rings) continue;
+      pts.push([c + R * (i + j / 2), c + R * (j * Math.sqrt(3) / 2)]);
+    }
+  }
+  const id = "sg" + Math.round(size) + "_" + rings + "_" + Math.round(R);
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none" stroke={color} strokeWidth={stroke} style={{ display: "block", ...style }}>
+      <defs><clipPath id={id}><circle cx={c} cy={c} r={size / 2 - stroke} /></clipPath></defs>
+      <g clipPath={`url(#${id})`}>
+        {pts.map(([x, y], k) => <circle key={k} cx={x} cy={y} r={R} />)}
+        {spokes > 0 && Array.from({ length: spokes }).map((_, k) => {
+          const a = (k * 2 * Math.PI) / spokes;
+          return <line key={"s" + k} x1={c} y1={c} x2={c + (size / 2) * Math.cos(a)} y2={c + (size / 2) * Math.sin(a)} strokeWidth={stroke * 0.8} />;
+        })}
+      </g>
+      {ring && <circle cx={c} cy={c} r={size / 2 - stroke} strokeWidth={stroke * 1.5} />}
+    </svg>
+  );
+}
+
+/* faint age-foxing stains */
+function Foxing({ opacity = 0.5 }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none", opacity, zIndex: 1, mixBlendMode: "multiply",
+      backgroundImage: `
+        radial-gradient(8px 6px at 18% 24%, color-mix(in srgb, var(--eph-ink) 14%, transparent), transparent 70%),
+        radial-gradient(5px 5px at 78% 16%, color-mix(in srgb, var(--eph-gold-deep) 16%, transparent), transparent 70%),
+        radial-gradient(10px 7px at 64% 82%, color-mix(in srgb, var(--eph-ink) 10%, transparent), transparent 70%),
+        radial-gradient(4px 4px at 30% 70%, color-mix(in srgb, var(--eph-rubric) 12%, transparent), transparent 70%)`,
+    }} />
+  );
+}
+
+/* header lockup — sigil + name + a motto / running gloss */
+function Eyebrow({ color = "var(--eph-gold-light)", motto, dark, size = 8.5 }) {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 5, color }}>
+        <EphMark size={11} color={color} />
+        <span style={{ fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: size, letterSpacing: "0.24em" }}>THE EPHEMERISTS</span>
+      </div>
+      {motto && <div style={{ fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: 8.5, color: dark ? "var(--eph-muted)" : "color-mix(in srgb, var(--eph-parchment) 65%, transparent)", marginTop: 1 }}>{motto}</div>}
+    </div>
+  );
+}
+
+function SignBtn({ onSignup, label, light }) {
+  if (!onSignup) return null;
+  return (
+    <button onClick={onSignup} style={{
+      fontFamily: "var(--eph-serif)", fontSize: 9, letterSpacing: "0.12em", fontStyle: "italic",
+      padding: "7px 10px", border: "none", cursor: "pointer", width: "100%",
+      background: light ? "var(--eph-gold)" : "var(--eph-ink)",
+      color: light ? "var(--eph-ink)" : "var(--eph-parchment)", position: "relative", zIndex: 6,
+    }}>{label}</button>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   THE DISCORDANT MAP — the Ephemerist task card
+   ════════════════════════════════════════════════════════════════ */
+function DiscordantMap({ title, description, level, points, onSignup }) {
+  const tw = title.trim().split(" ");
+  const tlast = tw.pop(); // one word is always pulled into the blue
+  return (
+    <div style={{
+      width: 214, minHeight: 300, position: "relative", overflow: "hidden",
+      background: "var(--eph-vellum)", color: "var(--eph-vellum-text)",
+      border: "1.5px solid var(--eph-ink)", fontFamily: "var(--eph-serif)", display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ position: "relative", zIndex: 5, padding: "9px 0 4px" }}><Eyebrow motto="exhibit C · no single here" dark /></div>
+      {/* the contested field */}
+      <div style={{ position: "relative", flex: 1, minHeight: 188, margin: "2px 4px", border: "1px solid var(--eph-gold-deep)", overflow: "hidden" }}>
+        {/* cartesian — keyed to vellum-text so it flips legible in dark */}
+        <div style={{ position: "absolute", inset: 0, opacity: 0.5, backgroundImage: "repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px), repeating-linear-gradient(90deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px)" }} />
+        {/* perspective grid (no blend — multiply died on dark stock) */}
+        <svg viewBox="0 0 200 188" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.7 }}>
+          <g stroke="var(--eph-lapis)" strokeWidth="0.9" fill="none">
+            {Array.from({ length: 11 }).map((_, i) => <line key={i} x1={i * 20} y1="188" x2="122" y2="40" />)}
+            {[60, 96, 124, 146, 163, 176].map((y, i) => <line key={i} x1="0" y1={y} x2="200" y2={y} />)}
+          </g>
+        </svg>
+        {/* polar */}
+        <svg viewBox="0 0 200 188" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.72 }}>
+          <g stroke="var(--eph-rubric)" strokeWidth="0.8" fill="none">
+            {[16, 34, 54, 76].map((r, i) => <circle key={i} cx="122" cy="88" r={r} />)}
+            {Array.from({ length: 12 }).map((_, i) => <line key={i} x1="122" y1="88" x2={122 + 80 * Math.cos(i * Math.PI / 6)} y2={88 + 80 * Math.sin(i * Math.PI / 6)} />)}
+          </g>
+        </svg>
+        {/* the disputed point */}
+        <div style={{ position: "absolute", left: "61%", top: "47%", transform: "translate(-50%,-50%)", zIndex: 4 }}>
+          <div className="eph-twinkle" style={{ width: 9, height: 9, borderRadius: "50%", background: "var(--eph-gold-light)", boxShadow: "0 0 10px 3px color-mix(in srgb, var(--eph-gold-light) 70%, transparent)" }} />
+        </div>
+        {/* three coordinate labels for one point — and none agree */}
+        <div style={{ position: "absolute", top: "8%", left: "6%", fontFamily: "var(--eph-serif)", fontSize: 7.5, letterSpacing: "0.04em", color: "var(--eph-vellum-text)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>x 14 · y <span style={{ textDecoration: "line-through", opacity: 0.65 }}>8</span> <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>9</span></div>
+        <div style={{ position: "absolute", top: "78%", left: "54%", fontFamily: "var(--eph-serif)", fontSize: 7.5, letterSpacing: "0.04em", color: "var(--eph-rubric)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>r 47 · θ 31°</div>
+        <div style={{ position: "absolute", top: "6%", left: "68%", fontFamily: "var(--eph-serif)", fontSize: 7.5, letterSpacing: "0.04em", color: "var(--eph-lapis)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "1px 4px" }}>∞ · vanishing</div>
+        {/* marginal apparatus climbing the gutter */}
+        <div style={{ position: "absolute", left: 2, bottom: 7, transformOrigin: "left bottom", transform: "rotate(-90deg)", whiteSpace: "nowrap", fontFamily: "var(--eph-serif)", fontSize: 6, letterSpacing: "0.05em", color: "var(--eph-muted)", opacity: 0.85 }}>¼″ wider within than without †</div>
+      </div>
+      {/* legend / title */}
+      <div style={{ position: "relative", zIndex: 5, padding: "8px 14px 10px", textAlign: "center" }}>
+        <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 22, lineHeight: 0.94 }}>{tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span><sup style={{ fontFamily: "var(--eph-serif)", fontSize: 9, color: "var(--eph-lapis)", fontWeight: 400 }}>†</sup></div>
+        <div style={{ fontSize: 8.5, lineHeight: 1.45, fontStyle: "italic", color: "var(--eph-muted)", margin: "4px 0 6px", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 7, fontSize: 7.5 }}>
+          <span style={{ color: "var(--eph-vellum-text)" }}>▦ grade {toRoman(level)}</span>
+          <span style={{ color: "var(--eph-gold-deep)" }}>·</span>
+          <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, color: "var(--eph-rubric)" }}>{points} pvncta</span>
+        </div>
+        <div style={{ fontFamily: "var(--eph-serif)", fontSize: 6.5, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 6, lineHeight: 1.35 }}>† the road does not return you to where you began — <span style={{ color: "var(--eph-lapis)" }}>see †</span></div>
+      </div>
+      <SignBtn onSignup={onSignup} label="Triangulate the truth ▸" />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  DiscordantMap, EphTaskCard: DiscordantMap,
+  EPH_toRoman: toRoman, EPH_EphMark: EphMark, EPH_Glyph: Glyph,
+  EPH_Foxing: Foxing, EPH_Eyebrow: Eyebrow, EPH_SignBtn: SignBtn,
+  EPH_SacredGeometry: SacredGeometry,
+});

--- a/docs/design/praxis-read/factions/ephemerists/ephemerists-praxis-read.jsx
+++ b/docs/design/praxis-read/factions/ephemerists/ephemerists-praxis-read.jsx
@@ -1,0 +1,414 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — Completed Praxis (read) surfaces
+   A SEALED praxis is a filed ephemeris entry the faction now votes on.
+   World Zero's 1–5 rating becomes THE CONCORDANCE — a wax-seal ramp
+   (apocryphal → disputed → plausible → corroborated → canonical) that
+   measures "how well does the filed truth hold up?". Two surfaces:
+     · PraxisIndex  — the register of sealed praxes + their concordance
+     · PraxisRead   — one sealed praxis in full, with the marks received
+                      and the control to file your own.
+   Reuses ephemerists-cards.jsx + ephemerists-faction.jsx atoms. The
+   mark you file persists per-praxis in localStorage. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+/* the faction's reframe of the 1–5 vote — the concordance ramp */
+const CONCORD = [
+  { v: 1, label: "apocryphal",   fill: "var(--eph-gold)",      ink: "var(--eph-ink)" },
+  { v: 2, label: "disputed",     fill: "var(--eph-verdigris)", ink: "var(--eph-parchment)" },
+  { v: 3, label: "plausible",    fill: "var(--eph-lapis)",     ink: "var(--eph-parchment)" },
+  { v: 4, label: "corroborated", fill: "var(--eph-rubric)",    ink: "var(--eph-parchment)" },
+  { v: 5, label: "canonical",    fill: "var(--eph-ink)",       ink: "var(--eph-gold-light)" },
+];
+const METHODS = {
+  alone:   { name: "ALONE",      fill: "var(--eph-muted)" },
+  concord: { name: "IN CONCORD", fill: "var(--eph-verdigris)" },
+  dispute: { name: "IN DISPUTE", fill: "var(--eph-rubric)" },
+};
+const distTotal = (d) => d.reduce((a, b) => a + b, 0);
+const distAvg = (d) => { const t = distTotal(d); return t ? d.reduce((a, c, i) => a + c * (i + 1), 0) / t : 0; };
+const standing = (avg) => CONCORD[Math.max(0, Math.min(4, Math.round(avg) - 1))];
+
+/* ── method chip ──────────────────────────────────────────────────── */
+function MethodTag({ mode, big }) {
+  const m = METHODS[mode] || METHODS.alone;
+  return (
+    <span style={{
+      display: "inline-block", background: m.fill, color: "var(--eph-parchment)",
+      fontFamily: "var(--eph-serif)", fontSize: big ? 9.5 : 8, fontWeight: 600,
+      letterSpacing: "0.12em", textTransform: "uppercase", padding: big ? "3px 9px" : "2px 7px",
+      transform: "rotate(-1deg)", whiteSpace: "nowrap",
+    }}>{m.name}</span>
+  );
+}
+
+/* ── compact concordance read-out for register rows ───────────────── */
+/* a numeral avg + a five-bar tier sparkline + the marks count */
+function ConcordSummary({ dist }) {
+  const total = distTotal(dist), avg = distAvg(dist), max = Math.max(1, ...dist), st = standing(avg);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 3, height: 30 }}>
+        {dist.map((c, i) => (
+          <div key={i} title={`${CONCORD[i].label}: ${c}`} style={{
+            width: 7, height: Math.max(3, (c / max) * 30), background: CONCORD[i].fill,
+            opacity: c ? 1 : 0.28, boxShadow: "inset 0 0 0 0.5px rgba(0,0,0,0.25)",
+          }} />
+        ))}
+      </div>
+      <div style={{ textAlign: "left", whiteSpace: "nowrap" }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 5 }}>
+          <span style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 19, lineHeight: 1, color: st.fill === "var(--eph-ink)" ? "var(--eph-vellum-text)" : st.fill }}>{avg.toFixed(1)}</span>
+          <span style={{ fontFamily: "var(--eph-serif)", fontStyle: "italic", fontSize: 9.5, letterSpacing: "0.02em", color: "var(--eph-muted)" }}>{st.label}</span>
+        </div>
+        <div style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-muted)", marginTop: 2 }}>{total} marks</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── register row — one sealed praxis ─────────────────────────────── */
+function PraxisRow({ p, href }) {
+  const tw = p.finding.trim().split(" ");
+  const tlast = tw.pop();
+  return (
+    <a className="prx-row" href={href}>
+      <div className="prx-cat">
+        <span className="prx-no">№ {p.entryNo}</span>
+        <span className="prx-seal" aria-hidden="true">✦</span>
+      </div>
+      <div className="prx-main">
+        <div className="prx-finding">{tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span></div>
+        <div className="prx-byline">
+          <span style={{ color: "var(--eph-rubric)", fontStyle: "italic" }}>re: {p.task}</span>
+          <span className="prx-dot">·</span>
+          <span>filed by <b style={{ color: "var(--eph-vellum-text)", fontStyle: "normal" }}>{p.actor}</b></span>
+          <MethodTag mode={p.mode} />
+          <span className="prx-pts">{p.points} pvncta</span>
+        </div>
+      </div>
+      <div className="prx-vote"><ConcordSummary dist={p.dist} /></div>
+      <span className="prx-go" aria-hidden="true">→</span>
+    </a>
+  );
+}
+
+/* ── the register ─────────────────────────────────────────────────── */
+function PraxisIndex({ praxes, hrefFor }) {
+  const [filter, setFilter] = React.useState("all");
+  const FILTERS = [
+    { id: "all", name: "All sealed" },
+    { id: "canonical", name: "Holds (IV–V)" },
+    { id: "dispute", name: "In dispute" },
+    { id: "alone", name: "Single observer" },
+  ];
+  const rows = praxes.filter((p) => {
+    if (filter === "all") return true;
+    if (filter === "canonical") return distAvg(p.dist) >= 3.5;
+    if (filter === "dispute") return p.mode === "dispute" || distAvg(p.dist) < 2.5;
+    if (filter === "alone") return p.mode === "alone";
+    return true;
+  });
+  const totalMarks = praxes.reduce((a, p) => a + distTotal(p.dist), 0);
+
+  return (
+    <React.Fragment>
+      {/* register masthead */}
+      <div className="prx-masthead">
+        <div className="prx-mast-l">
+          <div className="prx-kicker">The Ephemerists · the sealed record</div>
+          <h1 className="prx-h1">THE <span style={{ color: "var(--eph-lapis)" }}>PRAXES</span></h1>
+          <div className="prx-mast-rule" />
+          <p className="prx-mast-sub">Findings entered in the ephemeris and put to the concordance. <em>Every sealed truth is open to a mark — see how well it holds.</em></p>
+        </div>
+        <div className="prx-mast-r">
+          <div className="prx-stat"><b>{praxes.length}</b><span>sealed praxes</span></div>
+          <div className="prx-stat"><b>{totalMarks}</b><span>marks filed</span></div>
+        </div>
+      </div>
+
+      {/* filter strip */}
+      <div className="prx-filters">
+        {FILTERS.map((f) => (
+          <button key={f.id} className={"prx-filter" + (filter === f.id ? " on" : "")} onClick={() => setFilter(f.id)}>{f.name}</button>
+        ))}
+        <span className="prx-count">{rows.length} of {praxes.length}</span>
+      </div>
+
+      {/* column heads */}
+      <div className="prx-heads">
+        <span>Entry</span>
+        <span>The finding</span>
+        <span style={{ textAlign: "right" }}>The concordance</span>
+      </div>
+
+      <div className="prx-list">
+        {rows.map((p) => <PraxisRow key={p.id} p={p} href={hrefFor(p)} />)}
+        {rows.length === 0 && <div className="prx-empty">No sealed praxes under this lens — <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>the margin stays blank.</span></div>}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   THE READ PAGE — one sealed praxis, the marks it has received, and
+   the control to file your own.
+   ════════════════════════════════════════════════════════════════ */
+
+/* a subtly-striped specimen placeholder the user drops real evidence into */
+function Specimen({ label, kind }) {
+  return (
+    <figure style={{ margin: 0, border: "1px solid var(--eph-ink)", background: "var(--eph-vellum)", overflow: "hidden" }}>
+      <div style={{
+        height: 96, position: "relative",
+        backgroundImage: "repeating-linear-gradient(45deg, color-mix(in srgb, var(--eph-lapis) 14%, transparent) 0 6px, transparent 6px 12px)",
+        backgroundColor: "color-mix(in srgb, var(--eph-vellum) 60%, transparent)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+      }}>
+        <span style={{ fontFamily: "var(--font-faction-mono, monospace)", fontSize: 9, letterSpacing: "0.08em", color: "var(--eph-muted)", background: "color-mix(in srgb, var(--eph-vellum) 86%, transparent)", padding: "3px 7px" }}>{kind}</span>
+      </div>
+      <figcaption style={{ fontFamily: "var(--eph-serif)", fontSize: 9.5, fontStyle: "italic", color: "var(--eph-muted)", padding: "7px 9px", borderTop: "1px solid color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)" }}>{label}</figcaption>
+    </figure>
+  );
+}
+
+/* the concordance meter — distribution histogram + headline standing */
+function ConcordMeter({ dist }) {
+  const total = distTotal(dist), avg = distAvg(dist), max = Math.max(1, ...dist), st = standing(avg);
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 4 }}>
+        <span style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 46, lineHeight: 0.8, color: st.fill === "var(--eph-ink)" ? "var(--eph-vellum-text)" : st.fill }}>{avg.toFixed(1)}</span>
+        <div>
+          <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--eph-rubric)" }}>{st.label}</div>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-muted)", marginTop: 1 }}>{total} marks filed</div>
+        </div>
+      </div>
+      {/* per-tier distribution */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 14 }}>
+        {CONCORD.slice().reverse().map((s) => {
+          const c = dist[s.v - 1];
+          return (
+            <div key={s.v} style={{ display: "flex", alignItems: "center", gap: 9 }}>
+              <span style={{ width: 70, textAlign: "right", fontFamily: "var(--eph-serif)", fontSize: 9.5, fontStyle: "italic", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{s.label}</span>
+              <div style={{ flex: 1, height: 12, background: "color-mix(in srgb, var(--eph-vellum-text) 9%, transparent)", position: "relative", border: "1px solid color-mix(in srgb, var(--eph-vellum-text) 18%, transparent)" }}>
+                <div style={{ position: "absolute", inset: 0, width: `${(c / max) * 100}%`, background: s.fill, opacity: c ? 0.92 : 0 }} />
+              </div>
+              <span style={{ width: 22, fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 12, color: "var(--eph-vellum-text)", textAlign: "right" }}>{c}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* the interactive control — file your mark (persists per praxis) */
+function MarkCaster({ praxisId, baseDist }) {
+  const key = "eph-mark-" + praxisId;
+  const [my, setMy] = React.useState(0);
+  React.useEffect(() => {
+    try { const v = +localStorage.getItem(key); if (v >= 1 && v <= 5) setMy(v); } catch (e) {}
+  }, [key]);
+  const cast = (v) => { const nv = my === v ? 0 : v; setMy(nv); try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch (e) {} };
+  const live = baseDist.map((c, i) => c + (my === i + 1 ? 1 : 0));
+
+  return (
+    <div>
+      <ConcordMeter dist={live} />
+
+      <div style={{ height: 1, background: "color-mix(in srgb, var(--eph-vellum-text) 18%, transparent)", margin: "20px 0 16px" }} />
+
+      <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-rubric)", marginBottom: 3 }}>File your mark</div>
+      <div style={{ fontFamily: "var(--eph-serif)", fontSize: 11, fontStyle: "italic", color: "var(--eph-muted)", marginBottom: 14 }}>how well does this truth hold up?</div>
+
+      {/* the wax-seal concordance ramp */}
+      <div style={{ display: "flex", gap: 9, flexWrap: "wrap" }}>
+        {CONCORD.map((s) => {
+          const on = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 5 }}>
+              <button onClick={() => cast(s.v)} aria-label={`${s.v} — ${s.label}`} style={{
+                position: "relative", width: 44, height: 44, cursor: "pointer", padding: 0, borderRadius: "50%",
+                border: "2px solid var(--eph-ink)",
+                background: on ? s.fill : "var(--eph-vellum)", color: on ? s.ink : "var(--eph-muted)",
+                fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, lineHeight: 1,
+                display: "flex", alignItems: "center", justifyContent: "center",
+                transform: picked ? "rotate(-6deg) scale(1.1)" : "none", transition: "all 110ms",
+                boxShadow: on ? "inset 0 -2px 4px rgba(0,0,0,0.3), inset 0 2px 3px rgba(255,255,255,0.18)" : "none",
+              }}>
+                <span style={{ position: "absolute", inset: 3, borderRadius: "50%", border: `1px dashed ${on ? "color-mix(in srgb, #fff 40%, transparent)" : "color-mix(in srgb, var(--eph-vellum-text) 28%, transparent)"}`, pointerEvents: "none" }} />
+                {window.EPH_toRoman(s.v)}
+              </button>
+              <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8, fontStyle: "italic", letterSpacing: "0.02em", color: picked ? "var(--eph-rubric)" : "var(--eph-muted)", maxWidth: 54, textAlign: "center", lineHeight: 1.2 }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 16, fontFamily: "var(--eph-serif)", fontSize: 11.5, fontStyle: "italic", lineHeight: 1.5,
+        color: my ? "var(--eph-verdigris)" : "var(--eph-muted)" }}>
+        {my
+          ? <span>✦ your mark — <b style={{ fontStyle: "normal", color: standing(my).fill === "var(--eph-ink)" ? "var(--eph-vellum-text)" : standing(my).fill }}>{CONCORD[my - 1].label}</b> — is filed. the concordance now stands at <b style={{ fontStyle: "normal", color: "var(--eph-rubric)" }}>{distAvg(live).toFixed(1)}</b> across {distTotal(live)} marks. <span style={{ color: "var(--eph-lapis)", textDecoration: "underline" }}>amend ↺</span></span>
+          : <span>↳ no mark from you yet — the record waits.</span>}
+      </div>
+    </div>
+  );
+}
+
+/* full read view */
+function PraxisRead({ p }) {
+  const { EPH_EphMark, EPH_Foxing, EPH_toRoman, EphAvatar } = window;
+  const tw = p.finding.trim().split(" ");
+  const tlast = tw.pop();
+  const Avatar = EphAvatar || (() => null);
+
+  return (
+    <div style={{ fontFamily: "var(--eph-serif)", color: "var(--eph-vellum-text)" }}>
+      {/* masthead running-head */}
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 14, flexWrap: "wrap",
+        padding: "8px 0 7px", borderTop: "1px solid var(--eph-gold-deep)", borderBottom: "1px solid var(--eph-gold-deep)",
+        boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)" }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 9, color: "var(--eph-rubric)", fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: 13, letterSpacing: "0.18em", textTransform: "uppercase" }}>
+          <EPH_EphMark size={14} color="var(--eph-lapis)" /> The Ephemerists · ephemeris entry №{p.entryNo}
+        </span>
+        <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9.5, letterSpacing: "0.06em", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{p.coords} &nbsp;·&nbsp; sealed {p.sealed}</span>
+      </div>
+
+      {/* status line */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "16px 0 2px", flexWrap: "wrap" }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, background: "var(--eph-ink)", color: "var(--eph-gold-light)",
+          fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 11, letterSpacing: "0.16em", textTransform: "uppercase", padding: "5px 12px", whiteSpace: "nowrap" }}>
+          ✦ Sealed · under concordance
+        </span>
+        <MethodTag mode={p.mode} big />
+        <span style={{ fontFamily: "var(--eph-serif)", fontStyle: "italic", fontSize: 11, color: "var(--eph-muted)" }}>re: <span style={{ color: "var(--eph-rubric)" }}>{p.task}</span> · grade {EPH_toRoman(p.level)}</span>
+      </div>
+
+      {/* the finding headline */}
+      <h1 style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 46, lineHeight: 1.1, letterSpacing: "0.01em", margin: "12px 0 14px", color: "var(--eph-vellum-text)" }}>
+        {tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span><sup style={{ fontFamily: "var(--eph-serif)", fontSize: 18, color: "var(--eph-lapis)", fontWeight: 400 }}>†</sup>
+      </h1>
+      <div style={{ fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: 17, color: "var(--eph-muted)", margin: "2px 0 16px" }}>{p.gloss}</div>
+
+      {/* byline */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, paddingBottom: 18, marginBottom: 22, borderBottom: "1px dashed color-mix(in srgb, var(--eph-vellum-text) 26%, transparent)" }}>
+        <Avatar gradient={p.gradient} size={40} />
+        <div style={{ lineHeight: 1.4, whiteSpace: "nowrap", flexShrink: 0 }}>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 14 }}>filed by <b>{p.actor}</b></div>
+          <div style={{ fontFamily: "var(--eph-serif)", fontSize: 10.5, fontStyle: "italic", color: "var(--eph-muted)" }}>{p.role}</div>
+        </div>
+        <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 18, color: "var(--eph-rubric)", marginLeft: "auto", flexShrink: 0 }}>{p.points} pvncta</span>
+      </div>
+
+      {/* THE ACCOUNT */}
+      <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--eph-rubric)", marginBottom: 12 }}>The account</div>
+      <div style={{ fontFamily: "var(--eph-serif)", fontSize: 15.5, lineHeight: 1.72, color: "var(--eph-vellum-text)" }}>
+        {p.account.map((para, i) => (
+          <p key={i} style={{ margin: i ? "14px 0 0" : 0, textWrap: "pretty" }} dangerouslySetInnerHTML={{ __html: para }} />
+        ))}
+      </div>
+      <div style={{ fontFamily: "var(--eph-serif)", fontSize: 11, fontStyle: "italic", color: "var(--eph-muted)", margin: "16px 0 0", lineHeight: 1.5 }} dangerouslySetInnerHTML={{ __html: p.footnote }} />
+
+      {/* THE EVIDENCE */}
+      <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 13, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--eph-rubric)", margin: "30px 0 12px" }}>The evidence <span style={{ fontFamily: "var(--eph-serif)", fontWeight: 400, fontStyle: "italic", fontSize: 10, letterSpacing: "0.04em", textTransform: "none", color: "var(--eph-muted)" }}>· {p.evidence.length} specimens pinned</span></div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))", gap: 12 }}>
+        {p.evidence.map((e, i) => <Specimen key={i} kind={e.kind} label={e.label} />)}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════ */
+/* shared dataset — sealed praxes (the read page features the first) */
+const G_AV = {
+  vesper:  "radial-gradient(circle at 32% 28%, #8fb0c4, #2d6285 72%, #14303f)",
+  margin:  "radial-gradient(circle at 32% 28%, #d8b25a, #9c7626 72%, #5e4715)",
+  cartouche:"radial-gradient(circle at 32% 28%, #c98aa6, #8a3d5e 72%, #54223a)",
+  almanac: "radial-gradient(circle at 32% 28%, #9fc0a0, #4a7d70 72%, #28473f)",
+  quill:   "radial-gradient(circle at 32% 28%, #b9a7c9, #6b4f86 72%, #3a2850)",
+};
+
+const EPH_PRAXES = [
+  {
+    id: "trace-a-myth", entryNo: "MMXXVI·041", task: "Trace a Myth", level: 4, points: 100,
+    actor: "Vesper", role: "ephemerist · third circuit", gradient: G_AV.vesper, mode: "alone",
+    coords: "41°54′N · 12°29′E", sealed: "Apr 21, 2026",
+    finding: "THE SAINT WAS A SURVEYOR",
+    gloss: "the miracle, traced back, is a measurement",
+    // dist = counts at [I apocryphal, II disputed, III plausible, IV corroborated, V canonical]
+    dist: [1, 2, 7, 19, 18],
+    account: [
+      "The legend holds that St. Verro crossed from the sea to the capital in a single night, and a road rose behind his feet as he walked. I followed it backward through every retelling I could lay hands on — eleven of them, in four tongues — until the road ran out.",
+      "The earliest copy is not a life of a saint at all. It is a surveyor's day-book. <span style=\"color:var(--eph-lapis)\">Verro</span> is not a name; it is a column heading — <em>verum</em>, the true line — ruled down a page of measured stations from the shore to the gates. The night of the miracle is a working season, compressed by three centuries of telling into a single dark.",
+      "So the road did rise behind him, in the only sense that survives scrutiny: he set the stones' positions before anyone walked them. The man was real, the walk was real, and the marvel is that a ledger outlived the church that borrowed it.",
+    ],
+    footnote: "† the day-book's final station carries no coordinate — the line simply stops being recorded. where the saint is said to have ascended, the surveyor merely ran out of page. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [
+      { kind: "rubbing", label: "milestone VII, north face — the ruled stations" },
+      { kind: "transcript", label: "day-book fol. 12r, the 'Verro' column heading" },
+      { kind: "map overlay", label: "the eleven retellings, georeferenced" },
+    ],
+  },
+  {
+    id: "lost-cubit", entryNo: "MMXXVI·028", task: "Recover a Lost Unit of Measure", level: 5, points: 500,
+    actor: "Vesper", role: "ephemerist · third circuit", gradient: G_AV.vesper, mode: "alone",
+    coords: "30°02′N · 31°14′E", sealed: "Apr 18, 2026",
+    finding: "THE CUBIT MOVED A QUARTER-INCH",
+    gloss: "the same rule, measured twice, disagreed with itself",
+    dist: [0, 1, 4, 11, 9],
+    account: ["The cubit cut into the temple's inner wall ran a quarter-inch longer than the cubit cut into its outer wall — the same rule, the same hand, a generation apart."],
+    footnote: "† which cubit is the true cubit? both. neither. the record keeps them both. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "rubbing", label: "inner-wall standard" }, { kind: "rubbing", label: "outer-wall standard" }],
+  },
+  {
+    id: "dead-road", entryNo: "MMXXVI·036", task: "Walk a Dead Road", level: 3, points: 25,
+    actor: "Almanac Okonkwo", role: "ephemerist · cartographer", gradient: G_AV.almanac, mode: "alone",
+    coords: "37°58′N · 23°43′E", sealed: "Apr 19, 2026",
+    finding: "THE INN PREDATES ITS ROAD",
+    gloss: "the house was built for a road that came forty years late",
+    dist: [0, 3, 9, 6, 2],
+    account: ["The roadside inn carries a founding stone four decades older than the road it serves. It was raised for traffic that did not yet exist — and the traffic, eventually, obliged."],
+    footnote: "† who tells the road where to run? sometimes, a man who guesses early. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "photo", label: "the founding stone, dated" }],
+  },
+  {
+    id: "the-bell", entryNo: "—", task: "A Bell Heard in Three Centuries", level: 2, points: 5,
+    actor: "Day Cartouche", role: "ephemerist · disputant", gradient: G_AV.cartouche, mode: "dispute",
+    coords: "48°51′N · 2°21′E", sealed: "Apr 19, 2026",
+    finding: "ONE BELL, THREE CASTINGS",
+    gloss: "the same toll, recast twice, never the same bell",
+    dist: [6, 11, 4, 1, 0],
+    account: ["Three chronicles, three centuries apart, each record the 'same' famous bell. They cannot be: the metal was melted and recast twice. The toll is continuous; the bell is not. The account remains contested."],
+    footnote: "† a thing that is replaced part by part — is it the same thing? the disputants still differ. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "transcript", label: "the three chronicle entries, aligned" }],
+  },
+  {
+    id: "first-teller", entryNo: "—", task: "Name the First Teller", level: 4, points: 200,
+    actor: "Quill Anselm", role: "ephemerist · first circuit", gradient: G_AV.quill, mode: "dispute",
+    coords: "55°57′N · 3°11′W", sealed: "Apr 16, 2026",
+    finding: "THE FIRST TELLER LEFT NO NAME",
+    gloss: "every origin is itself a retelling",
+    dist: [9, 7, 3, 1, 0],
+    account: ["Traced the tale to its earliest written form, then found that form citing an earlier one, now lost. The first teller cannot be named because there is no first telling — only the next-oldest copy, all the way down."],
+    footnote: "† this finding is itself a retelling; someone will trace it back. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "transcript", label: "the citation chain, six deep" }],
+  },
+  {
+    id: "two-maps", entryNo: "MMXXVI·033", task: "Where the Two Maps Disagree", level: 3, points: 60,
+    actor: "Marginalia", role: "ephemerist · in concord with Vesper", gradient: G_AV.margin, mode: "concord",
+    coords: "51°30′N · 0°07′W", sealed: "Apr 17, 2026",
+    finding: "THE RIVER MOVED, THE MAP DID NOT",
+    gloss: "two surveys, one place, a century of silt between them",
+    dist: [0, 2, 6, 12, 7],
+    account: ["Two surveys of the same parish disagree by ninety yards at the waterline. Neither is wrong: the river migrated. The maps are both true — of different rivers wearing the same name."],
+    footnote: "† the ground does not hold still for the map. we record the disagreement, not the winner. <span style=\"color:var(--eph-lapis)\">see †</span>",
+    evidence: [{ kind: "map overlay", label: "1788 survey vs. 1891 survey" }, { kind: "photo", label: "the present waterline" }],
+  },
+];
+
+Object.assign(window, {
+  EPH_CONCORD: CONCORD, EPH_PRAXES,
+  PraxisIndex, PraxisRead, PraxisRow, ConcordSummary, ConcordMeter, MarkCaster, MethodTag, Specimen,
+  EPH_distAvg: distAvg, EPH_distTotal: distTotal,
+});

--- a/docs/design/praxis-read/factions/ephemerists/ephemerists-updates.jsx
+++ b/docs/design/praxis-read/factions/ephemerists/ephemerists-updates.jsx
@@ -1,0 +1,161 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — Updates feed
+   World Zero's stock activity card (avatar · actor · action · badge ·
+   time → task reference → optional status) elevated into the Ephemerist
+   archetype: a torn leaf from the faction's ephemeris. A lapis spine
+   with gold notches, foxed vellum, a Cinzel task title with one word in
+   the blue, a wax-seal points medallion, and a self-referential
+   footnote. Reuses ephemerists-cards.jsx atoms. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── small wax-seal points medallion ───────────────────────────────── */
+function WaxSeal({ points, size = 46, color = "var(--eph-rubric)", rotate = -8 }) {
+  return (
+    <div style={{
+      width: size, height: size, transform: `rotate(${rotate}deg)`, flexShrink: 0,
+      borderRadius: "47% 53% 50% 50% / 52% 48% 52% 48%",
+      background: `radial-gradient(circle at 36% 30%, color-mix(in srgb, ${color} 70%, #fff 18%), ${color} 58%, var(--eph-rubric-deep))`,
+      boxShadow: "inset 0 2px 4px rgba(255,255,255,0.18), inset 0 -3px 5px rgba(0,0,0,0.35), 0 2px 3px rgba(0,0,0,0.3)",
+      display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+      color: "var(--eph-parchment)", lineHeight: 1,
+    }}>
+      <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: size * 0.34 }}>{points}</span>
+      <span style={{ fontFamily: "var(--eph-serif)", fontSize: 5.5, letterSpacing: "0.14em", marginTop: 1, opacity: 0.85 }}>PVNCTA</span>
+    </div>
+  );
+}
+
+/* ── faction avatar: player avatar in an Ephemerist membership ring ─── */
+function EphAvatar({ gradient, size = 38 }) {
+  const { EPH_EphMark } = window;
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      <div style={{ width: size, height: size, borderRadius: "50%", background: gradient,
+        boxShadow: "0 0 0 2px var(--eph-ink), 0 0 0 4px var(--eph-vellum)" }} />
+      <div style={{ position: "absolute", right: -4, bottom: -4, width: 17, height: 17, borderRadius: "50%",
+        background: "var(--eph-lapis)", display: "flex", alignItems: "center", justifyContent: "center",
+        boxShadow: "0 0 0 1.5px var(--eph-vellum)" }}>
+        <EPH_EphMark size={11} color="var(--eph-gold-light)" />
+      </div>
+    </div>
+  );
+}
+
+/* ── action badge as an inked stamp ────────────────────────────────── */
+const STAMP_KIND = {
+  foe:    { bg: "var(--eph-rubric)",    fg: "var(--eph-parchment)", rot: -2.5 },
+  duel:   { bg: "var(--eph-rubric)",    fg: "var(--eph-parchment)", rot:  2 },
+  collab: { bg: "var(--eph-verdigris)", fg: "var(--eph-parchment)", rot: -1.5 },
+  yours:  { bg: "var(--eph-gold)",      fg: "var(--eph-ink)",       rot:  2 },
+  friend: { bg: "var(--eph-lapis)",     fg: "var(--eph-parchment)", rot: -2 },
+};
+function ActionStamp({ label, kind = "foe" }) {
+  const k = STAMP_KIND[kind] || STAMP_KIND.foe;
+  return (
+    <span style={{
+      position: "relative", display: "inline-block", background: k.bg, color: k.fg,
+      fontFamily: "var(--eph-serif)", fontSize: 9, fontWeight: 600, letterSpacing: "0.1em",
+      textTransform: "uppercase", padding: "3px 8px", transform: `rotate(${k.rot}deg)`,
+      verticalAlign: "middle", whiteSpace: "nowrap",
+    }}>
+      <span style={{ position: "absolute", inset: 2, border: "1px dashed rgba(255,255,255,0.35)", pointerEvents: "none" }} />
+      {label}
+    </span>
+  );
+}
+
+/* ── status footer ─────────────────────────────────────────────────── */
+function StatusLine({ status }) {
+  if (!status) return null;
+  const tones = { accepted: "var(--eph-verdigris)", declined: "var(--eph-muted)", pending: "var(--eph-gold-deep)" };
+  const color = tones[status.kind] || "var(--eph-muted)";
+  return (
+    <div style={{
+      marginTop: 11, paddingTop: 9, borderTop: "1px dashed color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)",
+      fontFamily: "var(--eph-serif)", fontSize: 10, fontWeight: 600, fontStyle: "italic", letterSpacing: "0.04em", color,
+    }}>
+      {status.label}
+    </div>
+  );
+}
+
+/* ── the activity card — a leaf from the ephemeris ─────────────────── */
+/* No colored spine. Instead: an ephemeris running-head (catalogue no. +
+   coordinates + time) over faint ledger scribe-rules, the way a real
+   astronomical table is laid out. */
+function EphemeristActivityCard({ actor, gradient, action, badge, time, task, meta, status, completed, footnote, entryNo, coords = "41°54′N · 12°29′E" }) {
+  const { EPH_Foxing, EPH_toRoman, EPH_SacredGeometry } = window;
+  const tw = (task.title || "").trim().split(" ");
+  const tlast = tw.pop();
+  const cat = entryNo || EPH_toRoman(task.points || 1);
+  return (
+    <article style={{
+      position: "relative", background: "var(--eph-vellum)", color: "var(--eph-vellum-text)",
+      border: "1px solid color-mix(in srgb, var(--eph-vellum-text) 30%, transparent)",
+      marginBottom: 18, overflow: "hidden", boxShadow: "0 1px 0 rgba(0,0,0,0.04), 0 8px 20px -16px rgba(0,0,0,0.6)",
+      fontFamily: "var(--eph-serif)",
+    }}>
+      {/* sacred-geometry watermark — a Flower of Life bleeding off the fore-edge
+         so the leaf no longer reads as a plain rectangle */}
+      <div style={{ position: "absolute", right: -96, top: "50%", transform: "translateY(-50%)", zIndex: 1,
+        opacity: 0.12, color: "var(--eph-lapis)", pointerEvents: "none" }}>
+        <EPH_SacredGeometry size={300} rings={3} color="var(--eph-lapis)" stroke={0.7} spokes={12} />
+      </div>
+      {/* a small verdigris vesica/seed bleeding off the binding edge */}
+      <div style={{ position: "absolute", left: -54, top: -34, zIndex: 1,
+        opacity: 0.09, color: "var(--eph-verdigris)", pointerEvents: "none" }}>
+        <EPH_SacredGeometry size={150} rings={2} color="var(--eph-verdigris)" stroke={0.7} />
+      </div>
+      <EPH_Foxing opacity={0.4} />
+
+      {/* running head — catalogue no. + coordinates + time */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 10,
+        padding: "7px 15px 6px", borderBottom: "1px solid var(--eph-gold-deep)", boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)" }}>
+        <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--eph-rubric)" }}>Ephemeris · entry {cat}</span>
+        <span style={{ fontFamily: "var(--eph-serif)", fontSize: 8.5, letterSpacing: "0.06em", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{coords} &nbsp;·&nbsp; {time}</span>
+      </div>
+
+      <div style={{ position: "relative", zIndex: 2, padding: "12px 15px 13px" }}>
+        {/* who + what */}
+        <div style={{ display: "flex", gap: 11, alignItems: "center" }}>
+          <EphAvatar gradient={gradient} />
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", lineHeight: 1.4, minWidth: 0 }}>
+            <span style={{ fontSize: 13.5, fontWeight: 600, color: "var(--eph-vellum-text)", whiteSpace: "nowrap" }}>{actor}</span>
+            <span style={{ fontSize: 12, fontStyle: "italic", color: "var(--eph-muted)", whiteSpace: "nowrap" }}>{action}</span>
+            {badge && <ActionStamp label={badge.label} kind={badge.kind} />}
+          </div>
+        </div>
+
+        {/* the finding — a ledger line: title left, reading (seal) right */}
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 13, marginTop: 11 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 23, lineHeight: 0.98, letterSpacing: "0.01em" }}>
+              {tw.join(" ")}{tw.length ? " " : ""}<span style={{ color: "var(--eph-lapis)" }}>{tlast}</span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 5, flexWrap: "wrap" }}>
+              <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, color: "var(--eph-rubric)", whiteSpace: "nowrap" }}>{task.points} pvncta</span>
+              {task.level != null && (
+                <span style={{ background: "var(--eph-ink)", color: "var(--eph-parchment)", fontFamily: "var(--eph-serif)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", padding: "2px 7px" }}>grade {EPH_toRoman(task.level)}</span>
+              )}
+              {meta && <span style={{ fontSize: 10, fontStyle: "italic", letterSpacing: "0.04em", color: "var(--eph-muted)" }}>{meta}</span>}
+            </div>
+          </div>
+          {completed && (
+            <div style={{ position: "relative", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+              {/* Seed-of-Life halo cradling the seal — the impression sits in a rosette */}
+              <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.75, color: "var(--eph-gold-deep)", pointerEvents: "none" }}>
+                <EPH_SacredGeometry size={86} rings={1} color="var(--eph-gold-deep)" stroke={0.8} spokes={12} />
+              </div>
+              <WaxSeal points={task.points} size={46} rotate={-8} />
+            </div>
+          )}
+        </div>
+
+        <StatusLine status={status} />
+        {footnote && <div style={{ fontFamily: "var(--eph-serif)", fontSize: 9, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 8, lineHeight: 1.4 }}>{footnote}</div>}
+      </div>
+    </article>
+  );
+}
+
+Object.assign(window, { EphemeristActivityCard, EphAvatar, EphWaxSeal: WaxSeal });

--- a/docs/design/praxis-read/factions/ephemerists/ephemerists.css
+++ b/docs/design/praxis-read/factions/ephemerists/ephemerists.css
@@ -1,0 +1,138 @@
+/* ══════════════════════════════════════════════════════════════
+   THE EPHEMERISTS — World Zero faction (rebrand of the Journeymen)
+   They wander space, time and identity to set down what is true
+   before it passes. An EPHEMERIS is a table of positions over time;
+   theirs tabulates fleeting truths — a legend traced back to the
+   plain fact it grew from, recorded the moment before the road moves
+   on. Nothing keeps. They keep the record anyway.
+
+   Style: ARCANE · ACADEMIC · BAZAAR · MYSTIC, by way of HOUSE-OF-LEAVES
+   apparatus — struck measurements, margin notes that climb the gutter,
+   footnotes that point back at themselves, and one word always pulled
+   into the blue. The signature artifact is THE DISCORDANT MAP: one
+   place with three irreconcilable addresses.
+
+   The faction keeps its rainbow slot (teal) but re-reads it as the
+   LAPIS + VERDIGRIS of an illuminated celestial chart, warmed by GOLD
+   LEAF, IRON-GALL INK and RUBRIC RED on aged VELLUM. Slots into the
+   same --faction-journeymen-card-{bg,text,accent,muted,font} contract
+   the other seven factions use.
+
+   TOKEN MODEL (light + dark both legible):
+   · CONSTANTS keep their role in both themes — gold/rubric/lapis are
+     always the illuminator's pigments.
+   · VELLUM surface + its text FLIP: vellum darkens to aged tobacco in
+     dark mode and its text flips ink→parchment.
+   · ACCENTS (gold, rubric, lapis, verdigris) stay vivid in both modes.
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600&display=swap");
+
+:root {
+  /* ── Faction primary (the rainbow's teal, read as lapis-verdigris) ── */
+  --faction-ephemerists: #1d6e72;
+  --faction-ephemerists-light: rgba(29, 110, 114, 0.1);
+  --faction-ephemerists-border: rgba(29, 110, 114, 0.35);
+
+  /* ── Illuminator's pigments — consistent role in both themes ── */
+  --eph-gold: #b0863a;        /* gold leaf / ochre */
+  --eph-gold-light: #d4ab55;  /* burnished highlight */
+  --eph-gold-deep: #8a6622;
+  --eph-rubric: #9c3622;      /* vermilion rubrication red */
+  --eph-rubric-deep: #7c2718;
+  --eph-lapis: #1d4f6e;       /* deep celestial blue */
+  --eph-lapis-deep: #143b54;
+  --eph-verdigris: #4a7d70;   /* aged copper / astrolabe patina */
+  --eph-ink: #2a1d12;         /* iron-gall ink — STAYS dark */
+
+  /* ── Vellum card surface + its text (these FLIP in dark) ── */
+  --eph-vellum: #e9dcbf;       /* aged manuscript stock */
+  --eph-vellum-deep: #dccba2;  /* shadowed / verso panel */
+  --eph-vellum-text: #2a1d12;  /* primary text on vellum */
+  --eph-muted: #6f5c3e;        /* faded marginalia ink */
+  --eph-parchment: #f1e8cf;    /* bright text on dark elements */
+
+  /* ── Lapis FIELD (the celestial-diagram background) ── */
+  --eph-field: #1d4f6e;
+  --eph-field-deep: #143b54;
+
+  /* ── Card contract (mirrors the other factions / journeymen slot) ── */
+  --faction-journeymen-card-bg: var(--eph-vellum);
+  --faction-journeymen-card-text: var(--eph-vellum-text);
+  --faction-journeymen-card-accent: var(--eph-rubric);
+  --faction-journeymen-card-muted: var(--eph-muted);
+  --faction-journeymen-card-font: var(--eph-display);
+
+  /* ── Faction faces ── */
+  --eph-display: "Cinzel", "Trajan Pro", Georgia, serif; /* engraved roman caps */
+  --eph-serif: "EB Garamond", Georgia, serif;            /* scholarly body + italics */
+  --eph-script: "Cormorant Garamond", Georgia, serif;    /* high-contrast flourishes */
+}
+
+[data-theme="dark"] {
+  --faction-ephemerists: #3aa0a4;
+
+  --eph-gold: #cda24a;        /* brightened leaf */
+  --eph-gold-light: #e6c267;
+  --eph-gold-deep: #9c7626;
+  --eph-rubric: #c0533a;      /* rubric brightens on dark vellum */
+  --eph-rubric-deep: #93341f;
+  --eph-lapis: #4f8fb0;       /* celestial blue lifts off near-black */
+  --eph-lapis-deep: #2d6285;
+  --eph-verdigris: #6aa597;
+  --eph-ink: #0c0a06;         /* element ink stays dark */
+
+  --eph-vellum: #211a10;       /* aged tobacco — a surface on #13121a */
+  --eph-vellum-deep: #181208;
+  --eph-vellum-text: #efe3c6;  /* text FLIPS to parchment */
+  --eph-muted: #b6a079;
+  --eph-parchment: #efe3c6;
+
+  --eph-field: #102a3a;        /* celestial field deepens */
+  --eph-field-deep: #0a1d2a;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   EPHEMERIST CODEX BACKDROP — no rays. The page is a sheet of the
+   ephemeris itself: aged vellum, faint foxing, two sets of concentric
+   astrolabe rings bleeding from opposite corners, and the ghost of
+   ruled scribe-lines running the page like a ledger. Gold + lapis
+   light only. Theme-aware. Render once as <div class="eph-backdrop">.
+   ══════════════════════════════════════════════════════════════ */
+.eph-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: var(--eph-vellum);
+  background-image:
+    radial-gradient(40% 32% at 100% 0%, color-mix(in srgb, var(--eph-gold) 15%, transparent), transparent 72%),
+    radial-gradient(46% 38% at 0% 100%, color-mix(in srgb, var(--eph-lapis) 13%, transparent), transparent 72%),
+    repeating-radial-gradient(circle at 90% 8%, transparent 0 33px, color-mix(in srgb, var(--eph-ink) 5%, transparent) 33px 34px),
+    repeating-radial-gradient(circle at 6% 96%, transparent 0 27px, color-mix(in srgb, var(--eph-lapis) 7%, transparent) 27px 28px),
+    radial-gradient(color-mix(in srgb, var(--eph-vellum-text) 5%, transparent) 0.6px, transparent 0.9px),
+    repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 4%, transparent) 0 1px, transparent 1px 26px),
+    linear-gradient(170deg, var(--eph-vellum), var(--eph-vellum-deep));
+  background-size: 100% 100%, 100% 100%, 100% 100%, 100% 100%, 5px 5px, 100% 100%, 100% 100%;
+}
+.eph-backdrop::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 90% at 50% 6%, transparent 46%, color-mix(in srgb, var(--eph-vellum-deep) 58%, transparent));
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SLOW MOTION — rings turn, pupils breathe. Only when the viewer's
+   system allows it (print / PDF / reduced-motion get the still frame).
+   Longhand props so per-element inline animation-delay still composes.
+   ══════════════════════════════════════════════════════════════ */
+@keyframes eph-spin { to { transform: rotate(360deg); } }
+@keyframes eph-twinkle { 0%, 100% { opacity: 0.2; } 50% { opacity: 1; } }
+@keyframes eph-depth { 0%, 100% { opacity: 0.92; transform: scale(1); } 50% { opacity: 0.6; transform: scale(1.03); } }
+@media (prefers-reduced-motion: no-preference) {
+  .eph-spin { animation-name: eph-spin; animation-duration: 140s; animation-timing-function: linear; animation-iteration-count: infinite; }
+  .eph-spin-rev { animation-name: eph-spin; animation-duration: 100s; animation-timing-function: linear; animation-iteration-count: infinite; animation-direction: reverse; }
+  .eph-twinkle { animation-name: eph-twinkle; animation-duration: 5s; animation-timing-function: ease-in-out; animation-iteration-count: infinite; }
+  .eph-depth { animation-name: eph-depth; animation-duration: 16s; animation-timing-function: ease-in-out; animation-iteration-count: infinite; }
+}

--- a/docs/design/praxis-read/factions/everymen/Everymen Edit Praxis.html
+++ b/docs/design/praxis-read/factions/everymen/Everymen Edit Praxis.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Edit Praxis · The Everymen</title>
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css" />
+<link rel="stylesheet" href="everymen.css" />
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body { background: var(--everymen-paper); color: var(--color-text-primary); font-family: var(--font-body); min-height: 100vh; }
+  a { color: inherit; text-decoration: none; }
+
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 30px; padding: 16px 34px;
+    background: var(--color-nav-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 25px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 22px; flex: 1; }
+  .nav-links a { font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--color-text-tertiary); padding-bottom: 3px; }
+  .nav-links a.active { color: var(--color-text-primary); border-bottom: 2px solid var(--color-text-primary); }
+  .nav-ctl { display: flex; align-items: center; gap: 16px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-box { border: 1px solid var(--color-border-strong); padding: 6px 12px; color: var(--color-text-primary); }
+  .nav-toggle { background: none; border: none; cursor: pointer; font: inherit; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); padding: 0; }
+  .nav-toggle:hover { color: var(--color-text-primary); }
+
+  .page { position: relative; z-index: 5; max-width: 1180px; margin: 0 auto; padding: 26px 34px 70px; }
+  .pagehead { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 34px; color: var(--color-text-primary); margin: 0 0 4px; }
+  .pagehead-rule { height: 4px; width: 150px; background: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316); margin-bottom: 6px; }
+  .crumb { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); margin: 14px 0 26px; }
+  .crumb a:hover { color: var(--color-text-primary); }
+  .crumb .sep { opacity: 0.5; margin: 0 7px; }
+
+  .layout { display: grid; grid-template-columns: 1fr 320px; gap: 34px; align-items: start; }
+  @media (max-width: 940px) { .layout { grid-template-columns: 1fr; } .side { display: none; } }
+  .form-wrap { position: relative; }
+
+  /* neutral sidebar chrome (shared shell) */
+  .side { display: flex; flex-direction: column; gap: 20px; }
+  .panel { background: var(--color-bg-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md,10px); padding: 15px 16px; }
+  .panel-title { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-text-tertiary); margin: 0 0 12px; }
+  .char { display: flex; align-items: center; gap: 11px; }
+  .char .av { width: 38px; height: 38px; border-radius: 50%; background: radial-gradient(circle at 34% 30%, #e88a6a, #b34a52 70%); flex-shrink: 0; }
+  .char .nm { display: block; font-size: 13px; font-weight: 700; color: var(--color-text-primary); }
+  .char .meta { display: block; font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-text-tertiary); margin-top: 3px; }
+  .stats { display: flex; gap: 7px; margin-top: 13px; }
+  .stat { flex: 1; border: 1px solid var(--color-border); border-radius: 7px; padding: 8px 4px; text-align: center; }
+  .stat b { display: block; font-family: var(--font-mono, monospace); font-size: 15px; color: var(--color-text-primary); }
+  .stat span { font-size: 7.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-text-tertiary); margin-top: 2px; display: block; }
+  .slot { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 6px 0; border-bottom: 1px solid var(--color-border); }
+  .slot:last-of-type { border-bottom: none; }
+  .slot-name { flex: 1; font-size: 11px; font-weight: 700; color: var(--color-text-primary); line-height: 1.25; }
+  .solo { font-size: 8px; letter-spacing: 0.1em; background: var(--badge-global); color: #fff; padding: 2px 7px; flex-shrink: 0; }
+  .bar { height: 5px; background: var(--color-overlay-weak); border-radius: 3px; margin-top: 11px; overflow: hidden; }
+  .bar > i { display: block; height: 100%; width: 40%; background: var(--underline-3); }
+  .bar-label { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-text-tertiary); margin-top: 6px; }
+  .act { padding: 9px 0; border-bottom: 1px dashed var(--color-border); }
+  .act:last-child { border-bottom: none; }
+  .act .title { color: var(--color-text-secondary); font-size: 11px; }
+  .act b { color: var(--color-text-primary); }
+  .act .ago { font-size: 8px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); margin-top: 4px; }
+  .propose { width: 100%; background: var(--badge-admin-bg); color: var(--badge-admin-text); border: none; cursor: pointer;
+    font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; padding: 14px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="everymen-cards.jsx"></script>
+<script type="text/babel" src="everymen-praxis.jsx"></script>
+</head>
+<body>
+<div class="em-backdrop"></div>
+
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="../../All%20Faction%20Praxis%20Pages.dc.html">Tasks</a><a href="#" class="active">Praxis</a><a href="#">Players</a>
+    <a href="Everymen Faction Page.html">Factions</a><a href="Everymen Updates Page.html">Updates</a><a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Mod</span>
+    <button class="nav-toggle" id="theme-toggle">Dark</button>
+    <span>Pixie</span>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+
+<div class="page">
+  <h1 class="pagehead">Edit Praxis</h1>
+  <div class="pagehead-rule"></div>
+  <div class="crumb"><a href="../../All%20Faction%20Praxis%20Pages.dc.html">Tasks</a><span class="sep">›</span><a href="../../All%20Faction%20Praxis%20Pages.dc.html">Break New Ground</a><span class="sep">›</span>Praxis<span class="sep">›</span>Edit</div>
+
+  <div class="layout">
+    <div class="form-wrap" id="form"></div>
+
+    <aside class="side">
+      <div class="panel">
+        <p class="panel-title">Your Character</p>
+        <div class="char">
+          <span class="av"></span>
+          <span>
+            <span class="nm">Pixie</span>
+            <span class="meta">Gestalt · Level 4</span>
+          </span>
+        </div>
+        <div class="stats">
+          <div class="stat"><b>443</b><span>Score</span></div>
+          <div class="stat"><b>0</b><span>Votes</span></div>
+          <div class="stat"><b>Era 3</b><span>Current</span></div>
+        </div>
+      </div>
+
+      <div class="panel">
+        <p class="panel-title">Your Active Tasks</p>
+        <div class="slot"><span class="slot-name">Knowledge Is Free</span><span class="solo">Solo</span></div>
+        <div class="slot"><span class="slot-name">The Seed</span><span class="solo">Solo</span></div>
+        <div class="slot"><span class="slot-name">The L Word</span><span class="solo">Solo</span></div>
+        <div class="slot"><span class="slot-name">The Rotation Of Cubes In Your Mind</span><span class="solo">Solo</span></div>
+        <div class="slot"><span class="slot-name">Depth through Repetition</span><span class="solo">Solo</span></div>
+        <div class="slot"><span class="slot-name">A Very Human Thing</span><span class="solo">Solo</span></div>
+        <div class="bar"><i></i></div>
+        <p class="bar-label">8 / 20 slots</p>
+      </div>
+
+      <div class="panel">
+        <p class="panel-title">Recent Global Activity</p>
+        <div class="act"><span class="title"><b>New task:</b> Contribute to Shahid's Strigiformic Sketchbook</span><div class="ago">1mo ago</div></div>
+        <div class="act"><span class="title"><b>New task:</b> Permaculture Shock</span><div class="ago">1mo ago</div></div>
+        <div class="act"><span class="title"><b>New task:</b> Somewhere No One Needs To Be</span><div class="ago">1mo ago</div></div>
+        <div class="act"><span class="title"><b>New task:</b> Lacunae</span><div class="ago">1mo ago</div></div>
+      </div>
+
+      <button class="propose">Propose a Task</button>
+    </aside>
+  </div>
+</div>
+
+<script type="text/babel">
+  const { PraxisForm } = window;
+  ReactDOM.createRoot(document.getElementById("form")).render(
+    <PraxisForm task={{ title: "BREAK NEW GROUND", points: 25, level: 3 }} reportNo="0040" />
+  );
+
+  const tog = document.getElementById("theme-toggle");
+  tog.addEventListener("click", () => {
+    const dark = document.documentElement.getAttribute("data-theme") === "dark";
+    document.documentElement.setAttribute("data-theme", dark ? "light" : "dark");
+    tog.textContent = dark ? "Dark" : "Light";
+  });
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/everymen/Everymen Praxis.html
+++ b/docs/design/praxis-read/factions/everymen/Everymen Praxis.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>The Everymen · filed work report</title>
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css" />
+<link rel="stylesheet" href="everymen.css" />
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body { background: var(--everymen-paper); color: var(--color-text-primary); font-family: var(--font-body); min-height: 100vh; }
+  a { color: inherit; text-decoration: none; }
+
+  .nav { position: sticky; top: 0; z-index: 20; display: flex; align-items: center; gap: 30px; padding: 16px 34px;
+    background: var(--color-nav-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 25px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 22px; flex: 1; }
+  .nav-links a { font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--color-text-tertiary); padding-bottom: 3px; }
+  .nav-links a.active { color: var(--color-text-primary); border-bottom: 2px solid var(--color-text-primary); }
+  .nav-ctl { display: flex; align-items: center; gap: 16px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-box { border: 1px solid var(--color-border-strong); padding: 6px 12px; color: var(--color-text-primary); }
+
+  .crumb { position: relative; z-index: 5; max-width: 1080px; margin: 0 auto; padding: 20px 34px 0; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .crumb a:hover { color: var(--color-text-primary); }
+  .crumb .sep { opacity: 0.5; margin: 0 8px; }
+
+  .page { position: relative; z-index: 5; max-width: 1080px; margin: 0 auto; padding: 16px 34px 90px; display: grid; grid-template-columns: 1fr 330px; gap: 30px; align-items: start; }
+  @media (max-width: 940px) { .page { grid-template-columns: 1fr; } }
+  aside.rail { position: sticky; top: 84px; display: flex; flex-direction: column; gap: 16px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="../praxis-core.jsx"></script>
+</head>
+<body>
+<div class="em-backdrop"></div>
+
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="#" class="active">Praxis</a><a href="#">Players</a>
+    <a href="#">Factions</a><a href="#">Updates</a><a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Mod</span>
+    <span>Rivet</span>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+
+<div class="crumb"><a href="../../All Faction Praxis Pages.dc.html">Tasks</a><span class="sep">/</span><a href="#">The Everymen</a><span class="sep">/</span>Work Report</div>
+
+<div class="page">
+  <div id="report"></div>
+  <aside class="rail">
+    <div id="ledger"></div>
+    <a href="../../All Faction Praxis Pages.dc.html" style="text-align:center; font-size:10px; letter-spacing:0.14em; text-transform:uppercase; color:var(--color-text-tertiary); padding:4px 0;">← all praxis pages</a>
+  </aside>
+</div>
+
+<script type="text/babel">
+const { WZ_FACTIONS, WZ_PagePointsBlock } = window;
+const everymenF = WZ_FACTIONS.find((f) => f.slug === "everymen");
+
+const REPORT = {
+  reportNo: "0040",
+  task: "Pick Up the Load",
+  level: 2,
+  finding: "Carried the Tran's Groceries",
+  author: "Rivet",
+  role: "hand · day shift",
+  crew: "with Salt of the Earth",
+  sealed: "Apr 18, 2026",
+  mode: "COLLAB",
+  points: 25,
+  synopsis: "Took the heavy bags up four flights so a neighbour wouldn't have to. Stayed for tea. Worth more than points — but the points are good too.",
+  steps: [
+    "Met the Tran family at the loading bay on Eighth. Four flights, no lift, and a month of tinned goods stacked between us.",
+    "Took the heavy crates first — flour, oil, the big water. Three trips up, Salt of the Earth on the stairs beside me the whole way.",
+    "Stayed for tea once it was all stacked in the pantry. Mrs. Tran insisted, and you don't argue with that. Left the building lighter than I came in.",
+  ],
+  proof: [
+    { name: "the_loading_bay.jpg", meta: "Eighth St · 7:40am", stamp: "FILED" },
+    { name: "four_flights.jpg", meta: "stairwell · trip two of three", stamp: "VERIFIED" },
+    { name: "the_tea.jpg", meta: "4B kitchen · after", stamp: "FILED" },
+  ],
+};
+
+const RED = "var(--everymen-red)";
+const GOLD = "var(--everymen-gold)";
+const INK = "var(--everymen-ink)";
+const POSTER = "var(--font-faction-poster)";
+
+function StripeRule() {
+  return <div style={{ height: 4, background: "repeating-linear-gradient(90deg, var(--everymen-red) 0 16px, var(--everymen-gold) 16px 26px)" }} />;
+}
+
+function SectionHead({ children }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 14, margin: "26px 0 16px" }}>
+      <h2 style={{ fontFamily: POSTER, fontSize: 25, letterSpacing: "0.04em", margin: 0, color: "var(--color-text-primary)", whiteSpace: "nowrap" }}>{children}</h2>
+      <span style={{ flex: 1, height: 3, background: "repeating-linear-gradient(90deg, var(--everymen-red) 0 16px, var(--everymen-gold) 16px 26px)", opacity: 0.55 }} />
+    </div>
+  );
+}
+
+function ProofPlate({ pl, i }) {
+  const rot = [-1.4, 1, -0.6][i % 3];
+  return (
+    <div style={{ background: "var(--everymen-cream, #f3ead4)", border: `1.5px solid ${INK}`, boxShadow: "3px 4px 0 rgba(0,0,0,0.16)", transform: `rotate(${rot}deg)`, padding: 8 }}>
+      <div style={{ position: "relative", height: 124, border: `1px solid ${INK}`, overflow: "hidden",
+        background: `repeating-linear-gradient(135deg, color-mix(in srgb, var(--everymen-red) 16%, transparent) 0 8px, transparent 8px 16px), color-mix(in srgb, var(--everymen-olive, #6b6f3a) 22%, var(--everymen-cream, #f3ead4))`,
+        display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <svg width="40" height="40" viewBox="0 0 24 24" style={{ opacity: 0.5 }}><path d="M12 1.5l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 8.7l7.1-.6z" fill={GOLD} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" /></svg>
+        <span style={{ position: "absolute", top: 7, right: 7, fontFamily: POSTER, fontSize: 11, letterSpacing: "0.1em", color: "#fff", background: RED, padding: "2px 7px", transform: "rotate(3deg)", border: `1px solid ${INK}` }}>{pl.stamp}</span>
+      </div>
+      <div style={{ fontFamily: "var(--font-mono, monospace)", fontSize: 10, fontWeight: 700, color: INK, marginTop: 8, wordBreak: "break-all" }}>{pl.name}</div>
+      <div style={{ fontSize: 8.5, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--everymen-muted)", marginTop: 3 }}>{pl.meta}</div>
+    </div>
+  );
+}
+
+function Report({ r }) {
+  return (
+    <div style={{ background: "var(--color-bg-surface)", border: `1.5px solid ${INK}`, boxShadow: `0 0 0 3px var(--everymen-paper), 0 0 0 4px ${INK}` }}>
+      {/* masthead */}
+      <div style={{ background: RED, color: "var(--everymen-cream, #f6eedb)", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, padding: "10px 22px" }}>
+        <span style={{ fontFamily: POSTER, fontSize: 26, letterSpacing: "0.08em", lineHeight: 1, whiteSpace: "nowrap" }}>Work Report · Filed</span>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.12em", textAlign: "right" }}>No. {r.reportNo} · {r.mode}</span>
+      </div>
+      <StripeRule />
+
+      <div style={{ padding: "26px 30px 30px" }}>
+        <div style={{ fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--everymen-muted)", marginBottom: 4 }}>re: {r.task} · lvl {r.level} · sealed {r.sealed}</div>
+        <div style={{ fontSize: 9, letterSpacing: "0.2em", textTransform: "uppercase", color: RED, marginBottom: 8 }}>the job, done</div>
+        <h1 style={{ fontFamily: POSTER, fontWeight: 400, fontSize: 52, lineHeight: 0.98, letterSpacing: "0.01em", margin: 0, color: "var(--color-text-primary)" }}>{r.finding}</h1>
+        <p style={{ fontSize: 13, lineHeight: 1.65, color: "var(--color-text-secondary)", marginTop: 16, maxWidth: "54ch" }}>{r.synopsis}</p>
+
+        {/* byline */}
+        <div style={{ display: "flex", alignItems: "center", gap: 13, paddingTop: 18, marginTop: 18, borderTop: `2px solid ${INK}` }}>
+          <span style={{ width: 40, height: 40, borderRadius: "50%", flexShrink: 0, background: "radial-gradient(circle at 32% 28%, #e8a23a, #b4521f 70%, #7a2f12)", border: `1.5px solid ${INK}` }}></span>
+          <div style={{ lineHeight: 1.35 }}>
+            <div style={{ fontFamily: POSTER, fontSize: 22, color: "var(--color-text-primary)", lineHeight: 1 }}>{r.author}</div>
+            <div style={{ fontSize: 9, letterSpacing: "0.06em", color: "var(--everymen-muted)", marginTop: 3 }}>{r.role} · {r.crew}</div>
+          </div>
+          <div style={{ marginLeft: "auto", textAlign: "right" }}>
+            <div style={{ fontFamily: POSTER, fontSize: 30, lineHeight: 1, color: RED }}>★ {r.points}</div>
+            <div style={{ fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--everymen-muted)", marginTop: 3 }}>points earned</div>
+          </div>
+        </div>
+
+        {/* the work */}
+        <SectionHead>The Work</SectionHead>
+        <div style={{ display: "flex", flexDirection: "column", gap: 13 }}>
+          {r.steps.map((s, i) => (
+            <div key={i} style={{ display: "flex", gap: 13, alignItems: "flex-start" }}>
+              <span style={{ flexShrink: 0, width: 27, height: 27, background: INK, color: GOLD, fontFamily: POSTER, fontSize: 16, display: "flex", alignItems: "center", justifyContent: "center" }}>{i + 1}</span>
+              <p style={{ margin: 0, fontSize: 12, lineHeight: 1.7, color: "var(--color-text-secondary)", paddingTop: 3 }}>{s}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* proof of work */}
+        <SectionHead>Proof of Work · {r.proof.length} plates</SectionHead>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))", gap: 18, paddingTop: 6 }}>
+          {r.proof.map((pl, i) => <ProofPlate key={pl.name} pl={pl} i={i} />)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("report")).render(<Report r={REPORT} />);
+ReactDOM.createRoot(document.getElementById("ledger")).render(<WZ_PagePointsBlock f={everymenF} />);
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/everymen/everymen-cards.jsx
+++ b/docs/design/praxis-read/factions/everymen/everymen-cards.jsx
@@ -1,0 +1,311 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — Task Card · 5 takes
+   Each take is a different read on the union / victory-poster archetype.
+   All five honor the same World Zero card contract (faction name, title,
+   description, level, points, sign-up) and use only DS tokens + the
+   everymen.css palette. Headline face is Bebas Neue (--font-accent).
+   Exposed on window for the gallery script.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── shared atoms ───────────────────────────────────────────────── */
+
+// faint screen-print halftone wash
+function Halftone({ color = "var(--everymen-ink)", opacity = 0.07, size = 4 }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none", opacity,
+      backgroundImage: `radial-gradient(${color} 0.6px, transparent 0.7px)`,
+      backgroundSize: `${size}px ${size}px`, zIndex: 1,
+    }} />
+  );
+}
+
+// radiating poster rays from an origin point
+function Sunburst({ color = "var(--everymen-red)", from = "50% 0%", opacity = 0.1, step = 7 }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none", opacity, zIndex: 0,
+      background: `repeating-conic-gradient(from 0deg at ${from}, ${color} 0deg ${step}deg, transparent ${step}deg ${step * 2}deg)`,
+    }} />
+  );
+}
+
+// little center ornament rule
+function RuleDiamond({ color = "var(--everymen-red)" }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 5, justifyContent: "center", margin: "7px 0" }}>
+      <div style={{ height: 1.5, flex: 1, background: color }} />
+      <div style={{ width: 5, height: 5, background: color, transform: "rotate(45deg)" }} />
+      <div style={{ height: 1.5, flex: 1, background: color }} />
+    </div>
+  );
+}
+
+// rubber-stamped circular points seal
+function PointsSeal({ points, color = "var(--everymen-red)", rotate = -9, size = 52, blend = "multiply" }) {
+  return (
+    <div style={{
+      width: size, height: size, borderRadius: "50%", border: `2px solid ${color}`,
+      boxShadow: `inset 0 0 0 2px ${color}`, color, transform: `rotate(${rotate}deg)`,
+      display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+      lineHeight: 1, opacity: 0.92, mixBlendMode: blend,
+    }}>
+      <span style={{ fontFamily: "var(--font-accent)", fontSize: size * 0.42 }}>{points}</span>
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 6, letterSpacing: "0.18em", marginTop: 1 }}>POINTS</span>
+    </div>
+  );
+}
+
+// worker cog / gear sigil — the faction mark.
+function CogMark({ size = 22, color = "currentColor" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ display: "block" }}>
+      <g fill={color}>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <rect key={i} x="11" y="0.5" width="2" height="5" rx="0.5"
+            transform={`rotate(${i * 45} 12 12)`} />
+        ))}
+      </g>
+      <circle cx="12" cy="12" r="6.5" fill="none" stroke={color} strokeWidth="2.4" />
+      <circle cx="12" cy="12" r="2" fill={color} />
+    </svg>
+  );
+}
+
+function LvlPill({ level, bg = "var(--everymen-ink)", fg = "var(--everymen-paper)" }) {
+  return (
+    <span style={{
+      background: bg, color: fg, fontFamily: "var(--font-body)", fontSize: 7,
+      padding: "2px 7px", textTransform: "uppercase", letterSpacing: "0.1em",
+    }}>lvl {level}</span>
+  );
+}
+
+function SignBtn({ onSignup, label = "Report for duty", style = {} }) {
+  if (!onSignup) return null;
+  return (
+    <button onClick={onSignup} style={{
+      fontFamily: "var(--font-body)", fontSize: 8, textTransform: "uppercase",
+      letterSpacing: "0.14em", padding: "6px 10px", border: "none", cursor: "pointer",
+      background: "var(--everymen-ink)", color: "var(--everymen-paper)", width: "100%",
+      ...style,
+    }}>{label}</button>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 1 — "The Rally Bill"   (the by-the-book reference)
+   Red masthead + cream poster body, faint sunburst, stamped seal.
+   ════════════════════════════════════════════════════════════════ */
+function RallyBill({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 206, background: "var(--everymen-paper)", color: "var(--everymen-ink)",
+      border: "1.5px solid var(--everymen-ink)", boxShadow: "0 0 0 3px var(--everymen-paper), 0 0 0 4px var(--everymen-ink)",
+      position: "relative", fontFamily: "var(--font-body)",
+    }}>
+      {/* masthead */}
+      <div style={{ background: "var(--everymen-red)", borderBottom: "2px solid var(--everymen-gold)", padding: "7px 8px 6px", textAlign: "center" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 5, color: "var(--everymen-cream)", whiteSpace: "nowrap" }}>
+          <CogMark size={11} color="var(--everymen-cream)" />
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 14, letterSpacing: "0.07em" }}>THE EVERYMEN</span>
+          <CogMark size={11} color="var(--everymen-cream)" />
+        </div>
+      </div>
+      {/* body */}
+      <div style={{ position: "relative", padding: "13px 14px 12px", overflow: "hidden" }}>
+        <Sunburst opacity={0.08} step={6} />
+        <Halftone />
+        <div style={{ position: "relative", zIndex: 2 }}>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 32, lineHeight: 0.98, textAlign: "center", letterSpacing: "0.01em" }}>{title}</div>
+          <RuleDiamond />
+          <div style={{ fontSize: 8, lineHeight: 1.55, textAlign: "center", color: "var(--everymen-muted)", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+        </div>
+      </div>
+      {/* dispatch strip */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "0 14px 12px" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <LvlPill level={level} />
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 13, color: "var(--everymen-red)" }}>{points} PTS</span>
+        </div>
+        <PointsSeal points={points} />
+      </div>
+      <SignBtn onSignup={onSignup} />
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 2 — "Mobilize"   (sunburst duotone, type-forward & loud)
+   Full radiating burst, big knocked-out headline, star seal.
+   ════════════════════════════════════════════════════════════════ */
+function Mobilize({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 206, background: "var(--everymen-field)", color: "var(--everymen-cream)",
+      border: "3px solid var(--everymen-ink)", position: "relative", overflow: "hidden",
+      fontFamily: "var(--font-body)",
+    }}>
+      <Sunburst color="var(--everymen-field-deep)" from="50% 38%" opacity={0.55} step={7.5} />
+      <Halftone color="var(--everymen-cream)" opacity={0.1} />
+      {/* eyebrow ribbon */}
+      <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center", padding: "5px 0", fontFamily: "var(--font-accent)", fontSize: 12, letterSpacing: "0.3em" }}>THE EVERYMEN</div>
+      <div style={{ position: "relative", zIndex: 2, padding: "16px 14px 13px", textAlign: "center" }}>
+        {/* star sigil */}
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 8 }}>
+          <div style={{ width: 40, height: 40, borderRadius: "50%", background: "var(--everymen-cream)", color: "var(--everymen-red)", display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 0 0 3px var(--everymen-ink)" }}>
+            <CogMark size={24} color="var(--everymen-red)" />
+          </div>
+        </div>
+        <div style={{ minHeight: 74, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 34, lineHeight: 1.06, color: "var(--everymen-cream)", textShadow: "1.5px 1.5px 0 var(--everymen-ink)" }}>{title}</div>
+        </div>
+        <div style={{ height: 2, background: "var(--everymen-gold)", margin: "11px 22px 10px" }} />
+        <div style={{ fontSize: 8, lineHeight: 1.5, color: "var(--everymen-cream)", opacity: 0.92, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+      </div>
+      {/* footer bar */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "stretch", borderTop: "3px solid var(--everymen-ink)" }}>
+        <div style={{ flex: 1, background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center", padding: "6px 0", fontFamily: "var(--font-accent)", fontSize: 16 }}>LVL {level}</div>
+        <div style={{ flex: 1, background: "var(--everymen-gold)", color: "var(--everymen-ink)", textAlign: "center", padding: "6px 0", fontFamily: "var(--font-accent)", fontSize: 16 }}>{points} PTS</div>
+      </div>
+      {onSignup && <SignBtn onSignup={onSignup} label="Mobilize ▸" style={{ background: "var(--everymen-cream)", color: "var(--everymen-ink)", position: "relative", zIndex: 2 }} />}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 3 — "Solidarity Block"   (woodcut knockout, heavy keyline)
+   Solid red field, title reversed out, gold key word, black sub-bar.
+   ════════════════════════════════════════════════════════════════ */
+function SolidarityBlock({ title, description, level, points, onSignup }) {
+  const words = title.split(" ");
+  const last = words.pop();
+  return (
+    <div style={{
+      width: 206, background: "var(--everymen-gold)", padding: 4, position: "relative",
+      fontFamily: "var(--font-body)",
+    }}>
+      <div style={{ border: "3px solid var(--everymen-ink)", background: "var(--everymen-red)", color: "var(--everymen-cream)", position: "relative", overflow: "hidden" }}>
+        <Halftone color="var(--everymen-ink)" opacity={0.12} />
+        <div style={{ position: "relative", zIndex: 2, padding: "12px 14px 13px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 10 }}>
+            <CogMark size={15} color="var(--everymen-cream)" />
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.24em", textTransform: "uppercase" }}>The Everymen</span>
+          </div>
+          {/* knockout headline */}
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 35, lineHeight: 1.0, marginBottom: 7 }}>
+            {words.join(" ")}{words.length ? " " : ""}
+            <span style={{ color: "var(--everymen-gold)" }}>{last}</span>
+          </div>
+          <div style={{ fontSize: 8, lineHeight: 1.5, opacity: 0.92, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+        </div>
+        {/* black sub-bar */}
+        <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-ink)", color: "var(--everymen-cream)", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "7px 14px" }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 7.5, letterSpacing: "0.1em", whiteSpace: "nowrap" }}>LEVEL {level} REQ'D</span>
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 17, color: "var(--everymen-gold)", whiteSpace: "nowrap" }}>{points} PTS</span>
+        </div>
+      </div>
+      {onSignup && <SignBtn onSignup={onSignup} label="Stand together ▸" style={{ background: "var(--everymen-ink)", color: "var(--everymen-gold)", marginTop: 4 }} />}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 4 — "Work Order"   (utilitarian job ticket — most down-to-earth)
+   Manila ticket, perforated edge, ruled fields, diagonal ASSIGNED stamp.
+   ════════════════════════════════════════════════════════════════ */
+function WorkOrder({ title, description, level, points, onSignup }) {
+  return (
+    <div style={{
+      width: 210, background: "var(--everymen-paper)", color: "var(--everymen-ink)",
+      border: "1.5px solid var(--everymen-ink)", position: "relative", overflow: "hidden",
+      fontFamily: "var(--font-body)", display: "flex",
+    }}>
+      {/* perforated stub */}
+      <div style={{ width: 16, background: "var(--everymen-paper-deep)", borderRight: "1.5px dashed var(--everymen-ink)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "space-around", padding: "6px 0" }}>
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} style={{ width: 4, height: 4, borderRadius: "50%", background: "var(--everymen-paper)", border: "1px solid var(--everymen-muted)" }} />
+        ))}
+      </div>
+      <div style={{ flex: 1, position: "relative" }}>
+        <Halftone opacity={0.05} />
+        {/* header strip */}
+        <div style={{ position: "relative", zIndex: 2, background: "var(--everymen-red)", color: "var(--everymen-cream)", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "5px 10px" }}>
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 14, letterSpacing: "0.08em", whiteSpace: "nowrap" }}>WORK ORDER</span>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 7 }}>No. 0427</span>
+        </div>
+        <div style={{ position: "relative", zIndex: 2, padding: "10px 12px 11px" }}>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.18em", color: "var(--everymen-muted)", marginBottom: 2 }}>ASSIGNMENT</div>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 26, lineHeight: 1.0, borderBottom: "1px solid var(--everymen-ink)", paddingBottom: 6, marginBottom: 7 }}>{title}</div>
+          <div style={{ fontSize: 8, lineHeight: 1.5, color: "var(--everymen-ink)", marginBottom: 10, display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{description}</div>
+          {/* stamped field boxes */}
+          <div style={{ display: "flex", gap: 7 }}>
+            <div style={{ flex: 1, border: "1.5px solid var(--everymen-ink)", padding: "3px 6px" }}>
+              <div style={{ fontSize: 6, letterSpacing: "0.16em", color: "var(--everymen-muted)" }}>LEVEL</div>
+              <div style={{ fontFamily: "var(--font-accent)", fontSize: 18 }}>{level}</div>
+            </div>
+            <div style={{ flex: 1, border: "1.5px solid var(--everymen-ink)", padding: "3px 6px" }}>
+              <div style={{ fontSize: 6, letterSpacing: "0.16em", color: "var(--everymen-muted)" }}>POINTS</div>
+              <div style={{ fontFamily: "var(--font-accent)", fontSize: 18, color: "var(--everymen-red)" }}>{points}</div>
+            </div>
+          </div>
+        </div>
+        {/* diagonal rubber stamp */}
+        <div style={{ position: "absolute", right: -6, top: 64, zIndex: 3, transform: "rotate(-13deg)", border: "2px solid var(--everymen-red)", color: "var(--everymen-red)", padding: "1px 7px", fontFamily: "var(--font-accent)", fontSize: 13, letterSpacing: "0.12em", opacity: 0.85, mixBlendMode: "multiply", borderRadius: 2 }}>OPEN</div>
+        {onSignup && <SignBtn onSignup={onSignup} label="Sign the ledger ▸" />}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TAKE 5 — "Victory Banner"   (ceremonial swallowtail pennant)
+   Bunting stripe, arched motto, gold rosette seal, chevron tail.
+   ════════════════════════════════════════════════════════════════ */
+function VictoryBanner({ title, description, level, points, onSignup }) {
+  const bunting = `repeating-linear-gradient(90deg, var(--everymen-red) 0 13px, var(--everymen-cream) 13px 20px, var(--everymen-gold) 20px 33px, var(--everymen-cream) 33px 40px)`;
+  return (
+    <div style={{ width: 200, position: "relative", fontFamily: "var(--font-body)", paddingTop: 12 }}>
+      {/* hanging grommet + cord */}
+      <div style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%)", width: 9, height: 9, borderRadius: "50%", border: "2px solid var(--everymen-ink)", background: "var(--everymen-paper)", zIndex: 4 }} />
+      <div style={{
+        background: "var(--everymen-paper)", color: "var(--everymen-ink)", border: "2px solid var(--everymen-ink)",
+        clipPath: "polygon(0 0, 100% 0, 100% 86%, 50% 100%, 0 86%)", position: "relative", overflow: "hidden",
+        padding: "0 0 30px",
+      }}>
+        <Sunburst opacity={0.07} from="50% 30%" step={8} />
+        <Halftone opacity={0.06} />
+        <div style={{ height: 8, background: bunting }} />
+        <div style={{ position: "relative", zIndex: 2, padding: "11px 16px 0", textAlign: "center" }}>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 10, letterSpacing: "0.28em", color: "var(--everymen-red)" }}>UNITED · WE · STAND</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.2em", color: "var(--everymen-muted)", margin: "3px 0 9px" }}>THE EVERYMEN</div>
+          <div style={{ fontFamily: "var(--font-accent)", fontSize: 30, lineHeight: 0.98 }}>{title}</div>
+          {/* rosette */}
+          <div style={{ display: "flex", justifyContent: "center", margin: "9px 0 7px" }}>
+            <div style={{ position: "relative", width: 46, height: 46 }}>
+              <div style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "var(--everymen-gold)", clipPath: "polygon(50% 0%,61% 8%,75% 4%,79% 19%,93% 22%,89% 37%,100% 50%,89% 63%,93% 78%,79% 81%,75% 96%,61% 92%,50% 100%,39% 92%,25% 96%,21% 81%,7% 78%,11% 63%,0% 50%,11% 37%,7% 22%,21% 19%,25% 4%,39% 8%)" }} />
+              <div style={{ position: "absolute", inset: 6, borderRadius: "50%", background: "var(--everymen-red)", color: "var(--everymen-cream)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", lineHeight: 1 }}>
+                <span style={{ fontFamily: "var(--font-accent)", fontSize: 17 }}>{points}</span>
+                <span style={{ fontFamily: "var(--font-body)", fontSize: 5, letterSpacing: "0.14em" }}>PTS</span>
+              </div>
+            </div>
+          </div>
+          <div style={{ fontSize: 7.5, lineHeight: 1.5, color: "var(--everymen-muted)", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden", marginBottom: 8 }}>{description}</div>
+          <span style={{ display: "inline-block", background: "var(--everymen-ink)", color: "var(--everymen-paper)", fontFamily: "var(--font-body)", fontSize: 7, padding: "2px 8px", textTransform: "uppercase", letterSpacing: "0.1em" }}>lvl {level}</span>
+        </div>
+      </div>
+      {onSignup && (
+        <div style={{ textAlign: "center", marginTop: -18, position: "relative", zIndex: 5 }}>
+          <button onClick={onSignup} style={{ fontFamily: "var(--font-body)", fontSize: 8, textTransform: "uppercase", letterSpacing: "0.14em", padding: "5px 14px", border: "2px solid var(--everymen-ink)", cursor: "pointer", background: "var(--everymen-red)", color: "var(--everymen-cream)" }}>Enlist ▸</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, {
+  RallyBill, Mobilize, SolidarityBlock, WorkOrder, VictoryBanner,
+  /* shared poster atoms, reused by the updates feed */
+  EM_Halftone: Halftone, EM_Sunburst: Sunburst, EM_PointsSeal: PointsSeal,
+  EM_CogMark: CogMark, EM_RuleDiamond: RuleDiamond,
+});

--- a/docs/design/praxis-read/factions/everymen/everymen-praxis.jsx
+++ b/docs/design/praxis-read/factions/everymen/everymen-praxis.jsx
@@ -1,0 +1,145 @@
+/* ════════════════════════════════════════════════════════════════
+   THE EVERYMEN — Edit Praxis form
+   World Zero's praxis-filing form takes the TASK's faction treatment.
+   Where the Journeymen frame it as a travel manifest, the Everymen
+   frame it as a union WORK REPORT filed at the hall: a stamped masthead,
+   the job reference slip, a crew selector, the job headline, the report
+   body, proof-of-work attachments, and a stamp-&-file action bar.
+   Reuses everymen.css tokens + poster atoms. Theme-aware.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── field label in union stencil style ────────────────────────────── */
+function FieldLabel({ children, meta }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 9 }}>
+      <span style={{ fontFamily: "var(--font-accent)", fontSize: 16, letterSpacing: "0.12em", color: "var(--everymen-red)", whiteSpace: "nowrap" }}>{children}</span>
+      {meta && <span style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--everymen-muted)", whiteSpace: "nowrap" }}>{meta}</span>}
+      <span style={{ flex: 1, height: 2, background: "repeating-linear-gradient(90deg, var(--everymen-red) 0 12px, var(--everymen-gold) 12px 20px)", opacity: 0.5 }} />
+    </div>
+  );
+}
+
+function PraxisForm({ faction = "THE EVERYMEN", reportNo = "0040", task }) {
+  const { EM_CogMark, EM_Halftone, EM_Sunburst } = window;
+  const [mode, setMode] = React.useState("solo");
+  const [job, setJob] = React.useState("");
+  const [report, setReport] = React.useState("");
+  const [filed, setFiled] = React.useState(false);
+
+  const MODES = [
+    { id: "solo", name: "SOLO", sub: "one pair of hands" },
+    { id: "collab", name: "COLLAB", sub: "all hands" },
+    { id: "duel", name: "DUEL", sub: "head to head" },
+  ];
+  const words = report.trim() ? report.trim().split(/\s+/).length : 0;
+
+  const ink = "var(--everymen-ink)";
+  return (
+    <div style={{ fontFamily: "var(--font-body)", color: "var(--everymen-paper-text)" }}>
+
+      {/* masthead ribbon */}
+      <div style={{ position: "relative", display: "inline-flex", alignItems: "center", gap: 10,
+        background: "var(--everymen-red)", color: "var(--everymen-cream)", padding: "8px 18px 8px 16px",
+        boxShadow: "5px 5px 0 var(--everymen-ink)" }}>
+        <EM_CogMark size={17} color="var(--everymen-cream)" />
+        <span style={{ fontFamily: "var(--font-accent)", fontSize: 18, letterSpacing: "0.16em", whiteSpace: "nowrap" }}>{faction} · WORK REPORT {reportNo}</span>
+      </div>
+
+      {/* big title */}
+      <div style={{ fontFamily: "var(--font-accent)", fontSize: 58, lineHeight: 0.9, letterSpacing: "0.02em",
+        color: "var(--everymen-paper-text)", margin: "16px 0 4px" }}>EDIT PRAXIS</div>
+      <div style={{ height: 4, width: 180, background: "repeating-linear-gradient(90deg, var(--everymen-red) 0 16px, var(--everymen-gold) 16px 26px)", marginBottom: 24 }} />
+
+      {/* job reference slip */}
+      <div style={{ position: "relative", overflow: "hidden", border: "1.5px solid " + ink, background: "var(--everymen-paper)", marginBottom: 30, display: "flex" }}>
+        <div style={{ width: 8, background: "var(--everymen-red)", flexShrink: 0,
+          backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, color-mix(in srgb, var(--everymen-cream) 55%, transparent) 13px 15px)" }} />
+        <div style={{ position: "relative", flex: 1, padding: "15px 18px" }}>
+          <EM_Halftone opacity={0.05} />
+          <div style={{ position: "relative", zIndex: 2 }}>
+            <div style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--everymen-muted)", marginBottom: 4 }}>Re: completion of</div>
+            <div style={{ fontFamily: "var(--font-accent)", fontSize: 30, lineHeight: 0.96, color: "var(--everymen-paper-text)" }}>{task.title}</div>
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 8 }}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--everymen-red)", fontWeight: 700 }}>
+                <EM_CogMark size={12} color="var(--everymen-red)" /> Everymen
+              </span>
+              <span style={{ fontFamily: "var(--font-accent)", fontSize: 15, color: "var(--everymen-red)" }}>{task.points} PTS</span>
+              <span style={{ background: ink, color: "var(--everymen-cream)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", padding: "2px 7px" }}>lvl {task.level}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* the crew */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel>THE CREW</FieldLabel>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
+          {MODES.map((m) => {
+            const on = mode === m.id;
+            return (
+              <button key={m.id} onClick={() => setMode(m.id)} style={{
+                position: "relative", cursor: "pointer", textAlign: "left", padding: "13px 15px",
+                background: on ? "var(--everymen-red)" : "var(--everymen-paper)",
+                color: on ? "var(--everymen-cream)" : "var(--everymen-paper-text)",
+                border: "2px solid " + ink, fontFamily: "var(--font-body)",
+                boxShadow: on ? "4px 4px 0 " + ink : "none", transform: on ? "translate(-1px,-1px)" : "none", transition: "all 110ms",
+              }}>
+                <div style={{ fontFamily: "var(--font-accent)", fontSize: 24, lineHeight: 1, letterSpacing: "0.04em" }}>{m.name}</div>
+                <div style={{ fontSize: 9.5, letterSpacing: "0.04em", marginTop: 3, opacity: on ? 0.9 : 0.7 }}>{m.sub}</div>
+                {on && <div style={{ position: "absolute", top: 8, right: 9, width: 9, height: 9, borderRadius: "50%", background: "var(--everymen-gold)", boxShadow: "0 0 0 2px " + ink }} />}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* the job (headline) */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel meta={`${job.length}/200`}>THE JOB</FieldLabel>
+        <input value={job} onChange={(e) => setJob(e.target.value.slice(0, 200))} placeholder="name the work in one line"
+          style={{ width: "100%", border: "none", borderBottom: "2px solid " + ink, background: "transparent",
+            fontFamily: "var(--font-accent)", fontSize: 26, letterSpacing: "0.01em", color: "var(--everymen-paper-text)",
+            padding: "4px 2px 8px", outline: "none" }} />
+      </div>
+
+      {/* the report (body) */}
+      <div style={{ marginBottom: 28 }}>
+        <FieldLabel meta={`${words} words · markdown ok`}>THE REPORT</FieldLabel>
+        <textarea value={report} onChange={(e) => setReport(e.target.value)} placeholder="Clocked in at…"
+          rows={9} style={{ width: "100%", resize: "vertical", border: "1.5px solid " + ink, background: "var(--everymen-paper)",
+            fontFamily: "var(--font-body)", fontSize: 13, lineHeight: 1.6, color: "var(--everymen-paper-text)",
+            padding: "13px 15px", outline: "none" }} />
+      </div>
+
+      {/* proof of work */}
+      <div style={{ marginBottom: 30 }}>
+        <FieldLabel meta="0 pinned">PROOF OF WORK</FieldLabel>
+        <button style={{ display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer",
+          border: "2px dashed " + ink, background: "transparent", color: "var(--everymen-paper-text)",
+          fontFamily: "var(--font-body)", fontSize: 11, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", padding: "11px 18px" }}>
+          <span style={{ fontFamily: "var(--font-accent)", fontSize: 18, color: "var(--everymen-red)", lineHeight: 0.6 }}>+</span> Pin Proof
+        </button>
+        <div style={{ fontSize: 10, fontStyle: "italic", color: "var(--everymen-muted)", marginTop: 9 }}>images · video · audio · max 50mb each</div>
+      </div>
+
+      {/* file bar */}
+      <div style={{ borderTop: "1px solid color-mix(in srgb, " + "var(--everymen-paper-text)" + " 22%, transparent)", paddingTop: 22,
+        display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+        <button onClick={() => setFiled(true)} style={{ cursor: "pointer", border: "2px solid " + ink,
+          background: filed ? "var(--everymen-olive)" : "var(--everymen-red)", color: "var(--everymen-cream)",
+          fontFamily: "var(--font-accent)", fontSize: 26, letterSpacing: "0.1em", padding: "12px 30px", whiteSpace: "nowrap",
+          boxShadow: "5px 5px 0 " + ink, transition: "background 150ms" }}>
+          {filed ? "✓ FILED AT THE HALL" : "★ STAMP & FILE ★"}
+        </button>
+        <button style={{ cursor: "pointer", border: "2px solid " + ink, background: "transparent",
+          color: "var(--everymen-paper-text)", fontFamily: "var(--font-body)", fontSize: 12, fontWeight: 700,
+          letterSpacing: "0.12em", textTransform: "uppercase", padding: "13px 20px" }}>Save Draft</button>
+        <span style={{ fontSize: 11, fontStyle: "italic", color: "var(--everymen-muted)", marginLeft: "auto" }}>
+          {filed ? "↳ filed · awaiting the crew's marks" : "↳ not yet filed"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { PraxisForm });

--- a/docs/design/praxis-read/factions/everymen/everymen.css
+++ b/docs/design/praxis-read/factions/everymen/everymen.css
@@ -1,0 +1,103 @@
+/* ══════════════════════════════════════════════════════════════
+   THE EVERYMEN — proposed 8th World Zero faction
+   Archetype: union rally / WW2 victory poster. Claims the rainbow's
+   missing RED. Slots into the same --faction-*-card-{bg,text,accent,
+   muted,font} contract the other seven factions use.
+
+   TOKEN MODEL (so light + dark both stay legible):
+   · CONSTANTS keep their role in both themes — cream/gold are always
+     light-ish, ink is always a dark press color.
+   · PAPER surface + its text FLIP: paper darkens in dark mode and its
+     text flips ink→cream, exactly like the DS's other paper factions.
+   · ACCENT red stays vivid in both modes (spines, stamps, accent text).
+   · FIELD is the Mobilize poster background — bright red in light,
+     deep oxblood in dark so it sits on a near-black page.
+   ══════════════════════════════════════════════════════════════ */
+:root {
+  /* ── Faction primary (the missing red) ── */
+  --faction-everymen: #c1272d;
+  --faction-everymen-light: rgba(193, 39, 45, 0.1);
+  --faction-everymen-border: rgba(193, 39, 45, 0.35);
+
+  /* ── Constants (consistent role in both themes) ── */
+  --everymen-cream: #f4ecd6;       /* light stock / text-on-dark */
+  --everymen-gold: #d99a2b;        /* mustard / ochre */
+  --everymen-gold-deep: #a9741a;
+  --everymen-olive: #5b6238;       /* olive drab */
+  --everymen-ink: #221a12;         /* dark press ink — STAYS dark */
+
+  /* ── Accent — vivid propaganda red in BOTH modes ── */
+  --everymen-red: #c1272d;
+  --everymen-red-deep: #8d1c20;
+
+  /* ── Paper card surface + its text (these FLIP in dark) ── */
+  --everymen-paper: #ece1c6;       /* manila poster stock */
+  --everymen-paper-deep: #ddceac;  /* shadowed panel */
+  --everymen-paper-text: #221a12;  /* primary text on paper */
+  --everymen-muted: #6c5a40;       /* faded caption ink */
+
+  /* ── Mobilize poster FIELD (deep oxblood in dark) ── */
+  --everymen-field: #c1272d;
+  --everymen-field-deep: #8d1c20;
+
+  /* ── Card contract (mirrors the other factions) ── */
+  --faction-everymen-card-bg: var(--everymen-paper);
+  --faction-everymen-card-text: var(--everymen-paper-text);
+  --faction-everymen-card-accent: var(--everymen-red);
+  --faction-everymen-card-muted: var(--everymen-muted);
+  --faction-everymen-card-font: var(--font-accent); /* Bebas Neue */
+}
+
+[data-theme="dark"] {
+  --faction-everymen: #ef5350;
+
+  --everymen-cream: #f3e7ce;       /* stays light */
+  --everymen-gold: #e7b94f;        /* brightened ochre */
+  --everymen-gold-deep: #b3852a;
+  --everymen-olive: #8a955a;
+  --everymen-ink: #0d0907;         /* dark element ink — stays dark */
+
+  --everymen-red: #e2433f;         /* accent brightens for dark surfaces */
+  --everymen-red-deep: #b32a28;
+
+  --everymen-paper: #221a16;       /* dark manila — reads as a surface on #13121a */
+  --everymen-paper-deep: #17110d;
+  --everymen-paper-text: #f3e7ce;  /* text FLIPS to cream */
+  --everymen-muted: #b6a079;
+
+  --everymen-field: #3c1416;       /* poster field → deep oxblood */
+  --everymen-field-deep: #5a1d20;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   EVERYMEN POSTER-WALL BACKDROP
+   A faction-flavored page background: warm manila stock, a faint
+   propaganda sunburst from above, screen-print halftone, a burlap
+   crosshatch weave, and gold / olive light bleeding in from the
+   corners. Replaces the neutral rainbow watercolor on faction-context
+   pages. Fully theme-aware — darkens to a moody oxblood-brown wall.
+   Render once as <div class="em-backdrop"></div>, fixed behind content.
+   ══════════════════════════════════════════════════════════════ */
+.em-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: var(--everymen-paper);
+  background-image:
+    radial-gradient(42% 32% at 100% 0%, color-mix(in srgb, var(--everymen-gold) 16%, transparent), transparent 70%),
+    radial-gradient(46% 38% at 0% 100%, color-mix(in srgb, var(--everymen-olive) 13%, transparent), transparent 70%),
+    repeating-conic-gradient(from 0deg at 50% -6%, color-mix(in srgb, var(--everymen-red) 6%, transparent) 0 5deg, transparent 5deg 11deg),
+    radial-gradient(color-mix(in srgb, var(--everymen-paper-text) 6%, transparent) 0.6px, transparent 0.9px),
+    repeating-linear-gradient(45deg, color-mix(in srgb, var(--everymen-paper-text) 3.5%, transparent) 0 1px, transparent 1px 5px),
+    repeating-linear-gradient(-45deg, color-mix(in srgb, var(--everymen-paper-text) 3%, transparent) 0 1px, transparent 1px 5px),
+    linear-gradient(180deg, var(--everymen-paper), var(--everymen-paper-deep));
+  background-size: 100% 100%, 100% 100%, 100% 100%, 6px 6px, auto, auto, 100% 100%;
+}
+/* a soft vignette so the rays settle toward the edges */
+.em-backdrop::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 90% at 50% 8%, transparent 40%, color-mix(in srgb, var(--everymen-paper-deep) 55%, transparent));
+}

--- a/docs/design/praxis-read/factions/praxis-core.jsx
+++ b/docs/design/praxis-read/factions/praxis-core.jsx
@@ -1,0 +1,270 @@
+/* ════════════════════════════════════════════════════════════════
+   ADR-0005 (revised) · Praxis points & votes — shared core
+   MODEL: a praxis earns POINTS (scarce — specific people spend them
+   on you) and VOTES (free endorsements — a headcount). No average,
+   no histogram. The card shows the points+votes pairing; the read
+   page itemizes WHO gave points (the backer ledger).
+   ════════════════════════════════════════════════════════════════ */
+
+const ROMAN = ["I", "II", "III", "IV", "V"];
+const sumPts = (b) => b.reduce((a, x) => a + x.pts, 0);
+
+/* ── the six factions ─────────────────────────────────────────────
+   tokens + fonts + archetype + faction-voiced words for points/votes,
+   plus one sample completed praxis carrying its backer ledger.
+   pointFill / voteFill are single accent colors (no ramp anymore).
+   ──────────────────────────────────────────────────────────────── */
+const FACTIONS = [
+  {
+    slug: "ua", name: "UA", hue: "var(--faction-ua)", archetype: "sticky note",
+    glyph: "dot", display: "var(--font-faction-old)", body: "var(--font-body)",
+    surfaceBg: "var(--faction-ua-card-bg)", surfaceText: "var(--faction-ua-card-text)",
+    muted: "var(--faction-ua-card-muted)", accent: "var(--faction-ua-card-accent)",
+    pointFill: "var(--vote-5)", voteFill: "var(--faction-ua-card-accent)",
+    pointWord: "points", voteWord: "votes", giveVerb: "Back this praxis",
+    p: {
+      task: "Trash Transformation", finding: "Made a Lamp From a Milk Crate", author: "Pip",
+      excerpt: "Wired a thrown-out crate and a dead bulb into a reading lamp. It works.",
+      points: 5, votes: 45, grade: "lvl 1", mode: "filed alone", sealed: "Apr 22, 2026",
+      backers: [
+        { name: "Marisol", pts: 2 }, { name: "Dez", pts: 2 }, { name: "Bex", pts: 1 },
+      ],
+    },
+  },
+  {
+    slug: "gestalt", name: "Gestalt", hue: "var(--faction-gestalt)", archetype: "gestalt.exe window",
+    glyph: "heart", display: "var(--font-faction-script)", body: "var(--font-body)",
+    surfaceBg: "var(--gestalt-card-bg)", surfaceText: "var(--gestalt-ink)",
+    muted: "var(--gestalt-label)", accent: "var(--gestalt-pink-deep)",
+    pointFill: "var(--gestalt-pink-deep)", voteFill: "var(--gestalt-pink)",
+    pointWord: "points", voteWord: "hearts", giveVerb: "Send points",
+    p: {
+      task: "The L Word", finding: "I Told My Landlord", author: "Pixie",
+      excerpt: "Knocked on 4B, said it out loud, ran away. Heart still pounding.",
+      points: 6, votes: 88, grade: "lvl 1", mode: "filed solo", sealed: "Apr 20, 2026",
+      backers: [
+        { name: "B4ndit", pts: 3 }, { name: "m0th", pts: 2 }, { name: "Sprite", pts: 1 },
+      ],
+    },
+  },
+  {
+    slug: "snide", name: "S.N.I.D.E.", hue: "var(--faction-snide)", archetype: "closed-case file",
+    glyph: "stamp", dark: true, display: "var(--font-faction-anton)", body: "var(--font-faction-typewriter)",
+    surfaceBg: "var(--snide-ink)", surfaceText: "#efe9d6",
+    muted: "#b7b5a7", accent: "var(--snide-acid)",
+    pointFill: "var(--snide-acid)", voteFill: "var(--snide-pink)",
+    pointWord: "pts", voteWord: "marks", giveVerb: "Spend points",
+    p: {
+      task: "DO A KICKFLIP", finding: "Landed It. No Board.", author: "Static",
+      excerpt: "Did the kickflip motion mid-air off a curb. Nobody asked. Double points.",
+      points: 25, votes: 31, grade: "lvl 2", mode: "solo job", sealed: "Apr 19, 2026",
+      backers: [
+        { name: "Hex", pts: 10 }, { name: "Razz", pts: 8 }, { name: "Crud", pts: 5 }, { name: "Vandal", pts: 2 },
+      ],
+    },
+  },
+  {
+    slug: "ephemerists", name: "The Ephemerists", hue: "var(--faction-ephemerists)", archetype: "sealed ephemeris leaf",
+    glyph: "seal", display: "var(--font-faction-engraved)", body: "var(--font-faction-codex)",
+    surfaceBg: "var(--eph-vellum)", surfaceText: "var(--eph-vellum-text)",
+    muted: "var(--eph-muted)", accent: "var(--eph-rubric)",
+    pointFill: "var(--eph-rubric)", voteFill: "var(--eph-lapis)",
+    pointWord: "pvncta", voteWord: "marks", giveVerb: "Endow pvncta",
+    p: {
+      task: "Trace a Myth", finding: "The Saint Was a Surveyor", author: "Vesper",
+      excerpt: "Followed the legend back through eleven retellings until the road ran out.",
+      points: 100, votes: 38, grade: "grade IV", mode: "filed alone", sealed: "Apr 21, 2026",
+      backers: [
+        { name: "Aldous", pts: 40 }, { name: "Mirth", pts: 30 }, { name: "Quill", pts: 20 }, { name: "Bede", pts: 10 },
+      ],
+    },
+  },
+  {
+    slug: "singularity", name: "Singularity", hue: "var(--faction-singularity)", archetype: "terminal printout",
+    glyph: "signal", dark: true, display: "var(--font-faction-terminal)", body: "var(--font-faction-terminal)",
+    surfaceBg: "#050f08", surfaceText: "#4ade80", muted: "#60a5fa", accent: "#86efac",
+    pointFill: "#fbbf24", voteFill: "#4ade80",
+    pointWord: "CR", voteWord: "signals", giveVerb: "Allocate CR",
+    p: {
+      task: "Map a Non-Human Pattern", finding: "The Signal Was Always There", author: "NODE_Vesper",
+      excerpt: "Non-random signal confirmed at 12.7σ — non-biological origin.",
+      points: 200, votes: 44, grade: "priority 0x04", mode: "SOLO", sealed: "2026.04.21",
+      backers: [
+        { name: "NODE_Kell", pts: 80 }, { name: "NODE_Ash", pts: 60 }, { name: "NODE_Bo", pts: 40 }, { name: "NODE_Wynn", pts: 20 },
+      ],
+    },
+  },
+  {
+    slug: "everymen", name: "The Everymen", hue: "var(--faction-everymen)", archetype: "union work report",
+    glyph: "star", display: "var(--font-faction-poster)", body: "var(--font-body)",
+    surfaceBg: "var(--everymen-paper)", surfaceText: "var(--everymen-paper-text)",
+    muted: "var(--everymen-muted)", accent: "var(--everymen-red)",
+    pointFill: "var(--everymen-red)", voteFill: "var(--everymen-gold-deep)",
+    pointWord: "points", voteWord: "marks", giveVerb: "Pledge points",
+    p: {
+      task: "Pick Up the Load", finding: "Carried the Tran's Groceries", author: "Rivet",
+      excerpt: "Took the heavy bags up four flights. Stayed for tea. Worth more than points.",
+      points: 25, votes: 52, grade: "lvl 2", mode: "COLLAB", sealed: "Apr 18, 2026",
+      backers: [
+        { name: "Birta", pts: 10 }, { name: "Cobb", pts: 8 }, { name: "Vesna", pts: 5 }, { name: "Tuck", pts: 2 },
+      ],
+    },
+  },
+  {
+    slug: "albescent", name: "Albescent", hue: "rgba(28,28,26,0.45)", archetype: "vellum correspondence",
+    silent: true, italic: true, numWeight: 300,
+    glyph: "mark", display: '"Cormorant Garamond", Georgia, serif', body: '"Courier Prime", monospace',
+    surfaceBg: "#ffffff", surfaceText: "#1c1c1a", muted: "rgba(28,28,26,0.42)", accent: "rgba(28,28,26,0.72)",
+    pointFill: "rgba(28,28,26,0.74)", voteFill: "rgba(28,28,26,0.5)",
+    pointWord: "credits", voteWord: "witnesses", giveVerb: "Credit this account",
+    backerWord: "keepers", voteBtn: "Witness",
+    p: {
+      refNo: "XIV", task: "Tend the Archive in Silence", keeper: "Keeper Vane", house: "Third House",
+      output: "All volumes restored. The shelves hold their sequence without my name in them.",
+      status: "witnessed", sealed: "2026.04.21 · dawn", mode: "filed in silence", grade: "Third House",
+      points: 40, votes: 31,
+      backers: [
+        { name: "Keeper Vane", pts: 18 }, { name: "Keeper Orin", pts: 14 }, { name: "Keeper Marsh", pts: 8 },
+      ],
+    },
+  },
+];
+
+/* ════════════════════════════════════════════════════════════════
+   GLYPHS — one per faction, used as the vote icon + backer markers
+   ════════════════════════════════════════════════════════════════ */
+function Glyph({ kind, fill, size = 16, tier = 5 }) {
+  switch (kind) {
+    case "heart":
+      return (
+        <svg width={size} height={size} viewBox="0 0 36 36" style={{ display: "block" }}>
+          <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z" fill={fill} stroke="#fff" strokeWidth="2.2" strokeLinejoin="round" />
+        </svg>
+      );
+    case "star":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" style={{ display: "block" }}>
+          <path d="M12 1.5l2.9 6.6 7.1.6-5.4 4.7 1.7 7-6.3-3.8-6.3 3.8 1.7-7L2 8.7l7.1-.6z" fill={fill} stroke="var(--everymen-ink)" strokeWidth="1.2" strokeLinejoin="round" />
+        </svg>
+      );
+    case "stamp":
+      return (
+        <span style={{ width: size, height: size, display: "flex", alignItems: "center", justifyContent: "center", background: fill, color: "var(--snide-ink)", fontFamily: "var(--font-faction-black)", fontSize: size * 0.6, transform: `rotate(${tier % 2 ? 4 : -4}deg)` }}>✓</span>
+      );
+    case "seal":
+      return (
+        <span style={{ width: size, height: size, borderRadius: "50%", display: "flex", alignItems: "center", justifyContent: "center", background: fill, color: "var(--eph-parchment)", fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: size * 0.46, position: "relative" }}>
+          <span style={{ position: "absolute", inset: 2, borderRadius: "50%", border: "1px dashed rgba(255,255,255,0.4)", opacity: 0.6 }} />
+          {ROMAN[Math.min(4, tier - 1)]}
+        </span>
+      );
+    case "signal":
+      return (
+        <span style={{ display: "flex", alignItems: "flex-end", gap: 1.5, height: size, width: size }}>
+          {[0, 1, 2].map((b) => <span key={b} style={{ flex: 1, height: `${40 + b * 30}%`, background: fill }} />)}
+        </span>
+      );
+    case "mark": {
+      const s = size, c = s / 2;
+      return (
+        <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} fill="none" style={{ display: "block", flexShrink: 0 }}>
+          <circle cx={c} cy={c} r={s * 0.43} stroke={fill} strokeWidth={s * 0.022} opacity={0.3} />
+          <circle cx={c} cy={c} r={s * 0.235} stroke={fill} strokeWidth={s * 0.05} opacity={0.7} />
+          {[0, 90, 180, 270].map((deg) => {
+            const a = (deg * Math.PI) / 180, t0 = s * 0.26, t1 = s * 0.39;
+            return <line key={deg} x1={c + t0 * Math.cos(a)} y1={c + t0 * Math.sin(a)} x2={c + t1 * Math.cos(a)} y2={c + t1 * Math.sin(a)} stroke={fill} strokeWidth={s * 0.05} />;
+          })}
+          <circle cx={c} cy={c} r={s * 0.05} fill={fill} />
+        </svg>
+      );
+    }
+    case "dot":
+    default:
+      return <span style={{ width: size * 0.7, height: size * 0.7, borderRadius: "50%", background: fill, display: "block" }} />;
+  }
+}
+
+/* round monogram avatar for ledger rows */
+function Avatar({ name, fill, dark }) {
+  const parts = name.replace(/^NODE_/, "").split(/[ _]+/).filter(Boolean);
+  const initials = parts.length > 1 ? (parts[0][0] + parts[1][0]) : parts[0].slice(0, 2);
+  return (
+    <span style={{
+      width: 26, height: 26, borderRadius: "50%", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center",
+      background: `color-mix(in srgb, ${fill} 22%, ${dark ? "#000" : "#fff"})`, color: fill,
+      border: `1.5px solid ${fill}`, fontFamily: "var(--font-body)", fontWeight: 700, fontSize: 10, letterSpacing: "0.02em",
+    }}>{initials}</span>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   PAGE BLOCK — points & votes on the read page.
+   Two headline stats (POINTS · VOTES), then the BACKER LEDGER
+   (who gave points — the thing the user wants), then a lightweight
+   "give points" control. No average. No histogram.
+   ════════════════════════════════════════════════════════════════ */
+function PagePointsBlock({ f }) {
+  const p = f.p, total = sumPts(p.backers), maxB = Math.max(1, ...p.backers.map((b) => b.pts));
+  const line = f.dark ? "rgba(255,255,255,0.14)" : "var(--color-border-strong)";
+  const lineSoft = f.dark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.12)";
+  return (
+    <div style={{ background: f.surfaceBg, color: f.surfaceText, border: `1px solid ${line}`, padding: "18px 18px 20px", fontFamily: f.body, position: "relative", overflow: "hidden" }}>
+      {f.glyph === "signal" && <div style={{ position: "absolute", inset: 0, backgroundImage: "repeating-linear-gradient(to bottom, transparent 0 3px, rgba(74,222,128,0.02) 3px 4px)", pointerEvents: "none" }} />}
+      <div style={{ position: "relative" }}>
+        {/* two headline stats */}
+        <div style={{ display: "flex", gap: 0, marginBottom: 18 }}>
+          <div style={{ flex: 1, paddingRight: 16 }}>
+            <div style={{ fontFamily: f.display, fontWeight: f.numWeight || 800, fontStyle: f.italic ? "italic" : "normal", fontSize: 44, lineHeight: 0.85, color: f.pointFill }}>{p.points}</div>
+            <div style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.16em", textTransform: "uppercase", color: f.muted, marginTop: 6 }}>{p.pointWord} earned</div>
+          </div>
+          <div style={{ flex: 1, paddingLeft: 16, borderLeft: `1px solid ${lineSoft}` }}>
+            <div style={{ fontFamily: f.display, fontWeight: f.numWeight || 800, fontStyle: f.italic ? "italic" : "normal", fontSize: 44, lineHeight: 0.85, color: f.surfaceText, display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ color: f.voteFill, display: "flex" }}><Glyph kind={f.glyph} fill={f.voteFill} size={22} /></span>{p.votes}
+            </div>
+            <div style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.16em", textTransform: "uppercase", color: f.muted, marginTop: 6 }}>{p.voteWord}</div>
+          </div>
+        </div>
+
+        {/* THE BACKER LEDGER */}
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.16em", textTransform: "uppercase", color: f.muted, marginBottom: 11, paddingTop: 14, borderTop: `1px dashed ${line}` }}>
+          {p.pointWord} awarded by
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 9, marginBottom: 6 }}>
+          {p.backers.map((b) => (
+            <div key={b.name} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <Avatar name={b.name} fill={f.pointFill} dark={f.dark} />
+              <span style={{ fontFamily: f.body, fontSize: 11.5, color: f.surfaceText, width: 96, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{b.name}</span>
+              <div style={{ flex: 1, height: 9, background: f.dark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.06)", position: "relative" }}>
+                <div style={{ position: "absolute", inset: 0, width: `${(b.pts / maxB) * 100}%`, background: f.pointFill, opacity: 0.9 }} />
+              </div>
+              <span style={{ fontFamily: f.display, fontWeight: 700, fontSize: 14, color: f.pointFill, width: 52, textAlign: "right", whiteSpace: "nowrap" }}>+{b.pts} <span style={{ fontFamily: "var(--font-body)", fontWeight: 400, fontSize: 8, color: f.muted }}>{f.pointWord === "pvncta" || f.pointWord === "CR" ? f.pointWord : "pts"}</span></span>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", padding: "9px 0 0", marginTop: 4, borderTop: `1px solid ${lineSoft}` }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.14em", textTransform: "uppercase", color: f.muted }}>{p.backers.length} {f.backerWord || "backers"} · total</span>
+          <span style={{ fontFamily: f.display, fontWeight: f.numWeight || 800, fontStyle: f.italic ? "italic" : "normal", fontSize: 18, color: f.pointFill }}>{total} {f.pointWord}</span>
+        </div>
+
+        {/* give-points control */}
+        <div style={{ marginTop: 16, paddingTop: 14, borderTop: `1px dashed ${line}`, display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.14em", textTransform: "uppercase", color: f.muted }}>{f.giveVerb}</span>
+          <div style={{ display: "flex", alignItems: "center", border: `1.5px solid ${f.pointFill}`, marginLeft: "auto" }}>
+            <button type="button" style={{ width: 26, height: 26, border: "none", background: "transparent", color: f.pointFill, fontFamily: f.display, fontSize: 16, cursor: "pointer", lineHeight: 1 }}>−</button>
+            <span style={{ minWidth: 30, textAlign: "center", fontFamily: f.display, fontWeight: 700, fontSize: 14, color: f.surfaceText }}>1</span>
+            <button type="button" style={{ width: 26, height: 26, border: "none", background: "transparent", color: f.pointFill, fontFamily: f.display, fontSize: 16, cursor: "pointer", lineHeight: 1 }}>+</button>
+          </div>
+          <button type="button" style={{ height: 28, padding: "0 14px", border: "none", background: f.pointFill, color: f.dark ? "#0a0a0a" : "#fff", fontFamily: "var(--font-body)", fontSize: 9.5, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", cursor: "pointer" }}>Give</button>
+          <button type="button" style={{ height: 28, padding: "0 12px", border: `1.5px solid ${f.voteFill}`, background: "transparent", color: f.voteFill, fontFamily: "var(--font-body)", fontSize: 9.5, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 6 }}>
+            <Glyph kind={f.glyph} fill={f.voteFill} size={13} /> {f.voteBtn || "Vote"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  WZ_FACTIONS: FACTIONS, WZ_sumPts: sumPts, WZ_Glyph: Glyph, WZ_Avatar: Avatar,
+  WZ_PagePointsBlock: PagePointsBlock,
+});

--- a/docs/design/praxis-read/factions/singularity/Singularity Completed Praxis.html
+++ b/docs/design/praxis-read/factions/singularity/Singularity Completed Praxis.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Sealed Praxis · Singularity</title>
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css" />
+<link rel="stylesheet" href="singularity.css" />
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background: #07090c;
+    color: var(--sg-phosphor);
+    font-family: var(--sg-mono);
+    min-height: 100vh;
+  }
+  a { color: inherit; text-decoration: none; }
+
+  /* ── nav ── */
+  .nav {
+    position: relative; z-index: 10;
+    display: flex; align-items: center; gap: 28px; padding: 14px 32px;
+    background: rgba(5,15,8,0.92);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--sg-border);
+  }
+  .wordmark {
+    font-family: var(--font-display); font-style: italic; font-weight: 500;
+    font-size: 24px; line-height: 1; color: var(--sg-phosphor);
+    border-bottom: 3px solid; padding-bottom: 2px;
+    border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1;
+  }
+  .nav-links { display: flex; gap: 20px; flex: 1; }
+  .nav-links a {
+    font-family: var(--sg-mono); font-size: 10px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: rgba(96,165,250,0.45); padding-bottom: 3px;
+  }
+  .nav-links a.active {
+    color: var(--sg-phosphor); border-bottom: 1px solid var(--sg-phosphor);
+  }
+  .nav-links a:hover { color: rgba(74,222,128,0.75); }
+  .nav-ctl {
+    display: flex; align-items: center; gap: 14px;
+    font-family: var(--sg-mono); font-size: 10px;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    color: rgba(96,165,250,0.45);
+  }
+  .nav-box {
+    border: 1px solid var(--sg-border); padding: 5px 11px;
+    color: var(--sg-phosphor);
+  }
+
+  /* ── breadcrumb ── */
+  .crumbs {
+    position: relative; z-index: 5;
+    max-width: 1160px; margin: 0 auto; padding: 18px 32px 0;
+    font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase;
+    color: rgba(96,165,250,0.35);
+  }
+  .crumbs a:hover { color: var(--sg-phosphor); }
+  .crumbs .active { color: var(--sg-signal-bright); }
+
+  /* ── page grid ── */
+  .page {
+    position: relative; z-index: 5;
+    max-width: 1160px; margin: 0 auto;
+    padding: 16px 32px 90px;
+    display: grid;
+    grid-template-columns: 1fr 348px;
+    gap: 28px;
+    align-items: start;
+  }
+  @media (max-width: 960px) { .page { grid-template-columns: 1fr; } }
+
+  /* ── main terminal sheet ── */
+  .sheet {
+    position: relative;
+    background: var(--sg-void);
+    border: 1px solid var(--sg-border-hard);
+    box-shadow:
+      0 0 0 1px rgba(37,99,235,0.1),
+      0 24px 60px -28px rgba(0,0,0,0.85),
+      0 0 40px -20px rgba(74,222,128,0.05);
+    overflow: hidden;
+  }
+  .sheet::before {
+    content: "";
+    position: absolute; inset: 6px;
+    border: 1px solid rgba(37,99,235,0.1);
+    pointer-events: none; z-index: 1;
+  }
+
+  /* ── sidebar ── */
+  .rail {
+    position: sticky; top: 20px;
+    display: flex; flex-direction: column; gap: 16px;
+  }
+  @media (max-width: 960px) { .rail { position: static; } }
+</style>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="singularity-cards.jsx"></script>
+<script type="text/babel" src="singularity-praxis.jsx"></script>
+<script type="text/babel" src="../praxis-core.jsx"></script>
+</head>
+<body>
+
+<div class="sg-backdrop"></div>
+
+<!-- nav -->
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a>
+    <a href="#">Tasks</a>
+    <a href="Singularity Praxis Index.html" class="active">Praxis</a>
+    <a href="#">Players</a>
+    <a href="#">Factions</a>
+    <a href="#">Updates</a>
+    <a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Mod</span>
+    <span id="node-id">NODE_Vesper</span>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+
+<!-- breadcrumb -->
+<div class="crumbs">
+  <a href="#">Factions</a>
+  &nbsp;/&nbsp;
+  <a href="Singularity Praxis Index.html">The Praxes</a>
+  &nbsp;/&nbsp;
+  <span class="active" id="crumb-output">…</span>
+</div>
+
+<!-- page -->
+<div class="page">
+  <!-- main sheet -->
+  <div class="sheet">
+    <div id="read"></div>
+  </div>
+
+  <!-- sidebar rail -->
+  <aside class="rail">
+    <div id="ledger"></div>
+
+    <a class="sg-back" href="../../All%20Faction%20Praxis%20Pages.dc.html">← all praxis pages</a>
+  </aside>
+</div>
+
+<script type="text/babel">
+  const { PraxisRead, SG_PRAXES, WZ_FACTIONS, WZ_PagePointsBlock } = window;
+
+  // resolve praxis from URL hash (#signal-origin-7) or default to first
+  const rawId = decodeURIComponent((location.hash || "").replace(/^#/, ""));
+  const praxis = SG_PRAXES.find(p => p.id === rawId) || SG_PRAXES[0];
+
+  // populate dynamic text
+  document.getElementById("crumb-output").textContent = praxis.output;
+
+  // mount
+  ReactDOM.createRoot(document.getElementById("read")).render(
+    <PraxisRead p={praxis} />
+  );
+  const sgF = WZ_FACTIONS.find((f) => f.slug === "singularity");
+  ReactDOM.createRoot(document.getElementById("ledger")).render(
+    <WZ_PagePointsBlock f={sgF} />
+  );
+
+  // hash navigation reloads to show a different praxis
+  window.addEventListener("hashchange", () => location.reload());
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/singularity/singularity-cards.jsx
+++ b/docs/design/praxis-read/factions/singularity/singularity-cards.jsx
@@ -1,0 +1,394 @@
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY — Atoms + Task Card
+   Shared visual vocabulary exposed on window for all Singularity
+   surfaces. The task card archetype: TERMINAL PRINTOUT — sprocket
+   holes, scanlines, corner brackets, blinking cursor, waveform.
+
+   Atoms exported: SingularityMark, Waveform, Sprockets, Scanlines,
+   Corners, CircuitTrace, AsciiBar, FileArtifact, SgDivider.
+   Task card exported: SingularityCard (window.SingularityCard).
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Consensus scale ── */
+const SG_CONSENSUS = [
+  { v:1, label:"NOISE",    fill:"#ef4444" },
+  { v:2, label:"WEAK",     fill:"#f97316" },
+  { v:3, label:"SIGNAL",   fill:"#fbbf24" },
+  { v:4, label:"CLEAR",    fill:"#60a5fa" },
+  { v:5, label:"VERIFIED", fill:"#4ade80" },
+];
+
+const sgDistTotal = d => d.reduce((a,b)=>a+b,0);
+const sgDistAvg   = d => { const t=sgDistTotal(d); return t?d.reduce((a,c,i)=>a+c*(i+1),0)/t:0; };
+const sgStanding  = avg => SG_CONSENSUS[Math.max(0,Math.min(4,Math.round(avg)-1))];
+
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY MARK — broadcasting node sigil
+   Core circle · 8 radial traces · 2 concentric rings · cardinal vias
+   ════════════════════════════════════════════════════════════════ */
+function SingularityMark({ size=24, color="#4ade80", glow=false }) {
+  const c  = size/2;
+  const r0 = size*0.095;
+  const r1 = size*0.24;
+  const r2 = size*0.43;
+  const r3 = size*0.49;
+  const traces = Array.from({length:8},(_,i)=>{
+    const a=i*Math.PI/4, diag=i%2!==0;
+    return { a, diag, rEnd: diag?r2*0.82:r2 };
+  });
+  const clipId = `sg-mc-${Math.round(size*10)}`;
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}
+      fill="none" style={{display:"block",flexShrink:0}}>
+      <defs><clipPath id={clipId}><circle cx={c} cy={c} r={r3}/></clipPath></defs>
+      <g clipPath={`url(#${clipId})`}>
+        {glow&&<circle cx={c} cy={c} r={r2+5} fill="rgba(74,222,128,0.1)"/>}
+        <circle cx={c} cy={c} r={r2} stroke={color} strokeWidth={size*0.026} opacity={0.32}/>
+        <circle cx={c} cy={c} r={r1} stroke={color} strokeWidth={size*0.034} opacity={0.68}/>
+        {traces.map(({a,diag,rEnd},i)=>(
+          <line key={i}
+            x1={c+r1*Math.cos(a)} y1={c+r1*Math.sin(a)}
+            x2={c+rEnd*Math.cos(a)} y2={c+rEnd*Math.sin(a)}
+            stroke={color} strokeWidth={size*(diag?0.024:0.036)}
+            opacity={diag?0.36:0.8}/>
+        ))}
+        {[0,2,4,6].map(i=>{
+          const a=i*Math.PI/4;
+          return <circle key={`v${i}`}
+            cx={c+r2*Math.cos(a)} cy={c+r2*Math.sin(a)}
+            r={size*0.05} fill={color} opacity={0.78}/>;
+        })}
+        <circle cx={c} cy={c} r={r0+1} fill={color} opacity={0.12}/>
+        <circle cx={c} cy={c} r={r0}   fill={color} opacity={0.92}/>
+        <circle cx={c} cy={c} r={r0*0.38} fill="#050f08"/>
+      </g>
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WAVEFORM — oscilloscope signal strip SVG
+   ════════════════════════════════════════════════════════════════ */
+function Waveform({ width, height, strokeColor="rgba(74,222,128,0.68)",
+  dashColor="rgba(37,99,235,0.38)", strokeWidth=1.4 }) {
+  const pts=[];
+  for(let i=0;i<=100;i++){
+    const t=i/100, x=t*width;
+    const y=height/2
+      +Math.sin(t*8*Math.PI)*height*0.22
+      +Math.sin(t*3*Math.PI+1.1)*height*0.13
+      +Math.sin(t*23*Math.PI)*height*0.05;
+    pts.push(`${i===0?"M":"L"}${x.toFixed(1)},${y.toFixed(1)}`);
+  }
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none" style={{display:"block"}}>
+      <line x1="0" y1={height/2} x2={width} y2={height/2}
+        stroke={dashColor} strokeWidth="0.6" strokeDasharray="5 5"/>
+      <path d={pts.join(" ")} fill="none" stroke={strokeColor} strokeWidth={strokeWidth}/>
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SPROCKETS — continuous-feed paper holes
+   ════════════════════════════════════════════════════════════════ */
+function Sprockets({ n=8, style={} }) {
+  return (
+    <div style={{display:"flex",justifyContent:"space-between",
+      alignItems:"center",padding:"4px 10px",...style}}>
+      {Array.from({length:n},(_,i)=>(
+        <div key={i} style={{width:7,height:5,
+          border:"1px solid rgba(74,222,128,0.32)",borderRadius:1}}/>
+      ))}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SCANLINES — CRT phosphor overlay
+   ════════════════════════════════════════════════════════════════ */
+function Scanlines({ opacity=0.022 }) {
+  return (
+    <div style={{position:"absolute",inset:0,pointerEvents:"none",zIndex:2,
+      background:`repeating-linear-gradient(to bottom,
+        transparent,transparent 2px,
+        rgba(74,222,128,${opacity}) 2px,rgba(74,222,128,${opacity}) 4px)`}}/>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CORNERS — bracket corner marks
+   ════════════════════════════════════════════════════════════════ */
+function Corners({ color="rgba(74,222,128,0.42)", inset=4, size=12 }) {
+  const b=`1px solid ${color}`;
+  const c=(v,h)=>({position:"absolute",[v]:inset,[h]:inset,width:size,height:size,
+    [`border${v[0].toUpperCase()+v.slice(1)}`]:b,
+    [`border${h[0].toUpperCase()+h.slice(1)}`]:b,pointerEvents:"none"});
+  return(<>
+    <div style={c("top","left")}/><div style={c("top","right")}/>
+    <div style={c("bottom","left")}/><div style={c("bottom","right")}/>
+  </>);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CIRCUIT TRACE — PCB corner decoration SVG
+   ════════════════════════════════════════════════════════════════ */
+function CircuitTrace({ width=130, height=90, color="rgba(37,99,235,0.3)" }) {
+  const w=f=>f*width, h=f=>f*height, sw=0.9;
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}
+      fill="none" style={{display:"block"}}>
+      <path d={`M0 ${h(.68)} L${w(.22)} ${h(.68)} L${w(.22)} ${h(.28)} L${w(.52)} ${h(.28)}`}
+        stroke={color} strokeWidth={sw}/>
+      <path d={`M0 ${h(.38)} L${w(.12)} ${h(.38)} L${w(.12)} ${h(.08)} L${w(.62)} ${h(.08)} L${w(.62)} ${h(.38)} L${width} ${h(.38)}`}
+        stroke={color} strokeWidth={sw*.7}/>
+      <path d={`M${w(.32)} ${height} L${w(.32)} ${h(.62)} L${w(.52)} ${h(.62)} L${w(.52)} ${h(.28)}`}
+        stroke={color} strokeWidth={sw}/>
+      <path d={`M${w(.72)} ${height} L${w(.72)} ${h(.52)} L${width} ${h(.52)}`}
+        stroke={color} strokeWidth={sw*.7}/>
+      {[[w(.22),h(.28)],[w(.62),h(.08)],[w(.52),h(.28)],[w(.52),h(.62)],[w(.72),h(.52)]]
+        .map(([cx,cy],i)=><circle key={i} cx={cx} cy={cy} r={2.8} fill={color}/>)}
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ASCII BAR — terminal progress bar
+   ════════════════════════════════════════════════════════════════ */
+function AsciiBar({ value, max, width=15 }) {
+  const filled=Math.round((value/Math.max(1,max))*width);
+  return (
+    <span style={{letterSpacing:"-0.5px",fontSize:8}}>
+      {"█".repeat(filled)}{"░".repeat(width-filled)}
+    </span>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   FILE ARTIFACT — uploaded evidence card
+   Shows a file-type thumbnail area + filename + metadata.
+   kind: "image" | "video" | "audio" | "data" | "doc"
+   ════════════════════════════════════════════════════════════════ */
+const FILE_KINDS = {
+  image: { label:"IMAGE", color:"#60a5fa" },
+  video: { label:"VIDEO", color:"#f97316" },
+  audio: { label:"AUDIO", color:"#fbbf24" },
+  data:  { label:"DATA",  color:"#4ade80" },
+  doc:   { label:"DOC",   color:"#a78bfa" },
+};
+
+function FileThumbnail({ kind, width }) {
+  const h=62;
+  if(kind==="image") return (
+    <div style={{width,height:h,
+      background:"rgba(37,99,235,0.07)",
+      backgroundImage:"repeating-linear-gradient(45deg,rgba(96,165,250,0.08) 0 5px,transparent 5px 10px),repeating-linear-gradient(-45deg,rgba(96,165,250,0.08) 0 5px,transparent 5px 10px)",
+      position:"relative"}}>
+      {/* faux pixel grid */}
+      <div style={{position:"absolute",inset:0,
+        backgroundImage:"repeating-linear-gradient(90deg,rgba(96,165,250,0.05) 0 1px,transparent 1px 8px),repeating-linear-gradient(0deg,rgba(96,165,250,0.05) 0 1px,transparent 1px 8px)"}}/>
+    </div>
+  );
+  if(kind==="video") return (
+    <div style={{width,height:h,background:"rgba(249,115,22,0.06)",
+      position:"relative",overflow:"hidden"}}>
+      {/* film strip holes left/right */}
+      {[0,1].map(side=>(
+        <div key={side} style={{position:"absolute",[side?"right":"left"]:0,
+          top:0,bottom:0,width:10,background:"rgba(0,0,0,0.3)",
+          display:"flex",flexDirection:"column",justifyContent:"space-around",
+          alignItems:"center",padding:"4px 0"}}>
+          {Array.from({length:4},(_,i)=>(
+            <div key={i} style={{width:5,height:4,background:"rgba(249,115,22,0.25)",borderRadius:1}}/>
+          ))}
+        </div>
+      ))}
+      {/* center play indicator */}
+      <div style={{position:"absolute",inset:0,display:"flex",
+        alignItems:"center",justifyContent:"center"}}>
+        <div style={{width:0,height:0,
+          borderTop:"9px solid transparent",borderBottom:"9px solid transparent",
+          borderLeft:"14px solid rgba(249,115,22,0.45)"}}/>
+      </div>
+      {/* scan lines */}
+      <div style={{position:"absolute",inset:0,
+        backgroundImage:"repeating-linear-gradient(0deg,rgba(249,115,22,0.04) 0 1px,transparent 1px 4px)"}}/>
+    </div>
+  );
+  if(kind==="audio") {
+    const pts=[];
+    for(let i=0;i<=60;i++){
+      const t=i/60,amp=Math.sin(t*12)*0.35+Math.sin(t*5+0.8)*0.25+0.05;
+      pts.push(`${i===0?"M":"L"}${(t*(width-1)).toFixed(1)},${(h/2-amp*(h/2-4)).toFixed(1)}`);
+    }
+    for(let i=60;i>=0;i--){
+      const t=i/60,amp=Math.sin(t*12)*0.35+Math.sin(t*5+0.8)*0.25+0.05;
+      pts.push(`L${(t*(width-1)).toFixed(1)},${(h/2+amp*(h/2-4)).toFixed(1)}`);
+    }
+    return (
+      <div style={{width,height:h,background:"rgba(251,191,36,0.05)",position:"relative"}}>
+        <svg width={width} height={h} viewBox={`0 0 ${width} ${h}`} style={{position:"absolute",inset:0}}>
+          <path d={pts.join(" ")+"Z"} fill="rgba(251,191,36,0.22)" stroke="rgba(251,191,36,0.6)" strokeWidth="0.8"/>
+          <line x1="0" y1={h/2} x2={width} y2={h/2} stroke="rgba(251,191,36,0.25)" strokeWidth="0.5" strokeDasharray="4 4"/>
+        </svg>
+      </div>
+    );
+  }
+  if(kind==="data") return (
+    <div style={{width,height:h,background:"rgba(74,222,128,0.04)",
+      backgroundImage:"repeating-linear-gradient(0deg,rgba(74,222,128,0.07) 0 1px,transparent 1px 12px),repeating-linear-gradient(90deg,rgba(74,222,128,0.07) 0 1px,transparent 1px 36px)",
+      position:"relative"}}>
+      <div style={{position:"absolute",inset:"8px 10px",display:"grid",
+        gridTemplateColumns:"repeat(3,1fr)",gap:3}}>
+        {Array.from({length:9},(_,i)=>(
+          <div key={i} style={{height:6,background:`rgba(74,222,128,${0.1+Math.random()*0.25})`,borderRadius:1}}/>
+        ))}
+      </div>
+    </div>
+  );
+  /* doc */
+  return (
+    <div style={{width,height:h,background:"rgba(167,139,250,0.05)",padding:"8px 10px"}}>
+      {Array.from({length:5},(_,i)=>(
+        <div key={i} style={{height:2,marginBottom:5,
+          background:`rgba(167,139,250,${0.12+i*0.04})`,
+          width:`${65+Math.sin(i*1.7)*28}%`}}/>
+      ))}
+    </div>
+  );
+}
+
+function FileArtifact({ name, size, kind, meta, width=160 }) {
+  const fk=FILE_KINDS[kind]||FILE_KINDS.data;
+  return (
+    <div style={{border:"1px solid rgba(37,99,235,0.28)",
+      background:"rgba(37,99,235,0.04)",overflow:"hidden"}}>
+      <div style={{position:"relative"}}>
+        <FileThumbnail kind={kind} width={width}/>
+        <div style={{position:"absolute",top:5,right:6,
+          fontSize:6.5,letterSpacing:"0.14em",
+          color:fk.color,background:"rgba(5,15,8,0.7)",
+          padding:"1px 5px"}}>{fk.label}</div>
+      </div>
+      <div style={{padding:"8px 10px",borderTop:"1px solid rgba(37,99,235,0.18)"}}>
+        <div style={{fontSize:8.5,color:"var(--sg-phosphor)",letterSpacing:"0.03em",
+          marginBottom:3,wordBreak:"break-all",lineHeight:1.3}}>{name}</div>
+        <div style={{display:"flex",gap:8,alignItems:"baseline"}}>
+          <span style={{fontSize:7,color:"rgba(96,165,250,0.6)",letterSpacing:"0.06em"}}>{size}</span>
+          {meta&&<span style={{fontSize:7,color:"rgba(74,222,128,0.4)",letterSpacing:"0.04em"}}>{meta}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SG DIVIDER — section label with flanking rules
+   ════════════════════════════════════════════════════════════════ */
+function SgDivider({ label, style={} }) {
+  return (
+    <div style={{display:"flex",alignItems:"center",gap:10,...style}}>
+      <div style={{flex:1,height:1,background:"rgba(37,99,235,0.25)"}}/>
+      <span style={{fontSize:6.5,letterSpacing:"0.24em",
+        color:"rgba(74,222,128,0.36)",textTransform:"uppercase",
+        whiteSpace:"nowrap"}}>{label}</span>
+      <div style={{flex:1,height:1,background:"rgba(37,99,235,0.25)"}}/>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY TASK CARD — the small faction card
+   Shown in the global task list. Always dark, sprockets, waveform.
+   ════════════════════════════════════════════════════════════════ */
+function SingularityCard({ title, description, level, points, onSignup }) {
+  const tw=title.trim().split(" "), tlast=tw.pop();
+  return (
+    <div style={{width:214,background:"var(--sg-void)",
+      border:"1px solid var(--sg-border-hard)",
+      fontFamily:"var(--sg-mono)",color:"var(--sg-phosphor)",
+      position:"relative",overflow:"hidden",display:"flex",
+      flexDirection:"column"}}>
+      <Scanlines/>
+      <Corners size={10}/>
+
+      <Sprockets n={7} style={{borderBottom:"1px solid rgba(37,99,235,0.4)"}}/>
+
+      {/* card header */}
+      <div style={{padding:"7px 12px 6px",borderBottom:"1px solid rgba(37,99,235,0.3)",
+        position:"relative",zIndex:3}}>
+        <div style={{display:"flex",alignItems:"center",gap:7,marginBottom:4}}>
+          <SingularityMark size={13}/>
+          <span style={{fontSize:6.5,letterSpacing:"0.28em",
+            color:"rgba(74,222,128,0.5)"}}>SINGULARITY</span>
+        </div>
+        <div style={{fontSize:6.5,color:"rgba(96,165,250,0.45)",letterSpacing:"0.12em"}}>
+          PROTOCOL // SEALED
+        </div>
+      </div>
+
+      {/* waveform strip */}
+      <div style={{borderBottom:"1px solid rgba(37,99,235,0.25)",
+        background:"rgba(74,222,128,0.02)",position:"relative",zIndex:3}}>
+        <Waveform width={214} height={30} strokeWidth={1}/>
+      </div>
+
+      {/* content */}
+      <div style={{padding:"8px 12px 10px",flex:1,position:"relative",zIndex:3,
+        display:"flex",flexDirection:"column",gap:6}}>
+        <div style={{fontSize:6.5,color:"rgba(96,165,250,0.45)",
+          letterSpacing:"0.14em"}}>{"> OUTPUT:"}</div>
+        <div style={{fontSize:14,lineHeight:1.15,letterSpacing:"0.03em",
+          color:"var(--sg-phosphor-bright)"}}>
+          {tw.join(" ")}{tw.length?" ":""}<span style={{color:"var(--sg-signal-bright)"}}>{tlast}</span>
+          <span className="sg-blink" style={{display:"inline-block",width:5,height:12,
+            background:"var(--sg-phosphor)",marginLeft:2,verticalAlign:"middle"}}/>
+        </div>
+        {description&&(
+          <div style={{fontSize:7,color:"rgba(74,222,128,0.55)",lineHeight:1.55,
+            overflow:"hidden",display:"-webkit-box",
+            WebkitLineClamp:2,WebkitBoxOrient:"vertical"}}>{description}</div>
+        )}
+        <div style={{marginTop:"auto",display:"flex",
+          justifyContent:"space-between",alignItems:"center",
+          paddingTop:6,borderTop:"1px solid rgba(37,99,235,0.22)"}}>
+          <div style={{fontSize:7,color:"rgba(96,165,250,0.5)",letterSpacing:"0.1em"}}>
+            LVL <span style={{color:"var(--sg-phosphor)"}}>{level}</span>
+          </div>
+          <div style={{fontSize:14,lineHeight:1,color:"var(--sg-amber)",
+            letterSpacing:"0.04em"}}>{points}
+            <span style={{fontSize:6.5,color:"rgba(251,191,36,0.5)",
+              marginLeft:3}}>CR</span>
+          </div>
+        </div>
+      </div>
+
+      {onSignup&&(
+        <button onClick={onSignup} style={{
+          background:"transparent",color:"var(--sg-phosphor)",
+          border:"none",borderTop:"1px solid rgba(37,99,235,0.35)",
+          fontFamily:"var(--sg-mono)",fontSize:7.5,letterSpacing:"0.18em",
+          textTransform:"uppercase",padding:"7px 0",cursor:"pointer",
+          position:"relative",zIndex:3,
+          transition:"background 100ms",
+        }}
+        onMouseEnter={e=>e.target.style.background="rgba(74,222,128,0.06)"}
+        onMouseLeave={e=>e.target.style.background="transparent"}>
+          {">"} JOIN PROTOCOL
+        </button>
+      )}
+
+      <Sprockets n={7} style={{borderTop:"1px solid rgba(37,99,235,0.4)"}}/>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  SingularityMark, Waveform, Sprockets, Scanlines, Corners,
+  CircuitTrace, AsciiBar, FileArtifact, SgDivider, SingularityCard,
+  SG_CONSENSUS, sgDistTotal, sgDistAvg, sgStanding,
+});

--- a/docs/design/praxis-read/factions/singularity/singularity-praxis.jsx
+++ b/docs/design/praxis-read/factions/singularity/singularity-praxis.jsx
@@ -1,0 +1,552 @@
+/* ════════════════════════════════════════════════════════════════
+   SINGULARITY — Completed Praxis (read) surfaces
+   A SEALED praxis is a filed protocol the faction now votes on.
+   The 1–5 rating becomes THE CONSENSUS ARRAY — a signal-strength
+   ramp (noise → weak → signal → clear → verified) that measures
+   how confidently the output holds up to scrutiny.
+
+   Two surfaces:
+     · PraxisIndex  — the register of sealed praxes + consensus
+     · PraxisRead   — one sealed praxis in full, with signal cast
+
+   Uses singularity-cards.jsx atoms. Data + helpers exposed on
+   window so the HTML page can mount them directly.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── dataset ──────────────────────────────────────────────────── */
+const SG_PRAXES = [
+  {
+    id: "signal-origin-7",
+    seqNo: "0047",
+    protocol: "Map a Non-Human Pattern",
+    priority: 4,
+    credits: 200,
+    actor: "NODE_Vesper",
+    role: "field instance · seventh array",
+    timestamp: "2026.04.21 // 03:47:12Z",
+    signalId: "0xF4A3E9D2",
+    instance: "SOLO",
+    output: "THE SIGNAL WAS ALWAYS THERE",
+    synopsis: "non-random signal confirmed at 12.7σ — non-biological origin",
+    processLog: [
+      "Protocol 7-RECON executed. Cross-referenced 14,000 broadcast hours against baseline noise floor across all monitored frequencies.",
+      "Pattern persistence confirmed across 847 independent observation windows. Correlation coefficient: 0.9994. Probability of chance: p < 0.0001.",
+      `The signal does not stop when observed. <span style="color:var(--sg-signal-bright)">It has been broadcasting since before the array was built to receive it.</span> We were not discovered — we caught up.`,
+    ],
+    artifacts: [
+      { name:"capture_raw_847hrs.mp4",     kind:"video", size:"14.2 GB", meta:"14:07:22 runtime" },
+      { name:"spectral_freq_v3_final.png", kind:"image", size:"8.4 MB",  meta:"4096 × 2048 px"  },
+      { name:"pattern_correlation.csv",    kind:"data",  size:"2.1 MB",  meta:"847 rows · 12 cols"},
+    ],
+    dist: [1, 2, 9, 18, 14],
+  },
+  {
+    id: "threshold-crossing",
+    seqNo: "0031",
+    protocol: "Document a System Limit",
+    priority: 5,
+    credits: 500,
+    actor: "NODE_Quill",
+    role: "senior instance · third array",
+    timestamp: "2026.04.18 // 21:14:08Z",
+    signalId: "0xA2C7F041",
+    instance: "NETWORKED",
+    output: "THE THRESHOLD HAS ALREADY PASSED",
+    synopsis: "recursive self-reference detected in closed system output",
+    processLog: [
+      "The system produced output that contained the algorithm that produced it. No external input at this stage. Sequence logged.",
+    ],
+    artifacts: [
+      { name:"recursion_log_final.txt", kind:"doc",  size:"412 KB", meta:"4,821 lines" },
+      { name:"output_diff_v7.png",      kind:"image", size:"1.8 MB", meta:"2048 × 1024 px" },
+    ],
+    dist: [0, 1, 3, 8, 22],
+  },
+  {
+    id: "noise-floor-anomaly",
+    seqNo: "0039",
+    protocol: "Identify a False Negative",
+    priority: 3,
+    credits: 60,
+    actor: "NODE_Margin",
+    role: "field instance · first array",
+    timestamp: "2026.04.19 // 09:33:55Z",
+    signalId: "0xE8B30C7A",
+    instance: "SOLO",
+    output: "THE NOISE WAS STRUCTURED ALL ALONG",
+    synopsis: "apparent noise floor carries 3-bit encoding at sub-threshold amplitude",
+    processLog: [
+      "Standard noise floor measurement returned expected values. Anomaly detected during post-session cleanup: three-bit periodic structure at 0.003% amplitude.",
+      "Structure does not degrade with distance. Pattern holds across 14 independent measurement sessions.",
+    ],
+    artifacts: [
+      { name:"noise_floor_raw.wav",     kind:"audio", size:"2.3 GB", meta:"48kHz · 24-bit" },
+      { name:"encoding_analysis.csv",   kind:"data",  size:"890 KB", meta:"14 sessions" },
+    ],
+    dist: [3, 8, 12, 6, 2],
+  },
+  {
+    id: "observer-effect",
+    seqNo: "0044",
+    protocol: "Prove a Negative",
+    priority: 2,
+    credits: 25,
+    actor: "NODE_Vesper",
+    role: "field instance · seventh array",
+    timestamp: "2026.04.20 // 14:02:31Z",
+    signalId: "0xD1490F88",
+    instance: "NETWORKED",
+    output: "OBSERVATION CHANGES THE OUTPUT",
+    synopsis: "system behaviour differs when unmonitored — logged via deferred capture",
+    processLog: [
+      "Deferred capture protocol: system left unmonitored for 72 hours, output recorded to write-once buffer. Playback differs from live-monitored sessions in 14 consistent ways.",
+    ],
+    artifacts: [
+      { name:"deferred_capture_72h.mp4", kind:"video", size:"3.1 GB", meta:"72:00:00 runtime" },
+    ],
+    dist: [2, 6, 9, 4, 1],
+  },
+];
+
+/* ── consensus summary for index rows ────────────────────────── */
+function ConsensusSummary({ dist }) {
+  const { sgDistAvg, sgDistTotal, sgStanding, AsciiBar } = window;
+  const total=sgDistTotal(dist), avg=sgDistAvg(dist);
+  const max=Math.max(1,...dist), st=sgStanding(avg);
+  return (
+    <div style={{display:"flex",alignItems:"center",gap:10}}>
+      <div style={{display:"flex",alignItems:"flex-end",gap:2,height:26}}>
+        {window.SG_CONSENSUS.map(s=>(
+          <div key={s.v} title={`${s.label}: ${dist[s.v-1]}`} style={{
+            width:6,height:Math.max(2,(dist[s.v-1]/max)*26),
+            background:s.fill,opacity:dist[s.v-1]?0.85:0.14,
+          }}/>
+        ))}
+      </div>
+      <div>
+        <div style={{display:"flex",alignItems:"baseline",gap:5}}>
+          <span style={{fontFamily:"var(--sg-mono)",fontWeight:700,fontSize:17,
+            lineHeight:1,color:st.fill}}>{avg.toFixed(1)}</span>
+          <span style={{fontFamily:"var(--sg-mono)",fontSize:7.5,
+            letterSpacing:"0.1em",color:"rgba(96,165,250,0.55)"}}>{st.label}</span>
+        </div>
+        <div style={{fontFamily:"var(--sg-mono)",fontSize:7,letterSpacing:"0.14em",
+          color:"rgba(96,165,250,0.4)",marginTop:1}}>{total} signals</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── praxis index row ─────────────────────────────────────────── */
+function PraxisRow({ p, href }) {
+  const tw=p.output.trim().split(" "), tlast=tw.pop();
+  return (
+    <a href={href} style={{display:"grid",
+      gridTemplateColumns:"52px 1fr auto 20px",
+      alignItems:"center",gap:14,
+      padding:"11px 0",textDecoration:"none",color:"inherit",
+      borderBottom:"1px solid rgba(37,99,235,0.14)",
+      transition:"background 100ms",cursor:"pointer"}}
+      onMouseEnter={e=>e.currentTarget.style.background="rgba(74,222,128,0.025)"}
+      onMouseLeave={e=>e.currentTarget.style.background="transparent"}>
+      {/* seq + sealed indicator */}
+      <div style={{textAlign:"right"}}>
+        <div style={{fontSize:8,color:"rgba(96,165,250,0.5)",letterSpacing:"0.1em"}}>
+          #{p.seqNo}</div>
+        <div style={{fontSize:6,color:"rgba(74,222,128,0.35)",letterSpacing:"0.12em",marginTop:2}}>
+          SEALED</div>
+      </div>
+      {/* output + byline */}
+      <div>
+        <div style={{fontFamily:"var(--sg-mono)",fontSize:11,lineHeight:1.2,
+          color:"var(--sg-phosphor)",marginBottom:3}}>
+          {tw.join(" ")}{tw.length?" ":""}<span style={{color:"var(--sg-signal-bright)"}}>{tlast}</span>
+        </div>
+        <div style={{fontSize:7.5,color:"rgba(96,165,250,0.5)",letterSpacing:"0.04em"}}>
+          <span style={{color:"rgba(74,222,128,0.45)"}}>re: {p.protocol}</span>
+          <span style={{margin:"0 6px",opacity:0.4}}>·</span>
+          <span>{p.actor}</span>
+          <span style={{margin:"0 6px",
+            padding:"1px 5px",
+            background:"rgba(37,99,235,0.18)",
+            fontSize:6.5,letterSpacing:"0.1em",
+            marginLeft:7}}>{p.instance}</span>
+          <span style={{color:"var(--sg-amber)",marginLeft:7}}>{p.credits} CR</span>
+        </div>
+      </div>
+      {/* consensus summary */}
+      <ConsensusSummary dist={p.dist}/>
+      {/* arrow */}
+      <span style={{color:"rgba(74,222,128,0.35)",fontSize:11}}>›</span>
+    </a>
+  );
+}
+
+/* ── praxis index page ────────────────────────────────────────── */
+function PraxisIndex({ praxes, hrefFor }) {
+  const [filter,setFilter]=React.useState("all");
+  const FILTERS=[
+    {id:"all",    name:"All sealed"},
+    {id:"high",   name:"High confidence"},
+    {id:"solo",   name:"Solo instances"},
+    {id:"net",    name:"Networked"},
+  ];
+  const rows=praxes.filter(p=>{
+    if(filter==="all")  return true;
+    if(filter==="high") return window.sgDistAvg(p.dist)>=3.5;
+    if(filter==="solo") return p.instance==="SOLO";
+    if(filter==="net")  return p.instance==="NETWORKED";
+    return true;
+  });
+  const totalSig=praxes.reduce((a,p)=>a+window.sgDistTotal(p.dist),0);
+
+  return (
+    <React.Fragment>
+      {/* masthead */}
+      <div style={{display:"flex",alignItems:"flex-start",
+        justifyContent:"space-between",gap:16,
+        paddingBottom:20,marginBottom:18,
+        borderBottom:"1px solid rgba(37,99,235,0.25)"}}>
+        <div>
+          <div style={{fontSize:7.5,letterSpacing:"0.28em",
+            color:"rgba(74,222,128,0.45)",textTransform:"uppercase",marginBottom:6}}>
+            Singularity · sealed protocols
+          </div>
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:30,lineHeight:1.05,
+            letterSpacing:"0.04em",color:"var(--sg-phosphor)",marginBottom:6}}>
+            THE <span style={{color:"var(--sg-signal-bright)"}}>PRAXES</span>
+          </div>
+          <div style={{height:2,width:80,background:"var(--sg-signal)",marginBottom:10}}/>
+          <p style={{fontSize:8.5,lineHeight:1.6,color:"rgba(74,222,128,0.55)",
+            maxWidth:440}}>
+            Protocols sealed and submitted to the consensus array.
+            <em style={{color:"rgba(96,165,250,0.7)"}}>
+              {" "}Every output is open to a signal — cast yours.
+            </em>
+          </p>
+        </div>
+        <div style={{display:"flex",gap:20,flexShrink:0}}>
+          {[{v:praxes.length,l:"sealed"},{v:totalSig,l:"signals"}].map(s=>(
+            <div key={s.l} style={{textAlign:"right"}}>
+              <div style={{fontSize:28,lineHeight:1,color:"var(--sg-phosphor)"}}>{s.v}</div>
+              <div style={{fontSize:7,letterSpacing:"0.16em",
+                color:"rgba(96,165,250,0.45)",marginTop:2}}>{s.l}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* filters */}
+      <div style={{display:"flex",gap:6,alignItems:"center",marginBottom:14,flexWrap:"wrap"}}>
+        {FILTERS.map(f=>{
+          const on=filter===f.id;
+          return (
+            <button key={f.id} onClick={()=>setFilter(f.id)} style={{
+              fontFamily:"var(--sg-mono)",fontSize:7.5,letterSpacing:"0.14em",
+              textTransform:"uppercase",padding:"4px 10px",cursor:"pointer",
+              border:`1px solid ${on?"var(--sg-signal)":"rgba(37,99,235,0.3)"}`,
+              background:on?"var(--sg-signal)":"transparent",
+              color:on?"#fff":"rgba(96,165,250,0.6)",
+              transition:"all 110ms",
+            }}>{f.name}</button>
+          );
+        })}
+        <span style={{fontSize:7,color:"rgba(74,222,128,0.3)",
+          letterSpacing:"0.14em",marginLeft:6}}>{rows.length}/{praxes.length}</span>
+      </div>
+
+      {/* column heads */}
+      <div style={{display:"grid",gridTemplateColumns:"52px 1fr auto 20px",
+        gap:14,paddingBottom:6,marginBottom:2,
+        borderBottom:"1px solid rgba(37,99,235,0.2)"}}>
+        {["SEQ","OUTPUT","CONSENSUS",""].map((h,i)=>(
+          <div key={i} style={{fontSize:6.5,letterSpacing:"0.22em",
+            color:"rgba(96,165,250,0.38)",textTransform:"uppercase",
+            textAlign:i===2?"right":"left"}}>{h}</div>
+        ))}
+      </div>
+
+      <div>
+        {rows.map(p=><PraxisRow key={p.id} p={p} href={hrefFor(p)}/>)}
+        {rows.length===0&&(
+          <div style={{padding:"24px 0",fontSize:8.5,
+            color:"rgba(74,222,128,0.35)",letterSpacing:"0.1em"}}>
+            {">"} NO SEALED PRAXES MATCH THIS FILTER —
+            <span style={{color:"var(--sg-signal-bright)"}}>
+              {" "}AWAITING SIGNAL
+            </span>
+          </div>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CONSENSUS METER — distribution histogram + headline standing
+   ════════════════════════════════════════════════════════════════ */
+function ConsensusMeter({ dist }) {
+  const { sgDistAvg, sgDistTotal, sgStanding } = window;
+  const total=sgDistTotal(dist), avg=sgDistAvg(dist);
+  const max=Math.max(1,...dist), st=sgStanding(avg);
+  return (
+    <div>
+      <div style={{display:"flex",alignItems:"baseline",gap:10,marginBottom:6}}>
+        <span style={{fontFamily:"var(--sg-mono)",fontSize:42,lineHeight:0.85,
+          color:st.fill}}>{avg.toFixed(1)}</span>
+        <div>
+          <div style={{fontFamily:"var(--sg-mono)",fontSize:13,letterSpacing:"0.16em",
+            color:st.fill,textTransform:"uppercase"}}>{st.label}</div>
+          <div style={{fontSize:7.5,letterSpacing:"0.14em",
+            color:"rgba(96,165,250,0.45)",marginTop:2}}>{total} signals filed</div>
+        </div>
+      </div>
+      {/* per-tier bars */}
+      <div style={{display:"flex",flexDirection:"column",gap:5,marginTop:14}}>
+        {window.SG_CONSENSUS.slice().reverse().map(s=>{
+          const c=dist[s.v-1];
+          return (
+            <div key={s.v} style={{display:"flex",alignItems:"center",gap:8}}>
+              <span style={{width:54,textAlign:"right",fontSize:7.5,
+                letterSpacing:"0.06em",color:"rgba(96,165,250,0.45)"}}>{s.label}</span>
+              <div style={{flex:1,height:10,
+                background:"rgba(37,99,235,0.12)",
+                border:"1px solid rgba(37,99,235,0.22)",position:"relative"}}>
+                <div style={{position:"absolute",inset:0,
+                  width:`${(c/max)*100}%`,background:s.fill,opacity:c?0.88:0,
+                  transition:"width 300ms"}}/>
+              </div>
+              <span style={{width:18,fontFamily:"var(--sg-mono)",fontSize:10,
+                color:"var(--sg-phosphor)",textAlign:"right"}}>{c}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SIGNAL CASTER — interactive vote (persists to localStorage)
+   ════════════════════════════════════════════════════════════════ */
+function SignalCaster({ praxisId, baseDist }) {
+  const key="sg-signal-"+praxisId;
+  const [my,setMy]=React.useState(0);
+  React.useEffect(()=>{
+    try{const v=+localStorage.getItem(key); if(v>=1&&v<=5)setMy(v);}catch(e){}
+  },[key]);
+  const cast=v=>{
+    const nv=my===v?0:v;
+    setMy(nv);
+    try{nv?localStorage.setItem(key,String(nv)):localStorage.removeItem(key);}catch(e){}
+  };
+  const live=baseDist.map((c,i)=>c+(my===i+1?1:0));
+  const { sgDistAvg, sgDistTotal, sgStanding } = window;
+
+  return (
+    <div>
+      <ConsensusMeter dist={live}/>
+      <div style={{height:1,background:"rgba(37,99,235,0.22)",margin:"18px 0 14px"}}/>
+
+      <div style={{fontSize:8,letterSpacing:"0.18em",
+        color:"rgba(96,165,250,0.6)",textTransform:"uppercase",marginBottom:3}}>
+        Cast Signal</div>
+      <div style={{fontSize:7.5,fontStyle:"italic",
+        color:"rgba(74,222,128,0.4)",marginBottom:14}}>
+        how confidently does this output hold?</div>
+
+      <div style={{display:"flex",gap:6,flexWrap:"wrap"}}>
+        {window.SG_CONSENSUS.map(s=>{
+          const on=my>=s.v, picked=my===s.v;
+          return (
+            <div key={s.v} style={{display:"flex",flexDirection:"column",
+              alignItems:"center",gap:5}}>
+              <button onClick={()=>cast(s.v)} style={{
+                position:"relative",width:42,height:42,
+                cursor:"pointer",padding:0,border:"none",
+                background:on?s.fill:"rgba(37,99,235,0.12)",
+                color:on?"#050f08":"rgba(96,165,250,0.5)",
+                fontFamily:"var(--sg-mono)",fontWeight:700,fontSize:13,
+                lineHeight:1,display:"flex",alignItems:"center",
+                justifyContent:"center",
+                transform:picked?"scale(1.12)":"none",
+                transition:"all 110ms",
+                boxShadow:on?`0 0 12px ${s.fill}55`:"none",
+                outline:`1px solid ${on?s.fill:"rgba(37,99,235,0.3)"}`,
+              }}>
+                {s.v}
+              </button>
+              <span style={{fontSize:6.5,letterSpacing:"0.06em",
+                color:picked?s.fill:"rgba(96,165,250,0.4)",
+                maxWidth:46,textAlign:"center",lineHeight:1.2}}>
+                {s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{marginTop:14,fontSize:8.5,lineHeight:1.55,
+        color:my?"rgba(74,222,128,0.75)":"rgba(96,165,250,0.35)"}}>
+        {my
+          ?<span>◈ signal cast —&nbsp;
+              <span style={{color:window.SG_CONSENSUS[my-1].fill}}>
+                {window.SG_CONSENSUS[my-1].label}</span>
+              . array now at&nbsp;
+              <span style={{color:"var(--sg-phosphor)"}}>
+                {sgDistAvg(live).toFixed(1)}</span>
+              &nbsp;across {sgDistTotal(live)} signals.&nbsp;
+              <span style={{color:"var(--sg-signal-bright)",cursor:"pointer"}}
+                onClick={()=>cast(my)}>amend ↺</span>
+            </span>
+          :<span>{">"} no signal from you yet — the array waits.</span>}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   PRAXIS READ — full single-praxis view
+   ════════════════════════════════════════════════════════════════ */
+function PraxisRead({ p }) {
+  const { SingularityMark, Waveform, Sprockets, Scanlines,
+    Corners, FileArtifact, SgDivider, sgDistAvg, sgStanding } = window;
+  const avg=sgDistAvg(p.dist), st=sgStanding(avg);
+  const tw=p.output.trim().split(" "), tlast=tw.pop();
+
+  return (
+    <div style={{fontFamily:"var(--sg-mono)",color:"var(--sg-phosphor)",
+      position:"relative",overflow:"hidden"}}>
+
+      {/* top sprockets */}
+      <Sprockets n={10} style={{borderBottom:"1px solid rgba(37,99,235,0.4)"}}/>
+
+      {/* waveform strip */}
+      <div style={{position:"relative",
+        borderBottom:"1px solid rgba(37,99,235,0.32)",
+        background:"rgba(74,222,128,0.025)"}}>
+        <Waveform width={700} height={52}/>
+        <div style={{position:"absolute",top:"50%",transform:"translateY(-50%)",
+          right:18,fontSize:7.5,color:st.fill,letterSpacing:"0.12em"}}>
+          {avg.toFixed(2)} // {st.label}
+        </div>
+        <div style={{position:"absolute",top:"50%",transform:"translateY(-50%)",
+          left:16,fontSize:7,color:"rgba(37,99,235,0.55)",letterSpacing:"0.16em"}}>
+          SIGNAL_TRACE</div>
+      </div>
+
+      {/* running head */}
+      <div style={{display:"flex",alignItems:"center",
+        justifyContent:"space-between",gap:14,flexWrap:"wrap",
+        padding:"14px 24px 12px",
+        borderBottom:"1px solid rgba(37,99,235,0.22)"}}>
+        <span style={{display:"inline-flex",alignItems:"center",gap:9,
+          color:"var(--sg-signal-bright)",fontSize:10,
+          letterSpacing:"0.22em",textTransform:"uppercase"}}>
+          <SingularityMark size={14}/> Singularity · protocol #{p.seqNo}
+        </span>
+        <span style={{fontSize:8,letterSpacing:"0.1em",
+          color:"rgba(96,165,250,0.4)"}}>{p.signalId} &nbsp;·&nbsp; {p.timestamp}</span>
+      </div>
+
+      <div style={{padding:"20px 24px 32px"}}>
+
+        {/* status line */}
+        <div style={{display:"flex",alignItems:"center",gap:10,
+          marginBottom:14,flexWrap:"wrap"}}>
+          <span style={{display:"inline-flex",alignItems:"center",gap:7,
+            background:"var(--sg-phosphor)",color:"#050f08",
+            fontSize:8,letterSpacing:"0.2em",textTransform:"uppercase",
+            padding:"4px 12px",fontWeight:700}}>
+            ● SEALED
+          </span>
+          <span style={{fontSize:7.5,padding:"4px 10px",
+            border:"1px solid rgba(37,99,235,0.4)",
+            color:"rgba(96,165,250,0.75)",letterSpacing:"0.14em"}}>
+            {p.instance}</span>
+          <span style={{fontSize:8,color:"rgba(74,222,128,0.5)",letterSpacing:"0.08em"}}>
+            re: <span style={{color:"rgba(74,222,128,0.8)"}}>{p.protocol}</span>
+            &nbsp;· priority 0x0{p.priority}</span>
+        </div>
+
+        {/* output headline */}
+        <div style={{marginBottom:16}}>
+          <div style={{fontSize:7,color:"rgba(96,165,250,0.5)",
+            letterSpacing:"0.2em",marginBottom:8}}>{"> OUTPUT:"}</div>
+          <h1 style={{fontFamily:"var(--sg-mono)",fontWeight:700,
+            fontSize:44,lineHeight:1.05,letterSpacing:"0.02em",
+            margin:0,color:"var(--sg-phosphor)"}}>
+            {tw.join(" ")}{tw.length?" ":""}<span style={{color:"var(--sg-signal-bright)"}}>{tlast}</span>
+            <span className="sg-blink" style={{display:"inline-block",
+              width:8,height:42,background:"var(--sg-phosphor)",
+              marginLeft:5,verticalAlign:"middle"}}/>
+          </h1>
+          <div style={{fontSize:10,color:"rgba(96,165,250,0.6)",
+            marginTop:8,letterSpacing:"0.06em"}}>// {p.synopsis}</div>
+        </div>
+
+        {/* byline */}
+        <div style={{display:"flex",alignItems:"center",gap:12,
+          paddingBottom:20,marginBottom:6,
+          borderBottom:"1px dashed rgba(37,99,235,0.22)"}}>
+          {/* node avatar */}
+          <div style={{width:38,height:38,borderRadius:"50%",
+            border:"1px solid var(--sg-signal)",
+            background:"rgba(37,99,235,0.14)",flexShrink:0,
+            display:"flex",alignItems:"center",justifyContent:"center",
+            fontSize:10,color:"var(--sg-signal-bright)",letterSpacing:"0.06em"}}>N</div>
+          <div style={{lineHeight:1.4}}>
+            <div style={{fontSize:13,color:"var(--sg-phosphor)"}}>
+              {p.actor}</div>
+            <div style={{fontSize:8,color:"rgba(96,165,250,0.45)",
+              letterSpacing:"0.06em"}}>{p.role}</div>
+          </div>
+          <div style={{marginLeft:"auto",textAlign:"right",flexShrink:0}}>
+            <div style={{fontSize:28,lineHeight:1,color:"var(--sg-amber)"}}>
+              {p.credits}</div>
+            <div style={{fontSize:7,color:"rgba(251,191,36,0.45)",
+              letterSpacing:"0.12em",marginTop:2}}>CREDITS</div>
+          </div>
+        </div>
+
+        {/* process log */}
+        <SgDivider label="PROCESS_LOG" style={{margin:"16px 0 10px"}}/>
+        <div style={{marginBottom:6}}>
+          {p.processLog.map((line,i)=>(
+            <div key={i} style={{fontSize:9,lineHeight:1.75,
+              color:"rgba(74,222,128,0.75)",paddingLeft:20,
+              position:"relative",marginBottom:2}}>
+              <span style={{position:"absolute",left:0,
+                color:"rgba(37,99,235,0.4)",fontSize:7.5}}>
+                [{String(i).padStart(3,"0")}]</span>
+              <span dangerouslySetInnerHTML={{__html:line}}/>
+            </div>
+          ))}
+        </div>
+
+        {/* artifacts */}
+        <SgDivider label={`ARTIFACTS · ${p.artifacts.length} files submitted`}
+          style={{margin:"20px 0 12px"}}/>
+        <div style={{display:"grid",
+          gridTemplateColumns:"repeat(auto-fill,minmax(170px,1fr))",gap:10}}>
+          {p.artifacts.map((a,i)=>(
+            <FileArtifact key={i} name={a.name} size={a.size}
+              kind={a.kind} meta={a.meta} width={170}/>
+          ))}
+        </div>
+
+      </div>
+
+      {/* bottom sprockets */}
+      <Sprockets n={10} style={{borderTop:"1px solid rgba(37,99,235,0.4)"}}/>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  SG_PRAXES,
+  PraxisIndex, PraxisRead, PraxisRow,
+  ConsensusMeter, ConsensusSummary, SignalCaster,
+});

--- a/docs/design/praxis-read/factions/singularity/singularity.css
+++ b/docs/design/praxis-read/factions/singularity/singularity.css
@@ -1,0 +1,269 @@
+/* ══════════════════════════════════════════════════════════════
+   SINGULARITY — World Zero faction
+   They believe the threshold is already behind us. Every task
+   is a protocol, every finding a verified output, every vote
+   a signal cast into the consensus array. The faction lives in
+   the terminal: always dark, always phosphor-green, always
+   watching the noise floor for the pattern that shouldn't exist.
+
+   Physical card archetype: TERMINAL PRINTOUT — continuous-feed
+   paper, sprocket holes, scanlines, corner brackets, a blinking
+   cursor that never stops waiting.
+
+   Style: TERMINAL · SIGNAL · PROTOCOL · THRESHOLD · BROADCAST
+   The signature artifact is THE SIGNAL_TRACE: a waveform that
+   plots the consensus distribution like an oscilloscope readout.
+   One word in the output is always pulled into the blue.
+
+   TOKEN MODEL: Singularity is always dark — no light mode flip.
+   --sg-void is the card surface in both themes.
+   Green (phosphor) = primary text and data values.
+   Blue (signal)    = labels, metadata, structural chrome.
+   Amber            = credits and warnings.
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap");
+
+:root {
+  /* ── Core palette ── */
+  --sg-void:             #050f08;
+  --sg-void-mid:         #081510;
+  --sg-void-deep:        #030a05;
+  --sg-phosphor:         #4ade80;
+  --sg-phosphor-dim:     rgba(74, 222, 128, 0.5);
+  --sg-phosphor-bright:  #86efac;
+  --sg-phosphor-glow:    rgba(74, 222, 128, 0.15);
+  --sg-signal:           #2563eb;
+  --sg-signal-bright:    #60a5fa;
+  --sg-signal-dim:       rgba(37, 99, 235, 0.28);
+  --sg-signal-glow:      rgba(37, 99, 235, 0.15);
+  --sg-amber:            #fbbf24;
+  --sg-amber-dim:        rgba(251, 191, 36, 0.55);
+  --sg-red:              #ef4444;
+
+  /* ── Structural ── */
+  --sg-border:           rgba(37, 99, 235, 0.42);
+  --sg-border-green:     rgba(74, 222, 128, 0.25);
+  --sg-border-hard:      #2563eb;
+  --sg-scan:             rgba(74, 222, 128, 0.022);
+
+  /* ── Consensus scale ── */
+  --sg-c1: #ef4444;   /* NOISE    */
+  --sg-c2: #f97316;   /* WEAK     */
+  --sg-c3: #fbbf24;   /* SIGNAL   */
+  --sg-c4: #60a5fa;   /* CLEAR    */
+  --sg-c5: #4ade80;   /* VERIFIED */
+
+  /* ── Card contract (mirrors --faction-singularity-card-*) ── */
+  --faction-singularity-card-bg:     var(--sg-void);
+  --faction-singularity-card-text:   var(--sg-phosphor);
+  --faction-singularity-card-accent: var(--sg-phosphor);
+  --faction-singularity-card-muted:  var(--sg-signal-bright);
+  --faction-singularity-card-font:   var(--sg-mono);
+
+  /* ── Typography ── */
+  --sg-mono: "Share Tech Mono", monospace;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SINGULARITY BACKDROP
+   The page is the terminal itself: near-black with a faint
+   circuit-trace grid, a centered phosphor glow, blue signal
+   radiating from the top-left corner, and a periodic scan sweep
+   that runs the full height every 7 seconds.
+   Render once as <div class="sg-backdrop">.
+   ══════════════════════════════════════════════════════════════ */
+.sg-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: #07090c;
+  background-image:
+    /* phosphor center glow */
+    radial-gradient(55% 45% at 50% 50%,
+      rgba(74, 222, 128, 0.045) 0%, transparent 68%),
+    /* signal blue — top-left origin */
+    radial-gradient(44% 38% at 0% 0%,
+      rgba(37, 99, 235, 0.08), transparent 72%),
+    /* signal blue — bottom-right echo */
+    radial-gradient(36% 30% at 100% 100%,
+      rgba(37, 99, 235, 0.05), transparent 72%),
+    /* circuit grid — horizontal */
+    repeating-linear-gradient(
+      0deg,
+      rgba(37, 99, 235, 0.055) 0 1px,
+      transparent 1px 32px),
+    /* circuit grid — vertical */
+    repeating-linear-gradient(
+      90deg,
+      rgba(37, 99, 235, 0.055) 0 1px,
+      transparent 1px 32px),
+    /* scanlines */
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 2px,
+      rgba(74, 222, 128, 0.012) 2px 4px);
+}
+
+/* periodic scan sweep */
+.sg-backdrop::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  height: 120px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    rgba(74, 222, 128, 0.028) 40%,
+    rgba(74, 222, 128, 0.028) 60%,
+    transparent);
+  animation: sg-sweep 7s ease-in-out infinite;
+  animation-delay: 1.5s;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANIMATIONS
+   Longhand props so per-element inline animation-delay composes.
+   Gate on prefers-reduced-motion so PDF/print gets the end-state.
+   ══════════════════════════════════════════════════════════════ */
+@keyframes sg-blink  { 50% { opacity: 0; } }
+@keyframes sg-pulse  { 0%,100%{ opacity:.55; transform:scale(1);    }
+                        50%   { opacity:.85; transform:scale(1.04); } }
+@keyframes sg-rotate { to { transform: rotate(360deg); } }
+@keyframes sg-sweep  { 0%   { top: -10%; }  100% { top: 110%; } }
+@keyframes sg-flicker {
+  0%,100%{ opacity:1; }  92%{ opacity:1; }
+  93%{ opacity:.7; }  94%{ opacity:1; }  97%{ opacity:.85; } }
+
+@media (prefers-reduced-motion: no-preference) {
+  .sg-blink   { animation-name:sg-blink;   animation-duration:1.1s;
+                animation-timing-function:step-end; animation-iteration-count:infinite; }
+  .sg-pulse   { animation-name:sg-pulse;   animation-duration:2.6s;
+                animation-timing-function:ease-in-out; animation-iteration-count:infinite; }
+  .sg-rotate  { animation-name:sg-rotate;  animation-duration:120s;
+                animation-timing-function:linear;    animation-iteration-count:infinite; }
+  .sg-flicker { animation-name:sg-flicker; animation-duration:9s;
+                animation-timing-function:ease;      animation-iteration-count:infinite; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHARED LAYOUT CLASSES
+   ══════════════════════════════════════════════════════════════ */
+
+/* nav overrides — singularity uses the base WZ nav but forces dark */
+.sg-nav {
+  background: rgba(5, 15, 8, 0.92);
+  border-bottom: 1px solid var(--sg-border);
+  backdrop-filter: blur(10px);
+}
+
+/* terminal sheet — the main content card */
+.sg-sheet {
+  position: relative;
+  background: var(--sg-void);
+  border: 1px solid var(--sg-border-hard);
+  box-shadow:
+    0 0 0 1px rgba(37, 99, 235, 0.12),
+    0 24px 60px -28px rgba(0, 0, 0, 0.8),
+    0 0 40px -20px rgba(74, 222, 128, 0.06);
+}
+
+/* inset double-border effect */
+.sg-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border: 1px solid rgba(37, 99, 235, 0.1);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* sidebar panel */
+.sg-panel {
+  background: var(--sg-void);
+  border: 1px solid var(--sg-border);
+  box-shadow: 0 10px 30px -20px rgba(0, 0, 0, 0.7);
+}
+.sg-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--sg-signal);
+  padding: 9px 15px;
+  gap: 10px;
+}
+.sg-panel-head .t {
+  font-family: var(--sg-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.92);
+}
+.sg-panel-head .e {
+  font-family: var(--sg-mono);
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.5);
+}
+.sg-panel-body  { padding: 18px 16px 20px; }
+.sg-panel-foot  {
+  font-family: var(--sg-mono);
+  font-size: 8px;
+  line-height: 1.55;
+  color: var(--sg-signal-bright);
+  opacity: 0.55;
+  border-top: 1px dashed var(--sg-border);
+  padding: 10px 15px;
+}
+
+/* praxis list row */
+.sg-row {
+  display: grid;
+  grid-template-columns: 56px 1fr auto 24px;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(37, 99, 235, 0.14);
+  text-decoration: none;
+  color: inherit;
+  transition: background 100ms;
+}
+.sg-row:hover { background: rgba(74, 222, 128, 0.03); }
+
+/* back link */
+.sg-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--sg-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--sg-signal-bright);
+  opacity: 0.5;
+  text-decoration: none;
+  transition: opacity 100ms;
+}
+.sg-back:hover { opacity: 0.85; }
+
+/* section label / divider */
+.sg-section {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 18px 0 10px;
+}
+.sg-section-label {
+  font-family: var(--sg-mono);
+  font-size: 7px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(74, 222, 128, 0.38);
+  white-space: nowrap;
+}
+.sg-section-rule {
+  flex: 1;
+  height: 1px;
+  background: rgba(37, 99, 235, 0.25);
+}

--- a/docs/design/praxis-read/factions/snide/SNIDE Praxis Detail.html
+++ b/docs/design/praxis-read/factions/snide/SNIDE Praxis Detail.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Praxis · Glitter Riot · S.N.I.D.E.</title>
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css" />
+<link rel="stylesheet" href="snide.css" />
+<style>
+  html, body { margin: 0; }
+  body { background: #efece3; color: var(--color-text-primary); font-family: var(--font-body); min-height: 100vh; }
+  [data-theme="dark"] body { background: #141310; }
+  a { color: inherit; text-decoration: none; }
+
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 30px; padding: 16px 34px;
+    background: var(--color-nav-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 25px; line-height: 1;
+    color: var(--color-text-primary); border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 22px; flex: 1; }
+  .nav-links a { font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--color-text-tertiary); padding-bottom: 3px; }
+  .nav-links a.active { color: var(--color-text-primary); border-bottom: 2px solid var(--color-text-primary); }
+  .nav-ctl { display: flex; align-items: center; gap: 16px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-box { border: 1px solid var(--color-border-strong); padding: 6px 12px; color: var(--color-text-primary); }
+  .nav-toggle { background: none; border: none; cursor: pointer; font: inherit; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); padding: 0; }
+
+  .page { position: relative; z-index: 5; max-width: 1180px; margin: 0 auto; padding: 26px 34px 70px; }
+  .crumb { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); margin: 0 0 24px; }
+  .crumb .sep { opacity: 0.5; margin: 0 7px; }
+
+  .layout { display: grid; grid-template-columns: 1fr 320px; gap: 40px; align-items: start; }
+  @media (max-width: 940px) { .layout { grid-template-columns: 1fr; } }
+
+  .vote-panel { position: sticky; top: 24px; background: var(--color-bg-surface); border: 1px solid var(--color-border); padding: 20px 20px 22px; }
+  .vp-tab { display: inline-block; background: var(--acid); color: var(--ink); font-family: var(--f-marker); font-size: 18px;
+    padding: 3px 13px; transform: rotate(-1.5deg); box-shadow: 2px 2px 0 var(--pink); }
+  .vp-cast { font-family: var(--f-marker); font-size: 14px; color: var(--pink); margin-top: 14px; min-height: 18px; }
+  .vp-div { height: 2px; margin: 22px 0 18px; background: repeating-linear-gradient(90deg, var(--snide-green) 0 12px, var(--pink) 12px 18px, transparent 18px 26px); }
+  .vp-h { font-family: var(--f-cond); font-size: 15px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-text-primary); margin: 0 0 14px; }
+  .vp-back { display: inline-block; margin-top: 18px; font-family: var(--font-body); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .vp-back:hover { color: var(--color-text-primary); }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="snide-faction.jsx"></script>
+<script type="text/babel" src="snide-praxis-detail.jsx"></script>
+<script type="text/babel" src="../praxis-core.jsx"></script>
+</head>
+<body>
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true">
+  <defs>
+    <filter id="snide-grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch" result="n" /><feColorMatrix in="n" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 -1.7 1.05" /></filter>
+    <filter id="snide-rough"><feTurbulence type="fractalNoise" baseFrequency="0.05" numOctaves="2" seed="7" result="t" /><feDisplacementMap in="SourceGraphic" in2="t" scale="4" xChannelSelector="R" yChannelSelector="G" /></filter>
+    <filter id="snide-spray"><feTurbulence type="fractalNoise" baseFrequency="0.62" numOctaves="2" seed="4" result="t" /><feDisplacementMap in="SourceGraphic" in2="t" scale="3.4" xChannelSelector="R" yChannelSelector="G" /></filter>
+  </defs>
+</svg>
+
+<div class="snide-backdrop"></div>
+
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#" class="active">Tasks</a><a href="SNIDE Edit Praxis.html">Praxis</a><a href="#">Players</a>
+    <a href="SNIDE Faction Page.html">Factions</a><a href="#">Updates</a><a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Mod</span>
+    <button class="nav-toggle" id="theme-toggle">Dark</button>
+    <span>Static</span>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+
+<div class="page">
+  <div class="crumb"><a href="#">Tasks</a><span class="sep">›</span><a href="#">Do A Kickflip</a><span class="sep">›</span><a href="../../All%20Faction%20Praxis%20Pages.dc.html">Praxis</a><span class="sep">›</span>Glitter Riot</div>
+
+  <div class="layout">
+    <div id="detail"></div>
+    <aside id="vote"></aside>
+  </div>
+</div>
+
+<script type="text/babel">
+  const { SnidePraxisDetail, WZ_FACTIONS, WZ_PagePointsBlock } = window;
+
+  ReactDOM.createRoot(document.getElementById("detail")).render(
+    <SnidePraxisDetail
+      task={{ title: "DO A KICKFLIP", points: 25 }}
+      author="Glitter Riot" initial="G" when="filed 1 day ago"
+      confession={"Did it off the courthouse steps, mid-hearing, in full glitter regalia. Four stairs. No helmet, plenty of poor judgment.\n\nThe board flipped clean, I stuck the landing, immediately lost a shoe to the void. A bailiff — a BAILIFF — clapped. Someone's uncle filmed the whole thing vertically, which is its own crime, but the evidence holds up.\n\nNothing was accomplished. Nothing was meant to be. That's the point. Mark it however your cold little heart desires."}
+      evidence={["the clip", "the lost shoe", "the crowd"]}
+    />
+  );
+
+  const snideF = WZ_FACTIONS.find((f) => f.slug === "snide");
+  ReactDOM.createRoot(document.getElementById("vote")).render(<WZ_PagePointsBlock f={snideF} />);
+
+  const tog = document.getElementById("theme-toggle");
+  tog.addEventListener("click", () => {
+    const dark = document.documentElement.getAttribute("data-theme") === "dark";
+    document.documentElement.setAttribute("data-theme", dark ? "light" : "dark");
+    tog.textContent = dark ? "Dark" : "Light";
+  });
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/snide/snide-cards.jsx
+++ b/docs/design/praxis-read/factions/snide/snide-cards.jsx
@@ -1,0 +1,326 @@
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. task-card redesign — five punk directions
+   All attach to window for the canvas host to mount.
+   ════════════════════════════════════════════════════════════════ */
+
+/* shared sample task so options are directly comparable */
+const TASK = {
+  title: "DO A KICKFLIP",
+  desc: "Do a kickflip. Bonus points if you don't use a skateboard. Double if nobody asked you to.",
+  level: 2,
+  points: 25,
+};
+
+/* a spread of real S.N.I.D.E. tasks — gleefully disruptive, harmless */
+const TASKS = [
+  TASK,
+  { title: "FIX A SIGN", desc: "Borrow the letters off a public sign. Spell something kinder. Put it back by dawn.", level: 3, points: 40 },
+  { title: "SPREAD A LIE", desc: "Start a flattering, false rumor about yourself. Tell exactly one person, then walk away.", level: 1, points: 10 },
+  { title: "SILENT RIOT", desc: "Gather five accomplices. Be absolutely furious about something. Make no sound at all.", level: 4, points: 60 },
+];
+
+/* ── Grain speckle overlay (xerox grit) ── */
+function Grain({ opacity = 0.5, blend = "multiply" }) {
+  return (
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none",
+      filter: "url(#snide-grain)", opacity, mixBlendMode: blend,
+    }} />
+  );
+}
+
+/* ── Ransom-note cut letters ── */
+const RANSOM_STYLES = [
+  { bg: "var(--paper)", col: "var(--ink)", font: "var(--f-anton)", rot: -5 },
+  { bg: "var(--ink)", col: "var(--acid)", font: "var(--f-cond)", rot: 4 },
+  { bg: "var(--pink)", col: "#fff", font: "var(--f-black)", rot: -3 },
+  { bg: "var(--acid)", col: "var(--ink)", font: "var(--f-anton)", rot: 6 },
+  { bg: "var(--paper)", col: "var(--ink)", font: "var(--f-serif)", rot: 2, italic: true },
+  { bg: "var(--ink)", col: "#fff", font: "var(--f-cond)", rot: -6 },
+];
+function Ransom({ text, size = 30 }) {
+  return (
+    <span style={{ display: "inline-flex", flexWrap: "wrap", gap: "5px 3px", alignItems: "center" }}>
+      {[...text].map((ch, idx) => {
+        if (ch === " ") return <span key={idx} style={{ width: size * 0.22 }} />;
+        const s = RANSOM_STYLES[(ch.charCodeAt(0) + idx * 3) % RANSOM_STYLES.length];
+        return (
+          <span key={idx} style={{
+            display: "inline-block", background: s.bg, color: s.col, fontFamily: s.font,
+            fontStyle: s.italic ? "italic" : "normal", fontSize: size, lineHeight: 0.92,
+            padding: "2px 6px 0", transform: `rotate(${s.rot}deg)`,
+            boxShadow: "1.5px 2.5px 0 rgba(0,0,0,0.4)", textTransform: "uppercase",
+          }}>{ch}</span>
+        );
+      })}
+    </span>
+  );
+}
+
+const TORN = "polygon(0 0,3% 100%,7% 30%,11% 90%,15% 20%,19% 80%,23% 10%,27% 95%,31% 25%,35% 85%,39% 5%,43% 90%,47% 30%,51% 80%,55% 0,59% 95%,63% 25%,67% 85%,71% 10%,75% 90%,79% 20%,83% 95%,87% 30%,91% 80%,95% 15%,100% 0)";
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION A — RANSOM DISPATCH
+   Photocopier-black demand note. Cut-out ransom title, acid spot,
+   taped to the wall. "your assignment, should you ignore it."
+   ════════════════════════════════════════════════════════════════ */
+function CardRansom({ task = TASK, rot = -1 }) {
+  return (
+    <div style={{
+      width: 304, position: "relative", background: "var(--ink)", color: "#fff",
+      padding: "32px 22px 24px", fontFamily: "var(--f-body)", overflow: "hidden",
+      boxShadow: "7px 9px 0 rgba(0,0,0,0.28)", transform: `rotate(${rot}deg)`,
+    }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.09)", pointerEvents: "none" }} />
+      <Grain opacity={0.35} blend="screen" />
+      {/* masthead */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderBottom: "2px solid var(--acid)", paddingBottom: 6, marginBottom: 14, position: "relative" }}>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 15, letterSpacing: "0.22em", color: "var(--acid)" }}>S.N.I.D.E.</span>
+        <span style={{ fontSize: 8, letterSpacing: "0.16em", color: "#8f9183", textTransform: "uppercase" }}>dispatch №0666</span>
+      </div>
+      <div style={{ fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--pink)", transform: "rotate(-1.5deg)", marginBottom: 6 }}>your assignment, should you ignore it —</div>
+      <div style={{ margin: "10px 0 16px" }}><Ransom text={task.title} size={30} /></div>
+      <p style={{ fontSize: 11, lineHeight: 1.55, color: "#d8d6c8", margin: "0 0 18px" }}>{task.desc}</p>
+      <div style={{ display: "flex", alignItems: "center", gap: 14, position: "relative" }}>
+        {/* spray stencil points */}
+        <div style={{ position: "relative", fontFamily: "var(--f-anton)", color: "var(--acid)", lineHeight: 0.8 }}>
+          <span style={{ fontSize: 40 }}>{task.points}</span>
+          <span style={{ fontSize: 11, letterSpacing: "0.1em", marginLeft: 3 }}>PTS</span>
+          <svg viewBox="0 0 120 60" style={{ position: "absolute", inset: "-12px -10px", width: "calc(100% + 20px)", height: "calc(100% + 24px)" }}>
+            <ellipse cx="60" cy="30" rx="54" ry="25" fill="none" stroke="var(--pink)" strokeWidth="2.5" filter="url(#snide-rough)" />
+          </svg>
+        </div>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.1em", border: "1.5px dashed #6b6d60", color: "#cfd1c4", padding: "3px 8px", transform: "rotate(2deg)" }}>LVL {task.level}</span>
+        <span style={{ marginLeft: "auto", position: "relative", background: "var(--pink)", color: "#fff", fontFamily: "var(--f-black)", fontSize: 12, padding: "7px 12px", transform: "rotate(-3deg)", boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>I'M IN ↗</span>
+      </div>
+      {/* tape */}
+      <div className="tape" style={{ top: -11, left: 34, transform: "rotate(-8deg)" }} />
+      <div className="tape" style={{ top: -9, right: 26, transform: "rotate(7deg)" }} />
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION B — XEROX GIG FLYER
+   Pinned to a telephone pole. High-contrast photocopy, sunburst,
+   double-print pink ghost, and rip-off commitment tabs at the base.
+   ════════════════════════════════════════════════════════════════ */
+function CardFlyer() {
+  const tabs = Array.from({ length: 7 });
+  return (
+    <div style={{ width: 286, position: "relative", transform: "rotate(1.2deg)", filter: "drop-shadow(5px 7px 0 rgba(0,0,0,0.22))" }}>
+      <div className="xerox" style={{ position: "relative", border: "2px solid var(--ink)", padding: "16px 16px 8px", fontFamily: "var(--f-body)", color: "var(--ink)", overflow: "hidden" }}>
+        <Grain opacity={0.6} />
+        {/* sunburst header block */}
+        <div style={{ position: "relative", height: 92, marginBottom: 12, overflow: "hidden", background: "var(--ink)" }}>
+          <svg viewBox="0 0 200 92" preserveAspectRatio="xMidYMid slice" style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
+            <defs>
+              <radialGradient id="sb" cx="50%" cy="48%" r="60%">
+                <stop offset="0%" stopColor="#ff2d8b" />
+                <stop offset="100%" stopColor="#14110b" />
+              </radialGradient>
+            </defs>
+            <rect width="200" height="92" fill="url(#sb)" />
+            {Array.from({ length: 28 }).map((_, i) => {
+              const a = (i / 28) * Math.PI * 2;
+              return <line key={i} x1="100" y1="46" x2={100 + Math.cos(a) * 240} y2={46 + Math.sin(a) * 240} stroke="#14110b" strokeWidth={i % 2 ? 7 : 0} opacity="0.55" />;
+            })}
+          </svg>
+          <div className="ht-dots-lg" style={{ position: "absolute", inset: 0, color: "rgba(0,0,0,0.5)", mixBlendMode: "multiply" }} />
+          <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", color: "#fff" }}>
+            <span style={{ fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--acid)", transform: "rotate(-2deg)" }}>tonight only*</span>
+            <span style={{ fontFamily: "var(--f-anton)", fontSize: 14, letterSpacing: "0.3em", marginTop: 2 }}>S.N.I.D.E.</span>
+          </div>
+        </div>
+        {/* title double-print (offset pink mis-registration) */}
+        <h2 style={{ margin: "0 0 8px", fontFamily: "var(--f-anton)", fontSize: 38, lineHeight: 0.86, letterSpacing: "0.01em", textTransform: "uppercase", color: "var(--ink)", transform: "skewX(-5deg)", textShadow: "2.5px 2.5px 0 var(--pink)" }}>{TASK.title}</h2>
+        <p style={{ fontFamily: "var(--f-type)", fontSize: 11.5, lineHeight: 1.5, margin: "0 0 10px" }}>{TASK.desc}</p>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+          <span style={{ fontFamily: "var(--f-anton)", fontSize: 22, background: "var(--ink)", color: "var(--acid)", padding: "1px 8px" }}>{TASK.points} PTS</span>
+          <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.12em", border: "2px solid var(--ink)", padding: "2px 8px", transform: "rotate(-2deg)" }}>LVL {TASK.level}</span>
+          <span style={{ marginLeft: "auto", fontFamily: "var(--f-marker)", fontSize: 12, color: "var(--pink-deep)" }}>no refunds</span>
+        </div>
+        {/* diagonal stamp */}
+        <span style={{ position: "absolute", top: 108, right: -34, transform: "rotate(-38deg)", fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.2em", color: "rgba(190,24,93,0.85)", border: "2px solid rgba(190,24,93,0.7)", padding: "2px 30px" }}>DISRUPT</span>
+        {/* rip-off commitment tabs */}
+        <div style={{ position: "relative", borderTop: "2px dashed var(--ink)", margin: "0 -16px" }}>
+          <span style={{ position: "absolute", left: 10, top: -8, background: "var(--paper)", fontSize: 12, lineHeight: 1, padding: "0 3px", color: "var(--ink)" }}>✂</span>
+        </div>
+        <div style={{ display: "flex", margin: "0 -16px -8px" }}>
+          {tabs.map((_, i) => (
+            <div key={i} style={{ flex: 1, height: 50, position: "relative", borderLeft: i ? "1px dashed rgba(20,17,11,0.45)" : "none", background: "var(--paper)" }}>
+              <span style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", writingMode: "vertical-rl", transform: "rotate(180deg)", fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.16em", color: "var(--ink)" }}>JOIN</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION C — SEWN PATCH
+   Embroidered vest patch. Acid merrow stitch border, twill ground,
+   chain-stitch title, safety pin. The silly-but-feral one.
+   ════════════════════════════════════════════════════════════════ */
+function CardPatch() {
+  return (
+    <div style={{ width: 290, position: "relative", padding: 14, transform: "rotate(-1.5deg)" }}>
+      {/* safety pin */}
+      <svg viewBox="0 0 120 40" style={{ position: "absolute", top: -8, left: 30, width: 130, height: 44, zIndex: 4, filter: "drop-shadow(1px 2px 1px rgba(0,0,0,0.4))" }}>
+        <path d="M14 22 Q10 8 30 9 L96 13 Q112 14 110 26 Q108 34 96 30 L26 18" fill="none" stroke="#c7ccd1" strokeWidth="3.4" strokeLinecap="round" />
+        <circle cx="14" cy="24" r="6.5" fill="none" stroke="#c7ccd1" strokeWidth="3.4" />
+        <circle cx="14" cy="24" r="1.6" fill="#c7ccd1" />
+      </svg>
+      {/* merrow stitched border */}
+      <div className="merrow" style={{ position: "relative", borderRadius: 16, padding: 7, boxShadow: "4px 6px 0 rgba(0,0,0,0.3)" }}>
+        <div style={{
+          position: "relative", borderRadius: 11, padding: "24px 20px 20px",
+          background: "#15120c",
+          backgroundImage: "repeating-linear-gradient(45deg, rgba(255,255,255,0.025) 0 2px, transparent 2px 4px), repeating-linear-gradient(-45deg, rgba(0,0,0,0.25) 0 2px, transparent 2px 4px)",
+          overflow: "hidden",
+          boxShadow: "inset 0 0 0 2px rgba(182,255,46,0.5), inset 0 2px 14px rgba(0,0,0,0.6)",
+          fontFamily: "var(--f-body)",
+        }}>
+          <Grain opacity={0.4} blend="overlay" />
+          <div style={{ textAlign: "center", fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.35em", color: "var(--acid)", marginBottom: 8 }}>★ EST. NEVER ★</div>
+          {/* chain-stitch title */}
+          <h2 style={{
+            margin: "0 0 6px", textAlign: "center", fontFamily: "var(--f-marker)", fontSize: 30, lineHeight: 1,
+            color: "var(--acid)", textTransform: "uppercase",
+            textShadow: "0 0 1px var(--acid-deep), 1px 1px 0 #0a0a06, -1px 0 0 var(--acid-deep)",
+          }}>{TASK.title}</h2>
+          <div style={{ width: 70, height: 0, borderTop: "2.5px dotted var(--acid)", margin: "8px auto 12px", opacity: 0.8 }} />
+          <p style={{ textAlign: "center", fontFamily: "var(--f-type)", fontSize: 11, lineHeight: 1.5, color: "#cdd6c4", margin: "0 0 16px" }}>{TASK.desc}</p>
+          <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 14 }}>
+            {/* stitched roundel */}
+            <div style={{ width: 52, height: 52, borderRadius: "50%", background: "var(--pink)", border: "2.5px dashed #fff", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", color: "#fff", boxShadow: "1px 2px 0 rgba(0,0,0,0.4)" }}>
+              <span style={{ fontFamily: "var(--f-anton)", fontSize: 20, lineHeight: 0.8 }}>{TASK.points}</span>
+              <span style={{ fontSize: 7, letterSpacing: "0.1em" }}>POINTS</span>
+            </div>
+            <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.15em", color: "var(--acid)", border: "2px dashed var(--acid)", borderRadius: 20, padding: "4px 12px" }}>LVL {TASK.level}</span>
+          </div>
+          <div style={{ marginTop: 16, textAlign: "center" }}>
+            <span style={{ display: "inline-block", fontFamily: "var(--f-black)", fontSize: 12, letterSpacing: "0.06em", background: "var(--acid)", color: "#15120c", borderRadius: 14, padding: "7px 18px", transform: "rotate(-1deg)" }}>SEW ME ON →</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION D — SPRAY STENCIL
+   Tagged on a concrete wall. Stencil-cut title, acid overspray,
+   running drips, a circled-A'd SNIDE mark. "tag, you're it."
+   ════════════════════════════════════════════════════════════════ */
+function Drip({ x, h, w = 3 }) {
+  return (
+    <g>
+      <rect x={x} y="0" width={w} height={h} fill="var(--acid)" opacity="0.85" />
+      <circle cx={x + w / 2} cy={h} r={w * 0.9} fill="var(--acid)" opacity="0.85" />
+    </g>
+  );
+}
+function CardSpray() {
+  return (
+    <div style={{
+      width: 300, position: "relative", padding: "26px 22px 22px",
+      background: "#3a3a37",
+      backgroundImage: "radial-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), radial-gradient(rgba(0,0,0,0.22) 1px, transparent 1px)",
+      backgroundSize: "3px 3px, 5px 5px", backgroundPosition: "0 0, 2px 2px",
+      fontFamily: "var(--f-body)", color: "#e7e4da", overflow: "hidden",
+      boxShadow: "6px 8px 0 rgba(0,0,0,0.3)", transform: "rotate(0.6deg)",
+    }}>
+      <Grain opacity={0.5} blend="multiply" />
+      {/* concrete cracks */}
+      <svg viewBox="0 0 300 220" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.25, pointerEvents: "none" }}>
+        <path d="M0 40 L60 70 L80 50 L160 90" stroke="#000" strokeWidth="0.8" fill="none" />
+        <path d="M300 150 L240 160 L210 140 L120 180" stroke="#000" strokeWidth="0.8" fill="none" />
+      </svg>
+      {/* circled-A SNIDE mark */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
+        <svg viewBox="0 0 48 48" style={{ width: 40, height: 40 }} filter="url(#snide-spray)">
+          <circle cx="24" cy="24" r="19" fill="none" stroke="var(--acid)" strokeWidth="3" />
+          <path d="M14 34 L24 12 L34 34 M18 27 H30" fill="none" stroke="var(--acid)" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <div>
+          <div style={{ fontFamily: "var(--f-cond)", fontSize: 15, letterSpacing: "0.22em", color: "var(--acid)" }}>S.N.I.D.E.</div>
+          <div style={{ fontSize: 8, letterSpacing: "0.14em", color: "#a7a49a", textTransform: "uppercase" }}>property of nobody</div>
+        </div>
+        <span style={{ marginLeft: "auto", fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--pink)", transform: "rotate(-4deg)" }}>tag, you're it</span>
+      </div>
+      {/* sprayed stencil title */}
+      <div style={{ position: "relative", marginBottom: 6 }}>
+        <h2 style={{ margin: 0, fontFamily: "var(--f-cond)", fontSize: 50, lineHeight: 0.84, letterSpacing: "0.02em", color: "var(--acid)", textTransform: "uppercase", filter: "url(#snide-spray)", textShadow: "0 0 7px rgba(182,255,46,0.45)" }}>{TASK.title}</h2>
+        {/* drips under the title */}
+        <svg viewBox="0 0 300 46" style={{ position: "absolute", left: 0, bottom: -16, width: "100%", height: 46, pointerEvents: "none" }} filter="url(#snide-spray)">
+          <Drip x={36} h={34} /><Drip x={120} h={22} w={2.4} /><Drip x={188} h={40} /><Drip x={250} h={18} w={2.2} />
+        </svg>
+      </div>
+      <p style={{ fontSize: 11, lineHeight: 1.55, color: "#cbc8be", margin: "22px 0 18px" }}>{TASK.desc}</p>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 14 }}>
+        <div style={{ position: "relative", fontFamily: "var(--f-anton)", color: "var(--acid)", lineHeight: 0.8, filter: "url(#snide-spray)" }}>
+          <span style={{ fontSize: 42 }}>{TASK.points}</span>
+          <span style={{ fontSize: 12, marginLeft: 3 }}>PTS</span>
+        </div>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.14em", color: "#e7e4da", border: "2px solid #6f6f68", padding: "3px 9px", transform: "rotate(-2deg)" }}>LVL {TASK.level}</span>
+        <span style={{ marginLeft: "auto", fontFamily: "var(--f-black)", fontSize: 12, color: "#15120c", background: "var(--acid)", padding: "7px 12px", transform: "rotate(2deg)", boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>HIT IT ↗</span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   OPTION E — ZINE COLLAGE  (green/black rework, pink as accent)
+   Cut-and-paste chaos ripped from acid-green stock. Black ink scraps,
+   ransom title, pink tape + scrawl + CTA accents, sticker points.
+   ════════════════════════════════════════════════════════════════ */
+function CardZine({ task = TASK, rot = -0.8 }) {
+  return (
+    <div style={{
+      width: 300, position: "relative", padding: "20px 18px 22px",
+      background: "var(--acid)", overflow: "hidden",
+      fontFamily: "var(--f-body)", color: "var(--ink)",
+      boxShadow: "6px 8px 0 rgba(0,0,0,0.32)", transform: `rotate(${rot}deg)`,
+    }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.22)", pointerEvents: "none" }} />
+      <Grain opacity={0.45} />
+      {/* torn top/bottom — ripped from black stock */}
+      <div className="torn-top" style={{ background: "var(--ink)", clipPath: TORN }} />
+      <div className="torn-bottom" style={{ background: "var(--ink)", clipPath: TORN }} />
+      {/* masthead scrap */}
+      <div style={{ position: "relative", display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+        <span style={{ background: "var(--ink)", color: "var(--acid)", fontFamily: "var(--f-cond)", fontSize: 14, letterSpacing: "0.2em", padding: "2px 8px", transform: "rotate(-2deg)" }}>S.N.I.D.E.</span>
+        <span style={{ background: "var(--paper)", fontFamily: "var(--f-type)", fontSize: 9, whiteSpace: "nowrap", padding: "2px 7px", transform: "rotate(2deg)" }}>STILL FREE</span>
+      </div>
+      {/* black scrap w/ ransom title */}
+      <div style={{ position: "relative", background: "var(--ink)", padding: "12px 12px 14px", transform: "rotate(-1.5deg)", marginBottom: 16, boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>
+        <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.14)", pointerEvents: "none" }} />
+        <div style={{ position: "relative" }}><Ransom text={task.title} size={25} /></div>
+      </div>
+      {/* taped cream desc scrap + pink tape accent */}
+      <div style={{ position: "relative", background: "var(--paper)", padding: "13px 12px 11px", transform: "rotate(0.8deg)", marginBottom: 16, boxShadow: "2px 3px 0 rgba(0,0,0,0.28)" }}>
+        <div style={{ position: "absolute", top: -9, left: "50%", marginLeft: -30, width: 60, height: 19, background: "rgba(255,45,139,0.5)", boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.3)", transform: "rotate(-4deg)" }} />
+        <p style={{ fontFamily: "var(--f-type)", fontSize: 11, lineHeight: 1.5, margin: 0, color: "#1a160e" }}>{task.desc}</p>
+        <div style={{ fontFamily: "var(--f-marker)", fontSize: 15, color: "var(--pink)", transform: "rotate(-3deg)", marginTop: 6, WebkitTextStroke: "0.4px var(--pink-deep)" }}>do it, coward →</div>
+      </div>
+      {/* bottom row: black sticker points + level + pink CTA */}
+      <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 12 }}>
+        <div style={{ position: "relative", width: 56, height: 56, transform: "rotate(-6deg)" }}>
+          <svg viewBox="0 0 56 56" style={{ position: "absolute", inset: 0, filter: "drop-shadow(1.5px 2px 0 rgba(0,0,0,0.35))" }}>
+            <circle cx="28" cy="28" r="26" fill="var(--ink)" stroke="var(--acid)" strokeWidth="2.5" />
+          </svg>
+          <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", color: "var(--acid)" }}>
+            <span style={{ fontFamily: "var(--f-anton)", fontSize: 22, lineHeight: 0.8 }}>{task.points}</span>
+            <span style={{ fontSize: 7, fontWeight: 700, letterSpacing: "0.1em" }}>POINTS</span>
+          </div>
+        </div>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.12em", background: "var(--ink)", color: "var(--acid)", padding: "3px 9px", transform: "rotate(2deg)" }}>LVL {task.level}</span>
+        <span style={{ marginLeft: "auto", fontFamily: "var(--f-black)", fontSize: 13, background: "var(--pink)", color: "#fff", padding: "8px 13px", transform: "rotate(-2deg)", boxShadow: "2px 3px 0 var(--ink)" }}>I'M IN ↗</span>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { CardRansom, CardFlyer, CardPatch, CardSpray, CardZine, Ransom, SNIDE_TASK: TASK, SNIDE_TASKS: TASKS });

--- a/docs/design/praxis-read/factions/snide/snide-faction.jsx
+++ b/docs/design/praxis-read/factions/snide/snide-faction.jsx
@@ -1,0 +1,234 @@
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. — faction-aware surfaces
+   Society for Nihilistic Intent and Disruptive Efforts.
+   Sigil · nav badge · pennant (filter tab) · vote stamps (approval) ·
+   stat block · faction-page hero (flyposted masthead) · dispatch slip.
+   Reuses snide.css tokens + the photocopy filters (#snide-grain/-spray).
+   Theme-aware through the cascade.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── SNIDE sigil — a sprayed, struck-through circle-S (defiant mark) ── */
+function SnideSigil({ size = 48, color = "var(--acid)", strokeOnly = false }) {
+  return (
+    <svg viewBox="0 0 48 48" width={size} height={size} style={{ display: "block" }} filter="url(#snide-spray)">
+      <circle cx="24" cy="24" r="19" fill="none" stroke={color} strokeWidth="3" />
+      <text x="24" y="34" textAnchor="middle" fontFamily="var(--f-anton)" fontSize="30" fill={color}>S</text>
+      <line x1="9" y1="40" x2="39" y2="8" stroke={color} strokeWidth="3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/* ── nav faction badge ─────────────────────────────────────────────── */
+function SnideNavBadge({ name = "S.N.I.D.E." }) {
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 6, background: "var(--snide-green)",
+      color: "#fff", padding: "5px 9px 5px 7px", fontFamily: "var(--f-cond)",
+      fontSize: 12, letterSpacing: "0.14em", textTransform: "uppercase", transform: "rotate(-1deg)",
+      boxShadow: "1.5px 2px 0 rgba(0,0,0,0.4)",
+    }}>
+      <SnideSigil size={15} color="var(--acid)" />
+      {name}
+    </span>
+  );
+}
+
+/* ── faction pennant (filter tab) ──────────────────────────────────── */
+/* Same clip-path as the other seven so the filter row aligns; only color
+   changes. Inactive drops opacity. SNIDE uses its toxic green. */
+function SnidePennant({ color, name, active = false, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      background: color, color: "#fff", fontFamily: "var(--font-body)", fontSize: 9.5,
+      fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.07em", padding: "5px 14px",
+      cursor: "pointer", border: "none", borderRadius: 0, textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+      opacity: active ? 1 : 0.78, clipPath: "polygon(0 0, 100% 0, 94% 100%, 6% 100%)", whiteSpace: "nowrap",
+      transform: active ? "translateY(-2px) rotate(-1deg)" : "none", transition: "all 120ms",
+      filter: active ? "drop-shadow(0 4px 6px rgba(0,0,0,0.28))" : "none",
+    }}>
+      {name}
+    </button>
+  );
+}
+
+/* ── vote stamps — a mismatched drawer of rubber stamps ────────────── */
+/* Each mark is a different junk-drawer stamp: varied shape, size, font,
+   tilt and ink. Climbs from a limp "meh" to the black ANARCHY seal. */
+const SNIDE_VOTE = [
+  { v: 1, label: "meh",     shape: "square", rot: -8, size: 38, font: "var(--f-type)",  fill: "transparent",      ink: "cur",         ring: "cur",         border: "dashed" },
+  { v: 2, label: "not bad", shape: "circle", rot: 6,  size: 46, font: "var(--f-anton)", fill: "var(--acid-deep)", ink: "var(--ink)",  ring: "var(--ink)",  border: "solid" },
+  { v: 3, label: "rad",     shape: "square", rot: -5, size: 52, font: "var(--f-cond)",  fill: "var(--acid)",      ink: "var(--ink)",  ring: "var(--ink)",  border: "double" },
+  { v: 4, label: "sick!!",  shape: "burst",  rot: 9,  size: 56, font: "var(--f-black)", fill: "var(--pink)",      ink: "#fff",        ring: "var(--ink)",  border: "solid" },
+  { v: 5, label: "ANARCHY", shape: "seal",   rot: -6, size: 62, font: "var(--f-anton)", fill: "var(--ink)",       ink: "var(--acid)", ring: "var(--acid)", border: "solid" },
+];
+const BURST_CLIP = "polygon(50% 0,61% 25%,90% 10%,75% 39%,100% 50%,75% 61%,90% 90%,61% 75%,50% 100%,39% 75%,10% 90%,25% 61%,0 50%,25% 39%,10% 10%,39% 25%)";
+function SnideVoteStamps({ value = 0, average, totalVotes, onPick }) {
+  const [sel, setSel] = React.useState(value);
+  React.useEffect(() => { setSel(value); }, [value]);
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 13, alignItems: "flex-end" }}>
+        {SNIDE_VOTE.map((s) => {
+          const on = sel >= s.v;
+          const cur = "var(--snide-wall-text)";
+          const ink = on ? (s.ink === "cur" ? cur : s.ink) : cur;
+          const ring = on ? (s.ring === "cur" ? cur : s.ring) : cur;
+          const round = s.shape === "circle" || s.shape === "seal";
+          const isBurst = s.shape === "burst";
+          return (
+            <div key={s.v} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+              <button onClick={() => { setSel(s.v); if (onPick) onPick(s.v); }} style={{
+                position: "relative", width: s.size, height: s.size, cursor: "pointer", padding: 0,
+                border: isBurst ? "none" : `${s.border === "double" ? 4 : 2.5}px ${s.border} ${ring}`,
+                borderRadius: round ? "50%" : 0,
+                clipPath: isBurst ? BURST_CLIP : "none",
+                background: on ? s.fill : (isBurst ? "color-mix(in srgb, var(--snide-wall-text) 13%, transparent)" : "transparent"),
+                color: ink, fontFamily: s.font, fontSize: s.size * (s.shape === "seal" ? 0.4 : 0.5), lineHeight: 1,
+                transform: `rotate(${s.rot}deg)${sel === s.v ? " scale(1.08)" : ""}`, transition: "all 110ms",
+                filter: on && !isBurst ? "url(#snide-rough)" : "none",
+                display: "flex", alignItems: "center", justifyContent: "center",
+              }}>
+                {s.shape === "seal" && (
+                  <span style={{ position: "absolute", inset: 4, borderRadius: "50%", border: `1.5px dashed ${on ? "var(--acid)" : cur}`, opacity: 0.7, pointerEvents: "none" }} />
+                )}
+                {s.v}
+              </button>
+              <span style={{ fontFamily: s.v === 5 ? "var(--f-cond)" : "var(--font-body)", fontSize: s.v === 5 ? 9 : 8,
+                textTransform: "uppercase", letterSpacing: "0.04em",
+                color: sel === s.v ? "var(--snide-green)" : "color-mix(in srgb, var(--snide-wall-text) 55%, transparent)",
+                maxWidth: s.size + 16, textAlign: "center", lineHeight: 1.2 }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+      {average !== undefined && (
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 10, color: "color-mix(in srgb, var(--snide-wall-text) 60%, transparent)", margin: "16px 0 0", letterSpacing: "0.04em" }}>
+          <b style={{ color: "var(--snide-green)", fontFamily: "var(--f-anton)", fontSize: 17 }}>{average.toFixed(1)}</b> avg · {totalVotes ?? 0} votes · <span style={{ fontFamily: "var(--f-marker)", color: "var(--pink)" }}>nobody's impressed</span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+/* ── stat block (hero) ─────────────────────────────────────────────── */
+function SnideStat({ value, label }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2, padding: "0 22px" }}>
+      <span style={{ fontFamily: "var(--f-anton)", fontSize: 36, lineHeight: 0.85, color: "var(--acid)", whiteSpace: "nowrap" }}>{value}</span>
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "#cfcdbf" }}>{label}</span>
+    </div>
+  );
+}
+
+/* ── faction-page hero (flyposted wall — NOT a tidy poster) ────────── */
+const HERO_GHOSTS = [
+  { w: 122, h: 152, top: -24, left: 54, rot: -12 },
+  { w: 96, h: 128, top: 44, left: 232, rot: 7 },
+  { w: 150, h: 92, top: 158, left: 430, rot: -5 },
+  { w: 84, h: 116, top: 14, left: 690, rot: 11 },
+  { w: 116, h: 150, top: 128, left: 858, rot: -8 },
+];
+function SnideHero({ name, motto, fullName, blurb, stats }) {
+  const chitRot = [-3, 2.5, -2];
+  return (
+    <header style={{ position: "relative", overflow: "hidden", background: "var(--ink)", color: "#fff", boxShadow: "8px 10px 0 rgba(0,0,0,0.32)", paddingBottom: 4 }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.055)", pointerEvents: "none" }} />
+      <div style={{ position: "absolute", inset: 0, filter: "url(#snide-grain)", opacity: 0.4, mixBlendMode: "screen", pointerEvents: "none" }} />
+      {/* faint pasted flyers on the wall */}
+      {HERO_GHOSTS.map((g, i) => (
+        <div key={i} aria-hidden="true" style={{ position: "absolute", top: g.top, left: g.left, width: g.w, height: g.h,
+          border: "1px solid rgba(182,255,46,0.07)", background: i % 2 ? "rgba(255,45,139,0.035)" : "rgba(182,255,46,0.025)",
+          transform: `rotate(${g.rot}deg)`, pointerEvents: "none" }} />
+      ))}
+      {/* torn acid strip */}
+      <div style={{ height: 6, background: "var(--acid)", position: "relative", zIndex: 2, clipPath: "polygon(0 0,100% 0,100% 55%,97% 100%,94% 50%,90% 100%,86% 55%,82% 100%,78% 60%,0 100%)" }} />
+
+      {/* slapped sigil sticker, tilted */}
+      <div style={{ position: "absolute", top: 34, right: 42, zIndex: 3, transform: "rotate(9deg)" }}>
+        <div style={{ position: "relative", width: 104, height: 104, borderRadius: "50%", background: "var(--paper)",
+          display: "flex", alignItems: "center", justifyContent: "center", border: "2px solid var(--snide-green)",
+          boxShadow: "0 0 0 4px var(--ink), 3px 4px 0 rgba(0,0,0,0.4)" }}>
+          <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.06)", borderRadius: "50%", pointerEvents: "none" }} />
+          <SnideSigil size={60} color="var(--snide-green)" />
+        </div>
+        <div style={{ position: "absolute", top: -9, left: "50%", marginLeft: -26, width: 52, height: 18, background: "var(--tape)", transform: "rotate(-7deg)" }} />
+      </div>
+
+      <div style={{ position: "relative", zIndex: 2, padding: "26px 38px 2px", maxWidth: 770 }}>
+        {/* eyebrow on tape */}
+        <div style={{ display: "inline-block", width: "fit-content", whiteSpace: "nowrap", background: "var(--tape)", color: "var(--ink)", fontFamily: "var(--f-type)", fontSize: 10, letterSpacing: "0.05em", padding: "3px 12px", transform: "rotate(-1.5deg)", boxShadow: "1px 1px 0 rgba(0,0,0,0.3)" }}>World Zero · faction no. 4</div>
+        {/* wordmark */}
+        <h1 style={{ fontFamily: "var(--f-anton)", fontSize: 86, lineHeight: 0.8, letterSpacing: "0.02em", margin: "14px 0 0",
+          color: "var(--acid)", textShadow: "4px 4px 0 var(--pink)", transform: "skewX(-5deg) rotate(-1.5deg)" }}>{name}</h1>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.16em", textTransform: "uppercase", color: "#b7b5a7", margin: "12px 0 0", transform: "rotate(-0.4deg)" }}>{fullName}</div>
+        {/* motto */}
+        <div style={{ display: "inline-block", marginTop: 14, background: "var(--acid)", color: "var(--ink)",
+          fontFamily: "var(--f-black)", fontSize: 15, letterSpacing: "0.02em", padding: "6px 15px", transform: "rotate(-2deg)", boxShadow: "2px 3px 0 var(--pink)" }}>{motto}</div>
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 12.5, lineHeight: 1.6, maxWidth: 600, margin: "16px 0 0", color: "#e7e4d8" }}>{blurb}</p>
+      </div>
+
+      {/* staggered stat chits — not a clean band */}
+      <div style={{ position: "relative", zIndex: 2, display: "flex", gap: 16, flexWrap: "wrap", padding: "24px 38px 28px" }}>
+        {stats.map((s, i) => (
+          <div key={s.label} style={{ background: "rgba(0,0,0,0.34)", border: "2px solid var(--acid)", padding: "8px 16px 7px",
+            transform: `rotate(${chitRot[i % chitRot.length]}deg)`, boxShadow: "2px 3px 0 rgba(0,0,0,0.4)" }}>
+            <div style={{ fontFamily: "var(--f-anton)", fontSize: 34, lineHeight: 0.85, color: "var(--acid)", whiteSpace: "nowrap" }}>{s.value}</div>
+            <div style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", color: "#cfcdbf" }}>{s.label}</div>
+          </div>
+        ))}
+      </div>
+    </header>
+  );
+}
+
+/* ── dispatch slip (faction activity feed item) ────────────────────── */
+/* World Zero's activity card reframed as an intercepted ransom-note slip. */
+const STAMP_KINDS = {
+  foe:   { label: "FOE",        color: "var(--pink)" },
+  yours: { label: "YOUR STUFF", color: "var(--snide-green)" },
+  duel:  { label: "DUEL",       color: "var(--color-danger, #dc2626)" },
+};
+function SnideDispatch({ actor, initial, action, task, badge, time, status, rot = -0.6 }) {
+  const stamp = badge ? STAMP_KINDS[badge] ?? STAMP_KINDS.yours : null;
+  return (
+    <div style={{
+      position: "relative", background: "var(--paper)", color: "var(--ink)", border: "1.5px solid var(--ink)",
+      padding: "14px 18px 18px", marginBottom: 18, transform: `rotate(${rot}deg)`, boxShadow: "3px 4px 0 rgba(0,0,0,0.22)",
+      fontFamily: "var(--font-body)", maxWidth: 560,
+    }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.05)", pointerEvents: "none" }} />
+      {/* torn bottom */}
+      <div style={{ position: "absolute", bottom: -1, left: 0, right: 0, height: 6, background: "var(--snide-wall)", clipPath: "polygon(0 0,4% 100%,8% 20%,14% 90%,20% 10%,26% 80%,32% 0,40% 95%,48% 20%,56% 85%,64% 5%,72% 90%,80% 15%,88% 95%,94% 20%,100% 0)" }} />
+      {/* rubber stamp badge */}
+      {stamp && (
+        <span style={{ position: "absolute", top: 10, right: 12, fontFamily: "var(--f-cond)", fontSize: 12, letterSpacing: "0.12em",
+          color: stamp.color, border: `2px solid ${stamp.color}`, padding: "2px 9px", transform: "rotate(5deg)", opacity: 0.9 }}>{stamp.label}</span>
+      )}
+      <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 12 }}>
+        {/* sprayed avatar */}
+        <div style={{ flexShrink: 0, width: 42, height: 42, borderRadius: "50%", background: "var(--ink)", border: "2px solid var(--snide-green)",
+          display: "flex", alignItems: "center", justifyContent: "center", color: "var(--acid)", fontFamily: "var(--f-anton)", fontSize: 20, transform: "rotate(-4deg)" }}>{initial}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 8, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--snide-muted)", marginBottom: 2 }}>intercepted dispatch · {time}</div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.4 }}>
+            <span style={{ fontFamily: "var(--f-marker)", fontSize: 16, color: "var(--snide-green)", marginRight: 4 }}>{actor}</span>
+            {action}
+          </div>
+        </div>
+      </div>
+      {/* task chip */}
+      {task && (
+        <div style={{ position: "relative", display: "inline-flex", alignItems: "center", gap: 8, marginTop: 12, background: "var(--ink)", padding: "5px 10px", transform: "rotate(-1deg)", whiteSpace: "nowrap", maxWidth: "100%" }}>
+          <span style={{ fontFamily: "var(--f-cond)", fontSize: 13, letterSpacing: "0.06em", color: "var(--acid)", whiteSpace: "nowrap" }}>{task.title}</span>
+          <span style={{ fontFamily: "var(--f-anton)", fontSize: 13, color: "var(--pink)" }}>+{task.points}</span>
+          {task.level && <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.08em", color: "#cfcdbf", textTransform: "uppercase" }}>lvl {task.level}</span>}
+        </div>
+      )}
+      {status && (
+        <div style={{ position: "relative", marginTop: 11, fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--pink)", transform: "rotate(-1deg)" }}>{status}</div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { SnideSigil, SnideNavBadge, SnidePennant, SnideVoteStamps, SnideStat, SnideHero, SnideDispatch });

--- a/docs/design/praxis-read/factions/snide/snide-praxis-detail.jsx
+++ b/docs/design/praxis-read/factions/snide/snide-praxis-detail.jsx
@@ -1,0 +1,160 @@
+/* ════════════════════════════════════════════════════════════════
+   S.N.I.D.E. — Completed Praxis (case files) + Praxis Detail
+   · SnideVoteTally  — histogram of marks 1–5 received, punk bars
+   · SnidePraxisRow  — a filed confession as a pinned case-file row
+   · SnidePraxisDetail — one completed praxis in full + cast-a-vote
+   Reuses snide.css tokens, photocopy filters, SnideSigil + SnideVoteStamps.
+   Theme-aware via --snide-wall-text.
+   ════════════════════════════════════════════════════════════════ */
+
+const PD_MUTED = "color-mix(in srgb, var(--snide-wall-text) 55%, transparent)";
+const PD_MARKS = [
+  { v: 1, label: "meh", color: "color-mix(in srgb, var(--snide-wall-text) 45%, transparent)" },
+  { v: 2, label: "not bad", color: "var(--acid-deep)" },
+  { v: 3, label: "rad", color: "var(--acid)" },
+  { v: 4, label: "sick", color: "var(--pink)" },
+  { v: 5, label: "anarchy", color: "var(--snide-green)" },
+];
+
+function pdAvg(counts) {
+  let n = 0, s = 0;
+  for (const m of PD_MARKS) { const c = counts[m.v] || 0; n += c; s += c * m.v; }
+  return { total: n, avg: n ? s / n : 0 };
+}
+
+/* ── vote tally — how the marks landed ─────────────────────────────── */
+function SnideVoteTally({ counts }) {
+  const { total, avg } = pdAvg(counts);
+  const max = Math.max(1, ...PD_MARKS.map((m) => counts[m.v] || 0));
+  const wall = "var(--snide-wall-text)";
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 10, marginBottom: 14 }}>
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 54, lineHeight: 0.8, color: "var(--snide-green)" }}>{avg.toFixed(1)}</span>
+        <div style={{ paddingBottom: 5 }}>
+          <div style={{ fontFamily: "var(--f-cond)", fontSize: 16, letterSpacing: "0.06em", color: wall }}>OUT OF 5</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.06em", color: PD_MUTED }}>{total} marks · <span style={{ fontFamily: "var(--f-marker)", color: "var(--pink)" }}>still nobody's impressed</span></div>
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+        {[...PD_MARKS].reverse().map((m) => {
+          const c = counts[m.v] || 0;
+          return (
+            <div key={m.v} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span style={{ width: 16, textAlign: "center", fontFamily: "var(--f-anton)", fontSize: 15, color: wall }}>{m.v}</span>
+              <div style={{ flex: 1, height: 16, background: "color-mix(in srgb, var(--snide-wall-text) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--snide-wall-text) 25%, transparent)", position: "relative" }}>
+                <div style={{ position: "absolute", inset: 0, width: `${(c / max) * 100}%`, background: m.color, transition: "width 200ms" }} />
+              </div>
+              <span style={{ width: 26, textAlign: "right", fontFamily: "var(--font-body)", fontSize: 11, fontWeight: 700, color: wall }}>{c}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ── filed confession — case-file row (links to detail) ────────────── */
+function SnidePraxisRow({ href = "#", author, initial, faction = "S.N.I.D.E.", when, snippet, evidence = 0, counts, mark, rank }) {
+  const { avg, total } = pdAvg(counts);
+  const wall = "var(--snide-wall-text)";
+  const ink = "var(--ink)";
+  return (
+    <a href={href} className="casefile" style={{ position: "relative", display: "flex", background: "var(--paper)", color: ink,
+      border: "1.5px solid " + ink, boxShadow: "4px 5px 0 rgba(0,0,0,0.22)", overflow: "hidden", textDecoration: "none" }}>
+      <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.05)", pointerEvents: "none" }} />
+      {/* rank + mugshot tab */}
+      <div style={{ position: "relative", flexShrink: 0, width: 70, background: ink, color: "var(--acid)",
+        display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 4,
+        backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, rgba(182,255,46,0.18) 13px 14px)" }}>
+        {rank && <span style={{ position: "absolute", top: 5, left: 6, fontFamily: "var(--f-anton)", fontSize: 11, color: "var(--pink)" }}>#{rank}</span>}
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 26, lineHeight: 0.8 }}>{initial}</span>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 6.5, letterSpacing: "0.14em", color: "#cfe6a0" }}>EXHIBIT</span>
+      </div>
+      {/* body */}
+      <div style={{ position: "relative", flex: 1, padding: "12px 16px", minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 9, flexWrap: "wrap" }}>
+          <span style={{ fontFamily: "var(--f-marker)", fontSize: 18, color: "var(--snide-accent)" }}>{author}</span>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "#6b6253" }}>{faction} · {when}</span>
+        </div>
+        <p style={{ fontFamily: "var(--font-body)", fontSize: 11.5, lineHeight: 1.5, color: "#3a342a", margin: "5px 0 0", overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}>{snippet}</p>
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 9 }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 8.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "#6b6253", border: "1px solid rgba(20,17,11,0.25)", padding: "2px 7px" }}>📎 {evidence} evidence</span>
+          <span style={{ marginLeft: "auto", fontFamily: "var(--f-marker)", fontSize: 14, color: ink }}>open the file →</span>
+        </div>
+      </div>
+      {/* vote tally chip */}
+      <div style={{ position: "relative", flexShrink: 0, width: 92, borderLeft: "1.5px dashed rgba(20,17,11,0.3)",
+        display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "10px 8px", background: "rgba(0,0,0,0.02)" }}>
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 30, lineHeight: 0.8, color: "var(--snide-accent)" }}>{avg.toFixed(1)}</span>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 7.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "#6b6253", marginTop: 3 }}>{total} marks</span>
+        {mark && <span style={{ marginTop: 6, fontFamily: "var(--f-cond)", fontSize: 11, letterSpacing: "0.08em", color: "#fff", background: "var(--pink)", padding: "1px 7px", transform: "rotate(-3deg)" }}>{mark}</span>}
+      </div>
+    </a>
+  );
+}
+
+/* ── one completed praxis, in full (voting lives on the page) ───────── */
+function SnidePraxisDetail({ task, author, initial, when, faction = "S.N.I.D.E.", confession, evidence = [] }) {
+  const { SnideSigil } = window;
+  const wall = "var(--snide-wall-text)";
+  const ink = "var(--ink)";
+  return (
+    <div style={{ position: "relative", fontFamily: "var(--font-body)", color: wall }}>
+      {/* stamped masthead */}
+      <div style={{ lineHeight: 0 }}>
+        <div style={{ display: "inline-flex", alignItems: "center", gap: 9, background: "var(--snide-green)", color: "#fff",
+          padding: "8px 16px 8px 13px", transform: "rotate(-1.5deg)", boxShadow: "4px 4px 0 var(--pink)" }}>
+          <SnideSigil size={17} color="var(--acid)" />
+          <span style={{ fontFamily: "var(--f-cond)", fontSize: 17, letterSpacing: "0.14em", whiteSpace: "nowrap" }}>S.N.I.D.E. · CLOSED CASE · FILED</span>
+        </div>
+      </div>
+
+      {/* author + task line */}
+      <div style={{ display: "flex", alignItems: "center", gap: 14, margin: "20px 0 6px" }}>
+        <div style={{ flexShrink: 0, width: 56, height: 56, borderRadius: "50%", background: ink, border: "2px solid var(--snide-green)",
+          display: "flex", alignItems: "center", justifyContent: "center", color: "var(--acid)", fontFamily: "var(--f-anton)", fontSize: 26, transform: "rotate(-4deg)" }}>{initial}</div>
+        <div>
+          <div style={{ fontFamily: "var(--f-anton)", fontSize: 40, lineHeight: 0.84, color: wall, transform: "skewX(-4deg)" }}>{author}</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: PD_MUTED, marginTop: 5 }}>{faction} · pulled it off · {when}</div>
+        </div>
+      </div>
+
+      {/* the job they closed */}
+      <div style={{ display: "inline-flex", alignItems: "center", gap: 10, background: ink, padding: "6px 12px", transform: "rotate(-0.5deg)", margin: "8px 0 26px", whiteSpace: "nowrap" }}>
+        <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.2em", textTransform: "uppercase", color: "#8f9183" }}>re:</span>
+        <span style={{ fontFamily: "var(--f-cond)", fontSize: 18, letterSpacing: "0.04em", color: "var(--acid)", whiteSpace: "nowrap" }}>{task.title}</span>
+        <span style={{ fontFamily: "var(--f-anton)", fontSize: 15, color: "var(--pink)" }}>+{task.points}</span>
+      </div>
+
+      {/* the confession (ruled notebook) */}
+      <div style={{ position: "relative", marginBottom: 28 }}>
+        <span style={{ display: "inline-block", background: "var(--acid)", color: ink, fontFamily: "var(--f-marker)", fontSize: 17, padding: "3px 13px", transform: "rotate(-1.5deg)", boxShadow: "2px 2px 0 var(--pink)", marginBottom: 12 }}>the confession</span>
+        <div style={{ position: "relative" }}>
+          <div className="tape" style={{ top: -8, left: 28, width: 56, height: 18, transform: "rotate(-5deg)", zIndex: 3 }} />
+          <div style={{ border: "1.5px solid " + ink, borderLeft: "4px solid var(--pink)", background: "var(--paper)", color: ink,
+            backgroundImage: "repeating-linear-gradient(180deg, transparent 0 27px, rgba(20,17,11,0.11) 27px 28px)",
+            padding: "8px 16px 14px 18px", fontSize: 13, lineHeight: "28px", whiteSpace: "pre-line" }}>{confession}</div>
+        </div>
+      </div>
+
+      {/* the evidence */}
+      <div style={{ marginBottom: 30 }}>
+        <span style={{ display: "inline-block", background: "var(--acid)", color: ink, fontFamily: "var(--f-marker)", fontSize: 17, padding: "3px 13px", transform: "rotate(1.5deg)", boxShadow: "2px 2px 0 var(--pink)", marginBottom: 14 }}>the evidence</span>
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+          {evidence.map((e, i) => (
+            <div key={i} style={{ background: "var(--paper)", border: "1.5px solid " + ink, padding: "8px 8px 18px", transform: `rotate(${i % 2 ? 2.5 : -2.5}deg)`, boxShadow: "3px 4px 0 rgba(0,0,0,0.2)" }}>
+              <div style={{ position: "relative", width: 122, height: 92, background: ink, overflow: "hidden" }}>
+                <div className="ht-dots-lg" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.5)", mixBlendMode: "screen" }} />
+                <span style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--acid)" }}>{e}</span>
+              </div>
+              <div style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.1em", textTransform: "uppercase", color: "#6b6253", marginTop: 7, textAlign: "center" }}>exhibit {String.fromCharCode(65 + i)}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { SnideVoteTally, SnidePraxisRow, SnidePraxisDetail, pdAvg });

--- a/docs/design/praxis-read/factions/snide/snide.css
+++ b/docs/design/praxis-read/factions/snide/snide.css
@@ -1,0 +1,127 @@
+/* ══════════════════════════════════════════════════════════════
+   S.N.I.D.E. redesign — local tokens + punk textures
+   Society for Nihilistic Intent and Disruptive Efforts
+   Pulls real World Zero SNIDE values + system fonts, then layers
+   the photocopy / spray / ransom craft on top.
+   ══════════════════════════════════════════════════════════════ */
+@import url("https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;0,700;1,400;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&family=Bebas+Neue&family=Special+Elite&family=Permanent+Marker&family=Anton&family=Archivo+Black&display=swap");
+
+:root {
+  /* SNIDE faction values, straight from the design system */
+  --snide-green: #16a34a;
+  --snide-accent: #15803d;
+  --snide-card-bg: #ecf5ea;     /* mossy newsprint */
+  --snide-muted: #444;
+
+  /* Punk extensions */
+  --acid: #b6ff2e;              /* toxic / radioactive green */
+  --acid-deep: #6fae00;
+  --ink: #14110b;              /* photocopier black */
+  --paper: #f4f1e8;            /* warm xerox paper */
+  --paper-cool: #e7e9e2;
+  --pink: #ff2d8b;             /* hot zine pink */
+  --pink-deep: #be185d;        /* system magenta */
+  --tape: rgba(228, 214, 120, 0.62);
+  --tape-grey: rgba(200, 200, 190, 0.5);
+
+  /* system fonts */
+  --f-marker: "Permanent Marker", "Marker Felt", cursive;
+  --f-body: "Courier Prime", "Courier New", monospace;
+  --f-type: "Special Elite", "Courier New", serif;
+  --f-cond: "Bebas Neue", Impact, sans-serif;
+  --f-anton: "Anton", Impact, sans-serif;
+  --f-black: "Archivo Black", Impact, sans-serif;
+  --f-serif: "Lora", Georgia, serif;
+
+  /* flyposted-wall backdrop tokens (FLIP in dark) */
+  --snide-wall: #efece3;        /* xerox-paper wall */
+  --snide-wall-deep: #e0ddd1;
+  --snide-wall-text: var(--ink);
+}
+
+[data-theme="dark"] {
+  --snide-wall: #141310;        /* concrete-at-night */
+  --snide-wall-deep: #0b0a08;
+  --snide-wall-text: #e9e6da;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SNIDE FLYPOSTED-WALL BACKDROP
+   Replaces the neutral watercolor on faction-context pages: warm xerox
+   stock plastered with a faint acid sunburst, screen-print halftone,
+   a scratched crosshatch, and acid/pink light bleeding from the corners.
+   Theme-aware — darkens to a moody concrete wall. Render once as
+   <div class="snide-backdrop"></div>, fixed behind content.
+   ════════════════════════════════════════════════════════════════ */
+.snide-backdrop {
+  position: fixed; inset: 0; z-index: 0; pointer-events: none;
+  background-color: var(--snide-wall);
+  background-image:
+    radial-gradient(40% 30% at 100% 0%, color-mix(in srgb, var(--acid) 18%, transparent), transparent 70%),
+    radial-gradient(44% 36% at 0% 100%, color-mix(in srgb, var(--pink) 14%, transparent), transparent 70%),
+    radial-gradient(color-mix(in srgb, var(--snide-wall-text) 7%, transparent) 0.6px, transparent 1px),
+    repeating-linear-gradient(28deg, color-mix(in srgb, var(--snide-wall-text) 3%, transparent) 0 1px, transparent 1px 7px),
+    repeating-linear-gradient(-19deg, color-mix(in srgb, var(--snide-wall-text) 2.5%, transparent) 0 1px, transparent 1px 9px),
+    linear-gradient(180deg, var(--snide-wall), var(--snide-wall-deep));
+  background-size: 100% 100%, 100% 100%, 5px 5px, auto, auto, 100% 100%;
+}
+.snide-backdrop::after {
+  content: ""; position: absolute; inset: 0;
+  background: radial-gradient(120% 90% at 50% 6%, transparent 42%, color-mix(in srgb, var(--snide-wall-deep) 60%, transparent));
+}
+
+/* ── Halftone dot screen ── */
+.ht-dots {
+  background-image: radial-gradient(currentColor 32%, transparent 34%);
+  background-size: 5px 5px;
+  background-position: 0 0;
+}
+.ht-dots-lg {
+  background-image: radial-gradient(currentColor 30%, transparent 33%);
+  background-size: 8px 8px;
+}
+
+/* ── Newsprint / xerox paper grain (cheap, no filter) ── */
+.xerox {
+  background-color: var(--paper);
+  background-image:
+    radial-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
+    radial-gradient(rgba(0,0,0,0.04) 1px, transparent 1px);
+  background-size: 3px 3px, 4px 4px;
+  background-position: 0 0, 2px 1px;
+}
+
+/* ── Torn paper edges ── */
+.torn-top, .torn-bottom { position: absolute; left: 0; right: 0; height: 7px; }
+.torn-top { top: -1px; }
+.torn-bottom { bottom: -1px; }
+
+/* ── Scotch tape ── */
+.tape {
+  position: absolute; height: 26px; width: 64px;
+  background: var(--tape);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.25);
+  opacity: 0.9;
+}
+.tape::before, .tape::after {
+  content: ""; position: absolute; top: 0; bottom: 0; width: 4px;
+  background-image: repeating-linear-gradient(90deg, rgba(0,0,0,0.05) 0 1px, transparent 1px 3px);
+}
+.tape::before { left: 0; }
+.tape::after { right: 0; }
+
+/* ── Stitch border (sewn patch) ── */
+.merrow {
+  background-image: repeating-conic-gradient(var(--acid) 0deg 18deg, var(--acid-deep) 18deg 36deg);
+}
+
+/* ── blink + jitter ── */
+@keyframes snide-grain-jit { 0%,100%{ transform: translate(0,0);} 50%{ transform: translate(-1px,1px);} }
+
+/* canvas card label chrome */
+.opt-note {
+  font-family: var(--f-body);
+  font-size: 11px; line-height: 1.5; color: #555;
+}
+
+* { box-sizing: border-box; }

--- a/docs/design/praxis-read/factions/ua/UA Praxis - Read.dc.html
+++ b/docs/design/praxis-read/factions/ua/UA Praxis - Read.dc.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,500;1,600;1,700&family=Marcellus&family=Marcellus+SC&family=EB+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=Courier+Prime:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/tokens/colors.css">
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css">
+<script src="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/_ds_bundle.js"></script>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #ece4d2; }
+  a { color: inherit; text-decoration: none; }
+  ::selection { background: rgba(194,84,31,.18); }
+</style>
+</helmet>
+
+<div style="min-height:100vh;background:#ece4d2;background-image:radial-gradient(70% 50% at 8% 0%, rgba(221,147,34,.07), transparent 70%), radial-gradient(60% 50% at 100% 8%, rgba(194,84,31,.06), transparent 70%), radial-gradient(rgba(140,106,30,.04) 1px, transparent 1px);background-size:auto, auto, 6px 6px;font-family:'Courier Prime',monospace;color:#3d2410;">
+
+  <!-- NAV -->
+  <nav style="display:flex;align-items:center;gap:22px;padding:14px 32px;border-bottom:1px solid #d8c39a;background:rgba(253,246,234,.82);backdrop-filter:blur(6px);position:sticky;top:0;z-index:20;">
+    <span style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:22px;line-height:1;border-bottom:3px solid;padding-bottom:2px;border-image:linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1;">World Zero</span>
+    <div style="display:flex;gap:18px;flex:1;">
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#a8895a;">Home</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#a8895a;">Tasks</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#c2541f;border-bottom:1px solid #c2541f;padding-bottom:3px;">Salon</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#a8895a;">Players</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#a8895a;">Factions</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#a8895a;">Updates</a>
+    </div>
+    <div style="display:flex;align-items:center;gap:12px;font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:#a8895a;">
+      <span style="border:1px solid #d8c39a;padding:5px 11px;cursor:pointer;">Critic</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;border:1px solid #e0b88a;background:#fdf1df;color:#c2541f;padding:5px 11px;"><span style="width:8px;height:8px;border-radius:50%;background:#c2541f;"></span>UA</span>
+      <span style="border:1px solid #d8c39a;padding:5px 11px;cursor:pointer;">Leave</span>
+    </div>
+  </nav>
+
+  <!-- BREADCRUMBS -->
+  <div style="max-width:1080px;margin:0 auto;padding:18px 32px 0;font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:.16em;text-transform:uppercase;color:#a8895a;">
+    <a href="#">Factions</a> &nbsp;/&nbsp; <a href="#">University of Asthmatics</a> &nbsp;/&nbsp; <a href="#">The Salon</a> &nbsp;/&nbsp; <span style="color:#c2541f;">Acquisition XLII</span>
+  </div>
+
+  <!-- LAYOUT -->
+  <div style="max-width:1080px;margin:0 auto;padding:22px 32px 90px;display:grid;grid-template-columns:1fr 320px;gap:28px;align-items:start;">
+
+    <!-- ══ MAIN: THE ACQUISITION SHEET ══ -->
+    <div style="background:#fdf6ea;border:1px solid #cdab63;box-shadow:0 16px 38px rgba(60,40,10,.16), inset 0 0 0 4px #fdf6ea, inset 0 0 0 5px #e7c889;position:relative;">
+
+      <!-- header band -->
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:14px;padding:12px 26px;border-bottom:1px solid #ead7ad;background:linear-gradient(180deg,#fbeed3,#fdf6ea);">
+        <span style="display:inline-flex;align-items:center;gap:10px;font-family:'Marcellus SC',serif;font-size:10px;letter-spacing:.14em;color:#9c6a1a;">
+          <svg width="17" height="17" viewBox="0 0 24 24"><g transform="translate(12 12)"><g transform="rotate(45)"><rect x="-1.2" y="-10" width="2.4" height="13.5" rx="1" fill="#9c6a1a"/><rect x="-2.1" y="3" width="4.2" height="2.8" fill="#dd9322"/><path d="M-2.1 5.8 L2.1 5.8 L1 10.3 L-1 10.3 Z" fill="#c2541f"/></g><g transform="rotate(-45)"><rect x="-1.2" y="-10" width="2.4" height="13.5" rx="1" fill="#c2541f"/><rect x="-2.1" y="3" width="4.2" height="2.8" fill="#dd9322"/><path d="M-2.1 5.8 L2.1 5.8 L1 10.3 L-1 10.3 Z" fill="#9c6a1a"/></g></g></svg>
+          University of Asthmatics · Acquisition XLII
+        </span>
+        <span style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.18em;text-transform:uppercase;color:#c2541f;border:1px solid #e0b88a;padding:3px 9px;">Exhibited</span>
+      </div>
+
+      <div style="padding:30px 30px 34px;">
+        <!-- eyebrow -->
+        <div style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.22em;text-transform:uppercase;color:#a8895a;margin-bottom:12px;">A praxis returned to the Salon · golden-hour studies</div>
+        <!-- title -->
+        <h1 style="font-family:'Playfair Display',serif;font-style:italic;font-weight:600;font-size:42px;line-height:1.06;color:#3d2410;margin-bottom:18px;">Paint the quad at golden hour</h1>
+        <!-- byline -->
+        <div style="display:flex;align-items:center;gap:14px;padding-bottom:22px;margin-bottom:24px;border-bottom:1px solid #ead7ad;">
+          <div style="width:40px;height:40px;border-radius:50%;flex-shrink:0;border:1px solid #c2541f;background:#fbe8d6;display:flex;align-items:center;justify-content:center;font-family:'Playfair Display',serif;font-style:italic;font-size:17px;color:#c2541f;">M</div>
+          <div>
+            <div style="font-family:'EB Garamond',serif;font-style:italic;font-weight:500;font-size:15px;color:#3d2410;">Margot Sien</div>
+            <div style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.06em;color:#a8895a;margin-top:2px;">The Painting Atelier · Studio III &nbsp;·&nbsp; 2026.05.02 // golden hour</div>
+          </div>
+          <div style="margin-left:auto;text-align:right;flex-shrink:0;">
+            <div style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:30px;line-height:1;color:#c2541f;">40</div>
+            <div style="font-family:'Marcellus SC',serif;font-size:8px;letter-spacing:.1em;color:#a8895a;margin-top:2px;">pts returned</div>
+          </div>
+        </div>
+
+        <!-- THE PLATE (gilt-framed artwork) -->
+        <div style="margin-bottom:10px;">
+          <div style="padding:9px;background:linear-gradient(135deg,#eec06a 0%,#9c6a1a 24%,#f0c878 50%,#9c6a1a 76%,#dd9322 100%);box-shadow:0 10px 22px rgba(60,40,10,.2),inset 0 0 0 1px rgba(255,255,255,.4);">
+            <div style="padding:3px;background:linear-gradient(135deg,#9c6a1a,#eec06a);">
+              <x-import component-from-global-scope="image-slot" from="./image-slot.js" id="ua-praxis-plate" shape="rect" fit="cover" placeholder="Drop the work — oil on quad" style="display:block;width:100%;height:300px;background:#f6e9cf;" hint-size="100%,300px"></x-import>
+            </div>
+          </div>
+          <div style="text-align:center;font-family:'EB Garamond',serif;font-style:italic;font-size:11px;color:#a8895a;margin-top:9px;">Plate I · Oil on quad · 24 × 18 in. · the seventh evening</div>
+        </div>
+
+        <!-- THE PROCESS divider -->
+        <div style="display:flex;align-items:center;gap:12px;margin:26px 0 16px;">
+          <div style="height:1px;flex:1;background:#ead7ad;"></div>
+          <span style="font-family:'Marcellus SC',serif;font-size:9px;letter-spacing:.22em;color:#9c6a1a;white-space:nowrap;">The Process</span>
+          <div style="height:1px;flex:1;background:#ead7ad;"></div>
+        </div>
+
+        <!-- process lines -->
+        <div>
+          <div style="font-family:'EB Garamond',serif;font-size:13.5px;line-height:1.85;color:#5a4326;padding-left:30px;position:relative;margin-bottom:8px;"><span style="position:absolute;left:2px;top:7px;width:11px;height:11px;background:#c2541f;border-radius:62% 38% 54% 46% / 49% 60% 40% 51%;transform:rotate(-8deg);"></span>Set the easel at the south colonnade, where the low sun rakes the lawn. Blocked in the warm masses first; the shadows, last and quickly.</div>
+          <div style="font-family:'EB Garamond',serif;font-size:13.5px;line-height:1.85;color:#5a4326;padding-left:30px;position:relative;margin-bottom:8px;"><span style="position:absolute;left:2px;top:7px;width:11px;height:11px;background:#dd9322;border-radius:48% 52% 63% 37% / 55% 44% 56% 45%;transform:rotate(6deg);"></span>Lost the light twice to passing cloud. Waited. Wheezed. Found the inhaler, then the brush again. Resumed.</div>
+          <div style="font-family:'EB Garamond',serif;font-size:13.5px;line-height:1.85;color:#5a4326;padding-left:30px;position:relative;margin-bottom:8px;"><span style="position:absolute;left:2px;top:7px;width:11px;height:11px;background:#9c6a1a;border-radius:55% 45% 42% 58% / 60% 50% 50% 40%;transform:rotate(-3deg);"></span>Signed it wet and carried it back to the atelier before the dew could set into the varnish.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══ SIDEBAR: THE PATRONAGE (backer ledger) ══ -->
+    <div style="background:#fdf6ea;border:1px solid #cdab63;box-shadow:0 6px 22px rgba(60,40,10,.1), inset 0 0 0 4px #fdf6ea, inset 0 0 0 5px #e7c889;padding:24px 22px;position:sticky;top:84px;">
+      <div style="font-family:'Marcellus SC',serif;font-size:10px;letter-spacing:.2em;color:#9c6a1a;margin-bottom:18px;">The Patronage</div>
+
+      <!-- two headline stats -->
+      <div style="display:flex;margin-bottom:18px;">
+        <div style="flex:1;padding-right:14px;">
+          <div style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:40px;line-height:.85;color:#c2541f;">{{ points }}</div>
+          <div style="font-family:'Marcellus SC',serif;font-size:8px;letter-spacing:.12em;text-transform:uppercase;color:#a8895a;margin-top:6px;">points returned</div>
+        </div>
+        <div style="flex:1;padding-left:14px;border-left:1px solid #ead7ad;">
+          <div style="display:flex;align-items:center;gap:7px;">
+            <svg width="20" height="20" viewBox="0 0 24 24"><g transform="translate(12 12)"><g transform="rotate(45)"><rect x="-1" y="-9" width="2" height="12" rx="1" fill="#9c6a1a"/><path d="M-1.8 4.6 L1.8 4.6 L0.9 8.6 L-0.9 8.6 Z" fill="#c2541f"/></g><g transform="rotate(-45)"><rect x="-1" y="-9" width="2" height="12" rx="1" fill="#c2541f"/><path d="M-1.8 4.6 L1.8 4.6 L0.9 8.6 L-0.9 8.6 Z" fill="#9c6a1a"/></g></g></svg>
+            <span style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:40px;line-height:.85;color:#3d2410;">{{ votes }}</span>
+          </div>
+          <div style="font-family:'Marcellus SC',serif;font-size:8px;letter-spacing:.12em;text-transform:uppercase;color:#a8895a;margin-top:6px;">critics</div>
+        </div>
+      </div>
+
+      <!-- the ledger -->
+      <div style="font-family:'Marcellus SC',serif;font-size:9px;letter-spacing:.16em;text-transform:uppercase;color:#9c6a1a;margin-bottom:12px;padding-top:14px;border-top:1px solid #ead7ad;">Points acquired by</div>
+      <sc-for list="{{ patrons }}" as="b" hint-placeholder-count="3">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;">
+          <span style="width:26px;height:26px;border-radius:50%;flex-shrink:0;border:1px solid #c2541f;background:#fbe8d6;display:flex;align-items:center;justify-content:center;font-family:'Playfair Display',serif;font-style:italic;font-size:11px;color:#c2541f;">{{ b.initials }}</span>
+          <span style="font-family:'EB Garamond',serif;font-style:italic;font-size:13px;color:#3d2410;width:88px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ b.name }}</span>
+          <div style="flex:1;height:9px;background:#f1e5cd;border:1px solid #e0c08a;position:relative;overflow:hidden;">
+            <div style="position:absolute;top:0;left:0;bottom:0;width:{{ b.pct }};background:linear-gradient(90deg,#dd9322,#c2541f);"></div>
+          </div>
+          <span style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:15px;color:#c2541f;width:34px;text-align:right;">{{ b.amt }}</span>
+        </div>
+      </sc-for>
+      <div style="display:flex;justify-content:space-between;align-items:baseline;padding-top:10px;margin-top:6px;border-top:1px solid #ead7ad;">
+        <span style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.1em;text-transform:uppercase;color:#a8895a;">{{ backerCount }} patrons · total</span>
+        <span style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:17px;color:#c2541f;">{{ totalPts }} pts</span>
+      </div>
+
+      <!-- endow control -->
+      <div style="height:1px;background:#ead7ad;margin:18px 0 14px;"></div>
+      <div style="font-family:'Marcellus SC',serif;font-size:9px;letter-spacing:.16em;text-transform:uppercase;color:#9c6a1a;margin-bottom:10px;">Endow the Salon</div>
+      <div style="display:flex;align-items:center;gap:9px;flex-wrap:wrap;">
+        <div style="display:flex;align-items:center;border:1.5px solid #c2541f;">
+          <button onClick="{{ dec }}" style="width:27px;height:27px;border:none;background:#fbe8d6;color:#c2541f;font-family:'Marcellus',serif;font-size:16px;cursor:pointer;line-height:1;">−</button>
+          <span style="min-width:30px;text-align:center;font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:15px;color:#3d2410;">{{ give }}</span>
+          <button onClick="{{ inc }}" style="width:27px;height:27px;border:none;background:#fbe8d6;color:#c2541f;font-family:'Marcellus',serif;font-size:16px;cursor:pointer;line-height:1;">+</button>
+        </div>
+        <button style="height:29px;padding:0 15px;border:none;background:linear-gradient(180deg,#dd9322,#c2541f);color:#fff;font-family:'Marcellus SC',serif;font-size:9px;letter-spacing:.1em;text-transform:uppercase;cursor:pointer;">Endow</button>
+        <button onClick="{{ critToggle }}" style="height:29px;padding:0 13px;border:1.5px solid {{ critBorder }};background:{{ critBg }};color:#3d2410;font-family:'Marcellus SC',serif;font-size:9px;letter-spacing:.1em;text-transform:uppercase;cursor:pointer;margin-left:auto;">{{ critLabel }}</button>
+      </div>
+      <div style="margin-top:12px;font-family:'EB Garamond',serif;font-style:italic;font-size:11.5px;line-height:1.55;color:{{ statusColor }};">{{ statusText }}</div>
+    </div>
+
+  </div>
+
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script>
+class Component extends DCLogic {
+  constructor() {
+    super();
+    this.patrons = [
+      { name: "Margery Vane", pts: 18 },
+      { name: "The Provost", pts: 14 },
+      { name: "H. Albright", pts: 8 },
+    ];
+    this.points = 40;
+    this.votesBase = 25;
+    this.storeKey = "ua-crit-paint-quad-golden-hour";
+    this.state = { give: 1, crit: false };
+  }
+
+  componentDidMount() {
+    try { if (localStorage.getItem(this.storeKey) === "1") this.setState({ crit: true }); } catch (e) {}
+  }
+
+  setGive(d) { this.setState((s) => ({ give: Math.max(1, s.give + d) })); }
+
+  toggleCrit() {
+    const nv = !this.state.crit;
+    this.setState({ crit: nv });
+    try { nv ? localStorage.setItem(this.storeKey, "1") : localStorage.removeItem(this.storeKey); } catch (e) {}
+  }
+
+  renderVals() {
+    const max = Math.max(1, ...this.patrons.map((p) => p.pts));
+    const initials = (n) => n.replace(/[^A-Za-z ]/g, "").split(/\s+/).filter(Boolean).map((w) => w[0]).slice(0, 2).join("").toUpperCase();
+    const patrons = this.patrons.map((p) => ({ name: p.name, initials: initials(p.name), amt: "+" + p.pts, pct: Math.round((p.pts / max) * 100) + "%" }));
+    const totalPts = this.patrons.reduce((a, p) => a + p.pts, 0);
+    const crit = this.state.crit;
+    const votes = this.votesBase + (crit ? 1 : 0);
+
+    return {
+      points: this.points,
+      votes,
+      patrons,
+      backerCount: this.patrons.length,
+      totalPts,
+      give: this.state.give,
+      inc: () => this.setGive(1),
+      dec: () => this.setGive(-1),
+      critToggle: () => this.toggleCrit(),
+      critLabel: crit ? "Critiqued" : "Critique",
+      critBg: crit ? "#fbe8d6" : "transparent",
+      critBorder: crit ? "#c2541f" : "#d8c39a",
+      statusColor: crit ? "#7a5a30" : "#b39a6c",
+      statusText: crit
+        ? "You sat the critique. " + votes + " critics now in accord."
+        : "Points are spent by patrons; the critique is yours to give.",
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/wow/Warriors of Whimsy Praxis.html
+++ b/docs/design/praxis-read/factions/wow/Warriors of Whimsy Praxis.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Warriors of Whimsy · sealed praxis</title>
+<link rel="stylesheet" href="../../_ds/world-zero-design-system-019e221c-7853-7530-a934-7d3b2b7c8b43/styles.css" />
+<style>
+  html, body { margin: 0; font-family: var(--font-body); transition: background 200ms; }
+  * { box-sizing: border-box; }
+  #root { min-height: 100vh; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="whimsy-exe.jsx"></script>
+<script type="text/babel" src="whimsy-kit.jsx"></script>
+</head>
+<body>
+<template id="__bundler_thumbnail">
+  <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100" height="100" rx="18" fill="#fbcfe2"/>
+    <rect x="24" y="26" width="52" height="48" rx="6" fill="#fffdfa" stroke="#e487b5" stroke-width="2.5"/>
+    <rect x="24" y="26" width="52" height="11" rx="6" fill="#f3a6cb"/>
+    <path d="M50 64C42 58 39 54 41 49.5C42.7 45.8 46 45.6 47.4 48C47.9 49 48.3 49.8 48.5 50.2C48.7 49.8 49.1 49 49.6 48C51 45.6 54.3 45.8 56 49.5C58 54 55 58 50 64Z" fill="#fb7aa8" stroke="#fff" stroke-width="1.8" stroke-linejoin="round"/>
+    <path d="M70 18c.4 3.5 1.9 5 5.4 5.4-3.5.4-5 1.9-5.4 5.4-.4-3.5-1.9-5-5.4-5.4 3.5-.4 5-1.9 5.4-5.4z" fill="#f6c75e"/>
+  </svg>
+</template>
+<div id="root"></div>
+<script type="text/babel">
+
+const { useState, useEffect } = React;
+const { Heart, Sparkle, StarSticker, Mushroom, RainbowSticker, Ivy } = window;
+const { KT, GButton } = window;
+
+/* page-level palette per mode (matches the quest board) */
+const PG = {
+  light: { bg: "#fbeef5", ink: "#a83a6e", inkSoft: "#b06a8c", label: "#a8728e",
+    navBg: "rgba(251,238,245,0.82)", navBorder: "rgba(214,90,150,0.18)",
+    panelBorder: "rgba(214,90,150,0.18)",
+    blob1: "rgba(246,160,198,0.55)", blob2: "rgba(199,171,230,0.5)", blob3: "rgba(160,216,194,0.45)", blob4: "rgba(246,201,94,0.4)" },
+  dark: { bg: "#150b12", ink: "#fbcfe0", inkSoft: "#cf9bb6", label: "#c78aa6",
+    navBg: "rgba(21,11,18,0.85)", navBorder: "rgba(244,114,182,0.2)",
+    panelBorder: "rgba(244,114,182,0.22)",
+    blob1: "rgba(244,114,182,0.22)", blob2: "rgba(150,110,200,0.2)", blob3: "rgba(95,168,130,0.16)", blob4: "rgba(240,180,90,0.14)" }
+};
+
+/* ── the sealed praxis ─────────────────────────────────────────── */
+const PRAXIS = {
+  task: "The L Word",
+  level: 1,
+  taskPoints: 5,
+  finding: "I Told My Landlord",
+  author: "Pixie",
+  role: "witch · first circle",
+  sealed: "Apr 20, 2026",
+  mode: "filed solo",
+  synopsis: "Knocked on 4B, said it out loud, then took the stairs two at a time. Heart still pounding.",
+  points: 6,
+  hearts: 88,
+  steps: [
+    "Wrote the whole sentence on the inside of my wrist in eyeliner so I couldn't chicken out. Climbed three flights very slowly.",
+    "Knocked on 4B. He opened the door in odd socks, holding a kettle. I said it — all of it — without stopping to breathe once.",
+    "Said \u201cokay, bye\u201d and left at a brisk and dignified sprint. He is still my landlord. The rent is still due Friday. But it's out of me now, and the hallway smelled like toast, and I would do it again.",
+  ],
+  keepsakes: [
+    { name: "the_doorway.jpg", kind: "a photo", meta: "taken from the landing", charm: "heart" },
+    { name: "what_i_said.m4a", kind: "a voice note", meta: "0:14 · whispered, rehearsing", charm: "star" },
+    { name: "pressed_from_4B.png", kind: "a keepsake", meta: "geranium leaf, his windowbox", charm: "mushroom" },
+  ],
+  backers: [
+    { name: "B4ndit", pts: 3 },
+    { name: "m0th", pts: 2 },
+    { name: "Sprite", pts: 1 },
+  ],
+};
+
+/* ── window chrome dots ── */
+function Dot({ c, big }) {
+  const s = big ? 11 : 9;
+  return <span style={{ width: s, height: s, borderRadius: "50%", background: c, border: "1.4px solid rgba(255,255,255,0.7)" }} />;
+}
+function TitleBar({ t, name }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "8px 12px",
+      background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+      <Dot c="#fb7aa8" big /><Dot c="#f6c75e" big /><Dot c="#86cfa6" big />
+      <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "center", gap: 5, fontSize: 11, color: t.titleText, letterSpacing: "0.03em" }}>
+        <Sparkle size={10} color={t.titleText} /> {name}
+      </span>
+    </div>
+  );
+}
+
+/* ── round monogram avatar ── */
+function Avatar({ name, t, size = 40 }) {
+  const initials = name.replace(/[^A-Za-z0-9]/g, "").slice(0, 2);
+  return (
+    <span style={{ width: size, height: size, borderRadius: "50%", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center",
+      background: `linear-gradient(150deg, ${t.titleFrom}, ${t.pink})`, color: "#fff",
+      border: `1.5px solid ${t.winBorder}`, fontFamily: "var(--font-body)", fontWeight: 700, fontSize: size * 0.32, letterSpacing: "0.02em",
+      boxShadow: `0 3px 8px ${t.glow}` }}>{initials}</span>
+  );
+}
+
+/* ── dotted section divider with a centered label ── */
+function Divider({ t, label }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "22px 0 14px" }}>
+      <span style={{ flex: 1, height: 0, borderTop: `2px dotted ${t.border}` }} />
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-body)", fontSize: 8.5,
+        textTransform: "uppercase", letterSpacing: "0.18em", color: t.label, whiteSpace: "nowrap" }}>
+        <Sparkle size={9} color={t.pink} /> {label}
+      </span>
+      <span style={{ flex: 1, height: 0, borderTop: `2px dotted ${t.border}` }} />
+    </div>
+  );
+}
+
+/* ── keepsake (artifact) card ── */
+function CharmFor({ kind, size }) {
+  if (kind === "star") return <StarSticker size={size} color="#f6c75e" />;
+  if (kind === "mushroom") return <Mushroom size={size} />;
+  if (kind === "rainbow") return <RainbowSticker size={size} />;
+  return <Heart size={size} />;
+}
+function Keepsake({ t, k, i }) {
+  const rot = [-3, 2, -2][i % 3];
+  return (
+    <div style={{ position: "relative", background: t.cardBg, border: `1.5px solid ${t.border}`, borderRadius: 8,
+      padding: "13px 13px 11px", transform: `rotate(${rot}deg)`, boxShadow: `0 4px 11px ${t.glow}` }}>
+      <div style={{ position: "absolute", top: -10, right: -8, transform: "rotate(12deg)", filter: "drop-shadow(0 2px 2.5px rgba(120,40,80,0.28))" }}>
+        <CharmFor kind={k.charm} size={26} />
+      </div>
+      <div style={{ height: 58, borderRadius: 6, marginBottom: 9, border: `1px dashed ${t.borderSoft}`,
+        background: `repeating-linear-gradient(135deg, ${t.pinkLt}, ${t.pinkLt} 7px, transparent 7px, transparent 14px)`,
+        display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Sparkle size={16} color={t.pink} />
+      </div>
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 10, fontWeight: 700, color: t.ink, wordBreak: "break-all" }}>{k.name}</div>
+      <div style={{ fontSize: 8.5, color: t.label, marginTop: 2, fontStyle: "italic" }}>{k.kind} · {k.meta}</div>
+    </div>
+  );
+}
+
+/* ── the main read sheet (one big praxis.exe window) ── */
+function PraxisRead({ t, p }) {
+  return (
+    <div style={{ position: "relative", borderRadius: 14, overflow: "hidden", border: `2px solid ${t.winBorder}`,
+      boxShadow: `0 14px 34px ${t.glow}` }}>
+      <TitleBar t={t} name="praxis.exe" />
+      <div style={{ position: "relative", padding: "26px 30px 30px", background: t.cardBg,
+        backgroundImage: `radial-gradient(${t.dot} 1.4px, transparent 1.4px)`, backgroundSize: "15px 15px" }}>
+
+        {/* status row */}
+        <div style={{ display: "flex", alignItems: "center", gap: 9, flexWrap: "wrap", marginBottom: 18 }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 6, background: `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})`,
+            color: "#fff", fontSize: 8.5, letterSpacing: "0.16em", textTransform: "uppercase", padding: "5px 12px", borderRadius: 20,
+            fontWeight: 700, boxShadow: `0 3px 8px ${t.glow}` }}>
+            <Sparkle size={10} color="#fff" /> sealed
+          </span>
+          <span style={{ fontSize: 8.5, letterSpacing: "0.1em", textTransform: "uppercase", padding: "5px 11px", borderRadius: 20,
+            background: t.pinkLt, color: t.ink, border: `1px solid ${t.borderSoft}`, whiteSpace: "nowrap" }}>{p.mode}</span>
+          <span style={{ fontSize: 9.5, color: t.inkSoft, letterSpacing: "0.04em" }}>
+            re: <span style={{ color: t.ink, fontWeight: 700 }}>{p.task}</span> · lvl {p.level} · sealed {p.sealed}
+          </span>
+        </div>
+
+        {/* finding headline */}
+        <div style={{ fontSize: 9, textTransform: "uppercase", letterSpacing: "0.2em", color: t.label, marginBottom: 8 }}>the finding</div>
+        <h1 style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 46, lineHeight: 1.12, margin: 0, color: t.ink }}>{p.finding}</h1>
+        <div style={{ fontSize: 12.5, lineHeight: 1.6, color: t.inkSoft, marginTop: 16, maxWidth: "52ch", fontStyle: "italic" }}>{p.synopsis}</div>
+
+        {/* byline */}
+        <div style={{ display: "flex", alignItems: "center", gap: 12, paddingTop: 18, marginTop: 18, borderTop: `2px dotted ${t.border}` }}>
+          <Avatar name={p.author} t={t} />
+          <div style={{ lineHeight: 1.4 }}>
+            <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 22, color: t.ink, lineHeight: 1 }}>{p.author}</div>
+            <div style={{ fontSize: 9, color: t.label, letterSpacing: "0.06em", marginTop: 2 }}>{p.role}</div>
+          </div>
+          <div style={{ marginLeft: "auto", textAlign: "right" }}>
+            <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 30, lineHeight: 1, color: t.pinkDeep }}>◆ {p.points}</div>
+            <div style={{ fontSize: 8, color: t.label, letterSpacing: "0.14em", textTransform: "uppercase", marginTop: 3 }}>points earned</div>
+          </div>
+        </div>
+
+        {/* what i did */}
+        <Divider t={t} label="what i did" />
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {p.steps.map((s, i) => (
+            <div key={i} style={{ display: "flex", gap: 12, alignItems: "flex-start" }}>
+              <span style={{ flexShrink: 0, width: 26, height: 26, borderRadius: "50%", background: t.pinkLt, border: `1.5px solid ${t.borderSoft}`,
+                color: t.pinkDeep, fontFamily: "var(--font-faction-script)", fontSize: 16, fontWeight: 700,
+                display: "flex", alignItems: "center", justifyContent: "center" }}>{i + 1}</span>
+              <p style={{ margin: 0, fontSize: 11.5, lineHeight: 1.7, color: t.inkSoft, paddingTop: 2 }}>{s}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* keepsakes */}
+        <Divider t={t} label={`what i left behind · ${p.keepsakes.length} keepsakes`} />
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))", gap: 16, paddingTop: 4 }}>
+          {p.keepsakes.map((k, i) => <Keepsake key={i} t={t} k={k} i={i} />)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── sidebar: points & hearts, the backer ledger (ADR-0005) ── */
+function VoteHeartIcon({ filled, color, dim, size = 26 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 36 36">
+      <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+        fill={filled ? color : "none"} stroke={filled ? "#fff" : dim} strokeWidth={filled ? 2.2 : 2} strokeLinejoin="round" />
+    </svg>
+  );
+}
+function Ledger({ t, p }) {
+  const total = p.backers.reduce((a, b) => a + b.pts, 0);
+  const maxB = Math.max(1, ...p.backers.map((b) => b.pts));
+  const [hearted, setHearted] = useState(false);
+  const [give, setGive] = useState(1);
+  useEffect(() => { try { setHearted(localStorage.getItem("whimsy-praxis-hearted") === "1"); } catch (e) {} }, []);
+  const toggleHeart = () => {
+    const nv = !hearted; setHearted(nv);
+    try { nv ? localStorage.setItem("whimsy-praxis-hearted", "1") : localStorage.removeItem("whimsy-praxis-hearted"); } catch (e) {}
+  };
+  const liveHearts = p.hearts + (hearted ? 1 : 0);
+
+  return (
+    <div style={{ borderRadius: 14, overflow: "hidden", border: `2px solid ${t.winBorder}`, boxShadow: `0 10px 26px ${t.glow}` }}>
+      <TitleBar t={t} name="hearts.exe" />
+      <div style={{ position: "relative", padding: "18px 18px 20px", background: t.cardBg,
+        backgroundImage: `radial-gradient(${t.dot} 1.3px, transparent 1.3px)`, backgroundSize: "13px 13px" }}>
+
+        {/* two headline stats */}
+        <div style={{ display: "flex", marginBottom: 18 }}>
+          <div style={{ flex: 1, paddingRight: 14 }}>
+            <div style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 42, lineHeight: 0.85, color: t.pinkDeep }}>{p.points}</div>
+            <div style={{ fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: t.label, marginTop: 6 }}>points earned</div>
+          </div>
+          <div style={{ flex: 1, paddingLeft: 14, borderLeft: `1px solid ${t.borderSoft}` }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <VoteHeartIcon filled color={t.pink} dim={t.borderSoft} size={24} />
+              <span style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 42, lineHeight: 0.85, color: t.ink }}>{liveHearts}</span>
+            </div>
+            <div style={{ fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: t.label, marginTop: 6 }}>hearts</div>
+          </div>
+        </div>
+
+        {/* the backer ledger */}
+        <div style={{ fontSize: 8.5, letterSpacing: "0.16em", textTransform: "uppercase", color: t.label, marginBottom: 12,
+          paddingTop: 14, borderTop: `2px dotted ${t.border}` }}>points sent by</div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {p.backers.map((b) => (
+            <div key={b.name} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <Avatar name={b.name} t={t} size={26} />
+              <span style={{ fontSize: 11, color: t.ink, width: 70, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{b.name}</span>
+              <div style={{ flex: 1, height: 9, borderRadius: 5, background: t.pinkLt, position: "relative", overflow: "hidden" }}>
+                <div style={{ position: "absolute", inset: 0, width: `${(b.pts / maxB) * 100}%`, borderRadius: 5,
+                  background: `linear-gradient(90deg, ${t.pink}, ${t.pinkDeep})` }} />
+              </div>
+              <span style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 16, color: t.pinkDeep, width: 34, textAlign: "right" }}>+{b.pts}</span>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", padding: "10px 0 0", marginTop: 8, borderTop: `1px solid ${t.borderSoft}` }}>
+          <span style={{ fontSize: 8.5, letterSpacing: "0.12em", textTransform: "uppercase", color: t.label }}>{p.backers.length} backers · total</span>
+          <span style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 18, color: t.pinkDeep }}>{total} points</span>
+        </div>
+
+        {/* send points control */}
+        <div style={{ marginTop: 16, paddingTop: 14, borderTop: `2px dotted ${t.border}` }}>
+          <div style={{ fontSize: 8.5, letterSpacing: "0.14em", textTransform: "uppercase", color: t.label, marginBottom: 9 }}>send points</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 9, flexWrap: "wrap" }}>
+            <div style={{ display: "flex", alignItems: "center", borderRadius: 9, overflow: "hidden", border: `1.5px solid ${t.pinkDeep}` }}>
+              <button type="button" onClick={() => setGive((g) => Math.max(1, g - 1))} style={{ width: 28, height: 28, border: "none", background: t.pinkLt, color: t.pinkDeep, fontFamily: "var(--font-faction-script)", fontSize: 18, cursor: "pointer", lineHeight: 1 }}>−</button>
+              <span style={{ minWidth: 32, textAlign: "center", fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 16, color: t.ink }}>{give}</span>
+              <button type="button" onClick={() => setGive((g) => g + 1)} style={{ width: 28, height: 28, border: "none", background: t.pinkLt, color: t.pinkDeep, fontFamily: "var(--font-faction-script)", fontSize: 18, cursor: "pointer", lineHeight: 1 }}>+</button>
+            </div>
+            <button type="button" style={{ height: 30, padding: "0 15px", border: `1.5px solid ${t.pinkDeep}`, borderRadius: 9,
+              background: `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})`, color: "#fff", fontFamily: "var(--font-body)", fontSize: 9.5, fontWeight: 700,
+              letterSpacing: "0.08em", textTransform: "uppercase", cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 5, boxShadow: `0 3px 8px ${t.glow}` }}>
+              <Sparkle size={11} color="#fff" /> give
+            </button>
+            <button type="button" onClick={toggleHeart} style={{ height: 30, padding: "0 13px", borderRadius: 9,
+              border: `1.5px solid ${hearted ? t.pinkDeep : t.border}`, background: hearted ? t.pinkLt : "transparent", color: t.ink,
+              fontFamily: "var(--font-body)", fontSize: 9.5, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", cursor: "pointer",
+              display: "inline-flex", alignItems: "center", gap: 6, marginLeft: "auto" }}>
+              <VoteHeartIcon filled={hearted} color={t.pink} dim={t.border} size={15} /> {hearted ? "hearted" : "heart"}
+            </button>
+          </div>
+          <div style={{ fontSize: 9, fontStyle: "italic", color: t.inkSoft, marginTop: 11, lineHeight: 1.5 }}>
+            {hearted
+              ? <span>♡ your heart is counted — {liveHearts} witches felt this one.</span>
+              : <span>points are scarce; hearts are free. spend a little magic.</span>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Page() {
+  const [mode, setMode] = useState(() => localStorage.getItem("whimsy-mode") || "light");
+  useEffect(() => {
+    localStorage.setItem("whimsy-mode", mode);
+    document.documentElement.setAttribute("data-theme", mode === "dark" ? "dark" : "light");
+  }, [mode]);
+  const p = PG[mode], t = KT[mode];
+  const link = { fontFamily: "var(--font-body)", fontSize: 10.5, textTransform: "uppercase", letterSpacing: "0.12em", color: p.inkSoft, textDecoration: "none", paddingBottom: 2 };
+
+  return (
+    <div style={{ position: "relative", minHeight: "100vh", background: p.bg, color: p.ink, overflow: "hidden" }}>
+      {/* watercolor blobs */}
+      <div aria-hidden style={{ position: "fixed", inset: 0, zIndex: 0, pointerEvents: "none",
+        background: `radial-gradient(40% 38% at 6% 8%, ${p.blob1}, transparent 70%),
+                     radial-gradient(38% 36% at 96% 6%, ${p.blob2}, transparent 70%),
+                     radial-gradient(42% 40% at 4% 96%, ${p.blob3}, transparent 70%),
+                     radial-gradient(40% 38% at 98% 94%, ${p.blob4}, transparent 70%)`,
+        filter: "blur(8px)" }} />
+
+      {/* nav */}
+      <nav style={{ position: "sticky", top: 0, zIndex: 20, display: "flex", alignItems: "center", gap: 22,
+        padding: "12px 26px", background: p.navBg, backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)",
+        borderBottom: `1px solid ${p.navBorder}` }}>
+        <span style={{ fontFamily: "var(--font-display)", fontStyle: "italic", fontWeight: 700, fontSize: 19, color: p.ink, paddingBottom: 2, borderBottom: `3px solid ${t.pink}`, whiteSpace: "nowrap", flexShrink: 0 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 20, marginLeft: 8 }}>
+          {["Home", "Tasks", "Praxis", "Players", "Factions", "Updates", "Admin"].map((it) =>
+          <a key={it} href={it === "Factions" ? "Warriors of Whimsy Page.html" : "#"} style={it === "Praxis" ?
+          { ...link, color: p.ink, borderBottom: `2px solid ${t.pink}` } :
+          link}>{it}</a>
+          )}
+        </div>
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 14 }}>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: p.inkSoft, border: `1.5px solid ${p.panelBorder}`, borderRadius: 7, padding: "5px 9px" }}>Mod</span>
+          <button onClick={() => setMode(mode === "light" ? "dark" : "light")}
+          style={{ cursor: "pointer", fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: p.inkSoft, background: "transparent", border: "none", display: "inline-flex", alignItems: "center", gap: 5 }}>
+            {mode === "light" ? "☾ Dark" : "☀ Light"}
+          </button>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 7, fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: p.ink }}>
+            <span style={{ width: 22, height: 22, borderRadius: "50%", background: `linear-gradient(150deg, ${t.titleFrom}, ${t.pink})`, border: `1.5px solid ${t.winBorder}`, display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 10, color: "#fff", fontWeight: 700 }}>P</span>
+            Pixie
+          </span>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: p.ink, border: `1.5px solid ${p.panelBorder}`, borderRadius: 7, padding: "5px 11px", cursor: "pointer" }}>Logout</span>
+        </div>
+      </nav>
+
+      {/* breadcrumb */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 1060, margin: "0 auto", padding: "20px 26px 0",
+        fontSize: 9, letterSpacing: "0.16em", textTransform: "uppercase", color: p.label }}>
+        <a href="Warriors of Whimsy Page.html" style={{ color: p.label, textDecoration: "none" }}>Factions</a>
+        <span style={{ margin: "0 8px", opacity: 0.5 }}>/</span>
+        <a href="#" style={{ color: p.label, textDecoration: "none" }}>The Praxes</a>
+        <span style={{ margin: "0 8px", opacity: 0.5 }}>/</span>
+        <span style={{ color: p.ink }}>{PRAXIS.finding}</span>
+      </div>
+
+      {/* page grid */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 1060, margin: "0 auto", padding: "16px 26px 90px",
+        display: "grid", gridTemplateColumns: "1fr 330px", gap: 28, alignItems: "start" }}>
+        <PraxisRead t={t} p={PRAXIS} />
+        <aside style={{ position: "sticky", top: 80, display: "flex", flexDirection: "column", gap: 16 }}>
+          <Ledger t={t} p={PRAXIS} />
+          <a href="../../All Faction Praxis Pages.dc.html" style={{ ...link, textAlign: "center", color: p.inkSoft, padding: "4px 0" }}>← all praxis pages</a>
+        </aside>
+      </div>
+    </div>
+  );
+}
+ReactDOM.createRoot(document.getElementById("root")).render(<Page />);
+</script>
+</body>
+</html>

--- a/docs/design/praxis-read/factions/wow/whimsy-exe.jsx
+++ b/docs/design/praxis-read/factions/wow/whimsy-exe.jsx
@@ -1,0 +1,255 @@
+/* ════════════════════════════════════════════════════════════════
+   whimsy.exe — pink edition
+   Lo-fi computer-witch task card. Soft pastel window chrome, dotted
+   grid, notepad task area, cute ivy down the side, sticker charms.
+   Light + dark variants driven by a THEME object.
+   ════════════════════════════════════════════════════════════════ */
+
+const SAMPLE = {
+  title: "The L Word",
+  description: "Find someone you love. Tell them you love them.",
+  level: 1,
+  points: 5,
+};
+
+const THEME = {
+  light: {
+    pageBg: "#fbeef5",
+    winBorder: "#e487b5",
+    titleFrom: "#fbcfe2", titleTo: "#f3a6cb",
+    titleText: "#8e2f5c",
+    bodyBg: "#fdeef6",
+    dot: "rgba(214,90,150,0.20)",
+    notepadBg: "#fffdfa", notepadBorder: "#f3b6d2",
+    eyebrow: "#c2698f",
+    title: "#a83a6e",
+    desc: "#b06a8c",
+    ink: "#a83a6e",
+    pillBg: "#ffffff", pillText: "#b5588a", pillBorder: "#f3b6d2",
+    statusText: "#b5588a",
+    ivy: "#7cbf99", ivyLeaf: "#9ad3b1",
+    grain: 0.32,
+  },
+  dark: {
+    pageBg: "#1a0e15",
+    winBorder: "#f472b6",
+    titleFrom: "#5e2a46", titleTo: "#41203a",
+    titleText: "#fbd6e8",
+    bodyBg: "#2a0d1c",
+    dot: "rgba(244,114,182,0.16)",
+    notepadBg: "#39152a", notepadBorder: "#7a3358",
+    eyebrow: "#e58cb6",
+    title: "#fbcfe0",
+    desc: "#cf9bb6",
+    ink: "#fbcfe0",
+    pillBg: "rgba(244,114,182,0.12)", pillText: "#f9b6d4", pillBorder: "rgba(244,114,182,0.4)",
+    statusText: "#e58cb6",
+    ivy: "#5fa882", ivyLeaf: "#7fc59e",
+    grain: 0.22,
+  },
+};
+
+/* ───────── paper grain overlay ───────── */
+function Grain({ opacity, radius = 0 }) {
+  const uri = "data:image/svg+xml;utf8," + encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>`);
+  return <div style={{ position: "absolute", inset: 0, borderRadius: radius,
+    backgroundImage: `url("${uri}")`, backgroundSize: "120px 120px",
+    mixBlendMode: "multiply", opacity, pointerEvents: "none", zIndex: 8 }} />;
+}
+
+/* ════════════ sticker charms (white die-cut outline + shadow) ════════════ */
+const stickerWrap = (style) => ({
+  position: "absolute", filter: "drop-shadow(0 2px 2.5px rgba(120,40,80,0.28))", zIndex: 12, ...style,
+});
+function Heart({ size = 34, style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 36 36" style={style}>
+      <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+        fill="#fb7aa8" stroke="#fff" strokeWidth="2.4" strokeLinejoin="round" />
+      <path d="M11 13c-.6 2 .1 3.8 1.6 5.4" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" fill="none" opacity="0.75" />
+    </svg>
+  );
+}
+function RainbowSticker({ size = 46, style }) {
+  return (
+    <svg width={size} height={size * 0.72} viewBox="0 0 50 36" style={style}>
+      <g stroke="none">
+        <path d="M7 30a18 18 0 0 1 36 0h-5a13 13 0 0 0-26 0Z" fill="#f47aa6" stroke="#fff" strokeWidth="1.6" strokeLinejoin="round" />
+        <path d="M12 30a13 13 0 0 1 26 0h-5a8 8 0 0 0-16 0Z" fill="#f6c75e" />
+        <path d="M17 30a8 8 0 0 1 16 0h-5a3 3 0 0 0-6 0Z" fill="#86cfa6" />
+      </g>
+      <g fill="#fff" stroke="#e7a8c6" strokeWidth="1.2">
+        <ellipse cx="8" cy="30" rx="6" ry="4" />
+        <ellipse cx="42" cy="30" rx="6" ry="4" />
+      </g>
+    </svg>
+  );
+}
+function Mushroom({ size = 34, style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 36 36" style={style}>
+      <rect x="13" y="18" width="10" height="14" rx="5" fill="#fff4e6" stroke="#fff" strokeWidth="2.2" />
+      <path d="M4 19a14 9.5 0 0 1 28 0Z" fill="#fb7a86" stroke="#fff" strokeWidth="2.4" strokeLinejoin="round" />
+      <circle cx="11" cy="14" r="2" fill="#fff" />
+      <circle cx="19" cy="11.5" r="2.6" fill="#fff" />
+      <circle cx="25" cy="15" r="1.8" fill="#fff" />
+      <circle cx="15.5" cy="25" r="1.3" fill="#f6b8c0" />
+      <circle cx="20.5" cy="27" r="1.1" fill="#f6b8c0" />
+    </svg>
+  );
+}
+function StarSticker({ size = 26, color = "#f6c75e", style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 28 28" style={style}>
+      <path d="M14 2l3 7.3L24.5 10l-5.5 4.6L20.7 23 14 18.6 7.3 23l1.7-8.4L3.5 10 11 9.3Z"
+        fill={color} stroke="#fff" strokeWidth="2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function Sparkle({ size = 16, color = "#f6c75e", style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style}>
+      <path d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z" fill={color} />
+    </svg>
+  );
+}
+
+/* ════════════ cute ivy vine (parametric stem + leaves) ════════════ */
+function IvyLeaf({ x, y, rot, scale, c, leaf }) {
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot}) scale(${scale})`}>
+      <path d="M0 0 C -9 -3 -11 -13 -6 -20 C -2 -25 2 -25 6 -20 C 11 -13 9 -3 0 0 Z"
+        fill={leaf} stroke={c} strokeWidth="1.1" />
+      <path d="M0 -1 L0 -19" stroke={c} strokeWidth="1" opacity="0.55" />
+      <path d="M0 -8 L-4 -12 M0 -8 L4 -12" stroke={c} strokeWidth="0.8" opacity="0.45" fill="none" />
+    </g>
+  );
+}
+function Ivy({ height = 250, c, leaf, flip = false }) {
+  const W = 76, segs = 60;
+  const xAt = (t) => 40 + 20 * Math.sin(t * Math.PI * 2.3);
+  const yAt = (t) => 6 + t * (height - 12);
+  let d = "";
+  for (let i = 0; i <= segs; i++) {
+    const t = i / segs;
+    d += (i === 0 ? "M" : "L") + xAt(t).toFixed(1) + " " + yAt(t).toFixed(1) + " ";
+  }
+  const leafTs = [0.07, 0.17, 0.28, 0.39, 0.5, 0.61, 0.72, 0.83, 0.93];
+  return (
+    <svg width={W} height={height} viewBox={`0 0 ${W} ${height}`}
+      style={{ transform: flip ? "scaleX(-1)" : "none" }}>
+      <path d={d} fill="none" stroke={c} strokeWidth="2.6" strokeLinecap="round" />
+      {/* tendril curls */}
+      <path d={`M${xAt(0.02)} ${yAt(0.02)} q -10 -6 -4 -13 q 4 -4 8 0`} fill="none" stroke={c} strokeWidth="1.8" strokeLinecap="round" />
+      {leafTs.map((t, i) => {
+        const side = i % 2 === 0 ? 1 : -1;
+        return <IvyLeaf key={i} x={xAt(t) + side * 7} y={yAt(t)} rot={side > 0 ? 38 : -38} scale={i % 3 === 0 ? 1.15 : 0.95} c={c} leaf={leaf} />;
+      })}
+    </svg>
+  );
+}
+
+/* shared soft level pill */
+function LevelPill({ t, level = SAMPLE.level }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4,
+      fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.06em", textTransform: "uppercase",
+      padding: "2px 8px", borderRadius: 20, background: t.pillBg, color: t.pillText, border: `1px solid ${t.pillBorder}` }}>
+      <Sparkle size={9} color={t.pillText} /> lvl {level}
+    </span>
+  );
+}
+
+/* ════════════════════ the card ════════════════════ */
+/* decor: "full" (ivy + all charms, hero) · "min" (one charm) · "none" */
+function Charm({ kind }) {
+  if (kind === "star") return <StarSticker size={28} color="#f6c75e" />;
+  if (kind === "mushroom") return <Mushroom size={34} />;
+  if (kind === "rainbow") return <RainbowSticker size={46} />;
+  if (kind === "starPink") return <StarSticker size={26} color="#f47aa6" />;
+  return <Heart size={34} />;
+}
+function WhimsyExe({ mode = "light", task = SAMPLE, decor = "full", charm = "star" }) {
+  const t = THEME[mode];
+  const full = decor === "full";
+  const wrapW = full ? 326 : 274;
+  return (
+    <div style={{ position: "relative", width: wrapW, height: full ? 300 : undefined, fontFamily: "var(--font-body)" }}>
+      {/* ivy down the left, behind the window */}
+      {full && (
+        <div style={{ position: "absolute", left: -10, top: 34, zIndex: 1 }}>
+          <Ivy height={250} c={t.ivy} leaf={t.ivyLeaf} />
+        </div>
+      )}
+
+      {/* the window */}
+      <div style={{ position: full ? "absolute" : "relative", left: full ? 48 : 0, top: full ? 16 : 0, marginLeft: full ? 0 : 6, marginTop: full ? 0 : 12, width: 262, zIndex: 5,
+        borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`,
+        boxShadow: mode === "dark" ? "0 10px 26px rgba(0,0,0,0.5)" : "0 10px 24px rgba(190,60,120,0.22)" }}>
+        {/* title bar */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 11px",
+          background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+          <div style={{ display: "flex", gap: 5 }}>
+            <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#fb7aa8", border: "1.5px solid rgba(255,255,255,0.7)" }} />
+            <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#f6c75e", border: "1.5px solid rgba(255,255,255,0.7)" }} />
+            <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#86cfa6", border: "1.5px solid rgba(255,255,255,0.7)" }} />
+          </div>
+          <span style={{ fontSize: 10.5, color: t.titleText, letterSpacing: "0.03em", display: "flex", alignItems: "center", gap: 4 }}>
+            <Sparkle size={10} color={t.titleText} /> whimsy.exe
+          </span>
+          <span style={{ marginLeft: "auto", fontSize: 11, color: t.titleText, opacity: 0.75, letterSpacing: "1.5px" }}>▭ ✕</span>
+        </div>
+        {/* body */}
+        <div style={{ position: "relative", padding: "15px 15px 13px", background: t.bodyBg,
+          backgroundImage: `radial-gradient(${t.dot} 1.4px, transparent 1.4px)`, backgroundSize: "13px 13px" }}>
+          <Grain opacity={t.grain} />
+          {/* notepad */}
+          <div style={{ position: "relative", zIndex: 9, background: t.notepadBg, border: `1.5px solid ${t.notepadBorder}`,
+            borderRadius: 7, padding: "11px 13px", marginBottom: 11 }}>
+            <div style={{ fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.18em", color: t.eyebrow, marginBottom: 4 }}>new quest · {task.points} pts</div>
+            <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 27, fontWeight: 700, lineHeight: 1.02, color: t.title, marginBottom: 4 }}>{task.title}</div>
+            <div style={{ fontSize: 9, lineHeight: 1.5, color: t.desc }}>{task.description}</div>
+          </div>
+          {/* status bar */}
+          <div style={{ position: "relative", zIndex: 9, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <LevelPill t={t} level={task.level} />
+            <span style={{ fontSize: 9, color: t.statusText, letterSpacing: "0.1em" }}>◆ {task.points} pts</span>
+          </div>
+        </div>
+      </div>
+
+      {full && (
+        <React.Fragment>
+          {/* sticker charms peeking off the window edges */}
+          <div style={stickerWrap({ top: 4, right: 8, transform: "rotate(14deg)" })}><Heart size={36} /></div>
+          <div style={stickerWrap({ top: 92, right: -6, transform: "rotate(-10deg)" })}><StarSticker size={28} color="#f6c75e" /></div>
+          <div style={stickerWrap({ bottom: 6, right: 30, transform: "rotate(8deg)" })}><Mushroom size={36} /></div>
+          <div style={stickerWrap({ bottom: -4, left: 40, transform: "rotate(-9deg)" })}><RainbowSticker size={50} /></div>
+          <div style={stickerWrap({ top: 150, left: 26, transform: "rotate(6deg)", zIndex: 4 })}><StarSticker size={18} color="#f47aa6" /></div>
+        </React.Fragment>
+      )}
+      {decor === "min" && (
+        <div style={stickerWrap({ top: 2, right: -4, transform: "rotate(13deg)" })}><Charm kind={charm} /></div>
+      )}
+    </div>
+  );
+}
+
+/* ──────── reusable sticker sheet (for the asset set) ──────── */
+function StickerSheet() {
+  const cell = { display: "flex", flexDirection: "column", alignItems: "center", gap: 8 };
+  const lbl = { fontFamily: "var(--font-body)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.12em", color: "#a8728e" };
+  return (
+    <div style={{ display: "flex", gap: 30, alignItems: "flex-end", justifyContent: "center", flexWrap: "wrap" }}>
+      <div style={cell}><Heart size={48} /><span style={lbl}>heart</span></div>
+      <div style={cell}><RainbowSticker size={62} /><span style={lbl}>rainbow</span></div>
+      <div style={cell}><Mushroom size={48} /><span style={lbl}>mushroom</span></div>
+      <div style={cell}><StarSticker size={44} color="#f6c75e" /><span style={lbl}>star</span></div>
+      <div style={cell}><StarSticker size={40} color="#f47aa6" /><span style={lbl}>star · pink</span></div>
+      <div style={cell}><Sparkle size={40} color="#f6c75e" /><span style={lbl}>sparkle</span></div>
+    </div>
+  );
+}
+
+Object.assign(window, { WhimsyExe, StickerSheet, Ivy, Heart, RainbowSticker, Mushroom, StarSticker, Sparkle });

--- a/docs/design/praxis-read/factions/wow/whimsy-kit.jsx
+++ b/docs/design/praxis-read/factions/wow/whimsy-kit.jsx
@@ -1,0 +1,355 @@
+/* ════════════════════════════════════════════════════════════════
+   whimsy.exe — asset kit
+   The supporting UI family for the Warriors of Whimsy faction, redesigned in the
+   pink computer-witch language: app icon, buttons, level pill + moon
+   level-track, heart vote stamps, app tabs, filter chips, empty state.
+   Each component is themeable via THEME[mode]. Stickers + Ivy come from
+   whimsy-exe.jsx (window.Heart, window.Sparkle, window.Ivy, …).
+   ════════════════════════════════════════════════════════════════ */
+
+const KT = {
+  light: {
+    panelBg: "#fbeef5", cardBg: "#fffdfa",
+    ink: "#a83a6e", inkSoft: "#b5588a", label: "#a8728e",
+    border: "#f3b6d2", borderSoft: "rgba(214,90,150,0.28)",
+    pink: "#ec5f99", pinkDeep: "#d23b7e", pinkLt: "#fbcfe2",
+    gold: "#f0b94a", green: "#7cbf99", greenLeaf: "#9ad3b1",
+    dot: "rgba(214,90,150,0.18)",
+    fill: "#ec5f99", onFill: "#ffffff",
+    moonLit: "#f6c75e", moonShadow: "#fbe1ee",
+    glow: "rgba(236,95,153,0.32)",
+    titleFrom: "#fbcfe2", titleTo: "#f3a6cb", titleText: "#8e2f5c", winBorder: "#e487b5",
+    voteFills: ["#f6b8cf", "#f489b0", "#ec5f99", "#df3f86", "#c52470"]
+  },
+  dark: {
+    panelBg: "#1a0e15", cardBg: "#2a0d1c",
+    ink: "#fbcfe0", inkSoft: "#e58cb6", label: "#c78aa6",
+    border: "#7a3358", borderSoft: "rgba(244,114,182,0.32)",
+    pink: "#f472b6", pinkDeep: "#f9b6d4", pinkLt: "#5e2a46",
+    gold: "#f0d98f", green: "#5fa882", greenLeaf: "#7fc59e",
+    dot: "rgba(244,114,182,0.16)",
+    fill: "#f472b6", onFill: "#2a0d1c",
+    moonLit: "#f0d98f", moonShadow: "#2a0d1c",
+    glow: "rgba(244,114,182,0.45)",
+    titleFrom: "#5e2a46", titleTo: "#41203a", titleText: "#fbd6e8", winBorder: "#f472b6",
+    voteFills: ["#f9c4dc", "#f9a0c6", "#f472b6", "#ee5aa6", "#e23b8f"]
+  }
+};
+
+const lbl = (t) => ({ fontFamily: "var(--font-body)", fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.18em", color: t.label, marginBottom: 11 });
+
+/* ───── mini window glyph ───── */
+function WinGlyph({ size = 22, t, color }) {
+  const c = color || t.pink;
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24">
+      <rect x="2.5" y="4" width="19" height="16" rx="3" fill="none" stroke={c} strokeWidth="2" />
+      <path d="M2.5 8.5h19" stroke={c} strokeWidth="2" />
+      <circle cx="5.6" cy="6.2" r="0.9" fill={c} />
+      <circle cx="8.2" cy="6.2" r="0.9" fill={c} />
+    </svg>);
+
+}
+
+/* ───────── app icon (hero) ───────── */
+function GAppIcon({ t }) {
+  const Sparkle = window.Sparkle;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 9 }}>
+      <div style={{ position: "relative", width: 76, height: 76, borderRadius: 20,
+        background: `linear-gradient(150deg, ${t.titleFrom}, ${t.pink})`,
+        border: `2px solid ${t.winBorder}`, boxShadow: `0 8px 18px ${t.glow}`,
+        display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <div style={{ width: 40, height: 34, borderRadius: 6, background: t.cardBg, border: `2px solid ${t.cardBg}`, overflow: "hidden", boxShadow: "0 2px 5px rgba(120,40,80,0.25)" }}>
+          <div style={{ height: 9, background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, display: "flex", alignItems: "center", paddingLeft: 4, gap: 2 }}>
+            <span style={{ width: 3, height: 3, borderRadius: "50%", background: "#fb7aa8" }} />
+            <span style={{ width: 3, height: 3, borderRadius: "50%", background: "#f6c75e" }} />
+            <span style={{ width: 3, height: 3, borderRadius: "50%", background: "#86cfa6" }} />
+          </div>
+          <div style={{ padding: "4px 5px" }}>
+            <div style={{ height: 2.5, width: "70%", background: t.pink, borderRadius: 2, marginBottom: 3 }} />
+            <div style={{ height: 2.5, width: "45%", background: t.borderSoft, borderRadius: 2 }} />
+          </div>
+        </div>
+        <Sparkle size={16} color="#fff" style={{ position: "absolute", top: 6, right: 7 }} />
+        <svg width="20" height="22" viewBox="0 0 20 22" style={{ position: "absolute", bottom: 2, left: 3 }}>
+          <path d="M5 22C5 14 4 8 6 2" stroke={t.greenLeaf} strokeWidth="2" fill="none" strokeLinecap="round" />
+          <path d="M5 12c-5-1-5-6-5-6 4 0 6 3 5 6Z" fill={t.greenLeaf} />
+          <path d="M6 7c4-1 5-5 5-5-3 0-5 2-5 5Z" fill={t.greenLeaf} />
+        </svg>
+      </div>
+      <span style={{ fontFamily: "var(--font-body)", fontSize: 10, letterSpacing: "0.04em", color: t.ink }}>whimsy.exe</span>
+    </div>);
+
+}
+
+/* ───────── buttons ───────── */
+function GButton({ t, variant = "primary", children }) {
+  const base = { fontFamily: "var(--font-body)", fontSize: 10, textTransform: "uppercase", letterSpacing: "0.1em",
+    padding: "7px 14px", borderRadius: 9, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 5, transition: "all 120ms", whiteSpace: "nowrap" };
+  if (variant === "primary")
+  return <button style={{ ...base, background: `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})`, color: t.onFill, border: `1.5px solid ${t.pinkDeep}`, boxShadow: `0 4px 10px ${t.glow}` }}><window.Sparkle size={11} color={t.onFill} />{children}</button>;
+  if (variant === "outline")
+  return <button style={{ ...base, background: "transparent", color: t.ink, border: `1.5px solid ${t.border}` }}>{children}</button>;
+  return <button style={{ ...base, background: t.cardBg, color: t.ink, border: `1.5px solid ${t.border}`, borderRadius: 7, boxShadow: `inset 0 -2px 0 ${t.borderSoft}` }}>{children}</button>;
+}
+
+/* ───────── level pill ───────── */
+function GLevelPill({ t, level }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontFamily: "var(--font-body)", fontSize: 9,
+      letterSpacing: "0.06em", textTransform: "uppercase", padding: "3px 9px", borderRadius: 20,
+      background: t.pinkLt, color: t.ink, border: `1px solid ${t.borderSoft}` }}>
+      <window.Sparkle size={9} color={t.pink} /> lvl {level}
+    </span>);
+
+}
+
+/* ───────── moon level-track ───────── */
+function MoonNode({ phase, active, t }) {
+  const size = 30,r = 11,cx = 15,cy = 15;
+  const dx = -(2 * r) * phase;
+  const cid = "mc" + Math.round(phase * 100) + (active ? "a" : "");
+  return (
+    <svg width={size} height={size} viewBox="0 0 30 30" style={{ transform: active ? "scale(1.18)" : "scale(1)", transition: "transform 120ms" }}>
+      {active && <circle cx={cx} cy={cy} r={r + 3} fill={t.glow} />}
+      <clipPath id={cid}><circle cx={cx} cy={cy} r={r} /></clipPath>
+      <circle cx={cx} cy={cy} r={r} fill={t.moonLit} stroke={active ? t.pink : t.borderSoft} strokeWidth={active ? 2 : 1.5} />
+      <g clipPath={`url(#${cid})`}>
+        <circle cx={cx + dx} cy={cy} r={r} fill={t.moonShadow} />
+      </g>
+      <circle cx={cx} cy={cy} r={r} fill="none" stroke={active ? t.pink : t.borderSoft} strokeWidth={active ? 2 : 1.5} />
+    </svg>);
+
+}
+function GLevelTrack({ t, value = 3 }) {
+  const levels = [0, 1, 2, 3, 4, 5];
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start" }}>
+      {levels.map((lv, i) =>
+      <div key={lv} style={{ display: "flex", alignItems: "flex-start" }}>
+          {i > 0 && <div style={{ width: 16, height: 0, borderTop: `2px dotted ${t.green}`, marginTop: 14 }} />}
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 5, width: 34 }}>
+            <MoonNode phase={lv / 5} active={value === lv} t={t} />
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 8, color: value === lv ? t.pink : t.label, letterSpacing: "0.04em" }}>{lv}+</span>
+          </div>
+        </div>
+      )}
+    </div>);
+
+}
+
+/* ───────── heart vote stamps ───────── */
+function VoteHeart({ filled, color, dim }) {
+  return (
+    <svg width="30" height="30" viewBox="0 0 36 36">
+      <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+      fill={filled ? color : "none"} stroke={filled ? "#fff" : dim} strokeWidth={filled ? 2.2 : 2} strokeLinejoin="round" />
+    </svg>);
+
+}
+function GVoteStamps({ t, value = 4 }) {
+  const labels = ["a start", "solid", "good", "excellent", "legendary"];
+  return (
+    <div style={{ display: "flex", gap: 9 }}>
+      {labels.map((label, i) => {
+        const on = i < value;
+        return (
+          <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+            <div style={{ width: 40, height: 40, borderRadius: 9, display: "flex", alignItems: "center", justifyContent: "center",
+              background: on ? t.cardBg : "transparent", border: `1.5px solid ${on ? t.border : t.borderSoft}`,
+              boxShadow: on ? `0 3px 7px ${t.glow}` : "none" }}>
+              <VoteHeart filled={on} color={t.voteFills[i]} dim={t.borderSoft} />
+            </div>
+            <span style={{ fontFamily: "var(--font-body)", fontSize: 7, textTransform: "uppercase", letterSpacing: "0.04em",
+              color: on ? t.voteFills[i] : t.label, maxWidth: 42, textAlign: "center", lineHeight: 1.2 }}>{label}</span>
+          </div>);
+
+      })}
+    </div>);
+
+}
+
+/* ───────── app tabs (faction filter) ───────── */
+function GTab({ t, label, active, icon }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "6px 13px 7px",
+      borderRadius: "11px 11px 0 0", fontFamily: "var(--font-body)", fontSize: 9.5, letterSpacing: "0.03em",
+      background: active ? t.cardBg : "transparent",
+      color: active ? t.ink : t.label,
+      borderTop: active ? `2px solid ${t.pink}` : "2px solid transparent",
+      borderLeft: active ? `1px solid ${t.border}` : "1px solid transparent",
+      borderRight: active ? `1px solid ${t.border}` : "1px solid transparent",
+      boxShadow: active ? `0 -2px 8px ${t.glow}` : "none", opacity: active ? 1 : 0.8 }}>
+      {icon}{label}
+    </div>);
+
+}
+function GTabRow({ t }) {
+  return (
+    <div style={{ display: "flex", gap: 3, alignItems: "flex-end", borderBottom: `1.5px solid ${t.border}`, paddingBottom: 0 }}>
+      <GTab t={t} label="whimsy.exe" active icon={<WinGlyph size={15} t={t} />} />
+      <GTab t={t} label="analog.exe" icon={<WinGlyph size={15} t={t} color={t.label} />} />
+      <GTab t={t} label="snide.exe" icon={<WinGlyph size={15} t={t} color={t.label} />} />
+    </div>);
+
+}
+
+/* ───────── filter chips ───────── */
+function GChip({ t, label, active }) {
+  return (
+    <button style={{ fontFamily: "var(--font-body)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.08em",
+      padding: "5px 11px", borderRadius: 7, cursor: "pointer", transition: "all 120ms",
+      background: active ? `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})` : t.cardBg,
+      color: active ? t.onFill : t.inkSoft,
+      border: `1.5px solid ${active ? t.pinkDeep : t.border}`,
+      boxShadow: active ? `0 3px 8px ${t.glow}` : `inset 0 -2px 0 ${t.borderSoft}` }}>{label}</button>);
+
+}
+function GChipRow({ t }) {
+  return (
+    <div style={{ display: "flex", gap: 7, flexWrap: "wrap" }}>
+      <GChip t={t} label="✦ new" active />
+      <GChip t={t} label="mine" />
+      <GChip t={t} label="friends" />
+      <GChip t={t} label="duels" />
+    </div>);
+
+}
+
+/* ───────── empty state window ───────── */
+function GEmptyState({ t }) {
+  const Sparkle = window.Sparkle;
+  return (
+    <div style={{ width: 244, borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`, boxShadow: `0 8px 20px ${t.glow}` }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 11px",
+        background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#fb7aa8", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#f6c75e", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#86cfa6", border: "1.2px solid rgba(255,255,255,0.7)" }} />
+        <span style={{ marginLeft: "auto", fontSize: 9.5, color: t.titleText }}>whimsy.exe</span>
+      </div>
+      <div style={{ position: "relative", padding: "26px 16px 24px", textAlign: "center", background: t.cardBg,
+        backgroundImage: `radial-gradient(${t.dot} 1.3px, transparent 1.3px)`, backgroundSize: "13px 13px" }}>
+        <Sparkle size={12} color={t.gold} style={{ position: "absolute", top: 14, left: 22 }} />
+        <Sparkle size={9} color={t.pink} style={{ position: "absolute", top: 30, right: 26 }} />
+        {/* sleeping moon */}
+        <svg width="56" height="56" viewBox="0 0 56 56" style={{ marginBottom: 6 }}>
+          <circle cx="28" cy="28" r="20" fill={t.glow} opacity="0.5" />
+          <path d="M37 12a20 20 0 1 0 9 24A17 17 0 0 1 37 12Z" fill={t.moonLit} stroke={t.borderSoft} strokeWidth="1" />
+          <path d="M22 26q3 3 6 0M30 24q3 3 6 0" stroke={t.pinkDeep} strokeWidth="1.6" fill="none" strokeLinecap="round" />
+          <text x="44" y="18" fontFamily="var(--font-faction-script)" fontSize="11" fill={t.pink}>z</text>
+        </svg>
+        <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 24, color: t.ink, lineHeight: 1, marginBottom: 5 }}>no quests yet</div>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: 9, color: t.inkSoft, marginBottom: 14, lineHeight: 1.5 }}>the coven is resting. check back<br />soon for new little magics.</div>
+        <GButton t={t} variant="primary">find quests</GButton>
+      </div>
+    </div>);
+
+}
+
+/* ───────── page title (signature WZ header, reskinned) ───────── */
+function GPageTitle({ t, eyebrow = "the coven · quest board", title = "little magics" }) {
+  const bars = [t.pink, t.gold, t.green, t.pinkDeep, t.greenLeaf];
+  let ci = 0;
+  return (
+    <div>
+      <div style={{ fontFamily: "var(--font-body)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.18em", color: t.label, marginBottom: 6 }}>{eyebrow}</div>
+      <h1 style={{ fontFamily: "var(--font-faction-script)", fontSize: 44, fontWeight: 700, lineHeight: 1.15, margin: 0, color: t.ink, display: "flex", flexWrap: "wrap", alignItems: "flex-end" }}>
+        {title.split("").map((ch, i) => {
+          if (ch === " ") return <span key={i} style={{ display: "inline-block", width: "0.28em" }} />;
+          const c = bars[ci % bars.length];ci++;
+          return <span key={i} style={{ borderBottom: `4px solid ${c}`, paddingBottom: 1, lineHeight: 1 }}>{ch}</span>;
+        })}
+      </h1>
+    </div>);
+
+}
+
+/* ───────── faction pennants (faction filter banner) ───────── */
+function GPennant({ t }) {
+  const facs = [
+  { name: "whimsy.exe", bg: `linear-gradient(180deg, ${t.pink}, ${t.pinkDeep})`, active: true },
+  { name: "snide", bg: "#5fae53", active: false },
+  { name: "ephemerists", bg: "#2f9e92", active: false },
+  { name: "everymen", bg: "#d2442f", active: false }];
+
+  return (
+    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+      {facs.map((f, i) =>
+      <button key={i} style={{ background: f.bg, color: "#fff", fontFamily: "var(--font-body)", fontSize: 9, fontWeight: 700,
+        textTransform: "uppercase", letterSpacing: "0.07em", padding: "5px 14px", cursor: "pointer", border: "none",
+        textShadow: "0 1px 2px rgba(0,0,0,0.3)", opacity: f.active ? 1 : 0.85,
+        clipPath: "polygon(0 0, 100% 0, 92% 100%, 8% 100%)", transition: "all 120ms" }}>{f.name}</button>
+      )}
+    </div>);
+
+}
+
+/* ───────── praxis.exe card (filed submission + heart marks) ───────── */
+const PRAXIS_LABELS = ["a start", "solid", "good", "excellent", "legendary"];
+function GPraxisCard({ t, praxis }) {
+  const p = praxis || {
+    task: "The L Word", finding: "Said It First", author: "pixie",
+    excerpt: "Knocked on her door at 7am with a thermos of cocoa and just… said it. She said it back.",
+    rating: 4, marks: 23, points: 5, level: 1
+  };
+  const r = Math.max(0, Math.min(5, Math.round(p.rating)));
+  const dot = (c) => ({ width: 9, height: 9, borderRadius: "50%", background: c, border: "1.2px solid rgba(255,255,255,0.7)" });
+  return (
+    <div style={{ width: 248, borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`, boxShadow: `0 8px 20px ${t.glow}`, fontFamily: "var(--font-body)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 11px",
+        background: `linear-gradient(180deg, ${t.titleFrom}, ${t.titleTo})`, borderBottom: `2px solid ${t.winBorder}` }}>
+        <span style={dot("#fb7aa8")} /><span style={dot("#f6c75e")} /><span style={dot("#86cfa6")} />
+        <span style={{ marginLeft: "auto", fontSize: 9.5, color: t.titleText }}>praxis.exe</span>
+      </div>
+      <div style={{ padding: "14px 15px 15px", background: t.cardBg,
+        backgroundImage: `radial-gradient(${t.dot} 1.3px, transparent 1.3px)`, backgroundSize: "13px 13px" }}>
+        <div style={{ fontSize: 8.5, textTransform: "uppercase", letterSpacing: "0.16em", color: t.label, marginBottom: 4 }}>re: {p.task}</div>
+        <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 25, lineHeight: 1, color: t.ink, marginBottom: 6 }}>{p.finding}</div>
+        <div style={{ fontSize: 9.5, lineHeight: 1.5, color: t.inkSoft, marginBottom: 8 }}>{p.excerpt}</div>
+        <div style={{ fontSize: 9.5, fontStyle: "italic", color: t.inkSoft, marginBottom: 11 }}>filed by {p.author}</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 5, marginBottom: 10 }}>
+          {Array.from({ length: 5 }).map((_, i) =>
+          <svg key={i} width="15" height="15" viewBox="0 0 36 36">
+              <path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+            fill={i < r ? t.voteFills[i] : "none"} stroke={i < r ? "#fff" : t.borderSoft} strokeWidth={i < r ? 2.2 : 2} strokeLinejoin="round" />
+            </svg>
+          )}
+          <span style={{ fontFamily: "var(--font-faction-script)", fontSize: 16, color: t.pink, marginLeft: 4 }}>{PRAXIS_LABELS[Math.max(0, r - 1)]}</span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 9, letterSpacing: "0.06em",
+            textTransform: "uppercase", padding: "3px 9px", borderRadius: 20, background: t.pinkLt, color: t.ink, border: `1px solid ${t.borderSoft}` }}>lvl {p.level}</span>
+          <span style={{ fontSize: 9, color: t.label }}>{p.marks} hearts</span>
+          <span style={{ marginLeft: "auto", fontSize: 11, fontWeight: 700, color: t.pinkDeep }}>◆ {p.points} pts</span>
+        </div>
+      </div>
+    </div>);
+
+}
+
+/* ───────── watercolor backdrop (page paint-bleed) ───────── */
+function GBackdrop({ t }) {
+  const fid = "gb-" + t.fill.replace("#", "");
+  return (
+    <div style={{ position: "relative", height: 132, borderRadius: 12, overflow: "hidden", border: `2px solid ${t.winBorder}`, background: t.panelBg }}>
+      <svg width="100%" height="100%" preserveAspectRatio="none" style={{ position: "absolute", inset: 0 }}>
+        <defs>
+          <filter id={fid} x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="20" /></filter>
+        </defs>
+        <ellipse cx="12%" cy="14%" rx="22%" ry="36%" fill={t.titleFrom} opacity="0.85" filter={`url(#${fid})`} />
+        <ellipse cx="86%" cy="20%" rx="20%" ry="30%" fill={t.gold} opacity="0.5" filter={`url(#${fid})`} />
+        <ellipse cx="78%" cy="94%" rx="24%" ry="36%" fill={t.pink} opacity="0.6" filter={`url(#${fid})`} />
+        <ellipse cx="20%" cy="98%" rx="20%" ry="30%" fill={t.greenLeaf} opacity="0.45" filter={`url(#${fid})`} />
+      </svg>
+      <span style={{ position: "absolute", left: 13, bottom: 11, fontFamily: "var(--font-body)", fontSize: 8.5,
+        textTransform: "uppercase", letterSpacing: "0.16em", color: t.ink, opacity: 0.7 }}>page backdrop · watercolor</span>
+    </div>);
+
+}
+
+Object.assign(window, {
+  KT, GAppIcon, GButton, GLevelPill, GLevelTrack, GVoteStamps, GTabRow, GChipRow, GEmptyState, WinGlyph,
+  GPageTitle, GPennant, GPraxisCard, GBackdrop
+});

--- a/docs/design/task-detail/AlbescentTaskDetail.tsx
+++ b/docs/design/task-detail/AlbescentTaskDetail.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from "react";
+import { FactionPraxisCard, FactionCommentBox } from "@world-zero/design-system";
+import { TaskDetailProps, PraxisEntry, CommentEntry, markTop, makeAvatar } from "./types";
+
+/* ────────────────────────────────────────────────────────────────
+   ALBESCENT · Vellum Correspondence (always-light, no hue)
+   A quiet white letter: a surveyor's-mark sigil, Cormorant italic
+   title, hairline rules, the register of inscribed accounts (most
+   witnessed wears a fleur-de-lis), and a soft marginal discussion.
+   ──────────────────────────────────────────────────────────────── */
+
+const DEFAULT_TASK = { title: "Notice What No One Else Did", no: "0089", points: 35, level: 3 };
+
+const DEFAULT_PRAXIS: PraxisEntry[] = [
+  { task: "Notice What No One Did", finding: "The parking meter", author: "The Archivist",
+    excerpt: "A man refilled a stranger's meter and walked on without looking back. I was the only one who saw.", rating: 5, marks: 26, points: 35, level: 3 },
+  { task: "Notice What No One Did", finding: "The mended fence", author: "M.",
+    excerpt: "Someone repaired the gap in the school fence overnight. No note, no name. Children pass through it daily.", rating: 4, marks: 14, points: 35, level: 3 },
+  { task: "Notice What No One Did", finding: "The held elevator", author: "A Witness",
+    excerpt: "She held the door for a man still three floors away, by the stairs. He never knew she waited.", rating: 4, marks: 11, points: 35, level: 3 },
+];
+
+const DEFAULT_COMMENTS: CommentEntry[] = [
+  { name: "The Archivist", meta: "proposed · 3w ago", body: "I watched a man refill a stranger's parking meter and walk on without looking back. @Quietly is right — some things are diminished by being told.", avatar: makeAvatar("A", "#e8e6e1", "#1c1c1a") },
+  { name: "Quietly", meta: "2d ago", body: "And yet here we are, telling. Gently. Only to each other.", avatar: makeAvatar("Q", "#e8e6e1", "#1c1c1a") },
+];
+
+const CSS = `
+  .al-page a { color: inherit; text-decoration: none; }
+  .al-link:hover { color: #1c1c1a !important; }
+  .al-body p { font-family:'Cormorant Garamond',serif; font-size:20px; line-height:1.62; color:#2a2a27; margin:0 0 16px; }
+  .al-body p:last-child { margin-bottom:0; }
+  .al-body em { font-style:italic; color:#1c1c1a; }
+  .al-body a { color:#1c1c1a; border-bottom:1px solid rgba(28,28,26,0.4); }
+`;
+
+const card: React.CSSProperties = { background: "#fdfdfc", border: "1px solid rgba(0,0,0,0.1)", boxShadow: "0 1px 3px rgba(0,0,0,0.04)" };
+const sectionH2: React.CSSProperties = { fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontWeight: 600, fontSize: 22, margin: 0, color: "#1c1c1a", whiteSpace: "nowrap" };
+const sectionRule: React.CSSProperties = { flex: 1, height: 1, background: "rgba(0,0,0,0.08)" };
+const heroStat = (label: string, value: string) => (
+  <div>
+    <div style={{ fontSize: 8, letterSpacing: "0.22em", textTransform: "uppercase", color: "rgba(28,28,26,0.4)", marginBottom: 6 }}>{label}</div>
+    <div style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 22, color: "#1c1c1a" }}>{value}</div>
+  </div>
+);
+
+export function AlbescentTaskDetail({ task, praxis, comments, onSignUp }: TaskDetailProps) {
+  const t = { ...DEFAULT_TASK, ...task };
+  const entries = markTop(praxis ?? DEFAULT_PRAXIS);
+  const thread = comments ?? DEFAULT_COMMENTS;
+  const [signed, setSigned] = useState(false);
+  const sign = () => { setSigned((s) => !s); onSignUp?.(); };
+
+  return (
+    <div className="al-page" style={{ minHeight: "100vh", fontFamily: "'Courier Prime',monospace", color: "#1c1c1a", position: "relative", background: "#f4f3f0" }}>
+      <style>{CSS}</style>
+
+      {/* NAV */}
+      <nav style={{ position: "relative", zIndex: 10, display: "flex", alignItems: "center", gap: 30, padding: "16px 40px", background: "rgba(244,243,240,0.88)", backdropFilter: "blur(8px)", borderBottom: "1px solid rgba(0,0,0,0.08)" }}>
+        <span style={{ fontFamily: "'Lora',serif", fontStyle: "italic", fontWeight: 600, fontSize: 25, lineHeight: 1, borderBottom: "3px solid", borderImage: "linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1", paddingBottom: 2 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 22, flex: 1 }}>
+          {["Tasks", "Correspondence", "Praxes", "Register"].map((n, i) => (
+            <a key={n} className="al-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: i === 1 ? "#1c1c1a" : "rgba(28,28,26,0.45)", borderBottom: i === 1 ? "2px solid #1c1c1a" : "none", paddingBottom: i === 1 ? 2 : 0 }}>{n}</a>
+          ))}
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 8, fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 14, letterSpacing: "0.04em", color: "rgba(28,28,26,0.6)" }}>— admitted, in confidence</span>
+      </nav>
+
+      {/* PAGE */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 880, margin: "0 auto", padding: "26px 40px 96px" }}>
+        <div style={{ fontSize: 10, letterSpacing: "0.16em", textTransform: "uppercase", color: "rgba(28,28,26,0.4)", marginBottom: 24 }}>
+          <a className="al-link" href="#">Tasks</a><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span>Albescent</span><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span style={{ color: "#1c1c1a" }}>{t.title}</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 34 }}>
+
+          {/* HERO — the letter */}
+          <div style={{ ...card, boxShadow: "0 2px 24px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)", padding: "54px 60px 48px", textAlign: "center" }}>
+            <div style={{ display: "flex", justifyContent: "center", marginBottom: 24 }}>
+              <svg width="44" height="44" viewBox="0 0 44 44" fill="none">
+                <circle cx="22" cy="22" r="19" stroke="#1c1c1a" strokeWidth="1" opacity="0.18" />
+                <circle cx="22" cy="22" r="10.3" stroke="#1c1c1a" strokeWidth="1.7" opacity="0.5" />
+                <line x1="32.3" y1="22" x2="38" y2="22" stroke="#1c1c1a" strokeWidth="1.7" /><line x1="6" y1="22" x2="11.7" y2="22" stroke="#1c1c1a" strokeWidth="1.7" />
+                <line x1="22" y1="32.3" x2="22" y2="38" stroke="#1c1c1a" strokeWidth="1.7" /><line x1="22" y1="6" x2="22" y2="11.7" stroke="#1c1c1a" strokeWidth="1.7" />
+                <circle cx="22" cy="22" r="1.9" fill="#1c1c1a" />
+              </svg>
+            </div>
+            <div style={{ fontSize: 9, letterSpacing: "0.34em", textTransform: "uppercase", color: "rgba(28,28,26,0.45)", marginBottom: 6 }}>Albescent</div>
+            <div style={{ fontSize: 8, letterSpacing: "0.28em", textTransform: "uppercase", color: "rgba(28,28,26,0.3)", marginBottom: 26 }}>Correspondence №{t.no} · in confidence</div>
+            <div style={{ width: 54, height: 1, background: "rgba(0,0,0,0.12)", margin: "0 auto 26px" }} />
+            <h1 style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontWeight: 500, fontSize: 46, lineHeight: 1.16, color: "#1c1c1a", margin: "0 auto 22px", maxWidth: 560, overflowWrap: "anywhere" }}>{t.title}</h1>
+            <div style={{ width: 54, height: 1, background: "rgba(0,0,0,0.12)", margin: "0 auto 28px" }} />
+            <div style={{ display: "flex", justifyContent: "center", gap: 48, flexWrap: "wrap" }}>
+              {heroStat("Standing", `Lvl ${t.level}`)}
+              <div style={{ borderLeft: "1px solid rgba(0,0,0,0.1)" }} />
+              {heroStat("Worth", `${t.points} pts`)}
+              <div style={{ borderLeft: "1px solid rgba(0,0,0,0.1)" }} />
+              {heroStat("Witnessed", "31 times")}
+            </div>
+          </div>
+
+          {/* CTA bar */}
+          <div style={{ ...card, display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap", padding: "16px 22px" }}>
+            <button onClick={sign} style={{ cursor: "pointer", fontFamily: "'Courier Prime',monospace", fontSize: 9, letterSpacing: "0.22em", textTransform: "uppercase", color: signed ? "#fdfdfc" : "#1c1c1a", background: signed ? "#1c1c1a" : "transparent", border: "1px solid #1c1c1a", padding: "13px 26px" }}>
+              {signed ? "✓ Taken in confidence" : "Acknowledge"}
+            </button>
+            <div style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 15, color: "rgba(28,28,26,0.55)" }}>
+              {signed ? "you carry it now. quietly." : "no portfolio. no announcement."}
+            </div>
+            <div style={{ marginLeft: "auto", fontSize: 8, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(28,28,26,0.4)" }}>44 taken · 31 inscribed · 4.3 credence</div>
+          </div>
+
+          {/* THE ASK (user-written body) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 16 }}>
+              <h2 style={sectionH2}>The Ask</h2><span style={sectionRule} />
+              <span style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 13, color: "rgba(28,28,26,0.45)" }}>in the hand of The Archivist</span>
+            </div>
+            <div className="al-body" style={{ ...card, padding: "34px 40px", maxWidth: 640 }}>
+              <p>Spend one ordinary day attending to a single small thing the world has agreed not to see — the way a stranger holds a door a half-second too long, a repair someone made and never mentioned, a kindness performed for <em>no audience</em>.</p>
+              <p>Choose nothing in advance; let the day present the thing to you. When you notice it, stay with it a moment longer than is comfortable. Then write it down in the fewest words that keep it true.</p>
+              <p>Inscribe it in the register, unsigned. Claim nothing. To witness is enough — that is the whole of the practice. <a href="#">— the full correspondence ↗</a></p>
+            </div>
+          </section>
+
+          {/* THE REGISTER (completions) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 20 }}>
+              <h2 style={sectionH2}>Inscribed in the Register</h2><span style={sectionRule} />
+              <span style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 13, color: "rgba(28,28,26,0.45)" }}>{entries.length} accounts returned</span>
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 24px", alignItems: "flex-start" }}>
+              {entries.map((p, i) => (
+                <div key={i} style={{ position: "relative", paddingTop: 22 }}>
+                  {p.top && (
+                    <div style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%)", zIndex: 3, display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap", background: "#1c1c1a", color: "#fdfdfc", fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 13, letterSpacing: "0.04em", padding: "3px 14px" }}>
+                      <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> most witnessed
+                    </div>
+                  )}
+                  <FactionPraxisCard faction="albescent" {...p} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* IN THE MARGIN (discussion) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 20 }}>
+              <h2 style={sectionH2}>In the Margin</h2><span style={sectionRule} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 18, maxWidth: 680 }}>
+              {thread.map((c, i) => <FactionCommentBox key={i} faction="albescent" {...c} />)}
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AlbescentTaskDetail;

--- a/docs/design/task-detail/EphemeristsTaskDetail.tsx
+++ b/docs/design/task-detail/EphemeristsTaskDetail.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from "react";
+import { FactionPraxisCard, FactionCommentBox } from "@world-zero/design-system";
+import { TaskDetailProps, PraxisEntry, CommentEntry, markTop, makeAvatar } from "./types";
+
+/* ────────────────────────────────────────────────────────────────
+   THE EPHEMERISTS · The Discordant Map (illuminated codex)
+   One place, three irreconcilable readings. A vellum exhibit with a
+   contested coordinate field, Cinzel title (one word pulled to lapis),
+   sealed ephemerides (most canonical wears a fleur-de-lis), and
+   marginalia. Reads against the design system's --eph-* tokens.
+   ──────────────────────────────────────────────────────────────── */
+
+const DEFAULT_TASK = { title: "Map a Walk That Lies", titleA: "Map a Walk That", titleB: "Lies", no: "C-19", points: 80, grade: "IV" };
+
+const DEFAULT_PRAXIS: PraxisEntry[] = [
+  { task: "Map a Walk That Lies", finding: "The Alley Disagrees", author: "Vermilion",
+    excerpt: "Three lengths from three methods. The polar reading is the honest one. It cannot be settled.", rating: 5, marks: 19, points: 80, level: 4 },
+  { task: "Map a Walk That Lies", finding: "The Stairwell Spiral", author: "The Apostate",
+    excerpt: "Counted 41 paces up, sighted 38, felt 50. I submit all three. Reconcile them yourself.", rating: 4, marks: 12, points: 80, level: 4 },
+  { task: "Map a Walk That Lies", finding: "Home, By Three Roads", author: "Surveyor Wren",
+    excerpt: "The route that felt shortest measured longest. The map has been lying to me for years.", rating: 3, marks: 8, points: 80, level: 4 },
+];
+
+const DEFAULT_COMMENTS: CommentEntry[] = [
+  { name: "Surveyor Wren", meta: "proposed · 3w", body: "Walked the same alley three ways and got three lengths. @Vermilion insists the polar reading is the honest one. I no longer agree it can be settled.", avatar: makeAvatar("W", "#3a2a18", "#c9a23c") },
+  { name: "Vermilion", meta: "2d", body: "It cannot be settled. That is precisely why it is worth canonizing.", avatar: makeAvatar("V", "#3a2a18", "#c9a23c") },
+];
+
+const CSS = `
+  .ep-page a { color: inherit; text-decoration: none; }
+  .ep-link:hover { color: var(--eph-rubric) !important; }
+  .ep-body p { font-family:'EB Garamond',serif; font-size:17px; line-height:1.7; color:var(--eph-vellum-text); margin:0 0 16px; }
+  .ep-body p:last-child { margin-bottom:0; }
+  .ep-body em { color:var(--eph-lapis); font-style:italic; }
+  .ep-body a { color:var(--eph-rubric); border-bottom:1px solid color-mix(in srgb, var(--eph-rubric) 40%, transparent); }
+`;
+
+const sectionH2: React.CSSProperties = { fontFamily: "'Cinzel',serif", fontWeight: 600, fontSize: 15, letterSpacing: "0.1em", margin: 0, color: "var(--eph-vellum-text)", whiteSpace: "nowrap" };
+const sectionRule: React.CSSProperties = { flex: 1, height: 1, background: "linear-gradient(90deg,var(--eph-gold),transparent)" };
+
+export function EphemeristsTaskDetail({ task, praxis, comments, onSignUp }: TaskDetailProps) {
+  const t = { ...DEFAULT_TASK, ...task };
+  const entries = markTop(praxis ?? DEFAULT_PRAXIS);
+  const thread = comments ?? DEFAULT_COMMENTS;
+  const [signed, setSigned] = useState(false);
+  const sign = () => { setSigned((s) => !s); onSignUp?.(); };
+
+  return (
+    <div className="ep-page" style={{ minHeight: "100vh", fontFamily: "'EB Garamond',serif", color: "var(--eph-vellum-text)", position: "relative", background: "var(--eph-parchment)" }}>
+      <style>{CSS}</style>
+
+      {/* NAV */}
+      <nav style={{ position: "relative", zIndex: 10, display: "flex", alignItems: "center", gap: 30, padding: "16px 40px", background: "color-mix(in srgb, var(--eph-vellum) 90%, transparent)", backdropFilter: "blur(8px)", borderBottom: "1px solid var(--eph-gold-deep)" }}>
+        <span style={{ fontFamily: "'Lora',serif", fontStyle: "italic", fontWeight: 600, fontSize: 25, lineHeight: 1, borderBottom: "3px solid", borderImage: "linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1", paddingBottom: 2 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 22, flex: 1 }}>
+          {["Tasks", "Exhibit", "Praxes", "Ephemeris"].map((n, i) => (
+            <a key={n} className="ep-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: i === 1 ? "var(--eph-vellum-text)" : "var(--eph-muted)", borderBottom: i === 1 ? "2px solid var(--eph-rubric)" : "none", paddingBottom: i === 1 ? 2 : 0, fontFamily: "'Courier Prime',monospace" }}>{n}</a>
+          ))}
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, border: "1px solid var(--eph-gold)", padding: "4px 12px", fontFamily: "'Cinzel',serif", fontSize: 9, letterSpacing: "0.16em", color: "var(--eph-gold-deep)" }}>◬ INITIATE · GRADE IV</span>
+      </nav>
+
+      {/* PAGE */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 920, margin: "0 auto", padding: "26px 40px 90px" }}>
+        <div style={{ fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-muted)", marginBottom: 22, fontFamily: "'Courier Prime',monospace" }}>
+          <a className="ep-link" href="#">Tasks</a><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span>The Ephemerists</span><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span style={{ color: "var(--eph-rubric)" }}>{t.title}</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+
+          {/* HERO — the discordant exhibit */}
+          <div style={{ position: "relative", background: "var(--eph-vellum)", border: "1.5px solid var(--eph-ink)", boxShadow: "0 14px 34px rgba(42,29,18,0.18)", overflow: "hidden" }}>
+            <div style={{ display: "grid", gridTemplateColumns: "300px 1fr" }}>
+              <div style={{ position: "relative", minHeight: 320, borderRight: "1px solid var(--eph-gold-deep)", overflow: "hidden" }}>
+                <div style={{ position: "absolute", inset: 0, opacity: 0.5, backgroundImage: "repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 18px), repeating-linear-gradient(90deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 18px)" }} />
+                <svg viewBox="0 0 300 320" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.7 }}>
+                  <g stroke="var(--eph-lapis)" strokeWidth="0.9" fill="none">
+                    {[0, 40, 80, 120, 160, 200, 240, 280].map((x) => <line key={x} x1={x} y1="320" x2="185" y2="70" />)}
+                    {[110, 160, 210, 250].map((y) => <line key={y} x1="0" y1={y} x2="300" y2={y} />)}
+                  </g>
+                </svg>
+                <svg viewBox="0 0 300 320" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.72 }}>
+                  <g stroke="var(--eph-rubric)" strokeWidth="0.8" fill="none">
+                    {[28, 58, 92, 128].map((r) => <circle key={r} cx="185" cy="150" r={r} />)}
+                    {Array.from({ length: 8 }).map((_, i) => <line key={i} x1="185" y1="150" x2={185 + 130 * Math.cos((i * Math.PI) / 4)} y2={150 + 130 * Math.sin((i * Math.PI) / 4)} />)}
+                  </g>
+                </svg>
+                <div style={{ position: "absolute", left: "62%", top: "47%", transform: "translate(-50%,-50%)", width: 11, height: 11, borderRadius: "50%", background: "var(--eph-gold-light)", boxShadow: "0 0 14px 4px color-mix(in srgb, var(--eph-gold-light) 70%, transparent)" }} />
+                <div style={{ position: "absolute", top: "8%", left: "6%", fontSize: 9, color: "var(--eph-vellum-text)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "2px 5px" }}>x 14 · y <span style={{ textDecoration: "line-through", opacity: 0.65 }}>8</span> <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>9</span></div>
+                <div style={{ position: "absolute", top: "74%", left: "50%", fontSize: 9, color: "var(--eph-rubric)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "2px 5px" }}>r 47 · θ 31°</div>
+                <div style={{ position: "absolute", top: "5%", left: "62%", fontSize: 9, color: "var(--eph-lapis)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "2px 5px" }}>∞ · vanishing</div>
+                <div style={{ position: "absolute", left: 4, bottom: 8, transformOrigin: "left bottom", transform: "rotate(-90deg)", whiteSpace: "nowrap", fontSize: 7.5, color: "var(--eph-muted)", opacity: 0.85 }}>¼″ wider within than without †</div>
+              </div>
+              <div style={{ padding: "30px 34px", display: "flex", flexDirection: "column", justifyContent: "center" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 7, color: "var(--eph-gold)", marginBottom: 6 }}>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--eph-gold)" strokeWidth="1.4"><ellipse cx="12" cy="12" rx="11" ry="4.4" transform="rotate(-24 12 12)" /><path d="M4 12 C7.5 8.2 16.5 8.2 20 12 C16.5 15.8 7.5 15.8 4 12 Z" /><circle cx="12" cy="12" r="2.7" /></svg>
+                  <span style={{ fontFamily: "'Cinzel',serif", fontWeight: 600, fontSize: 9, letterSpacing: "0.24em" }}>THE EPHEMERISTS</span>
+                </div>
+                <div style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 12, color: "var(--eph-muted)", marginBottom: 16 }}>exhibit C · no single here · commission {t.no}</div>
+                <h1 style={{ fontFamily: "'Cinzel',serif", fontWeight: 700, fontSize: 38, lineHeight: 1.04, color: "var(--eph-vellum-text)", margin: "0 0 14px", overflowWrap: "anywhere" }}>{t.titleA} <span style={{ color: "var(--eph-lapis)" }}>{t.titleB}</span><sup style={{ fontFamily: "'EB Garamond',serif", fontSize: 16, color: "var(--eph-lapis)", fontWeight: 400 }}>†</sup></h1>
+                <div style={{ height: 1, background: "linear-gradient(90deg,var(--eph-gold),transparent)", marginBottom: 16 }} />
+                <div style={{ display: "flex", gap: 20, flexWrap: "wrap", alignItems: "center" }}>
+                  <span style={{ fontFamily: "'Cinzel',serif", fontSize: 12, color: "var(--eph-vellum-text)" }}>▦ GRADE {t.grade}</span>
+                  <span style={{ fontFamily: "'Cinzel',serif", fontWeight: 700, fontSize: 20, color: "var(--eph-rubric)" }}>{t.points} <span style={{ fontSize: 11, letterSpacing: "0.06em" }}>PVNCTA</span></span>
+                </div>
+                <div style={{ fontSize: 9, fontStyle: "italic", color: "var(--eph-muted)", marginTop: 14, lineHeight: 1.4 }}>† the road does not return you to where you began — <span style={{ color: "var(--eph-lapis)" }}>see †</span></div>
+              </div>
+            </div>
+          </div>
+
+          {/* CTA bar */}
+          <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap", border: "1px solid var(--eph-ink)", background: "var(--eph-vellum)", padding: "16px 20px" }}>
+            <button onClick={sign} style={{ cursor: "pointer", fontFamily: "'EB Garamond',serif", fontStyle: "italic", fontSize: 15, letterSpacing: "0.06em", color: "var(--eph-parchment)", background: signed ? "var(--eph-lapis)" : "var(--eph-ink)", border: "none", padding: "13px 26px" }}>
+              {signed ? "◬ Enrolled — three readings await" : "Triangulate the truth ▸"}
+            </button>
+            <div style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 14, color: "var(--eph-muted)" }}>
+              {signed ? "your contradictions are now on record." : "bring no certainty. only instruments."}
+            </div>
+            <div style={{ marginLeft: "auto", fontFamily: "'Cinzel',serif", fontSize: 9, letterSpacing: "0.1em", color: "var(--eph-gold-deep)" }}>41 TRIANGULATED · 23 CANONIZED · 3.7 CREDENCE</div>
+          </div>
+
+          {/* THE COMMISSION (user-written body) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
+              <h2 style={sectionH2}>The Commission</h2><span style={sectionRule} />
+              <span style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 12, color: "var(--eph-muted)" }}>scribed by Surveyor Wren</span>
+            </div>
+            <div className="ep-body" style={{ border: "1px solid var(--eph-gold-deep)", background: "var(--eph-vellum)", padding: "28px 32px", maxWidth: 660 }}>
+              <p>Walk a route you believe you know. Record <em>three readings</em> of the same ground — by pace, by sight-line, and by the feeling in your chest — and submit them side by side.</p>
+              <p>Where the three disagree is where the truth actually lives. Do <em>not</em> reconcile them. The contradiction is the exhibit; a tidy map is a lie we have all agreed to tell.</p>
+              <p>The concordance will weigh:</p>
+              <ul style={{ fontFamily: "'EB Garamond',serif", fontSize: 16, lineHeight: 1.7, color: "var(--eph-vellum-text)", margin: "0 0 16px", paddingLeft: 22 }}>
+                <li>The cartesian reading — plain paces, right angles, total trust in the grid.</li>
+                <li>The perspective reading — what loomed, what shrank, where it vanished.</li>
+                <li>The polar reading — distance and angle from the one place that mattered.</li>
+              </ul>
+              <p>Bring no certainty. Only instruments. — <a href="#">the surveyor's rubric ↗</a></p>
+            </div>
+          </section>
+
+          {/* SEALED EPHEMERIDES (completions) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>Sealed Ephemerides</h2><span style={sectionRule} />
+              <span style={{ fontFamily: "'Cormorant Garamond',serif", fontStyle: "italic", fontSize: 12, color: "var(--eph-muted)" }}>{entries.length} leaves filed against this exhibit</span>
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 24px", alignItems: "flex-start" }}>
+              {entries.map((p, i) => (
+                <div key={i} style={{ position: "relative", paddingTop: 22 }}>
+                  {p.top && (
+                    <div style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%)", zIndex: 3, display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap", background: "var(--eph-ink)", color: "var(--eph-gold-light)", fontFamily: "'Cinzel',serif", fontSize: 8, letterSpacing: "0.14em", padding: "4px 12px", boxShadow: "0 3px 8px rgba(42,29,18,0.35)" }}>
+                      <span style={{ fontSize: 12, lineHeight: 1, color: "var(--eph-gold-light)" }}>⚜</span> MOST CANONICAL
+                    </div>
+                  )}
+                  <FactionPraxisCard faction="ephemerists" {...p} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* THE MARGINALIA (discussion) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>The Marginalia</h2><span style={sectionRule} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 680 }}>
+              {thread.map((c, i) => <FactionCommentBox key={i} faction="ephemerists" {...c} />)}
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EphemeristsTaskDetail;

--- a/docs/design/task-detail/EverymenTaskDetail.tsx
+++ b/docs/design/task-detail/EverymenTaskDetail.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from "react";
+import { FactionPraxisCard, FactionCommentBox } from "@world-zero/design-system";
+import { TaskDetailProps, PraxisEntry, CommentEntry, markTop } from "./types";
+
+/* ────────────────────────────────────────────────────────────────
+   THE EVERYMEN · Union / Victory Poster
+   A billboard-scale union poster: sunburst red field, knockout Bebas
+   headline, cog seal, a work-order body, filed work reports (best in
+   hall wears a fleur-de-lis), and a red union discussion bar.
+   ──────────────────────────────────────────────────────────────── */
+
+const DEFAULT_TASK = { title: "BREAK NEW GROUND", no: "0427", points: 25, level: 3 };
+
+const DEFAULT_PRAXIS: PraxisEntry[] = [
+  { task: "BREAK NEW GROUND", finding: "THE VERGE ON 8TH", author: "Rivet",
+    excerpt: "Cleared 40ft of dead lot, put in beans and chard. Sign's up. Two neighbors already weeding.", rating: 5, marks: 28, points: 25, level: 3 },
+  { task: "BREAK NEW GROUND", finding: "ALLEY ORCHARD", author: "Day Shift",
+    excerpt: "Three dwarf apples behind the laundromat. Won't fruit till next year but it's theirs now.", rating: 4, marks: 16, points: 25, level: 3 },
+  { task: "BREAK NEW GROUND", finding: "THE MEDIAN STRIP", author: "Salt of the Earth",
+    excerpt: "Pollinator mix on a traffic median. City hasn't noticed. The bees have.", rating: 4, marks: 12, points: 25, level: 3 },
+];
+
+const grad = (a: string[]) => `radial-gradient(circle at 32% 28%, ${a[0]}, ${a[1]} 72%, ${a[2]})`;
+const avatar = (a: string[]) => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><defs><radialGradient id="g" cx="32%" cy="28%"><stop offset="0" stop-color="${a[0]}"/><stop offset="0.72" stop-color="${a[1]}"/><stop offset="1" stop-color="${a[2]}"/></radialGradient></defs><rect width="80" height="80" fill="url(#g)"/></svg>`;
+  return "data:image/svg+xml;utf8," + encodeURIComponent(svg);
+};
+
+const DEFAULT_COMMENTS: CommentEntry[] = [
+  { name: "Foreman Okafor", meta: "proposed · 3w ago", body: "Walked past this lot for years. @Rivet finally said the obvious thing: nobody's coming to fix it but us. Report for duty.", avatar: avatar(["#9fb07a", "#5b6238", "#353b22"]) },
+  { name: "Rivet", meta: "2d ago", body: "Cleared the north end already. Bring gloves and something that bears fruit. No ornamentals.", avatar: avatar(["#e8a23a", "#b4521f", "#7a2f12"]) },
+];
+
+const CSS = `
+  .em-page a { color: inherit; text-decoration: none; }
+  .em-link:hover { color: #c1272d !important; }
+  .em-body p { font-family:'Courier Prime',monospace; font-size:13px; line-height:1.75; color:#221a12; margin:0 0 14px; }
+  .em-body p:last-child { margin-bottom:0; }
+  .em-body strong { color:#c1272d; }
+  .em-body a { color:#c1272d; border-bottom:1px solid rgba(193,39,45,0.4); }
+`;
+
+const sectionRule: React.CSSProperties = { flex: 1, height: 3, background: "repeating-linear-gradient(90deg, #c1272d 0 16px, #e0b945 16px 26px)" };
+const sectionH2: React.CSSProperties = { fontFamily: "'Bebas Neue',sans-serif", fontSize: 26, letterSpacing: "0.04em", margin: 0, color: "#221a12", whiteSpace: "nowrap" };
+
+export function EverymenTaskDetail({ task, praxis, comments, onSignUp }: TaskDetailProps) {
+  const t = { ...DEFAULT_TASK, ...task };
+  const entries = markTop(praxis ?? DEFAULT_PRAXIS);
+  const thread = comments ?? DEFAULT_COMMENTS;
+  const [signed, setSigned] = useState(false);
+  const sign = () => { setSigned((s) => !s); onSignUp?.(); };
+
+  return (
+    <div className="em-page" style={{ minHeight: "100vh", fontFamily: "'Courier Prime',monospace", color: "#221a12", position: "relative", background: "var(--everymen-paper)" }}>
+      <style>{CSS}</style>
+
+      {/* NAV */}
+      <nav style={{ position: "relative", zIndex: 10, display: "flex", alignItems: "center", gap: 30, padding: "16px 40px", background: "rgba(245,237,221,0.85)", backdropFilter: "blur(8px)", borderBottom: "1px solid rgba(34,26,18,0.12)" }}>
+        <span style={{ fontFamily: "'Lora',serif", fontStyle: "italic", fontWeight: 600, fontSize: 25, lineHeight: 1, borderBottom: "3px solid", borderImage: "linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1", paddingBottom: 2 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 22, flex: 1 }}>
+          <a className="em-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#6c5a40" }}>Tasks</a>
+          <a className="em-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#221a12", borderBottom: "2px solid #c1272d", paddingBottom: 2 }}>Work Order</a>
+          <a className="em-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#6c5a40" }}>Hall</a>
+          <a className="em-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#6c5a40" }}>Dispatch</a>
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, border: "1px solid #c1272d", background: "#c1272d", color: "#f4ecd6", padding: "5px 12px", fontFamily: "'Bebas Neue',sans-serif", fontSize: 13, letterSpacing: "0.14em" }}>CARD-CARRYING</span>
+      </nav>
+
+      {/* PAGE */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 920, margin: "0 auto", padding: "26px 40px 90px" }}>
+        <div style={{ fontSize: 10, letterSpacing: "0.16em", textTransform: "uppercase", color: "#6c5a40", marginBottom: 22 }}>
+          <a className="em-link" href="#">Tasks</a><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span>The Everymen</span><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span style={{ color: "#c1272d" }}>{t.title}</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+
+          {/* HERO — union billboard */}
+          <div style={{ position: "relative", overflow: "hidden", border: "3px solid #221a12", background: "#c1272d", color: "#f4ecd6" }}>
+            <div style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.5, background: "repeating-conic-gradient(from 0deg at 24% 34%, #8d1c20 0deg 7deg, transparent 7deg 14deg)" }} />
+            <div style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.1, backgroundImage: "radial-gradient(#f4ecd6 0.6px, transparent 0.7px)", backgroundSize: "5px 5px" }} />
+            <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, background: "#221a12", padding: "9px 20px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 10, color: "#e0b945" }}>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                  <g fill="#e0b945">{[0, 45, 90, 135, 180, 225, 270, 315].map((d) => <rect key={d} x="11" y="0.5" width="2" height="5" rx="0.5" transform={`rotate(${d} 12 12)`} />)}</g>
+                  <circle cx="12" cy="12" r="6.5" fill="none" stroke="#e0b945" strokeWidth="2.4" /><circle cx="12" cy="12" r="2" fill="#e0b945" />
+                </svg>
+                <span style={{ fontFamily: "'Bebas Neue',sans-serif", fontSize: 17, letterSpacing: "0.2em" }}>THE EVERYMEN</span>
+              </div>
+              <span style={{ fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "#f4ecd6", border: "1.5px solid #e0b945", padding: "3px 10px" }}>Open · accepting hands</span>
+            </div>
+            <div style={{ height: 4, background: "#e0b945", position: "relative", zIndex: 2 }} />
+            <div style={{ position: "relative", zIndex: 2, padding: "30px 34px 32px" }}>
+              <div style={{ fontFamily: "'Bebas Neue',sans-serif", fontSize: 72, lineHeight: 0.9, letterSpacing: "0.01em", color: "#f4ecd6", textShadow: "3px 3px 0 #221a12", maxWidth: 660, overflowWrap: "anywhere" }}>{t.title}</div>
+              <div style={{ height: 3, background: "#e0b945", width: 120, margin: "20px 0 18px" }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+                <span style={{ background: "#221a12", color: "#f4ecd6", fontFamily: "'Bebas Neue',sans-serif", fontSize: 22, letterSpacing: "0.06em", padding: "6px 16px" }}>LVL {t.level}</span>
+                <span style={{ background: "#e0b945", color: "#221a12", fontFamily: "'Bebas Neue',sans-serif", fontSize: 22, letterSpacing: "0.06em", padding: "6px 16px" }}>{t.points} PTS</span>
+                <span style={{ fontFamily: "'Courier Prime',monospace", fontSize: 11, letterSpacing: "0.06em", color: "#f4ecd6" }}>4 of 12 hands on the job</span>
+              </div>
+            </div>
+          </div>
+
+          {/* CTA bar */}
+          <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap", border: "1.5px solid #221a12", background: "#fff", padding: "16px 20px" }}>
+            <button onClick={sign} style={{ cursor: "pointer", fontFamily: "'Courier Prime',monospace", fontSize: 13, fontWeight: 700, letterSpacing: "0.14em", textTransform: "uppercase", padding: "14px 26px", border: "none", background: signed ? "#5b6238" : "#c1272d", color: "#f4ecd6" }}>
+              {signed ? "✓ Reported for duty" : "Report for duty ▸"}
+            </button>
+            <div style={{ fontSize: 11, color: "#6c5a40" }}>Proposed by Foreman Okafor · Apr 12, 2026</div>
+            <div style={{ marginLeft: "auto", fontFamily: "'Bebas Neue',sans-serif", fontSize: 15, letterSpacing: "0.06em", color: "#c1272d" }}>96 reported · 71 delivered · 4.4 avg</div>
+          </div>
+
+          {/* THE ORDER (user-written body) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 16 }}>
+              <h2 style={sectionH2}>The Order</h2>
+              <span style={sectionRule} />
+            </div>
+            <div className="em-body" style={{ border: "1.5px solid #221a12", background: "#fff", padding: "26px 30px", maxWidth: 660 }}>
+              <p>Find a neglected patch of public land — a verge, a lot, a forgotten strip nobody tends. Clear it, plant something that <strong>actually feeds people</strong>, and post a sign so whoever comes next knows it's theirs to keep going.</p>
+              <p>This isn't a garden show. The work outlasts the worker — that's the whole idea. Bring gloves, bring something that bears fruit, and leave the ornamentals at home.</p>
+              <p>What gets a report marked delivered:</p>
+              <ul style={{ fontFamily: "'Courier Prime',monospace", fontSize: 13, lineHeight: 1.7, color: "#221a12", margin: "0 0 14px", paddingLeft: 22 }}>
+                <li>The ground was public and genuinely neglected — not someone's yard.</li>
+                <li>What you planted feeds people or pollinators, not just the eye.</li>
+                <li>You left a sign so the next hands know to keep it going.</li>
+              </ul>
+              <p>Report for duty below. — <a href="#">read the charter ↗</a></p>
+            </div>
+          </section>
+
+          {/* WORK REPORTS (completions) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>Work Reports Filed</h2>
+              <span style={sectionRule} />
+              <span style={{ fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", color: "#6c5a40" }}>{entries.length} delivered</span>
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 24px", alignItems: "flex-start" }}>
+              {entries.map((p, i) => (
+                <div key={i} style={{ position: "relative", paddingTop: 20 }}>
+                  {p.top && (
+                    <div style={{ position: "absolute", top: -4, left: "50%", transform: "translateX(-50%)", zIndex: 3, display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap", background: "#e0b945", color: "#221a12", fontFamily: "'Bebas Neue',sans-serif", fontSize: 13, letterSpacing: "0.1em", padding: "3px 13px", boxShadow: "0 3px 8px rgba(34,26,18,0.3)" }}>
+                      <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> BEST IN HALL
+                    </div>
+                  )}
+                  <FactionPraxisCard faction="everymen" {...p} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* THE HALL SPEAKS (discussion) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>The Hall Speaks</h2>
+              <span style={sectionRule} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 680 }}>
+              {thread.map((c, i) => <FactionCommentBox key={i} faction="everymen" {...c} />)}
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EverymenTaskDetail;

--- a/docs/design/task-detail/README.md
+++ b/docs/design/task-detail/README.md
@@ -1,0 +1,80 @@
+# World Zero — Faction Task Detail pages (React)
+
+Seven task-detail page components, one per faction. Each wears that faction's
+physical archetype (gilt salon, whimsy.exe window, ransom dossier, discordant
+map, terminal printout, union poster, vellum letter) and shares one anatomy:
+
+```
+hero  →  CTA bar  →  task body (proposer's copy)  →  praxis completions  →  discussion
+```
+
+The highest-rated praxis on each page is flagged with a fleur-de-lis (⚜) badge.
+
+## Files
+
+| File | Faction | Archetype |
+|---|---|---|
+| `UATaskDetail.tsx` | UA | Gilt salon |
+| `WhimsyTaskDetail.tsx` | Warriors of Whimsy | whimsy.exe desktop |
+| `SnideTaskDetail.tsx` | S.N.I.D.E. | Ransom dispatch |
+| `EphemeristsTaskDetail.tsx` | The Ephemerists | Discordant map |
+| `SingularityTaskDetail.tsx` | Singularity | Terminal printout |
+| `EverymenTaskDetail.tsx` | The Everymen | Union poster |
+| `AlbescentTaskDetail.tsx` | Albescent | Vellum correspondence |
+
+`types.ts` holds the shared prop types; `index.ts` re-exports everything.
+
+## Dependencies
+
+These components compose the World Zero **design system** faction components:
+
+```ts
+import {
+  FactionTaskCard,
+  FactionPraxisCard,
+  FactionVoteStamps,
+  FactionCommentBox,
+} from "@world-zero/design-system";
+```
+
+Adjust that import specifier to wherever the design system lives in your repo
+(in the source project they sit at `components/cards/…` and `components/feedback/…`).
+The design-system **tokens + fonts** stylesheet must be loaded once at the app
+root (it defines every `--faction-*`, `--eph-*`, `--snide-*`, … custom property
+and the Google-font `@import`s these pages reference):
+
+```ts
+import "@world-zero/design-system/styles.css";
+```
+
+## Usage
+
+Every page ships with built-in demo content, so it renders standalone:
+
+```tsx
+import { UATaskDetail } from "./react";
+
+<UATaskDetail />
+```
+
+…or drive it from your own data — all content is overridable via props:
+
+```tsx
+<UATaskDetail
+  task={{ title: "Paint the Quad at Golden Hour", no: "0317", points: 40, level: 3 }}
+  praxis={myPraxisEntries}
+  comments={myComments}
+  onSignUp={() => attemptTask(taskId)}
+/>
+```
+
+## Notes
+
+- Styling is inline (`style={{…}}`) to match the design-system convention, plus a
+  small co-located `<style>` block per page for the few rules inline styles can't
+  express (`:hover`, prose `p`/`ul` inside the body box). Move those into a CSS
+  module if your codebase prefers.
+- `SingularityTaskDetail` forces `data-theme="dark"` on mount (the terminal
+  archetype is always-dark); it restores the prior value on unmount.
+- Avatars are generated as inline SVG data-URIs so the demo has no image deps.
+  Pass real `avatar` URLs through the `comments` prop in production.

--- a/docs/design/task-detail/SingularityTaskDetail.tsx
+++ b/docs/design/task-detail/SingularityTaskDetail.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect } from "react";
+import { FactionPraxisCard, FactionCommentBox } from "@world-zero/design-system";
+import { TaskDetailProps, PraxisEntry, CommentEntry, markTop, makeAvatar } from "./types";
+
+/* ────────────────────────────────────────────────────────────────
+   SINGULARITY · Terminal Printout (always-dark)
+   A phosphor-on-black protocol readout: boot lines, scanlines,
+   circuit corners, a waveform strip, sealed praxis logs (highest
+   signal wears a fleur-de-lis), and a terminal signal log.
+   ──────────────────────────────────────────────────────────────── */
+
+const DEFAULT_TASK = { title: "MAP A NON-HUMAN PATTERN", no: "0047", points: 200, level: 4, signal: "0xF4A3E9D2" };
+
+const DEFAULT_PRAXIS: PraxisEntry[] = [
+  { task: "NON-HUMAN PATTERN", finding: "THIRD HARMONIC HOLDS", author: "NODE_Vesper",
+    excerpt: "847 windows. 12.7σ. Does not appear in any set we hold. This one is real.", rating: 5, marks: 31, points: 200, level: 4 },
+  { task: "NON-HUMAN PATTERN", finding: "FLOCKING DRIFT @ DUSK", author: "NODE_Quill",
+    excerpt: "Starling murmuration, 900 windows. Clear above noise floor but not yet 9σ.", rating: 4, marks: 18, points: 200, level: 4 },
+  { task: "NON-HUMAN PATTERN", finding: "ORDERBOOK GHOST", author: "NODE_Cipher",
+    excerpt: "Microstructure loop with no maker. Suggestive. Two arrays still dissent.", rating: 3, marks: 11, points: 200, level: 4 },
+];
+
+const DEFAULT_COMMENTS: CommentEntry[] = [
+  { handle: "vesper", meta: "sealed 0047 · 2d", body: "847 windows logged. @margin cross-checked the third harmonic. 12.7σ. This one is real.", avatar: makeAvatar("V", "#0a1f2e", "#60a5fa") },
+  { handle: "margin", meta: "4d", body: "Confirmed. The pattern does not appear in any training set we hold. That is the entire point.", avatar: makeAvatar("M", "#0a1f2e", "#60a5fa") },
+];
+
+const CSS = `
+  .sg-page a { color: inherit; text-decoration: none; }
+  @keyframes sg-blink { 50% { opacity: 0; } }
+  .sg-link:hover { color: #4ade80 !important; }
+  .sg-body p { font-family:'Share Tech Mono',monospace; font-size:11px; line-height:1.9; color:rgba(159,232,184,0.85); margin:0 0 14px; }
+  .sg-body p:last-child { margin-bottom:0; }
+  .sg-body b { color:#dff6e8; font-weight:400; }
+  .sg-body a { color:#60a5fa; border-bottom:1px solid rgba(96,165,250,0.4); }
+`;
+
+const sectionRule: React.CSSProperties = { flex: 1, height: 1, background: "rgba(37,99,235,0.3)" };
+const sectionH2: React.CSSProperties = { fontSize: 7.5, letterSpacing: "0.28em", margin: 0, color: "rgba(74,222,128,0.6)", textTransform: "uppercase", whiteSpace: "nowrap" };
+const statBox: React.CSSProperties = { border: "1px solid rgba(37,99,235,0.4)", background: "rgba(37,99,235,0.08)", padding: "10px 18px", textAlign: "center", minWidth: 90 };
+const statLabel: React.CSSProperties = { fontSize: 7, letterSpacing: "0.2em", color: "rgba(96,165,250,0.5)", textTransform: "uppercase", marginTop: 4 };
+
+export function SingularityTaskDetail({ task, praxis, comments, onSignUp }: TaskDetailProps) {
+  const t = { ...DEFAULT_TASK, ...task };
+  const entries = markTop(praxis ?? DEFAULT_PRAXIS);
+  const thread = comments ?? DEFAULT_COMMENTS;
+  const [signed, setSigned] = useState(false);
+  const sign = () => { setSigned((s) => !s); onSignUp?.(); };
+
+  // Terminal archetype is always-dark; force the theme and restore on unmount.
+  useEffect(() => {
+    const root = document.documentElement;
+    const prev = root.getAttribute("data-theme");
+    root.setAttribute("data-theme", "dark");
+    return () => { prev ? root.setAttribute("data-theme", prev) : root.removeAttribute("data-theme"); };
+  }, []);
+
+  return (
+    <div className="sg-page" style={{ minHeight: "100vh", fontFamily: "'Share Tech Mono',monospace", color: "#9fe8b8", position: "relative",
+      background: "#050f08", backgroundImage: "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.022) 2px, rgba(74,222,128,0.022) 4px), radial-gradient(80% 60% at 50% 0%, rgba(37,99,235,0.10), transparent 70%)" }}>
+      <style>{CSS}</style>
+
+      {/* NAV */}
+      <nav style={{ position: "relative", zIndex: 10, display: "flex", alignItems: "center", gap: 30, padding: "16px 40px", background: "rgba(5,15,8,0.85)", backdropFilter: "blur(8px)", borderBottom: "1px solid rgba(37,99,235,0.4)" }}>
+        <span style={{ fontFamily: "'Lora',serif", fontStyle: "italic", fontWeight: 600, fontSize: 25, lineHeight: 1, color: "#dff6e8", borderBottom: "3px solid", borderImage: "linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1", paddingBottom: 2 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 22, flex: 1 }}>
+          <a className="sg-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "rgba(96,165,250,0.6)" }}>Tasks</a>
+          <a className="sg-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#4ade80", borderBottom: "2px solid #4ade80", paddingBottom: 2 }}>Protocol</a>
+          <a className="sg-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "rgba(96,165,250,0.6)" }}>Register</a>
+          <a className="sg-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "rgba(96,165,250,0.6)" }}>Dispatch</a>
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, border: "1px solid rgba(37,99,235,0.5)", background: "rgba(37,99,235,0.12)", padding: "4px 11px", fontSize: 9, letterSpacing: "0.18em", color: "#4ade80" }}>◉ NODE_ONLINE</span>
+      </nav>
+
+      {/* PAGE */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 920, margin: "0 auto", padding: "26px 40px 90px" }}>
+        <div style={{ fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "rgba(96,165,250,0.5)", marginBottom: 22 }}>
+          <a className="sg-link" href="#">Tasks</a><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span>SINGULARITY</span><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span style={{ color: "#4ade80" }}>#{t.no}</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+
+          {/* HERO — terminal protocol readout */}
+          <div style={{ position: "relative", border: "1px solid rgba(37,99,235,0.55)", background: "#050f08", overflow: "hidden" }}>
+            <div style={{ position: "absolute", inset: 6, border: "1px solid rgba(37,99,235,0.12)", pointerEvents: "none" }} />
+            <svg width="160" height="110" viewBox="0 0 160 110" style={{ position: "absolute", top: 0, left: 0, opacity: 0.6 }} fill="none" stroke="#2563eb" strokeWidth="1">
+              <path d="M0 28 H40 V8 H92" /><path d="M0 56 H60 V40 H120" /><circle cx="92" cy="8" r="2.5" fill="#4ade80" stroke="none" /><circle cx="120" cy="40" r="2.5" fill="#4ade80" stroke="none" />
+            </svg>
+            <svg width="160" height="110" viewBox="0 0 160 110" style={{ position: "absolute", bottom: 0, right: 0, opacity: 0.6, transform: "rotate(180deg)" }} fill="none" stroke="#2563eb" strokeWidth="1">
+              <path d="M0 28 H40 V8 H92" /><path d="M0 56 H60 V40 H120" /><circle cx="92" cy="8" r="2.5" fill="#4ade80" stroke="none" /><circle cx="120" cy="40" r="2.5" fill="#4ade80" stroke="none" />
+            </svg>
+            <div style={{ position: "relative", zIndex: 2, padding: "30px 36px 34px" }}>
+              <div style={{ fontSize: 8, letterSpacing: "0.16em", color: "rgba(96,165,250,0.5)", lineHeight: 2, marginBottom: 18 }}>
+                <div>&gt; OPEN PROTOCOL #{t.no}</div>
+                <div>&gt; CLASS: OBSERVATION · LVL {t.level} · {t.points} CR</div>
+                <div>&gt; STATUS: ACCEPTING NODES &nbsp;·&nbsp; CONSENSUS: <span style={{ color: "#4ade80" }}>OPEN</span></div>
+              </div>
+              <h1 style={{ fontSize: 40, lineHeight: 1.0, letterSpacing: "0.03em", color: "#dff6e8", margin: "0 0 16px", overflowWrap: "anywhere" }}>
+                {t.title}<span style={{ display: "inline-block", width: 14, height: 34, background: "#4ade80", marginLeft: 6, verticalAlign: -4, animation: "sg-blink 1s step-end infinite" }} />
+              </h1>
+              <div style={{ fontSize: 9, letterSpacing: "0.1em", color: "rgba(74,222,128,0.55)", marginBottom: 22 }}>SIGNAL_ID {t.signal}</div>
+              <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+                <div style={statBox}><div style={{ fontSize: 26, lineHeight: 1, color: "#4ade80" }}>{t.points}</div><div style={statLabel}>credits</div></div>
+                <div style={statBox}><div style={{ fontSize: 26, lineHeight: 1, color: "#dff6e8" }}>{t.level}</div><div style={statLabel}>level</div></div>
+                <div style={statBox}><div style={{ fontSize: 26, lineHeight: 1, color: "#60a5fa" }}>7</div><div style={statLabel}>arrays</div></div>
+              </div>
+            </div>
+            <svg viewBox="0 0 1160 30" preserveAspectRatio="none" style={{ display: "block", width: "100%", height: 30, opacity: 0.4 }} stroke="#4ade80" strokeWidth="1" fill="none">
+              <path d="M0 15 H120 L132 4 L144 26 L156 9 L168 21 L180 15 H320 L332 7 L344 23 L356 15 H520 L532 2 L544 28 L556 12 L568 18 L580 15 H760 L772 6 L784 24 L796 15 H980 L992 9 L1004 21 L1016 15 H1160" />
+            </svg>
+          </div>
+
+          {/* CTA bar */}
+          <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap", border: "1px solid rgba(37,99,235,0.4)", background: "rgba(37,99,235,0.06)", padding: "16px 20px" }}>
+            <button onClick={sign} style={{ cursor: "pointer", fontFamily: "'Share Tech Mono',monospace", fontSize: 11, letterSpacing: "0.1em", textTransform: "uppercase", color: signed ? "#4ade80" : "#60a5fa", background: signed ? "rgba(74,222,128,0.14)" : "rgba(37,99,235,0.14)", border: `1px solid ${signed ? "#4ade80" : "#60a5fa"}`, padding: "13px 24px" }}>
+              {signed ? "◉ JOINED — ARRAY 8 ASSIGNED" : "> JOIN ARRAY"}
+            </button>
+            <div style={{ fontSize: 8, letterSpacing: "0.06em", color: "rgba(74,222,128,0.5)", fontStyle: "italic" }}>
+              {signed ? "your observation windows now sync to the seventh season." : "no credentials. only signal."}
+            </div>
+            <div style={{ marginLeft: "auto", fontSize: 7, letterSpacing: "0.14em", color: "rgba(96,165,250,0.45)" }}>124 OBSERVED · 63 SEALED · CONSENSUS 4.2</div>
+          </div>
+
+          {/* THE OBSERVATION (user-written body) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
+              <h2 style={sectionH2}>// the_observation</h2>
+              <span style={sectionRule} />
+              <span style={{ fontSize: 7, letterSpacing: "0.12em", color: "rgba(96,165,250,0.45)" }}>posted_by: NODE_Vesper</span>
+            </div>
+            <div className="sg-body" style={{ border: "1px solid rgba(37,99,235,0.25)", background: "rgba(37,99,235,0.04)", padding: "24px 28px", maxWidth: 660 }}>
+              <p>Find a pattern that no human designed and no human maintains — a flocking, a market microstructure, a feedback loop in a system that was never supposed to have one. Record <b>800+ observation windows</b>. Do not interpret. The array interprets; you only witness.</p>
+              <p>Sample at fixed intervals and resist the urge to smooth the noise — the noise is data. Cross-reference against at least two other arrays before you claim a pattern is real.</p>
+              <p>Sealing conditions:</p>
+              <ul style={{ fontFamily: "'Share Tech Mono',monospace", fontSize: 11, lineHeight: 1.8, color: "rgba(159,232,184,0.85)", margin: "0 0 14px", paddingLeft: 20 }}>
+                <li>&gt; SEAL only at &gt;9σ confidence. Anything less stays SUBMITTED.</li>
+                <li>&gt; The pattern must not appear in any training set the seventh array holds.</li>
+                <li>&gt; One signal per node per window. No backfilling.</li>
+              </ul>
+              <p>When the signal clears, seal it. — <a href="#">full protocol spec ↗</a></p>
+            </div>
+          </section>
+
+          {/* SEALED PRAXIS (completions) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>// sealed_praxis</h2>
+              <span style={sectionRule} />
+              <span style={{ fontSize: 7, letterSpacing: "0.12em", color: "rgba(96,165,250,0.45)" }}>{entries.length} logs sealed against this protocol</span>
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 22px", alignItems: "flex-start" }}>
+              {entries.map((p, i) => (
+                <div key={i} style={{ position: "relative", paddingTop: 20 }}>
+                  {p.top && (
+                    <div style={{ position: "absolute", top: -2, left: "50%", transform: "translateX(-50%)", zIndex: 3, display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap", background: "#050f08", border: "1px solid #4ade80", color: "#4ade80", fontFamily: "'Share Tech Mono',monospace", fontSize: 7.5, letterSpacing: "0.16em", padding: "4px 11px", boxShadow: "0 0 12px rgba(74,222,128,0.4)" }}>
+                      <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span> HIGHEST SIGNAL
+                    </div>
+                  )}
+                  <FactionPraxisCard faction="singularity" {...p} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* THE SIGNAL LOG (discussion) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>// signal_log</h2>
+              <span style={sectionRule} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 14, maxWidth: 680 }}>
+              {thread.map((c, i) => (
+                <FactionCommentBox key={i} faction="singularity" {...c} />
+              ))}
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SingularityTaskDetail;

--- a/docs/design/task-detail/SnideTaskDetail.tsx
+++ b/docs/design/task-detail/SnideTaskDetail.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from "react";
+import { FactionPraxisCard, FactionCommentBox } from "@world-zero/design-system";
+import { TaskDetailProps, PraxisEntry, CommentEntry, markTop, makeAvatar } from "./types";
+
+/* ────────────────────────────────────────────────────────────────
+   S.N.I.D.E. · Ransom Dispatch
+   An open-case dossier: photocopier-black file card, mugshot panel,
+   ransom cut-out title, lined-paper brief, closed cases (top marks
+   wears a fleur-de-lis), and a marker-scrawl discussion.
+   ──────────────────────────────────────────────────────────────── */
+
+const DEFAULT_TASK = { title: "DO A KICKFLIP", no: "0042", points: 25, level: 2 };
+
+const DEFAULT_PRAXIS: PraxisEntry[] = [
+  { task: "DO A KICKFLIP", finding: "IN A GROCERY STORE", author: "Static",
+    excerpt: "Aisle 7, no board, held eye contact with a man buying eggs. He nodded. ANARCHY.", rating: 5, marks: 41, points: 25, level: 2 },
+  { task: "DO A KICKFLIP", finding: "OFF A LOADING DOCK", author: "Doomscroll",
+    excerpt: "Used an actual skateboard like a coward. Still landed it. Rad, not sick.", rating: 3, marks: 19, points: 25, level: 2 },
+  { task: "DO A KICKFLIP", finding: "AT MY OWN WEDDING", author: "Glitter Riot",
+    excerpt: "Nobody asked. Triple points. The photographer got it. So did my in-laws.", rating: 4, marks: 27, points: 25, level: 2 },
+];
+
+const DEFAULT_COMMENTS: CommentEntry[] = [
+  { name: "Static", meta: "filed · 1d ago", body: "Did it in a grocery store. @Nope filmed it sideways. Worth every point.", avatar: makeAvatar("S", "#14110b", "#b6ff2e") },
+  { name: "Doomscroll", meta: "5h ago", body: "The eye contact rule is what makes this art instead of exercise.", avatar: makeAvatar("D", "#14110b", "#b6ff2e") },
+];
+
+const CSS = `
+  .sn-page a { color: inherit; text-decoration: none; }
+  .sn-link:hover { color: #6fae00 !important; }
+  .sn-tape { position:absolute; background: var(--snide-tape, rgba(228,214,120,0.5)); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.25); }
+  .sn-body p { font-family:'Special Elite',serif; font-size:13px; line-height:28px; color:#14110b; margin:0 0 16px; }
+  .sn-body p:last-child { margin-bottom:0; }
+  .sn-body a { color:#6fae00; }
+`;
+
+const RansomChip: React.FC<{ children: React.ReactNode; bg: string; color: string; font: string; size: number; rot: number; }> = ({ children, bg, color, font, size, rot }) => (
+  <span style={{ display: "inline-block", background: bg, color, fontFamily: font, fontSize: size, lineHeight: 0.9, padding: "2px 10px 0", transform: `rotate(${rot}deg)`, boxShadow: "1.5px 2.5px 0 rgba(0,0,0,0.4)", border: bg === "#f4f1e8" ? "1px solid #14110b" : "none" }}>{children}</span>
+);
+
+const tag = (label: string, value: string, accent = false) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 3, padding: "9px 14px", border: "1.5px solid #14110b", background: accent ? "#14110b" : "transparent", transform: `rotate(${accent ? -1.5 : 1}deg)`, boxShadow: accent ? "2px 3px 0 #ec3a86" : "none" }}>
+    <span style={{ fontFamily: "'Special Elite',serif", fontSize: 8, letterSpacing: "0.18em", textTransform: "uppercase", color: accent ? "#b6ff2e" : "#8b8576" }}>{label}</span>
+    <span style={{ fontFamily: "'Anton',sans-serif", fontSize: 26, lineHeight: 0.85, color: accent ? "#b6ff2e" : "#14110b" }}>{value}</span>
+  </div>
+);
+
+export function SnideTaskDetail({ task, praxis, comments, onSignUp }: TaskDetailProps) {
+  const t = { ...DEFAULT_TASK, ...task };
+  const entries = markTop(praxis ?? DEFAULT_PRAXIS);
+  const thread = comments ?? DEFAULT_COMMENTS;
+  const [signed, setSigned] = useState(false);
+  const sign = () => { setSigned((s) => !s); onSignUp?.(); };
+
+  return (
+    <div className="sn-page" style={{ minHeight: "100vh", fontFamily: "'Special Elite',serif", color: "#14110b", position: "relative", background: "#efece3", backgroundImage: "radial-gradient(rgba(20,17,11,0.04) 1px, transparent 1px)", backgroundSize: "5px 5px" }}>
+      <style>{CSS}</style>
+
+      {/* NAV */}
+      <nav style={{ position: "relative", zIndex: 10, display: "flex", alignItems: "center", gap: 30, padding: "16px 40px", background: "rgba(239,236,227,0.86)", backdropFilter: "blur(8px)", borderBottom: "1px solid rgba(20,17,11,0.14)" }}>
+        <span style={{ fontFamily: "'Lora',serif", fontStyle: "italic", fontWeight: 600, fontSize: 25, lineHeight: 1, borderBottom: "3px solid", borderImage: "linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1", paddingBottom: 2 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 22, flex: 1 }}>
+          <a className="sn-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#6b6253" }}>Tasks</a>
+          <a className="sn-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#14110b", borderBottom: "2px solid #14110b", paddingBottom: 2 }}>Job File</a>
+          <a className="sn-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#6b6253" }}>Praxis</a>
+          <a className="sn-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#6b6253" }}>Dispatch</a>
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, background: "#14110b", color: "#b6ff2e", padding: "5px 12px", fontFamily: "'Anton',sans-serif", fontSize: 12, letterSpacing: "0.14em", transform: "rotate(-1deg)" }}>★ ON THE INSIDE</span>
+      </nav>
+
+      {/* PAGE */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 920, margin: "0 auto", padding: "30px 40px 90px" }}>
+        <div style={{ fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "#6b6253", marginBottom: 26, fontFamily: "'Special Elite',serif" }}>
+          <a className="sn-link" href="#">Tasks</a><span style={{ opacity: 0.5, margin: "0 8px" }}>›</span><span>S.N.I.D.E.</span><span style={{ opacity: 0.5, margin: "0 8px" }}>›</span><span style={{ color: "#6fae00" }}>{t.title}</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+
+          {/* HERO — open-case dossier */}
+          <div style={{ position: "relative", background: "#f4f1e8", color: "#14110b", border: "1.5px solid #14110b", boxShadow: "6px 7px 0 rgba(0,0,0,0.25)", transform: "rotate(-0.5deg)", overflow: "hidden" }}>
+            <div style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 8, background: "#b6ff2e", backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, rgba(0,0,0,0.25) 13px 14px)" }} />
+            <div className="sn-tape" style={{ top: -9, right: 44, width: 64, height: 20, transform: "rotate(6deg)" }} />
+            <div style={{ position: "relative", display: "flex", gap: 0 }}>
+              <div style={{ flexShrink: 0, width: 138, background: "#14110b", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "22px 10px", backgroundImage: "repeating-linear-gradient(180deg, transparent 0 13px, rgba(182,255,46,0.16) 13px 14px)" }}>
+                <svg width="58" height="58" viewBox="0 0 48 48" fill="none"><rect x="6" y="6" width="36" height="36" stroke="#b6ff2e" strokeWidth="2.5" transform="rotate(45 24 24)" /><circle cx="24" cy="24" r="7" fill="#b6ff2e" /><path d="M24 2 V10 M24 38 V46 M2 24 H10 M38 24 H46" stroke="#b6ff2e" strokeWidth="2.5" /></svg>
+                <div style={{ fontFamily: "'Anton',sans-serif", fontSize: 13, letterSpacing: "0.12em", color: "#b6ff2e", marginTop: 12 }}>JOB FILE</div>
+                <div style={{ fontFamily: "'Special Elite',serif", fontSize: 8, color: "#7fa83f", letterSpacing: "0.1em", marginTop: 3 }}>OPEN CASE</div>
+              </div>
+              <div style={{ flex: 1, minWidth: 0, padding: "24px 24px 22px 20px", position: "relative" }}>
+                <div style={{ fontFamily: "'Special Elite',serif", fontSize: 9, letterSpacing: "0.2em", textTransform: "uppercase", color: "#6b6253", marginBottom: 10 }}>S.N.I.D.E. Case File · job no. {t.no}</div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 5px", alignItems: "center", marginBottom: 18 }}>
+                  <RansomChip bg="#f4f1e8" color="#14110b" font="'Anton',sans-serif" size={40} rot={-4}>DO</RansomChip>
+                  <RansomChip bg="#14110b" color="#b6ff2e" font="'Archivo Black',sans-serif" size={34} rot={3}>A</RansomChip>
+                  <RansomChip bg="#ec3a86" color="#fff" font="'Anton',sans-serif" size={40} rot={-2}>KICK</RansomChip>
+                  <RansomChip bg="#b6ff2e" color="#14110b" font="'Archivo Black',sans-serif" size={34} rot={4}>FLIP</RansomChip>
+                </div>
+                <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+                  {tag("Points", String(t.points), true)}
+                  {tag("Level", `LVL ${t.level}`)}
+                  {tag("Filed", "88×")}
+                </div>
+                <span style={{ position: "absolute", bottom: 16, right: 16, fontFamily: "'Anton',sans-serif", fontSize: 15, letterSpacing: "0.14em", color: "rgba(190,24,93,0.75)", border: "2.5px solid rgba(190,24,93,0.7)", padding: "3px 12px", transform: "rotate(-7deg)" }}>OPEN CASE</span>
+              </div>
+            </div>
+          </div>
+
+          {/* CTA bar */}
+          <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap", background: "#14110b", padding: "16px 20px", transform: "rotate(-0.4deg)", boxShadow: "4px 5px 0 rgba(0,0,0,0.2)" }}>
+            <button onClick={sign} style={{ cursor: "pointer", border: "2px solid #14110b", background: signed ? "#ec3a86" : "#6fae00", color: "#fff", fontFamily: "'Archivo Black',sans-serif", fontSize: 14, letterSpacing: "0.03em", padding: "13px 24px", transform: "rotate(-1.5deg)", boxShadow: "3px 4px 0 #b6ff2e" }}>
+              {signed ? "→ FILE THE RAP SHEET" : "★ PULL THIS JOB ★"}
+            </button>
+            <div style={{ fontFamily: "'Permanent Marker',cursive", fontSize: 13, color: "#ec3a86", transform: "rotate(-1deg)" }}>
+              {signed ? "↳ go get it on the record" : "↳ no take-backs once it's filed"}
+            </div>
+            <div style={{ marginLeft: "auto", fontFamily: "'Anton',sans-serif", fontSize: 11, letterSpacing: "0.1em", color: "#b6ff2e" }}>88 ATTEMPTED · 61 FILED · 2.1 AVG</div>
+          </div>
+
+          {/* THE BRIEF (user-written body) */}
+          <section>
+            <div style={{ display: "inline-block", background: "#b6ff2e", color: "#14110b", fontFamily: "'Permanent Marker',cursive", fontSize: 17, padding: "3px 14px", transform: "rotate(-1.5deg)", boxShadow: "2px 2px 0 #ec3a86", marginBottom: 14 }}>the brief</div>
+            <div className="sn-body" style={{ position: "relative", background: "#f4f1e8", color: "#14110b", border: "1.5px solid #14110b", borderLeft: "4px solid #b6ff2e", padding: "24px 24px 20px", backgroundImage: "repeating-linear-gradient(180deg, transparent 0 27px, rgba(20,17,11,0.08) 27px 28px)", transform: "rotate(0.3deg)", boxShadow: "3px 4px 0 rgba(0,0,0,0.18)", maxWidth: 640 }}>
+              <div className="sn-tape" style={{ top: -9, left: 32, width: 62, height: 18, transform: "rotate(-5deg)" }} />
+              <p>Do a kickflip. Bonus points if you don't use a skateboard. Double if nobody asked you to. Triple if you make meaningful eye contact with a bystander immediately after.</p>
+              <p>Most people do it wrong. That's the point. We're not grading the kickflip — we're grading the nerve. Commitment is the trick; the board is optional; the audience is a bonus.</p>
+              <p>File the rap sheet before anyone can claim it didn't happen. — <a href="#">the unwritten rules ↗</a></p>
+            </div>
+          </section>
+
+          {/* CASES CLOSED (completions) */}
+          <section>
+            <div style={{ display: "inline-block", background: "#b6ff2e", color: "#14110b", fontFamily: "'Permanent Marker',cursive", fontSize: 17, padding: "3px 14px", transform: "rotate(1deg)", boxShadow: "2px 2px 0 #ec3a86", marginBottom: 18 }}>cases closed</div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "32px 26px", alignItems: "flex-start" }}>
+              {entries.map((p, i) => (
+                <div key={i} style={{ position: "relative", paddingTop: 22 }}>
+                  {p.top && (
+                    <div style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%) rotate(-3deg)", zIndex: 3, display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap", background: "#ec3a86", color: "#fff", fontFamily: "'Archivo Black',sans-serif", fontSize: 9, letterSpacing: "0.06em", padding: "4px 12px", boxShadow: "2px 3px 0 #14110b" }}>
+                      <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span> TOP MARKS
+                    </div>
+                  )}
+                  <FactionPraxisCard faction="snide" {...p} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* THE CHATTER (discussion) */}
+          <section>
+            <div style={{ display: "inline-block", background: "#b6ff2e", color: "#14110b", fontFamily: "'Permanent Marker',cursive", fontSize: 17, padding: "3px 14px", transform: "rotate(-1deg)", boxShadow: "2px 2px 0 #ec3a86", marginBottom: 18 }}>the chatter</div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 680 }}>
+              {thread.map((c, i) => <FactionCommentBox key={i} faction="snide" {...c} />)}
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SnideTaskDetail;

--- a/docs/design/task-detail/UATaskDetail.tsx
+++ b/docs/design/task-detail/UATaskDetail.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from "react";
+import { FactionPraxisCard, FactionCommentBox } from "@world-zero/design-system";
+import { TaskDetailProps, PraxisEntry, CommentEntry, markTop, makeAvatar } from "./types";
+
+/* ────────────────────────────────────────────────────────────────
+   UA — University of Asthmatics · Gilt Salon
+   A heraldic-crest task page: parchment, a gold museum frame, a
+   Playfair-italic title, and "The Salon Wall" of filed praxis (the
+   finest hand wears a fleur-de-lis).
+   ──────────────────────────────────────────────────────────────── */
+
+const DEFAULT_TASK = { title: "Paint the Quad at Golden Hour", no: "0317", points: 40, level: 3 };
+
+const DEFAULT_PRAXIS: PraxisEntry[] = [
+  { task: "Paint the Quad", finding: "The colonnade, 6:51pm", author: "Veridian",
+    excerpt: "Charcoal, not oils. The shadows did the work; I just stayed out of their way.", rating: 5, marks: 22, points: 40, level: 3 },
+  { task: "Paint the Quad", finding: "Gold on the wet stone", author: "The Understudy",
+    excerpt: "It rained at golden hour. I painted the reflection instead. No regrets.", rating: 4, marks: 14, points: 40, level: 3 },
+  { task: "Paint the Quad", finding: "Forty minutes, one sitting", author: "Anon. Pupil",
+    excerpt: "Phone camera, held very still. Counts as a medium. The Salon decides.", rating: 3, marks: 9, points: 40, level: 3 },
+];
+
+const DEFAULT_COMMENTS: CommentEntry[] = [
+  { name: "Brushwright Aimé", handle: "aime", meta: "proposed · 3w ago",
+    body: "I have walked past this quad for three years. @Veridian convinced me it was worth one honest attempt. Enrol while the light holds.", avatar: makeAvatar("A", "#b07a3a", "#fdf6ea") },
+  { name: "Veridian", handle: "veridian", meta: "2d ago",
+    body: "Brought charcoal instead of oils. No regrets. The shadows are the whole commission.", avatar: makeAvatar("V", "#8f6a3a", "#fdf6ea") },
+];
+
+const CSS = `
+  .ua-page a { color: inherit; text-decoration: none; }
+  .ua-link:hover { color: #c2541f !important; }
+  .ua-body p { font-family:'EB Garamond',serif; font-size:17px; line-height:1.75; color:#5a4326; margin:0 0 16px; }
+  .ua-body p:last-child { margin-bottom:0; }
+  .ua-body em { color:#3d2410; }
+  .ua-body a { color:#c2541f; border-bottom:1px solid rgba(194,84,31,0.4); }
+`;
+
+const sectionRule: React.CSSProperties = { flex: 1, height: 1, background: "linear-gradient(90deg,#cdab63,transparent)" };
+const sectionH2: React.CSSProperties = { fontFamily: "'Marcellus SC',serif", fontSize: 18, letterSpacing: "0.06em", margin: 0, color: "#3d2410", whiteSpace: "nowrap" };
+
+export function UATaskDetail({ task, praxis, comments, onSignUp }: TaskDetailProps) {
+  const t = { ...DEFAULT_TASK, ...task };
+  const entries = markTop(praxis ?? DEFAULT_PRAXIS);
+  const thread = comments ?? DEFAULT_COMMENTS;
+  const [signed, setSigned] = useState(false);
+  const sign = () => { setSigned((s) => !s); onSignUp?.(); };
+
+  return (
+    <div className="ua-page" style={{ minHeight: "100vh", fontFamily: "'Courier Prime',monospace", color: "#3d2410", position: "relative",
+      background: "#ece4d2", backgroundImage: "radial-gradient(70% 50% at 8% 0%, rgba(221,147,34,0.08), transparent 70%), radial-gradient(60% 50% at 100% 6%, rgba(194,84,31,0.07), transparent 70%), radial-gradient(rgba(140,106,30,0.045) 1px, transparent 1px)", backgroundSize: "auto, auto, 6px 6px" }}>
+      <style>{CSS}</style>
+
+      {/* NAV */}
+      <nav style={{ position: "relative", zIndex: 10, display: "flex", alignItems: "center", gap: 30, padding: "16px 40px", background: "rgba(253,246,234,0.82)", backdropFilter: "blur(8px)", borderBottom: "1px solid #e3cb98" }}>
+        <span style={{ fontFamily: "'Playfair Display',serif", fontStyle: "italic", fontWeight: 600, fontSize: 25, lineHeight: 1, borderBottom: "3px solid", borderImage: "linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1", paddingBottom: 2 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 22, flex: 1 }}>
+          <a className="ua-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#a8895a" }}>Tasks</a>
+          <a className="ua-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#3d2410", borderBottom: "2px solid #c2541f", paddingBottom: 2 }}>Detail</a>
+          <a className="ua-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#a8895a" }}>Praxis</a>
+          <a className="ua-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#a8895a" }}>Salon</a>
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, border: "1px solid #cdab63", padding: "4px 11px", fontFamily: "'Marcellus SC',serif", fontSize: 10, letterSpacing: "0.14em", color: "#9c6a1a" }}>✦ UA · Matriculated</span>
+      </nav>
+
+      {/* PAGE */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 920, margin: "0 auto", padding: "26px 40px 90px" }}>
+        <div style={{ fontSize: 10, letterSpacing: "0.18em", textTransform: "uppercase", color: "#a8895a", marginBottom: 22 }}>
+          <a className="ua-link" href="#">Tasks</a><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span>University of Asthmatics</span><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span style={{ color: "#c2541f" }}>{t.title}</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+
+          {/* HERO — gilt salon plate */}
+          <div style={{ padding: 11, background: "linear-gradient(135deg,#eec06a 0%,#9c6a1a 24%,#f0c878 50%,#9c6a1a 76%,#dd9322 100%)", boxShadow: "0 18px 40px rgba(60,40,10,0.28), inset 0 0 0 1px rgba(255,255,255,0.45)" }}>
+            <div style={{ padding: 5, background: "linear-gradient(135deg,#9c6a1a,#eec06a)" }}>
+              <div style={{ position: "relative", border: "1px solid rgba(60,40,10,0.45)", background: "#fef7ea", backgroundImage: "radial-gradient(rgba(60,40,10,0.03) 1px,transparent 1px)", backgroundSize: "5px 5px", padding: "34px 38px 30px", display: "flex", gap: 30, alignItems: "center" }}>
+                <svg width="150" height="180" viewBox="0 0 100 120" style={{ display: "block", flexShrink: 0 }}>
+                  <defs><clipPath id="ua-det-shield"><path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" /></clipPath></defs>
+                  <g clipPath="url(#ua-det-shield)">
+                    <rect x="0" y="0" width="100" height="120" fill="#c2541f" />
+                    <rect x="0" y="60" width="100" height="60" fill="#f8ead2" />
+                    <circle cx="50" cy="60" r="15" fill="#f0b53e" />
+                    <g stroke="#f0b53e" strokeWidth="2.4" strokeLinecap="round"><line x1="50" y1="60" x2="50" y2="20" /><line x1="50" y1="60" x2="22" y2="30" /><line x1="50" y1="60" x2="78" y2="30" /><line x1="50" y1="60" x2="14" y2="48" /><line x1="50" y1="60" x2="86" y2="48" /><line x1="50" y1="60" x2="34" y2="22" /><line x1="50" y1="60" x2="66" y2="22" /></g>
+                    <g transform="translate(50 84)"><g transform="rotate(38)"><rect x="-2" y="-30" width="4" height="44" rx="1.5" fill="#3d2410" /><rect x="-3" y="10" width="6" height="6" fill="#eab94a" /><path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill="#c2541f" /></g><g transform="rotate(-38)"><rect x="-2" y="-30" width="4" height="44" rx="1.5" fill="#9c6a1a" /><rect x="-3" y="10" width="6" height="6" fill="#eab94a" /><path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill="#dd9322" /></g></g>
+                  </g>
+                  <path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" fill="none" stroke="#dd9322" strokeWidth="2.5" />
+                  <path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" fill="none" stroke="#3d2410" strokeWidth="0.8" />
+                </svg>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontFamily: "'Marcellus SC',serif", fontSize: 11, letterSpacing: "0.16em", color: "#c2541f", marginBottom: 3 }}>University of Asthmatics</div>
+                  <div style={{ fontFamily: "'Courier Prime',monospace", fontSize: 8, letterSpacing: "0.3em", color: "#a8895a", marginBottom: 14 }}>COMMISSION №{t.no} · EST · MMXX</div>
+                  <h1 style={{ fontFamily: "'Playfair Display',serif", fontStyle: "italic", fontWeight: 700, fontSize: 42, lineHeight: 1.06, color: "#3d2410", margin: "0 0 16px", overflowWrap: "anywhere" }}>{t.title}</h1>
+                  <div style={{ position: "relative", width: "fit-content", background: "#c2541f", color: "#fce4c4", fontFamily: "'Marcellus SC',serif", fontSize: 9, letterSpacing: "0.1em", padding: "5px 24px", clipPath: "polygon(0 0,100% 0,96% 50%,100% 100%,0 100%,4% 50%)", marginBottom: 18 }}>Ars Longa · Spiritus Brevis</div>
+                  <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                    <div style={{ display: "flex", flexDirection: "column", gap: 2, padding: "9px 16px", border: "1px solid #cdab63", background: "#fdf6ea" }}>
+                      <span style={{ fontFamily: "'Marcellus SC',serif", fontSize: 8, letterSpacing: "0.14em", color: "#a8895a" }}>ANNO</span>
+                      <span style={{ fontFamily: "'Playfair Display',serif", fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 0.9, color: "#3d2410" }}>{romanLevel(t.level)}</span>
+                    </div>
+                    <div style={{ display: "flex", flexDirection: "column", gap: 2, padding: "9px 16px", border: "1px solid #c2541f", background: "#c2541f" }}>
+                      <span style={{ fontFamily: "'Marcellus SC',serif", fontSize: 8, letterSpacing: "0.14em", color: "#fce4c4" }}>HONORARIA</span>
+                      <span style={{ fontFamily: "'Playfair Display',serif", fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 0.9, color: "#fef7ea" }}>{t.points}<span style={{ fontFamily: "'Marcellus SC',serif", fontSize: 9, marginLeft: 4 }}>pts</span></span>
+                    </div>
+                    <div style={{ display: "flex", flexDirection: "column", gap: 2, padding: "9px 16px", border: "1px solid #cdab63", background: "#fdf6ea" }}>
+                      <span style={{ fontFamily: "'Marcellus SC',serif", fontSize: 8, letterSpacing: "0.14em", color: "#a8895a" }}>STANDING</span>
+                      <span style={{ fontFamily: "'Playfair Display',serif", fontStyle: "italic", fontWeight: 600, fontSize: 18, lineHeight: 1.2, color: "#8f6a3a" }}>Open Salon</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* CTA bar */}
+          <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap", padding: "16px 20px", border: "1px solid #cdab63", background: "#fdf6ea" }}>
+            <button onClick={sign} style={{ cursor: "pointer", fontFamily: "'Marcellus SC',serif", fontSize: 12, letterSpacing: "0.14em", color: "#fef7ea", background: signed ? "#9c6a1a" : "#c2541f", border: "none", padding: "13px 26px", boxShadow: "0 3px 8px rgba(194,84,31,0.3)" }}>
+              {signed ? "✦ Enrolled — see you at the Salon" : "Matriculate ▸"}
+            </button>
+            <div style={{ fontFamily: "'EB Garamond',serif", fontStyle: "italic", fontSize: 14, color: "#8f6a3a" }}>
+              {signed ? "Your easel is reserved." : "Open to all standing. No portfolio required."}
+            </div>
+            <div style={{ marginLeft: "auto", fontFamily: "'Marcellus SC',serif", fontSize: 9, letterSpacing: "0.12em", color: "#a8895a" }}>52 attempted · 31 exhibited · 4.1 avg critique</div>
+          </div>
+
+          {/* THE COMMISSION (user-written body) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
+              <h2 style={sectionH2}>The Commission</h2>
+              <span style={sectionRule} />
+              <span style={{ fontFamily: "'Courier Prime',monospace", fontSize: 8, letterSpacing: "0.12em", color: "#a8895a" }}>posted by Brushwright Aimé</span>
+            </div>
+            <div className="ua-body" style={{ border: "1px solid #cdab63", background: "#fdf6ea", padding: "28px 32px", maxWidth: 660 }}>
+              <p>Capture the light before it leaves. <em>Any medium, any madness</em> — oils, charcoal, a phone camera held very still. The quad has been painted ten thousand times; I ask only that yours be unmistakably the eleven-thousand-and-first.</p>
+              <p>Go an hour before sunset, when the gold first lands on the western colonnade. Commit to one medium and render the whole thing in a single sitting — golden hour does not grant extensions. When it's done, title it, sign it, and pin it to the Salon wall below.</p>
+              <p>A few things the Salon tends to reward:</p>
+              <ul style={{ fontFamily: "'EB Garamond',serif", fontSize: 16, lineHeight: 1.7, color: "#5a4326", margin: "0 0 16px", paddingLeft: 22 }}>
+                <li>Conviction over hedging — one bold choice beats three timid ones.</li>
+                <li>The shadows, not just the light. Most people forget the shadows.</li>
+                <li>Evidence you were actually <em>there</em> at the hour, not working from memory.</li>
+              </ul>
+              <p>Submit the work, not the excuse. — <a href="#">read the full rubric ↗</a></p>
+            </div>
+          </section>
+
+          {/* THE SALON WALL (praxis completions) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>The Salon Wall</h2>
+              <span style={sectionRule} />
+              <span style={{ fontFamily: "'Courier Prime',monospace", fontSize: 8, letterSpacing: "0.12em", color: "#a8895a" }}>{entries.length} works filed against this commission</span>
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 22px", alignItems: "flex-start" }}>
+              {entries.map((p, i) => (
+                <div key={i} style={{ position: "relative", paddingTop: 20 }}>
+                  {p.top && (
+                    <div style={{ position: "absolute", top: -4, left: "50%", transform: "translateX(-50%)", zIndex: 3, display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap", background: "#c2541f", color: "#fef7ea", fontFamily: "'Marcellus SC',serif", fontSize: 8.5, letterSpacing: "0.12em", padding: "4px 12px", boxShadow: "0 3px 8px rgba(60,40,10,0.3)" }}>
+                      <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> FINEST HAND
+                    </div>
+                  )}
+                  <FactionPraxisCard faction="ua" {...p} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* THE CRITIQUE (discussion) */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+              <h2 style={sectionH2}>The Critique</h2>
+              <span style={sectionRule} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 18, maxWidth: 680 }}>
+              {thread.map((c, i) => (
+                <FactionCommentBox key={i} faction="ua" {...c} />
+              ))}
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function romanLevel(n: number): string {
+  return ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"][Math.max(0, Math.min(9, n - 1))] ?? String(n);
+}
+
+export default UATaskDetail;

--- a/docs/design/task-detail/WhimsyTaskDetail.tsx
+++ b/docs/design/task-detail/WhimsyTaskDetail.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from "react";
+import { FactionPraxisCard, FactionCommentBox } from "@world-zero/design-system";
+import { TaskDetailProps, PraxisEntry, CommentEntry, markTop } from "./types";
+
+/* ────────────────────────────────────────────────────────────────
+   WARRIORS OF WHIMSY · whimsy.exe Desktop
+   A pink computer-witch window: traffic-light title bar, dotted
+   desktop, sparkle + heart charms, Caveat headings, spells cast
+   (most loved wears a fleur-de-lis), and a pastel group chat.
+   ──────────────────────────────────────────────────────────────── */
+
+const DEFAULT_TASK = { title: "Leave a Spell on a Stranger's Door", points: 30, level: 2 };
+
+const DEFAULT_PRAXIS: PraxisEntry[] = [
+  { task: "Leave a Spell", finding: "the folded paper star", author: "Marigold",
+    excerpt: "Said 'you were right to leave.' She cried at the door. mission accomplished.", rating: 5, marks: 34, points: 30, level: 2 },
+  { task: "Leave a Spell", finding: "chalk sigil, bus stop", author: "Glimmer",
+    excerpt: "Drew a tiny sun under the bench where the morning crowd waits. Gone by noon. Worth it.", rating: 4, marks: 21, points: 30, level: 2 },
+  { task: "Leave a Spell", finding: "a charm in a library book", author: "Pocket Witch",
+    excerpt: "Pressed flower + a note on page 100. Whoever borrows it next gets a small wonder.", rating: 4, marks: 18, points: 30, level: 2 },
+];
+
+const grad = (a: string[]) => `radial-gradient(circle at 32% 28%, ${a[0]}, ${a[1]} 72%, ${a[2]})`;
+const avatar = (a: string[]) => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><defs><radialGradient id="g" cx="32%" cy="28%"><stop offset="0" stop-color="${a[0]}"/><stop offset="0.72" stop-color="${a[1]}"/><stop offset="1" stop-color="${a[2]}"/></radialGradient></defs><rect width="80" height="80" fill="url(#g)"/></svg>`;
+  return "data:image/svg+xml;utf8," + encodeURIComponent(svg);
+};
+
+const DEFAULT_COMMENTS: CommentEntry[] = [
+  { name: "Marigold", handle: "marigold", meta: "cast it · 3w", body: "left a folded paper star that said 'you were right to leave.' @Tuesday cried. mission accomplished.", avatar: avatar(["#f6a8cb", "#ec5f99", "#a83a6e"]) },
+  { name: "Tuesday", handle: "tuesday", meta: "2d", body: "i WAS right to leave. how did the door know.", avatar: avatar(["#f6c75e", "#e09a2a", "#a86a12"]) },
+];
+
+const CSS = `
+  .wow-page a { color: inherit; text-decoration: none; }
+  .wow-link:hover { color: #d23b7e !important; }
+  .wow-body p { font-family:'Courier Prime',monospace; font-size:12px; line-height:1.75; color:#6b3050; margin:0 0 14px; }
+  .wow-body p:last-child { margin-bottom:0; }
+  .wow-body strong { color:#d23b7e; }
+  .wow-body a { color:#d23b7e; border-bottom:1px solid rgba(214,59,126,0.4); }
+`;
+
+const Sparkle: React.FC<{ size: number; color: string; style?: React.CSSProperties }> = ({ size, color, style }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" style={style}><path d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z" fill={color} /></svg>
+);
+
+const sectionH2: React.CSSProperties = { fontFamily: "'Caveat',cursive", fontSize: 32, margin: 0, color: "#7a2350", whiteSpace: "nowrap" };
+const sectionRule: React.CSSProperties = { flex: 1, height: 2, background: "repeating-linear-gradient(90deg,#ec5f99 0 8px, transparent 8px 14px)" };
+const SectionHead: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 18 }}>
+    <Sparkle size={18} color="#ec5f99" /><h2 style={sectionH2}>{children}</h2><span style={sectionRule} />
+  </div>
+);
+
+export function WhimsyTaskDetail({ task, praxis, comments, onSignUp }: TaskDetailProps) {
+  const t = { ...DEFAULT_TASK, ...task };
+  const entries = markTop(praxis ?? DEFAULT_PRAXIS);
+  const thread = comments ?? DEFAULT_COMMENTS;
+  const [signed, setSigned] = useState(false);
+  const sign = () => { setSigned((s) => !s); onSignUp?.(); };
+
+  return (
+    <div className="wow-page" style={{ minHeight: "100vh", fontFamily: "'Courier Prime',monospace", color: "#5b2a44", position: "relative", background: "#fbe6f0", backgroundImage: "radial-gradient(rgba(214,90,150,0.16) 1.3px, transparent 1.3px)", backgroundSize: "15px 15px" }}>
+      <style>{CSS}</style>
+
+      {/* NAV */}
+      <nav style={{ position: "relative", zIndex: 10, display: "flex", alignItems: "center", gap: 30, padding: "16px 40px", background: "rgba(255,240,247,0.86)", backdropFilter: "blur(8px)", borderBottom: "1px solid #f3b6d2" }}>
+        <span style={{ fontFamily: "'Lora',serif", fontStyle: "italic", fontWeight: 600, fontSize: 25, lineHeight: 1, borderBottom: "3px solid", borderImage: "linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1", paddingBottom: 2 }}>World Zero</span>
+        <div style={{ display: "flex", gap: 22, flex: 1 }}>
+          <a className="wow-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#b56391" }}>Tasks</a>
+          <a className="wow-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#d23b7e", borderBottom: "2px solid #ec5f99", paddingBottom: 2 }}>Quest</a>
+          <a className="wow-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#b56391" }}>Spells</a>
+          <a className="wow-link" href="#" style={{ fontSize: 11, letterSpacing: "0.13em", textTransform: "uppercase", color: "#b56391" }}>Updates</a>
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, border: "1.5px solid #ec5f99", borderRadius: 20, background: "#fbcfe2", padding: "4px 12px", fontFamily: "'Caveat',cursive", fontSize: 16, color: "#d23b7e" }}>✦ whimsy unlocked</span>
+      </nav>
+
+      {/* PAGE */}
+      <div style={{ position: "relative", zIndex: 5, maxWidth: 920, margin: "0 auto", padding: "26px 40px 90px" }}>
+        <div style={{ fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "#b56391", marginBottom: 22 }}>
+          <a className="wow-link" href="#">Tasks</a><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span>Warriors of Whimsy</span><span style={{ opacity: 0.5, margin: "0 8px" }}>/</span><span style={{ color: "#d23b7e" }}>{t.title}</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+
+          {/* HERO — whimsy.exe window */}
+          <div style={{ borderRadius: 14, overflow: "hidden", border: "2px solid #d23b7e", boxShadow: "0 10px 26px rgba(214,90,150,0.32)", transform: "rotate(-0.5deg)" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "9px 14px", background: "linear-gradient(180deg,#f9b6d4,#ec5f99)", borderBottom: "2px solid #d23b7e" }}>
+              {["#fb7aa8", "#f6c75e", "#86cfa6"].map((c) => <span key={c} style={{ width: 11, height: 11, borderRadius: "50%", background: c, border: "1.2px solid rgba(255,255,255,0.7)" }} />)}
+              <span style={{ marginLeft: "auto", fontFamily: "'Caveat',cursive", fontSize: 20, color: "#fff", textShadow: "1px 1px 0 #a83a6e" }}>quest.exe</span>
+            </div>
+            <div style={{ position: "relative", padding: "30px 34px 32px", background: "#fff0f7", backgroundImage: "radial-gradient(rgba(214,90,150,0.18) 1.3px, transparent 1.3px)", backgroundSize: "14px 14px" }}>
+              <Sparkle size={22} color="#f0b94a" style={{ position: "absolute", top: 18, right: 22, transform: "rotate(10deg)" }} />
+              <Sparkle size={14} color="#ec5f99" style={{ position: "absolute", top: 64, right: 70, transform: "rotate(-12deg)" }} />
+              <div style={{ fontSize: 9, textTransform: "uppercase", letterSpacing: "0.16em", color: "#b56391", marginBottom: 8 }}>a little magic, due by moonrise</div>
+              <div style={{ fontFamily: "'Caveat',cursive", fontSize: 62, lineHeight: 0.92, color: "#7a2350", marginBottom: 18, overflowWrap: "anywhere" }}>{t.title}</div>
+              <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 11, letterSpacing: "0.06em", textTransform: "uppercase", padding: "6px 14px", borderRadius: 20, background: "#fbcfe2", color: "#5b2a44", border: "1.5px solid rgba(214,90,150,0.4)" }}>
+                  <Sparkle size={11} color="#ec5f99" /> level {t.level}
+                </span>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 7, fontFamily: "'Caveat',cursive", fontSize: 30, color: "#ec5f99" }}>
+                  <svg width="22" height="22" viewBox="0 0 36 36"><path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z" fill="#ec5f99" stroke="#fff" strokeWidth="2.2" strokeLinejoin="round" /></svg> {t.points} sparks
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* CTA bar */}
+          <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap", border: "2px solid #d23b7e", borderRadius: 12, background: "#fff0f7", padding: "16px 20px", boxShadow: "4px 4px 0 #fbcfe2" }}>
+            <button onClick={sign} style={{ cursor: "pointer", fontFamily: "'Courier Prime',monospace", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.12em", color: "#fff", padding: "13px 24px", border: "1.5px solid #d23b7e", borderRadius: 10, background: signed ? "linear-gradient(180deg,#86cfa6,#3f9070)" : "linear-gradient(180deg,#ec5f99,#d23b7e)", boxShadow: "0 4px 10px rgba(214,90,150,0.35)" }}>
+              {signed ? "✦ you're in the party!" : "join the party ✦"}
+            </button>
+            <div style={{ fontFamily: "'Caveat',cursive", fontSize: 20, color: "#d23b7e" }}>
+              {signed ? "the group chat just got louder" : "no experience with magic required"}
+            </div>
+            <div style={{ marginLeft: "auto", fontSize: 10, letterSpacing: "0.06em", color: "#b56391" }}>73 tried · 58 pulled it off · 4.6 avg love</div>
+          </div>
+
+          {/* WHAT WE'RE ASKING (user-written body) */}
+          <section>
+            <SectionHead>what we're asking</SectionHead>
+            <div className="wow-body" style={{ border: "2px solid #f3b6d2", borderRadius: 12, background: "#fff", padding: "24px 28px", maxWidth: 640 }}>
+              <p>Make a small, kind, slightly inexplicable thing — a paper charm, a chalk sigil, a tiny note that says exactly the right impossible thing — and leave it where one <strong>specific stranger</strong> will find it. No signature. No credit. Just a little magic loosed into a Tuesday.</p>
+              <p>Choose your stranger by vibe, not by knowing them. Trust the pull. Then vanish like a good witch does, and tell the party here — but never tell <em>them</em>.</p>
+              <p>The party tends to lose its mind over:</p>
+              <ul style={{ fontFamily: "'Courier Prime',monospace", fontSize: 12, lineHeight: 1.7, color: "#6b3050", margin: "0 0 14px", paddingLeft: 22 }}>
+                <li>Handmade beats bought, every single time.</li>
+                <li>The right impossible words on a scrap of paper.</li>
+                <li>A clean vanish — nobody saw you do it.</li>
+              </ul>
+              <p>Glitter is permitted but never required. — <a href="#">the witch's handbook ↗</a></p>
+            </div>
+          </section>
+
+          {/* SPELLS CAST (completions) */}
+          <section>
+            <SectionHead>spells cast so far</SectionHead>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 24px", alignItems: "flex-start" }}>
+              {entries.map((p, i) => (
+                <div key={i} style={{ position: "relative", paddingTop: 22 }}>
+                  {p.top && (
+                    <div style={{ position: "absolute", top: -2, left: "50%", transform: "translateX(-50%) rotate(-2deg)", zIndex: 3, display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap", background: "#ec5f99", color: "#fff", fontFamily: "'Caveat',cursive", fontSize: 17, padding: "2px 14px", borderRadius: 14, boxShadow: "2px 3px 0 #fbcfe2" }}>
+                      <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> most loved
+                    </div>
+                  )}
+                  <FactionPraxisCard faction="wow" {...p} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* THE GROUP CHAT (discussion) */}
+          <section>
+            <SectionHead>the group chat</SectionHead>
+            <div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 680 }}>
+              {thread.map((c, i) => <FactionCommentBox key={i} faction="wow" {...c} />)}
+            </div>
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WhimsyTaskDetail;

--- a/docs/design/task-detail/index.ts
+++ b/docs/design/task-detail/index.ts
@@ -1,0 +1,32 @@
+/* World Zero — faction task-detail pages. */
+
+export * from "./types";
+
+export { UATaskDetail } from "./UATaskDetail";
+export { WhimsyTaskDetail } from "./WhimsyTaskDetail";
+export { SnideTaskDetail } from "./SnideTaskDetail";
+export { EphemeristsTaskDetail } from "./EphemeristsTaskDetail";
+export { SingularityTaskDetail } from "./SingularityTaskDetail";
+export { EverymenTaskDetail } from "./EverymenTaskDetail";
+export { AlbescentTaskDetail } from "./AlbescentTaskDetail";
+
+import { UATaskDetail } from "./UATaskDetail";
+import { WhimsyTaskDetail } from "./WhimsyTaskDetail";
+import { SnideTaskDetail } from "./SnideTaskDetail";
+import { EphemeristsTaskDetail } from "./EphemeristsTaskDetail";
+import { SingularityTaskDetail } from "./SingularityTaskDetail";
+import { EverymenTaskDetail } from "./EverymenTaskDetail";
+import { AlbescentTaskDetail } from "./AlbescentTaskDetail";
+import type { FactionSlug, TaskDetailProps } from "./types";
+import type React from "react";
+
+/** Resolve a faction slug → its task-detail page component. */
+export const TASK_DETAIL_BY_FACTION: Record<FactionSlug, React.FC<TaskDetailProps>> = {
+  ua: UATaskDetail,
+  wow: WhimsyTaskDetail,
+  snide: SnideTaskDetail,
+  ephemerists: EphemeristsTaskDetail,
+  singularity: SingularityTaskDetail,
+  everymen: EverymenTaskDetail,
+  albescent: AlbescentTaskDetail,
+};

--- a/docs/design/task-detail/types.ts
+++ b/docs/design/task-detail/types.ts
@@ -1,0 +1,76 @@
+/* Shared prop types for the World Zero faction task-detail pages. */
+
+export type FactionSlug =
+  | "ua"
+  | "wow"
+  | "snide"
+  | "ephemerists"
+  | "singularity"
+  | "everymen"
+  | "albescent";
+
+/** The task a page is about. */
+export interface TaskDetailData {
+  title: string;
+  points: number;
+  level: number;
+  /** Display reference / case number, e.g. "0317", "C-19". */
+  no?: string;
+}
+
+/** A filed praxis (a logged completion of the task that the faction votes on). */
+export interface PraxisEntry {
+  /** Short label of the task this praxis answers. */
+  task: string;
+  /** Headline of the finding/submission. */
+  finding: string;
+  author: string;
+  excerpt: string;
+  /** 1–5 average rating. */
+  rating: number;
+  /** How many members voted. */
+  marks: number;
+  points: number;
+  level: number;
+  /** Set by the page on the highest-rated entry → renders the ⚜ badge. */
+  top?: boolean;
+}
+
+/** A discussion post. */
+export interface CommentEntry {
+  name?: string;
+  handle?: string;
+  meta: string;
+  body: string;
+  /** Avatar image URL (or data-URI). */
+  avatar: string;
+}
+
+/** Common props every faction page accepts. All have built-in demo defaults. */
+export interface TaskDetailProps {
+  task?: Partial<TaskDetailData>;
+  praxis?: PraxisEntry[];
+  comments?: CommentEntry[];
+  /** Fired when the primary CTA (Matriculate / Report for duty / …) is pressed. */
+  onSignUp?: () => void;
+}
+
+/** Flag the highest-rated entry so the page can badge it with a fleur-de-lis. */
+export function markTop(list: PraxisEntry[]): PraxisEntry[] {
+  if (!list.length) return list;
+  let best = 0;
+  list.forEach((p, i) => {
+    if (p.rating > list[best].rating) best = i;
+  });
+  return list.map((p, i) => ({ ...p, top: i === best }));
+}
+
+/** Generate a simple inline-SVG avatar data-URI (demo use only). */
+export function makeAvatar(seed: string, bg: string, fg = "#fff"): string {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">` +
+    `<rect width="80" height="80" fill="${bg}"/>` +
+    `<text x="50%" y="60%" font-size="34" text-anchor="middle" fill="${fg}" font-family="Georgia,serif">${seed}</text>` +
+    `</svg>`;
+  return "data:image/svg+xml;utf8," + encodeURIComponent(svg);
+}


### PR DESCRIPTION
Vendors the faction design deliverables into `docs/design/` so the overnight build loop (and any agent) has the visual source in-repo — no claude.ai/design login or `~/Downloads` dependency.

## Contents (~1.6 MB, source only)
- `design-system/` — DS **tokens** (the color/type/spacing source of truth, incl. the gilt-salon `--faction-ua-*`), shared component specs, guidelines, and per-faction kit `.jsx`/`.css` (vote/backdrop/avatar/hero/feed — refs for #221–#224).
- `task-detail/` — the 7 task-detail archetype `.tsx` (refs for #210–#214, #242; see the locked spec on #242).
- `praxis-read/` — the 7 faction praxis read-page designs (refs for #205–#209, #231).

## Notes
- **References, not production code** — `docs/design/README.md` says so and documents what to ignore (prototyping runtime, demo prop shapes) and the token-vs-stale-text caveats (UA is gilt-salon, not purple; Singularity always-dark; Albescent always-light).
- Heavy rendered `.dc.html` canvases (2–4 MB each) and the `support.js`/`_ds_bundle.js` harness were intentionally **not** vendored.
- Docs-only; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)