### PR TITLE
Build & register the 6 designed activity-feed frames

### DIFF
--- a/frontend/src/components/__tests__/factionFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/factionFeedFrame.test.tsx
@@ -14,6 +14,10 @@ import FactionFeedFrame, {
 
 const CARD = <span>card-body</span>;
 
+// Snapshot the real registrations at module load — the manual drop-in test's
+// afterEach mutates the live map, so capture before anything clears it.
+const REGISTERED_AT_LOAD = new Set(Object.keys(FACTION_FEED_FRAMES));
+
 afterEach(() => {
   // Frames are registered into a module-level map; keep tests isolated.
   for (const key of Object.keys(FACTION_FEED_FRAMES)) {
@@ -22,8 +26,18 @@ afterEach(() => {
 });
 
 describe("FactionFeedFrame dispatch", () => {
-  it("passes the card through unchanged when no frame is registered", () => {
-    for (const slug of [null, undefined, "", "ua", "everymen"]) {
+  it("registers the five designed faction frames (ua undesigned)", () => {
+    for (const slug of ["everymen", "ephemerists", "wow", "snide", "singularity"]) {
+      expect(REGISTERED_AT_LOAD.has(slug), `${slug} frame registered`).toBe(true);
+    }
+    // UA feed is undesigned — it must fall through to the neutral default.
+    expect(REGISTERED_AT_LOAD.has("ua"), "ua feed undesigned").toBe(false);
+  });
+
+  it("passes the card through unchanged for an unregistered slug", () => {
+    // Run after a clear so the map is empty — guards the neutral passthrough.
+    for (const key of Object.keys(FACTION_FEED_FRAMES)) delete FACTION_FEED_FRAMES[key];
+    for (const slug of [null, undefined, "", "ua", "aged_out"]) {
       const html = renderToStaticMarkup(
         <FactionFeedFrame slug={slug}>{CARD}</FactionFeedFrame>,
       );

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react'
+
+import { EphMark, Foxing } from '../cards/ephemeristsAtoms'
+
+/**
+ * Ephemerists feed-card FRAME (surface #12, SPEC-faction-ui-profile.md).
+ *
+ * A thin presentational wrapper that dresses the neutral feed card (`children`)
+ * as a leaf torn from the faction's ephemeris: foxed-vellum stock, an iron-gall
+ * ink hairline, a gold-ruled running edge, and a rubric marginal sigil. The card
+ * internals (avatar / actor / badge / time) are untouched — they arrive via
+ * `{children}` and render in the content area.
+ *
+ * Theme-aware through the --eph-* cascade; no document-theme mutation, no hex.
+ */
+export default function EphemeristsFeedFrame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        marginBottom: 14,
+        padding: '10px 12px 12px 16px',
+        background:
+          'linear-gradient(170deg, var(--eph-vellum), var(--eph-vellum-deep))',
+        border: '1px solid color-mix(in srgb, var(--eph-vellum-text) 30%, transparent)',
+        boxShadow:
+          'inset 3px 0 0 -1px color-mix(in srgb, var(--eph-gold) 70%, transparent), 0 8px 20px -16px rgba(0, 0, 0, 0.6)',
+        overflow: 'hidden',
+      }}
+    >
+      {/* age-foxing stains over the vellum stock */}
+      <Foxing opacity={0.35} />
+
+      {/* rubric marginal ornament — the watching-wanderer sigil in the gutter */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: 3,
+          top: 9,
+          zIndex: 1,
+          opacity: 0.5,
+          color: 'var(--eph-rubric)',
+          pointerEvents: 'none',
+        }}
+      >
+        <EphMark size={12} color="var(--eph-rubric)" stroke={1.2} />
+      </div>
+
+      {/* the neutral feed card, rendered in the content area */}
+      <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/EverymenFeedFrame.tsx
+++ b/frontend/src/components/feed/EverymenFeedFrame.tsx
@@ -1,0 +1,100 @@
+/**
+ * Everymen feed frame — the "printed union dispatch slip" chrome.
+ *
+ * A thin presentational wrapper (surface #12, SPEC-faction-ui-profile.md): it
+ * skins the neutral feed card (`children`) in the Everymen physical archetype —
+ * a red masthead spine on the left edge, manila paper stock with a screen-print
+ * halftone wash, and an inked border with gold trim. It does NOT reimplement the
+ * card internals (avatar/actor/badge/time/task-ref) — those arrive via
+ * `{children}` and render untouched in the content area.
+ *
+ * Theme-aware via everymen.css tokens (light + dark both defined); no document
+ * theme mutation. Visual intent from design-system/templates/everymen.
+ */
+import type { ReactNode } from 'react'
+
+export default function EverymenFeedFrame({ children }: { children: ReactNode }) {
+  return (
+    <article
+      style={{
+        position: 'relative',
+        display: 'flex',
+        overflow: 'hidden',
+        background: 'var(--everymen-paper)',
+        color: 'var(--everymen-paper-text)',
+        border:
+          '1px solid color-mix(in srgb, var(--everymen-paper-text) 26%, transparent)',
+        borderLeft: 'none',
+        boxShadow:
+          '0 1px 0 rgba(0,0,0,0.04), 0 6px 16px -12px rgba(0,0,0,0.5)',
+      }}
+    >
+      {/* red masthead spine with cream notches (union ribbon) */}
+      <div
+        aria-hidden
+        style={{
+          flexShrink: 0,
+          width: 8,
+          background: 'var(--everymen-red)',
+          backgroundImage:
+            'repeating-linear-gradient(180deg, transparent 0 13px, color-mix(in srgb, var(--everymen-cream) 55%, transparent) 13px 15px)',
+          boxShadow:
+            'inset -1px 0 0 color-mix(in srgb, var(--everymen-red-deep) 70%, transparent)',
+        }}
+      />
+
+      {/* content area: paper texture + halftone wash behind the card body */}
+      <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
+        {/* gold trim rule hugging the spine */}
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            insetBlock: 0,
+            left: 0,
+            width: 2,
+            background: 'var(--everymen-gold)',
+            opacity: 0.55,
+            pointerEvents: 'none',
+            zIndex: 1,
+          }}
+        />
+
+        {/* woven paper texture (burlap crosshatch + warm mottle) */}
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1,
+            pointerEvents: 'none',
+            backgroundImage: [
+              'repeating-linear-gradient(45deg, color-mix(in srgb, var(--everymen-paper-text) 7%, transparent) 0 1px, transparent 1px 4px)',
+              'repeating-linear-gradient(-45deg, color-mix(in srgb, var(--everymen-paper-text) 5%, transparent) 0 1px, transparent 1px 4px)',
+              'radial-gradient(130% 90% at 5% 0%, color-mix(in srgb, var(--everymen-cream) 18%, transparent), transparent 55%)',
+              'radial-gradient(120% 85% at 100% 100%, color-mix(in srgb, var(--everymen-paper-deep) 65%, transparent), transparent 52%)',
+            ].join(', '),
+          }}
+        />
+
+        {/* screen-print halftone wash */}
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1,
+            pointerEvents: 'none',
+            opacity: 0.06,
+            backgroundImage:
+              'radial-gradient(color-mix(in srgb, var(--everymen-ink) 100%, transparent) 0.7px, transparent 0.9px)',
+            backgroundSize: '5px 5px',
+          }}
+        />
+
+        {/* the neutral feed card, rendered above the chrome */}
+        <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -13,12 +13,24 @@
 import type { ComponentType, ReactNode } from 'react'
 
 import { pickVariant } from '../../utils/factionDispatch'
+import EverymenFeedFrame from './EverymenFeedFrame'
+import EphemeristsFeedFrame from './EphemeristsFeedFrame'
+import WowFeedFrame from './WowFeedFrame'
+import SnideFeedFrame from './SnideFeedFrame'
+import SingularityFeedFrame from './SingularityFeedFrame'
 
 type FrameProps = { children: ReactNode }
 
-/** Per-faction frames. Empty until design delivers them; each row makes that
- *  faction's feed cards bespoke. albescent/aged_out inherit ua via pickVariant. */
-const FACTION_FEED_FRAMES: Record<string, ComponentType<FrameProps>> = {}
+/** Per-faction frames. Each row makes that faction's feed cards bespoke.
+ *  albescent/aged_out inherit ua via pickVariant. UA feed is undesigned, so
+ *  ua falls through to the neutral DefaultFeedFrame (#224). */
+const FACTION_FEED_FRAMES: Record<string, ComponentType<FrameProps>> = {
+  everymen: EverymenFeedFrame,
+  ephemerists: EphemeristsFeedFrame,
+  wow: WowFeedFrame,
+  snide: SnideFeedFrame,
+  singularity: SingularityFeedFrame,
+}
 
 /** Neutral fallback: render the card unchanged (today's behaviour — the event
  *  cards carry their own tint, so the default frame adds no chrome). */

--- a/frontend/src/components/feed/SingularityFeedFrame.tsx
+++ b/frontend/src/components/feed/SingularityFeedFrame.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Singularity per-faction feed frame (surface #12, SPEC-faction-ui-profile.md).
+ *
+ * A thin presentational WRAPPER: it skins the neutral feed card (`children`) as a
+ * terminal dispatch/printout. The frame supplies only the OUTER chrome — a
+ * terminal-black slab with a signal-blue inset border, scanline overlay, and a
+ * `>` boot/prompt strip header — and renders the unchanged card as the printout
+ * body. It must NOT reimplement the card internals; those arrive via `children`.
+ *
+ * Singularity is ALWAYS DARK: its --faction-singularity-* tokens are identical in
+ * both themes, so the container styles itself with them and reads as a terminal
+ * regardless of the global theme — it never mutates data-theme.
+ */
+
+// Token shorthands — every color resolves to a --faction-singularity-* var.
+const VOID = 'var(--faction-singularity-card-bg)' // terminal black
+const PHOSPHOR = 'var(--faction-singularity-card-accent)' // green
+const SIGNAL = 'var(--faction-singularity-card-muted)' // blue chrome
+const BORDER_HARD = 'var(--faction-singularity-border-hard)'
+const FONT = 'var(--font-faction-terminal)'
+
+// color-mix helper for the blue chrome at reduced opacity.
+const signal = (pct: number): string =>
+  `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+export default function SingularityFeedFrame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        overflow: 'hidden',
+        border: `1px solid ${BORDER_HARD}`,
+        background: VOID,
+        color: PHOSPHOR,
+        fontFamily: FONT,
+      }}
+    >
+      {/* inset signal border */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 4,
+          border: `1px solid ${signal(18)}`,
+          pointerEvents: 'none',
+          zIndex: 3,
+        }}
+      />
+      {/* scanline overlay */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          zIndex: 3,
+          background:
+            'repeating-linear-gradient(to bottom,transparent,transparent 2px,rgba(255,255,255,0.018) 2px,rgba(255,255,255,0.018) 4px)',
+        }}
+      />
+
+      {/* boot/prompt strip header */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'relative',
+          zIndex: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '6px 12px',
+          borderBottom: `1px solid ${signal(20)}`,
+          fontSize: 7,
+          letterSpacing: '0.18em',
+          color: signal(55),
+          textTransform: 'uppercase',
+        }}
+      >
+        <span style={{ color: PHOSPHOR }}>{'>'}</span>
+        <span>DISPATCH · SIGNAL ONLINE</span>
+      </div>
+
+      {/* printout body — the neutral card, unchanged */}
+      <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/SnideFeedFrame.tsx
+++ b/frontend/src/components/feed/SnideFeedFrame.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react'
+
+/**
+ * S.N.I.D.E. activity-feed FRAME (surface #12, SPEC-faction-ui-profile.md).
+ *
+ * A thin presentational WRAPPER — not a card. It dresses the neutral feed card
+ * (`children`) in SNIDE's outer chrome: an "intercepted ransom-note slip" cut
+ * from warm xerox paper, bound in a photocopier-ink border, taped down at the
+ * top, tilted on the wall, dusted with halftone, with an acid-green margin
+ * stripe running its left edge. The card body itself stays exactly as passed in
+ * — this only adds the skin around `{children}`.
+ *
+ * Always-dark by intent: SNIDE is the ransom/xerox dossier. We scope the
+ * theme-stable --faction-snide-card-* / -paper / -ink / -acid tokens to this
+ * frame's own container only; we never mutate the document theme, and we avoid
+ * the --faction-snide-*-wall-text tokens that flip between light/dark.
+ */
+export default function SnideFeedFrame({ children }: { children: ReactNode }) {
+  const ink = 'var(--faction-snide-ink)'
+  const paper = 'var(--faction-snide-paper)'
+  const acid = 'var(--faction-snide-acid)'
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        background: paper,
+        border: `1.5px solid ${ink}`,
+        // halftone dust over the xerox slab — ink at low opacity, theme-stable.
+        backgroundImage:
+          'radial-gradient(color-mix(in srgb, var(--faction-snide-ink) 6%, transparent) 1px, transparent 1px),' +
+          'radial-gradient(color-mix(in srgb, var(--faction-snide-ink) 4%, transparent) 1px, transparent 1px)',
+        backgroundSize: '3px 3px, 4px 4px',
+        backgroundPosition: '0 0, 2px 1px',
+        boxShadow: '3px 4px 0 rgba(0,0,0,0.22)',
+        transform: 'rotate(-0.6deg)',
+        padding: '16px 18px 18px 22px',
+        marginBottom: 18,
+        overflow: 'hidden',
+      }}
+    >
+      {/* acid margin stripe — sprocket-ruled, hugging the left edge */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: 8,
+          background: acid,
+          backgroundImage:
+            'repeating-linear-gradient(180deg, transparent 0 13px, rgba(0,0,0,0.25) 13px 14px)',
+        }}
+      />
+      {/* a strip of tape pinning the slip to the wall */}
+      <div
+        className="snide-tape"
+        aria-hidden="true"
+        style={{ top: -9, right: 40, width: 64, height: 20, transform: 'rotate(5deg)' }}
+      />
+      {/* the slip body — the neutral feed card, untouched */}
+      <div style={{ position: 'relative' }}>{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/WowFeedFrame.tsx
+++ b/frontend/src/components/feed/WowFeedFrame.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Warriors of Whimsy feed frame — the neutral feed card dressed as a tiny
+ * "whimsy.exe" desktop window. A pink title bar (traffic-light dots + a script
+ * window name + a sparkle charm) sits above a notepad/paper body that holds the
+ * untouched card `{children}`. Frame-level chrome only: this is a thin wrapper,
+ * not a reimplementation of the card. Flips with the theme via the WoW tokens.
+ */
+
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const TITLE_FROM = 'var(--faction-wow-title-from)'
+const TITLE_TO = 'var(--faction-wow-title-to)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const SCRIPT = 'var(--faction-wow-card-font)'
+const PINK = 'var(--faction-wow)'
+
+/** The four-point sparkle charm — WoW's signature window flourish. */
+function Sparkle({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={PINK}
+      />
+    </svg>
+  )
+}
+
+export default function WowFeedFrame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        borderRadius: 13,
+        overflow: 'hidden',
+        border: `2px solid ${WIN_BORDER}`,
+        boxShadow: `0 6px 18px color-mix(in srgb, ${PINK} 22%, transparent)`,
+      }}
+    >
+      {/* title bar — traffic-light dots + window name + sparkle */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          padding: '7px 12px',
+          background: `linear-gradient(180deg, ${TITLE_FROM}, ${TITLE_TO})`,
+          borderBottom: `2px solid ${WIN_BORDER}`,
+        }}
+      >
+        {[
+          'var(--faction-wow-scrap-deep)',
+          'var(--faction-wow-tape)',
+          'var(--faction-wow-ivy-leaf)',
+        ].map((lightColor) => (
+          <span
+            key={lightColor}
+            style={{
+              width: 9,
+              height: 9,
+              borderRadius: '50%',
+              background: lightColor,
+              border: '1.2px solid rgba(255,255,255,0.7)',
+            }}
+          />
+        ))}
+        <span
+          style={{
+            marginLeft: 'auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontFamily: SCRIPT,
+            fontSize: 17,
+            color: TITLE_TEXT,
+          }}
+        >
+          whimsy.exe
+          <Sparkle size={12} />
+        </span>
+      </div>
+
+      {/* notepad/paper body — holds the neutral card, untouched */}
+      <div
+        style={{
+          background: NOTEPAD_BG,
+          borderTop: `1px solid ${NOTEPAD_BORDER}`,
+          padding: 12,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #224

Implements one bespoke `*FeedFrame` per **designed** faction and registers them in `components/feed/FactionFeedFrame.tsx` `FACTION_FEED_FRAMES` (the dispatch seam + `context_faction_slug` shipped in PR #199).

| Faction | Frame | Skin |
|---|---|---|
| everymen | `EverymenFeedFrame` | Printed union dispatch slip (red spine, manila, halftone) |
| ephemerists | `EphemeristsFeedFrame` | Illuminated vellum slip (ink hairline, foxing, rubric) |
| wow | `WowFeedFrame` | whimsy.exe window (title bar + notepad body) |
| snide | `SnideFeedFrame` | Intercepted ransom slip (xerox, ink border, tape) — always-dark |
| singularity | `SingularityFeedFrame` | Terminal printout (signal border, scanlines, `>` prompt) — always-dark |

Each frame is a thin `ComponentType<{ children }>` wrapper adding the faction's **outer chrome** around the existing neutral feed card — it never reimplements the card internals (avatar/actor/badge/time), which stay in `children`. Always-dark factions scope identical light/dark tokens to their own container; **no document-theme mutation, no hardcoded hex**.

**UA feed is undesigned** — `ua` falls through to the neutral `DefaultFeedFrame` (noted inline).

## Tests
Updates the feed-frame dispatch test: snapshots the registrations at module load (stable against the drop-in test's `afterEach` clear), asserts the 5 frames are registered and `ua` is not, and keeps the neutral-passthrough + drop-in guards. `npm test` — **71/71 pass**. `npx tsc --noEmit` clean.

⚠️ `npm run build` red only on the pre-existing, unrelated `CollaborationDetail.tsx` break (flagged separately); CI green, no new build errors.