### PR TITLE
NavBar: route the active life's name to the FieldDesk (#274)

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -131,7 +131,9 @@ export default function NavBar() {
             <>
               {user.character ? (
                 <NavLink
-                  to={`/characters/${user.character.id}/edit`}
+                  to="/"
+                  end
+                  title="Your FieldDesk — switch lives or begin a new one"
                   className="nav-link transition-colors"
                   style={{ color: 'var(--color-text-secondary)' }}
                 >


### PR DESCRIPTION
Small standalone entrypoint change, split out so it can deploy independently.

The active life's name in the navbar previously linked to `/characters/{id}/edit`.
It now links to `/` (the FieldDesk roster) so "switch lives / begin a new one" has
a navbar entrypoint. Edit-character stays reachable from the character profile.

One file, +3/-1 (`frontend/src/components/NavBar.tsx`).

## ⚠️ Depends on the FieldDesk (PR #283)
`/` only renders the FieldDesk for authed users once #283 is deployed. Until then,
`/` is the existing Home page — so this should merge **after or together with #283**,
otherwise clicking the name routes to Home rather than the desk (not broken, just not
the intended destination yet).

Verified live (dev-login): clicking the name navigates to `/` and renders the
FieldDesk ("Whose shoes today?"), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)