### PR TITLE
Lift feed-card faction tint into FactionFeedFrame (#142 feed sub-task)

### DIFF
--- a/frontend/src/components/__tests__/factionFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/factionFeedFrame.test.tsx
@@ -34,15 +34,28 @@ describe("FactionFeedFrame dispatch", () => {
     expect(REGISTERED_AT_LOAD.has("ua"), "ua feed undesigned").toBe(false);
   });
 
-  it("passes the card through unchanged for an unregistered slug", () => {
-    // Run after a clear so the map is empty — guards the neutral passthrough.
-    for (const key of Object.keys(FACTION_FEED_FRAMES)) delete FACTION_FEED_FRAMES[key];
-    for (const slug of [null, undefined, "", "ua", "aged_out"]) {
+  it("passes the card through unchanged for a neutral (slug-less) card", () => {
+    // Neutral cards (era_announcement etc.) bring their own chrome — the default
+    // frame must add nothing.
+    for (const slug of [null, undefined, ""]) {
       const html = renderToStaticMarkup(
         <FactionFeedFrame slug={slug}>{CARD}</FactionFeedFrame>,
       );
       expect(html).toBe("<span>card-body</span>");
     }
+  });
+
+  it("tints (does not swallow) a non-null unregistered faction card", () => {
+    // The default frame owns the faction tint lifted off the cards: ua/aged_out
+    // have no bespoke frame, so they get the neutral tinted chrome here — but the
+    // card body must still render inside it.
+    for (const key of Object.keys(FACTION_FEED_FRAMES)) delete FACTION_FEED_FRAMES[key];
+    const html = renderToStaticMarkup(
+      <FactionFeedFrame slug="ua">{CARD}</FactionFeedFrame>,
+    );
+    expect(html).not.toBe("<span>card-body</span>");
+    expect(html).toContain("<span>card-body</span>");
+    expect(html).toContain("card-bg");
   });
 
   it("wraps the card in a registered faction frame (design drop-in)", () => {

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -13,6 +13,7 @@
 import type { ComponentType, ReactNode } from 'react'
 
 import { pickVariant } from '../../utils/factionDispatch'
+import { factionCssVar } from '../../utils/factions'
 import EverymenFeedFrame from './EverymenFeedFrame'
 import EphemeristsFeedFrame from './EphemeristsFeedFrame'
 import WowFeedFrame from './WowFeedFrame'
@@ -32,10 +33,24 @@ const FACTION_FEED_FRAMES: Record<string, ComponentType<FrameProps>> = {
   singularity: SingularityFeedFrame,
 }
 
-/** Neutral fallback: render the card unchanged (today's behaviour — the event
- *  cards carry their own tint, so the default frame adds no chrome). */
-function DefaultFeedFrame({ children }: FrameProps) {
-  return <>{children}</>
+/** Neutral fallback. Owns the per-faction tint that the event cards used to
+ *  hand-roll (card-bg fill + accent border), so a faction with a bespoke frame
+ *  never double-skins. A null/neutral slug (e.g. era_announcement, which brings
+ *  its own dark chrome) stays a true passthrough. */
+function DefaultFeedFrame({ slug, children }: { slug?: string | null; children: ReactNode }) {
+  if (!slug) return <>{children}</>
+  return (
+    <div
+      className="sidebar-card"
+      style={{
+        padding: 0,
+        background: factionCssVar(slug, 'card-bg'),
+        borderLeft: `4px solid ${factionCssVar(slug, 'card-accent')}`,
+      }}
+    >
+      {children}
+    </div>
+  )
 }
 
 interface Props {
@@ -45,6 +60,8 @@ interface Props {
 
 export default function FactionFeedFrame({ slug, children }: Props) {
   const Frame = pickVariant(FACTION_FEED_FRAMES, slug, DefaultFeedFrame)
+  // Only the default frame needs the slug (to tint); bespoke frames are slug-blind.
+  if (Frame === DefaultFeedFrame) return <DefaultFeedFrame slug={slug}>{children}</DefaultFeedFrame>
   return <Frame>{children}</Frame>
 }
 

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
 import { respondToInvite } from "../../api/praxis";
-import { factionColor, factionCssVar } from "../../utils/factions";
+import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
@@ -67,14 +67,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
 
   return (
     <>
-      <div
-        className="sidebar-card"
-        style={{
-          padding: "12px 16px",
-          background: factionCssVar(task_faction_slug, "card-bg"),
-          borderLeft: `4px solid ${factionCssVar(task_faction_slug, "card-accent")}`,
-        }}
-      >
+      <div style={{ padding: "12px 16px" }}>
         <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
           <Link to={`/characters/${inviter_character_id}`}>
             <div

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
 import { respondToInvite } from "../../api/praxis";
-import { factionColor, factionCssVar } from "../../utils/factions";
+import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
@@ -66,14 +66,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
 
   return (
     <>
-      <div
-        className="sidebar-card"
-        style={{
-          padding: "12px 16px",
-          borderLeft: `4px solid ${factionCssVar(task_faction_slug, "card-accent")}`,
-          background: factionCssVar(task_faction_slug, "card-bg"),
-        }}
-      >
+      <div style={{ padding: "12px 16px" }}>
         <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
           <Link to={`/characters/${challenger_character_id}`}>
             <div

--- a/frontend/src/components/feed/FeedCardFoeCompletion.tsx
+++ b/frontend/src/components/feed/FeedCardFoeCompletion.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionCssVar } from '../../utils/factions'
+import { factionColor } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -14,7 +14,7 @@ export default function FeedCardFoeCompletion({ item }: Props) {
   const taskColor = factionColor(task_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
+    <div style={{ padding: '12px 16px', position: 'relative' }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <Link to={`/characters/${character_id}`}>
           <div

--- a/frontend/src/components/feed/FeedCardFoeTaunt.tsx
+++ b/frontend/src/components/feed/FeedCardFoeTaunt.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionCssVar } from '../../utils/factions'
+import { factionColor } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 
 interface Props {
@@ -18,15 +18,7 @@ export default function FeedCardFoeTaunt({ item }: Props) {
     : trigger_type
 
   return (
-    <div
-      className="sidebar-card"
-      style={{
-        background: factionCssVar(item.actor_faction_slug, 'card-bg'),
-        borderLeft: `4px solid ${factionCssVar(item.actor_faction_slug, 'card-accent')}`,
-        padding: '16px 20px',
-        position: 'relative',
-      }}
-    >
+    <div style={{ padding: '16px 20px', position: 'relative' }}>
       {/* Header */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
         <span className="eyebrow">FOE</span>

--- a/frontend/src/components/feed/FeedCardFriendActivity.tsx
+++ b/frontend/src/components/feed/FeedCardFriendActivity.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionCssVar } from '../../utils/factions'
+import { factionColor } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -14,7 +14,7 @@ export default function FeedCardFriendActivity({ item }: Props) {
   const taskColor = factionColor(task_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
+    <div style={{ padding: '12px 16px', position: 'relative' }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         {/* Avatar */}
         <Link to={`/characters/${character_id}`}>

--- a/frontend/src/components/feed/FeedCardFriendDefection.tsx
+++ b/frontend/src/components/feed/FeedCardFriendDefection.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
-import { factionColor, factionCssVar } from "../../utils/factions";
+import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
@@ -20,14 +20,7 @@ export default function FeedCardFriendDefection({ item }: Props) {
   const oldColor = factionColor(old_faction_slug);
 
   return (
-    <div
-      className="sidebar-card"
-      style={{
-        padding: "12px 16px",
-        background: factionCssVar(new_faction_slug, "card-bg"),
-        borderLeft: `4px solid ${factionCssVar(new_faction_slug, "card-accent")}`,
-      }}
-    >
+    <div style={{ padding: "12px 16px" }}>
       <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
         <Link to={`/characters/${character_id}`}>
           <div

--- a/frontend/src/components/feed/FeedCardFriendSignup.tsx
+++ b/frontend/src/components/feed/FeedCardFriendSignup.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionCssVar } from '../../utils/factions'
+import { factionColor } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -14,7 +14,7 @@ export default function FeedCardFriendSignup({ item }: Props) {
   const taskColor = factionColor(task_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', background: factionCssVar(task_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(task_faction_slug, 'card-accent')}` }}>
+    <div style={{ padding: '12px 16px' }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <Link to={`/characters/${character_id}`}>
           <div

--- a/frontend/src/components/feed/FeedCardGlobalTask.tsx
+++ b/frontend/src/components/feed/FeedCardGlobalTask.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
-import { factionColor, factionCssVar } from "../../utils/factions";
+import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
@@ -19,14 +19,7 @@ export default function FeedCardGlobalTask({ item }: Props) {
   const taskColor = factionColor(task_faction_slug);
 
   return (
-    <div
-      className="sidebar-card"
-      style={{
-        padding: "12px 16px",
-        borderLeft: `4px solid ${factionCssVar(task_faction_slug, "card-accent")}`,
-        background: factionCssVar(task_faction_slug, "card-bg"),
-      }}
-    >
+    <div style={{ padding: "12px 16px" }}>
       <div
         style={{
           display: "flex",

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
-import { factionColor, factionCssVar } from "../../utils/factions";
+import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
@@ -13,15 +13,7 @@ export default function FeedCardInvitationLetter({ item }: Props) {
   const color = factionColor(faction_slug);
 
   return (
-    <div
-      className="sidebar-card"
-      style={{
-        padding: "16px 20px",
-        borderLeft: `4px solid ${factionCssVar(faction_slug, "card-accent")}`,
-        background: factionCssVar(faction_slug, "card-bg"),
-        position: "relative",
-      }}
-    >
+    <div style={{ padding: "16px 20px", position: "relative" }}>
       <div
         style={{
           display: "flex",

--- a/frontend/src/components/feed/FeedCardVoteNotification.tsx
+++ b/frontend/src/components/feed/FeedCardVoteNotification.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import { factionColor, factionCssVar } from '../../utils/factions'
+import { factionColor } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import FeedBadge from './FeedBadge'
 
@@ -13,7 +13,7 @@ export default function FeedCardVoteNotification({ item }: Props) {
   const color = factionColor(item.actor_faction_slug)
 
   return (
-    <div className="sidebar-card" style={{ padding: '12px 16px', position: 'relative', background: factionCssVar(item.actor_faction_slug, 'card-bg'), borderLeft: `4px solid ${factionCssVar(item.actor_faction_slug, 'card-accent')}` }}>
+    <div style={{ padding: '12px 16px', position: 'relative' }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         {/* Avatar */}
         <div


### PR DESCRIPTION
Tackles the **feed sub-task** folded into #142 — lifts the per-card faction tint into `FactionFeedFrame` so a registered faction frame never double-skins. Scoped to `frontend/src/components/feed/`. Net **−14 lines** (58+/72−).

## What changed
- **`DefaultFeedFrame`** now owns the neutral faction tint (`card-bg` fill + 4px accent border, keyed on `context_faction_slug`). A null/neutral slug stays a true passthrough so `era_announcement` keeps its own always-dark chrome.
- **All 11 event cards** are now content-only — stripped the outer `sidebar-card` tint wrapper and the now-dead `factionCssVar` import.
- The 5 cards that tinted to `task_faction_slug` (friend/foe completion, collab, duel, signup) now defer to the frame's actor-keyed tint, so frame and card never diverge. Per the design call, all cards tint to `context_faction_slug` (`actor_faction_slug or task_faction_slug` — see `schemas/activity_feed.py`), making double-skinning impossible by construction.
- **Test** split: pure passthrough for slug-less cards; new assertion that a non-null unregistered slug (`ua`) gets tinted chrome **without** swallowing the card body.

## Verified
- `factionFeedFrame.test.tsx` green
- Full frontend suite: 76/76
- `npm run build` clean (the chunk-size warning is pre-existing)

## Not done (deliberate)
- The ~110-file global inline-style→Tailwind sweep (the other half of #142) was **skipped** as negative-value churn — the inline styles already use CSS vars / no hardcoded hex / `[data-theme]` cascade, and the faction surfaces degrade into worse `[arbitrary-value]` classes under Tailwind. Recommend downgrading/closing that half.
- Live browser e2e of all 11 seeded card types not run — needs the full stack + seeded events across every type/faction. The change is DOM-equivalent for the default case and the intended de-double-skin for the 5 framed factions; **worth one eyeball against real feed data during QA** before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)