### PR TITLE
Build & wire ua's vote, backdrop, hero archetypes

### DIFF
--- a/frontend/src/components/backdrop/FactionBackdrop.tsx
+++ b/frontend/src/components/backdrop/FactionBackdrop.tsx
@@ -5,6 +5,7 @@ import WowBackdrop from './WowBackdrop'
 import SnideBackdrop from './SnideBackdrop'
 import EphemeristsBackdrop from './EphemeristsBackdrop'
 import SingularityBackdrop from './SingularityBackdrop'
+import UABackdrop from './UABackdrop'
 import { useBackdropSlug } from './BackdropContext'
 import { pickVariant } from '../../utils/factionDispatch'
 
@@ -20,6 +21,7 @@ const FACTION_BACKDROPS: Record<string, ComponentType> = {
   snide: SnideBackdrop,
   ephemerists: EphemeristsBackdrop,
   singularity: SingularityBackdrop,
+  ua: UABackdrop,
 }
 
 export default function FactionBackdrop() {

--- a/frontend/src/components/backdrop/UABackdrop.tsx
+++ b/frontend/src/components/backdrop/UABackdrop.tsx
@@ -1,0 +1,29 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * UA full-page backdrop — the gilt salon: a parchment wall (`--ua-wall`) lit by
+ * a low gilt glow from the corners and overlaid with a faint ledger dot-grid.
+ * UA is always-light: its `--ua-*` / `--faction-ua-*` tokens are identical in
+ * both themes, so this never flips with data-theme. Fixed behind page content
+ * at z-index 0.
+ */
+const backdropStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 0,
+  pointerEvents: 'none',
+  backgroundColor: 'var(--ua-wall)',
+  backgroundImage: [
+    // low gilt glow — top-left origin (old gold, light)
+    'radial-gradient(70% 50% at 8% 0%, color-mix(in srgb, var(--ua-gold-lt) 7%, transparent), transparent 70%)',
+    // burnt-amber echo — top-right
+    'radial-gradient(60% 50% at 100% 8%, color-mix(in srgb, var(--ua-orange) 6%, transparent), transparent 70%)',
+    // faint ledger dot-grid (gilt ink)
+    'radial-gradient(color-mix(in srgb, var(--ua-gold) 5%, transparent) 1px, transparent 1px)',
+  ].join(', '),
+  backgroundSize: 'auto, auto, 6px 6px',
+}
+
+export default function UABackdrop() {
+  return <div style={backdropStyle} aria-hidden="true" />
+}

--- a/frontend/src/components/cards/UAFactionHero.tsx
+++ b/frontend/src/components/cards/UAFactionHero.tsx
@@ -1,0 +1,276 @@
+import type { FactionHeroProps } from "../../pages/FactionDetail";
+
+/**
+ * UA (University of Asthmatics) faction-page hero — a gilt-salon frontispiece.
+ * The masthead reads as an art-academy museum plate: a gold museum frame
+ * (--ua-gilt) around a parchment field, a heraldic crest, a regal serif
+ * wordmark, a Latin motto cartouche, and the three counts engraved as salon
+ * regalia (patrons / commissions / acquisitions). Ported from the UA design kit
+ * (UATaskDetail hero / ua.css); conforms to {@link FactionHeroProps}.
+ *
+ * UA is ALWAYS LIGHT: its --faction-ua-* / --ua-* tokens are identical in both
+ * themes, so the salon styles itself with them and never dims — it does not
+ * mutate data-theme.
+ *
+ * The page passes raw counts; the salon labels them in its own regal voice.
+ * Motto + full name are faction constants (not backend fields).
+ */
+
+const FULL_NAME = "University of Asthmatics";
+const MOTTO = "Ars Longa · Spiritus Brevis";
+
+// Token shorthands — every value resolves to a --ua-* / --faction-ua-* var.
+const GILT = "var(--ua-gilt)";
+const PAPER = "var(--faction-ua-card-bg)"; // parchment sheet
+const PAPER_WARM = "var(--ua-paper-warm)";
+const INK = "var(--faction-ua-card-text)"; // brown ink — all text
+const ACCENT = "var(--faction-ua-card-accent)"; // burnt amber
+const SUB = "var(--faction-ua-card-muted)"; // secondary serif
+const MUTED = "var(--ua-muted)"; // mono / metadata labels
+const GOLD = "var(--ua-gold)";
+const GOLD_LT = "var(--ua-gold-lt)";
+const GOLD_PALE = "var(--ua-gold-pale)";
+const LINE = "var(--ua-line)"; // hairline borders
+
+// Regal serif faces. The display face is the UA card-font token (a loaded
+// serif); engraved regalia labels fall back to Georgia serif.
+const DISPLAY = "var(--faction-ua-card-font)";
+const ENGRAVED = '"Marcellus", Georgia, serif';
+
+// color-mix helper for shades with no dedicated token.
+const ink = (pct: number): string =>
+  `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
+
+/** Heraldic crest — a shield with a rising sun and crossed brushes. */
+function UACrest({ width, height }: { width: number; height: number }) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 100 120"
+      aria-hidden="true"
+      style={{ display: "block", flexShrink: 0 }}
+    >
+      <defs>
+        <clipPath id="ua-hero-shield">
+          <path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" />
+        </clipPath>
+      </defs>
+      <g clipPath="url(#ua-hero-shield)">
+        <rect x="0" y="0" width="100" height="120" fill={ACCENT} />
+        <rect x="0" y="60" width="100" height="60" fill={PAPER_WARM} />
+        <circle cx="50" cy="60" r="15" fill={GOLD_LT} />
+        <g stroke={GOLD_LT} strokeWidth="2.4" strokeLinecap="round">
+          <line x1="50" y1="60" x2="50" y2="20" />
+          <line x1="50" y1="60" x2="22" y2="30" />
+          <line x1="50" y1="60" x2="78" y2="30" />
+          <line x1="50" y1="60" x2="14" y2="48" />
+          <line x1="50" y1="60" x2="86" y2="48" />
+          <line x1="50" y1="60" x2="34" y2="22" />
+          <line x1="50" y1="60" x2="66" y2="22" />
+        </g>
+        <g transform="translate(50 84)">
+          <g transform="rotate(38)">
+            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill={INK} />
+            <rect x="-3" y="10" width="6" height="6" fill={GOLD_PALE} />
+            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill={ACCENT} />
+          </g>
+          <g transform="rotate(-38)">
+            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill={GOLD} />
+            <rect x="-3" y="10" width="6" height="6" fill={GOLD_PALE} />
+            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill={GOLD_LT} />
+          </g>
+        </g>
+      </g>
+      <path
+        d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z"
+        fill="none"
+        stroke={GOLD_LT}
+        strokeWidth="2.5"
+      />
+      <path
+        d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z"
+        fill="none"
+        stroke={INK}
+        strokeWidth="0.8"
+      />
+    </svg>
+  );
+}
+
+export default function UAFactionHero({
+  name,
+  description,
+  members,
+  tasks,
+  praxes,
+}: FactionHeroProps) {
+  // The salon engraves its own counts — page passes raw numbers only.
+  const stats = [
+    { value: members, label: "patrons" },
+    { value: tasks, label: "commissions" },
+    { value: praxes, label: "acquisitions" },
+  ];
+
+  return (
+    <header style={{ marginBottom: 32 }}>
+      {/* gilt museum frame — outer leaf */}
+      <div
+        style={{
+          padding: 11,
+          background: GILT,
+          boxShadow:
+            "0 18px 40px rgba(60,40,10,0.28), inset 0 0 0 1px rgba(255,255,255,0.45)",
+        }}
+      >
+        {/* inner gold leaf */}
+        <div
+          style={{
+            padding: 5,
+            background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
+          }}
+        >
+          {/* parchment plate */}
+          <div
+            style={{
+              position: "relative",
+              overflow: "hidden",
+              border: `1px solid ${ink(45)}`,
+              background: PAPER,
+              backgroundImage: `radial-gradient(${ink(3)} 1px, transparent 1px)`,
+              backgroundSize: "5px 5px",
+              padding: "34px 38px 30px",
+              display: "flex",
+              gap: 30,
+              alignItems: "center",
+            }}
+          >
+            <UACrest width={150} height={180} />
+
+            <div style={{ flex: 1, minWidth: 0 }}>
+              {/* engraved house line */}
+              <div
+                style={{
+                  fontFamily: ENGRAVED,
+                  fontSize: 11,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  color: ACCENT,
+                  marginBottom: 3,
+                }}
+              >
+                {FULL_NAME}
+              </div>
+              {/* eyebrow — engraved metadata */}
+              <div
+                style={{
+                  fontFamily: ENGRAVED,
+                  fontSize: 8,
+                  letterSpacing: "0.3em",
+                  textTransform: "uppercase",
+                  color: MUTED,
+                  marginBottom: 14,
+                }}
+              >
+                World Zero · The Salon · Est · MMXX
+              </div>
+
+              {/* regal wordmark */}
+              <h1
+                style={{
+                  fontFamily: DISPLAY,
+                  fontStyle: "italic",
+                  fontWeight: 700,
+                  fontSize: 54,
+                  lineHeight: 1.04,
+                  letterSpacing: "0.01em",
+                  margin: "0 0 16px",
+                  color: INK,
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {name}
+              </h1>
+
+              {/* motto cartouche */}
+              <div
+                style={{
+                  position: "relative",
+                  width: "fit-content",
+                  background: ACCENT,
+                  color: PAPER_WARM,
+                  fontFamily: ENGRAVED,
+                  fontSize: 11,
+                  letterSpacing: "0.1em",
+                  padding: "5px 26px",
+                  clipPath:
+                    "polygon(0 0,100% 0,96% 50%,100% 100%,0 100%,4% 50%)",
+                  marginBottom: 18,
+                }}
+              >
+                {MOTTO}
+              </div>
+
+              {/* statement */}
+              <p
+                style={{
+                  fontFamily: DISPLAY,
+                  fontStyle: "italic",
+                  fontSize: 15,
+                  lineHeight: 1.7,
+                  color: SUB,
+                  maxWidth: 560,
+                  margin: "0 0 22px",
+                }}
+              >
+                {description ??
+                  "Any medium, any madness. The Salon decides what endures."}
+              </p>
+
+              {/* engraved regalia plaques */}
+              <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                {stats.map((s) => (
+                  <div
+                    key={s.label}
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 3,
+                      padding: "9px 18px",
+                      border: `1px solid ${LINE}`,
+                      background: PAPER,
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontFamily: DISPLAY,
+                        fontStyle: "italic",
+                        fontWeight: 700,
+                        fontSize: 26,
+                        lineHeight: 0.9,
+                        color: INK,
+                      }}
+                    >
+                      {s.value}
+                    </span>
+                    <span
+                      style={{
+                        fontFamily: ENGRAVED,
+                        fontSize: 8,
+                        letterSpacing: "0.16em",
+                        textTransform: "uppercase",
+                        color: MUTED,
+                      }}
+                    >
+                      {s.label}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/vote/UAVote.tsx
+++ b/frontend/src/components/vote/UAVote.tsx
@@ -1,0 +1,166 @@
+import type { VoteUIProps } from './VoteUI'
+import { useVote } from './useVote'
+import { VoteLoginGate, VoteSummary } from './VoteShell'
+
+/**
+ * UA (University of Asthmatics) vote UI — THE GILT SALON. The 1-5 approval is
+ * cast as an acquisition/appraisal ramp: the Salon judging a filed work from a
+ * polite "noted" up to the gilt "ACQUIRED" plate. Each rung is an engraved
+ * museum placard on parchment, framed in old gold; the chosen rung lights up
+ * in burnt amber. Always-light — the salon never dims, so every token reads
+ * identically in both themes and we never touch data-theme.
+ *
+ * Same 1-5 data model as every other faction; purely a visual reskin driven by
+ * the shared {@link useVote} hook so cast/refetch logic lives in one place.
+ */
+
+interface AppraisalRung {
+  value: number
+  /** Engraved placard label — the Salon's verdict. */
+  label: string
+}
+
+export const UA_APPRAISALS: AppraisalRung[] = [
+  { value: 1, label: 'Noted' },
+  { value: 2, label: 'Sketch' },
+  { value: 3, label: 'Hung' },
+  { value: 4, label: 'Commended' },
+  { value: 5, label: 'Acquired' },
+]
+
+const PLATE_FONT = 'var(--faction-ua-card-font)'
+
+export default function UAVote({
+  praxisId,
+  currentStars,
+  averageStars,
+  totalVotes,
+  mode = 'caster',
+}: VoteUIProps) {
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentStars)
+
+  if (mode === 'summary') {
+    const rung =
+      UA_APPRAISALS[Math.max(0, Math.round(averageStars ?? 0) - 1)] ?? UA_APPRAISALS[0]
+    const acquired = rung.value === 5
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+        <div
+          style={{
+            minWidth: 50,
+            height: 30,
+            padding: '0 9px',
+            border: '1px solid var(--ua-line)',
+            background: acquired ? 'var(--ua-gilt)' : 'var(--faction-ua-card-bg)',
+            color: acquired ? 'var(--ua-paper)' : 'var(--faction-ua-card-accent)',
+            fontFamily: PLATE_FONT,
+            fontSize: 11,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: acquired ? 'inset 0 0 0 1px color-mix(in srgb, var(--ua-paper) 45%, transparent)' : 'none',
+          }}
+        >
+          {rung.label}
+        </div>
+        <span
+          style={{
+            fontFamily: PLATE_FONT,
+            fontSize: 7,
+            letterSpacing: '0.1em',
+            color: 'var(--faction-ua-card-muted)',
+            textAlign: 'center',
+          }}
+        >
+          {totalVotes ?? 0} appraisals
+        </span>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return <VoteLoginGate />
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'center' }}>
+        {UA_APPRAISALS.map((rung) => {
+          const active = selected === rung.value
+          const reached = selected >= rung.value
+          const top = rung.value === 5
+          return (
+            <div
+              key={rung.value}
+              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 5 }}
+            >
+              <button
+                disabled={saving}
+                onClick={() => void vote(rung.value)}
+                aria-label={`Appraise ${rung.value} — ${rung.label}`}
+                style={{
+                  minWidth: 60,
+                  height: 40,
+                  padding: '0 14px',
+                  cursor: saving ? 'default' : 'pointer',
+                  border: active && top ? 'none' : `1px solid ${reached ? 'var(--faction-ua-card-accent)' : 'var(--ua-line)'}`,
+                  background: active
+                    ? top
+                      ? 'var(--ua-gilt)'
+                      : 'var(--faction-ua-card-accent)'
+                    : reached
+                      ? 'color-mix(in srgb, var(--faction-ua-card-accent) 12%, var(--faction-ua-card-bg))'
+                      : 'var(--faction-ua-card-bg)',
+                  color: active
+                    ? 'var(--ua-paper)'
+                    : reached
+                      ? 'var(--faction-ua-card-accent)'
+                      : 'var(--faction-ua-card-muted)',
+                  fontFamily: PLATE_FONT,
+                  fontSize: 12,
+                  letterSpacing: '0.1em',
+                  textTransform: 'uppercase',
+                  transform: active ? 'scale(1.06)' : 'none',
+                  boxShadow: active
+                    ? '0 4px 10px color-mix(in srgb, var(--ua-ink) 22%, transparent), inset 0 0 0 1px color-mix(in srgb, var(--ua-paper) 40%, transparent)'
+                    : 'none',
+                  transition: 'all 120ms',
+                }}
+              >
+                {rung.label}
+              </button>
+              <span
+                style={{
+                  fontFamily: PLATE_FONT,
+                  fontSize: 8,
+                  letterSpacing: '0.14em',
+                  color: active ? 'var(--faction-ua-card-accent)' : 'var(--faction-ua-card-muted)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                {rung.value === 5 ? '✦' : `№${rung.value}`}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <VoteSummary
+        selected={selected}
+        averageStars={averageStars}
+        totalVotes={totalVotes}
+        error={error}
+        theme={{
+          muted: 'var(--faction-ua-card-muted)',
+          accent: 'var(--faction-ua-card-accent)',
+          accentFont: PLATE_FONT,
+          avgFontSize: 16,
+          errorColor: 'var(--ua-orange-deep)',
+          avgLetterSpacing: '0.04em',
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -6,6 +6,7 @@ import WowVote from './WowVote'
 import SnideVote from './SnideVote'
 import EphemeristsVote from './EphemeristsVote'
 import SingularityVote from './SingularityVote'
+import UAVote from './UAVote'
 
 /**
  * Per-faction vote/rating UI dispatcher (Tier-3 surface). Keyed by the voted
@@ -27,6 +28,7 @@ const FACTION_VOTE: Record<string, ComponentType<VoteUIProps>> = {
   snide: SnideVote,
   ephemerists: EphemeristsVote,
   singularity: SingularityVote,
+  ua: UAVote,
 }
 
 export default function VoteUI({

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -9,6 +9,7 @@ import EphemeristsFactionHero from "../components/cards/EphemeristsFactionHero";
 import SnideFactionHero from "../components/cards/SnideFactionHero";
 import SingularityFactionHero from "../components/cards/SingularityFactionHero";
 import EverymenFactionHero from "../components/cards/EverymenFactionHero";
+import UAFactionHero from "../components/cards/UAFactionHero";
 
 /**
  * Faction detail page (`/factions/:slug`). Per-faction surface #13 in
@@ -38,6 +39,7 @@ const FACTION_HEROES: Record<string, ComponentType<FactionHeroProps>> = {
   snide: SnideFactionHero,
   singularity: SingularityFactionHero,
   everymen: EverymenFactionHero,
+  ua: UAFactionHero,
   // wow: undesigned — falls through to the shared title/description chrome.
 };
 


### PR DESCRIPTION
Closes #221

Registers UA's bespoke Tier-3 surfaces on the now-gilt UA tokens (#240), mirroring the other faction dispatchers, built from the gilt-salon design (`docs/design/design-system/templates/ua/ua.css` + the UA task-detail kit).

| Surface | Component | Dispatcher |
|---|---|---|
| Vote | `vote/UAVote.tsx` | `FACTION_VOTE` — gilt-salon appraisal/acquisition ramp |
| Backdrop | `backdrop/UABackdrop.tsx` | `FACTION_BACKDROPS` — parchment wall + gilt glow + ledger dot-grid |
| Faction hero | `cards/UAFactionHero.tsx` | `FACTION_HEROES` — gilt-framed academy frontispiece |

The hero labels counts in the salon voice (members→patrons, tasks→commissions, praxes→acquisitions).

## Always-light
Every surface styles its own container with the UA gilt tokens (identical light/dark — the salon never dims); **no document-theme mutation, no hardcoded hex** (shades via `color-mix` on `--faction-ua-*`/`--ua-*`).

## Scope note
**UA avatar is undesigned** — omitted from `FACTION_AVATARS` (ua keeps the default avatar); that cell reopens when the design lands.

## Tests
`npm test` — 70/70 pass. `npx tsc --noEmit` clean. (`npm run build` red only on the pre-existing, unrelated `CollaborationDetail.tsx` break, flagged separately.)