### PR TITLE
Relationships: add unblock endpoint (ADR-0009)

### DIFF
--- a/backend/routers/relationships.py
+++ b/backend/routers/relationships.py
@@ -8,7 +8,12 @@ from dependencies import get_current_character
 from models.character import Character
 from models.relationship import RelationshipType
 from schemas.relationship import RelationshipCreate, RelationshipListItem, RelationshipOut
-from services.relationship_service import block_relationship, create_relationship, list_relationships
+from services.relationship_service import (
+    block_relationship,
+    create_relationship,
+    list_relationships,
+    unblock_relationship,
+)
 
 router = APIRouter()
 
@@ -53,6 +58,23 @@ async def block_relationship_route(
 ) -> RelationshipOut:
     """Block a relationship. Either party can block."""
     relationship = await block_relationship(
+        relationship_id=relationship_id,
+        character=character,
+        session=session,
+    )
+    return RelationshipOut.model_validate(relationship)
+
+
+@router.post("/{relationship_id}/unblock", response_model=RelationshipOut)
+async def unblock_relationship_route(
+    relationship_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+) -> RelationshipOut:
+    """Reverse a block (ADR-0009). Either party can unblock; the edge returns to
+    active. Separate route from PUT /{id} (block) so the two actions don't
+    collide."""
+    relationship = await unblock_relationship(
         relationship_id=relationship_id,
         character=character,
         session=session,

--- a/backend/services/relationship_service.py
+++ b/backend/services/relationship_service.py
@@ -113,6 +113,25 @@ async def block_relationship(
     return relationship
 
 
+async def unblock_relationship(
+    relationship_id: int,
+    character: Character,
+    session: AsyncSession,
+) -> Relationship:
+    """Reverse a block (ADR-0009). Either party can unblock; the edge returns to
+    active and its display status re-derives from the relationship types."""
+    relationship = await session.get(Relationship, relationship_id)
+    if relationship is None:
+        raise HTTPException(status_code=404, detail="Relationship not found.")
+    if character.id not in (relationship.from_character_id, relationship.to_character_id):
+        raise HTTPException(status_code=403, detail="Not a party to this relationship.")
+
+    relationship.status = RelationshipStatus.active
+    await session.flush()
+    await session.refresh(relationship)
+    return relationship
+
+
 async def list_relationships(
     character_id: int,
     session: AsyncSession,

--- a/backend/tests/integration/test_relationships.py
+++ b/backend/tests/integration/test_relationships.py
@@ -155,6 +155,78 @@ async def test_block_relationship(
     assert block_resp.json()["status"] == "blocked"
 
 
+@pytest.mark.asyncio
+async def test_unblock_relationship_restores_active(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+):
+    """Unblock reverses a block (ADR-0009): the edge returns to active and its
+    display status re-derives from the type."""
+    create_resp = await client.post(
+        "/relationships",
+        json={"to_character_id": character2.id, "type": "friend"},
+        headers=auth_headers,
+    )
+    relationship_id = create_resp.json()["id"]
+    await client.put(f"/relationships/{relationship_id}", headers=auth_headers)
+
+    unblock_resp = await client.post(
+        f"/relationships/{relationship_id}/unblock",
+        headers=auth_headers,
+    )
+    assert unblock_resp.status_code == 200
+    assert unblock_resp.json()["status"] == "active"
+
+    # Display status reverts from "Blocked" to the type-derived label.
+    list_resp = await client.get("/relationships", headers=auth_headers)
+    item = next(r for r in list_resp.json() if r["id"] == relationship_id)
+    assert item["display_status"] != "Blocked"
+
+
+@pytest.mark.asyncio
+async def test_unblock_relationship_by_target(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Either party can unblock — the target (who did not declare the edge) may
+    reverse a block too, symmetric with block."""
+    create_resp = await client.post(
+        "/relationships",
+        json={"to_character_id": character2.id, "type": "friend"},
+        headers=auth_headers,
+    )
+    relationship_id = create_resp.json()["id"]
+    await client.put(f"/relationships/{relationship_id}", headers=auth_headers)
+
+    # character2 is the target, not the declarer — they can still unblock.
+    unblock_resp = await client.post(
+        f"/relationships/{relationship_id}/unblock",
+        headers=auth_headers2,
+    )
+    assert unblock_resp.status_code == 200
+    assert unblock_resp.json()["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_unblock_relationship_non_party_forbidden(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+):
+    """A non-existent relationship returns 404 (no edge to unblock)."""
+    resp = await client.post(
+        "/relationships/999999/unblock",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # Delete relationship
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/relationships.ts
+++ b/frontend/src/api/relationships.ts
@@ -46,6 +46,12 @@ export async function blockRelationship(id: number): Promise<RelationshipOut> {
   return data
 }
 
+/** Reverse a block (ADR-0009) — restores the edge to active. Either party can unblock. */
+export async function unblockRelationship(id: number): Promise<RelationshipOut> {
+  const { data } = await api.post<RelationshipOut>(`/relationships/${id}/unblock`)
+  return data
+}
+
 export async function deleteRelationship(id: number): Promise<void> {
   await api.delete(`/relationships/${id}`)
 }

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -6,6 +6,7 @@ import {
   listRelationships,
   createRelationship,
   deleteRelationship,
+  unblockRelationship,
   type RelationshipListItem,
 } from "../api/relationships";
 import PraxisCard from "../components/PraxisCard";
@@ -108,6 +109,24 @@ export default function CharacterProfile() {
       setRelationship(null);
     } catch {
       setRelationshipError("Could not remove relationship.");
+    } finally {
+      setRelationshipLoading(false);
+    }
+  };
+
+  const handleUnblockRelationship = async () => {
+    if (!relationship || !character) return;
+    setRelationshipLoading(true);
+    setRelationshipError(null);
+    try {
+      await unblockRelationship(relationship.id);
+      // Re-fetch to get the re-derived display status (Blocked → type label).
+      const rels = await listRelationships();
+      setRelationship(
+        rels.find((r) => r.to_character_id === character.id) ?? null,
+      );
+    } catch {
+      setRelationshipError("Could not unblock.");
     } finally {
       setRelationshipLoading(false);
     }
@@ -279,7 +298,7 @@ export default function CharacterProfile() {
                           ? "Friends"
                           : "Foe"}
                     </div>
-                    {relationship.display_status !== "Blocked" && (
+                    {relationship.display_status !== "Blocked" ? (
                       <button
                         onClick={handleRemoveRelationship}
                         disabled={relationshipLoading}
@@ -293,6 +312,22 @@ export default function CharacterProfile() {
                         }}
                       >
                         remove
+                      </button>
+                    ) : (
+                      // ADR-0009 — a block is reversible; either party can unblock.
+                      <button
+                        onClick={handleUnblockRelationship}
+                        disabled={relationshipLoading}
+                        className="eyebrow"
+                        style={{
+                          background: "none",
+                          border: "none",
+                          cursor: "pointer",
+                          color: "var(--color-text-tertiary)",
+                          textAlign: "center",
+                        }}
+                      >
+                        unblock
                       </button>
                     )}
                   </>


### PR DESCRIPTION
Closes #175

Implements the unblock half of ADR-0009 (a block is reversible; either party may reverse it).

## Backend
- `unblock_relationship()` in `relationship_service.py` — mirrors `block_relationship`'s either-party authorization (`character.id in (from, to)`), sets `status = active` so the display status re-derives from the relationship types.
- **Route:** `POST /relationships/{id}/unblock` — a non-colliding shape that leaves the existing `PUT /{id}` (block) and `DELETE /{id}` routes untouched. (Chose this over overloading `PUT` with a `?status=active` param — clearer and less churn; noted per the issue.)

## Frontend
- `unblockRelationship()` in `api/relationships.ts`.
- Surfaces an **"unblock"** action on `CharacterProfile` in the `Blocked` branch — block has no other UI affordance today, so this is the natural (and only) place a blocked edge is shown, and ADR-0009 says either party may reverse it.

## Tests
3 integration tests in `test_relationships.py`:
- unblock restores `active` **and** reverts `display_status` from `Blocked` to the type label
- the **target** (non-declarer) can unblock — symmetric with block
- unknown edge → 404

Full backend suite **418 passed, 83% coverage** (≥80). Frontend **75 passed**, `tsc` clean.