### PR TITLE
Character Creation epic: multi-life backend + invitations + FieldDesk/creation UI

### DIFF
--- a/backend/alembic/versions/0009_account_active_character.py
+++ b/backend/alembic/versions/0009_account_active_character.py
@@ -1,0 +1,36 @@
+"""Add account.active_character_id — the "last carried life" (ADR-0019, #270).
+
+Revision ID: 0009_account_active_character
+Revises: 0008_praxis_submit_proposed_at
+Create Date: 2026-06-26
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009_account_active_character"
+down_revision: Union[str, None] = "0008_praxis_submit_proposed_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: fresh DBs built from create_all already have this column.
+    op.execute(sa.text(
+        "ALTER TABLE account ADD COLUMN IF NOT EXISTS active_character_id INTEGER"
+    ))
+    # Postgres has no ADD CONSTRAINT IF NOT EXISTS — guard so create_all-built DBs
+    # (which already carry the FK) don't error on re-run.
+    op.execute(sa.text(
+        "DO $$ BEGIN"
+        " IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_account_active_character') THEN"
+        " ALTER TABLE account ADD CONSTRAINT fk_account_active_character"
+        " FOREIGN KEY (active_character_id) REFERENCES character (id);"
+        " END IF; END $$;"
+    ))
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_account_active_character", "account", type_="foreignkey")
+    op.drop_column("account", "active_character_id")

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from config import settings
 from routers import activity_feed, admin, auth, characters, duel, factions, game_config, leaderboard, messages, praxes, relationships, tasks, taunts, votes
-from routers import comments, contact
+from routers import comments, contact, me
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +77,7 @@ app.mount("/media", StaticFiles(directory=settings.MEDIA_ROOT, check_dir=False),
 # Routers
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(characters.router, prefix="/characters", tags=["characters"])
+app.include_router(me.router, prefix="/me", tags=["me"])
 app.include_router(tasks.router, prefix="/tasks", tags=["tasks"])
 app.include_router(praxes.router, prefix="/praxes", tags=["praxes"])
 app.include_router(duel.router, prefix="/duels", tags=["duels"])

--- a/backend/models/account.py
+++ b/backend/models/account.py
@@ -25,9 +25,21 @@ class Account(TimestampMixin, Base):
     status: Mapped[AccountStatus] = mapped_column(
         Enum(AccountStatus, create_type=False), nullable=False, default=AccountStatus.active
     )
+    # The "last carried life" — which character this account is currently playing as.
+    # Nullable: a 0-life account, or one that has not switched yet. use_alter avoids a
+    # chicken-and-egg DDL cycle with character.account_id → account.id.
+    active_character_id: Mapped[int | None] = mapped_column(
+        ForeignKey("character.id", use_alter=True, name="fk_account_active_character"),
+        nullable=True,
+    )
 
+    # foreign_keys pins this to character.account_id — active_character_id adds a
+    # second FK path between the tables that would otherwise be ambiguous.
     characters: Mapped[List["Character"]] = relationship(
-        "Character", back_populates="account", lazy="raise"
+        "Character",
+        back_populates="account",
+        lazy="raise",
+        foreign_keys="Character.account_id",
     )
     oauth_providers: Mapped[List["OAuthProvider"]] = relationship(
         "OAuthProvider", back_populates="account", lazy="raise"

--- a/backend/models/character.py
+++ b/backend/models/character.py
@@ -39,7 +39,10 @@ class Character(TimestampMixin, Base):
     # votes_available is computed on read: services.scoring.compute_votes_available
 
     account: Mapped["Account"] = relationship(
-        "Account", back_populates="characters", lazy="raise"
+        "Account",
+        back_populates="characters",
+        lazy="raise",
+        foreign_keys="Character.account_id",
     )
     praxes: Mapped[List["Praxis"]] = relationship(
         "Praxis",

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,25 +1,14 @@
-from dataclasses import asdict
-
 from authlib.integrations.starlette_client import OAuth
 from fastapi import APIRouter, Depends, Response
 from fastapi import Request
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from db import get_db
-from dependencies import account_has_admin_role
 from models.account import Account
-from models.character import Character, CharacterStatus
 from schemas.auth import CurrentUser
 from services.auth import create_jwt, create_or_get_account, get_current_account
-from services.character import (
-    build_character_out,
-    can_create_additional_character,
-    can_start_as_albescent,
-)
-from services.character_capabilities import compute_capabilities
-from services.era import load_current_era_stats
+from services.current_user import build_current_user
 
 router = APIRouter()
 
@@ -79,51 +68,13 @@ async def auth_me(
     account: Account = Depends(get_current_account),
     session: AsyncSession = Depends(get_db),
 ):
-    """Return the current account and its first active character.
+    """Return the current account and its carried (active) character.
 
     Exposes account_id — this is intentional and the single authorized exception to the
     "never leak account_id publicly" rule. Caller is authenticated; they receive only their
     own id. See SPEC-backend-architecture.md §4.
     """
-    result = await session.execute(
-        select(Character)
-        .where(
-            Character.account_id == account.id,
-            Character.status == CharacterStatus.active,
-        )
-        .order_by(Character.created_at)
-        .limit(1)
-    )
-    character = result.scalar_one_or_none()
-
-    char_out = None
-    character_level: int | None = None
-    if character:
-        stats = await load_current_era_stats(character.id, session)
-        char_out = build_character_out(character, stats)
-        character_level = stats.level if stats else 0
-
-    is_admin = await account_has_admin_role(account.id, session)
-
-    # Eligibility flags depend on the era being seeded. Fall back to False in
-    # fresh test environments where no era row exists yet.
-    try:
-        can_create_more = await can_create_additional_character(account.id, session)
-        can_albescent = await can_start_as_albescent(account.id, session)
-    except Exception:
-        can_create_more = False
-        can_albescent = False
-
-    capabilities = compute_capabilities(character_level, is_admin)
-
-    return CurrentUser(
-        account_id=account.id,
-        character=char_out,
-        is_admin=is_admin,
-        can_create_additional_character=can_create_more,
-        can_start_as_albescent=can_albescent,
-        **asdict(capabilities),
-    )
+    return await build_current_user(account, session)
 
 
 @router.post("/logout")

--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -1,0 +1,52 @@
+"""Account-scoped "my lives" endpoints (ADR-0019, #270).
+
+Distinct from /characters (public roster): these read the authenticated account's
+own characters and which life it is currently carrying.
+"""
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db import get_db
+from models.account import Account
+from schemas.auth import CurrentUser
+from schemas.character import ActiveCharacterIn, CharacterOut
+from services.auth import get_current_account
+from services.character import (
+    build_character_out,
+    get_account_invited_faction_slugs,
+    list_account_roster,
+    set_active_character,
+)
+from services.current_user import build_current_user
+
+router = APIRouter()
+
+
+@router.get("/characters", response_model=list[CharacterOut])
+async def my_characters(
+    account: Account = Depends(get_current_account),
+    session: AsyncSession = Depends(get_db),
+):
+    """The account's own roster — active + paused lives, carried life first."""
+    rows = await list_account_roster(account, session)
+    return [build_character_out(character, stats) for character, stats in rows]
+
+
+@router.post("/active-character", response_model=CurrentUser)
+async def switch_active_character(
+    data: ActiveCharacterIn,
+    account: Account = Depends(get_current_account),
+    session: AsyncSession = Depends(get_db),
+):
+    """Carry a different owned, active life; return the refreshed current user."""
+    await set_active_character(account, data.character_id, session)
+    return await build_current_user(account, session)
+
+
+@router.get("/invited-factions", response_model=list[str])
+async def my_invited_factions(
+    account: Account = Depends(get_current_account),
+    session: AsyncSession = Depends(get_db),
+):
+    """Faction slugs the account holds a current-era invitation for (empty until #272)."""
+    return await get_account_invited_faction_slugs(account.id, session)

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -22,6 +22,10 @@ class CurrentUser(BaseModel):
     # the propose/see flags to True; the eligibility flags have their own rules.
     can_create_additional_character: bool = False
     can_start_as_albescent: bool = False
+    # FieldDesk "locked dossier" gate copy reads these (#270/#274): the level an
+    # existing life must reach to unlock a second life, and the live era's name.
+    second_character_level_required: int = 0
+    era_name: str = ""
     can_propose_task: bool = False
     can_propose_metatask: bool = False
     can_see_retired_tasks: bool = False

--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -29,14 +29,21 @@ class CharacterOut(BaseModel):
 
 
 class CharacterCreate(BaseModel):
-    username: str = Field(..., min_length=3, max_length=30)
-    display_name: str = Field(..., max_length=50)
+    # username is optional: the server derives a unique @handle from display_name
+    # when absent (ADR-0019). An explicit one is still accepted for back-compat.
+    username: str | None = Field(default=None, min_length=3, max_length=30)
+    display_name: str = Field(..., min_length=1, max_length=50)
     bio: str = Field(default="", max_length=500)
     avatar_url: str = Field(default="", max_length=500)
     location: str = Field(default="", max_length=100)
-    # Optional starting faction. Only "albescent" is accepted as a non-default
-    # starting faction, and it requires a level-8 character on the account.
+    # Optional starting faction. Born unaffiliated ("na") by default; a non-None
+    # slug must be one the account holds an invitation for. "albescent" is never
+    # a creation option (join-in-the-field only).
     faction_slug: str | None = Field(default=None, max_length=50)
+
+
+class ActiveCharacterIn(BaseModel):
+    character_id: int
 
 
 class CharacterUpdate(BaseModel):

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -1,4 +1,5 @@
 import dataclasses
+import re
 from typing import Optional
 
 from fastapi import HTTPException
@@ -7,13 +8,22 @@ from sqlalchemy.sql import Select, false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
+from models.account import Account
 from models.character import Character, CharacterStatus
 from models.character_stats import CharacterStats
+from models.invitation_letter import InvitationLetter
 from models.praxis import ModerationStatus, Praxis, PraxisStatus
 from models.task import Task
 from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
 from services.era import get_current_era_row, get_current_era_row_safe, get_or_create_stats
 from services.scoring import compute_level, compute_vote_budget, compute_votes_available
+
+# Status set for the account-scoped roster: a player's own lives, excluding banned.
+_ROSTER_STATUSES: frozenset[CharacterStatus] = frozenset(
+    {CharacterStatus.active, CharacterStatus.paused}
+)
+_DEFAULT_HANDLE = "wanderer"
+_HANDLE_MAX_LEN = 14
 
 
 def build_character_out(
@@ -162,6 +172,124 @@ async def can_start_as_albescent(
     return False
 
 
+async def get_account_invited_faction_slugs(
+    account_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> list[str]:
+    """Faction slugs the account holds a current-era invitation for (ADR-0019).
+
+    Account-pooled: an invite on *any* of the account's characters counts. Sentinels
+    (``na``, ``aged_out``) and ``albescent`` are excluded — they are never invite-joinable.
+    Returns ``[]`` when the era is unseeded or no invites exist (the norm until #272
+    delivers invitations).
+    """
+    era_row = await get_current_era_row_safe(session)
+    if era_row is None:
+        return []
+    result = await session.execute(
+        select(InvitationLetter.faction_slug)
+        .distinct()
+        .join(Character, Character.id == InvitationLetter.character_id)
+        .where(
+            Character.account_id == account_id,
+            InvitationLetter.era_id == era_row.id,
+            InvitationLetter.faction_slug.notin_(list(_ALBESCENT_SENTINEL_SLUGS)),
+        )
+    )
+    return sorted(row[0] for row in result.all())
+
+
+async def _derive_unique_username(display_name: str, session: AsyncSession) -> str:
+    """Lowercase + strip non-alphanumerics + slice; ``wanderer`` fallback; auto-suffix
+    (``wren``, ``wren2``, …) until globally unique."""
+    base = re.sub(r"[^a-z0-9]", "", display_name.lower())[:_HANDLE_MAX_LEN] or _DEFAULT_HANDLE
+    candidate = base
+    suffix = 2
+    # ponytail: serial probe; the username UNIQUE constraint is the real backstop
+    # against a concurrent-create race. Loop handles the common (sequential) case.
+    while await session.scalar(
+        select(Character.id).where(Character.username == candidate)
+    ) is not None:
+        candidate = f"{base}{suffix}"
+        suffix += 1
+    return candidate
+
+
+async def resolve_active_character(
+    account: Account,
+    session: AsyncSession,
+) -> Character | None:
+    """The account's "carried" life: ``active_character_id`` when it points at an
+    owned active character, else the most-recently-created active one, else None."""
+    if account.active_character_id is not None:
+        active = await session.scalar(
+            select(Character).where(
+                Character.id == account.active_character_id,
+                Character.account_id == account.id,
+                Character.status == CharacterStatus.active,
+            )
+        )
+        if active is not None:
+            return active
+    return await session.scalar(
+        select(Character)
+        .where(
+            Character.account_id == account.id,
+            Character.status == CharacterStatus.active,
+        )
+        .order_by(Character.created_at.desc())
+        .limit(1)
+    )
+
+
+async def set_active_character(
+    account: Account,
+    character_id: int,
+    session: AsyncSession,
+) -> None:
+    """Point the account at a different owned, active life. 404 if not owned/missing,
+    409 if the target life is paused/banned (can't carry a non-active life)."""
+    character = await session.get(Character, character_id)
+    if character is None or character.account_id != account.id:
+        raise HTTPException(status_code=404, detail="Character not found.")
+    if character.status != CharacterStatus.active:
+        raise HTTPException(status_code=409, detail="That life is not active.")
+    account.active_character_id = character_id
+    await session.flush()
+
+
+async def list_account_roster(
+    account: Account,
+    session: AsyncSession,
+) -> list[tuple[Character, CharacterStats | None]]:
+    """The account's own lives (active + paused, not banned) with current-era stats,
+    carried life first then newest-first."""
+    era_row = await get_current_era_row_safe(session)
+    era_id = era_row.id if era_row else None
+    join_condition = (
+        (CharacterStats.character_id == Character.id) & sa_false()
+        if era_id is None
+        else (CharacterStats.character_id == Character.id)
+        & (CharacterStats.era_id == era_id)
+    )
+    result = await session.execute(
+        select(Character, CharacterStats)
+        .outerjoin(CharacterStats, join_condition)
+        .where(
+            Character.account_id == account.id,
+            Character.status.in_(list(_ROSTER_STATUSES)),
+        )
+        .order_by(Character.created_at.desc())
+    )
+    rows = list(result.all())
+    active = await resolve_active_character(account, session)
+    active_id = active.id if active else None
+    # Carried life first; created_at desc otherwise (already ordered by the query).
+    rows.sort(key=lambda row: row[0].id != active_id)
+    return rows
+
+
 async def create_character(
     account_id: int,
     data: CharacterCreate,
@@ -169,6 +297,10 @@ async def create_character(
     era: EraConfig = CURRENT_ERA,
 ) -> CharacterCreationResult:
     era_row = await get_current_era_row(session)
+
+    display_name = (data.display_name or "").strip()
+    if not display_name:
+        raise HTTPException(status_code=400, detail="A chosen name is required.")
 
     requested_faction_slug = (data.faction_slug or "").strip().lower() or None
 
@@ -193,33 +325,31 @@ async def create_character(
                 ),
             )
 
-    # Albescent unlock gate: requires at least one character at era.albescent_level_required.
-    if requested_faction_slug == ALBESCENT_FACTION_SLUG:
-        if not await can_start_as_albescent(account_id, session, era):
-            raise HTTPException(
-                status_code=403,
-                detail=(
-                    f"Albescent characters require a level-{era.albescent_level_required} "
-                    "character on the account who has completed a task from each faction."
-                ),
-            )
-        starting_faction_slug = ALBESCENT_FACTION_SLUG
-    elif requested_faction_slug in (None, "", "ua"):
-        # Default onboarding: everyone starts in UA.
-        starting_faction_slug = "ua"
-    else:
+    # ADR-0019: born unaffiliated by default. A non-None faction must be one the
+    # account holds an invitation for. Albescent is never a creation option.
+    if requested_faction_slug is None:
+        starting_faction_slug = "na"
+    elif requested_faction_slug == ALBESCENT_FACTION_SLUG:
         raise HTTPException(
             status_code=400,
-            detail=(
-                "New characters must start in UA (or Albescent, if unlocked). "
-                "Other factions are joined later via faction graduation."
-            ),
+            detail="Albescent is joined in the field, not chosen at creation.",
         )
+    else:
+        invited = await get_account_invited_faction_slugs(account_id, session, era)
+        if requested_faction_slug not in invited:
+            raise HTTPException(
+                status_code=400,
+                detail="You don't hold an invitation for that faction.",
+            )
+        starting_faction_slug = requested_faction_slug
+
+    explicit_username = (data.username or "").strip() or None
+    username = explicit_username or await _derive_unique_username(display_name, session)
 
     character = Character(
         account_id=account_id,
-        username=data.username,
-        display_name=data.display_name,
+        username=username,
+        display_name=display_name,
         bio=data.bio or "",
         avatar_url=data.avatar_url or "",
         location=data.location or "",
@@ -233,6 +363,10 @@ async def create_character(
         character_id=character.id,
         era_id=era_row.id,
     )
+
+    # Carry the new life: it becomes the account's active character.
+    account = await session.get(Account, account_id)
+    account.active_character_id = character.id
 
     await session.flush()
     await session.refresh(character)

--- a/backend/services/current_user.py
+++ b/backend/services/current_user.py
@@ -1,0 +1,60 @@
+"""Assemble the /auth/me CurrentUser payload.
+
+Shared by GET /auth/me and POST /me/active-character so the "switch life then
+return the refreshed user" path doesn't duplicate the composition.
+"""
+from dataclasses import asdict
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dependencies import account_has_admin_role
+from game_config import CURRENT_ERA, EraConfig
+from models.account import Account
+from schemas.auth import CurrentUser
+from services.character import (
+    build_character_out,
+    can_create_additional_character,
+    can_start_as_albescent,
+    resolve_active_character,
+)
+from services.character_capabilities import compute_capabilities
+from services.era import load_current_era_stats
+
+
+async def build_current_user(
+    account: Account,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> CurrentUser:
+    character = await resolve_active_character(account, session)
+
+    char_out = None
+    character_level: int | None = None
+    if character:
+        stats = await load_current_era_stats(character.id, session)
+        char_out = build_character_out(character, stats)
+        character_level = stats.level if stats else 0
+
+    is_admin = await account_has_admin_role(account.id, session)
+
+    # Eligibility flags depend on the era being seeded. Fall back to False in
+    # fresh test environments where no era row exists yet.
+    try:
+        can_create_more = await can_create_additional_character(account.id, session, era)
+        can_albescent = await can_start_as_albescent(account.id, session, era)
+    except Exception:
+        can_create_more = False
+        can_albescent = False
+
+    capabilities = compute_capabilities(character_level, is_admin)
+
+    return CurrentUser(
+        account_id=account.id,
+        character=char_out,
+        is_admin=is_admin,
+        can_create_additional_character=can_create_more,
+        can_start_as_albescent=can_albescent,
+        second_character_level_required=era.second_character_level_required,
+        era_name=era.name,
+        **asdict(capabilities),
+    )

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -1,6 +1,7 @@
 """Integration tests for /characters endpoints."""
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.account import Account
@@ -51,7 +52,8 @@ async def test_create_character(
     assert resp.status_code == 201
     data = resp.json()
     assert data["username"] == "newchar"
-    assert data["faction_slug"] == "ua"
+    # ADR-0019: born unaffiliated, not forced into UA.
+    assert data["faction_slug"] == "na"
     assert "account_id" not in data
 
 
@@ -341,290 +343,120 @@ async def test_second_character_allowed_at_level5(
     assert "account_id" not in data
 
 
-async def _seed_all_faction_completions(
+@pytest.mark.asyncio
+async def test_albescent_rejected_at_creation(
+    client: AsyncClient,
+    account: Account,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """ADR-0019: Albescent is join-in-the-field only — never a creation option."""
+    resp = await client.post(
+        "/characters",
+        json={"display_name": "Wannabe", "faction_slug": "albescent"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_uninvited_faction_rejected_at_creation(
+    client: AsyncClient,
+    account: Account,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """A faction the account holds no invitation for is rejected (born-na is the default)."""
+    resp = await client.post(
+        "/characters",
+        json={"display_name": "Hopeful", "faction_slug": "ua"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_in_invited_faction(
+    client: AsyncClient,
     db_session: AsyncSession,
+    account: Account,
     character: Character,
-) -> None:
-    """Seed one submitted praxis per non-sentinel era faction for the given character.
-
-    Creates faction DB rows, tasks, and submitted praxes as needed. Safe to
-    call multiple times — skips faction rows that already exist.
-    """
-    from game_config import CURRENT_ERA
-    from models.faction import Faction, FactionStatus
-    from models.praxis import Praxis, PraxisStatus, PraxisType
-    from models.task import Task, TaskStatus
-    from sqlalchemy import select
-
-    sentinel_slugs = frozenset({"na", "aged_out", "albescent"})
-    required_slugs = [
-        slug for slug in CURRENT_ERA.factions if slug not in sentinel_slugs
-    ]
-
-    for faction_slug in required_slugs:
-        result = await db_session.execute(
-            select(Faction).where(Faction.slug == faction_slug)
-        )
-        if result.scalar_one_or_none() is None:
-            db_session.add(
-                Faction(
-                    slug=faction_slug,
-                    name=faction_slug,
-                    description=f"{faction_slug} test faction",
-                    status=FactionStatus.visible,
-                )
-            )
-            await db_session.flush()
-
-        task = Task(
-            title=f"Albescent gate task: {faction_slug}",
-            description="test",
-            point_value=5,
-            level_required=0,
-            status=TaskStatus.active,
-            created_by=character.id,
-            primary_faction_slug=faction_slug,
-        )
-        db_session.add(task)
-        await db_session.flush()
-
-        praxis = Praxis(
-            task_id=task.id,
-            created_by_id=character.id,
-            type=PraxisType.solo,
-            title=f"Albescent gate praxis: {faction_slug}",
-            body_text="proof",
-            status=PraxisStatus.submitted,
-        )
-        db_session.add(praxis)
-
-    await db_session.commit()
-
-
-@pytest.mark.asyncio
-async def test_albescent_requires_level8_and_faction_completions(
-    client: AsyncClient,
-    db_session: AsyncSession,
-    account2: Account,
-    character2: Character,
     era: Era,
     faction_ua: Faction,
-    auth_headers2: dict,
+    auth_headers: dict,
 ):
-    """Creating an Albescent character requires a level-8 character who has
-    completed a task from every non-sentinel faction (R.7)."""
-    from models.faction import FactionStatus
-    from sqlalchemy import select
+    """With an account-pooled invitation, a new life may be born straight into that faction."""
+    from models.invitation_letter import InvitationLetter
 
-    # Ensure the albescent faction exists (required FK)
-    result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
-    if result.scalar_one_or_none() is None:
-        db_session.add(
-            Faction(
-                slug="albescent",
-                name="Albescent",
-                description="Albescent faction",
-                status=FactionStatus.visible,
-            )
-        )
-        await db_session.commit()
-
-    # character2 is level 5 — raise to 7 (still below 8)
-    stats_result = await db_session.execute(
-        select(CharacterStats).where(
-            CharacterStats.character_id == character2.id,
-            CharacterStats.era_id == era.id,
-        )
+    # character (account's first life) holds a current-era UA invite; raise to the
+    # second-character gate so the create is allowed.
+    stats = await db_session.scalar(
+        select(CharacterStats).where(CharacterStats.character_id == character.id)
     )
-    stats = stats_result.scalar_one()
-    stats.level = 7
+    stats.level = 4
+    db_session.add(InvitationLetter(character_id=character.id, faction_slug="ua", era_id=era.id))
     await db_session.commit()
-
-    # Level 7 — Albescent should be blocked (fails the level gate first)
-    resp_blocked = await client.post(
-        "/characters",
-        json={
-            "username": "alb_second",
-            "display_name": "Alb Second",
-            "faction_slug": "albescent",
-        },
-        headers=auth_headers2,
-    )
-    assert resp_blocked.status_code == 403
-    assert "8" in resp_blocked.json()["detail"]
-
-    # Raise to level 8 and seed all faction completions
-    stats.level = 8
-    await db_session.commit()
-    await _seed_all_faction_completions(db_session, character2)
-
-    resp_allowed = await client.post(
-        "/characters",
-        json={
-            "username": "alb_second2",
-            "display_name": "Alb Second 2",
-            "faction_slug": "albescent",
-        },
-        headers=auth_headers2,
-    )
-    assert resp_allowed.status_code == 201
-    assert resp_allowed.json()["faction_slug"] == "albescent"
-
-
-@pytest.mark.asyncio
-async def test_albescent_character_starts_in_albescent_faction(
-    client: AsyncClient,
-    db_session: AsyncSession,
-    account2: Account,
-    character2: Character,
-    era: Era,
-    faction_ua: Faction,
-    auth_headers2: dict,
-):
-    """A second character created as Albescent has faction_slug='albescent' (R.8), not 'ua'."""
-    from models.faction import FactionStatus
-    from sqlalchemy import select
-
-    # Ensure the albescent faction exists
-    result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
-    if result.scalar_one_or_none() is None:
-        db_session.add(
-            Faction(
-                slug="albescent",
-                name="Albescent",
-                description="Albescent faction",
-                status=FactionStatus.visible,
-            )
-        )
-        await db_session.commit()
-
-    # Raise character2 to level 8 and seed all faction completions
-    stats_result = await db_session.execute(
-        select(CharacterStats).where(
-            CharacterStats.character_id == character2.id,
-            CharacterStats.era_id == era.id,
-        )
-    )
-    stats = stats_result.scalar_one()
-    stats.level = 8
-    await db_session.commit()
-    await _seed_all_faction_completions(db_session, character2)
 
     resp = await client.post(
         "/characters",
-        json={
-            "username": "alb_starter",
-            "display_name": "Alb Starter",
-            "faction_slug": "albescent",
-        },
-        headers=auth_headers2,
+        json={"display_name": "Invited One", "faction_slug": "ua"},
+        headers=auth_headers,
     )
     assert resp.status_code == 201
-    data = resp.json()
-    # Must land directly in Albescent, not UA
-    assert data["faction_slug"] == "albescent"
-    assert data["faction_slug"] != "ua"
+    assert resp.json()["faction_slug"] == "ua"
 
 
 @pytest.mark.asyncio
-async def test_albescent_blocked_when_one_faction_missing(
+async def test_username_derived_from_display_name(
     client: AsyncClient,
-    db_session: AsyncSession,
-    account2: Account,
-    character2: Character,
+    account: Account,
     era: Era,
     faction_ua: Faction,
-    auth_headers2: dict,
+    auth_headers: dict,
 ):
-    """Albescent is blocked when a level-8 character is missing a completion
-    from exactly one non-sentinel faction."""
-    from game_config import CURRENT_ERA
-    from models.faction import Faction, FactionStatus
-    from models.praxis import Praxis, PraxisStatus, PraxisType
-    from models.task import Task, TaskStatus
-    from sqlalchemy import select
-
-    # Ensure albescent faction row exists
-    result = await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
-    if result.scalar_one_or_none() is None:
-        db_session.add(
-            Faction(
-                slug="albescent",
-                name="Albescent",
-                description="Albescent faction",
-                status=FactionStatus.visible,
-            )
-        )
-        await db_session.commit()
-
-    # Raise character2 to level 8
-    stats_result = await db_session.execute(
-        select(CharacterStats).where(
-            CharacterStats.character_id == character2.id,
-            CharacterStats.era_id == era.id,
-        )
-    )
-    stats = stats_result.scalar_one()
-    stats.level = 8
-    await db_session.commit()
-
-    sentinel_slugs = frozenset({"na", "aged_out", "albescent"})
-    required_slugs = [
-        slug for slug in CURRENT_ERA.factions if slug not in sentinel_slugs
-    ]
-    # Seed completions for all factions except the last one
-    slugs_to_seed = required_slugs[:-1]
-
-    for faction_slug in slugs_to_seed:
-        result = await db_session.execute(
-            select(Faction).where(Faction.slug == faction_slug)
-        )
-        if result.scalar_one_or_none() is None:
-            db_session.add(
-                Faction(
-                    slug=faction_slug,
-                    name=faction_slug,
-                    description=f"{faction_slug} test faction",
-                    status=FactionStatus.visible,
-                )
-            )
-            await db_session.flush()
-
-        task = Task(
-            title=f"Albescent gate task: {faction_slug}",
-            description="test",
-            point_value=5,
-            level_required=0,
-            status=TaskStatus.active,
-            created_by=character2.id,
-            primary_faction_slug=faction_slug,
-        )
-        db_session.add(task)
-        await db_session.flush()
-
-        praxis = Praxis(
-            task_id=task.id,
-            created_by_id=character2.id,
-            type=PraxisType.solo,
-            title=f"Albescent gate praxis: {faction_slug}",
-            body_text="proof",
-            status=PraxisStatus.submitted,
-        )
-        db_session.add(praxis)
-
-    await db_session.commit()
-
-    # One faction missing — Albescent must still be blocked
+    """Omitted username → derived from display_name (lowercase, alphanumeric-only)."""
     resp = await client.post(
         "/characters",
-        json={
-            "username": "alb_almost",
-            "display_name": "Alb Almost",
-            "faction_slug": "albescent",
-        },
-        headers=auth_headers2,
+        json={"display_name": "Wren O'Hara!"},
+        headers=auth_headers,
     )
-    assert resp.status_code == 403
+    assert resp.status_code == 201
+    assert resp.json()["username"] == "wrenohara"
+
+
+@pytest.mark.asyncio
+async def test_username_collision_auto_suffix(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """A derived handle that collides gets an auto-suffix (wren, wren2)."""
+    # Clear the second-character gate so both creates are allowed.
+    stats = await db_session.scalar(
+        select(CharacterStats).where(CharacterStats.character_id == character.id)
+    )
+    stats.level = 4
+    await db_session.commit()
+
+    first = await client.post("/characters", json={"display_name": "Wren"}, headers=auth_headers)
+    assert first.json()["username"] == "wren"
+    second = await client.post("/characters", json={"display_name": "Wren"}, headers=auth_headers)
+    assert second.json()["username"] == "wren2"
+
+
+@pytest.mark.asyncio
+async def test_empty_display_name_rejected(
+    client: AsyncClient, account: Account, era: Era, auth_headers: dict
+):
+    """A non-empty display_name is required."""
+    resp = await client.post("/characters", json={"display_name": "   "}, headers=auth_headers)
+    assert resp.status_code in (400, 422)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_me.py
+++ b/backend/tests/integration/test_me.py
@@ -1,0 +1,191 @@
+"""Integration tests for /me/* account-scoped endpoints (ADR-0019, #270)."""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character, CharacterStatus
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction
+from models.invitation_letter import InvitationLetter
+
+
+async def _add_character(
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    *,
+    username: str,
+    status: CharacterStatus = CharacterStatus.active,
+    faction_slug: str = "na",
+) -> Character:
+    ch = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username.title(),
+        faction_slug=faction_slug,
+        status=status,
+    )
+    db_session.add(ch)
+    await db_session.flush()
+    db_session.add(CharacterStats(character_id=ch.id, era_id=era.id, votes_spent_this_era=0))
+    await db_session.commit()
+    await db_session.refresh(ch)
+    return ch
+
+
+# --- /me/characters ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_my_characters_excludes_banned_includes_paused(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    paused = await _add_character(db_session, account, era, username="pausedlife", status=CharacterStatus.paused)
+    await _add_character(db_session, account, era, username="bannedlife", status=CharacterStatus.banned)
+
+    resp = await client.get("/me/characters", headers=auth_headers)
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert character.id in ids
+    assert paused.id in ids
+    assert len(ids) == 2  # banned excluded
+
+
+@pytest.mark.asyncio
+async def test_my_characters_carried_life_first(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    second = await _add_character(db_session, account, era, username="secondlife")
+    account.active_character_id = second.id
+    await db_session.commit()
+
+    resp = await client.get("/me/characters", headers=auth_headers)
+    assert resp.json()[0]["id"] == second.id
+
+
+@pytest.mark.asyncio
+async def test_my_characters_empty_account(
+    client: AsyncClient, account: Account, era: Era, auth_headers: dict
+):
+    resp = await client.get("/me/characters", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# --- /me/active-character ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_switch_active_character_happy(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    second = await _add_character(db_session, account, era, username="secondlife")
+    resp = await client.post(
+        "/me/active-character", json={"character_id": second.id}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["character"]["id"] == second.id
+
+    # /auth/me now resolves to the carried life.
+    me = await client.get("/auth/me", headers=auth_headers)
+    assert me.json()["character"]["id"] == second.id
+
+
+@pytest.mark.asyncio
+async def test_switch_active_character_not_owned(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+):
+    resp = await client.post(
+        "/me/active-character", json={"character_id": character2.id}, headers=auth_headers
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_switch_active_character_non_active_rejected(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    paused = await _add_character(db_session, account, era, username="pausedlife", status=CharacterStatus.paused)
+    resp = await client.post(
+        "/me/active-character", json={"character_id": paused.id}, headers=auth_headers
+    )
+    assert resp.status_code == 409
+
+
+# --- /me/invited-factions ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invited_factions_empty_by_default(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    resp = await client.get("/me/invited-factions", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_invited_factions_account_pooled(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    db_session.add(InvitationLetter(character_id=character.id, faction_slug="ua", era_id=era.id))
+    db_session.add(InvitationLetter(character_id=character.id, faction_slug="albescent", era_id=era.id))
+    # albescent FK row
+    from models.faction import FactionStatus
+    db_session.add(Faction(slug="albescent", name="Albescent", description="x", status=FactionStatus.visible))
+    await db_session.commit()
+
+    resp = await client.get("/me/invited-factions", headers=auth_headers)
+    assert resp.status_code == 200
+    # albescent is excluded (never invite-joinable at the picker)
+    assert resp.json() == ["ua"]
+
+
+# --- /auth/me new fields ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_me_surfaces_gate_copy_fields(
+    client: AsyncClient, character: Character, era: Era, auth_headers: dict
+):
+    from game_config import CURRENT_ERA
+
+    resp = await client.get("/auth/me", headers=auth_headers)
+    data = resp.json()
+    assert data["second_character_level_required"] == CURRENT_ERA.second_character_level_required
+    assert data["era_name"] == CURRENT_ERA.name


### PR DESCRIPTION
Implements the **Character Creation epic (#275)** end to end, in dependency order. Stacked on one branch.

| Issue | What |
|---|---|
| **#270** | Backend multi-life plumbing — `Account.active_character_id` (+ migration 0009), `/me/characters`, `/me/active-character`, `/me/invited-factions`, born-`na` creation with server-derived `@handle`, `/auth/me` active-resolution + `era_name`/`second_character_level_required` |
| **#272** | Faction invitation delivery (ADR-0022) — 2 tasks + 50 points, folded into `recalculate_character_stats`, idempotent, retires the level≥3/score≥20/pledge rule |
| **#271** | Skinnable `CredentialCard` — color + font only, `--faction-<slug>-card-*` → `--fc-*`; na/factionless → neutral |
| **#274** | FieldDesk roster at `/` (authed) — pill, life cards, active-switch, locked/unlocked "Begin a new self" dossier |
| **#273** | Adaptive creation page — picker iff invited set non-empty; one submit path; live credential preview |

Closes #270
Closes #271
Closes #272
Closes #273
Closes #274

## Verification
- **Backend:** 446 tests pass (incl. 6 new invitation-delivery + `test_me.py` roster/switch/invited-factions). Migration 0009 up+down executed against real Postgres.
- **Frontend:** `vite build` + `tsc` clean (my files), 79 vitest pass (incl. new `credentialCard.test.tsx`).
- **Live (dev-login, dev DB migrated to head):** FieldDesk pill/cards/unlocked dossier render; creation factionless variant renders; live `@handle` preview + card re-skin track typing; **a real button-in-button DOM-nesting bug was caught here and fixed** (avatar is a `<button>` only when it's an upload affordance).

## Notes
- `can_start_as_albescent` stays on `/auth/me` (dormant) — only the creation *birth path* is retired.
- ponytail shortcuts (marked in code): serial `@handle` probe backed by the UNIQUE constraint; per-faction invitation recompute reuses recalc's gathered praxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)