### PR TITLE
Build the Albescent praxis-read archetype — first-class identity

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -216,6 +216,15 @@
   --faction-everymen-card-muted: var(--everymen-muted);
   --faction-everymen-card-font: var(--font-accent); /* Bebas Neue */
 
+  /* ── Albescent · vellum register (always-light — identical in both themes,
+     same mechanism Singularity uses to stay always-dark; #231). First-class
+     read-surface identity; the global albescent→ua alias stays until #232. ── */
+  --faction-albescent-card-bg: #ffffff;
+  --faction-albescent-card-text: #1c1c1a; /* near-black ink, no hue */
+  --faction-albescent-card-accent: rgba(28, 28, 26, 0.72);
+  --faction-albescent-card-muted: rgba(28, 28, 26, 0.44);
+  --faction-albescent-card-font: "Cormorant Garamond", Georgia, serif;
+
   /* ── Vote stamp colors (orange → yellow → green → blue → magenta) ── */
   --vote-1: #c2410c;
   --vote-2: #ca8a04;
@@ -366,6 +375,14 @@
   --faction-snide-wall-text: #e9e6da;
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
   --faction-ua-masters-card-muted: #b06040;
+
+  /* Albescent — always-light: identical to the :root values so the vellum
+     register never dims, regardless of the global theme (#231). */
+  --faction-albescent-card-bg: #ffffff;
+  --faction-albescent-card-text: #1c1c1a;
+  --faction-albescent-card-accent: rgba(28, 28, 26, 0.72);
+  --faction-albescent-card-muted: rgba(28, 28, 26, 0.44);
+  --faction-albescent-card-font: "Cormorant Garamond", Georgia, serif;
 
   /* ══ Ephemerists palette (dark) — pigments stay vivid; vellum darkens
      to aged tobacco and its text flips ink→parchment. The card contract

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -19,6 +19,7 @@ import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxis
 import EverymenPraxisDetail from './praxisDetail/archetypes/EverymenPraxisDetail'
 import WowPraxisDetail from './praxisDetail/archetypes/WowPraxisDetail'
 import UAPraxisDetail from './praxisDetail/archetypes/UAPraxisDetail'
+import AlbescentPraxisDetail from './praxisDetail/archetypes/AlbescentPraxisDetail'
 import CommentThread from '../components/comments/CommentThread'
 
 /**
@@ -32,6 +33,9 @@ export const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDeta
   everymen: EverymenPraxisDetail,
   wow: WowPraxisDetail,
   ua: UAPraxisDetail,
+  // First-class read-surface identity (#231); explicit entry beats the
+  // albescent→ua alias via pickVariant. Global alias stays until #232.
+  albescent: AlbescentPraxisDetail,
 }
 
 export default function PraxisDetail() {

--- a/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
@@ -1,0 +1,238 @@
+/**
+ * Albescent praxis-read archetype — "The Register" (ADR-0017, issue #231).
+ *
+ * A returned task is a filed account the faction now witnesses: always-light
+ * vellum, Cormorant Garamond italic, near-black ink, a quiet mono for labels,
+ * and the "bear witness" framing around the interactive caster. Ported from the
+ * design bundle's EntryRead onto the real PraxisDetailState.
+ *
+ * Albescent is a FIRST-CLASS identity on this surface (not a ua alias): the
+ * explicit ARCHETYPE_BY_SLUG['albescent'] entry beats the albescent→ua alias via
+ * pickVariant, and the archetype reads its own component-private
+ * --faction-albescent-* tokens (identical light/dark — always-light, never dims).
+ * The behavior slots come from the shared module; this archetype owns only
+ * presentation.
+ */
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import MediaGallery from '../../../components/MediaGallery'
+import VoteUI from '../../../components/vote/VoteUI'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+const INK = 'var(--faction-albescent-card-text)'
+const FONT = 'var(--faction-albescent-card-font)'
+const MONO = 'var(--font-body)'
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+/** Quiet mono section divider, e.g. "Account" / "Plates". */
+function Divider({ label }: { label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '22px 0 12px' }}>
+      <div style={{ height: 1, flex: 1, background: ink(8) }} />
+      <span
+        style={{
+          fontFamily: MONO,
+          fontSize: 8,
+          letterSpacing: '0.24em',
+          textTransform: 'uppercase',
+          color: ink(28),
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </span>
+      <div style={{ height: 1, flex: 1, background: ink(8) }} />
+    </div>
+  )
+}
+
+export default function AlbescentPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const mode =
+    praxis.type === 'solo' ? 'sole account' : praxis.type === 'collab' ? 'joint account' : 'contested account'
+
+  return (
+    <div
+      className="py-8 max-w-2xl"
+      style={{
+        background: 'var(--faction-albescent-card-bg)',
+        border: `1px solid ${ink(10)}`,
+        color: INK,
+        fontFamily: MONO,
+      }}
+    >
+      {/* ── Header band ── */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 14,
+          padding: '10px 24px',
+          borderBottom: `1px solid ${ink(7)}`,
+          background: ink(2),
+        }}
+      >
+        <span
+          style={{
+            fontSize: 9,
+            letterSpacing: '0.22em',
+            textTransform: 'uppercase',
+            color: ink(30),
+          }}
+        >
+          Albescent · Ref. {praxis.id}
+        </span>
+        <span
+          style={{
+            fontSize: 7,
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+            color: ink(28),
+            borderBottom: `1px solid ${ink(18)}`,
+            paddingBottom: 1,
+          }}
+        >
+          {praxis.moderation_status === 'flagged' ? 'under review' : praxis.status === 'submitted' ? 'returned' : praxis.status}
+        </span>
+      </div>
+
+      <div style={{ padding: '24px 24px 28px' }}>
+        {/* ── Behavior slots (invariant — shared module) ── */}
+        <PraxisAdminBar state={state} />
+        <PraxisStatusBanners state={state} />
+
+        {/* ── Status strip ── */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12, flexWrap: 'wrap' }}>
+          <Link
+            to={`/tasks/${praxis.task_id}`}
+            style={{ fontSize: 7.5, letterSpacing: '0.14em', color: ink(34), textDecoration: 'none', textTransform: 'uppercase' }}
+          >
+            re: {praxis.task_title}
+          </Link>
+          <span style={{ color: ink(20), fontSize: 8 }}>·</span>
+          <span style={{ fontSize: 7.5, letterSpacing: '0.1em', color: ink(34) }}>Grade {praxis.task_level_required || '—'}</span>
+          <span style={{ color: ink(20), fontSize: 8 }}>·</span>
+          <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 10, color: ink(38) }}>{mode}</span>
+          <span style={{ color: ink(20), fontSize: 8 }}>·</span>
+          <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 10, color: ink(38) }}>filed {formatTimestamp(sealedDate)}</span>
+        </div>
+
+        {/* ── The finding ── */}
+        <h1
+          style={{
+            fontFamily: FONT,
+            fontStyle: 'italic',
+            fontWeight: 300,
+            fontSize: 44,
+            lineHeight: 1.05,
+            color: INK,
+            margin: '0 0 16px',
+          }}
+        >
+          {praxis.title ?? 'Untitled account'}
+        </h1>
+
+        {/* ── Owner actions ── */}
+        <PraxisOwnerActions state={state} />
+
+        {/* ── Byline (actor-scoped to the author's faction) ── */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 14,
+            paddingBottom: 20,
+            marginBottom: 6,
+            borderBottom: `1px solid ${ink(6)}`,
+          }}
+        >
+          <Link to={`/characters/${praxis.created_by_id}`}>
+            <div
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: '50%',
+                flexShrink: 0,
+                border: `1px solid ${ink(12)}`,
+                background: `linear-gradient(135deg, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}, ${factionCssVar(praxis.created_by_faction_slug, 'card-bg')})`,
+              }}
+            />
+          </Link>
+          <div style={{ minWidth: 0 }}>
+            <Link
+              to={`/characters/${praxis.created_by_id}`}
+              style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 15, color: ink(72), textDecoration: 'none', display: 'block' }}
+            >
+              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
+            </Link>
+            <span style={{ fontSize: 7.5, letterSpacing: '0.06em', color: ink(34) }}>{mode}</span>
+          </div>
+          <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
+            <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 28, lineHeight: 1, color: ink(55) }}>
+              {praxis.task_point_value}
+            </div>
+            <div style={{ fontSize: 7, letterSpacing: '0.14em', color: ink(26), marginTop: 2 }}>pts returned</div>
+          </div>
+        </div>
+
+        {/* ── The account ── */}
+        {praxis.body_text && (
+          <>
+            <Divider label="Account" />
+            <div
+              className="markdown-preview"
+              style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, lineHeight: 1.7, color: ink(62) }}
+            >
+              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
+            </div>
+          </>
+        )}
+
+        {/* ── The plates (evidence) ── */}
+        {praxis.media_items.length > 0 && (
+          <>
+            <Divider label={`Plates · ${praxis.media_items.length}`} />
+            <div style={{ border: `1px solid ${ink(10)}`, padding: 10 }}>
+              <MediaGallery media={praxis.media_items} layout="grid" />
+            </div>
+          </>
+        )}
+
+        {/* ── Bear witness (vote caster) ── */}
+        <Divider label="Bear Witness" />
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 10, marginBottom: 12 }}>
+          <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 13, color: ink(48) }}>
+            How completely was this account attended?
+          </span>
+          {votes && votes.total_votes > 0 && (
+            <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 16, color: ink(60), whiteSpace: 'nowrap' }}>
+              +{votes.total_score}{' '}
+              <span style={{ fontFamily: MONO, fontSize: 7, letterSpacing: '0.14em', color: ink(30) }}>FROM WITNESSES</span>
+            </span>
+          )}
+        </div>
+        <VoteUI
+          factionSlug={praxis.task_faction_slug}
+          praxisId={praxis.id}
+          averageStars={votes?.average_value}
+          totalVotes={votes?.total_votes}
+          mode="caster"
+        />
+
+        {/* ── Flag block ── */}
+        <PraxisFlagBlock state={state} />
+
+        {/* Backer ledger slot — per-voter breakdown; reserved (#195) */}
+        {/* Comments slot — neutral chrome rendered by the dispatcher (#167) */}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #231

Makes **Albescent a first-class identity on the praxis-read surface** (no longer a `ua` alias) by adding `AlbescentPraxisDetail` and registering it explicitly in `ARCHETYPE_BY_SLUG['albescent']` — `pickVariant`'s explicit entry beats the `albescent→ua` alias, so no global change is needed and the alias stays until #232.

## Tokens
Adds component-private `--faction-albescent-card-{bg,text,accent,muted,font}` to `index.css` with **identical values in the light and `[data-theme="dark"]` blocks** (always-light vellum — same mechanism the always-dark factions use to never switch). Per the issue, **`CSS_KEY` is deliberately not touched** (added once in #232's final step; adding it early would regress every still-aliased surface).

## Archetype
Ports the design bundle's "The Register" `EntryRead` onto the real `PraxisDetailState`: always-light vellum, Cormorant Garamond italic finding, near-black ink, quiet mono labels, the "bear witness" framing around the caster. Places the shared behavior slots (admin bar / banners / owner actions / flag) and reconstructs every ADR-0017 §2 invariant slot:
- Identity/status — finding, `re:` task link, grade, mode, filed date, moderation
- Actor-scoped author byline · markdown account · evidence via `MediaGallery`
- Interactive caster (`VoteUI` dispatcher under "Bear Witness") · points-returned (`task_point_value` + `votes.total_score`)

Metatask, backer-ledger (#195), and comments (#167) left as reserved slots.

## Tests
- The existing ADR-0017 invariant test walks `ARCHETYPE_BY_SLUG`, so it now covers `albescent` automatically — **8/8** in that suite.
- `npm test` — **70/70 pass**. `npx tsc --noEmit` clean.
- ⚠️ `npm run build` red only on the **pre-existing, unrelated** `CollaborationDetail.tsx` `getPraxisVotes` break (flagged separately); CI (`npm test` + `pytest`) green, no new build errors here.