### PR TITLE
Build 5 praxis-read faction archetypes (snide/singularity/everymen/wow/ua)

### DIFF
--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -14,14 +14,24 @@ import type { PraxisDetailState } from './praxisDetail/usePraxisDetail'
 import { pickVariant } from '../utils/factionDispatch'
 import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
 import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
+import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
+import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
+import EverymenPraxisDetail from './praxisDetail/archetypes/EverymenPraxisDetail'
+import WowPraxisDetail from './praxisDetail/archetypes/WowPraxisDetail'
+import UAPraxisDetail from './praxisDetail/archetypes/UAPraxisDetail'
 import CommentThread from '../components/comments/CommentThread'
 
 /**
  * Per-faction praxis-read archetype map. Keyed by task faction slug.
  * Add one row per faction as its read-page design lands (ADR-0017, gap tracker).
  */
-const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDetailState }>> = {
+export const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDetailState }>> = {
   ephemerists: EphemeristsPraxisDetail,
+  snide: SnidePraxisDetail,
+  singularity: SingularityPraxisDetail,
+  everymen: EverymenPraxisDetail,
+  wow: WowPraxisDetail,
+  ua: UAPraxisDetail,
 }
 
 export default function PraxisDetail() {

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Praxis-read content-slot invariant guard (ADR-0017 §2, ADR-0002).
+ *
+ * Every per-faction praxis-read archetype wears a different skin (gilt salon,
+ * ransom dossier, terminal printout, union poster, whimsy.exe, illuminated
+ * vellum) but must render the same CONTENT slots — an archetype may *arrange*
+ * them freely but may not *drop* one. This walks the real `ARCHETYPE_BY_SLUG`
+ * registry (plus the Default fallback) and asserts every registered archetype
+ * still emits the invariant slots, so a new faction that drops one fails here.
+ *
+ * Rendered to static markup (no DOM); `useAuth` resolves to its default
+ * anonymous context, so the vote caster renders its login gate rather than
+ * throwing. We assert the structural anchors each slot leaves behind: the
+ * finding text, the "re:" task link, and the author-byline character link.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { ARCHETYPE_BY_SLUG } from "../../PraxisDetail";
+import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
+import type { PraxisDetailState } from "../usePraxisDetail";
+import type { PraxisOut } from "../../../api/praxis";
+import type { VoteSummary } from "../../../api/votes";
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  // Tag-stripped text — several archetypes split the finding across spans
+  // (the Ephemerists' lapis last-word), so the headline only reads contiguously
+  // once the wrapping tags are removed.
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+const PRAXIS: PraxisOut = {
+  id: 1,
+  task_id: 7,
+  task_title: "Mangrove",
+  task_point_value: 30,
+  task_level_required: 3,
+  task_faction_slug: "ua",
+  type: "solo",
+  status: "submitted",
+  title: "Reforestation",
+  body_text: "Seedlings planted along the estuary.",
+  moderation_status: "visible",
+  admin_note: null,
+  flagged_at: null,
+  submitted_at: "2026-01-02T00:00:00Z",
+  created_by_id: 3,
+  created_by_display_name: "Ada",
+  created_by_faction_slug: "ua",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+  members: [],
+  invites: [],
+  media_items: [],
+  score: 42,
+  duel_id: null,
+  can_flag: true,
+  applied_metatasks: [],
+};
+
+const VOTES: VoteSummary = {
+  praxis_id: 1,
+  total_votes: 4,
+  average_value: 4.2,
+  total_score: 16,
+};
+
+/** Minimal state — the read archetypes consume praxis + votes for presentation;
+ *  behavior-slot state is left in its default (anonymous, non-owner) shape. */
+function state(): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: PRAXIS,
+    fetchError: null,
+    votes: VOTES,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: "",
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: "",
+    setFlagReason: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleResubmit: async () => {},
+    handleFlag: async () => {},
+    metatasks: [],
+    metataskLoading: false,
+    metataskError: null,
+    applyingMetataskId: null,
+    removingMetataskId: null,
+    handleApplyMetatask: async () => {},
+    handleRemoveMetatask: async () => {},
+  };
+}
+
+// Default fallback is a registered renderable too — guard it alongside the map.
+const archetypes = { ...ARCHETYPE_BY_SLUG, __default__: DefaultPraxisDetail };
+
+describe("praxis-read content-slot invariant", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders the finding, task link, and author byline`, () => {
+      const { html, text } = render(<Archetype state={state()} />);
+      expect(text, "finding/title slot").toContain("Reforestation");
+      expect(text, "account-body slot").toContain("Seedlings");
+      expect(html, "re-task-link slot").toContain('href="/tasks/7"');
+      expect(html, "author-byline slot").toContain('href="/characters/3"');
+    });
+  }
+});

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -1,0 +1,270 @@
+/**
+ * The Everymen praxis-read page archetype.
+ *
+ * Built from the Everymen canon: a union WORK REPORT filed at the hall, skinned
+ * as a WW2 mobilize / victory poster. Stamped red masthead with a hard ink
+ * drop-shadow, a red→gold stripe rule, the job-reference eyebrow, a poster
+ * headline, the actor-scoped byline + base points, the report body, proof-of-work
+ * plates, and the approval-stamp Concordance caster.
+ *
+ * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
+ * the shared module — this archetype owns only presentation.
+ *
+ * All colors via --faction-everymen* + the private --everymen-* palette
+ * (index.css). Fonts via var(--font-accent) (Bebas) / var(--font-body).
+ * Shades via color-mix(). Theme flips automatically through the tokens.
+ * Actor-scoped byline themes to the AUTHOR's faction, not the task's.
+ */
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import MediaGallery from '../../../components/MediaGallery'
+import EverymenVote from '../../../components/vote/EverymenVote'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+const POSTER = 'var(--font-accent)' // Bebas Neue
+const BODY = 'var(--font-body)'
+const STRIPE = 'repeating-linear-gradient(90deg, var(--everymen-red) 0 16px, var(--everymen-gold) 16px 26px)'
+
+function SectionHead({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 14, margin: '26px 0 16px' }}>
+      <h2
+        style={{
+          fontFamily: POSTER,
+          fontSize: 25,
+          letterSpacing: '0.04em',
+          margin: 0,
+          color: 'var(--everymen-paper-text)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {children}
+      </h2>
+      <span style={{ flex: 1, height: 3, background: STRIPE, opacity: 0.55 }} />
+    </div>
+  )
+}
+
+export default function EverymenPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const modeLabel = praxis.type === 'collab' ? 'COLLAB' : praxis.type === 'duel' ? 'DUEL' : 'SOLO'
+
+  return (
+    <div
+      className="py-8"
+      style={{
+        maxWidth: '46rem',
+        background: 'var(--everymen-paper)',
+        border: '1.5px solid var(--everymen-ink)',
+        boxShadow: '0 0 0 3px var(--everymen-paper), 0 0 0 4px var(--everymen-ink)',
+        padding: 0,
+        color: 'var(--everymen-paper-text)',
+        fontFamily: BODY,
+      }}
+    >
+      {/* ── Stamped masthead ── */}
+      <div
+        style={{
+          background: 'var(--everymen-red)',
+          color: 'var(--everymen-cream)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 12,
+          padding: '10px 22px',
+        }}
+      >
+        <span style={{ fontFamily: POSTER, fontSize: 26, letterSpacing: '0.08em', lineHeight: 1, whiteSpace: 'nowrap' }}>
+          Work Report · Filed
+        </span>
+        <span style={{ fontFamily: BODY, fontSize: 9, letterSpacing: '0.12em', textAlign: 'right' }}>
+          {modeLabel}
+        </span>
+      </div>
+      {/* red→gold stripe rule */}
+      <div style={{ height: 4, background: STRIPE }} />
+
+      <div style={{ padding: '24px 30px 30px' }}>
+        {/* ── Behavior slots (invariant — from shared module) ── */}
+        <PraxisAdminBar state={state} />
+        <PraxisStatusBanners state={state} />
+
+        {/* ── Identity / status strip ── */}
+        <div style={{ fontSize: 9, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--everymen-muted)', marginBottom: 4 }}>
+          <Link to={`/tasks/${praxis.task_id}`} style={{ color: 'var(--everymen-muted)', textDecoration: 'none' }}>
+            re: {praxis.task_title}
+          </Link>
+          {' · '}lvl {praxis.task_level_required}
+          {' · '}sealed {formatTimestamp(sealedDate)}
+          {praxis.moderation_status === 'flagged' && (
+            <>
+              {' · '}
+              <span
+                style={{
+                  fontFamily: POSTER,
+                  letterSpacing: '0.1em',
+                  color: 'var(--everymen-cream)',
+                  background: 'var(--everymen-red)',
+                  border: '1px solid var(--everymen-ink)',
+                  padding: '1px 6px',
+                }}
+              >
+                FLAGGED
+              </span>
+            </>
+          )}
+        </div>
+        <div style={{ fontSize: 9, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--everymen-red)', marginBottom: 8 }}>
+          the job, done
+        </div>
+
+        {/* ── Poster headline ── */}
+        <h1
+          style={{
+            fontFamily: POSTER,
+            fontWeight: 400,
+            fontSize: 52,
+            lineHeight: 0.98,
+            letterSpacing: '0.01em',
+            margin: 0,
+            color: 'var(--everymen-paper-text)',
+          }}
+        >
+          {praxis.title || 'Untitled filing'}
+        </h1>
+
+        {/* ── Owner actions ── */}
+        <div style={{ marginTop: 16 }}>
+          <PraxisOwnerActions state={state} />
+        </div>
+
+        {/* ── Actor-scoped byline + base points ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 13,
+            paddingTop: 18,
+            marginTop: 18,
+            borderTop: '2px solid var(--everymen-ink)',
+          }}
+        >
+          <Link to={`/characters/${praxis.created_by_id}`} style={{ flexShrink: 0 }}>
+            <span
+              style={{
+                display: 'block',
+                width: 40,
+                height: 40,
+                borderRadius: '50%',
+                background: `radial-gradient(circle at 32% 28%, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}, ${factionCssVar(praxis.created_by_faction_slug, 'card-bg')} 72%)`,
+                border: '1.5px solid var(--everymen-ink)',
+              }}
+            />
+          </Link>
+          <div style={{ lineHeight: 1.35, minWidth: 0, flex: 1 }}>
+            <Link
+              to={`/characters/${praxis.created_by_id}`}
+              style={{
+                fontFamily: POSTER,
+                fontSize: 22,
+                color: 'var(--everymen-paper-text)',
+                lineHeight: 1,
+                textDecoration: 'none',
+                display: 'block',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
+            </Link>
+            <div style={{ fontSize: 9, letterSpacing: '0.06em', color: 'var(--everymen-muted)', marginTop: 3 }}>
+              {praxis.type === 'collab' ? 'all hands' : praxis.type === 'duel' ? 'head to head' : 'one pair of hands'}
+            </div>
+          </div>
+          {/* base points from the task */}
+          <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
+            <div style={{ fontFamily: POSTER, fontSize: 30, lineHeight: 1, color: 'var(--everymen-red)' }}>
+              ★ {praxis.task_point_value}
+            </div>
+            <div style={{ fontSize: 8, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--everymen-muted)', marginTop: 3 }}>
+              base points
+            </div>
+          </div>
+        </div>
+
+        {/* ── The report (account body) ── */}
+        {praxis.body_text && (
+          <>
+            <SectionHead>The Work</SectionHead>
+            <div
+              className="markdown-preview"
+              style={{
+                fontFamily: BODY,
+                fontSize: 13,
+                lineHeight: 1.7,
+                color: 'var(--everymen-paper-text)',
+              }}
+            >
+              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
+            </div>
+          </>
+        )}
+
+        {/* ── Proof of work (evidence) ── */}
+        {praxis.media_items.length > 0 && (
+          <>
+            <SectionHead>
+              Proof of Work · {praxis.media_items.length} {praxis.media_items.length === 1 ? 'plate' : 'plates'}
+            </SectionHead>
+            <div
+              style={{
+                border: '1.5px solid var(--everymen-ink)',
+                background: 'var(--everymen-cream)',
+                boxShadow: '3px 4px 0 color-mix(in srgb, var(--everymen-ink) 18%, transparent)',
+                padding: 10,
+              }}
+            >
+              <MediaGallery media={praxis.media_items} layout="grid" />
+            </div>
+          </>
+        )}
+
+        {/* ── The crew's marks (vote caster) ── */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', margin: '26px 0 16px', gap: 14 }}>
+          <h2 style={{ fontFamily: POSTER, fontSize: 25, letterSpacing: '0.04em', margin: 0, color: 'var(--everymen-paper-text)', whiteSpace: 'nowrap' }}>
+            The Crew's Marks
+          </h2>
+          {/* points from votes */}
+          {votes && votes.total_votes > 0 && (
+            <div style={{ textAlign: 'right', flexShrink: 0 }}>
+              <span style={{ fontFamily: POSTER, fontSize: 24, lineHeight: 1, color: 'var(--everymen-red)' }}>
+                +{votes.total_score}
+              </span>
+              <span style={{ fontFamily: BODY, fontSize: 8, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--everymen-muted)', marginLeft: 6 }}>
+                pts from votes
+              </span>
+            </div>
+          )}
+        </div>
+        <div style={{ marginBottom: 20 }}>
+          <EverymenVote
+            praxisId={praxis.id}
+            averageStars={votes?.average_value}
+            totalVotes={votes?.total_votes}
+            mode="caster"
+          />
+        </div>
+
+        {/* ── Flag block ── */}
+        <PraxisFlagBlock state={state} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -1,0 +1,448 @@
+/**
+ * The Singularity praxis-read page archetype.
+ *
+ * Built from the Singularity canon: the TERMINAL PRINTOUT — continuous-feed
+ * paper with sprocket holes, scanlines, corner brackets, a blinking cursor, and
+ * the signal-trace running head. A SEALED praxis is a filed protocol the faction
+ * now casts signals on; the 1-5 vote is THE CONSENSUS ARRAY.
+ *
+ * Singularity is ALWAYS-DARK — its --faction-singularity-* tokens hold identical
+ * terminal values in both themes, so this archetype styles its own container with
+ * those tokens and NEVER mutates document theme. No hardcoded hex: every colour
+ * is a --faction-singularity-* token or a color-mix / rgba overlay derived from
+ * one. Actor-scoped byline themes to the AUTHOR's faction, not the task's.
+ *
+ * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
+ * the shared module — this archetype owns only presentation.
+ */
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import MediaGallery from '../../../components/MediaGallery'
+import SingularityVote from '../../../components/vote/SingularityVote'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+// ── Terminal atoms (presentation only — no shared behavior) ──────────────────
+
+/** Continuous-feed sprocket strip — the printout's torn-edge perforation. */
+function Sprockets({ position }: { position: 'top' | 'bottom' }) {
+  const border =
+    position === 'top'
+      ? { borderBottom: '1px solid var(--faction-singularity-border-hard)' }
+      : { borderTop: '1px solid var(--faction-singularity-border-hard)' }
+  return (
+    <div
+      aria-hidden
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '5px 10px',
+        background: 'color-mix(in srgb, var(--faction-singularity-muted) 10%, transparent)',
+        ...border,
+      }}
+    >
+      {Array.from({ length: 14 }).map((_, sprocketIndex) => (
+        <span
+          key={sprocketIndex}
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: '50%',
+            background: 'var(--faction-singularity-card-bg)',
+            border: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 45%, transparent)',
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** A labelled section rule — `> LABEL ─────────`. */
+function SgDivider({ label }: { label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '20px 0 12px' }}>
+      <span
+        style={{
+          fontFamily: 'var(--font-faction-terminal)',
+          fontSize: 7,
+          letterSpacing: '0.24em',
+          textTransform: 'uppercase',
+          color: 'color-mix(in srgb, var(--faction-singularity-card-accent) 55%, transparent)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {'> '}{label}
+      </span>
+      <div
+        style={{
+          flex: 1,
+          height: 1,
+          background: 'color-mix(in srgb, var(--faction-singularity-muted) 28%, transparent)',
+        }}
+      />
+    </div>
+  )
+}
+
+const INSTANCE_LABEL: Record<string, string> = {
+  solo: 'SOLO',
+  collab: 'NETWORKED',
+  duel: 'ADVERSARIAL',
+}
+
+export default function SingularityPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const grade = praxis.task_level_required > 0 ? praxis.task_level_required : '—'
+  const instance = INSTANCE_LABEL[praxis.type] ?? praxis.type.toUpperCase()
+
+  return (
+    <div
+      className="py-8 max-w-2xl"
+      style={{
+        position: 'relative',
+        fontFamily: 'var(--font-faction-terminal)',
+        color: 'var(--faction-singularity-card-text)',
+        background: 'var(--faction-singularity-card-bg)',
+        border: '1px solid var(--faction-singularity-border-hard)',
+        boxShadow:
+          '0 0 0 1px color-mix(in srgb, var(--faction-singularity-muted) 12%, transparent), 0 0 40px -20px color-mix(in srgb, var(--faction-singularity-card-accent) 30%, transparent)',
+        overflow: 'hidden',
+        padding: 0,
+      }}
+    >
+      {/* Scanline overlay — phosphor-green stripes, multiply-soft, never interactive */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          inset: 0,
+          zIndex: 1,
+          pointerEvents: 'none',
+          backgroundImage:
+            'repeating-linear-gradient(to bottom, transparent 0 2px, rgba(74,222,128,0.025) 2px 4px)',
+        }}
+      />
+
+      <div style={{ position: 'relative', zIndex: 2 }}>
+        {/* ── Top perforation ── */}
+        <Sprockets position="top" />
+
+        {/* ── Signal-trace running head ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+            flexWrap: 'wrap',
+            padding: '12px 24px',
+            borderBottom: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 28%, transparent)',
+            background: 'color-mix(in srgb, var(--faction-singularity-card-accent) 3%, transparent)',
+          }}
+        >
+          <span
+            style={{
+              fontSize: 9,
+              letterSpacing: '0.22em',
+              textTransform: 'uppercase',
+              color: 'var(--faction-singularity-muted)',
+            }}
+          >
+            Singularity · sealed protocol
+          </span>
+          <span
+            style={{
+              fontSize: 8,
+              letterSpacing: '0.12em',
+              color: 'color-mix(in srgb, var(--faction-singularity-muted) 55%, transparent)',
+            }}
+          >
+            SIGNAL_TRACE // {formatTimestamp(sealedDate)}
+          </span>
+        </div>
+
+        <div style={{ padding: '20px 24px 28px' }}>
+          {/* ── Behavior slots (invariant — from shared module) ── */}
+          <PraxisAdminBar state={state} />
+          <PraxisStatusBanners state={state} />
+
+          {/* ── Status line — identity + moderation ── */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              marginBottom: 16,
+              flexWrap: 'wrap',
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 7,
+                background: 'var(--faction-singularity-card-accent)',
+                color: 'var(--faction-singularity-card-bg)',
+                fontSize: 8,
+                letterSpacing: '0.2em',
+                textTransform: 'uppercase',
+                padding: '4px 12px',
+                fontWeight: 700,
+              }}
+            >
+              ● SEALED
+            </span>
+            <span
+              style={{
+                fontSize: 7.5,
+                padding: '4px 10px',
+                border: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 40%, transparent)',
+                color: 'color-mix(in srgb, var(--faction-singularity-muted) 80%, transparent)',
+                letterSpacing: '0.14em',
+              }}
+            >
+              {instance}
+            </span>
+            <Link
+              to={`/tasks/${praxis.task_id}`}
+              style={{
+                fontSize: 8,
+                letterSpacing: '0.08em',
+                textDecoration: 'none',
+                color: 'color-mix(in srgb, var(--faction-singularity-card-accent) 65%, transparent)',
+              }}
+            >
+              re: {praxis.task_title}
+            </Link>
+            <span style={{ color: 'color-mix(in srgb, var(--faction-singularity-muted) 35%, transparent)', fontSize: 8 }}>·</span>
+            <span
+              style={{
+                fontSize: 8,
+                letterSpacing: '0.1em',
+                color: 'color-mix(in srgb, var(--faction-singularity-muted) 60%, transparent)',
+              }}
+            >
+              GRADE 0x0{grade} · {praxis.task_point_value} CR
+            </span>
+            {praxis.moderation_status === 'flagged' && (
+              <>
+                <span style={{ color: 'color-mix(in srgb, var(--faction-singularity-muted) 35%, transparent)', fontSize: 8 }}>·</span>
+                <span
+                  style={{
+                    fontSize: 7,
+                    letterSpacing: '0.12em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-danger)',
+                    border: '1px solid var(--color-danger)',
+                    padding: '1px 6px',
+                  }}
+                >
+                  flagged
+                </span>
+              </>
+            )}
+          </div>
+
+          {/* ── Output headline ── */}
+          <div style={{ marginBottom: 18 }}>
+            <div
+              style={{
+                fontSize: 7,
+                letterSpacing: '0.2em',
+                marginBottom: 8,
+                color: 'color-mix(in srgb, var(--faction-singularity-muted) 55%, transparent)',
+              }}
+            >
+              {'> OUTPUT:'}
+            </div>
+            <h1
+              style={{
+                fontFamily: 'var(--font-faction-terminal)',
+                fontWeight: 700,
+                fontSize: 34,
+                lineHeight: 1.08,
+                letterSpacing: '0.02em',
+                margin: 0,
+                color: 'var(--faction-singularity-card-accent)',
+              }}
+            >
+              {praxis.title ?? 'UNTITLED OUTPUT'}
+              <span
+                className="sg-blink"
+                aria-hidden
+                style={{
+                  display: 'inline-block',
+                  width: 8,
+                  height: 30,
+                  marginLeft: 6,
+                  verticalAlign: 'middle',
+                  background: 'var(--faction-singularity-card-accent)',
+                }}
+              />
+            </h1>
+          </div>
+
+          {/* ── Owner actions ── */}
+          <PraxisOwnerActions state={state} />
+
+          {/* ── Actor-scoped byline — themed to AUTHOR's faction ── */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              paddingBottom: 18,
+              marginBottom: 8,
+              borderBottom: '1px dashed color-mix(in srgb, var(--faction-singularity-muted) 28%, transparent)',
+            }}
+          >
+            <Link to={`/characters/${praxis.created_by_id}`}>
+              <div
+                style={{
+                  width: 38,
+                  height: 38,
+                  borderRadius: '50%',
+                  flexShrink: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 10,
+                  letterSpacing: '0.06em',
+                  color: 'var(--faction-singularity-muted)',
+                  background: `color-mix(in srgb, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')} 20%, var(--faction-singularity-card-bg))`,
+                  border: `1px solid ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}`,
+                }}
+              >
+                N
+              </div>
+            </Link>
+            <div style={{ flex: 1, minWidth: 0, lineHeight: 1.4 }}>
+              <Link
+                to={`/characters/${praxis.created_by_id}`}
+                style={{
+                  fontSize: 13,
+                  textDecoration: 'none',
+                  color: 'var(--faction-singularity-card-accent)',
+                  display: 'block',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                NODE_{praxis.created_by_display_name || `#${praxis.created_by_id}`}
+              </Link>
+              <span
+                style={{
+                  fontSize: 8,
+                  letterSpacing: '0.06em',
+                  color: 'color-mix(in srgb, var(--faction-singularity-muted) 50%, transparent)',
+                }}
+              >
+                {instance.toLowerCase()} instance
+              </span>
+            </div>
+            {/* Base point value from task */}
+            <div style={{ textAlign: 'right', flexShrink: 0 }}>
+              <div style={{ fontSize: 26, lineHeight: 1, color: 'var(--faction-singularity-card-accent)' }}>
+                {praxis.task_point_value}
+              </div>
+              <div
+                style={{
+                  fontSize: 7,
+                  letterSpacing: '0.12em',
+                  marginTop: 2,
+                  color: 'color-mix(in srgb, var(--faction-singularity-muted) 50%, transparent)',
+                }}
+              >
+                BASE CREDITS
+              </div>
+            </div>
+          </div>
+
+          {/* ── The account body → PROCESS_LOG ── */}
+          {praxis.body_text && (
+            <>
+              <SgDivider label="PROCESS_LOG" />
+              <div
+                className="markdown-preview"
+                style={{
+                  fontSize: 11,
+                  lineHeight: 1.75,
+                  color: 'color-mix(in srgb, var(--faction-singularity-card-accent) 78%, transparent)',
+                  marginBottom: 8,
+                }}
+              >
+                <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
+              </div>
+            </>
+          )}
+
+          {/* ── Evidence → ARTIFACTS, terminal-framed ── */}
+          {praxis.media_items.length > 0 && (
+            <>
+              <SgDivider
+                label={`ARTIFACTS · ${praxis.media_items.length} ${praxis.media_items.length === 1 ? 'file' : 'files'} submitted`}
+              />
+              <div
+                style={{
+                  border: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 30%, transparent)',
+                  background: 'color-mix(in srgb, var(--faction-singularity-muted) 6%, transparent)',
+                  padding: 10,
+                }}
+              >
+                <MediaGallery media={praxis.media_items} layout="grid" />
+              </div>
+            </>
+          )}
+
+          {/* ── The consensus array (vote caster) ── */}
+          <SgDivider label="CONSENSUS_ARRAY" />
+          <div style={{ marginBottom: 20 }}>
+            {votes && votes.total_votes > 0 && (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  justifyContent: 'flex-end',
+                  gap: 6,
+                  marginBottom: 12,
+                }}
+              >
+                <span style={{ fontSize: 18, lineHeight: 1, color: 'var(--faction-singularity-card-accent)' }}>
+                  +{votes.total_score}
+                </span>
+                <span
+                  style={{
+                    fontSize: 7,
+                    letterSpacing: '0.14em',
+                    color: 'color-mix(in srgb, var(--faction-singularity-muted) 55%, transparent)',
+                  }}
+                >
+                  CR FROM SIGNALS
+                </span>
+              </div>
+            )}
+            <SingularityVote
+              praxisId={praxis.id}
+              averageStars={votes?.average_value}
+              totalVotes={votes?.total_votes}
+              mode="caster"
+            />
+          </div>
+
+          {/* ── Flag block ── */}
+          <PraxisFlagBlock state={state} />
+        </div>
+
+        {/* ── Bottom perforation ── */}
+        <Sprockets position="bottom" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -1,0 +1,433 @@
+/**
+ * The S.N.I.D.E. praxis-read page archetype.
+ *
+ * Built from the SNIDE canon: a ransom/xerox dossier — a CLOSED CASE filed on
+ * photocopier-ink stock, with acid-green and hot-zine-pink ransom stamps, taped
+ * confession on ruled notebook paper, and exhibit-framed evidence. SNIDE is
+ * ALWAYS-DARK: the ink surface is scoped to this archetype's own container via
+ * the --faction-snide-card-* / --faction-snide-* tokens (index.css). We never
+ * mutate the document theme, so the dossier reads identically in light + dark.
+ *
+ * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
+ * the shared module — this archetype owns only presentation. The actor-scoped
+ * byline themes to the AUTHOR's faction, not the task's.
+ */
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import MediaGallery from '../../../components/MediaGallery'
+import SnideVote from '../../../components/vote/SnideVote'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+// Always-dark dossier tokens (scoped to this archetype's container).
+const INK = 'var(--faction-snide-card-bg)' // photocopier ink — the surface
+const PAPER_TEXT = 'var(--faction-snide-card-text)' // warm xerox paper, on ink
+const MUTED = 'var(--faction-snide-card-muted)' // faded newsprint grey
+const ACID = 'var(--faction-snide-acid)' // toxic / radioactive green
+const PINK = 'var(--faction-snide-pink)' // hot zine pink
+const PAPER = 'var(--faction-snide-paper)' // warm xerox stock (the notebook)
+const PAPER_INK = 'var(--faction-snide-ink)' // ink on the paper inserts
+
+const F_ANTON = 'var(--faction-snide-font-impact)'
+const F_COND = 'var(--faction-snide-font-cond)'
+const F_MARKER = 'var(--faction-snide-font-marker)'
+const F_BODY = 'var(--font-body)'
+
+export default function SnidePraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const grade = praxis.task_level_required > 0 ? praxis.task_level_required : '—'
+  const mode =
+    praxis.type === 'solo' ? 'solo job' : praxis.type === 'collab' ? 'crew job' : 'turf war'
+
+  return (
+    <div
+      className="py-8 max-w-2xl"
+      style={{
+        position: 'relative',
+        fontFamily: F_BODY,
+        color: PAPER_TEXT,
+        background: INK,
+        border: `1.5px solid ${ACID}`,
+        boxShadow: '6px 7px 0 rgba(0,0,0,0.4)',
+        padding: '28px 30px',
+      }}
+    >
+      {/* Halftone screen over the ink — pointer-events: none */}
+      <div
+        className="ht-dots"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          color: 'rgba(182,255,46,0.06)',
+          pointerEvents: 'none',
+          zIndex: 1,
+        }}
+      />
+
+      {/* All content sits above the halftone */}
+      <div style={{ position: 'relative', zIndex: 2 }}>
+
+        {/* ── Stamped masthead ── */}
+        <div style={{ lineHeight: 0, marginBottom: 18 }}>
+          <div
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 9,
+              background: ACID,
+              color: PAPER_INK,
+              padding: '8px 16px',
+              transform: 'rotate(-1.5deg)',
+              boxShadow: `4px 4px 0 ${PINK}`,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: F_COND,
+                fontSize: 17,
+                letterSpacing: '0.14em',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              S.N.I.D.E. · CLOSED CASE · FILED
+            </span>
+          </div>
+        </div>
+
+        {/* ── Behavior slots (invariant — from shared module) ── */}
+        <PraxisAdminBar state={state} />
+        <PraxisStatusBanners state={state} />
+
+        {/* ── Case-file status strip ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            marginBottom: 14,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Link
+            to={`/tasks/${praxis.task_id}`}
+            style={{
+              fontFamily: F_COND,
+              fontSize: 13,
+              letterSpacing: '0.08em',
+              color: ACID,
+              textDecoration: 'none',
+              textTransform: 'uppercase',
+            }}
+          >
+            re: {praxis.task_title}
+          </Link>
+          <span style={{ color: MUTED, fontSize: 9 }}>·</span>
+          <span
+            style={{
+              fontFamily: F_BODY,
+              fontSize: 8.5,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: MUTED,
+            }}
+          >
+            grade {grade}
+          </span>
+          <span style={{ color: MUTED, fontSize: 9 }}>·</span>
+          <span
+            style={{
+              fontFamily: F_BODY,
+              fontSize: 8.5,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: MUTED,
+            }}
+          >
+            {mode}
+          </span>
+          <span style={{ color: MUTED, fontSize: 9 }}>·</span>
+          <span
+            style={{
+              fontFamily: F_BODY,
+              fontSize: 8.5,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: MUTED,
+            }}
+          >
+            filed {formatTimestamp(sealedDate)}
+          </span>
+          {praxis.moderation_status === 'flagged' && (
+            <span
+              style={{
+                fontFamily: F_COND,
+                fontSize: 11,
+                letterSpacing: '0.1em',
+                color: '#fff',
+                background: PINK,
+                padding: '1px 8px',
+                transform: 'rotate(-3deg)',
+                textTransform: 'uppercase',
+              }}
+            >
+              flagged
+            </span>
+          )}
+        </div>
+
+        {/* ── The finding (headline) ── */}
+        <h1
+          style={{
+            fontFamily: F_ANTON,
+            fontSize: 40,
+            lineHeight: 0.9,
+            color: PAPER_TEXT,
+            margin: '0 0 14px',
+            transform: 'skewX(-4deg)',
+            letterSpacing: '0.01em',
+          }}
+        >
+          {praxis.title ?? 'Untitled confession'}
+        </h1>
+
+        {/* Acid rule */}
+        <div
+          style={{
+            height: 2,
+            background: `linear-gradient(90deg, ${PINK}, ${ACID}, transparent)`,
+            marginBottom: 16,
+          }}
+        />
+
+        {/* ── Owner actions ── */}
+        <PraxisOwnerActions state={state} />
+
+        {/* ── Actor-scoped byline (mugshot tab) ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 14,
+            marginBottom: 24,
+            paddingBottom: 16,
+            borderBottom: `1.5px dashed color-mix(in srgb, ${PAPER_TEXT} 30%, transparent)`,
+          }}
+        >
+          <Link to={`/characters/${praxis.created_by_id}`} style={{ flexShrink: 0 }}>
+            <div
+              style={{
+                width: 52,
+                height: 52,
+                borderRadius: '50%',
+                background: `linear-gradient(135deg, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}, ${factionCssVar(praxis.created_by_faction_slug, 'card-bg')})`,
+                border: `2px solid ${ACID}`,
+                transform: 'rotate(-4deg)',
+              }}
+            />
+          </Link>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Link
+              to={`/characters/${praxis.created_by_id}`}
+              style={{
+                fontFamily: F_MARKER,
+                fontSize: 22,
+                color: PINK,
+                textDecoration: 'none',
+                display: 'block',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
+            </Link>
+            <span
+              style={{
+                fontFamily: F_BODY,
+                fontSize: 8.5,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: MUTED,
+              }}
+            >
+              pulled it off
+            </span>
+          </div>
+          {/* Base point value from task */}
+          <div
+            style={{
+              flexShrink: 0,
+              display: 'inline-flex',
+              alignItems: 'baseline',
+              gap: 4,
+              background: PAPER_INK,
+              border: `1.5px solid ${PINK}`,
+              padding: '4px 10px',
+              transform: 'rotate(1.5deg)',
+            }}
+          >
+            <span style={{ fontFamily: F_ANTON, fontSize: 22, color: ACID, lineHeight: 1 }}>
+              +{praxis.task_point_value}
+            </span>
+            <span
+              style={{
+                fontFamily: F_BODY,
+                fontSize: 7,
+                letterSpacing: '0.14em',
+                textTransform: 'uppercase',
+                color: MUTED,
+              }}
+            >
+              base
+            </span>
+          </div>
+        </div>
+
+        {/* ── The confession (taped notebook) ── */}
+        {praxis.body_text && (
+          <div style={{ position: 'relative', marginBottom: 28 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                background: ACID,
+                color: PAPER_INK,
+                fontFamily: F_MARKER,
+                fontSize: 17,
+                padding: '3px 13px',
+                transform: 'rotate(-1.5deg)',
+                boxShadow: `2px 2px 0 ${PINK}`,
+                marginBottom: 12,
+              }}
+            >
+              the confession
+            </span>
+            <div
+              className="markdown-preview"
+              style={{
+                border: `1.5px solid ${PAPER_INK}`,
+                borderLeft: `4px solid ${PINK}`,
+                background: PAPER,
+                color: PAPER_INK,
+                backgroundImage:
+                  'repeating-linear-gradient(180deg, transparent 0 27px, color-mix(in srgb, var(--faction-snide-ink) 11%, transparent) 27px 28px)',
+                padding: '10px 18px 16px',
+                fontFamily: F_BODY,
+                fontSize: 13,
+                lineHeight: '28px',
+              }}
+            >
+              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* ── The evidence (exhibit frames) ── */}
+        {praxis.media_items.length > 0 && (
+          <div style={{ marginBottom: 30 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                background: ACID,
+                color: PAPER_INK,
+                fontFamily: F_MARKER,
+                fontSize: 17,
+                padding: '3px 13px',
+                transform: 'rotate(1.5deg)',
+                boxShadow: `2px 2px 0 ${PINK}`,
+                marginBottom: 14,
+              }}
+            >
+              evidence · {praxis.media_items.length}
+            </span>
+            <div
+              style={{
+                border: `1.5px solid ${ACID}`,
+                background: 'color-mix(in srgb, var(--faction-snide-acid) 6%, transparent)',
+                padding: 10,
+              }}
+            >
+              <MediaGallery media={praxis.media_items} layout="grid" />
+            </div>
+          </div>
+        )}
+
+        {/* ── Ransom divider ── */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 20 }}>
+          <div style={{ flex: 1, height: 2, background: `color-mix(in srgb, ${ACID} 40%, transparent)` }} />
+          <span style={{ fontFamily: F_MARKER, fontSize: 14, color: PINK, transform: 'rotate(-2deg)' }}>×</span>
+          <div style={{ flex: 1, height: 2, background: `color-mix(in srgb, ${ACID} 40%, transparent)` }} />
+        </div>
+
+        {/* ── Cast a vote (the verdict) ── */}
+        <div style={{ marginBottom: 20 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 10,
+              flexWrap: 'wrap',
+              marginBottom: 12,
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                background: PINK,
+                color: '#fff',
+                fontFamily: F_MARKER,
+                fontSize: 17,
+                padding: '3px 13px',
+                transform: 'rotate(-1deg)',
+                boxShadow: `2px 2px 0 ${PAPER_INK}`,
+              }}
+            >
+              the verdict
+            </span>
+            {/* Points from votes */}
+            {votes && votes.total_votes > 0 && (
+              <div
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'baseline',
+                  gap: 4,
+                  transform: 'rotate(1deg)',
+                }}
+              >
+                <span style={{ fontFamily: F_ANTON, fontSize: 22, color: ACID, lineHeight: 1 }}>
+                  +{votes.total_score}
+                </span>
+                <span
+                  style={{
+                    fontFamily: F_BODY,
+                    fontSize: 7,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: MUTED,
+                  }}
+                >
+                  pts from votes
+                </span>
+              </div>
+            )}
+          </div>
+          <SnideVote
+            praxisId={praxis.id}
+            averageStars={votes?.average_value}
+            totalVotes={votes?.total_votes}
+            mode="caster"
+          />
+        </div>
+
+        {/* ── Flag block ── */}
+        <PraxisFlagBlock state={state} />
+
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
@@ -1,0 +1,347 @@
+/**
+ * The University of Asthmatics (UA) praxis-read page archetype — the GILT SALON.
+ *
+ * Built from the UA canon: an acquisition sheet exhibited on a salon wall —
+ * burnt-amber/cream/gold/brown-ink palette, gilt-framed plate for the evidence,
+ * Playfair italics for the headline, EB-Garamond serif body, Marcellus-SC small
+ * caps for the regalia labels. The salon never dims: UA is always-light, so its
+ * --faction-ua* / --ua-* tokens are identical in both themes and we style the
+ * container with them directly without mutating the document theme.
+ *
+ * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
+ * the shared module — this archetype owns only presentation. Voting routes
+ * through the <VoteUI factionSlug=…> dispatcher, which falls back to the global
+ * vote stamps for UA (no bespoke UA vote component exists).
+ *
+ * All colors via --faction-ua* + the gilt private palette (--ua-*), index.css.
+ * Actor-scoped byline themes to the AUTHOR's faction, not the task's.
+ */
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import MediaGallery from '../../../components/MediaGallery'
+import VoteUI from '../../../components/vote/VoteUI'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+const DISPLAY = "'Playfair Display', serif"
+const REGALIA = "'Marcellus SC', serif"
+const SERIF = "'EB Garamond', serif"
+const MONO = "'Courier Prime', monospace"
+
+function modeLabel(type: string): string {
+  if (type === 'solo') return 'a sole acquisition'
+  if (type === 'collab') return 'a collaborative acquisition'
+  return 'a dueling acquisition'
+}
+
+export default function UAPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+
+  return (
+    <div
+      className="py-8 max-w-2xl"
+      style={{
+        position: 'relative',
+        background: 'var(--ua-paper)',
+        // gilt salon double-frame: paper inset, then a thin gold line
+        border: '1px solid var(--ua-line)',
+        boxShadow: `0 16px 38px color-mix(in srgb, var(--ua-ink) 16%, transparent),
+                    inset 0 0 0 4px var(--ua-paper),
+                    inset 0 0 0 5px var(--ua-line-soft)`,
+        padding: 0,
+      }}
+    >
+      {/* ── Header band — the acquisition sheet's letterhead ── */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 14,
+          padding: '12px 26px',
+          borderBottom: '1px solid var(--ua-line-soft)',
+          background: 'linear-gradient(180deg, color-mix(in srgb, var(--ua-gold-pale) 28%, var(--ua-paper)), var(--ua-paper))',
+        }}
+      >
+        <Link
+          to={`/tasks/${praxis.task_id}`}
+          style={{
+            fontFamily: REGALIA,
+            fontSize: 10,
+            letterSpacing: '0.14em',
+            color: 'var(--ua-gold)',
+            textDecoration: 'none',
+          }}
+        >
+          re: {praxis.task_title}
+        </Link>
+        <span
+          style={{
+            fontFamily: MONO,
+            fontSize: 8,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'var(--faction-ua)',
+            border: '1px solid var(--faction-ua-border)',
+            padding: '3px 9px',
+          }}
+        >
+          {praxis.moderation_status === 'flagged'
+            ? 'Under review'
+            : praxis.moderation_status === 'failed'
+            ? 'Returned'
+            : praxis.moderation_status === 'hidden'
+            ? 'Withdrawn from view'
+            : 'Exhibited'}
+        </span>
+      </div>
+
+      <div style={{ padding: '30px 30px 34px' }}>
+        {/* ── Behavior slots (invariant — from shared module) ── */}
+        <PraxisAdminBar state={state} />
+        <PraxisStatusBanners state={state} />
+
+        {/* ── Eyebrow: grade · mode · sealed ── */}
+        <div
+          style={{
+            fontFamily: MONO,
+            fontSize: 8,
+            letterSpacing: '0.22em',
+            textTransform: 'uppercase',
+            color: 'var(--ua-muted)',
+            marginBottom: 12,
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 8,
+            alignItems: 'center',
+          }}
+        >
+          <span>Acquisition · Grade {praxis.task_level_required > 0 ? praxis.task_level_required : '—'}</span>
+          <span style={{ color: 'var(--ua-line)' }}>·</span>
+          <span>{modeLabel(praxis.type)}</span>
+          <span style={{ color: 'var(--ua-line)' }}>·</span>
+          <span style={{ fontFamily: SERIF, fontSize: 11, fontStyle: 'italic', letterSpacing: 0, textTransform: 'none', color: 'var(--ua-sub)' }}>
+            returned to the Salon {formatTimestamp(sealedDate)}
+          </span>
+        </div>
+
+        {/* ── The headline ── */}
+        <h1
+          style={{
+            fontFamily: DISPLAY,
+            fontStyle: 'italic',
+            fontWeight: 600,
+            fontSize: 42,
+            lineHeight: 1.06,
+            color: 'var(--ua-ink)',
+            marginBottom: 18,
+          }}
+        >
+          {praxis.title ?? 'Untitled acquisition'}
+        </h1>
+
+        {/* ── Owner actions ── */}
+        <PraxisOwnerActions state={state} />
+
+        {/* ── Actor-scoped byline (themed to AUTHOR faction) ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 14,
+            paddingBottom: 22,
+            marginBottom: 24,
+            borderBottom: '1px solid var(--ua-line-soft)',
+          }}
+        >
+          <Link to={`/characters/${praxis.created_by_id}`}>
+            <div
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: '50%',
+                flexShrink: 0,
+                border: `1px solid ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}`,
+                background: `linear-gradient(135deg, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}, ${factionCssVar(praxis.created_by_faction_slug, 'card-bg')})`,
+              }}
+            />
+          </Link>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Link
+              to={`/characters/${praxis.created_by_id}`}
+              style={{
+                fontFamily: SERIF,
+                fontStyle: 'italic',
+                fontWeight: 500,
+                fontSize: 15,
+                color: 'var(--ua-ink)',
+                textDecoration: 'none',
+                display: 'block',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
+            </Link>
+            <span
+              style={{
+                fontFamily: MONO,
+                fontSize: 8,
+                letterSpacing: '0.06em',
+                color: 'var(--ua-muted)',
+              }}
+            >
+              The acquiring hand
+            </span>
+          </div>
+          {/* Base point value from the task */}
+          <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
+            <div
+              style={{
+                fontFamily: DISPLAY,
+                fontStyle: 'italic',
+                fontWeight: 700,
+                fontSize: 30,
+                lineHeight: 1,
+                color: 'var(--ua-orange)',
+              }}
+            >
+              {praxis.task_point_value}
+            </div>
+            <div
+              style={{
+                fontFamily: REGALIA,
+                fontSize: 8,
+                letterSpacing: '0.1em',
+                color: 'var(--ua-muted)',
+                marginTop: 2,
+              }}
+            >
+              pts at stake
+            </div>
+          </div>
+        </div>
+
+        {/* ── The account (body) ── */}
+        {praxis.body_text && (
+          <div style={{ marginBottom: 26 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, margin: '0 0 16px' }}>
+              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
+              <span style={{ fontFamily: REGALIA, fontSize: 9, letterSpacing: '0.22em', color: 'var(--ua-gold)', whiteSpace: 'nowrap' }}>
+                The Process
+              </span>
+              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
+            </div>
+            <div
+              className="markdown-preview"
+              style={{
+                fontFamily: SERIF,
+                fontSize: 14,
+                lineHeight: 1.85,
+                color: 'var(--ua-sub)',
+              }}
+            >
+              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* ── The evidence — gilt-framed plate ── */}
+        {praxis.media_items.length > 0 && (
+          <div style={{ marginBottom: 26 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, margin: '0 0 16px' }}>
+              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
+              <span style={{ fontFamily: REGALIA, fontSize: 9, letterSpacing: '0.22em', color: 'var(--ua-gold)', whiteSpace: 'nowrap' }}>
+                The Plate · {praxis.media_items.length} {praxis.media_items.length === 1 ? 'work' : 'works'}
+              </span>
+              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
+            </div>
+            {/* gilt frame: gold-leaf outer, gold inner mat, then the gallery */}
+            <div
+              style={{
+                padding: 9,
+                background: 'var(--ua-gilt)',
+                boxShadow: `0 10px 22px color-mix(in srgb, var(--ua-ink) 20%, transparent),
+                            inset 0 0 0 1px color-mix(in srgb, white 40%, transparent)`,
+              }}
+            >
+              <div
+                style={{
+                  padding: 3,
+                  background: 'linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))',
+                }}
+              >
+                <div style={{ background: 'var(--ua-paper)', padding: 6 }}>
+                  <MediaGallery media={praxis.media_items} layout="grid" />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ── The critique (vote caster) ── */}
+        <div style={{ marginBottom: 18 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              justifyContent: 'space-between',
+              gap: 12,
+              marginBottom: 14,
+              paddingTop: 16,
+              borderTop: '1px solid var(--ua-line-soft)',
+            }}
+          >
+            <span style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: '0.2em', color: 'var(--ua-gold)' }}>
+              The Patronage
+            </span>
+            {/* Points earned from votes */}
+            {votes && votes.total_votes > 0 && (
+              <div style={{ textAlign: 'right' }}>
+                <span
+                  style={{
+                    fontFamily: DISPLAY,
+                    fontStyle: 'italic',
+                    fontWeight: 700,
+                    fontSize: 22,
+                    color: 'var(--ua-orange)',
+                  }}
+                >
+                  +{votes.total_score}
+                </span>
+                <span
+                  style={{
+                    fontFamily: REGALIA,
+                    fontSize: 8,
+                    letterSpacing: '0.12em',
+                    textTransform: 'uppercase',
+                    color: 'var(--ua-muted)',
+                    marginLeft: 6,
+                  }}
+                >
+                  points returned
+                </span>
+              </div>
+            )}
+          </div>
+          <VoteUI
+            factionSlug={praxis.task_faction_slug}
+            praxisId={praxis.id}
+            averageStars={votes?.average_value}
+            totalVotes={votes?.total_votes}
+            mode="caster"
+          />
+        </div>
+
+        {/* ── Flag block ── */}
+        <PraxisFlagBlock state={state} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -1,0 +1,447 @@
+/**
+ * Warriors of Whimsy praxis-read archetype — the sealed praxis rendered as a
+ * "praxis.exe" desktop window: pink computer-witch chrome with a traffic-light
+ * title bar, a dotted desktop body, Caveat-script "finding" headline, sparkle
+ * charms, dotted-running-rule section dividers, and a window-framed evidence
+ * shelf. Ported visually from the WoW praxis design kit (Warriors of Whimsy
+ * Praxis.html / whimsy-exe.jsx); wired to the real {@link PraxisDetailState}.
+ *
+ * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
+ * the shared module — this archetype owns only presentation. WoW flips with the
+ * theme normally, so every color reads from --faction-wow* tokens (light + dark
+ * already defined in index.css). No document-theme mutation, no hardcoded hex.
+ * The author byline themes to the AUTHOR's faction, not the task's.
+ */
+import type { CSSProperties } from 'react'
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import MediaGallery from '../../../components/MediaGallery'
+import WowVote from '../../../components/vote/WowVote'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+// ── whimsy.exe token vocabulary (same as TaskDetailWow) ──────────────────────
+const PINK = 'var(--faction-wow)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const DOT = 'var(--faction-wow-dot)'
+const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const BODY = 'var(--font-body)' // Courier Prime
+const ON_ACCENT = 'var(--color-text-on-accent)'
+
+/** Party-voiced label for the filing mode. */
+function modeVoice(type: string): string {
+  if (type === 'collab') return 'cast together'
+  if (type === 'duel') return 'cast in a duel'
+  return 'filed solo'
+}
+
+/** Sparkle charm — the kit's signature four-point star. */
+function Sparkle({ size, color, style }: { size: number; color: string; style?: CSSProperties }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style} aria-hidden="true">
+      <path
+        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+/** Dotted section divider with a centered sparkle + uppercase label. */
+function Divider({ label }: { label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, margin: '24px 0 16px' }}>
+      <span style={{ flex: 1, height: 0, borderTop: `2px dotted var(--faction-wow-border)` }} />
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          fontFamily: BODY,
+          fontSize: 9,
+          textTransform: 'uppercase',
+          letterSpacing: '0.18em',
+          color: CARD_MUTED,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <Sparkle size={9} color={PINK} /> {label}
+      </span>
+      <span style={{ flex: 1, height: 0, borderTop: `2px dotted var(--faction-wow-border)` }} />
+    </div>
+  )
+}
+
+/** Pink window title bar — traffic lights + a sparkle-prefixed window name. */
+function TitleBar({ name }: { name: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 7,
+        padding: '9px 14px',
+        background: `linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))`,
+        borderBottom: `2px solid ${WIN_BORDER}`,
+      }}
+    >
+      {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((lightColor) => (
+        <span
+          key={lightColor}
+          style={{
+            width: 11,
+            height: 11,
+            borderRadius: '50%',
+            background: lightColor,
+            border: '1.4px solid rgba(255,255,255,0.7)',
+          }}
+        />
+      ))}
+      <span
+        style={{
+          marginLeft: 'auto',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 5,
+          fontFamily: SCRIPT,
+          fontSize: 20,
+          color: TITLE_TEXT,
+          letterSpacing: '0.03em',
+        }}
+      >
+        <Sparkle size={11} color={TITLE_TEXT} /> {name}
+      </span>
+    </div>
+  )
+}
+
+export default function WowPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+
+  /** Soft rounded status pill shared across the chrome. */
+  const pill: CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    fontSize: 8.5,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    padding: '5px 11px',
+    borderRadius: 20,
+    background: 'var(--faction-wow-light)',
+    color: CARD_TEXT,
+    border: `1px solid var(--faction-wow-border)`,
+    whiteSpace: 'nowrap',
+  }
+
+  return (
+    <div className="py-8" style={{ fontFamily: BODY, color: CARD_TEXT }}>
+      <div style={{ maxWidth: 720, display: 'flex', flexDirection: 'column', gap: 16 }}>
+        {/* ── Behavior slots (invariant — from shared module) ── */}
+        <PraxisAdminBar state={state} />
+        <PraxisStatusBanners state={state} />
+
+        {/* ── The praxis.exe window ── */}
+        <div
+          style={{
+            position: 'relative',
+            borderRadius: 14,
+            overflow: 'hidden',
+            border: `2px solid ${WIN_BORDER}`,
+            boxShadow: `0 14px 34px color-mix(in srgb, ${PINK} 30%, transparent)`,
+          }}
+        >
+          <TitleBar name="praxis.exe" />
+
+          {/* desktop body — dotted grid */}
+          <div
+            style={{
+              position: 'relative',
+              padding: '26px 30px 30px',
+              background: NOTEPAD_BG,
+              backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+              backgroundSize: '15px 15px',
+            }}
+          >
+            <Sparkle
+              size={20}
+              color="var(--faction-wow-tape)"
+              style={{ position: 'absolute', top: 18, right: 22, transform: 'rotate(10deg)' }}
+            />
+
+            {/* ── 1 · status row: sealed · mode · re:task · level · moderation ── */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 9, flexWrap: 'wrap', marginBottom: 18 }}>
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  background: `linear-gradient(180deg, ${PINK}, ${CARD_MUTED})`,
+                  color: ON_ACCENT,
+                  fontSize: 8.5,
+                  letterSpacing: '0.16em',
+                  textTransform: 'uppercase',
+                  padding: '5px 12px',
+                  borderRadius: 20,
+                  fontWeight: 700,
+                  boxShadow: `0 3px 8px var(--faction-wow-light)`,
+                }}
+              >
+                <Sparkle size={10} color={ON_ACCENT} /> sealed
+              </span>
+              <span style={pill}>{modeVoice(praxis.type)}</span>
+              <span style={{ fontSize: 9.5, color: CARD_MUTED, letterSpacing: '0.04em' }}>
+                re:{' '}
+                <Link
+                  to={`/tasks/${praxis.task_id}`}
+                  style={{ color: TITLE_TEXT, fontWeight: 700, textDecoration: 'none' }}
+                >
+                  {praxis.task_title}
+                </Link>{' '}
+                · lvl {praxis.task_level_required} · sealed {formatTimestamp(sealedDate)}
+              </span>
+              {praxis.moderation_status === 'flagged' && (
+                <span
+                  style={{
+                    ...pill,
+                    color: 'var(--color-danger)',
+                    borderColor: 'var(--color-danger)',
+                    background: 'transparent',
+                  }}
+                >
+                  flagged
+                </span>
+              )}
+            </div>
+
+            {/* ── 1 · the finding headline ── */}
+            <div
+              style={{
+                fontSize: 9,
+                textTransform: 'uppercase',
+                letterSpacing: '0.2em',
+                color: CARD_MUTED,
+                marginBottom: 8,
+              }}
+            >
+              the finding
+            </div>
+            <h1
+              style={{
+                fontFamily: SCRIPT,
+                fontWeight: 700,
+                fontSize: 46,
+                lineHeight: 1.12,
+                margin: 0,
+                color: TITLE_TEXT,
+                overflowWrap: 'anywhere',
+              }}
+            >
+              {praxis.title ?? 'Untitled spell'}
+            </h1>
+
+            {/* ── Owner actions (invariant) ── */}
+            <div style={{ marginTop: 16 }}>
+              <PraxisOwnerActions state={state} />
+            </div>
+
+            {/* ── 2 · author byline (themed to AUTHOR faction) + 6 · points earned ── */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                paddingTop: 18,
+                marginTop: 18,
+                borderTop: `2px dotted var(--faction-wow-border)`,
+              }}
+            >
+              <Link to={`/characters/${praxis.created_by_id}`} style={{ flexShrink: 0 }}>
+                <span
+                  style={{
+                    display: 'flex',
+                    width: 40,
+                    height: 40,
+                    borderRadius: '50%',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: `linear-gradient(150deg, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}, ${factionCssVar(praxis.created_by_faction_slug, 'card-bg')})`,
+                    border: `1.5px solid ${WIN_BORDER}`,
+                    color: ON_ACCENT,
+                    fontFamily: SCRIPT,
+                    fontSize: 20,
+                    fontWeight: 700,
+                  }}
+                >
+                  {(praxis.created_by_display_name || '?')[0]?.toUpperCase()}
+                </span>
+              </Link>
+              <div style={{ lineHeight: 1.4, minWidth: 0 }}>
+                <Link
+                  to={`/characters/${praxis.created_by_id}`}
+                  style={{
+                    fontFamily: SCRIPT,
+                    fontSize: 22,
+                    color: TITLE_TEXT,
+                    lineHeight: 1,
+                    textDecoration: 'none',
+                    display: 'block',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {praxis.created_by_display_name || `#${praxis.created_by_id}`}
+                </Link>
+                <div
+                  style={{ fontSize: 9, color: CARD_MUTED, letterSpacing: '0.06em', marginTop: 2 }}
+                >
+                  the witch who cast it
+                </div>
+              </div>
+              <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
+                <div style={{ fontFamily: SCRIPT, fontSize: 30, lineHeight: 1, color: PINK }}>
+                  ◆ {praxis.task_point_value}
+                </div>
+                <div
+                  style={{
+                    fontSize: 8,
+                    color: CARD_MUTED,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    marginTop: 3,
+                  }}
+                >
+                  base points
+                </div>
+              </div>
+            </div>
+
+            {/* ── 3 · the account (body text) ── */}
+            {praxis.body_text && (
+              <>
+                <Divider label="what i did" />
+                <div
+                  className="markdown-preview"
+                  style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.75, color: CARD_TEXT }}
+                >
+                  <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
+                </div>
+              </>
+            )}
+
+            {/* ── 4 · the evidence (media) — window-framed shelf ── */}
+            {praxis.media_items.length > 0 && (
+              <>
+                <Divider
+                  label={`what i left behind · ${praxis.media_items.length} ${praxis.media_items.length === 1 ? 'keepsake' : 'keepsakes'}`}
+                />
+                <div
+                  style={{
+                    borderRadius: 12,
+                    overflow: 'hidden',
+                    border: `2px solid ${NOTEPAD_BORDER}`,
+                    boxShadow: `0 6px 16px color-mix(in srgb, ${PINK} 18%, transparent)`,
+                  }}
+                >
+                  <TitleBar name="keepsakes.exe" />
+                  <div
+                    style={{
+                      padding: 12,
+                      background: NOTEPAD_BG,
+                      backgroundImage: `radial-gradient(${DOT} 1.3px, transparent 1.3px)`,
+                      backgroundSize: '13px 13px',
+                    }}
+                  >
+                    <MediaGallery media={praxis.media_items} layout="grid" />
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* ── 5 · vote caster + 6 · points from votes — hearts.exe window ── */}
+        <div
+          style={{
+            borderRadius: 14,
+            overflow: 'hidden',
+            border: `2px solid ${WIN_BORDER}`,
+            boxShadow: `0 10px 26px color-mix(in srgb, ${PINK} 26%, transparent)`,
+          }}
+        >
+          <TitleBar name="hearts.exe" />
+          <div
+            style={{
+              padding: '20px 24px 22px',
+              background: NOTEPAD_BG,
+              backgroundImage: `radial-gradient(${DOT} 1.3px, transparent 1.3px)`,
+              backgroundSize: '13px 13px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                flexWrap: 'wrap',
+                gap: 8,
+                marginBottom: 14,
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  fontFamily: SCRIPT,
+                  fontSize: 24,
+                  color: TITLE_TEXT,
+                }}
+              >
+                <Sparkle size={14} color={PINK} /> send a little love
+              </span>
+              {votes && votes.total_votes > 0 && (
+                <div style={{ textAlign: 'right' }}>
+                  <span style={{ fontFamily: SCRIPT, fontSize: 26, color: PINK, lineHeight: 1 }}>
+                    +{votes.total_score}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 8,
+                      color: CARD_MUTED,
+                      letterSpacing: '0.14em',
+                      textTransform: 'uppercase',
+                      marginLeft: 6,
+                    }}
+                  >
+                    points from votes
+                  </span>
+                </div>
+              )}
+            </div>
+            <WowVote
+              praxisId={praxis.id}
+              averageStars={votes?.average_value}
+              totalVotes={votes?.total_votes}
+              mode="caster"
+            />
+          </div>
+        </div>
+
+        {/* ── 7 · flag block (invariant) ── */}
+        <PraxisFlagBlock state={state} />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #205 #206 #207 #208 #209

Adds the per-faction **praxis-read** pages (`/praxes/:id`) that currently fall through to `DefaultPraxisDetail`, mirroring the `EphemeristsPraxisDetail` reference and registered in `PraxisDetail.tsx` `ARCHETYPE_BY_SLUG`.

| Slug | Archetype | Issue |
|---|---|---|
| `snide` | Ransom / xerox dossier (always-dark) | #205 |
| `singularity` | Terminal printout (always-dark) | #206 |
| `everymen` | Union / victory poster | #207 |
| `wow` | whimsy.exe desktop window | #208 |
| `ua` | Gilt salon (always-light, on the #240 gilt tokens) | #209 |

## Contract (ADR-0017 §2 / ADR-0002)
Each archetype is `({ state }) => JSX` consuming `usePraxisDetail`. It owns only **presentation** and **places** the shared behavior slots (`PraxisAdminBar` / `PraxisStatusBanners` / `PraxisOwnerActions` / `PraxisFlagBlock`) — never reimplements them. Every invariant slot is reconstructed:
1. Identity/status — finding, `re:` task link, grade/level, solo/collab/duel mode, sealed date, moderation status
2. Author byline — avatar + name + link, themed to the **author's** faction (actor-scoped)
3. Account body — `body_text` markdown
4. Evidence — shared `MediaGallery`
5. Vote caster — the faction `<…Vote mode="caster">` (UA uses the `VoteUI` dispatcher fallback)
6. Points earned — `task_point_value` + `votes.total_score`
7. Behavior slots (shared module)

## Dark mode
Always-dark factions (`snide`, `singularity`) scope identical light/dark tokens to their own container; `ua` is always-light — **none mutate the global theme**. No hardcoded hex; every colour maps to existing `--faction-*` / private-palette tokens (**no token additions needed**).

## Tests
- New **ADR-0017 §2 invariant test** (`praxisDetail/__tests__/archetypeSlots.test.tsx`): walks the real `ARCHETYPE_BY_SLUG` + Default fallback, asserting the finding, `re:` task link, account body, and author-byline slots. Scales free as factions are added.
- `npm test` — **69/69 pass**. `npx tsc --noEmit` clean for all new files.

## Scope notes
- Albescent (#231) excluded — needs a net-new `--al-*` token foundation (separate work).
- ⚠️ `npm run build` (vite) is red only on the **pre-existing, unrelated** `CollaborationDetail.tsx` `getPraxisVotes` break (ADR-0014 fallout, flagged separately). CI (`npm test` + `pytest`) is green; this PR adds no new build errors.