### PR TITLE
Collaboration redesign: co-ownership + lazy-consensus publish (ADR-0013 + ADR-0012)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -51,6 +51,16 @@ ALBESCENT_FACTION_SLUG = "albescent"
 # ---------------------------------------------------------------------------
 
 
+def _require_member(praxis: Praxis, character_id: int, action: str) -> None:
+    """403 unless ``character_id`` is a member of ``praxis`` (ADR-0013 co-ownership).
+
+    A collab is co-owned by every member; solo/duel praxes have exactly one
+    member (the creator), so this is equivalent to creator-only for those types.
+    """
+    if character_id not in {m.character_id for m in praxis.members}:
+        raise HTTPException(status_code=403, detail=f"Only a member can {action} this praxis.")
+
+
 def _build_member_out(member: PraxisMember) -> PraxisMemberOut:
     return PraxisMemberOut(
         id=member.id,
@@ -423,10 +433,9 @@ async def update_praxis(
     character_id: int,
     session: AsyncSession,
 ) -> Praxis:
-    """Update title/body_text. Only the creator can update."""
+    """Update title/body_text. Any member may edit (ADR-0013)."""
     praxis = await get_praxis(praxis_id, session)
-    if praxis.created_by_id != character_id:
-        raise HTTPException(status_code=403, detail="Cannot edit another character's praxis.")
+    _require_member(praxis, character_id, "edit")
     if data.title is not None:
         praxis.title = data.title
     if data.body_text is not None:
@@ -443,15 +452,14 @@ async def withdraw_praxis(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> Praxis:
-    """Move praxis back to editing (in_progress). Creator only.
+    """Move praxis back to editing (in_progress). Any member may reopen (ADR-0013).
 
     Votes are preserved but stop contributing to score until resubmitted via
     ``submit_praxis``. For collabs/duels, member submission flags are reset so
     the full group must re-submit.
     """
     praxis = await get_praxis(praxis_id, session)
-    if praxis.created_by_id != character_id:
-        raise HTTPException(status_code=403, detail="Cannot edit another character's praxis.")
+    _require_member(praxis, character_id, "reopen")
     if praxis.status == PraxisStatus.in_progress:
         raise HTTPException(status_code=422, detail="Praxis is already in editing mode.")
 
@@ -800,11 +808,10 @@ async def kick_member(
     requester_id: int,
     session: AsyncSession,
 ) -> None:
-    """Remove a member. Only the creator can kick. Cannot kick self."""
+    """Remove a member. Any member may kick another (incl. the creator); not self (ADR-0013)."""
     praxis = await get_praxis(praxis_id, session)
 
-    if praxis.created_by_id != requester_id:
-        raise HTTPException(status_code=403, detail="Only the creator can kick members.")
+    _require_member(praxis, requester_id, "kick from")
 
     if member_id == requester_id:
         raise HTTPException(status_code=400, detail="Cannot kick yourself.")
@@ -819,12 +826,14 @@ async def kick_member(
     if kickee_member is None:
         raise HTTPException(status_code=400, detail="Target player is not a member.")
 
-    await session.delete(kickee_member)
+    # Remove via the collection so delete-orphan cascades the DELETE *and* the
+    # in-memory members list stays consistent — the route reuses this same
+    # identity-mapped praxis to build its response.
+    praxis.members.remove(kickee_member)
 
     # Reset all submitted states when membership changes
     for member in praxis.members:
-        if member.character_id != member_id:
-            member.has_submitted = False
+        member.has_submitted = False
     praxis.status = PraxisStatus.in_progress
 
     await session.flush()

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -704,6 +704,109 @@ async def test_edit_praxis_wrong_owner_returns_403(
 
 
 # ---------------------------------------------------------------------------
+# Collab co-ownership (ADR-0013): any member may edit / reopen / kick
+# ---------------------------------------------------------------------------
+
+
+async def _two_member_collab(
+    client: AsyncClient,
+    task: Task,
+    creator_headers: dict,
+    invitee_id: int,
+    invitee_headers: dict,
+) -> int:
+    """Create a collab owned by ``creator_headers`` and add ``invitee`` as a member."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": task.id, "type": "collab", "title": "Co-owned"},
+        headers=creator_headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+    invite_resp = await client.post(
+        f"/praxes/{praxis_id}/invite",
+        json={"invitee_id": invitee_id},
+        headers=creator_headers,
+    )
+    invite_id = invite_resp.json()["id"]
+    await client.post(
+        f"/praxes/{praxis_id}/invite/{invite_id}/respond",
+        json={"accept": True},
+        headers=invitee_headers,
+    )
+    return praxis_id
+
+
+@pytest.mark.asyncio
+async def test_collab_non_creator_can_edit(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A non-creator member can edit a collab's title/body (ADR-0013)."""
+    # character2 creates, character (non-creator) edits.
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    resp = await client.put(
+        f"/praxes/{praxis_id}",
+        json={"title": "Edited by member", "body_text": "ours"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Edited by member"
+
+
+@pytest.mark.asyncio
+async def test_collab_non_creator_can_reopen(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A non-creator member can reopen (withdraw) a submitted collab (ADR-0013)."""
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    # Both submit so the collab is fully submitted.
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+    submit2 = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+    assert submit2.json()["status"] == "submitted"
+
+    resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_collab_non_creator_can_kick_creator(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A non-creator member can kick the creator; created_by has no special power (ADR-0013)."""
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    # character (non-creator) kicks character2 (the creator).
+    resp = await client.post(
+        f"/praxes/{praxis_id}/kick/{character2.id}", headers=auth_headers
+    )
+    assert resp.status_code == 200
+    remaining = {m["character_id"] for m in resp.json()["members"]}
+    assert character2.id not in remaining
+    assert character.id in remaining
+
+
+# ---------------------------------------------------------------------------
 # Moderation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #187
Closes #186
Closes #262

The two collaboration-redesign issues share `services/praxis.py` and #186 depends on #187's co-ownership relaxation, so they're built together in one branch.

## ADR-0013 — collaborations are co-owned (#187)
- New `_require_member` helper replaces the `created_by`-only guard in `update_praxis`, `withdraw_praxis` (reopen), `kick_member`, and the media add/delete routes. Any collab member may now edit / reopen / kick (incl. the creator) without a 403. Solo/duel have one member, so the membership check is equivalent to creator-only for them.
- Stale-response fix: `kick_member` now removes via the collection (delete-orphan cascade) so the response reflects the removal.

## ADR-0012 — lazy-consensus publish (#186)
A collab publishes by lazy consensus with a silence-is-consent timeout:
- `EraConfig.collab_auto_submit_days` (= 10); value lives in `eras/era_1.py` + `_template.py`, never hardcoded.
- `praxis.submit_proposed_at` opens the pending-publish window (migration `0008`).
- `submit_praxis`: a partial collab submit opens the window; all-submit goes Live immediately and clears it. Solo/duel publish at once, no window.
- Edit hard-reset (`cancel_pending_publish_on_edit`): a title/body (`update_praxis`) or media (routes) edit cancels the window and un-submits everyone → drafting.
- `leave_praxis` + `POST /praxes/{id}/leave`: a member removes their own membership; if everyone who stayed has submitted, the collab goes Live. Distinct from kick/withdraw.
- Lazy-on-access timeout: `get_praxis` / `list_praxes` publish a pending collab whose window lapsed and recalc its members — no scheduler. `ponytail:` comment notes the unobserved-collab gap + in-process-sweep upgrade path.
- `kick`/`withdraw` also clear `submit_proposed_at` (ADR-0013 reset semantics).

## Frontend
- Leave action, pending-publish notice, `submit_proposed_at` on `PraxisOut`.
- Fixes the kick button passing the `PraxisMember` row id where the route expects `character_id` (closes #262).

## Tests
12 new integration tests across both ADRs (co-ownership edit/reopen/kick; window open/clear/cancel/timeout/leave/solo). **Full backend suite: 428 passed.**

## Known pre-existing issue (not introduced here)
`CollaborationDetail.tsx` still imports `getPraxisVotes`/`DuelVoteSummary` removed by ADR-0014, so `vite build` is red independent of this PR (CI runs `vitest`, not `build`). Tracked separately; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)