### PR TITLE
Build & wire singularity's vote, backdrop, avatar, hero archetypes

### DIFF
--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -6,6 +6,7 @@ import EverymenAvatar from './EverymenAvatar'
 import WowAvatar from './WowAvatar'
 import SnideAvatar from './SnideAvatar'
 import EphemeristsAvatar from './EphemeristsAvatar'
+import SingularityAvatar from './SingularityAvatar'
 
 /**
  * Per-faction avatar + membership-badge dispatcher (Tier-3 surface). Keyed by
@@ -145,6 +146,7 @@ const FACTION_AVATARS: Record<string, ComponentType<FactionAvatarProps>> = {
   wow: WowAvatar,
   snide: SnideAvatar,
   ephemerists: EphemeristsAvatar,
+  singularity: SingularityAvatar,
 }
 
 export default function FactionAvatar({ character, size }: FactionAvatarProps) {

--- a/frontend/src/components/avatar/SingularityAvatar.tsx
+++ b/frontend/src/components/avatar/SingularityAvatar.tsx
@@ -1,0 +1,53 @@
+import { BadgedAvatar, type FactionAvatarProps } from "./FactionAvatar";
+
+/**
+ * The Singularity membership sigil — a terminal prompt (`>`) trailed by a
+ * blinking-cursor block, the faction's pervasive boot-line motif rendered at
+ * badge scale. Drawn in the badge ring color so the dispatcher can recolor it.
+ */
+function SingularitySigil(size: number, color: string) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 12 12"
+      fill="none"
+      style={{ display: "block", flexShrink: 0 }}
+    >
+      {/* terminal prompt caret ">" */}
+      <polyline
+        points="2,3 5,6 2,9"
+        stroke={color}
+        strokeWidth={1.4}
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+      />
+      {/* cursor block */}
+      <rect x="7" y="7.5" width="3" height="1.6" fill={color} />
+    </svg>
+  );
+}
+
+/**
+ * The Singularity avatar — a terminal-black circle in faction monospace plus a
+ * blue membership badge carrying the prompt/cursor sigil. Singularity is
+ * always-dark: its tokens are identical across themes, so no theme mutation is
+ * needed. Colors via --faction-singularity-* tokens.
+ */
+export default function SingularityAvatar({ character, size }: FactionAvatarProps) {
+  return (
+    <BadgedAvatar
+      character={character}
+      size={size}
+      circle={{
+        borderColor: "var(--faction-singularity-border-hard)",
+        bg: "var(--faction-singularity-card-bg)",
+        textColor: "var(--faction-singularity-card-text)",
+        fontFamily: "var(--font-faction-terminal)",
+      }}
+      badgeBg="var(--faction-singularity-card-bg)"
+      badgeRing="var(--faction-singularity-card-muted)"
+      glyph={(s, _color) => SingularitySigil(s, "var(--faction-singularity-card-accent)")}
+    />
+  );
+}

--- a/frontend/src/components/backdrop/FactionBackdrop.tsx
+++ b/frontend/src/components/backdrop/FactionBackdrop.tsx
@@ -4,6 +4,7 @@ import EverymenBackdrop from './EverymenBackdrop'
 import WowBackdrop from './WowBackdrop'
 import SnideBackdrop from './SnideBackdrop'
 import EphemeristsBackdrop from './EphemeristsBackdrop'
+import SingularityBackdrop from './SingularityBackdrop'
 import { useBackdropSlug } from './BackdropContext'
 import { pickVariant } from '../../utils/factionDispatch'
 
@@ -18,6 +19,7 @@ const FACTION_BACKDROPS: Record<string, ComponentType> = {
   wow: WowBackdrop,
   snide: SnideBackdrop,
   ephemerists: EphemeristsBackdrop,
+  singularity: SingularityBackdrop,
 }
 
 export default function FactionBackdrop() {

--- a/frontend/src/components/backdrop/SingularityBackdrop.tsx
+++ b/frontend/src/components/backdrop/SingularityBackdrop.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Singularity full-page backdrop — the page as the terminal itself: a
+ * terminal-black field with a faint blue circuit-trace grid, a centered
+ * phosphor-green glow, signal blue bleeding from the corners, and fine
+ * green scanlines. Singularity is always-dark: its `--faction-singularity-*`
+ * tokens are identical in both themes, so this never flips with data-theme.
+ * Fixed behind page content at z-index 0.
+ */
+const backdropStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 0,
+  pointerEvents: 'none',
+  backgroundColor: 'var(--faction-singularity-card-bg)',
+  backgroundImage: [
+    // phosphor center glow (green)
+    'radial-gradient(55% 45% at 50% 50%, color-mix(in srgb, var(--faction-singularity-card-accent) 5%, transparent) 0%, transparent 68%)',
+    // signal blue — top-left origin
+    'radial-gradient(44% 38% at 0% 0%, color-mix(in srgb, var(--faction-singularity-card-muted) 9%, transparent), transparent 72%)',
+    // signal blue — bottom-right echo
+    'radial-gradient(36% 30% at 100% 100%, color-mix(in srgb, var(--faction-singularity-card-muted) 6%, transparent), transparent 72%)',
+    // circuit grid — horizontal (blue)
+    'repeating-linear-gradient(0deg, color-mix(in srgb, var(--faction-singularity-border-hard) 22%, transparent) 0 1px, transparent 1px 32px)',
+    // circuit grid — vertical (blue)
+    'repeating-linear-gradient(90deg, color-mix(in srgb, var(--faction-singularity-border-hard) 22%, transparent) 0 1px, transparent 1px 32px)',
+    // scanlines (faint phosphor-green over black)
+    'repeating-linear-gradient(to bottom, transparent 0 2px, color-mix(in srgb, var(--faction-singularity-card-accent) 4%, transparent) 2px 4px)',
+  ].join(', '),
+}
+
+export default function SingularityBackdrop() {
+  return <div style={backdropStyle} aria-hidden="true" />
+}

--- a/frontend/src/components/cards/SingularityFactionHero.tsx
+++ b/frontend/src/components/cards/SingularityFactionHero.tsx
@@ -1,0 +1,280 @@
+import type { FactionHeroProps } from "../../pages/FactionDetail";
+
+/**
+ * Singularity faction-page hero — a terminal boot-sequence frontispiece. The
+ * masthead reads as the faction initializing itself: a phosphor-green/blue
+ * printout on a terminal-black field, framed by an inset signal border,
+ * scanlines, a corner phosphor glow, and a slow-spinning sigil. Ported from the
+ * Singularity design kit (SgHero); conforms to {@link FactionHeroProps}.
+ *
+ * Singularity is ALWAYS DARK: its --faction-singularity-* tokens are identical
+ * in both themes, so the container styles itself with them and reads as a
+ * terminal regardless of the global theme — it never mutates data-theme.
+ *
+ * The page passes raw counts; the faction labels them in its own terminal
+ * voice. Motto + boot lines are faction constants (not backend fields).
+ */
+
+const MOTTO = "THE THRESHOLD IS ALREADY BEHIND US";
+
+// Token shorthands — every color resolves to a --faction-singularity-* var.
+const VOID = "var(--faction-singularity-card-bg)"; // terminal black
+const PHOSPHOR = "var(--faction-singularity-card-accent)"; // green
+const PHOSPHOR_TEXT = "var(--faction-singularity-card-text)"; // green
+const SIGNAL = "var(--faction-singularity-card-muted)"; // blue
+const BORDER = "var(--faction-singularity-border)";
+const BORDER_HARD = "var(--faction-singularity-border-hard)";
+const FONT = "var(--font-faction-terminal)";
+
+// color-mix helpers for shades that have no dedicated token.
+const phosphor = (pct: number): string =>
+  `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`;
+const signal = (pct: number): string =>
+  `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`;
+const signalFill = "var(--faction-singularity)"; // blue brand fill
+
+/** Minimal phosphor sigil — three concentric rings around a node. */
+function SingularityMark({
+  size,
+  color,
+}: {
+  size: number;
+  color: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      <g fill="none" stroke={color} strokeWidth="1.5">
+        <circle cx="50" cy="50" r="46" />
+        <circle cx="50" cy="50" r="30" strokeDasharray="3 5" />
+        <circle cx="50" cy="50" r="14" />
+      </g>
+      <circle cx="50" cy="50" r="4" fill={color} />
+    </svg>
+  );
+}
+
+export default function SingularityFactionHero({
+  name,
+  description,
+  members,
+  tasks,
+  praxes,
+}: FactionHeroProps) {
+  // The faction labels its own counts — page passes raw numbers only.
+  const stats = [
+    { value: members, label: "nodes online" },
+    { value: tasks, label: "open protocols" },
+    { value: praxes, label: "sealed lately" },
+  ];
+
+  return (
+    <header
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        marginBottom: 32,
+        border: `1px solid ${BORDER_HARD}`,
+        background: VOID,
+        color: PHOSPHOR_TEXT,
+        fontFamily: FONT,
+        boxShadow: "0 24px 60px -28px rgba(0,0,0,0.8)",
+      }}
+    >
+      {/* inset signal border */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          inset: 6,
+          border: `1px solid ${signal(18)}`,
+          pointerEvents: "none",
+          zIndex: 3,
+        }}
+      />
+      {/* scanlines */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          inset: 0,
+          pointerEvents: "none",
+          background:
+            "repeating-linear-gradient(to bottom,transparent,transparent 2px,rgba(255,255,255,0.018) 2px,rgba(255,255,255,0.018) 4px)",
+        }}
+      />
+      {/* corner phosphor glow */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: -60,
+          left: -60,
+          width: 260,
+          height: 260,
+          borderRadius: "50%",
+          background: `radial-gradient(circle, ${phosphor(12)}, transparent 70%)`,
+          pointerEvents: "none",
+        }}
+      />
+
+      <div
+        style={{
+          position: "relative",
+          zIndex: 2,
+          padding: "36px 40px 40px",
+          display: "grid",
+          gridTemplateColumns: "1fr auto",
+          gap: 32,
+          alignItems: "center",
+        }}
+      >
+        <div>
+          {/* boot lines */}
+          <div
+            style={{
+              fontSize: 8.5,
+              letterSpacing: "0.18em",
+              color: signal(55),
+              marginBottom: 14,
+              lineHeight: 1.9,
+            }}
+          >
+            <div>{">"} FACTION: {name.toUpperCase()}</div>
+            <div>{">"} STATUS: ACTIVE · ARRAYS ONLINE</div>
+            <div>
+              {">"} THRESHOLD:{" "}
+              <span style={{ color: PHOSPHOR }}>CROSSED</span>
+            </div>
+          </div>
+
+          {/* name */}
+          <h1
+            style={{
+              fontFamily: FONT,
+              fontSize: 56,
+              lineHeight: 0.9,
+              letterSpacing: "0.04em",
+              margin: "0 0 12px",
+              color: PHOSPHOR,
+              fontWeight: 400,
+            }}
+          >
+            {name}
+          </h1>
+
+          {/* motto */}
+          <div
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.28em",
+              color: signal(70),
+              textTransform: "uppercase",
+              marginBottom: 16,
+            }}
+          >
+            {MOTTO}
+          </div>
+
+          {/* blurb */}
+          <p
+            style={{
+              fontSize: 11,
+              lineHeight: 1.7,
+              color: phosphor(60),
+              maxWidth: 520,
+              margin: "0 0 28px",
+            }}
+          >
+            {description ??
+              "We watch the noise floor for the pattern that shouldn't exist."}
+          </p>
+
+          {/* stats */}
+          <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+            {stats.map((s) => (
+              <div
+                key={s.label}
+                style={{
+                  border: `1px solid ${BORDER}`,
+                  background: "var(--faction-singularity-light)",
+                  padding: "10px 18px",
+                  textAlign: "center",
+                  minWidth: 96,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 26,
+                    lineHeight: 1,
+                    color: PHOSPHOR,
+                    marginBottom: 4,
+                  }}
+                >
+                  {s.value}
+                </div>
+                <div
+                  style={{
+                    fontSize: 7,
+                    letterSpacing: "0.2em",
+                    color: signal(55),
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* spinning sigil */}
+        <div style={{ position: "relative", flexShrink: 0 }}>
+          <div
+            aria-hidden="true"
+            className="sg-pulse"
+            style={{
+              position: "absolute",
+              inset: -20,
+              borderRadius: "50%",
+              background: `radial-gradient(circle, ${phosphor(28)}, transparent 70%)`,
+              opacity: 0.2,
+              pointerEvents: "none",
+            }}
+          />
+          <div className="sg-rotate">
+            <SingularityMark size={120} color={phosphor(55)} />
+          </div>
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <SingularityMark size={44} color={PHOSPHOR} />
+          </div>
+        </div>
+      </div>
+
+      {/* signal strip at the foot of the masthead */}
+      <div
+        aria-hidden="true"
+        style={{
+          height: 4,
+          background: signalFill,
+          position: "relative",
+          zIndex: 2,
+          opacity: 0.7,
+        }}
+      />
+    </header>
+  );
+}

--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -1,0 +1,176 @@
+import type { VoteUIProps } from './VoteUI'
+import { useVote } from './useVote'
+import { VoteLoginGate, VoteSummary } from './VoteShell'
+
+/**
+ * Singularity faction vote UI — THE CONSENSUS ARRAY. The 1-5 rating is rendered
+ * as a signal-strength ramp cast into the terminal: noise → weak → signal →
+ * clear → verified, measuring how confidently a sealed output holds up to
+ * scrutiny. Square mono "cast signal" keys glow when reached; the selected key
+ * scales up. Singularity is ALWAYS-DARK — its tokens hold identical terminal
+ * values in both themes, so this never touches data-theme.
+ *
+ * Same 1-5 data model as every other faction — a pure terminal reskin driven by
+ * the shared {@link useVote} hook so cast/refetch logic lives in one place.
+ */
+
+interface SignalTier {
+  value: number
+  label: string
+  /** Confidence ramp colour — token-derived, low (blue chrome) → high (green). */
+  fill: string
+}
+
+/**
+ * Signal ramp. The design ramp runs cool→warm→green; with the available always-
+ * dark tokens we express the same "weak → verified" confidence climb by mixing
+ * the terminal-green accent up from the blue brand chrome as confidence rises.
+ */
+export const SG_CONSENSUS: SignalTier[] = [
+  { value: 1, label: 'NOISE', fill: 'var(--faction-singularity-card-muted)' },
+  { value: 2, label: 'WEAK', fill: 'color-mix(in srgb, var(--faction-singularity-card-muted) 70%, var(--faction-singularity-card-accent))' },
+  { value: 3, label: 'SIGNAL', fill: 'color-mix(in srgb, var(--faction-singularity-card-muted) 40%, var(--faction-singularity-card-accent))' },
+  { value: 4, label: 'CLEAR', fill: 'color-mix(in srgb, var(--faction-singularity-card-accent) 75%, var(--faction-singularity-card-muted))' },
+  { value: 5, label: 'VERIFIED', fill: 'var(--faction-singularity-card-accent)' },
+]
+
+const KEY_SIZE = 42
+
+export default function SingularityVote({ praxisId, currentStars, averageStars, totalVotes, mode = 'caster' }: VoteUIProps) {
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentStars)
+
+  if (mode === 'summary') {
+    const tier = SG_CONSENSUS[Math.max(0, Math.round(averageStars ?? 0) - 1)] ?? SG_CONSENSUS[0]
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+        <div
+          style={{
+            minWidth: 46,
+            height: 30,
+            padding: '0 9px',
+            background: 'var(--faction-singularity-card-bg)',
+            outline: `1px solid ${tier.fill}`,
+            color: tier.fill,
+            fontFamily: 'var(--font-faction-terminal)',
+            fontSize: 9,
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: `0 0 10px color-mix(in srgb, ${tier.fill} 33%, transparent)`,
+          }}
+        >
+          {tier.label}
+        </div>
+        <span
+          style={{
+            fontFamily: 'var(--font-faction-terminal)',
+            fontSize: 7,
+            letterSpacing: '0.12em',
+            color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 55%, transparent)',
+            textAlign: 'center',
+          }}
+        >
+          {totalVotes ?? 0} signals
+        </span>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return <VoteLoginGate />
+  }
+
+  return (
+    <div style={{ fontFamily: 'var(--font-faction-terminal)' }}>
+      <div
+        style={{
+          fontSize: 8,
+          letterSpacing: '0.18em',
+          color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 75%, transparent)',
+          textTransform: 'uppercase',
+          marginBottom: 3,
+        }}
+      >
+        Cast Signal
+      </div>
+      <div
+        style={{
+          fontSize: 7.5,
+          fontStyle: 'italic',
+          color: 'color-mix(in srgb, var(--faction-singularity-card-accent) 50%, transparent)',
+          marginBottom: 12,
+        }}
+      >
+        how confidently does this output hold?
+      </div>
+
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {SG_CONSENSUS.map((tier) => {
+          const reached = selected >= tier.value
+          const picked = selected === tier.value
+          return (
+            <div key={tier.value} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 5 }}>
+              <button
+                disabled={saving}
+                onClick={() => void vote(tier.value)}
+                aria-label={`Cast ${tier.value} — ${tier.label}`}
+                style={{
+                  position: 'relative',
+                  width: KEY_SIZE,
+                  height: KEY_SIZE,
+                  cursor: saving ? 'default' : 'pointer',
+                  padding: 0,
+                  border: 'none',
+                  background: reached ? tier.fill : 'var(--faction-singularity-light)',
+                  color: reached ? 'var(--faction-singularity-card-bg)' : 'color-mix(in srgb, var(--faction-singularity-card-muted) 55%, transparent)',
+                  fontFamily: 'var(--font-faction-terminal)',
+                  fontWeight: 700,
+                  fontSize: 13,
+                  lineHeight: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  transform: picked ? 'scale(1.12)' : 'none',
+                  transition: 'all 110ms',
+                  outline: `1px solid ${reached ? tier.fill : 'var(--faction-singularity-border)'}`,
+                  boxShadow: reached ? `0 0 12px color-mix(in srgb, ${tier.fill} 33%, transparent)` : 'none',
+                }}
+              >
+                {tier.value}
+              </button>
+              <span
+                style={{
+                  fontSize: 6.5,
+                  letterSpacing: '0.08em',
+                  color: picked ? tier.fill : 'color-mix(in srgb, var(--faction-singularity-card-muted) 45%, transparent)',
+                  maxWidth: KEY_SIZE + 8,
+                  textAlign: 'center',
+                  lineHeight: 1.2,
+                }}
+              >
+                {tier.label}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <VoteSummary
+        selected={selected}
+        averageStars={averageStars}
+        totalVotes={totalVotes}
+        error={error}
+        theme={{
+          muted: 'color-mix(in srgb, var(--faction-singularity-card-muted) 60%, transparent)',
+          accent: 'var(--faction-singularity-card-accent)',
+          accentFont: 'var(--font-faction-terminal)',
+          avgFontSize: 17,
+          errorColor: 'var(--color-danger)',
+          avgLetterSpacing: '0.08em',
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -5,6 +5,7 @@ import EverymenVote from './EverymenVote'
 import WowVote from './WowVote'
 import SnideVote from './SnideVote'
 import EphemeristsVote from './EphemeristsVote'
+import SingularityVote from './SingularityVote'
 
 /**
  * Per-faction vote/rating UI dispatcher (Tier-3 surface). Keyed by the voted
@@ -25,6 +26,7 @@ const FACTION_VOTE: Record<string, ComponentType<VoteUIProps>> = {
   wow: WowVote,
   snide: SnideVote,
   ephemerists: EphemeristsVote,
+  singularity: SingularityVote,
 }
 
 export default function VoteUI({

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -895,3 +895,11 @@
   .eph-twinkle { animation: eph-twinkle 5s ease-in-out infinite; }
   .eph-depth { animation: eph-depth 16s ease-in-out infinite; }
 }
+
+/* Singularity terminal — phosphor glow breathes, sigil turns. (#222) */
+@keyframes sg-pulse { 0%, 100% { opacity: 0.55; transform: scale(1); } 50% { opacity: 0.85; transform: scale(1.04); } }
+@keyframes sg-rotate { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: no-preference) {
+  .sg-pulse { animation: sg-pulse 2.6s ease-in-out infinite; }
+  .sg-rotate { animation: sg-rotate 120s linear infinite; }
+}

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -7,6 +7,7 @@ import { useFactionDetail } from "./factionDetail/useFactionDetail";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import EphemeristsFactionHero from "../components/cards/EphemeristsFactionHero";
 import SnideFactionHero from "../components/cards/SnideFactionHero";
+import SingularityFactionHero from "../components/cards/SingularityFactionHero";
 
 /**
  * Faction detail page (`/factions/:slug`). Per-faction surface #13 in
@@ -34,6 +35,7 @@ export interface FactionHeroProps {
 const FACTION_HEROES: Record<string, ComponentType<FactionHeroProps>> = {
   ephemerists: EphemeristsFactionHero,
   snide: SnideFactionHero,
+  singularity: SingularityFactionHero,
 };
 
 export default function FactionDetail() {


### PR DESCRIPTION
Closes #222

Registers Singularity's four bespoke Tier-3 surfaces, mirroring the existing faction dispatchers, ported from `docs/design/design-system/templates/singularity/` onto real app props/tokens.

| Surface | Component | Dispatcher |
|---|---|---|
| Vote | `vote/SingularityVote.tsx` | `FACTION_VOTE` (VoteUI.tsx) |
| Backdrop | `backdrop/SingularityBackdrop.tsx` | `FACTION_BACKDROPS` (FactionBackdrop.tsx) |
| Avatar | `avatar/SingularityAvatar.tsx` | `FACTION_AVATARS` (FactionAvatar.tsx) |
| Faction hero | `cards/SingularityFactionHero.tsx` | `FACTION_HEROES` (FactionDetail.tsx) |

- **Vote** mirrors the `EphemeristsVote`/`SnideVote` contract (caster/summary modes, `useVote`, login gate) as a terminal consensus-array confidence ramp.
- **Avatar** composes the shared `BadgedAvatar` with terminal-token circle + an inline terminal-prompt `>` sigil.
- **Hero** consumes `FactionHeroProps`, labeling members/tasks/praxes counts in the terminal voice.

## Always-dark
Every surface styles its own container with the `--faction-singularity-*` tokens (identical light/dark terminal black/green/blue) — **no `document` theme mutation**. No hardcoded hex; sub-shades via `color-mix`. Adds the `sg-pulse` / `sg-rotate` keyframes (reduced-motion-guarded) used by the hero glow/sigil.

## Tests
- `npm test` — 62/62 pass. `npx tsc --noEmit` clean for all new files.
- ⚠️ `npm run build` red only on the **pre-existing, unrelated** `CollaborationDetail.tsx` `getPraxisVotes` break (ADR-0014 fallout, flagged separately); CI (`npm test` + `pytest`) is green and this PR adds no new build errors.