### PR TITLE
Build 5 task-detail faction archetypes (dispatch kit)

### DIFF
--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -13,14 +13,23 @@ import { pickVariant } from "../utils/factionDispatch";
 import { useTaskDetail, type TaskDetailState } from "./taskDetail/useTaskDetail";
 import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
 import TaskDetailSNIDE from "./taskDetail/archetypes/TaskDetailSNIDE";
+import TaskDetailEverymen from "./taskDetail/archetypes/TaskDetailEverymen";
+import TaskDetailWow from "./taskDetail/archetypes/TaskDetailWow";
+import TaskDetailEphemerists from "./taskDetail/archetypes/TaskDetailEphemerists";
+import TaskDetailSingularity from "./taskDetail/archetypes/TaskDetailSingularity";
 import CommentThread from "../components/comments/CommentThread";
 
 type Archetype = (props: { state: TaskDetailState }) => JSX.Element | null;
 
 // Only factions with a bespoke archetype are listed; everything else (incl.
-// albescent / aged_out) falls through to DefaultTaskDetail below.
-const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
+// albescent / aged_out / ua — pending their recolors) falls through to
+// DefaultTaskDetail below.
+export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   snide: TaskDetailSNIDE,
+  everymen: TaskDetailEverymen,
+  wow: TaskDetailWow,
+  ephemerists: TaskDetailEphemerists,
+  singularity: TaskDetailSingularity,
 };
 
 export default function TaskDetail() {

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Task-detail content-slot invariant guard (ADR-0002).
+ *
+ * Every per-faction task-detail archetype wears a wildly different skin (gilt
+ * salon, ransom dossier, terminal printout, union poster…) but must render the
+ * same CONTENT slots. The slots are convention-only — an archetype may *arrange*
+ * them freely but may not *drop* one. This test walks the real
+ * `ARCHETYPE_BY_SLUG` registry (plus the Default fallback) and asserts every
+ * registered archetype still emits the invariant slots. A new faction that drops
+ * a slot fails here, so the guard scales free as factions are added.
+ *
+ * We render to static markup (no DOM, no context) and assert on the structural
+ * anchors each slot leaves behind: slot text and the stable hrefs
+ * (`/tasks`, `/praxes/:id/edit`). Distinctive fixture values keep the substring
+ * checks from colliding with incidental markup. Submissions are left empty so
+ * the test never has to mount the context-bound <PraxisCard> wrapper — the
+ * praxis section is anchored instead by its always-present sort toggle, and
+ * PraxisCard composition is guarded separately by factionCardSlots.test.tsx.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { ARCHETYPE_BY_SLUG } from "../../TaskDetail";
+import DefaultTaskDetail from "../archetypes/DefaultTaskDetail";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut } from "../../../api/tasks";
+import type { PraxisCardOut } from "../../../api/praxis";
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  // Tag-stripped text — several archetypes split the title across spans (SNIDE's
+  // ransom-note fragments, the Ephemerists' lapis last-word), so the title slot
+  // only reads contiguously once the wrapping tags are removed.
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+const TASK: TaskOut = {
+  id: 7,
+  title: "Reforestation",
+  description: "Mangrove",
+  point_value: 30,
+  level_required: 3,
+  status: "active",
+  task_type: "standard",
+  created_by: 3,
+  primary_faction_slug: "snide",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+const MY_PRAXIS: PraxisCardOut = {
+  id: 55,
+  task_id: 7,
+  task_title: "Reforestation",
+  task_point_value: 30,
+  task_level_required: 3,
+  type: "solo",
+  status: "submitted",
+  title: "Seedlings",
+  moderation_status: "visible",
+  created_by_id: 3,
+  created_by_display_name: "Ada",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  submitted_at: "2026-01-02T00:00:00Z",
+  member_count: 1,
+  score: 4.2,
+  average_value: null,
+  voter_count: 0,
+  task_faction_slug: "snide",
+};
+
+/** Base state — every flag off; scenarios override what they exercise. */
+function baseState(overrides: Partial<TaskDetailState>): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: false,
+    slotsOpen: 13,
+    maxTaskSlots: 17,
+    factionMultiplier: 1.0,
+    modifiedPoints: 4242,
+    avgVote: "—",
+    avgVoteNumber: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+// Default fallback is a registered renderable too — guard it alongside the map.
+const archetypes = { ...ARCHETYPE_BY_SLUG, __default__: DefaultTaskDetail };
+
+describe("task-detail content-slot invariant", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders title, description, breadcrumb + sort toggle`, () => {
+      const { html, text } = render(
+        <Archetype state={baseState({ canSignUp: true })} />,
+      );
+      expect(text, "title slot").toContain("Reforestation");
+      expect(text, "description slot").toContain("Mangrove");
+      expect(html, "all-tasks breadcrumb slot").toContain('href="/tasks"');
+      // Sort toggle: every archetype labels the recency option "recent".
+      expect(html.toLowerCase(), "sort-toggle slot").toContain("recent");
+    });
+
+    it(`${slug} renders the signup CTA when canSignUp`, () => {
+      const { text } = render(
+        <Archetype state={baseState({ canSignUp: true })} />,
+      );
+      // Every signup CTA quotes the points-on-offer ("earn up to N pts").
+      expect(text.toLowerCase(), "signup-CTA slot").toContain("earn up to");
+    });
+
+    it(`${slug} renders the edit control for a submitted praxis`, () => {
+      const { html } = render(
+        <Archetype state={baseState({ mySubmission: MY_PRAXIS })} />,
+      );
+      expect(html, "edit-submission slot").toContain('href="/praxes/55/edit"');
+    });
+
+    it(`${slug} renders the continue control while in progress`, () => {
+      const { html } = render(
+        <Archetype
+          state={baseState({ isInProgress: true, inProgressPraxisId: 99 })}
+        />,
+      );
+      expect(html, "continue-in-progress slot").toContain(
+        'href="/praxes/99/edit"',
+      );
+    });
+  }
+});

--- a/frontend/src/pages/taskDetail/archetypes/TaskDetailEphemerists.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/TaskDetailEphemerists.tsx
@@ -1,0 +1,877 @@
+import { Link } from "react-router-dom";
+import PraxisCard from "../../../components/PraxisCard";
+import { mediaUrl } from "../../../utils/media";
+import { factionName } from "../../../utils/factions";
+import { EphMark, Foxing, LapisLastWord } from "../../../components/cards/ephemeristsAtoms";
+import { ErrorBanner, relationOf } from "./shared";
+import type { TaskSignupOut } from "../../../api/tasks";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * The Ephemerists task-detail archetype — the job rendered as a DISCORDANT MAP /
+ * illuminated codex exhibit: a contested coordinate field on vellum, a Cinzel
+ * title with one word pulled to lapis, the commission (brief), sealed
+ * ephemerides (completions, the most-canonical wearing a fleur-de-lis), and a
+ * read-only credence line in the faction's voice. Ported from the Ephemerists
+ * design kit (EphemeristsTaskDetail.tsx); wired to the real
+ * {@link TaskDetailState}. Reads only --eph-* / --faction-ephemerists-* tokens.
+ *
+ * Decorative / not backend-backed (marked inline): the "commission no." (derived
+ * from task.id) and the vellum coordinate diagram glyphs.
+ */
+
+const INK = "var(--eph-ink)";
+const VELLUM_TEXT = "var(--eph-vellum-text)";
+const MUTED = "var(--eph-muted)";
+
+/** Section header — a Cinzel label with a gold rule trailing off to nothing. */
+function SectionHead({
+  title,
+  gloss,
+}: {
+  title: string;
+  gloss?: string;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 16 }}>
+      <h2
+        style={{
+          fontFamily: "var(--eph-display)",
+          fontWeight: 600,
+          fontSize: 15,
+          letterSpacing: "0.1em",
+          margin: 0,
+          color: VELLUM_TEXT,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {title}
+      </h2>
+      <span
+        style={{
+          flex: 1,
+          height: 1,
+          background: "linear-gradient(90deg, var(--eph-gold), transparent)",
+        }}
+      />
+      {gloss && (
+        <span
+          style={{
+            fontFamily: "var(--eph-script)",
+            fontStyle: "italic",
+            fontSize: 12,
+            color: MUTED,
+          }}
+        >
+          {gloss}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** The contested coordinate field — a vellum cartographic exhibit with three
+ *  irreconcilable readings (cartesian grid, perspective rays, polar rings). */
+function DiscordantMap() {
+  return (
+    <div
+      style={{
+        position: "relative",
+        minHeight: 320,
+        borderRight: "1px solid var(--eph-gold-deep)",
+        overflow: "hidden",
+        background: "var(--eph-vellum)",
+      }}
+    >
+      {/* cartesian grid */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          opacity: 0.5,
+          backgroundImage:
+            "repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 18px), repeating-linear-gradient(90deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 18px)",
+        }}
+      />
+      {/* perspective vanishing rays (lapis) */}
+      <svg
+        viewBox="0 0 300 320"
+        preserveAspectRatio="none"
+        style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.7 }}
+        aria-hidden="true"
+      >
+        <g stroke="var(--eph-lapis)" strokeWidth="0.9" fill="none">
+          {[0, 40, 80, 120, 160, 200, 240, 280].map((x) => (
+            <line key={x} x1={x} y1="320" x2="185" y2="70" />
+          ))}
+          {[110, 160, 210, 250].map((y) => (
+            <line key={y} x1="0" y1={y} x2="300" y2={y} />
+          ))}
+        </g>
+      </svg>
+      {/* polar reading (rubric) */}
+      <svg
+        viewBox="0 0 300 320"
+        style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.72 }}
+        aria-hidden="true"
+      >
+        <g stroke="var(--eph-rubric)" strokeWidth="0.8" fill="none">
+          {[28, 58, 92, 128].map((r) => (
+            <circle key={r} cx="185" cy="150" r={r} />
+          ))}
+          {Array.from({ length: 8 }).map((_, i) => (
+            <line
+              key={i}
+              x1="185"
+              y1="150"
+              x2={185 + 130 * Math.cos((i * Math.PI) / 4)}
+              y2={150 + 130 * Math.sin((i * Math.PI) / 4)}
+            />
+          ))}
+        </g>
+      </svg>
+      {/* the contested point — a gold-leaf glimmer */}
+      <div
+        style={{
+          position: "absolute",
+          left: "62%",
+          top: "47%",
+          transform: "translate(-50%,-50%)",
+          width: 11,
+          height: 11,
+          borderRadius: "50%",
+          background: "var(--eph-gold-light)",
+          boxShadow: "0 0 14px 4px color-mix(in srgb, var(--eph-gold-light) 70%, transparent)",
+        }}
+      />
+      {/* decorative coordinate marginalia — not backend-backed */}
+      <div
+        style={{
+          position: "absolute",
+          top: "8%",
+          left: "6%",
+          fontSize: 9,
+          color: VELLUM_TEXT,
+          background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)",
+          padding: "2px 5px",
+        }}
+      >
+        x 14 · y <span style={{ textDecoration: "line-through", opacity: 0.65 }}>8</span>{" "}
+        <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>9</span>
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          top: "74%",
+          left: "50%",
+          fontSize: 9,
+          color: "var(--eph-rubric)",
+          background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)",
+          padding: "2px 5px",
+        }}
+      >
+        r 47 · θ 31°
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          top: "5%",
+          left: "62%",
+          fontSize: 9,
+          color: "var(--eph-lapis)",
+          background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)",
+          padding: "2px 5px",
+        }}
+      >
+        ∞ · vanishing
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          left: 4,
+          bottom: 8,
+          transformOrigin: "left bottom",
+          transform: "rotate(-90deg)",
+          whiteSpace: "nowrap",
+          fontSize: 7.5,
+          color: MUTED,
+          opacity: 0.85,
+        }}
+      >
+        ¼″ wider within than without †
+      </div>
+    </div>
+  );
+}
+
+/** Marginalia of cartographers — real signup avatars on the vellum margin,
+ *  each linking to its character, friend/foe noted in the surveyor's voice. */
+function SurveyorRow({
+  signups,
+  friends,
+  foes,
+}: {
+  signups: TaskSignupOut[];
+  friends: Set<number>;
+  foes: Set<number>;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+      {signups.map((m) => {
+        const rel = relationOf(m.character_id, friends, foes);
+        const relColor = rel === "friend" ? "var(--eph-lapis)" : "var(--eph-rubric)";
+        return (
+          <Link
+            key={m.character_id}
+            to={`/characters/${m.character_id}`}
+            title={`${m.display_name}${rel ? ` · ${rel}` : ""}`}
+            style={{
+              position: "relative",
+              width: 38,
+              height: 38,
+              flexShrink: 0,
+              textDecoration: "none",
+            }}
+          >
+            {m.avatar_url ? (
+              <img
+                src={mediaUrl(m.avatar_url)}
+                alt={m.display_name}
+                style={{
+                  width: 38,
+                  height: 38,
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                  border: "1.5px solid var(--eph-gold-deep)",
+                }}
+              />
+            ) : (
+              <span
+                style={{
+                  display: "flex",
+                  width: 38,
+                  height: 38,
+                  borderRadius: "50%",
+                  background: "var(--eph-vellum-deep)",
+                  border: "1.5px solid var(--eph-gold-deep)",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "var(--eph-rubric)",
+                  fontFamily: "var(--eph-display)",
+                  fontSize: 15,
+                }}
+              >
+                {m.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+            {rel && (
+              <span
+                title={rel}
+                style={{
+                  position: "absolute",
+                  right: -2,
+                  bottom: -2,
+                  width: 11,
+                  height: 11,
+                  borderRadius: "50%",
+                  background: relColor,
+                  border: "1.5px solid var(--eph-vellum)",
+                }}
+              />
+            )}
+          </Link>
+        );
+      })}
+      <span
+        style={{
+          fontFamily: "var(--eph-script)",
+          fontStyle: "italic",
+          fontSize: 13,
+          color: MUTED,
+          marginLeft: 4,
+        }}
+      >
+        triangulating
+      </span>
+    </div>
+  );
+}
+
+export default function TaskDetailEphemerists({
+  state,
+}: {
+  state: TaskDetailState;
+}) {
+  const {
+    task,
+    signups,
+    submissions,
+    friends,
+    foes,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    avgVoteNumber,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  // Decorative: the Ephemerists letter a "commission no." — derive from real id.
+  const commissionNo = `C-${task.id}`;
+  const isMeta = task.task_type === "metatask";
+  // The faction's voice: an active task is an OPEN commission; else honest status.
+  const statusLabel = task.status === "active" ? "open commission" : task.status;
+  // Top-rated ephemeris (most canonical) by real score.
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null;
+
+  return (
+    <div
+      className="py-8"
+      style={{ fontFamily: "var(--eph-serif)", color: VELLUM_TEXT }}
+    >
+      {/* ── Breadcrumb ── */}
+      <nav
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: MUTED,
+          fontFamily: "var(--eph-display)",
+          marginBottom: 22,
+        }}
+      >
+        <Link
+          to="/tasks"
+          style={{ color: "var(--faction-ephemerists)", textDecoration: "none" }}
+        >
+          Tasks
+        </Link>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
+        <span>The Ephemerists</span>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
+        <span style={{ color: "var(--eph-rubric)" }}>{task.title}</span>
+      </nav>
+
+      <div style={{ maxWidth: 920, display: "flex", flexDirection: "column", gap: 30 }}>
+        {/* ── Hero — the discordant exhibit ── */}
+        <div
+          style={{
+            position: "relative",
+            background: "var(--eph-vellum)",
+            border: "1.5px solid var(--eph-ink)",
+            boxShadow: "0 14px 34px rgba(42,29,18,0.18)",
+            overflow: "hidden",
+          }}
+        >
+          <Foxing opacity={0.35} />
+          <div
+            style={{
+              position: "relative",
+              zIndex: 2,
+              display: "grid",
+              gridTemplateColumns: "300px 1fr",
+            }}
+          >
+            <DiscordantMap />
+            <div
+              style={{
+                padding: "30px 34px",
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "center",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 7,
+                  color: "var(--eph-gold)",
+                  marginBottom: 6,
+                }}
+              >
+                <EphMark size={13} color="var(--eph-gold)" />
+                <span
+                  style={{
+                    fontFamily: "var(--eph-display)",
+                    fontWeight: 600,
+                    fontSize: 9,
+                    letterSpacing: "0.24em",
+                  }}
+                >
+                  THE EPHEMERISTS
+                </span>
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--eph-script)",
+                  fontStyle: "italic",
+                  fontSize: 12,
+                  color: MUTED,
+                  marginBottom: 16,
+                }}
+              >
+                {statusLabel} · commission {commissionNo}
+              </div>
+              {isMeta && (
+                <div
+                  style={{
+                    fontFamily: "var(--eph-display)",
+                    fontSize: 11,
+                    letterSpacing: "0.14em",
+                    textTransform: "uppercase",
+                    color: "var(--eph-rubric)",
+                    marginBottom: 10,
+                  }}
+                >
+                  ↳ metatask for {factionName(task.metatask_faction_slug)}
+                </div>
+              )}
+              <h1
+                style={{
+                  fontFamily: "var(--eph-display)",
+                  fontWeight: 700,
+                  fontSize: 38,
+                  lineHeight: 1.04,
+                  color: VELLUM_TEXT,
+                  margin: "0 0 14px",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                <LapisLastWord text={task.title} footnote />
+              </h1>
+              <div
+                style={{
+                  height: 1,
+                  background: "linear-gradient(90deg, var(--eph-gold), transparent)",
+                  marginBottom: 16,
+                }}
+              />
+              <div
+                style={{
+                  display: "flex",
+                  gap: 20,
+                  flexWrap: "wrap",
+                  alignItems: "center",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: "var(--eph-display)",
+                    fontSize: 12,
+                    color: VELLUM_TEXT,
+                  }}
+                >
+                  ▦ GRADE {task.level_required}
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--eph-display)",
+                    fontWeight: 700,
+                    fontSize: 20,
+                    color: "var(--eph-rubric)",
+                  }}
+                >
+                  {modifiedPoints}{" "}
+                  <span style={{ fontSize: 11, letterSpacing: "0.06em" }}>PVNCTA</span>
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--eph-script)",
+                    fontStyle: "italic",
+                    fontSize: 13,
+                    color: MUTED,
+                  }}
+                >
+                  {signups.length} triangulating · {submissions.length} sealed
+                </span>
+              </div>
+              <div
+                style={{
+                  fontSize: 9,
+                  fontStyle: "italic",
+                  color: MUTED,
+                  marginTop: 14,
+                  lineHeight: 1.4,
+                }}
+              >
+                † the road does not return you to where you began —{" "}
+                <span style={{ color: "var(--eph-lapis)" }}>see †</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── The Commission (brief) ── */}
+        <section>
+          <SectionHead title="The Commission" />
+          <div
+            className="font-body"
+            style={{
+              position: "relative",
+              border: "1px solid var(--eph-gold-deep)",
+              background: "var(--eph-vellum)",
+              padding: "28px 32px",
+              maxWidth: 660,
+              fontFamily: "var(--eph-serif)",
+              fontSize: 17,
+              lineHeight: 1.7,
+              color: VELLUM_TEXT,
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            <Foxing opacity={0.3} />
+            <span style={{ position: "relative", zIndex: 2 }}>
+              {task.description ||
+                "No commission is scribed. Walk the ground and let the contradictions guide you."}
+            </span>
+          </div>
+        </section>
+
+        {/* ── Signup CTA — only when the viewer may enroll ── */}
+        {canSignUp && (
+          <section
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 18,
+              flexWrap: "wrap",
+              border: "1px solid var(--eph-ink)",
+              background: "var(--eph-vellum)",
+              padding: "16px 20px",
+            }}
+          >
+            <button
+              onClick={handleSignup}
+              style={{
+                cursor: "pointer",
+                fontFamily: "var(--eph-serif)",
+                fontStyle: "italic",
+                fontSize: 15,
+                letterSpacing: "0.06em",
+                color: "var(--eph-parchment)",
+                background: "var(--eph-ink)",
+                border: "none",
+                padding: "13px 26px",
+              }}
+            >
+              Triangulate the truth ▸ earn up to {modifiedPoints} pts
+            </button>
+            <div
+              style={{
+                fontFamily: "var(--eph-script)",
+                fontStyle: "italic",
+                fontSize: 14,
+                color: MUTED,
+              }}
+            >
+              bring no certainty. only instruments.
+            </div>
+            <div
+              style={{
+                marginLeft: "auto",
+                fontFamily: "var(--eph-display)",
+                fontSize: 9,
+                letterSpacing: "0.1em",
+                color: "var(--eph-gold-deep)",
+                textTransform: "uppercase",
+              }}
+            >
+              {slotsOpen} of {maxTaskSlots} leaves open · grade {task.level_required} met
+            </div>
+          </section>
+        )}
+        {canSignUp && (
+          <ErrorBanner
+            message={signupError}
+            style={{
+              background: "color-mix(in srgb, var(--eph-rubric) 8%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--eph-rubric) 30%, transparent)",
+              color: "var(--eph-rubric)",
+            }}
+          />
+        )}
+
+        {/* ── My enrolment states ── */}
+        {mySubmission && (
+          <section
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              flexWrap: "wrap",
+              border: "1px solid var(--eph-gold-deep)",
+              background: "var(--eph-vellum)",
+              padding: "14px 20px",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--eph-script)",
+                fontStyle: "italic",
+                fontSize: 14,
+                color: VELLUM_TEXT,
+              }}
+            >
+              your leaf is filed against this exhibit.
+            </span>
+            <Link
+              to={`/praxes/${mySubmission.id}/edit`}
+              style={{
+                fontFamily: "var(--eph-display)",
+                fontSize: 11,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                color: "var(--eph-parchment)",
+                background: "var(--eph-lapis)",
+                padding: "9px 18px",
+                textDecoration: "none",
+              }}
+            >
+              edit
+            </Link>
+          </section>
+        )}
+
+        {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+          <section
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              flexWrap: "wrap",
+              border: "1px solid var(--eph-gold-deep)",
+              background: "var(--eph-vellum)",
+              padding: "14px 20px",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--eph-script)",
+                fontStyle: "italic",
+                fontSize: 14,
+                color: VELLUM_TEXT,
+              }}
+            >
+              your readings are unsealed — the survey is unfinished.
+            </span>
+            <Link
+              to={`/praxes/${inProgressPraxisId}/edit`}
+              style={{
+                fontFamily: "var(--eph-display)",
+                fontSize: 11,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                color: "var(--eph-parchment)",
+                background: "var(--eph-ink)",
+                padding: "9px 18px",
+                textDecoration: "none",
+              }}
+            >
+              continue
+            </Link>
+            <button
+              onClick={handleDrop}
+              style={{
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                fontFamily: "var(--eph-script)",
+                fontStyle: "italic",
+                fontSize: 14,
+                color: "var(--eph-rubric)",
+              }}
+            >
+              drop
+            </button>
+          </section>
+        )}
+
+        {/* ── Marginalia of cartographers (signups) ── */}
+        {signups.length > 0 && (
+          <section>
+            <SectionHead title="The Cartographers" gloss={`${signups.length} on the ground`} />
+            <SurveyorRow signups={signups} friends={friends} foes={foes} />
+          </section>
+        )}
+
+        {/* ── Credence (read-only vote aggregate) ── */}
+        <section>
+          <SectionHead title="The Credence" />
+          {voteCount > 0 ? (
+            <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
+              <span
+                style={{
+                  fontFamily: "var(--eph-display)",
+                  fontWeight: 700,
+                  fontSize: 54,
+                  lineHeight: 0.8,
+                  color: "var(--eph-rubric)",
+                }}
+              >
+                {avgVoteNumber.toFixed(1)}
+              </span>
+              <div style={{ paddingBottom: 6 }}>
+                <div
+                  style={{
+                    fontFamily: "var(--eph-display)",
+                    fontSize: 14,
+                    letterSpacing: "0.06em",
+                    color: VELLUM_TEXT,
+                  }}
+                >
+                  OF V
+                </div>
+                <div
+                  style={{
+                    fontFamily: "var(--eph-script)",
+                    fontStyle: "italic",
+                    fontSize: 13,
+                    color: MUTED,
+                  }}
+                >
+                  weighed across {voteCount} sealed leaves
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p
+              style={{
+                fontFamily: "var(--eph-script)",
+                fontStyle: "italic",
+                fontSize: 15,
+                color: MUTED,
+                margin: 0,
+              }}
+            >
+              no credence yet. the concordance awaits its first leaf.
+            </p>
+          )}
+        </section>
+
+        {/* ── Sealed Ephemerides (completed praxis) ── */}
+        <section>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+              flexWrap: "wrap",
+              marginBottom: 16,
+            }}
+          >
+            <SectionHead
+              title="Sealed Ephemerides"
+              gloss={`${submissions.length} leaves filed`}
+            />
+            <div style={{ display: "flex", gap: 0 }}>
+              {(["score", "recent"] as const).map((sort) => {
+                const on = submissionSort === sort;
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: "var(--eph-display)",
+                      fontSize: 10,
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      padding: "5px 12px",
+                      background: on ? "var(--eph-ink)" : "transparent",
+                      color: on ? "var(--eph-gold-light)" : MUTED,
+                      border: `1px solid ${on ? "var(--eph-ink)" : "var(--eph-gold-deep)"}`,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {sort === "score" ? "Most Canonical" : "Recent"}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {sortedSubmissions.length === 0 ? (
+            <p
+              style={{
+                fontFamily: "var(--eph-script)",
+                fontStyle: "italic",
+                fontSize: 15,
+                color: MUTED,
+                margin: 0,
+              }}
+            >
+              no leaves sealed yet. be the first to file your contradictions.
+            </p>
+          ) : (
+            <>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 24px", alignItems: "flex-start" }}>
+                {sortedSubmissions.slice(0, 4).map((s) => (
+                  <div key={s.id} style={{ position: "relative", paddingTop: s.id === topId ? 22 : 0 }}>
+                    {s.id === topId && (
+                      <div
+                        style={{
+                          position: "absolute",
+                          top: 0,
+                          left: "50%",
+                          transform: "translateX(-50%)",
+                          zIndex: 3,
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: 5,
+                          whiteSpace: "nowrap",
+                          background: INK,
+                          color: "var(--eph-gold-light)",
+                          fontFamily: "var(--eph-display)",
+                          fontSize: 8,
+                          letterSpacing: "0.14em",
+                          padding: "4px 12px",
+                          boxShadow: "0 3px 8px rgba(42,29,18,0.35)",
+                        }}
+                      >
+                        <span style={{ fontSize: 12, lineHeight: 1, color: "var(--eph-gold-light)" }}>⚜</span>{" "}
+                        MOST CANONICAL
+                      </div>
+                    )}
+                    <PraxisCard praxis={s} />
+                  </div>
+                ))}
+              </div>
+              {submissions.length > 4 && (
+                <div style={{ marginTop: 16 }}>
+                  <Link
+                    to={`/praxes?task_id=${task.id}`}
+                    style={{
+                      fontFamily: "var(--eph-script)",
+                      fontStyle: "italic",
+                      fontSize: 15,
+                      color: "var(--eph-rubric)",
+                      textDecoration: "none",
+                      borderBottom: "1px solid color-mix(in srgb, var(--eph-rubric) 40%, transparent)",
+                    }}
+                  >
+                    view all {submissions.length} ephemerides ↗
+                  </Link>
+                </div>
+              )}
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/archetypes/TaskDetailEverymen.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/TaskDetailEverymen.tsx
@@ -1,0 +1,773 @@
+import type { CSSProperties, ReactNode } from "react";
+import { Link } from "react-router-dom";
+import PraxisCard from "../../../components/PraxisCard";
+import { mediaUrl } from "../../../utils/media";
+import { ErrorBanner, relationOf } from "./shared";
+import type { TaskSignupOut } from "../../../api/tasks";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * The Everymen task-detail archetype — the job rendered as a UNION WORK ORDER:
+ * a billboard-scale sunburst poster (cog seal, knockout Bebas headline, status
+ * in the union's voice), a stamped CTA bar, a typewritten "The Order" body,
+ * the hands signed on, the filed work reports (best-in-hall wears a fleur-de-lis),
+ * and a read-only hall verdict. Ported from the Everymen design kit
+ * (EverymenTaskDetail.tsx); wired to the real {@link TaskDetailState}.
+ *
+ * The kit's top <nav> and discussion thread are dropped (TaskDetail.tsx renders
+ * the breadcrumb context and CommentThread). Every raw hex from the kit is
+ * mapped onto the existing CSS vars in index.css so the surface flips with the
+ * theme without mutating the document theme.
+ */
+
+const INK = "var(--everymen-ink)";
+const CREAM = "var(--everymen-cream)";
+const RED = "var(--everymen-red)";
+const RED_DEEP = "var(--everymen-red-deep)";
+const GOLD = "var(--everymen-gold)";
+const OLIVE = "var(--everymen-olive)";
+const MUTED = "var(--everymen-muted)";
+const PAPER = "var(--everymen-paper)";
+
+/** The Everymen cog seal — a riveted gear, the union's mark. */
+function CogSeal({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <g fill={GOLD}>
+        {[0, 45, 90, 135, 180, 225, 270, 315].map((deg) => (
+          <rect
+            key={deg}
+            x="11"
+            y="0.5"
+            width="2"
+            height="5"
+            rx="0.5"
+            transform={`rotate(${deg} 12 12)`}
+          />
+        ))}
+      </g>
+      <circle cx="12" cy="12" r="6.5" fill="none" stroke={GOLD} strokeWidth="2.4" />
+      <circle cx="12" cy="12" r="2" fill={GOLD} />
+    </svg>
+  );
+}
+
+const sectionRule: CSSProperties = {
+  flex: 1,
+  height: 3,
+  background: `repeating-linear-gradient(90deg, ${RED} 0 16px, ${GOLD} 16px 26px)`,
+};
+const sectionH2: CSSProperties = {
+  fontFamily: "var(--font-accent)",
+  fontSize: 26,
+  letterSpacing: "0.04em",
+  margin: 0,
+  color: INK,
+  whiteSpace: "nowrap",
+};
+
+/** Section header — Bebas heading with the red/gold picket rule. */
+function SectionHead({
+  title,
+  trailing,
+}: {
+  title: string;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        marginBottom: 18,
+      }}
+    >
+      <h2 style={sectionH2}>{title}</h2>
+      <span style={sectionRule} />
+      {trailing}
+    </div>
+  );
+}
+
+/** Hands signed on — real signup avatars with friend/foe dots. */
+function HandsRow({
+  signups,
+  friends,
+  foes,
+}: {
+  signups: TaskSignupOut[];
+  friends: Set<number>;
+  foes: Set<number>;
+}) {
+  return (
+    <div
+      style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}
+    >
+      {signups.map((hand) => {
+        const rel = relationOf(hand.character_id, friends, foes);
+        const relColor = rel === "friend" ? OLIVE : RED;
+        return (
+          <Link
+            key={hand.character_id}
+            to={`/characters/${hand.character_id}`}
+            title={`${hand.display_name}${rel ? ` · ${rel}` : ""}`}
+            style={{
+              position: "relative",
+              width: 40,
+              height: 40,
+              flexShrink: 0,
+            }}
+          >
+            {hand.avatar_url ? (
+              <img
+                src={mediaUrl(hand.avatar_url)}
+                alt={hand.display_name}
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                  border: `2px solid ${INK}`,
+                }}
+              />
+            ) : (
+              <span
+                style={{
+                  display: "flex",
+                  width: 40,
+                  height: 40,
+                  borderRadius: "50%",
+                  background: INK,
+                  border: `2px solid ${GOLD}`,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: GOLD,
+                  fontFamily: "var(--font-accent)",
+                  fontSize: 18,
+                }}
+              >
+                {hand.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+            {rel && (
+              <span
+                title={rel}
+                style={{
+                  position: "absolute",
+                  right: -2,
+                  bottom: -2,
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  background: relColor,
+                  border: `2px solid ${CREAM}`,
+                }}
+              />
+            )}
+          </Link>
+        );
+      })}
+      <span
+        style={{
+          fontFamily: "var(--font-body)",
+          fontSize: 10,
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          color: MUTED,
+          marginLeft: 4,
+        }}
+      >
+        on the job
+      </span>
+    </div>
+  );
+}
+
+export default function TaskDetailEverymen({
+  state,
+}: {
+  state: TaskDetailState;
+}) {
+  const {
+    task,
+    signups,
+    submissions,
+    friends,
+    foes,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    avgVoteNumber,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  // Status in the union's voice: active reads as an open call for hands.
+  const statusVoice =
+    task.status === "active" ? "Open · accepting hands" : task.status;
+
+  // Top-rated work report wears the fleur-de-lis.
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null;
+
+  return (
+    <div
+      className="py-8"
+      style={{ fontFamily: "var(--font-body)", color: INK }}
+    >
+      {/* ── Breadcrumb ── */}
+      <nav
+        className="font-body mb-4"
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.16em",
+          textTransform: "uppercase",
+          color: MUTED,
+        }}
+      >
+        <Link to="/tasks" style={{ color: RED, textDecoration: "none" }}>
+          Tasks
+        </Link>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
+        <span>The Everymen</span>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
+        <span style={{ color: RED }}>{task.title}</span>
+      </nav>
+
+      <div style={{ maxWidth: 920 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+          {/* ── HERO — union billboard ── */}
+          <div
+            style={{
+              position: "relative",
+              overflow: "hidden",
+              border: `3px solid ${INK}`,
+              background: RED,
+              color: CREAM,
+            }}
+          >
+            {/* sunburst rays */}
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                pointerEvents: "none",
+                opacity: 0.5,
+                background: `repeating-conic-gradient(from 0deg at 24% 34%, ${RED_DEEP} 0deg 7deg, transparent 7deg 14deg)`,
+              }}
+            />
+            {/* halftone dot field */}
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                pointerEvents: "none",
+                opacity: 0.1,
+                backgroundImage: `radial-gradient(${CREAM} 0.6px, transparent 0.7px)`,
+                backgroundSize: "5px 5px",
+              }}
+            />
+            {/* seal + status banner */}
+            <div
+              style={{
+                position: "relative",
+                zIndex: 2,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                flexWrap: "wrap",
+                background: INK,
+                padding: "9px 20px",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  color: GOLD,
+                }}
+              >
+                <CogSeal size={18} />
+                <span
+                  style={{
+                    fontFamily: "var(--font-accent)",
+                    fontSize: 17,
+                    letterSpacing: "0.2em",
+                  }}
+                >
+                  THE EVERYMEN
+                </span>
+              </div>
+              <span
+                style={{
+                  fontSize: 9,
+                  letterSpacing: "0.14em",
+                  textTransform: "uppercase",
+                  color: CREAM,
+                  border: `1.5px solid ${GOLD}`,
+                  padding: "3px 10px",
+                }}
+              >
+                {statusVoice}
+              </span>
+            </div>
+            <div
+              style={{
+                height: 4,
+                background: GOLD,
+                position: "relative",
+                zIndex: 2,
+              }}
+            />
+            <div
+              style={{ position: "relative", zIndex: 2, padding: "30px 34px 32px" }}
+            >
+              <div
+                style={{
+                  fontFamily: "var(--font-accent)",
+                  fontSize: 72,
+                  lineHeight: 0.9,
+                  letterSpacing: "0.01em",
+                  color: CREAM,
+                  textShadow: `3px 3px 0 ${INK}`,
+                  maxWidth: 660,
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {task.title}
+              </div>
+              <div
+                style={{
+                  height: 3,
+                  background: GOLD,
+                  width: 120,
+                  margin: "20px 0 18px",
+                }}
+              />
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  flexWrap: "wrap",
+                }}
+              >
+                <span
+                  style={{
+                    background: INK,
+                    color: CREAM,
+                    fontFamily: "var(--font-accent)",
+                    fontSize: 22,
+                    letterSpacing: "0.06em",
+                    padding: "6px 16px",
+                  }}
+                >
+                  LVL {task.level_required}
+                </span>
+                <span
+                  style={{
+                    background: GOLD,
+                    color: INK,
+                    fontFamily: "var(--font-accent)",
+                    fontSize: 22,
+                    letterSpacing: "0.06em",
+                    padding: "6px 16px",
+                  }}
+                >
+                  {modifiedPoints} PTS
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--font-body)",
+                    fontSize: 11,
+                    letterSpacing: "0.06em",
+                    color: CREAM,
+                  }}
+                >
+                  {signups.length} on the job · {submissions.length} delivered
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* ── CTA bar / signed-on states ── */}
+          {canSignUp && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 18,
+                flexWrap: "wrap",
+                border: `1.5px solid ${INK}`,
+                background: PAPER,
+                padding: "16px 20px",
+              }}
+            >
+              <button
+                onClick={handleSignup}
+                style={{
+                  cursor: "pointer",
+                  fontFamily: "var(--font-body)",
+                  fontSize: 13,
+                  fontWeight: 700,
+                  letterSpacing: "0.14em",
+                  textTransform: "uppercase",
+                  padding: "14px 26px",
+                  border: "none",
+                  background: RED,
+                  color: CREAM,
+                }}
+              >
+                Report for duty ▸
+              </button>
+              <div style={{ fontSize: 11, color: MUTED }}>
+                earn up to {modifiedPoints} pts · {slotsOpen} of {maxTaskSlots}{" "}
+                slots open
+              </div>
+              <div
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: "var(--font-accent)",
+                  fontSize: 15,
+                  letterSpacing: "0.06em",
+                  color: RED,
+                }}
+              >
+                Level {task.level_required} required · met
+              </div>
+              <ErrorBanner
+                message={signupError}
+                style={{
+                  flexBasis: "100%",
+                  background: "var(--everymen-red-light, rgba(193,39,45,0.08))",
+                  border: `1px solid ${RED}`,
+                  color: RED_DEEP,
+                }}
+              />
+            </div>
+          )}
+
+          {mySubmission && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 16,
+                flexWrap: "wrap",
+                border: `1.5px solid ${INK}`,
+                background: PAPER,
+                padding: "16px 20px",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-accent)",
+                  fontSize: 18,
+                  letterSpacing: "0.08em",
+                  color: OLIVE,
+                }}
+              >
+                ✓ Your report is filed
+              </span>
+              <Link
+                to={`/praxes/${mySubmission.id}/edit`}
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: "var(--font-body)",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  padding: "10px 20px",
+                  background: INK,
+                  color: CREAM,
+                  textDecoration: "none",
+                }}
+              >
+                edit
+              </Link>
+            </div>
+          )}
+
+          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 16,
+                flexWrap: "wrap",
+                border: `1.5px solid ${INK}`,
+                background: PAPER,
+                padding: "16px 20px",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-accent)",
+                  fontSize: 18,
+                  letterSpacing: "0.08em",
+                  color: RED,
+                }}
+              >
+                You're on the job
+              </span>
+              <Link
+                to={`/praxes/${inProgressPraxisId}/edit`}
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: "var(--font-body)",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  padding: "10px 20px",
+                  background: RED,
+                  color: CREAM,
+                  textDecoration: "none",
+                }}
+              >
+                continue
+              </Link>
+              <button
+                onClick={handleDrop}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: "var(--font-body)",
+                  fontSize: 10,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  color: MUTED,
+                }}
+              >
+                drop
+              </button>
+              <ErrorBanner
+                message={signupError}
+                style={{
+                  flexBasis: "100%",
+                  background: "var(--everymen-red-light, rgba(193,39,45,0.08))",
+                  border: `1px solid ${RED}`,
+                  color: RED_DEEP,
+                }}
+              />
+            </div>
+          )}
+
+          {/* ── THE ORDER — the work-order body ── */}
+          <section>
+            <SectionHead title="The Order" />
+            <div
+              style={{
+                border: `1.5px solid ${INK}`,
+                background: PAPER,
+                padding: "26px 30px",
+                maxWidth: 660,
+              }}
+            >
+              <p
+                style={{
+                  fontFamily: "var(--font-body)",
+                  fontSize: 13,
+                  lineHeight: 1.75,
+                  color: INK,
+                  margin: 0,
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {task.description ||
+                  "No order posted yet. The work outlasts the worker — figure out what needs doing and report for duty."}
+              </p>
+            </div>
+          </section>
+
+          {/* ── Hands signed on ── */}
+          {signups.length > 0 && (
+            <section>
+              <SectionHead title="Hands On The Job" />
+              <HandsRow signups={signups} friends={friends} foes={foes} />
+            </section>
+          )}
+
+          {/* ── Hall verdict (read-only aggregate) ── */}
+          <section>
+            <SectionHead title="The Hall's Verdict" />
+            {voteCount > 0 ? (
+              <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
+                <span
+                  style={{
+                    fontFamily: "var(--font-accent)",
+                    fontSize: 54,
+                    lineHeight: 0.8,
+                    color: RED,
+                  }}
+                >
+                  {avgVoteNumber.toFixed(1)}
+                </span>
+                <div style={{ paddingBottom: 6 }}>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-accent)",
+                      fontSize: 16,
+                      letterSpacing: "0.06em",
+                      color: INK,
+                    }}
+                  >
+                    OUT OF 5
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-body)",
+                      fontSize: 10,
+                      letterSpacing: "0.06em",
+                      color: MUTED,
+                    }}
+                  >
+                    {voteCount} report{voteCount === 1 ? "" : "s"} on the books
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p
+                style={{
+                  fontFamily: "var(--font-body)",
+                  fontSize: 13,
+                  color: MUTED,
+                }}
+              >
+                No verdict yet. The hall hasn't weighed in — be the first to deliver.
+              </p>
+            )}
+          </section>
+
+          {/* ── Work reports filed (completions) ── */}
+          <section>
+            <SectionHead
+              title="Work Reports Filed"
+              trailing={
+                <div style={{ display: "flex", gap: 0 }}>
+                  {(["score", "recent"] as const).map((sort) => {
+                    const on = submissionSort === sort;
+                    return (
+                      <button
+                        key={sort}
+                        onClick={() => setSubmissionSort(sort)}
+                        style={{
+                          fontFamily: "var(--font-body)",
+                          fontSize: 9,
+                          fontWeight: 700,
+                          letterSpacing: "0.1em",
+                          textTransform: "uppercase",
+                          padding: "5px 12px",
+                          background: on ? INK : "transparent",
+                          color: on ? CREAM : MUTED,
+                          border: `1.5px solid ${
+                            on
+                              ? INK
+                              : "color-mix(in srgb, var(--everymen-ink) 30%, transparent)"
+                          }`,
+                          cursor: "pointer",
+                        }}
+                      >
+                        {sort === "score" ? "Top Rated" : "Recent"}
+                      </button>
+                    );
+                  })}
+                </div>
+              }
+            />
+            {sortedSubmissions.length === 0 ? (
+              <p
+                style={{
+                  fontFamily: "var(--font-body)",
+                  fontSize: 13,
+                  color: MUTED,
+                }}
+              >
+                No reports filed yet. Be the first hand to deliver.
+              </p>
+            ) : (
+              <>
+                <div
+                  style={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: "30px 24px",
+                    alignItems: "flex-start",
+                  }}
+                >
+                  {sortedSubmissions.slice(0, 4).map((s) => (
+                    <div
+                      key={s.id}
+                      style={{ position: "relative", paddingTop: 20 }}
+                    >
+                      {s.id === topId && (
+                        <div
+                          style={{
+                            position: "absolute",
+                            top: -4,
+                            left: "50%",
+                            transform: "translateX(-50%)",
+                            zIndex: 3,
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 5,
+                            whiteSpace: "nowrap",
+                            background: GOLD,
+                            color: INK,
+                            fontFamily: "var(--font-accent)",
+                            fontSize: 13,
+                            letterSpacing: "0.1em",
+                            padding: "3px 13px",
+                            boxShadow: "0 3px 8px rgba(0,0,0,0.3)",
+                          }}
+                        >
+                          <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> BEST IN
+                          HALL
+                        </div>
+                      )}
+                      <PraxisCard praxis={s} />
+                    </div>
+                  ))}
+                </div>
+                {submissions.length > 4 && (
+                  <div style={{ marginTop: 18 }}>
+                    <Link
+                      to={`/praxes?task_id=${task.id}`}
+                      style={{
+                        fontFamily: "var(--font-accent)",
+                        fontSize: 15,
+                        letterSpacing: "0.06em",
+                        color: RED,
+                        textDecoration: "none",
+                      }}
+                    >
+                      View all {submissions.length} reports &rarr;
+                    </Link>
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/archetypes/TaskDetailSNIDE.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/TaskDetailSNIDE.tsx
@@ -9,19 +9,26 @@ import type { TaskSignupOut } from "../../../api/tasks";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
- * S.N.I.D.E. task-detail archetype — the job rendered as an OPEN-CASE DOSSIER:
- * evidence file header, the brief, accomplices on file, a read-only mob verdict,
- * and a "PULL THIS JOB" sign-up CTA. Ported from the SNIDE design kit
- * (snide-task-detail.jsx); wired to the real {@link TaskDetailState}.
+ * S.N.I.D.E. task-detail archetype — the "ransom dispatch": an OPEN-CASE
+ * DOSSIER whose title is cut from a ransom note (mixed-font chips), a black-ink
+ * CTA slab, a lined-paper brief, accomplices on file, a read-only mob verdict,
+ * and CASES CLOSED with a ⚜ TOP MARKS badge on the highest-scored completion.
+ * Ported from the improved SNIDE design kit (SnideTaskDetail.tsx) and wired to
+ * the real {@link TaskDetailState}.
+ *
+ * Always-dark by styling its own container with --faction-snide-* tokens; it
+ * does NOT mutate the document theme.
  *
  * Decorative / not backend-backed (marked inline): the "job no." (derived from
- * task.id), and the EvidenceTag labels are relabelled to honest counts.
+ * task.id). EvidenceTag labels are relabelled to honest counts.
  */
 
 const INK = "var(--faction-snide-ink)";
+const ACID = "var(--faction-snide-acid)";
+const PINK = "var(--faction-snide-pink)";
+const PAPER = "var(--faction-snide-paper)";
 
-/** The shared "rap sheet" CTA skin — a skewed, ink-shadowed slab button/link.
- *  `big` is the primary PULL size; default is the secondary edit/continue size. */
+/** The shared "rap sheet" CTA skin — a skewed, acid-shadowed slab button/link. */
 function rapSheetStyle(background: string, big = false): CSSProperties {
   return {
     display: "inline-block",
@@ -30,13 +37,70 @@ function rapSheetStyle(background: string, big = false): CSSProperties {
     background,
     color: "#fff",
     fontFamily: "var(--faction-snide-font-black)",
-    fontSize: big ? 20 : 18,
-    letterSpacing: "0.04em",
-    padding: big ? "16px 30px" : "14px 26px",
+    fontSize: big ? 15 : 14,
+    letterSpacing: "0.03em",
+    padding: big ? "14px 26px" : "12px 22px",
     textDecoration: "none",
     transform: "rotate(-1.5deg)",
-    boxShadow: `5px 6px 0 ${INK}`,
+    boxShadow: `3px 4px 0 ${ACID}`,
   };
+}
+
+/* ── Ransom title ──
+ * Cut the real task title into ransom-note chips: each word (or word-half for
+ * long words) gets its own font / colour / tilt, photocopied out of the page.
+ * Purely visual reinterpretation of the real `task.title`. */
+const RANSOM_SKINS: ReadonlyArray<{ bg: string; color: string; font: string }> =
+  [
+    { bg: PAPER, color: INK, font: "var(--faction-snide-font-impact)" },
+    { bg: INK, color: ACID, font: "var(--faction-snide-font-black)" },
+    { bg: PINK, color: "#fff", font: "var(--faction-snide-font-impact)" },
+    { bg: ACID, color: INK, font: "var(--faction-snide-font-black)" },
+  ];
+
+/** Split the title into ransom fragments (words, long words halved). */
+function ransomFragments(title: string): string[] {
+  const out: string[] = [];
+  for (const word of title.trim().split(/\s+/).filter(Boolean)) {
+    if (word.length > 7) {
+      const mid = Math.ceil(word.length / 2);
+      out.push(word.slice(0, mid), word.slice(mid));
+    } else {
+      out.push(word);
+    }
+  }
+  return out.length ? out : [title];
+}
+
+function RansomChip({
+  text,
+  index,
+}: {
+  text: string;
+  index: number;
+}) {
+  const skin = RANSOM_SKINS[index % RANSOM_SKINS.length];
+  const big = index % 2 === 0;
+  const rots = [-4, 3, -2, 4];
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        background: skin.bg,
+        color: skin.color,
+        fontFamily: skin.font,
+        fontSize: big ? 38 : 32,
+        lineHeight: 0.9,
+        padding: "2px 10px 0",
+        textTransform: "uppercase",
+        transform: `rotate(${rots[index % rots.length]}deg)`,
+        boxShadow: "1.5px 2.5px 0 rgba(0,0,0,0.4)",
+        border: skin.bg === PAPER ? `1px solid ${INK}` : "none",
+      }}
+    >
+      {text}
+    </span>
+  );
 }
 
 function EvidenceTag({
@@ -54,22 +118,22 @@ function EvidenceTag({
         display: "flex",
         flexDirection: "column",
         gap: 3,
-        padding: "10px 14px",
+        padding: "9px 14px",
         border: `1.5px solid ${INK}`,
         background: accent ? INK : "transparent",
         transform: `rotate(${accent ? -1.5 : 1}deg)`,
-        boxShadow: accent ? "2px 3px 0 var(--faction-snide-pink)" : "none",
+        boxShadow: accent ? `2px 3px 0 ${PINK}` : "none",
       }}
     >
       <span
         style={{
-          fontFamily: "var(--font-body)",
+          fontFamily: "var(--faction-snide-font-type)",
           fontSize: 8,
           letterSpacing: "0.18em",
           textTransform: "uppercase",
           color: accent
-            ? "var(--faction-snide-acid)"
-            : "color-mix(in srgb, var(--faction-snide-wall-text) 55%, transparent)",
+            ? ACID
+            : "color-mix(in srgb, var(--faction-snide-ink) 55%, transparent)",
         }}
       >
         {label}
@@ -79,7 +143,7 @@ function EvidenceTag({
           fontFamily: "var(--faction-snide-font-impact)",
           fontSize: 26,
           lineHeight: 0.85,
-          color: accent ? "var(--faction-snide-acid)" : "var(--faction-snide-wall-text)",
+          color: accent ? ACID : INK,
         }}
       >
         {value}
@@ -94,14 +158,14 @@ function MarkerTab({ text, rot = -1.5 }: { text: string; rot?: number }) {
     <div
       style={{
         display: "inline-block",
-        background: "var(--faction-snide-acid)",
+        background: ACID,
         color: INK,
         fontFamily: "var(--faction-snide-font-marker)",
-        fontSize: 16,
-        padding: "3px 13px",
+        fontSize: 17,
+        padding: "3px 14px",
         transform: `rotate(${rot}deg)`,
-        boxShadow: "2px 2px 0 var(--faction-snide-pink)",
-        marginBottom: 13,
+        boxShadow: `2px 2px 0 ${PINK}`,
+        marginBottom: 14,
       }}
     >
       {text}
@@ -125,7 +189,7 @@ function AccompliceRow({
     >
       {signups.map((m, i) => {
         const rel = relationOf(m.character_id, friends, foes);
-        const relColor = rel === "friend" ? "var(--faction-snide)" : "var(--faction-snide-pink)";
+        const relColor = rel === "friend" ? "var(--faction-snide)" : PINK;
         return (
           <Link
             key={m.character_id}
@@ -163,7 +227,7 @@ function AccompliceRow({
                   border: "2px solid var(--faction-snide)",
                   alignItems: "center",
                   justifyContent: "center",
-                  color: "var(--faction-snide-acid)",
+                  color: ACID,
                   fontFamily: "var(--faction-snide-font-impact)",
                   fontSize: 16,
                 }}
@@ -182,7 +246,7 @@ function AccompliceRow({
                   height: 12,
                   borderRadius: "50%",
                   background: relColor,
-                  border: "1.5px solid var(--faction-snide-paper)",
+                  border: `1.5px solid ${PAPER}`,
                 }}
               />
             )}
@@ -191,7 +255,7 @@ function AccompliceRow({
       })}
       <span
         style={{
-          fontFamily: "var(--font-body)",
+          fontFamily: "var(--faction-snide-font-type)",
           fontSize: 10,
           letterSpacing: "0.1em",
           textTransform: "uppercase",
@@ -221,6 +285,8 @@ export default function TaskDetailSNIDE({
     inProgressPraxisId,
     canSignUp,
     modifiedPoints,
+    slotsOpen,
+    maxTaskSlots,
     avgVoteNumber,
     voteCount,
     sortedSubmissions,
@@ -239,13 +305,24 @@ export default function TaskDetailSNIDE({
   // Decorative: SNIDE invents a "case file number" — derive it from the real id.
   const caseNo = String(task.id).padStart(4, "0");
   const isMeta = task.task_type === "metatask";
+  const fragments = ransomFragments(task.title);
+  // The highest-scored completion wears the ⚜ TOP MARKS badge.
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null;
 
   return (
-    <div className="py-8" style={{ fontFamily: "var(--font-body)", color: wall }}>
+    <div className="py-8" style={{ fontFamily: "var(--faction-snide-font-type)", color: wall }}>
       {/* ── Breadcrumb ── */}
       <nav
-        className="font-body mb-4"
-        style={{ fontSize: 9, letterSpacing: "0.1em", color: muted }}
+        className="mb-4"
+        style={{
+          fontFamily: "var(--faction-snide-font-type)",
+          fontSize: 10,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: muted,
+        }}
       >
         <Link
           to="/tasks"
@@ -253,37 +330,27 @@ export default function TaskDetailSNIDE({
         >
           Tasks
         </Link>
-        {" › "}
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ fontFamily: "var(--faction-snide-font-cond)", letterSpacing: "0.12em" }}>
           S.N.I.D.E.
         </span>
-        {" › "}
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ color: wall }}>{task.title}</span>
       </nav>
 
-      <div style={{ maxWidth: 760 }}>
-        {/* ── Open-case dossier header ── */}
+      <div style={{ maxWidth: 760, display: "flex", flexDirection: "column", gap: 30 }}>
+        {/* ── Open-case dossier header (ransom cut-out title) ── */}
         <div
           style={{
             position: "relative",
-            background: "var(--faction-snide-paper)",
+            background: PAPER,
             color: INK,
             border: `1.5px solid ${INK}`,
             boxShadow: "6px 7px 0 rgba(0,0,0,0.25)",
             transform: "rotate(-0.5deg)",
-            marginBottom: 30,
             overflow: "hidden",
           }}
         >
-          <div
-            className="ht-dots"
-            style={{
-              position: "absolute",
-              inset: 0,
-              color: "rgba(20,17,11,0.04)",
-              pointerEvents: "none",
-            }}
-          />
           {/* margin stripe (acid-on-green) */}
           <div
             style={{
@@ -291,47 +358,52 @@ export default function TaskDetailSNIDE({
               left: 0,
               top: 0,
               bottom: 0,
-              width: 7,
+              width: 8,
               background: "var(--faction-snide)",
               backgroundImage:
                 "repeating-linear-gradient(180deg, transparent 0 13px, rgba(0,0,0,0.25) 13px 14px)",
             }}
+          />
+          {/* tape top-right */}
+          <div
+            className="snide-tape"
+            style={{ top: -9, right: 44, width: 64, height: 20, transform: "rotate(6deg)" }}
           />
           <div style={{ position: "relative", display: "flex", gap: 0 }}>
             {/* mugshot panel */}
             <div
               style={{
                 flexShrink: 0,
-                width: 110,
+                width: 138,
                 background: INK,
                 display: "flex",
                 flexDirection: "column",
                 alignItems: "center",
                 justifyContent: "center",
-                padding: "18px 8px",
+                padding: "22px 10px",
                 backgroundImage:
-                  "repeating-linear-gradient(180deg, transparent 0 13px, rgba(182,255,46,0.18) 13px 14px)",
+                  "repeating-linear-gradient(180deg, transparent 0 13px, rgba(182,255,46,0.16) 13px 14px)",
               }}
             >
-              <SnideSigil size={48} color="var(--faction-snide-acid)" />
+              <SnideSigil size={58} color={ACID} />
               <div
                 style={{
-                  fontFamily: "var(--faction-snide-font-cond)",
-                  fontSize: 11,
+                  fontFamily: "var(--faction-snide-font-impact)",
+                  fontSize: 13,
                   letterSpacing: "0.12em",
-                  color: "var(--faction-snide-acid)",
-                  marginTop: 8,
+                  color: ACID,
+                  marginTop: 12,
                 }}
               >
                 JOB FILE
               </div>
               <div
                 style={{
-                  fontFamily: "var(--font-body)",
+                  fontFamily: "var(--faction-snide-font-type)",
                   fontSize: 8,
-                  color: "#a0c080",
-                  letterSpacing: "0.08em",
-                  marginTop: 2,
+                  color: "color-mix(in srgb, var(--faction-snide-acid) 60%, var(--faction-snide-ink))",
+                  letterSpacing: "0.1em",
+                  marginTop: 3,
                 }}
               >
                 OPEN CASE
@@ -341,35 +413,36 @@ export default function TaskDetailSNIDE({
             <div
               style={{
                 flex: 1,
-                padding: "18px 20px 18px 16px",
+                minWidth: 0,
+                padding: "24px 24px 22px 20px",
                 position: "relative",
               }}
             >
               <div
                 style={{
-                  fontFamily: "var(--font-body)",
-                  fontSize: 8.5,
+                  fontFamily: "var(--faction-snide-font-type)",
+                  fontSize: 9,
                   letterSpacing: "0.2em",
                   textTransform: "uppercase",
-                  color: "#6b6253",
-                  marginBottom: 6,
+                  color: "color-mix(in srgb, var(--faction-snide-ink) 60%, transparent)",
+                  marginBottom: 10,
                 }}
               >
                 S.N.I.D.E. Case File · job no. {caseNo}
               </div>
+              {/* Ransom-note title cut from the real task.title */}
               <h1
                 style={{
-                  fontFamily: "var(--faction-snide-font-impact)",
-                  fontSize: 38,
-                  lineHeight: 0.86,
-                  margin: "0 0 12px",
-                  letterSpacing: "0.02em",
-                  textTransform: "uppercase",
-                  transform: "skewX(-4deg)",
-                  color: INK,
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "6px 5px",
+                  alignItems: "center",
+                  margin: "0 0 18px",
                 }}
               >
-                {task.title}
+                {fragments.map((frag, i) => (
+                  <RansomChip key={i} text={frag} index={i} />
+                ))}
               </h1>
               {isMeta && (
                 <div
@@ -379,7 +452,7 @@ export default function TaskDetailSNIDE({
                     letterSpacing: "0.14em",
                     textTransform: "uppercase",
                     color: "var(--faction-snide-pink-deep)",
-                    marginBottom: 10,
+                    marginBottom: 12,
                   }}
                 >
                   ↳ metatask for {factionName(task.metatask_faction_slug)}
@@ -390,7 +463,6 @@ export default function TaskDetailSNIDE({
                   display: "flex",
                   gap: 10,
                   flexWrap: "wrap",
-                  marginBottom: 14,
                 }}
               >
                 <EvidenceTag label="Points" value={modifiedPoints} accent />
@@ -399,17 +471,17 @@ export default function TaskDetailSNIDE({
                 <EvidenceTag label="Filed" value={`${signups.length}`} />
                 <EvidenceTag label="Closed" value={`${submissions.length}`} />
               </div>
-              {/* OPEN CASE stamp */}
+              {/* OPEN CASE / real-status stamp */}
               <span
                 style={{
                   position: "absolute",
-                  bottom: 14,
-                  right: 14,
+                  bottom: 16,
+                  right: 16,
                   fontFamily: "var(--faction-snide-font-cond)",
                   fontSize: 15,
                   letterSpacing: "0.14em",
-                  color: "rgba(190,24,93,0.75)",
-                  border: "2.5px solid rgba(190,24,93,0.7)",
+                  color: "color-mix(in srgb, var(--faction-snide-pink-deep) 75%, transparent)",
+                  border: "2.5px solid color-mix(in srgb, var(--faction-snide-pink-deep) 70%, transparent)",
                   padding: "3px 12px",
                   transform: "rotate(-7deg)",
                 }}
@@ -418,33 +490,141 @@ export default function TaskDetailSNIDE({
               </span>
             </div>
           </div>
-          {/* tape top-right */}
-          <div
-            className="snide-tape"
-            style={{ top: -8, right: 38, width: 56, height: 18, transform: "rotate(6deg)" }}
-          />
         </div>
 
-        {/* ── The brief ── */}
-        <div style={{ marginBottom: 28 }}>
+        {/* ── CTA slab (black-ink dispatch bar) ── */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 18,
+            flexWrap: "wrap",
+            background: INK,
+            padding: "16px 20px",
+            transform: "rotate(-0.4deg)",
+            boxShadow: "4px 5px 0 rgba(0,0,0,0.2)",
+          }}
+        >
+          {canSignUp && (
+            <>
+              <button onClick={handleSignup} style={rapSheetStyle("var(--faction-snide-acid-deep)", true)}>
+                ★ PULL THIS JOB ★
+              </button>
+              <div
+                style={{
+                  fontFamily: "var(--faction-snide-font-marker)",
+                  fontSize: 13,
+                  color: PINK,
+                  transform: "rotate(-1deg)",
+                }}
+              >
+                ↳ no take-backs once it's filed
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-body)",
+                  fontSize: 10,
+                  letterSpacing: "0.06em",
+                  color: muted,
+                  width: "100%",
+                }}
+              >
+                earn up to {modifiedPoints} pts · {slotsOpen} of {maxTaskSlots}{" "}
+                slots open · lvl {task.level_required} met
+              </div>
+            </>
+          )}
+
+          {mySubmission && (
+            <>
+              <Link
+                to={`/praxes/${mySubmission.id}/edit`}
+                style={rapSheetStyle(PINK)}
+              >
+                → EDIT THE RAP SHEET
+              </Link>
+              <div
+                style={{
+                  fontFamily: "var(--faction-snide-font-marker)",
+                  fontSize: 13,
+                  color: ACID,
+                  transform: "rotate(-1deg)",
+                }}
+              >
+                ↳ filed. on the record.
+              </div>
+            </>
+          )}
+
+          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+            <>
+              <Link
+                to={`/praxes/${inProgressPraxisId}/edit`}
+                style={rapSheetStyle("var(--faction-snide-acid-deep)")}
+              >
+                → CONTINUE THE RAP SHEET
+              </Link>
+              <button
+                onClick={handleDrop}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: "var(--faction-snide-font-marker)",
+                  fontSize: 13,
+                  color: PINK,
+                  transform: "rotate(-1deg)",
+                }}
+              >
+                ↳ ditch the job
+              </button>
+            </>
+          )}
+
+          {/* Mob verdict — read-only aggregate, pinned to the slab's right edge */}
+          <div
+            style={{
+              marginLeft: "auto",
+              fontFamily: "var(--faction-snide-font-impact)",
+              fontSize: 11,
+              letterSpacing: "0.1em",
+              color: ACID,
+            }}
+          >
+            {voteCount > 0
+              ? `${submissions.length} CLOSED · ${avgVoteNumber.toFixed(1)} AVG`
+              : "NO VERDICT YET"}
+          </div>
+        </div>
+        <ErrorBanner
+          message={signupError}
+          style={{
+            background: "color-mix(in srgb, var(--faction-snide-pink) 8%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--faction-snide-pink) 30%, transparent)",
+          }}
+        />
+
+        {/* ── The brief (lined paper) ── */}
+        <section>
           <MarkerTab text="the brief" rot={-1.5} />
           <div
             style={{
               position: "relative",
-              background: "var(--faction-snide-paper)",
+              background: PAPER,
               color: INK,
               border: `1.5px solid ${INK}`,
               borderLeft: "4px solid var(--faction-snide)",
-              padding: "16px 18px",
+              padding: "24px 24px 20px",
               backgroundImage:
-                "repeating-linear-gradient(180deg, transparent 0 27px, rgba(20,17,11,0.09) 27px 28px)",
-              transform: "rotate(0.4deg)",
+                "repeating-linear-gradient(180deg, transparent 0 27px, rgba(20,17,11,0.08) 27px 28px)",
+              transform: "rotate(0.3deg)",
               boxShadow: "3px 4px 0 rgba(0,0,0,0.18)",
+              maxWidth: 640,
             }}
           >
             <div
               className="snide-tape"
-              style={{ top: -8, left: 30, width: 56, height: 17, transform: "rotate(-5deg)" }}
+              style={{ top: -9, left: 32, width: 62, height: 18, transform: "rotate(-5deg)" }}
             />
             <p
               style={{
@@ -458,162 +638,29 @@ export default function TaskDetailSNIDE({
               {task.description || "No brief on file. Figure it out."}
             </p>
           </div>
-        </div>
+        </section>
 
         {/* ── Accomplices on file ── */}
         {signups.length > 0 && (
-          <div style={{ marginBottom: 28 }}>
+          <section>
             <MarkerTab text="accomplices on file" rot={1} />
             <AccompliceRow signups={signups} friends={friends} foes={foes} />
-          </div>
+          </section>
         )}
 
-        {/* ── Mob verdict (read-only aggregate) ── */}
-        <div style={{ marginBottom: 30 }}>
-          <MarkerTab text="mob verdict" rot={-1} />
-          {voteCount > 0 ? (
-            <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
-              <span
-                style={{
-                  fontFamily: "var(--faction-snide-font-impact)",
-                  fontSize: 54,
-                  lineHeight: 0.8,
-                  color: "var(--faction-snide)",
-                }}
-              >
-                {avgVoteNumber.toFixed(1)}
-              </span>
-              <div style={{ paddingBottom: 6 }}>
-                <div
-                  style={{
-                    fontFamily: "var(--faction-snide-font-cond)",
-                    fontSize: 16,
-                    letterSpacing: "0.06em",
-                    color: wall,
-                  }}
-                >
-                  OUT OF 5
-                </div>
-                <div
-                  style={{
-                    fontFamily: "var(--font-body)",
-                    fontSize: 10,
-                    letterSpacing: "0.06em",
-                    color: muted,
-                  }}
-                >
-                  {voteCount} on file ·{" "}
-                  <span style={{ fontFamily: "var(--faction-snide-font-marker)", color: "var(--faction-snide-pink)" }}>
-                    nobody's impressed
-                  </span>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <p style={{ fontFamily: "var(--faction-snide-font-marker)", fontSize: 14, color: "var(--faction-snide-pink)" }}>
-              no verdict yet. be the first to pull it off.
-            </p>
-          )}
-        </div>
-
-        {/* ── Pull this job / signed-up states ── */}
-        <div
-          style={{
-            borderTop:
-              "2px dashed color-mix(in srgb, var(--faction-snide-wall-text) 22%, transparent)",
-            paddingTop: 24,
-            display: "flex",
-            alignItems: "center",
-            gap: 18,
-            flexWrap: "wrap",
-          }}
-        >
-          {canSignUp && (
-            <>
-              <button onClick={handleSignup} style={rapSheetStyle("var(--faction-snide)", true)}>
-                ★ PULL THIS JOB ★
-              </button>
-              <div
-                style={{
-                  fontFamily: "var(--faction-snide-font-marker)",
-                  fontSize: 14,
-                  color: "var(--faction-snide-pink)",
-                  transform: "rotate(-1.5deg)",
-                }}
-              >
-                ↳ nobody's watching. probably.
-              </div>
-            </>
-          )}
-
-          {mySubmission && (
-            <>
-              <Link
-                to={`/praxes/${mySubmission.id}/edit`}
-                style={rapSheetStyle("var(--faction-snide-pink)")}
-              >
-                → EDIT THE RAP SHEET
-              </Link>
-              <div
-                style={{
-                  fontFamily: "var(--faction-snide-font-marker)",
-                  fontSize: 14,
-                  color: "var(--faction-snide)",
-                  transform: "rotate(-1.5deg)",
-                }}
-              >
-                ↳ filed. on the record.
-              </div>
-            </>
-          )}
-
-          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
-            <>
-              <Link
-                to={`/praxes/${inProgressPraxisId}/edit`}
-                style={rapSheetStyle("var(--faction-snide)")}
-              >
-                → CONTINUE THE RAP SHEET
-              </Link>
-              <button
-                onClick={handleDrop}
-                style={{
-                  background: "none",
-                  border: "none",
-                  cursor: "pointer",
-                  fontFamily: "var(--faction-snide-font-marker)",
-                  fontSize: 14,
-                  color: "var(--faction-snide-pink)",
-                  transform: "rotate(-1.5deg)",
-                }}
-              >
-                ↳ ditch the job
-              </button>
-            </>
-          )}
-        </div>
-        <ErrorBanner
-          message={signupError}
-          style={{
-            background: "rgba(255,45,139,0.08)",
-            border: "1px solid rgba(255,45,139,0.3)",
-          }}
-        />
-
-        {/* ── The record (completed praxis) ── */}
-        <div style={{ marginTop: 34 }}>
+        {/* ── Cases closed (completed praxis) ── */}
+        <section>
           <div
             style={{
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
-              marginBottom: 14,
               flexWrap: "wrap",
               gap: 8,
             }}
           >
-            <MarkerTab text={`the record · ${submissions.length}`} rot={-1} />
-            <div style={{ display: "flex", gap: 0 }}>
+            <MarkerTab text={`cases closed · ${submissions.length}`} rot={1} />
+            <div style={{ display: "flex", gap: 0, marginBottom: 14 }}>
               {(["score", "recent"] as const).map((sort) => {
                 const on = submissionSort === sort;
                 return (
@@ -627,12 +674,12 @@ export default function TaskDetailSNIDE({
                       textTransform: "uppercase",
                       padding: "5px 12px",
                       background: on ? INK : "transparent",
-                      color: on ? "var(--faction-snide-acid)" : muted,
+                      color: on ? ACID : muted,
                       border: `1.5px solid ${on ? INK : "color-mix(in srgb, var(--faction-snide-wall-text) 30%, transparent)"}`,
                       cursor: "pointer",
                     }}
                   >
-                    {sort === "score" ? "top rated" : "recent"}
+                    {sort === "score" ? "top marks" : "recent"}
                   </button>
                 );
               })}
@@ -644,16 +691,42 @@ export default function TaskDetailSNIDE({
               style={{
                 fontFamily: "var(--faction-snide-font-marker)",
                 fontSize: 15,
-                color: "var(--faction-snide-pink)",
+                color: PINK,
               }}
             >
               no files yet. nobody's pulled it off.
             </p>
           ) : (
             <>
-              <div className="flex flex-wrap gap-4 items-start">
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "32px 26px", alignItems: "flex-start" }}>
                 {sortedSubmissions.slice(0, 4).map((s) => (
-                  <PraxisCard key={s.id} praxis={s} />
+                  <div key={s.id} style={{ position: "relative", paddingTop: s.id === topId ? 22 : 0 }}>
+                    {s.id === topId && (
+                      <div
+                        style={{
+                          position: "absolute",
+                          top: 0,
+                          left: "50%",
+                          transform: "translateX(-50%) rotate(-3deg)",
+                          zIndex: 3,
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: 5,
+                          whiteSpace: "nowrap",
+                          background: PINK,
+                          color: "#fff",
+                          fontFamily: "var(--faction-snide-font-black)",
+                          fontSize: 9,
+                          letterSpacing: "0.06em",
+                          padding: "4px 12px",
+                          boxShadow: `2px 3px 0 ${INK}`,
+                        }}
+                      >
+                        <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span> TOP MARKS
+                      </div>
+                    )}
+                    <PraxisCard praxis={s} />
+                  </div>
                 ))}
               </div>
               {submissions.length > 4 && (
@@ -673,7 +746,7 @@ export default function TaskDetailSNIDE({
               )}
             </>
           )}
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/pages/taskDetail/archetypes/TaskDetailSingularity.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/TaskDetailSingularity.tsx
@@ -1,0 +1,674 @@
+import type { CSSProperties } from "react";
+import { Link } from "react-router-dom";
+import PraxisCard from "../../../components/PraxisCard";
+import { mediaUrl } from "../../../utils/media";
+import { ErrorBanner, relationOf } from "./shared";
+import type { TaskSignupOut } from "../../../api/tasks";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * Singularity task-detail archetype — the job rendered as a TERMINAL PRINTOUT:
+ * a phosphor-on-black protocol readout with boot lines, scanlines, circuit
+ * corners, sealed-praxis logs (highest signal wears a fleur-de-lis), and a
+ * "JOIN ARRAY" sign-up CTA. Ported from the Singularity design kit
+ * (SingularityTaskDetail.tsx); wired to the real {@link TaskDetailState}.
+ *
+ * ALWAYS-DARK without theme mutation: the kit forced `data-theme="dark"` on the
+ * document on mount. That effect is dropped entirely. The `--faction-singularity-*`
+ * card tokens hold identical terminal-black/green values in BOTH themes, so the
+ * archetype styles its own container with those tokens and reads as a terminal
+ * regardless of the global theme.
+ */
+
+// Terminal-fixed tokens (identical in light + dark).
+const BLACK = "var(--faction-singularity-card-bg)"; // terminal black
+const GREEN = "var(--faction-singularity-card-text)"; // phosphor green
+const BLUE = "var(--faction-singularity-card-muted)"; // blue chrome
+const HARD = "var(--faction-singularity-border-hard)"; // hard blue border
+const TERM_FONT = "var(--font-faction-terminal)"; // Share Tech Mono
+
+// Shades derived from tokens (never raw hex; rgba black/white allowed for overlays).
+const RULE = "color-mix(in srgb, var(--faction-singularity-border-hard) 30%, transparent)";
+const PANEL_BORDER = "color-mix(in srgb, var(--faction-singularity-border-hard) 55%, transparent)";
+const PANEL_BG = "color-mix(in srgb, var(--faction-singularity-border-hard) 8%, transparent)";
+const BODY_BORDER = "color-mix(in srgb, var(--faction-singularity-border-hard) 25%, transparent)";
+const BODY_BG = "color-mix(in srgb, var(--faction-singularity-border-hard) 4%, transparent)";
+const BLUE_FAINT = "color-mix(in srgb, var(--faction-singularity-card-muted) 50%, transparent)";
+const BLUE_DIM = "color-mix(in srgb, var(--faction-singularity-card-muted) 45%, transparent)";
+const GREEN_DIM = "color-mix(in srgb, var(--faction-singularity-card-text) 55%, transparent)";
+const GREEN_SOFT = "color-mix(in srgb, var(--faction-singularity-card-text) 60%, transparent)";
+
+const sectionRule: CSSProperties = { flex: 1, height: 1, background: RULE };
+const sectionH2: CSSProperties = {
+  fontSize: 7.5,
+  letterSpacing: "0.28em",
+  margin: 0,
+  color: GREEN_SOFT,
+  textTransform: "uppercase",
+  whiteSpace: "nowrap",
+  fontFamily: TERM_FONT,
+};
+const statBox: CSSProperties = {
+  border: `1px solid ${PANEL_BORDER}`,
+  background: PANEL_BG,
+  padding: "10px 18px",
+  textAlign: "center",
+  minWidth: 90,
+};
+const statLabel: CSSProperties = {
+  fontSize: 7,
+  letterSpacing: "0.2em",
+  color: BLUE_FAINT,
+  textTransform: "uppercase",
+  marginTop: 4,
+};
+
+/** A single circuit-trace corner SVG (token-stroked). */
+function CircuitCorner({ flip }: { flip?: boolean }) {
+  return (
+    <svg
+      width="160"
+      height="110"
+      viewBox="0 0 160 110"
+      style={{
+        position: "absolute",
+        ...(flip ? { bottom: 0, right: 0, transform: "rotate(180deg)" } : { top: 0, left: 0 }),
+        opacity: 0.6,
+      }}
+      fill="none"
+      stroke={HARD}
+      strokeWidth="1"
+    >
+      <path d="M0 28 H40 V8 H92" />
+      <path d="M0 56 H60 V40 H120" />
+      <circle cx="92" cy="8" r="2.5" fill={GREEN} stroke="none" />
+      <circle cx="120" cy="40" r="2.5" fill={GREEN} stroke="none" />
+    </svg>
+  );
+}
+
+/** Array roster — real signup avatars with friend/foe markers. */
+function ArrayRoster({
+  signups,
+  friends,
+  foes,
+}: {
+  signups: TaskSignupOut[];
+  friends: Set<number>;
+  foes: Set<number>;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+      {signups.map((member) => {
+        const rel = relationOf(member.character_id, friends, foes);
+        const relColor = rel === "friend" ? GREEN : BLUE;
+        return (
+          <Link
+            key={member.character_id}
+            to={`/characters/${member.character_id}`}
+            title={`${member.display_name}${rel ? ` · ${rel}` : ""}`}
+            style={{ position: "relative", width: 34, height: 34, flexShrink: 0 }}
+          >
+            {member.avatar_url ? (
+              <img
+                src={mediaUrl(member.avatar_url)}
+                alt={member.display_name}
+                style={{
+                  width: 34,
+                  height: 34,
+                  objectFit: "cover",
+                  border: `1px solid ${PANEL_BORDER}`,
+                }}
+              />
+            ) : (
+              <span
+                style={{
+                  display: "flex",
+                  width: 34,
+                  height: 34,
+                  background: BLACK,
+                  border: `1px solid ${PANEL_BORDER}`,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: GREEN,
+                  fontFamily: TERM_FONT,
+                  fontSize: 13,
+                }}
+              >
+                {member.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+            {rel && (
+              <span
+                title={rel}
+                style={{
+                  position: "absolute",
+                  right: -3,
+                  bottom: -3,
+                  width: 10,
+                  height: 10,
+                  background: relColor,
+                  border: `1.5px solid ${BLACK}`,
+                }}
+              />
+            )}
+          </Link>
+        );
+      })}
+      <span
+        style={{
+          fontFamily: TERM_FONT,
+          fontSize: 8,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: BLUE_DIM,
+          marginLeft: 6,
+        }}
+      >
+        nodes on array
+      </span>
+    </div>
+  );
+}
+
+export default function TaskDetailSingularity({
+  state,
+}: {
+  state: TaskDetailState;
+}) {
+  const {
+    task,
+    signups,
+    submissions,
+    friends,
+    foes,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    avgVoteNumber,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  // Terminal-voiced status: an active job is a RUNNING/OPEN protocol; else the real status.
+  const statusVoice =
+    task.status === "active" ? "ACCEPTING NODES" : task.status.toUpperCase();
+  const consensusVoice = task.status === "active" ? "OPEN" : task.status.toUpperCase();
+  // Highest-signal log wears the fleur-de-lis.
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null;
+
+  return (
+    <div
+      className="py-8"
+      style={{
+        fontFamily: TERM_FONT,
+        color: GREEN,
+        position: "relative",
+        background: BLACK,
+        backgroundImage:
+          "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.022) 2px, rgba(74,222,128,0.022) 4px), radial-gradient(80% 60% at 50% 0%, rgba(37,99,235,0.10), transparent 70%)",
+      }}
+    >
+      <style>{`@keyframes sg-blink { 50% { opacity: 0; } }`}</style>
+
+      <div style={{ maxWidth: 920, margin: "0 auto", padding: "0 24px" }}>
+        {/* ── Breadcrumb ── */}
+        <nav
+          className="font-body"
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: BLUE_FAINT,
+            marginBottom: 22,
+          }}
+        >
+          <Link to="/tasks" style={{ color: BLUE, textDecoration: "none" }}>
+            Tasks
+          </Link>
+          <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
+          <span>SINGULARITY</span>
+          <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
+          <span style={{ color: GREEN }}>{task.title}</span>
+        </nav>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+          {/* ── Hero — terminal protocol readout ── */}
+          <div
+            style={{
+              position: "relative",
+              border: `1px solid ${PANEL_BORDER}`,
+              background: BLACK,
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                position: "absolute",
+                inset: 6,
+                border: `1px solid color-mix(in srgb, var(--faction-singularity-border-hard) 12%, transparent)`,
+                pointerEvents: "none",
+              }}
+            />
+            <CircuitCorner />
+            <CircuitCorner flip />
+            <div style={{ position: "relative", zIndex: 2, padding: "30px 36px 34px" }}>
+              <div
+                style={{
+                  fontSize: 8,
+                  letterSpacing: "0.16em",
+                  color: BLUE_FAINT,
+                  lineHeight: 2,
+                  marginBottom: 18,
+                }}
+              >
+                <div>&gt; OPEN PROTOCOL #{String(task.id).padStart(4, "0")}</div>
+                <div>
+                  &gt; CLASS: OBSERVATION · LVL {task.level_required} · {modifiedPoints} CR
+                </div>
+                <div>
+                  &gt; STATUS: {statusVoice} &nbsp;·&nbsp; CONSENSUS:{" "}
+                  <span style={{ color: GREEN }}>{consensusVoice}</span>
+                </div>
+              </div>
+              <h1
+                style={{
+                  fontSize: 40,
+                  lineHeight: 1.0,
+                  letterSpacing: "0.03em",
+                  color: GREEN,
+                  margin: "0 0 22px",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {task.title}
+                <span
+                  style={{
+                    display: "inline-block",
+                    width: 14,
+                    height: 34,
+                    background: GREEN,
+                    marginLeft: 6,
+                    verticalAlign: -4,
+                    animation: "sg-blink 1s step-end infinite",
+                  }}
+                />
+              </h1>
+              <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+                <div style={statBox}>
+                  <div style={{ fontSize: 26, lineHeight: 1, color: GREEN }}>
+                    {modifiedPoints}
+                  </div>
+                  <div style={statLabel}>credits</div>
+                </div>
+                <div style={statBox}>
+                  <div style={{ fontSize: 26, lineHeight: 1, color: GREEN }}>
+                    {task.level_required}
+                  </div>
+                  <div style={statLabel}>level</div>
+                </div>
+                <div style={statBox}>
+                  <div style={{ fontSize: 26, lineHeight: 1, color: BLUE }}>
+                    {signups.length}
+                  </div>
+                  <div style={statLabel}>arrays</div>
+                </div>
+                <div style={statBox}>
+                  <div style={{ fontSize: 26, lineHeight: 1, color: GREEN }}>
+                    {submissions.length}
+                  </div>
+                  <div style={statLabel}>sealed</div>
+                </div>
+              </div>
+            </div>
+            <svg
+              viewBox="0 0 1160 30"
+              preserveAspectRatio="none"
+              style={{ display: "block", width: "100%", height: 30, opacity: 0.4 }}
+              stroke={GREEN}
+              strokeWidth="1"
+              fill="none"
+            >
+              <path d="M0 15 H120 L132 4 L144 26 L156 9 L168 21 L180 15 H320 L332 7 L344 23 L356 15 H520 L532 2 L544 28 L556 12 L568 18 L580 15 H760 L772 6 L784 24 L796 15 H980 L992 9 L1004 21 L1016 15 H1160" />
+            </svg>
+          </div>
+
+          {/* ── The observation (task body) ── */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
+              <h2 style={sectionH2}>// the_observation</h2>
+              <span style={sectionRule} />
+            </div>
+            <div
+              style={{
+                border: `1px solid ${BODY_BORDER}`,
+                background: BODY_BG,
+                padding: "24px 28px",
+                maxWidth: 660,
+              }}
+            >
+              <p
+                style={{
+                  fontFamily: TERM_FONT,
+                  fontSize: 11,
+                  lineHeight: 1.9,
+                  color: GREEN_DIM,
+                  margin: 0,
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {task.description ||
+                  "No protocol logged. Find the signal yourself; the array interprets, you only witness."}
+              </p>
+            </div>
+          </section>
+
+          {/* ── CTA bar / signed-up states ── */}
+          {canSignUp && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 18,
+                flexWrap: "wrap",
+                border: `1px solid ${PANEL_BORDER}`,
+                background: PANEL_BG,
+                padding: "16px 20px",
+              }}
+            >
+              <button
+                onClick={handleSignup}
+                style={{
+                  cursor: "pointer",
+                  fontFamily: TERM_FONT,
+                  fontSize: 11,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  color: BLUE,
+                  background: PANEL_BG,
+                  border: `1px solid ${BLUE}`,
+                  padding: "13px 24px",
+                }}
+              >
+                &gt; JOIN ARRAY — earn up to {modifiedPoints} pts
+              </button>
+              <div
+                style={{
+                  fontSize: 8,
+                  letterSpacing: "0.06em",
+                  color: GREEN_DIM,
+                  fontStyle: "italic",
+                }}
+              >
+                no credentials. only signal. · {slotsOpen} of {maxTaskSlots} arrays open
+              </div>
+              <div
+                style={{
+                  marginLeft: "auto",
+                  fontSize: 7,
+                  letterSpacing: "0.14em",
+                  color: BLUE_DIM,
+                }}
+              >
+                LVL {task.level_required} REQUIRED · MET
+              </div>
+            </div>
+          )}
+
+          {mySubmission && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 18,
+                flexWrap: "wrap",
+                border: `1px solid ${PANEL_BORDER}`,
+                background: PANEL_BG,
+                padding: "16px 20px",
+              }}
+            >
+              <Link
+                to={`/praxes/${mySubmission.id}/edit`}
+                style={{
+                  fontFamily: TERM_FONT,
+                  fontSize: 11,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  color: GREEN,
+                  background: "color-mix(in srgb, var(--faction-singularity-card-text) 14%, transparent)",
+                  border: `1px solid ${GREEN}`,
+                  padding: "13px 24px",
+                  textDecoration: "none",
+                }}
+              >
+                &gt; EDIT SIGNAL LOG
+              </Link>
+              <div style={{ fontSize: 8, letterSpacing: "0.06em", color: GREEN_DIM, fontStyle: "italic" }}>
+                ◉ your log is sealed against this protocol.
+              </div>
+            </div>
+          )}
+
+          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 18,
+                flexWrap: "wrap",
+                border: `1px solid ${PANEL_BORDER}`,
+                background: PANEL_BG,
+                padding: "16px 20px",
+              }}
+            >
+              <Link
+                to={`/praxes/${inProgressPraxisId}/edit`}
+                style={{
+                  fontFamily: TERM_FONT,
+                  fontSize: 11,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  color: GREEN,
+                  background: "color-mix(in srgb, var(--faction-singularity-card-text) 14%, transparent)",
+                  border: `1px solid ${GREEN}`,
+                  padding: "13px 24px",
+                  textDecoration: "none",
+                }}
+              >
+                &gt; CONTINUE OBSERVATION
+              </Link>
+              <button
+                onClick={handleDrop}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: TERM_FONT,
+                  fontSize: 9,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  color: BLUE_DIM,
+                }}
+              >
+                &gt; abort array
+              </button>
+            </div>
+          )}
+
+          <ErrorBanner
+            message={signupError}
+            style={{
+              background: "rgba(37,99,235,0.08)",
+              border: `1px solid ${PANEL_BORDER}`,
+              color: GREEN,
+            }}
+          />
+
+          {/* ── Array roster (signups) ── */}
+          {signups.length > 0 && (
+            <section>
+              <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
+                <h2 style={sectionH2}>// array_roster</h2>
+                <span style={sectionRule} />
+                <span style={{ fontSize: 7, letterSpacing: "0.12em", color: BLUE_DIM }}>
+                  {signups.length} nodes synced
+                </span>
+              </div>
+              <ArrayRoster signups={signups} friends={friends} foes={foes} />
+            </section>
+          )}
+
+          {/* ── Mob verdict (read-only vote aggregate) ── */}
+          <section>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
+              <h2 style={sectionH2}>// consensus_signal</h2>
+              <span style={sectionRule} />
+            </div>
+            {voteCount > 0 ? (
+              <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
+                <span style={{ fontFamily: TERM_FONT, fontSize: 48, lineHeight: 0.8, color: GREEN }}>
+                  {avgVoteNumber.toFixed(1)}
+                </span>
+                <div style={{ paddingBottom: 4 }}>
+                  <div
+                    style={{
+                      fontFamily: TERM_FONT,
+                      fontSize: 12,
+                      letterSpacing: "0.1em",
+                      color: BLUE,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    consensus / 5
+                  </div>
+                  <div style={{ fontSize: 8, letterSpacing: "0.1em", color: BLUE_DIM }}>
+                    {voteCount} logs sealed
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p style={{ fontFamily: TERM_FONT, fontSize: 11, color: GREEN_DIM, margin: 0 }}>
+                &gt; no consensus yet. the array is silent. seal the first signal.
+              </p>
+            )}
+          </section>
+
+          {/* ── Sealed praxis (completed submissions) ── */}
+          <section>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 14,
+                marginBottom: 18,
+                flexWrap: "wrap",
+              }}
+            >
+              <h2 style={sectionH2}>// sealed_praxis</h2>
+              <span style={sectionRule} />
+              <span style={{ fontSize: 7, letterSpacing: "0.12em", color: BLUE_DIM }}>
+                {submissions.length} logs sealed
+              </span>
+              <div style={{ display: "flex", gap: 0 }}>
+                {(["score", "recent"] as const).map((sort) => {
+                  const on = submissionSort === sort;
+                  return (
+                    <button
+                      key={sort}
+                      onClick={() => setSubmissionSort(sort)}
+                      style={{
+                        fontFamily: TERM_FONT,
+                        fontSize: 8,
+                        letterSpacing: "0.1em",
+                        textTransform: "uppercase",
+                        padding: "5px 12px",
+                        background: on ? "color-mix(in srgb, var(--faction-singularity-card-text) 14%, transparent)" : "transparent",
+                        color: on ? GREEN : BLUE_DIM,
+                        border: `1px solid ${on ? GREEN : RULE}`,
+                        cursor: "pointer",
+                      }}
+                    >
+                      {sort === "score" ? "highest signal" : "recent"}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {sortedSubmissions.length === 0 ? (
+              <p style={{ fontFamily: TERM_FONT, fontSize: 11, color: GREEN_DIM, margin: 0 }}>
+                &gt; no logs sealed. no node has witnessed this yet.
+              </p>
+            ) : (
+              <>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 22px", alignItems: "flex-start" }}>
+                  {sortedSubmissions.slice(0, 4).map((s) => (
+                    <div key={s.id} style={{ position: "relative", paddingTop: s.id === topId ? 20 : 0 }}>
+                      {s.id === topId && (
+                        <div
+                          style={{
+                            position: "absolute",
+                            top: -2,
+                            left: "50%",
+                            transform: "translateX(-50%)",
+                            zIndex: 3,
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 5,
+                            whiteSpace: "nowrap",
+                            background: BLACK,
+                            border: `1px solid ${GREEN}`,
+                            color: GREEN,
+                            fontFamily: TERM_FONT,
+                            fontSize: 7.5,
+                            letterSpacing: "0.16em",
+                            padding: "4px 11px",
+                            boxShadow: "0 0 12px rgba(74,222,128,0.4)",
+                          }}
+                        >
+                          <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span> HIGHEST SIGNAL
+                        </div>
+                      )}
+                      <PraxisCard praxis={s} />
+                    </div>
+                  ))}
+                </div>
+                {submissions.length > 4 && (
+                  <div style={{ marginTop: 16 }}>
+                    <Link
+                      to={`/praxes?task_id=${task.id}`}
+                      style={{
+                        fontFamily: TERM_FONT,
+                        fontSize: 10,
+                        letterSpacing: "0.1em",
+                        textTransform: "uppercase",
+                        color: BLUE,
+                        textDecoration: "none",
+                      }}
+                    >
+                      &gt; view all {submissions.length} logs &rarr;
+                    </Link>
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/archetypes/TaskDetailWow.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/TaskDetailWow.tsx
@@ -1,0 +1,736 @@
+import type { CSSProperties } from "react";
+import { Link } from "react-router-dom";
+import PraxisCard from "../../../components/PraxisCard";
+import { mediaUrl } from "../../../utils/media";
+import { ErrorBanner, relationOf } from "./shared";
+import type { TaskSignupOut } from "../../../api/tasks";
+import type { PraxisCardOut } from "../../../api/praxis";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * Warriors of Whimsy task-detail archetype — the job rendered as a
+ * "whimsy.exe" desktop window: a pink computer-witch chrome with a
+ * traffic-light title bar, a dotted desktop body, Caveat-script headings,
+ * sparkle charms, "spells cast" completions (the most-loved one wears a
+ * fleur-de-lis), and a playful party-voiced CTA. Ported visually from the
+ * WoW design kit (WhimsyTaskDetail.tsx); wired to the real
+ * {@link TaskDetailState}. The kit's demo props, FactionPraxisCard /
+ * FactionCommentBox, top <nav> and group-chat block are discarded — the real
+ * <PraxisCard> and the shared state replace them.
+ */
+
+const PINK = "var(--faction-wow)";
+const TITLE_TEXT = "var(--faction-wow-title-text)";
+const CARD_TEXT = "var(--faction-wow-card-text)";
+const CARD_MUTED = "var(--faction-wow-card-muted)";
+const WIN_BORDER = "var(--faction-wow-win-border)";
+const NOTEPAD_BG = "var(--faction-wow-notepad-bg)";
+const NOTEPAD_BORDER = "var(--faction-wow-notepad-border)";
+const DOT = "var(--faction-wow-dot)";
+const SCRIPT = "var(--faction-wow-card-font)"; // Caveat
+const BODY = "var(--font-body)"; // Courier Prime
+const ACCENT = "var(--font-accent)"; // Bebas Neue
+const ON_ACCENT = "var(--color-text-on-accent)";
+
+/** Sparkle charm — the kit's signature four-point star. */
+function Sparkle({
+  size,
+  color,
+  style,
+}: {
+  size: number;
+  color: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style}>
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+/** Caveat-script section heading with a sparkle and a dashed running rule. */
+function SectionHead({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        marginBottom: 18,
+      }}
+    >
+      <Sparkle size={18} color={PINK} />
+      <h2
+        style={{
+          fontFamily: SCRIPT,
+          fontSize: 32,
+          margin: 0,
+          color: TITLE_TEXT,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {children}
+      </h2>
+      <span
+        style={{
+          flex: 1,
+          height: 2,
+          background: `repeating-linear-gradient(90deg, ${PINK} 0 8px, transparent 8px 14px)`,
+        }}
+      />
+    </div>
+  );
+}
+
+/** Party-voiced status phrasing — active reads as a playful "open" line. */
+function statusVoice(status: string): string {
+  return status === "active" ? "open · the party's still gathering" : status;
+}
+
+/** Real signup avatars as a little coven row, tilted, with friend/foe charms. */
+function PartyRow({
+  signups,
+  friends,
+  foes,
+}: {
+  signups: TaskSignupOut[];
+  friends: Set<number>;
+  foes: Set<number>;
+}) {
+  return (
+    <div
+      style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
+    >
+      {signups.map((m, index) => {
+        const rel = relationOf(m.character_id, friends, foes);
+        const relColor = rel === "friend" ? PINK : "var(--faction-wow-ivy)";
+        return (
+          <Link
+            key={m.character_id}
+            to={`/characters/${m.character_id}`}
+            title={`${m.display_name}${rel ? ` · ${rel}` : ""}`}
+            style={{
+              position: "relative",
+              width: 38,
+              height: 38,
+              flexShrink: 0,
+              transform: `rotate(${index % 2 ? 4 : -3}deg)`,
+            }}
+          >
+            {m.avatar_url ? (
+              <img
+                src={mediaUrl(m.avatar_url)}
+                alt={m.display_name}
+                style={{
+                  width: 38,
+                  height: 38,
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                  border: `2px solid ${PINK}`,
+                }}
+              />
+            ) : (
+              <span
+                style={{
+                  display: "flex",
+                  width: 38,
+                  height: 38,
+                  borderRadius: "50%",
+                  background: `color-mix(in srgb, ${PINK} 22%, transparent)`,
+                  border: `2px solid ${PINK}`,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: TITLE_TEXT,
+                  fontFamily: SCRIPT,
+                  fontSize: 20,
+                }}
+              >
+                {m.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+            {rel && (
+              <span
+                title={rel}
+                style={{
+                  position: "absolute",
+                  right: -3,
+                  bottom: -3,
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  background: relColor,
+                  border: `1.5px solid ${NOTEPAD_BG}`,
+                }}
+              />
+            )}
+          </Link>
+        );
+      })}
+      <span
+        style={{
+          fontFamily: SCRIPT,
+          fontSize: 18,
+          color: PINK,
+          marginLeft: 6,
+        }}
+      >
+        in the party
+      </span>
+    </div>
+  );
+}
+
+export default function TaskDetailWow({ state }: { state: TaskDetailState }) {
+  const {
+    task,
+    signups,
+    submissions,
+    friends,
+    foes,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    avgVoteNumber,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  // Top-rated submission gets the "most loved" fleur-de-lis charm.
+  const topId: number | null = submissions.length
+    ? submissions.reduce(
+        (best: PraxisCardOut, candidate: PraxisCardOut) =>
+          (candidate.score ?? 0) > (best.score ?? 0) ? candidate : best,
+      ).id
+    : null;
+
+  /** The pill stat skin used across the hero chrome. */
+  const pill: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    fontSize: 11,
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    padding: "6px 14px",
+    borderRadius: 20,
+    background: "var(--faction-wow-light)",
+    color: CARD_TEXT,
+    border: `1.5px solid var(--faction-wow-border)`,
+  };
+
+  return (
+    <div className="py-8" style={{ fontFamily: BODY, color: CARD_TEXT }}>
+      {/* ── Breadcrumb ── */}
+      <nav
+        className="font-body mb-4"
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: CARD_MUTED,
+        }}
+      >
+        <Link to="/tasks" style={{ color: PINK, textDecoration: "none" }}>
+          Tasks
+        </Link>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
+        <span style={{ fontFamily: SCRIPT, fontSize: 18 }}>
+          Warriors of Whimsy
+        </span>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
+        <span style={{ color: PINK }}>{task.title}</span>
+      </nav>
+
+      <div style={{ maxWidth: 920, display: "flex", flexDirection: "column", gap: 30 }}>
+        {/* ── HERO · whimsy.exe window ── */}
+        <div
+          style={{
+            borderRadius: 14,
+            overflow: "hidden",
+            border: `2px solid ${WIN_BORDER}`,
+            boxShadow: `0 10px 26px color-mix(in srgb, ${PINK} 32%, transparent)`,
+            transform: "rotate(-0.5deg)",
+          }}
+        >
+          {/* title bar — traffic lights + window name */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "9px 14px",
+              background: `linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))`,
+              borderBottom: `2px solid ${WIN_BORDER}`,
+            }}
+          >
+            {["var(--faction-wow-scrap-deep)", "var(--faction-wow-tape)", "var(--faction-wow-ivy-leaf)"].map(
+              (lightColor) => (
+                <span
+                  key={lightColor}
+                  style={{
+                    width: 11,
+                    height: 11,
+                    borderRadius: "50%",
+                    background: lightColor,
+                    border: "1.2px solid rgba(255,255,255,0.7)",
+                  }}
+                />
+              ),
+            )}
+            <span
+              style={{
+                marginLeft: "auto",
+                fontFamily: SCRIPT,
+                fontSize: 20,
+                color: ON_ACCENT,
+                textShadow: `1px 1px 0 ${TITLE_TEXT}`,
+              }}
+            >
+              quest.exe
+            </span>
+          </div>
+
+          {/* desktop body */}
+          <div
+            style={{
+              position: "relative",
+              padding: "30px 34px 32px",
+              background: NOTEPAD_BG,
+              backgroundImage: `radial-gradient(${DOT} 1.3px, transparent 1.3px)`,
+              backgroundSize: "14px 14px",
+            }}
+          >
+            <Sparkle
+              size={22}
+              color="var(--faction-wow-tape)"
+              style={{
+                position: "absolute",
+                top: 18,
+                right: 22,
+                transform: "rotate(10deg)",
+              }}
+            />
+            <Sparkle
+              size={14}
+              color={PINK}
+              style={{
+                position: "absolute",
+                top: 64,
+                right: 70,
+                transform: "rotate(-12deg)",
+              }}
+            />
+            <div
+              style={{
+                fontSize: 9,
+                textTransform: "uppercase",
+                letterSpacing: "0.16em",
+                color: CARD_MUTED,
+                marginBottom: 8,
+              }}
+            >
+              {statusVoice(task.status)}
+            </div>
+            <div
+              style={{
+                fontFamily: SCRIPT,
+                fontSize: 62,
+                lineHeight: 0.92,
+                color: TITLE_TEXT,
+                marginBottom: 18,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {task.title}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                flexWrap: "wrap",
+              }}
+            >
+              <span style={pill}>
+                <Sparkle size={11} color={PINK} /> level {task.level_required}
+              </span>
+              <span
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 7,
+                  fontFamily: SCRIPT,
+                  fontSize: 30,
+                  color: PINK,
+                }}
+              >
+                <svg width="22" height="22" viewBox="0 0 36 36">
+                  <path
+                    d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+                    fill={PINK}
+                    stroke={NOTEPAD_BG}
+                    strokeWidth="2.2"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                {modifiedPoints} sparks
+              </span>
+              <span style={pill}>
+                {signups.length} tried · {submissions.length} pulled it off
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Signup CTA bar (only when sign-up is possible) ── */}
+        {canSignUp && (
+          <div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 18,
+                flexWrap: "wrap",
+                border: `2px solid ${WIN_BORDER}`,
+                borderRadius: 12,
+                background: NOTEPAD_BG,
+                padding: "16px 20px",
+                boxShadow: `4px 4px 0 var(--faction-wow-scrap-deep)`,
+              }}
+            >
+              <button
+                onClick={handleSignup}
+                style={{
+                  cursor: "pointer",
+                  fontFamily: BODY,
+                  fontSize: 11,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.12em",
+                  color: ON_ACCENT,
+                  padding: "13px 24px",
+                  border: `1.5px solid ${WIN_BORDER}`,
+                  borderRadius: 10,
+                  background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+                  boxShadow: `0 4px 10px color-mix(in srgb, ${PINK} 35%, transparent)`,
+                }}
+              >
+                join the party ✦ earn up to {modifiedPoints} pts
+              </button>
+              <div style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK }}>
+                no experience with magic required
+              </div>
+              <div
+                style={{
+                  marginLeft: "auto",
+                  fontSize: 10,
+                  letterSpacing: "0.06em",
+                  color: CARD_MUTED,
+                  textAlign: "right",
+                }}
+              >
+                <div>
+                  {slotsOpen} of {maxTaskSlots} slots open
+                </div>
+                <div>level {task.level_required} required · met</div>
+              </div>
+            </div>
+            <ErrorBanner message={signupError} />
+          </div>
+        )}
+
+        {/* ── My submission — edit the spell ── */}
+        {mySubmission && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              flexWrap: "wrap",
+              border: `2px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 12,
+              background: NOTEPAD_BG,
+              padding: "14px 20px",
+            }}
+          >
+            <span style={{ fontFamily: SCRIPT, fontSize: 22, color: TITLE_TEXT }}>
+              ✦ your spell is cast
+            </span>
+            <Link
+              to={`/praxes/${mySubmission.id}/edit`}
+              style={{
+                fontFamily: BODY,
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.12em",
+                color: ON_ACCENT,
+                padding: "10px 20px",
+                border: `1.5px solid ${WIN_BORDER}`,
+                borderRadius: 10,
+                background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+                textDecoration: "none",
+              }}
+            >
+              edit
+            </Link>
+          </div>
+        )}
+
+        {/* ── In progress — continue / drop ── */}
+        {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              flexWrap: "wrap",
+              border: `2px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 12,
+              background: NOTEPAD_BG,
+              padding: "14px 20px",
+            }}
+          >
+            <span style={{ fontFamily: SCRIPT, fontSize: 22, color: TITLE_TEXT }}>
+              ✦ your spell is half-woven
+            </span>
+            <Link
+              to={`/praxes/${inProgressPraxisId}/edit`}
+              style={{
+                fontFamily: BODY,
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.12em",
+                color: ON_ACCENT,
+                padding: "10px 20px",
+                border: `1.5px solid ${WIN_BORDER}`,
+                borderRadius: 10,
+                background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+                textDecoration: "none",
+              }}
+            >
+              continue
+            </Link>
+            <button
+              onClick={handleDrop}
+              style={{
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                fontFamily: SCRIPT,
+                fontSize: 18,
+                color: CARD_MUTED,
+              }}
+            >
+              leave the party
+            </button>
+          </div>
+        )}
+
+        {/* ── The party so far (signups) ── */}
+        {signups.length > 0 && (
+          <section>
+            <SectionHead>the party so far</SectionHead>
+            <PartyRow signups={signups} friends={friends} foes={foes} />
+          </section>
+        )}
+
+        {/* ── What we're asking (description) ── */}
+        <section>
+          <SectionHead>what we're asking</SectionHead>
+          <div
+            style={{
+              border: `2px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 12,
+              background: NOTEPAD_BG,
+              padding: "24px 28px",
+              maxWidth: 640,
+            }}
+          >
+            <p
+              style={{
+                fontFamily: BODY,
+                fontSize: 12,
+                lineHeight: 1.75,
+                color: CARD_TEXT,
+                margin: 0,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {task.description ||
+                "No spell written yet. Trust the pull and conjure something kind."}
+            </p>
+          </div>
+        </section>
+
+        {/* ── The love so far (vote aggregate) ── */}
+        <section>
+          <SectionHead>the love so far</SectionHead>
+          {voteCount > 0 ? (
+            <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
+              <span
+                style={{
+                  fontFamily: ACCENT,
+                  fontSize: 54,
+                  lineHeight: 0.8,
+                  color: PINK,
+                }}
+              >
+                {avgVoteNumber.toFixed(1)}
+              </span>
+              <div style={{ paddingBottom: 6 }}>
+                <div
+                  style={{
+                    fontFamily: SCRIPT,
+                    fontSize: 22,
+                    color: TITLE_TEXT,
+                  }}
+                >
+                  avg love · out of 5
+                </div>
+                <div style={{ fontSize: 10, color: CARD_MUTED }}>
+                  {voteCount} {voteCount === 1 ? "spell" : "spells"} adored
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p style={{ fontFamily: SCRIPT, fontSize: 22, color: PINK }}>
+              no love yet — be the first to cast a little wonder.
+            </p>
+          )}
+        </section>
+
+        {/* ── Spells cast (completed praxis) ── */}
+        <section>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              flexWrap: "wrap",
+              gap: 12,
+              marginBottom: 18,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 12, flex: 1 }}>
+              <Sparkle size={18} color={PINK} />
+              <h2
+                style={{
+                  fontFamily: SCRIPT,
+                  fontSize: 32,
+                  margin: 0,
+                  color: TITLE_TEXT,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                spells cast so far · {submissions.length}
+              </h2>
+            </div>
+            <div style={{ display: "flex", gap: 0 }}>
+              {(["score", "recent"] as const).map((sort) => {
+                const on = submissionSort === sort;
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: BODY,
+                      fontSize: 9,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.1em",
+                      padding: "5px 12px",
+                      borderRadius: on ? 8 : 0,
+                      background: on ? PINK : "transparent",
+                      color: on ? ON_ACCENT : CARD_MUTED,
+                      border: `1.5px solid ${on ? PINK : NOTEPAD_BORDER}`,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {sort === "score" ? "most loved" : "recent"}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {sortedSubmissions.length === 0 ? (
+            <p style={{ fontFamily: SCRIPT, fontSize: 22, color: PINK }}>
+              no spells cast yet. nobody's pulled it off.
+            </p>
+          ) : (
+            <>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "30px 24px",
+                  alignItems: "flex-start",
+                }}
+              >
+                {sortedSubmissions.slice(0, 4).map((s) => (
+                  <div key={s.id} style={{ position: "relative", paddingTop: 22 }}>
+                    {s.id === topId && (
+                      <div
+                        style={{
+                          position: "absolute",
+                          top: -2,
+                          left: "50%",
+                          transform: "translateX(-50%) rotate(-2deg)",
+                          zIndex: 3,
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: 5,
+                          whiteSpace: "nowrap",
+                          background: PINK,
+                          color: ON_ACCENT,
+                          fontFamily: SCRIPT,
+                          fontSize: 17,
+                          padding: "2px 14px",
+                          borderRadius: 14,
+                          boxShadow: `2px 3px 0 var(--faction-wow-scrap-deep)`,
+                        }}
+                      >
+                        <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span>{" "}
+                        most loved
+                      </div>
+                    )}
+                    <PraxisCard praxis={s} />
+                  </div>
+                ))}
+              </div>
+              {submissions.length > 4 && (
+                <div style={{ marginTop: 18 }}>
+                  <Link
+                    to={`/praxes?task_id=${task.id}`}
+                    style={{
+                      fontFamily: SCRIPT,
+                      fontSize: 22,
+                      color: PINK,
+                      textDecoration: "none",
+                    }}
+                  >
+                    see all {submissions.length} spells ✦
+                  </Link>
+                </div>
+              )}
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #211 #212 #213 #214 #242

Builds five per-faction task-detail archetypes to the **locked spec** in #242 (grilling session 2026-06-25), porting the delivered design kit (`docs/design/task-detail/*.tsx`) onto the real shared `TaskDetailState`.

## Archetypes (registered in `TaskDetail.tsx` `ARCHETYPE_BY_SLUG`)
| Slug | Archetype | Issue |
|---|---|---|
| `everymen` | Union / victory poster | #211 |
| `wow` | whimsy.exe desktop window | #212 |
| `ephemerists` | Illuminated discordant map | #213 |
| `singularity` | Always-dark terminal printout | #214 |
| `snide` | Redesigned ransom-dispatch dossier (replaces the prior bespoke) | #242 |

## Contract honored (ADR-0002 content-slot invariant)
Each archetype is `({ state }) => JSX` consuming `useTaskDetail`, rearranging but never dropping a slot. Every backend-driven state the static mockups omit is reconstructed:
- Breadcrumb · hero with the **real `task.status`** voiced per faction (no hardcoded "OPEN") · description
- Signup CTA (+ points / slots / level + `signupError` banner) when `canSignUp`
- Edit-my-submission link · in-progress **continue + drop**
- Signups row with friend/foe badges · read-only vote aggregate (empty vs avg)
- Completed-praxis section: count + **score/recent sort toggle** + list + view-all + empty state + ⚜ top-rated badge

Completions **compose the existing `PraxisCard`** — no new praxis component, no API change. Comments stay with `TaskDetail.tsx`'s neutral `CommentThread` (kit discussion block dropped). Metatask omitted (tracked in #241).

## Dark mode
`singularity` + `snide` are **always-dark** via identical light/dark tokens scoped to their own container — **no `document` theme mutation** (the kit's `data-theme` effect was dropped). No hardcoded hex anywhere: every kit colour maps to the `--faction-*` / private-palette tokens already vendored in `index.css` (tokens + fonts needed **no additions**).

## Tests
- New **ADR-0002 parametrized invariant test** (`taskDetail/__tests__/archetypeSlots.test.tsx`): walks the real `ARCHETYPE_BY_SLUG` + Default fallback, renders each with fixed `TaskDetailState` fixtures, asserts the invariant slots. Scales free as factions are added.
- `npm test` — **62/62 pass** (38 prior + 24 new). `npx tsc --noEmit` — clean for all new files.

## Scope notes
- UA (#210) + Albescent task-detail excluded — depend on faction recolors, not in this PR.
- ⚠️ `npm run build` (vite) is currently red on `main` due to a **pre-existing, unrelated** break: `CollaborationDetail.tsx` imports `getPraxisVotes`/`DuelVoteSummary` removed by the ADR-0014 praxis-scoring refactor. CI gates on `npm test` (vitest) + `pytest`, both green. This batch adds **no** new build errors (tsc-clean); the build goes green once that pre-existing break is fixed (flagged separately).