### PR TITLE
Finish edit-praxis shared controls: title/body/mode/publish (ADR-0016)

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
@@ -12,11 +12,21 @@ import type { CSSProperties, ReactNode } from "react";
 import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
-import MarkdownPreview from "../blocks/MarkdownPreview";
 import MediaArt from "../blocks/MediaArt";
 import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
 import { Breadcrumb, ErrorBanner, formatAutosave } from "./shared";
-import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  ModePicker,
+  PublishButton,
+  SaveButton,
+  TitleField,
+} from "./controls";
 import { EphMark, Foxing, LapisLastWord, toRoman } from "../../../components/cards/ephemeristsAtoms";
 import type { EditPraxisState } from "../useEditPraxis";
 
@@ -177,19 +187,18 @@ export default function EditPraxisEphemeris({ state }: Props) {
         {!state.controlsLocked && (
           <div style={{ marginBottom: 28 }}>
             <FieldLabel meta="how the account was taken">THE METHOD</FieldLabel>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
-              {MODE_OPTIONS.filter((opt) => allowedModes.includes(opt.key)).map((opt) => {
-                const on = praxis.type === opt.key;
-                const disabled = state.modeIsLocked || state.switchingMode !== null;
-                if (state.modeIsLocked && !on) return null;
-                return (
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: { display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 },
+                options: MODE_OPTIONS,
+                allowedModes,
+                renderOption: (opt, { active: on, disabled, onSelect }) => (
                   <button
                     key={opt.key}
                     type="button"
                     aria-pressed={on}
-                    onClick={() => {
-                      if (!disabled) void state.changeMode(opt.key);
-                    }}
+                    onClick={onSelect}
                     disabled={disabled && !on}
                     style={{
                       position: "relative",
@@ -212,9 +221,9 @@ export default function EditPraxisEphemeris({ state }: Props) {
                       <div style={{ position: "absolute", top: 8, right: 9, width: 9, height: 9, borderRadius: "50%", background: "var(--eph-gold-light)", boxShadow: `0 0 0 2px ${INK}` }} />
                     )}
                   </button>
-                );
-              })}
-            </div>
+                ),
+              }}
+            />
           </div>
         )}
 
@@ -242,24 +251,23 @@ export default function EditPraxisEphemeris({ state }: Props) {
         {/* the finding (headline) */}
         <div style={{ marginBottom: 28 }}>
           <FieldLabel meta={`${state.title.length}/200 · name the plain fact`}>THE FINDING</FieldLabel>
-          <input
-            type="text"
-            maxLength={200}
-            value={state.title}
-            onChange={(event) => state.setTitle(event.target.value)}
-            placeholder="the ordinary event the legend grew from"
-            style={{
-              width: "100%",
-              border: "none",
-              borderBottom: `2px solid ${INK}`,
-              background: "transparent",
-              fontFamily: "var(--eph-display)",
-              fontWeight: 700,
-              fontSize: 24,
-              letterSpacing: "0.01em",
-              color: TEXT,
-              padding: "4px 2px 8px",
-              outline: "none",
+          <TitleField
+            state={state}
+            skin={{
+              placeholder: "the ordinary event the legend grew from",
+              inputStyle: {
+                width: "100%",
+                border: "none",
+                borderBottom: `2px solid ${INK}`,
+                background: "transparent",
+                fontFamily: "var(--eph-display)",
+                fontWeight: 700,
+                fontSize: 24,
+                letterSpacing: "0.01em",
+                color: TEXT,
+                padding: "4px 2px 8px",
+                outline: "none",
+              },
             }}
           />
         </div>
@@ -267,38 +275,37 @@ export default function EditPraxisEphemeris({ state }: Props) {
         {/* the account (body) */}
         <div style={{ marginBottom: 28 }}>
           <FieldLabel meta={`${state.wordCount} words · markdown ok`}>THE ACCOUNT</FieldLabel>
-          <textarea
-            value={state.body}
-            onChange={(event) => state.setBody(event.target.value)}
-            rows={9}
-            placeholder="Followed it backward through every retelling. The first teller…"
-            style={{
-              width: "100%",
-              resize: "vertical",
-              border: `1.5px solid ${INK}`,
-              background: "var(--eph-vellum)",
-              fontFamily: "var(--eph-serif)",
-              fontSize: 14,
-              lineHeight: 1.65,
-              color: TEXT,
-              padding: "13px 15px",
-              outline: "none",
+          <BodyTextarea
+            state={state}
+            skin={{
+              rows: 9,
+              placeholder: "Followed it backward through every retelling. The first teller…",
+              textareaStyle: {
+                width: "100%",
+                resize: "vertical",
+                border: `1.5px solid ${INK}`,
+                background: "var(--eph-vellum)",
+                fontFamily: "var(--eph-serif)",
+                fontSize: 14,
+                lineHeight: 1.65,
+                color: TEXT,
+                padding: "13px 15px",
+                outline: "none",
+              },
             }}
           />
           <div style={{ fontSize: 9.5, fontStyle: "italic", color: MUTED, marginTop: 7 }}>
             † the account you file is itself a retelling. someone will trace it back. —{" "}
             <span style={{ color: "var(--eph-lapis)" }}>see †</span>
           </div>
-          {state.body.trim() && (
-            <div style={{ marginTop: 14, background: "var(--eph-vellum-deep)", border: `1.5px solid ${GOLD}`, padding: "16px 18px" }}>
-              <FieldLabel>PREVIEW</FieldLabel>
-              <MarkdownPreview
-                source={state.body}
-                className="markdown-preview"
-                style={{ fontFamily: "var(--eph-serif)", fontSize: 14, lineHeight: 1.65, color: TEXT }}
-              />
-            </div>
-          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: { marginTop: 14, background: "var(--eph-vellum-deep)", border: `1.5px solid ${GOLD}`, padding: "16px 18px" },
+              label: <FieldLabel>PREVIEW</FieldLabel>,
+              markdownStyle: { fontFamily: "var(--eph-serif)", fontSize: 14, lineHeight: 1.65, color: TEXT },
+            }}
+          />
         </div>
 
         {/* the evidence */}
@@ -396,12 +403,12 @@ export default function EditPraxisEphemeris({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
-          {!state.isPublished && (
-            <button
-              type="button"
-              onClick={() => void state.publish()}
-              disabled={state.saving || state.submitting || state.switchingMode !== null}
-              style={{
+          <PublishButton
+            state={state}
+            skin={{
+              idleLabel: "✦ SEAL & ENTER ✦",
+              busyLabel: "✦ SEALING…",
+              style: {
                 cursor: state.submitting ? "wait" : "pointer",
                 border: "1px solid var(--eph-gold)",
                 background: RUBRIC,
@@ -414,30 +421,28 @@ export default function EditPraxisEphemeris({ state }: Props) {
                 whiteSpace: "nowrap",
                 boxShadow:
                   "inset 0 2px 4px rgba(255,255,255,0.16), inset 0 -4px 7px rgba(0,0,0,0.38), 0 2px 5px rgba(0,0,0,0.25)",
-              }}
-            >
-              {state.submitting ? "✦ SEALING…" : "✦ SEAL & ENTER ✦"}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void state.save()}
-            disabled={state.saving || state.submitting}
-            style={{
-              cursor: state.saving ? "wait" : "pointer",
-              border: `1px solid ${INK}`,
-              background: "transparent",
-              color: TEXT,
-              fontFamily: "var(--eph-serif)",
-              fontSize: 12,
-              fontWeight: 600,
-              letterSpacing: "0.1em",
-              textTransform: "uppercase",
-              padding: "13px 20px",
+              },
             }}
-          >
-            {state.saving ? "saving…" : "Keep as marginalia"}
-          </button>
+          />
+          <SaveButton
+            state={state}
+            skin={{
+              idleLabel: "Keep as marginalia",
+              busyLabel: "saving…",
+              style: {
+                cursor: state.saving ? "wait" : "pointer",
+                border: `1px solid ${INK}`,
+                background: "transparent",
+                color: TEXT,
+                fontFamily: "var(--eph-serif)",
+                fontSize: 12,
+                fontWeight: 600,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                padding: "13px 20px",
+              },
+            }}
+          />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
@@ -10,7 +10,6 @@ import { useRef } from "react";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import type { MediaItemOut } from "../../../api/praxis";
-import MarkdownPreview from "../blocks/MarkdownPreview";
 import MediaArt from "../blocks/MediaArt";
 import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
 import {
@@ -19,7 +18,15 @@ import {
   TaskMetaInline,
   formatAutosave,
 } from "./shared";
-import { DropButton } from "./controls";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  ModePicker,
+  PublishButton,
+  SaveButton,
+  TitleField,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -297,28 +304,22 @@ export default function EditPraxisEverymen({ state }: Props) {
         {!state.controlsLocked && (
           <div style={{ marginBottom: 28 }}>
             <FieldLabel>THE CREW</FieldLabel>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(3, 1fr)",
-                gap: 12,
-              }}
-            >
-              {MODE_OPTIONS.filter((opt) =>
-                allowedModes.includes(opt.key),
-              ).map((opt) => {
-                const active = praxis.type === opt.key;
-                const disabled =
-                  state.modeIsLocked || state.switchingMode !== null;
-                if (state.modeIsLocked && !active) return null;
-                return (
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: {
+                  display: "grid",
+                  gridTemplateColumns: "repeat(3, 1fr)",
+                  gap: 12,
+                },
+                options: MODE_OPTIONS,
+                allowedModes,
+                renderOption: (opt, { active, disabled, onSelect }) => (
                   <button
                     key={opt.key}
                     type="button"
                     aria-pressed={active}
-                    onClick={() => {
-                      if (!disabled) void state.changeMode(opt.key);
-                    }}
+                    onClick={onSelect}
                     disabled={disabled && !active}
                     style={{
                       position: "relative",
@@ -370,9 +371,9 @@ export default function EditPraxisEverymen({ state }: Props) {
                       />
                     )}
                   </button>
-                );
-              })}
-            </div>
+                ),
+              }}
+            />
           </div>
         )}
 
@@ -385,23 +386,22 @@ export default function EditPraxisEverymen({ state }: Props) {
         {/* The job (headline) */}
         <div style={{ marginBottom: 28 }}>
           <FieldLabel meta={`${state.title.length}/200`}>THE JOB</FieldLabel>
-          <input
-            type="text"
-            maxLength={200}
-            value={state.title}
-            onChange={(event) => state.setTitle(event.target.value)}
-            placeholder="name the work in one line"
-            style={{
-              width: "100%",
-              border: "none",
-              borderBottom: `2px solid ${INK}`,
-              background: "transparent",
-              fontFamily: ACCENT_FONT,
-              fontSize: 26,
-              letterSpacing: "0.01em",
-              color: PAPER_TEXT,
-              padding: "4px 2px 8px",
-              outline: "none",
+          <TitleField
+            state={state}
+            skin={{
+              placeholder: "name the work in one line",
+              inputStyle: {
+                width: "100%",
+                border: "none",
+                borderBottom: `2px solid ${INK}`,
+                background: "transparent",
+                fontFamily: ACCENT_FONT,
+                fontSize: 26,
+                letterSpacing: "0.01em",
+                color: PAPER_TEXT,
+                padding: "4px 2px 8px",
+                outline: "none",
+              },
             }}
           />
           <div
@@ -427,57 +427,56 @@ export default function EditPraxisEverymen({ state }: Props) {
           <FieldLabel meta={`${state.wordCount} words · markdown ok`}>
             THE REPORT
           </FieldLabel>
-          <textarea
-            value={state.body}
-            onChange={(event) => state.setBody(event.target.value)}
-            rows={9}
-            placeholder="Clocked in at…"
-            style={{
-              width: "100%",
-              resize: "vertical",
-              border: `1.5px solid ${INK}`,
-              background: PAPER,
-              fontFamily: BODY_FONT,
-              fontSize: 13,
-              lineHeight: 1.6,
-              color: PAPER_TEXT,
-              padding: "13px 15px",
-              outline: "none",
-              minHeight: 200,
+          <BodyTextarea
+            state={state}
+            skin={{
+              rows: 9,
+              placeholder: "Clocked in at…",
+              textareaStyle: {
+                width: "100%",
+                resize: "vertical",
+                border: `1.5px solid ${INK}`,
+                background: PAPER,
+                fontFamily: BODY_FONT,
+                fontSize: 13,
+                lineHeight: 1.6,
+                color: PAPER_TEXT,
+                padding: "13px 15px",
+                outline: "none",
+                minHeight: 200,
+              },
             }}
           />
-          {state.body.trim() && (
-            <div
-              style={{
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: {
                 marginTop: 14,
                 borderLeft: `4px solid ${RED}`,
                 paddingLeft: 14,
-              }}
-            >
-              <div
-                style={{
-                  fontFamily: BODY_FONT,
-                  fontSize: 9,
-                  letterSpacing: "0.2em",
-                  textTransform: "uppercase",
-                  color: MUTED,
-                  marginBottom: 6,
-                }}
-              >
-                Foreman's preview
-              </div>
-              <MarkdownPreview
-                source={state.body}
-                className="markdown-preview"
-                style={{
-                  fontFamily: BODY_FONT,
-                  fontSize: 13,
-                  lineHeight: 1.6,
-                  color: PAPER_TEXT,
-                }}
-              />
-            </div>
-          )}
+              },
+              label: (
+                <div
+                  style={{
+                    fontFamily: BODY_FONT,
+                    fontSize: 9,
+                    letterSpacing: "0.2em",
+                    textTransform: "uppercase",
+                    color: MUTED,
+                    marginBottom: 6,
+                  }}
+                >
+                  Foreman's preview
+                </div>
+              ),
+              markdownStyle: {
+                fontFamily: BODY_FONT,
+                fontSize: 13,
+                lineHeight: 1.6,
+                color: PAPER_TEXT,
+              },
+            }}
+          />
         </div>
 
         {/* Already pinned proof */}
@@ -580,16 +579,12 @@ export default function EditPraxisEverymen({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
-          {!state.isPublished && (
-            <button
-              type="button"
-              onClick={() => void state.publish()}
-              disabled={
-                state.saving ||
-                state.submitting ||
-                state.switchingMode !== null
-              }
-              style={{
+          <PublishButton
+            state={state}
+            skin={{
+              idleLabel: "★ STAMP & FILE ★",
+              busyLabel: "✓ FILING…",
+              style: {
                 cursor: state.submitting ? "wait" : "pointer",
                 border: `2px solid ${INK}`,
                 background: state.submitting ? OLIVE : RED,
@@ -601,32 +596,29 @@ export default function EditPraxisEverymen({ state }: Props) {
                 whiteSpace: "nowrap",
                 boxShadow: `5px 5px 0 ${INK}`,
                 transition: "background 150ms",
-              }}
-            >
-              {state.submitting ? "✓ FILING…" : "★ STAMP & FILE ★"}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void state.save()}
-            disabled={
-              state.saving || state.submitting || state.switchingMode !== null
-            }
-            style={{
-              cursor: state.saving ? "wait" : "pointer",
-              border: `2px solid ${INK}`,
-              background: "transparent",
-              color: PAPER_TEXT,
-              fontFamily: BODY_FONT,
-              fontSize: 12,
-              fontWeight: 700,
-              letterSpacing: "0.12em",
-              textTransform: "uppercase",
-              padding: "13px 20px",
+              },
             }}
-          >
-            {state.saving ? "Saving…" : "Save Draft"}
-          </button>
+          />
+          <SaveButton
+            state={state}
+            skin={{
+              lockOnSwitch: true,
+              idleLabel: "Save Draft",
+              busyLabel: "Saving…",
+              style: {
+                cursor: state.saving ? "wait" : "pointer",
+                border: `2px solid ${INK}`,
+                background: "transparent",
+                color: PAPER_TEXT,
+                fontFamily: BODY_FONT,
+                fontSize: 12,
+                fontWeight: 700,
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                padding: "13px 20px",
+              },
+            }}
+          />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisGazette.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisGazette.tsx
@@ -5,7 +5,6 @@
 import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
-import MarkdownPreview from "../blocks/MarkdownPreview";
 import MediaArt from "../blocks/MediaArt";
 import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
 import {
@@ -17,7 +16,18 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  ModePicker,
+  PublishButton,
+  SaveButton,
+  TitleField,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -278,55 +288,47 @@ export default function EditPraxisGazette({ state }: Props) {
             >
               ⁘ Manner of Proof ⁘
             </span>
-            <div
-              style={{ display: "flex", gap: 0, border: `1px solid ${ink}` }}
-            >
-              {MODE_OPTIONS.filter((opt) => allowedModes.includes(opt.key)).map(
-                (opt, index) => {
-                  const active = praxis.type === opt.key;
-                  const disabled =
-                    state.modeIsLocked || state.switchingMode !== null;
-                  if (state.modeIsLocked && !active) return null;
-                  return (
-                    <button
-                      key={opt.key}
-                      type="button"
-                      aria-pressed={active}
-                      onClick={() => {
-                        if (!disabled) void state.changeMode(opt.key);
-                      }}
-                      disabled={disabled && !active}
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: { display: "flex", gap: 0, border: `1px solid ${ink}` },
+                options: MODE_OPTIONS,
+                allowedModes,
+                renderOption: (opt, { active, disabled, onSelect, index }) => (
+                  <button
+                    key={opt.key}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={onSelect}
+                    disabled={disabled && !active}
+                    style={{
+                      flex: 1,
+                      cursor: disabled ? "not-allowed" : "pointer",
+                      background: active ? ink : lightBg,
+                      color: active ? surface : ink,
+                      border: "none",
+                      borderLeft: index > 0 ? `1px solid ${ink}` : "none",
+                      padding: "14px 16px",
+                      fontFamily: "'IM Fell English', serif",
+                      textAlign: "center",
+                    }}
+                  >
+                    <div
                       style={{
-                        flex: 1,
-                        cursor: disabled ? "not-allowed" : "pointer",
-                        background: active ? ink : lightBg,
-                        color: active ? surface : ink,
-                        border: "none",
-                        borderLeft: index > 0 ? `1px solid ${ink}` : "none",
-                        padding: "14px 16px",
-                        fontFamily: "'IM Fell English', serif",
-                        textAlign: "center",
+                        fontStyle: "italic",
+                        fontSize: 22,
+                        lineHeight: 1.05,
                       }}
                     >
-                      <div
-                        style={{
-                          fontStyle: "italic",
-                          fontSize: 22,
-                          lineHeight: 1.05,
-                        }}
-                      >
-                        {opt.label}
-                      </div>
-                      <div
-                        style={{ fontSize: 10, marginTop: 4, opacity: 0.85 }}
-                      >
-                        {opt.desc}
-                      </div>
-                    </button>
-                  );
-                },
-              )}
-            </div>
+                      {opt.label}
+                    </div>
+                    <div style={{ fontSize: 10, marginTop: 4, opacity: 0.85 }}>
+                      {opt.desc}
+                    </div>
+                  </button>
+                ),
+              }}
+            />
           </div>
         )}
 
@@ -386,24 +388,23 @@ export default function EditPraxisGazette({ state }: Props) {
           >
             headline
           </span>
-          <input
-            type="text"
-            maxLength={200}
-            value={state.title}
-            onChange={(event) => state.setTitle(event.target.value)}
-            placeholder="On the closing of..."
-            style={{
-              width: "100%",
-              fontFamily: "'IM Fell English', serif",
-              fontStyle: "italic",
-              fontSize: 30,
-              color: ink,
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              borderBottom: `2px solid ${ink}`,
-              padding: "4px 0 8px",
-              textAlign: "center",
+          <TitleField
+            state={state}
+            skin={{
+              placeholder: "On the closing of...",
+              inputStyle: {
+                width: "100%",
+                fontFamily: "'IM Fell English', serif",
+                fontStyle: "italic",
+                fontSize: 30,
+                color: ink,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                borderBottom: `2px solid ${ink}`,
+                padding: "4px 0 8px",
+                textAlign: "center",
+              },
             }}
           />
           <RainbowUnderline opacity={0.55} height={2} />
@@ -439,28 +440,30 @@ export default function EditPraxisGazette({ state }: Props) {
           >
             the account · {state.wordCount} words · markdown ok
           </span>
-          <textarea
-            value={state.body}
-            onChange={(event) => state.setBody(event.target.value)}
-            rows={14}
-            placeholder="The kitchen-light loop closed today..."
-            style={{
-              width: "100%",
-              fontFamily: "'IM Fell English', serif",
-              fontSize: 15,
-              lineHeight: 1.55,
-              color: ink,
-              background: lightBg,
-              border: `1px solid ${ink}`,
-              padding: "20px 22px",
-              outline: "none",
-              resize: "vertical",
-              minHeight: 240,
+          <BodyTextarea
+            state={state}
+            skin={{
+              rows: 14,
+              placeholder: "The kitchen-light loop closed today...",
+              textareaStyle: {
+                width: "100%",
+                fontFamily: "'IM Fell English', serif",
+                fontSize: 15,
+                lineHeight: 1.55,
+                color: ink,
+                background: lightBg,
+                border: `1px solid ${ink}`,
+                padding: "20px 22px",
+                outline: "none",
+                resize: "vertical",
+                minHeight: 240,
+              },
             }}
           />
-          {state.body.trim() && (
-            <div
-              style={{
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: {
                 marginTop: 14,
                 background: lightBg,
                 border: `1px solid ${ink}`,
@@ -468,32 +471,29 @@ export default function EditPraxisGazette({ state }: Props) {
                 columnCount: 2,
                 columnGap: 28,
                 columnRule: `0.5px solid ${muted}`,
-              }}
-            >
-              <span
-                className="eyebrow"
-                style={{
-                  color: muted,
-                  letterSpacing: "0.2em",
-                  display: "block",
-                  marginBottom: 6,
-                  columnSpan: "all",
-                }}
-              >
-                Set in type
-              </span>
-              <MarkdownPreview
-                source={state.body}
-                className="markdown-preview"
-                style={{
-                  fontFamily: "'IM Fell English', serif",
-                  fontSize: 14,
-                  lineHeight: 1.5,
-                  color: ink,
-                }}
-              />
-            </div>
-          )}
+              },
+              label: (
+                <span
+                  className="eyebrow"
+                  style={{
+                    color: muted,
+                    letterSpacing: "0.2em",
+                    display: "block",
+                    marginBottom: 6,
+                    columnSpan: "all",
+                  }}
+                >
+                  Set in type
+                </span>
+              ),
+              markdownStyle: {
+                fontFamily: "'IM Fell English', serif",
+                fontSize: 14,
+                lineHeight: 1.5,
+                color: ink,
+              },
+            }}
+          />
         </div>
 
         {/* Plates */}
@@ -641,14 +641,24 @@ export default function EditPraxisGazette({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
-          {!state.isPublished && (
-            <button
-              type="button"
-              onClick={() => void state.publish()}
-              disabled={
-                state.saving || state.submitting || state.switchingMode !== null
-              }
-              style={{
+          <PublishButton
+            state={state}
+            skin={{
+              idleLabel: "❦ Press & Seal ❦",
+              busyLabel: "Sealing...",
+              ornament: (
+                <span
+                  aria-hidden
+                  style={{
+                    position: "absolute",
+                    inset: 4,
+                    border: `1px solid ${surface}`,
+                    opacity: 0.5,
+                    pointerEvents: "none",
+                  }}
+                />
+              ),
+              style: {
                 position: "relative",
                 background: HOUSE_BLUE,
                 color: surface,
@@ -661,39 +671,27 @@ export default function EditPraxisGazette({ state }: Props) {
                 cursor: state.submitting ? "wait" : "pointer",
                 letterSpacing: "0.05em",
                 boxShadow: `2px 3px 0 ${ink}`,
-              }}
-            >
-              <span
-                aria-hidden
-                style={{
-                  position: "absolute",
-                  inset: 4,
-                  border: `1px solid ${surface}`,
-                  opacity: 0.5,
-                  pointerEvents: "none",
-                }}
-              />
-              {state.submitting ? "Sealing..." : "❦ Press & Seal ❦"}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void state.save()}
-            disabled={state.saving || state.submitting}
-            style={{
-              background: "transparent",
-              color: ink,
-              fontFamily: "'IM Fell English', serif",
-              fontStyle: "italic",
-              fontSize: 13,
-              border: `1px solid ${ink}`,
-              padding: "10px 18px",
-              cursor: state.saving ? "wait" : "pointer",
-              letterSpacing: "0.08em",
+              },
             }}
-          >
-            {state.saving ? "saving..." : "save as draft"}
-          </button>
+          />
+          <SaveButton
+            state={state}
+            skin={{
+              idleLabel: "save as draft",
+              busyLabel: "saving...",
+              style: {
+                background: "transparent",
+                color: ink,
+                fontFamily: "'IM Fell English', serif",
+                fontStyle: "italic",
+                fontSize: 13,
+                border: `1px solid ${ink}`,
+                padding: "10px 18px",
+                cursor: state.saving ? "wait" : "pointer",
+                letterSpacing: "0.08em",
+              },
+            }}
+          />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
@@ -6,7 +6,6 @@
 import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
-import MarkdownPreview from "../blocks/MarkdownPreview";
 import MediaArt from "../blocks/MediaArt";
 import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
 import {
@@ -16,7 +15,18 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  ModePicker,
+  PublishButton,
+  SaveButton,
+  TitleField,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -388,22 +398,18 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                 <span style={{ ...eyebrowStyle, marginBottom: 10 }}>
                   how are you walking?
                 </span>
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                  {MODE_OPTIONS.filter((opt) =>
-                    allowedModes.includes(opt.key),
-                  ).map((opt) => {
-                    const active = praxis.type === opt.key;
-                    const disabled =
-                      state.modeIsLocked || state.switchingMode !== null;
-                    if (state.modeIsLocked && !active) return null;
-                    return (
+                <ModePicker
+                  state={state}
+                  skin={{
+                    containerStyle: { display: "flex", gap: 8, flexWrap: "wrap" },
+                    options: MODE_OPTIONS,
+                    allowedModes,
+                    renderOption: (opt, { active, disabled, onSelect }) => (
                       <button
                         key={opt.key}
                         type="button"
                         aria-pressed={active}
-                        onClick={() => {
-                          if (!disabled) void state.changeMode(opt.key);
-                        }}
+                        onClick={onSelect}
                         disabled={disabled && !active}
                         style={{
                           flex: "1 1 180px",
@@ -412,9 +418,7 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                           background: active
                             ? `linear-gradient(180deg, ${pink}, ${pinkDeep})`
                             : notepadBg,
-                          color: active
-                            ? "var(--color-text-on-accent)"
-                            : ink,
+                          color: active ? "var(--color-text-on-accent)" : ink,
                           border: `1.5px solid ${active ? pinkDeep : notepadBorder}`,
                           borderRadius: 9,
                           padding: "11px 14px 13px",
@@ -438,9 +442,9 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                           {opt.desc}
                         </div>
                       </button>
-                    );
-                  })}
-                </div>
+                    ),
+                  }}
+                />
               </div>
             )}
 
@@ -478,23 +482,22 @@ export default function EditPraxisPaperCollage({ state }: Props) {
               <span style={{ ...eyebrowStyle, marginBottom: 8 }}>
                 title · what whimsy arose?
               </span>
-              <input
-                type="text"
-                maxLength={200}
-                value={state.title}
-                onChange={(event) => state.setTitle(event.target.value)}
-                placeholder="What whimsy arose?"
-                style={{
-                  width: "100%",
-                  fontFamily: cardFont,
-                  fontSize: 28,
-                  fontWeight: 700,
-                  color: ink,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  borderBottom: `2px solid ${notepadBorder}`,
-                  padding: "4px 0 8px",
+              <TitleField
+                state={state}
+                skin={{
+                  placeholder: "What whimsy arose?",
+                  inputStyle: {
+                    width: "100%",
+                    fontFamily: cardFont,
+                    fontSize: 28,
+                    fontWeight: 700,
+                    color: ink,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    borderBottom: `2px solid ${notepadBorder}`,
+                    padding: "4px 0 8px",
+                  },
                 }}
               />
               <div
@@ -518,51 +521,50 @@ export default function EditPraxisPaperCollage({ state }: Props) {
               <span style={{ ...eyebrowStyle, marginBottom: 8 }}>
                 field notes · {state.wordCount} words · markdown ok
               </span>
-              <textarea
-                value={state.body}
-                onChange={(event) => state.setBody(event.target.value)}
-                rows={12}
-                placeholder="Tonight I walked..."
-                style={{
-                  width: "100%",
-                  fontFamily: "var(--font-body)",
-                  fontSize: 14,
-                  lineHeight: "24px",
-                  color: ink,
-                  background: bodyBg,
-                  border: `1.5px solid ${notepadBorder}`,
-                  borderRadius: 7,
-                  padding: "16px 18px",
-                  outline: "none",
-                  resize: "vertical",
-                  minHeight: 220,
+              <BodyTextarea
+                state={state}
+                skin={{
+                  rows: 12,
+                  placeholder: "Tonight I walked...",
+                  textareaStyle: {
+                    width: "100%",
+                    fontFamily: "var(--font-body)",
+                    fontSize: 14,
+                    lineHeight: "24px",
+                    color: ink,
+                    background: bodyBg,
+                    border: `1.5px solid ${notepadBorder}`,
+                    borderRadius: 7,
+                    padding: "16px 18px",
+                    outline: "none",
+                    resize: "vertical",
+                    minHeight: 220,
+                  },
                 }}
               />
-              {state.body.trim() && (
-                <div
-                  style={{
+              <BodyPreview
+                state={state}
+                skin={{
+                  wrapperStyle: {
                     marginTop: 14,
                     background: bodyBg,
                     border: `1.5px solid ${notepadBorder}`,
                     borderRadius: 7,
                     padding: "16px 18px",
-                  }}
-                >
-                  <span style={{ ...eyebrowStyle, marginBottom: 6 }}>
-                    preview
-                  </span>
-                  <MarkdownPreview
-                    source={state.body}
-                    className="markdown-preview"
-                    style={{
-                      fontFamily: "var(--font-body)",
-                      fontSize: 15,
-                      lineHeight: 1.65,
-                      color: ink,
-                    }}
-                  />
-                </div>
-              )}
+                  },
+                  label: (
+                    <span style={{ ...eyebrowStyle, marginBottom: 6 }}>
+                      preview
+                    </span>
+                  ),
+                  markdownStyle: {
+                    fontFamily: "var(--font-body)",
+                    fontSize: 15,
+                    lineHeight: 1.65,
+                    color: ink,
+                  },
+                }}
+              />
             </div>
 
             {/* Media — notepad panel */}
@@ -703,16 +705,15 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                 flexWrap: "wrap",
               }}
             >
-              {!state.isPublished && (
-                <button
-                  type="button"
-                  onClick={() => void state.publish()}
-                  disabled={
-                    state.saving ||
-                    state.submitting ||
-                    state.switchingMode !== null
-                  }
-                  style={{
+              <PublishButton
+                state={state}
+                skin={{
+                  ornament: (
+                    <Sparkle size={12} color="var(--color-text-on-accent)" />
+                  ),
+                  idleLabel: "publish",
+                  busyLabel: "publishing...",
+                  style: {
                     display: "inline-flex",
                     alignItems: "center",
                     gap: 6,
@@ -728,31 +729,28 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                     borderRadius: 9,
                     cursor: state.submitting ? "wait" : "pointer",
                     boxShadow: "0 4px 12px rgba(236,95,153,.32)",
-                  }}
-                >
-                  <Sparkle size={12} color="var(--color-text-on-accent)" />
-                  {state.submitting ? "publishing..." : "publish"}
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => void state.save()}
-                disabled={state.saving || state.submitting}
-                style={{
-                  background: notepadBg,
-                  color: ink,
-                  fontFamily: "var(--font-body)",
-                  fontSize: 11,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.1em",
-                  border: `1.5px solid ${notepadBorder}`,
-                  borderRadius: 7,
-                  padding: "10px 18px",
-                  cursor: state.saving ? "wait" : "pointer",
+                  },
                 }}
-              >
-                {state.saving ? "saving..." : "save draft"}
-              </button>
+              />
+              <SaveButton
+                state={state}
+                skin={{
+                  idleLabel: "save draft",
+                  busyLabel: "saving...",
+                  style: {
+                    background: notepadBg,
+                    color: ink,
+                    fontFamily: "var(--font-body)",
+                    fontSize: 11,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.1em",
+                    border: `1.5px solid ${notepadBorder}`,
+                    borderRadius: 7,
+                    padding: "10px 18px",
+                    cursor: state.saving ? "wait" : "pointer",
+                  },
+                }}
+              />
               <div style={{ flex: 1 }} />
               <DropButton
                 state={state}

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
@@ -6,7 +6,6 @@
 import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
-import MarkdownPreview from "../blocks/MarkdownPreview";
 import MediaArt from "../blocks/MediaArt";
 import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
 import {
@@ -18,7 +17,18 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  ModePicker,
+  PublishButton,
+  SaveButton,
+  TitleField,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -203,13 +213,13 @@ export default function EditPraxisPunkZine({ state }: Props) {
             >
               how shall we DO this??
             </div>
-            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-              {MODE_OPTIONS.filter((opt) => allowedModes.includes(opt.key)).map(
-                (opt, index) => {
-                  const active = praxis.type === opt.key;
-                  const disabled =
-                    state.modeIsLocked || state.switchingMode !== null;
-                  if (state.modeIsLocked && !active) return null;
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: { display: "flex", gap: 12, flexWrap: "wrap" },
+                options: MODE_OPTIONS,
+                allowedModes,
+                renderOption: (opt, { active, disabled, onSelect, index }) => {
                   const bg = active
                     ? opt.key === "duel"
                       ? hot
@@ -221,9 +231,7 @@ export default function EditPraxisPunkZine({ state }: Props) {
                       key={opt.key}
                       type="button"
                       aria-pressed={active}
-                      onClick={() => {
-                        if (!disabled) void state.changeMode(opt.key);
-                      }}
+                      onClick={onSelect}
                       disabled={disabled && !active}
                       style={{
                         cursor: disabled ? "not-allowed" : "pointer",
@@ -258,8 +266,8 @@ export default function EditPraxisPunkZine({ state }: Props) {
                     </button>
                   );
                 },
-              )}
-            </div>
+              }}
+            />
           </div>
         )}
 
@@ -330,21 +338,20 @@ export default function EditPraxisPunkZine({ state }: Props) {
               </span>
             )}
           </div>
-          <input
-            type="text"
-            maxLength={200}
-            value={state.title}
-            onChange={(event) => state.setTitle(event.target.value)}
-            placeholder="type your headline · we'll cut the letters for you"
-            style={{
-              width: "100%",
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 13,
-              padding: "6px 10px",
-              background: surface,
-              color: ink,
-              border: `1.5px dashed ${accentDeep}`,
-              outline: "none",
+          <TitleField
+            state={state}
+            skin={{
+              placeholder: "type your headline · we'll cut the letters for you",
+              inputStyle: {
+                width: "100%",
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 13,
+                padding: "6px 10px",
+                background: surface,
+                color: ink,
+                border: `1.5px dashed ${accentDeep}`,
+                outline: "none",
+              },
             }}
           />
           <RainbowUnderline opacity={0.5} />
@@ -359,30 +366,32 @@ export default function EditPraxisPunkZine({ state }: Props) {
             ↳ the manifesto · {state.wordCount} words · markdown ok
           </span>
           <div style={{ position: "relative", transform: "rotate(0.3deg)" }}>
-            <textarea
-              value={state.body}
-              onChange={(event) => state.setBody(event.target.value)}
-              rows={12}
-              placeholder="lead with the lie. bury the truth in paragraph five..."
-              style={{
-                width: "100%",
-                fontFamily: "'Special Elite', serif",
-                fontSize: 13,
-                lineHeight: 1.7,
-                color: ink,
-                background: surface,
-                border: `2px solid ${accentDeep}`,
-                padding: "20px 22px",
-                outline: "none",
-                resize: "vertical",
-                minHeight: 220,
-                boxShadow: `4px 4px 0 ${accentDeep}`,
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 12,
+                placeholder: "lead with the lie. bury the truth in paragraph five...",
+                textareaStyle: {
+                  width: "100%",
+                  fontFamily: "'Special Elite', serif",
+                  fontSize: 13,
+                  lineHeight: 1.7,
+                  color: ink,
+                  background: surface,
+                  border: `2px solid ${accentDeep}`,
+                  padding: "20px 22px",
+                  outline: "none",
+                  resize: "vertical",
+                  minHeight: 220,
+                  boxShadow: `4px 4px 0 ${accentDeep}`,
+                },
               }}
             />
           </div>
-          {state.body.trim() && (
-            <div
-              style={{
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: {
                 marginTop: 14,
                 background: surface,
                 border: `2px solid ${accentDeep}`,
@@ -391,26 +400,23 @@ export default function EditPraxisPunkZine({ state }: Props) {
                 columnGap: 22,
                 columnRule: `0.5px solid ${accentDeep}`,
                 boxShadow: `4px 4px 0 ${accentDeep}`,
-              }}
-            >
-              <span
-                className="eyebrow"
-                style={{ color: accentDeep, display: "block", marginBottom: 6 }}
-              >
-                Preview
-              </span>
-              <MarkdownPreview
-                source={state.body}
-                className="markdown-preview"
-                style={{
-                  fontFamily: "'Special Elite', serif",
-                  fontSize: 12,
-                  lineHeight: 1.6,
-                  color: ink,
-                }}
-              />
-            </div>
-          )}
+              },
+              label: (
+                <span
+                  className="eyebrow"
+                  style={{ color: accentDeep, display: "block", marginBottom: 6 }}
+                >
+                  Preview
+                </span>
+              ),
+              markdownStyle: {
+                fontFamily: "'Special Elite', serif",
+                fontSize: 12,
+                lineHeight: 1.6,
+                color: ink,
+              },
+            }}
+          />
         </div>
 
         {/* Existing media */}
@@ -660,14 +666,23 @@ export default function EditPraxisPunkZine({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
-          {!state.isPublished && (
-            <button
-              type="button"
-              onClick={() => void state.publish()}
-              disabled={
-                state.saving || state.submitting || state.switchingMode !== null
-              }
-              style={{
+          <PublishButton
+            state={state}
+            skin={{
+              idleLabel: "xerox & staple",
+              busyLabel: "xeroxing...",
+              ornament: (
+                <span
+                  aria-hidden
+                  style={{
+                    position: "absolute",
+                    inset: 4,
+                    border: `1.5px dashed rgba(255,255,255,.6)`,
+                    pointerEvents: "none",
+                  }}
+                />
+              ),
+              style: {
                 background: accent,
                 color: "var(--color-text-on-accent)",
                 fontFamily: "'Permanent Marker', cursive",
@@ -679,40 +694,29 @@ export default function EditPraxisPunkZine({ state }: Props) {
                 position: "relative",
                 transform: "rotate(-1.8deg)",
                 boxShadow: `4px 4px 0 ${ink}`,
-              }}
-            >
-              <span
-                aria-hidden
-                style={{
-                  position: "absolute",
-                  inset: 4,
-                  border: `1.5px dashed rgba(255,255,255,.6)`,
-                  pointerEvents: "none",
-                }}
-              />
-              {state.submitting ? "xeroxing..." : "xerox & staple"}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void state.save()}
-            disabled={state.saving || state.submitting}
-            style={{
-              background: surface,
-              color: accentDeep,
-              fontFamily: "'Special Elite', serif",
-              fontSize: 12,
-              fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: "0.12em",
-              padding: "10px 18px",
-              border: `2px solid ${accentDeep}`,
-              cursor: state.saving ? "wait" : "pointer",
-              transform: "rotate(0.6deg)",
+              },
             }}
-          >
-            {state.saving ? "saving..." : "save draft"}
-          </button>
+          />
+          <SaveButton
+            state={state}
+            skin={{
+              idleLabel: "save draft",
+              busyLabel: "saving...",
+              style: {
+                background: surface,
+                color: accentDeep,
+                fontFamily: "'Special Elite', serif",
+                fontSize: 12,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.12em",
+                padding: "10px 18px",
+                border: `2px solid ${accentDeep}`,
+                cursor: state.saving ? "wait" : "pointer",
+                transform: "rotate(0.6deg)",
+              },
+            }}
+          />
           <div style={{ flex: 1 }} />
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
@@ -4,7 +4,6 @@
  */
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
-import MarkdownPreview from "../blocks/MarkdownPreview";
 import MediaArt from "../blocks/MediaArt";
 import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
 import {
@@ -16,7 +15,18 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  ModePicker,
+  PublishButton,
+  SaveButton,
+  TitleField,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -189,20 +199,18 @@ export default function EditPraxisStickyNote({ state }: Props) {
             >
               how →
             </div>
-            {MODE_OPTIONS.filter((opt) => allowedModes.includes(opt.key)).map(
-              (opt, index) => {
-                const active = praxis.type === opt.key;
-                const disabled =
-                  state.modeIsLocked || state.switchingMode !== null;
-                if (state.modeIsLocked && !active) return null;
-                return (
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: { display: "contents" },
+                options: MODE_OPTIONS,
+                allowedModes,
+                renderOption: (opt, { active, disabled, onSelect, index }) => (
                   <button
                     key={opt.key}
                     type="button"
                     aria-pressed={active}
-                    onClick={() => {
-                      if (!disabled) void state.changeMode(opt.key);
-                    }}
+                    onClick={onSelect}
                     disabled={disabled && !active}
                     style={{
                       background: opt.bg,
@@ -247,9 +255,9 @@ export default function EditPraxisStickyNote({ state }: Props) {
                       </span>
                     )}
                   </button>
-                );
-              },
-            )}
+                ),
+              }}
+            />
           </div>
         )}
 
@@ -311,23 +319,22 @@ export default function EditPraxisStickyNote({ state }: Props) {
           >
             ↳ what'd you call it?
           </div>
-          <input
-            type="text"
-            maxLength={200}
-            value={state.title}
-            onChange={(event) => state.setTitle(event.target.value)}
-            placeholder="give it a name"
-            style={{
-              width: "100%",
-              fontFamily: "'Caveat', cursive",
-              fontSize: 30,
-              color: SLATE_DEEP,
-              fontWeight: 700,
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              borderBottom: `2px dashed ${SLATE}`,
-              padding: "4px 0 6px",
+          <TitleField
+            state={state}
+            skin={{
+              placeholder: "give it a name",
+              inputStyle: {
+                width: "100%",
+                fontFamily: "'Caveat', cursive",
+                fontSize: 30,
+                color: SLATE_DEEP,
+                fontWeight: 700,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                borderBottom: `2px dashed ${SLATE}`,
+                padding: "4px 0 6px",
+              },
             }}
           />
           <RainbowUnderline opacity={0.55} height={2} />
@@ -372,54 +379,53 @@ export default function EditPraxisStickyNote({ state }: Props) {
           >
             ↓ what happened ({state.wordCount} words · md ok)
           </div>
-          <textarea
-            value={state.body}
-            onChange={(event) => state.setBody(event.target.value)}
-            rows={10}
-            placeholder="just write whatever..."
-            style={{
-              width: "100%",
-              fontFamily: "'Caveat', cursive",
-              fontSize: 18,
-              lineHeight: 1.5,
-              color: SLATE_DEEP,
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              resize: "vertical",
-              minHeight: 200,
+          <BodyTextarea
+            state={state}
+            skin={{
+              rows: 10,
+              placeholder: "just write whatever...",
+              textareaStyle: {
+                width: "100%",
+                fontFamily: "'Caveat', cursive",
+                fontSize: 18,
+                lineHeight: 1.5,
+                color: SLATE_DEEP,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                resize: "vertical",
+                minHeight: 200,
+              },
             }}
           />
-          {state.body.trim() && (
-            <div
-              style={{
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: {
                 borderTop: `1px dashed ${SLATE}`,
                 marginTop: 12,
                 paddingTop: 10,
-              }}
-            >
-              <div
-                style={{
-                  fontFamily: "'Permanent Marker', cursive",
-                  fontSize: 11,
-                  color: SLATE,
-                  marginBottom: 6,
-                }}
-              >
-                preview ↓
-              </div>
-              <MarkdownPreview
-                source={state.body}
-                className="markdown-preview"
-                style={{
-                  fontFamily: "'Caveat', cursive",
-                  fontSize: 18,
-                  lineHeight: 1.5,
-                  color: SLATE_DEEP,
-                }}
-              />
-            </div>
-          )}
+              },
+              label: (
+                <div
+                  style={{
+                    fontFamily: "'Permanent Marker', cursive",
+                    fontSize: 11,
+                    color: SLATE,
+                    marginBottom: 6,
+                  }}
+                >
+                  preview ↓
+                </div>
+              ),
+              markdownStyle: {
+                fontFamily: "'Caveat', cursive",
+                fontSize: 18,
+                lineHeight: 1.5,
+                color: SLATE_DEEP,
+              },
+            }}
+          />
         </div>
 
         {/* Photos */}
@@ -568,14 +574,23 @@ export default function EditPraxisStickyNote({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
-          {!state.isPublished && (
-            <button
-              type="button"
-              onClick={() => void state.publish()}
-              disabled={
-                state.saving || state.submitting || state.switchingMode !== null
-              }
-              style={{
+          <PublishButton
+            state={state}
+            skin={{
+              idleLabel: "tack it up →",
+              busyLabel: "tacking...",
+              ornament: (
+                <span
+                  aria-hidden
+                  style={{
+                    position: "absolute",
+                    inset: 4,
+                    border: "1.5px dashed rgba(255,255,255,.5)",
+                    pointerEvents: "none",
+                  }}
+                />
+              ),
+              style: {
                 background: "#dc2626",
                 color: STICKY_PAPER,
                 fontFamily: "'Permanent Marker', cursive",
@@ -588,37 +603,26 @@ export default function EditPraxisStickyNote({ state }: Props) {
                 transform: "rotate(-2deg)",
                 boxShadow: "4px 5px 8px rgba(0,0,0,.3)",
                 position: "relative",
-              }}
-            >
-              <span
-                aria-hidden
-                style={{
-                  position: "absolute",
-                  inset: 4,
-                  border: "1.5px dashed rgba(255,255,255,.5)",
-                  pointerEvents: "none",
-                }}
-              />
-              {state.submitting ? "tacking..." : "tack it up →"}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void state.save()}
-            disabled={state.saving || state.submitting}
-            style={{
-              background: STICKY_PAPER,
-              color: SLATE_DEEP,
-              fontFamily: "'Permanent Marker', cursive",
-              fontSize: 16,
-              padding: "10px 18px",
-              border: `2px solid ${SLATE_DEEP}`,
-              cursor: state.saving ? "wait" : "pointer",
-              transform: "rotate(1deg)",
+              },
             }}
-          >
-            {state.saving ? "saving..." : "save for later"}
-          </button>
+          />
+          <SaveButton
+            state={state}
+            skin={{
+              idleLabel: "save for later",
+              busyLabel: "saving...",
+              style: {
+                background: STICKY_PAPER,
+                color: SLATE_DEEP,
+                fontFamily: "'Permanent Marker', cursive",
+                fontSize: 16,
+                padding: "10px 18px",
+                border: `2px solid ${SLATE_DEEP}`,
+                cursor: state.saving ? "wait" : "pointer",
+                transform: "rotate(1deg)",
+              },
+            }}
+          />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
@@ -6,9 +6,19 @@ import { useEffect, useMemo, useState } from "react";
 import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
-import MarkdownPreview from "../blocks/MarkdownPreview";
 import { Breadcrumb, ErrorBanner, TitleCounter, formatClock } from "./shared";
-import { DropButton, FilePicker, InviteSearch, MetatasksList } from "./controls";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  ModePicker,
+  PublishButton,
+  SaveButton,
+  TitleField,
+} from "./controls";
 import type { EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -203,55 +213,49 @@ export default function EditPraxisTerminal({ state }: Props) {
             <div style={{ fontSize: 10, color: dim, marginBottom: 10 }}>
               <span style={{ color: term }}>$ </span>wz praxis set-mode --select
             </div>
-            <div style={{ display: "flex", gap: 0 }}>
-              {MODE_OPTIONS.filter((opt) => allowedModes.includes(opt.key)).map(
-                (opt) => {
-                  const active = praxis.type === opt.key;
-                  const disabled =
-                    state.modeIsLocked || state.switchingMode !== null;
-                  if (state.modeIsLocked && !active) return null;
-                  return (
-                    <button
-                      key={opt.key}
-                      type="button"
-                      aria-pressed={active}
-                      onClick={() => {
-                        if (!disabled) void state.changeMode(opt.key);
-                      }}
-                      disabled={disabled && !active}
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: { display: "flex", gap: 0 },
+                options: MODE_OPTIONS,
+                allowedModes,
+                renderOption: (opt, { active, disabled, onSelect }) => (
+                  <button
+                    key={opt.key}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={onSelect}
+                    disabled={disabled && !active}
+                    style={{
+                      flex: 1,
+                      cursor: disabled ? "not-allowed" : "pointer",
+                      textAlign: "left",
+                      background: active ? term : "transparent",
+                      color: active ? bg : term,
+                      border: `1px solid ${active ? term : accent}`,
+                      borderRight: "none",
+                      padding: "10px 12px",
+                      fontFamily: "'Share Tech Mono', monospace",
+                    }}
+                  >
+                    <div
                       style={{
-                        flex: 1,
-                        cursor: disabled ? "not-allowed" : "pointer",
-                        textAlign: "left",
-                        background: active ? term : "transparent",
-                        color: active ? bg : term,
-                        border: `1px solid ${active ? term : accent}`,
-                        borderRight: "none",
-                        padding: "10px 12px",
-                        fontFamily: "'Share Tech Mono', monospace",
+                        fontSize: 12,
+                        fontWeight: 700,
+                        marginBottom: 2,
                       }}
                     >
-                      <div
-                        style={{
-                          fontSize: 12,
-                          fontWeight: 700,
-                          marginBottom: 2,
-                        }}
-                      >
-                        {active && "["}
-                        {opt.flag}
-                        {active && "]"}
-                      </div>
-                      <div
-                        style={{ fontSize: 9, opacity: active ? 0.85 : 0.6 }}
-                      >
-                        {opt.desc}
-                      </div>
-                    </button>
-                  );
-                },
-              )}
-            </div>
+                      {active && "["}
+                      {opt.flag}
+                      {active && "]"}
+                    </div>
+                    <div style={{ fontSize: 9, opacity: active ? 0.85 : 0.6 }}>
+                      {opt.desc}
+                    </div>
+                  </button>
+                ),
+              }}
+            />
           </div>
         )}
 
@@ -315,22 +319,21 @@ export default function EditPraxisTerminal({ state }: Props) {
             >
               #{" "}
             </span>
-            <input
-              type="text"
-              maxLength={200}
-              value={state.title}
-              onChange={(event) => state.setTitle(event.target.value)}
-              placeholder="title_goes_here.md"
-              style={{
-                width: "100%",
-                paddingLeft: 22,
-                fontFamily: "'Lora', serif",
-                fontStyle: "italic",
-                fontSize: 26,
-                color: term,
-                background: "transparent",
-                border: "none",
-                outline: "none",
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: "title_goes_here.md",
+                inputStyle: {
+                  width: "100%",
+                  paddingLeft: 22,
+                  fontFamily: "'Lora', serif",
+                  fontStyle: "italic",
+                  fontSize: 26,
+                  color: term,
+                  background: "transparent",
+                  border: "none",
+                  outline: "none",
+                },
               }}
             />
           </div>
@@ -383,23 +386,25 @@ export default function EditPraxisTerminal({ state }: Props) {
             <div
               style={{ flex: 1, padding: "12px 14px", position: "relative" }}
             >
-              <textarea
-                value={state.body}
-                onChange={(event) => state.setBody(event.target.value)}
-                rows={12}
-                placeholder="# what did you do?\n\nwrite here. supports markdown.\n\n--INSERT--"
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  minHeight: 220,
-                  fontFamily: "'Share Tech Mono', monospace",
-                  fontSize: 12,
-                  lineHeight: 1.7,
-                  color: term,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  resize: "vertical",
+              <BodyTextarea
+                state={state}
+                skin={{
+                  rows: 12,
+                  placeholder:
+                    "# what did you do?\n\nwrite here. supports markdown.\n\n--INSERT--",
+                  textareaStyle: {
+                    width: "100%",
+                    height: "100%",
+                    minHeight: 220,
+                    fontFamily: "'Share Tech Mono', monospace",
+                    fontSize: 12,
+                    lineHeight: 1.7,
+                    color: term,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    resize: "vertical",
+                  },
                 }}
               />
               {!state.body && (
@@ -446,30 +451,28 @@ export default function EditPraxisTerminal({ state }: Props) {
                   : "unsaved"}
             </span>
           </div>
-          {state.body.trim() && (
-            <div
-              style={{
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: {
                 marginTop: 14,
                 border: `1px solid ${accent}`,
                 padding: "14px 18px",
                 background: "rgba(0,0,0,.5)",
-              }}
-            >
-              <div style={{ fontSize: 9, color: dim, marginBottom: 8 }}>
-                <span style={{ color: term }}>$ </span>render --markdown
-              </div>
-              <MarkdownPreview
-                source={state.body}
-                className="markdown-preview"
-                style={{
-                  fontFamily: "'Share Tech Mono', monospace",
-                  fontSize: 12,
-                  lineHeight: 1.7,
-                  color: term,
-                }}
-              />
-            </div>
-          )}
+              },
+              label: (
+                <div style={{ fontSize: 9, color: dim, marginBottom: 8 }}>
+                  <span style={{ color: term }}>$ </span>render --markdown
+                </div>
+              ),
+              markdownStyle: {
+                fontFamily: "'Share Tech Mono', monospace",
+                fontSize: 12,
+                lineHeight: 1.7,
+                color: term,
+              },
+            }}
+          />
         </div>
 
         {/* Media */}
@@ -660,14 +663,23 @@ export default function EditPraxisTerminal({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
-          {!state.isPublished && (
-            <button
-              type="button"
-              onClick={() => void state.publish()}
-              disabled={
-                state.saving || state.submitting || state.switchingMode !== null
-              }
-              style={{
+          <PublishButton
+            state={state}
+            skin={{
+              idleLabel: '$ git commit -m "publish"',
+              busyLabel: "$ committing...",
+              ornament: (
+                <span
+                  aria-hidden
+                  style={{
+                    position: "absolute",
+                    inset: 3,
+                    border: "1px dashed rgba(0,0,0,.3)",
+                    pointerEvents: "none",
+                  }}
+                />
+              ),
+              style: {
                 background: term,
                 color: bg,
                 fontFamily: "'Share Tech Mono', monospace",
@@ -679,40 +691,27 @@ export default function EditPraxisTerminal({ state }: Props) {
                 cursor: state.submitting ? "wait" : "pointer",
                 textTransform: "uppercase",
                 position: "relative",
-              }}
-            >
-              <span
-                aria-hidden
-                style={{
-                  position: "absolute",
-                  inset: 3,
-                  border: "1px dashed rgba(0,0,0,.3)",
-                  pointerEvents: "none",
-                }}
-              />
-              {state.submitting
-                ? "$ committing..."
-                : '$ git commit -m "publish"'}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void state.save()}
-            disabled={state.saving || state.submitting}
-            style={{
-              background: "transparent",
-              color: term,
-              fontFamily: "'Share Tech Mono', monospace",
-              fontSize: 11,
-              letterSpacing: "0.1em",
-              padding: "10px 16px",
-              border: `1px solid ${term}`,
-              cursor: state.saving ? "wait" : "pointer",
-              textTransform: "uppercase",
+              },
             }}
-          >
-            {state.saving ? ":saving" : ":w (save draft)"}
-          </button>
+          />
+          <SaveButton
+            state={state}
+            skin={{
+              idleLabel: ":w (save draft)",
+              busyLabel: ":saving",
+              style: {
+                background: "transparent",
+                color: term,
+                fontFamily: "'Share Tech Mono', monospace",
+                fontSize: 11,
+                letterSpacing: "0.1em",
+                padding: "10px 16px",
+                border: `1px solid ${term}`,
+                cursor: state.saving ? "wait" : "pointer",
+                textTransform: "uppercase",
+              },
+            }}
+          />
           <div style={{ flex: 1 }} />
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -5,9 +5,11 @@
  * that must always render: file picker, member chips, search dropdown.
  */
 import { useRef } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import LevelPill from "../../../components/ui/LevelPill";
 import { factionCssVar, factionName } from "../../../utils/factions";
+import type { PraxisType } from "../../../api/praxis";
+import MarkdownPreview from "../blocks/MarkdownPreview";
 import type { EditPraxisState } from "../useEditPraxis";
 
 export interface InviteSearchSkin {
@@ -306,5 +308,219 @@ export function MetatasksList({
         );
       })}
     </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* TitleField — the single 200-char title input.                              */
+/* The archetype owns every surrounding ornament (labels, counters, ransom    */
+/* previews); this control only owns the value/onChange binding so no         */
+/* archetype re-implements it.                                                */
+/* -------------------------------------------------------------------------- */
+export interface TitleFieldSkin {
+  inputStyle: CSSProperties;
+  placeholder?: string;
+}
+
+export function TitleField({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin: TitleFieldSkin;
+}) {
+  return (
+    <input
+      type="text"
+      maxLength={200}
+      value={state.title}
+      onChange={(event) => state.setTitle(event.target.value)}
+      placeholder={skin.placeholder}
+      style={skin.inputStyle}
+    />
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* BodyTextarea — the body textarea bound to state.body / state.setBody.       */
+/* Kept separate from BodyPreview so archetypes that wrap the textarea in      */
+/* bespoke chrome (line-number gutters, etc.) can still consume the shared     */
+/* binding.                                                                    */
+/* -------------------------------------------------------------------------- */
+export interface BodyTextareaSkin {
+  textareaStyle: CSSProperties;
+  rows?: number;
+  placeholder?: string;
+}
+
+export function BodyTextarea({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin: BodyTextareaSkin;
+}) {
+  return (
+    <textarea
+      value={state.body}
+      onChange={(event) => state.setBody(event.target.value)}
+      rows={skin.rows}
+      placeholder={skin.placeholder}
+      style={skin.textareaStyle}
+    />
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* BodyPreview — the live markdown preview block. Owns the `state.body.trim()` */
+/* guard (renders nothing until the body has content) and reuses the shared    */
+/* MarkdownPreview block component. The archetype supplies the bespoke wrapper, */
+/* eyebrow label, and markdown typography via the skin.                        */
+/* -------------------------------------------------------------------------- */
+export interface BodyPreviewSkin {
+  wrapperStyle?: CSSProperties;
+  label?: ReactNode;
+  markdownClassName?: string;
+  markdownStyle?: CSSProperties;
+}
+
+export function BodyPreview({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin: BodyPreviewSkin;
+}) {
+  if (!state.body.trim()) return null;
+  return (
+    <div style={skin.wrapperStyle}>
+      {skin.label}
+      <MarkdownPreview
+        source={state.body}
+        className={skin.markdownClassName ?? "markdown-preview"}
+        style={skin.markdownStyle}
+      />
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* ModePicker — the solo/collab/duel selector. Owns the lock/hide guards so no */
+/* archetype re-implements them: it filters to allowed modes, hides every      */
+/* non-active option once the mode is locked, computes the disabled flag, and  */
+/* wires the confirm-then-switch onClick. The archetype supplies its option    */
+/* metadata and renders each option's bespoke button via `renderOption` —      */
+/* arrangement stays the faction's identity (ADR-0016).                        */
+/* -------------------------------------------------------------------------- */
+export interface ModeOptionRenderArgs {
+  active: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+  index: number;
+}
+
+export interface ModePickerSkin<O extends { key: PraxisType }> {
+  containerStyle?: CSSProperties;
+  options: O[];
+  /** The task's allowed modes. Typed as `string[]` to match TaskOut.allowed_modes;
+   * each option whose `key` is present is rendered. */
+  allowedModes: readonly string[];
+  renderOption: (option: O, args: ModeOptionRenderArgs) => ReactNode;
+}
+
+export function ModePicker<O extends { key: PraxisType }>({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin: ModePickerSkin<O>;
+}) {
+  const praxis = state.praxis!;
+  return (
+    <div style={skin.containerStyle}>
+      {skin.options
+        .filter((option) => skin.allowedModes.includes(option.key))
+        .map((option, index) => {
+          const active = praxis.type === option.key;
+          const disabled =
+            state.modeIsLocked || state.switchingMode !== null;
+          if (state.modeIsLocked && !active) return null;
+          return skin.renderOption(option, {
+            active,
+            disabled,
+            index,
+            onSelect: () => {
+              if (!disabled) void state.changeMode(option.key);
+            },
+          });
+        })}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* PublishButton / SaveButton — the seal-and-save pair. Each owns its own      */
+/* guard: PublishButton renders nothing once published and is disabled while   */
+/* saving / submitting / switching mode; SaveButton is disabled while saving / */
+/* submitting (optionally also while switching). The archetype arranges them   */
+/* inside its bespoke file bar and supplies faction-voiced labels via skin.    */
+/* -------------------------------------------------------------------------- */
+export interface PublishButtonSkin {
+  style: CSSProperties;
+  idleLabel: ReactNode;
+  busyLabel: ReactNode;
+  ornament?: ReactNode;
+}
+
+export function PublishButton({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin: PublishButtonSkin;
+}) {
+  if (state.isPublished) return null;
+  return (
+    <button
+      type="button"
+      onClick={() => void state.publish()}
+      disabled={state.saving || state.submitting || state.switchingMode !== null}
+      style={skin.style}
+    >
+      {skin.ornament}
+      {state.submitting ? skin.busyLabel : skin.idleLabel}
+    </button>
+  );
+}
+
+export interface SaveButtonSkin {
+  style: CSSProperties;
+  idleLabel: ReactNode;
+  busyLabel: ReactNode;
+  /** When true, also disable while a mode switch is in flight (matches the
+   * archetypes that guarded save on `switchingMode`). */
+  lockOnSwitch?: boolean;
+}
+
+export function SaveButton({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin: SaveButtonSkin;
+}) {
+  const disabled =
+    state.saving ||
+    state.submitting ||
+    (skin.lockOnSwitch ? state.switchingMode !== null : false);
+  return (
+    <button
+      type="button"
+      onClick={() => void state.save()}
+      disabled={disabled}
+      style={skin.style}
+    >
+      {state.saving ? skin.busyLabel : skin.idleLabel}
+    </button>
   );
 }


### PR DESCRIPTION
Closes #204

Extracts the four still-inlined, copy-pasted edit-praxis controls into shared skinnable components in `pages/editPraxis/archetypes/controls.tsx` (joining the existing `InviteSearch`/`FilePicker`/`DropButton`/`MetatasksList`), each taking only `{ state, skin }` and owning its own `state` binding + guards:

- **`TitleField`** — title input (`state.title`/`setTitle`)
- **`BodyTextarea`** + **`BodyPreview`** — body textarea + the `MarkdownPreview` block (preview owns the `body.trim()` guard)
- **`ModePicker<O>`** — solo/collab/duel; owns the lock/hide guards (hide non-active when `modeIsLocked`, disable while `switchingMode`); archetype supplies bespoke `renderOption`
- **`PublishButton`** + **`SaveButton`** — own the `isPublished` hide + `saving`/`submitting`/`switchingMode` disable guards

All **7 archetypes** (Ephemeris/Everymen/Gazette/PaperCollage/PunkZine/StickyNote/Terminal) consume these with per-archetype skins; **none re-implements the control logic** (verified: `changeMode(` and `<textarea` live only in `controls.tsx`).

### Why BodyField/PublishBar are split
The issue names `BodyField` and `PublishBar`. I split each into two controls (textarea+preview, publish+save) because every archetype wraps **bespoke chrome between those halves** (line-number gutters, newspaper columns, file bars). A monolithic control would force a fixed arrangement — which **ADR-0016 explicitly rejects** ("arrangement is the per-faction identity; no shared fixed-layout scaffold"). The split keeps each half shared while leaving arrangement fully bespoke, which is the ADR's intent. Outer frames + arrangement are untouched.

## Tests
`npx tsc --noEmit` clean; `npm test` — **75/75 pass** (factionCardSlots + archetype-slot tests included). Behavior preserved 1:1 (incl. Everymen's save-disables-on-switching-mode variance). (`npm run build` red only on the pre-existing, unrelated `CollaborationDetail.tsx` break, flagged separately.)