### PR TITLE
Build & register UaFeedFrame (gilt salon, feed surface #12)

### DIFF
--- a/frontend/src/components/__tests__/factionFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/factionFeedFrame.test.tsx
@@ -26,12 +26,10 @@ afterEach(() => {
 });
 
 describe("FactionFeedFrame dispatch", () => {
-  it("registers the five designed faction frames (ua undesigned)", () => {
-    for (const slug of ["everymen", "ephemerists", "wow", "snide", "singularity"]) {
+  it("registers all six designed faction frames", () => {
+    for (const slug of ["everymen", "ephemerists", "wow", "snide", "singularity", "ua"]) {
       expect(REGISTERED_AT_LOAD.has(slug), `${slug} frame registered`).toBe(true);
     }
-    // UA feed is undesigned — it must fall through to the neutral default.
-    expect(REGISTERED_AT_LOAD.has("ua"), "ua feed undesigned").toBe(false);
   });
 
   it("passes the card through unchanged for a neutral (slug-less) card", () => {

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -19,18 +19,19 @@ import EphemeristsFeedFrame from './EphemeristsFeedFrame'
 import WowFeedFrame from './WowFeedFrame'
 import SnideFeedFrame from './SnideFeedFrame'
 import SingularityFeedFrame from './SingularityFeedFrame'
+import UaFeedFrame from './UaFeedFrame'
 
 type FrameProps = { children: ReactNode }
 
 /** Per-faction frames. Each row makes that faction's feed cards bespoke.
- *  albescent/aged_out inherit ua via pickVariant. UA feed is undesigned, so
- *  ua falls through to the neutral DefaultFeedFrame (#224). */
+ *  albescent/aged_out inherit ua via pickVariant. */
 const FACTION_FEED_FRAMES: Record<string, ComponentType<FrameProps>> = {
   everymen: EverymenFeedFrame,
   ephemerists: EphemeristsFeedFrame,
   wow: WowFeedFrame,
   snide: SnideFeedFrame,
   singularity: SingularityFeedFrame,
+  ua: UaFeedFrame,
 }
 
 /** Neutral fallback. Owns the per-faction tint that the event cards used to

--- a/frontend/src/components/feed/UaFeedFrame.tsx
+++ b/frontend/src/components/feed/UaFeedFrame.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from 'react'
+
+/**
+ * University of Asthmatics per-faction feed frame (surface #12,
+ * SPEC-faction-ui-profile.md).
+ *
+ * A thin presentational WRAPPER: it skins the neutral feed card (`children`) as a
+ * gilt-salon submission. The frame supplies only the OUTER chrome — a gilt border
+ * holding a gold-gradient liner around a parchment body, topped by an engraved
+ * masthead strip — and renders the unchanged card as the salon-mounted body. It
+ * must NOT reimplement the card internals; those arrive via `children`.
+ *
+ * UA is ALWAYS LIGHT: its --ua-* / --faction-ua-* tokens are identical in both
+ * themes, so the container styles itself with them and reads as a lit salon
+ * regardless of the global theme — it never mutates data-theme. (Mirror of
+ * SingularityFeedFrame, which is always-dark.)
+ */
+
+// Token shorthands — every color resolves to a --ua-* var.
+const GILT = 'var(--ua-gilt)' // gold frame gradient
+const GOLD = 'var(--ua-gold)' // old gold liner
+const GOLD_PALE = 'var(--ua-gold-pale)'
+const PAPER = 'var(--ua-paper)' // parchment body
+const INK = 'var(--ua-ink)' // brown ink — borders & shadow
+const ORANGE = 'var(--ua-orange)' // burnt amber — masthead eyebrow
+const FONT_ENGRAVED = 'var(--font-faction-engraved)' // Cinzel
+
+// color-mix helper for brown ink derivatives (border, shadow, dot texture).
+const ink = (pct: number): string =>
+  `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+export default function UaFeedFrame({ children }: { children: ReactNode }) {
+  return (
+    // Outer gilt border + soft brown drop-shadow & inset white hairline.
+    <div
+      style={{
+        padding: 6,
+        background: GILT,
+        boxShadow: `0 10px 24px ${ink(26)}, inset 0 0 0 1px rgba(255,255,255,0.45)`,
+      }}
+    >
+      {/* gold-gradient liner */}
+      <div
+        style={{
+          padding: 3,
+          background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
+        }}
+      >
+        {/* parchment body — brown hairline + faint radial-dot texture */}
+        <div
+          style={{
+            border: `1px solid ${ink(45)}`,
+            background: PAPER,
+            backgroundImage: `radial-gradient(${ink(3)} 1px, transparent 1px)`,
+            backgroundSize: '5px 5px',
+            padding: '13px 17px',
+          }}
+        >
+          {/* engraved masthead strip + gold hairline divider */}
+          <div
+            aria-hidden="true"
+            style={{
+              fontFamily: FONT_ENGRAVED,
+              fontSize: 8.5,
+              letterSpacing: '0.13em',
+              textTransform: 'uppercase',
+              color: ORANGE,
+            }}
+          >
+            University of Asthmatics
+          </div>
+          <div
+            aria-hidden="true"
+            style={{
+              height: 1,
+              margin: '9px 0 11px',
+              background: `linear-gradient(90deg, ${GOLD}, transparent)`,
+            }}
+          />
+
+          {/* salon-mounted body — the neutral card, unchanged */}
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -560,6 +560,7 @@
   --font-faction-blackletter: "UnifrakturCook", "Blackletter", serif;
   --font-faction-script: "Caveat", cursive;
   --font-faction-old: "IM Fell English", Georgia, serif;
+  --font-faction-engraved: "Cinzel", serif;
 }
 
 @layer base {


### PR DESCRIPTION
Adds the 6th and final per-faction activity-feed frame — the **UA gilt-salon** chrome. UA was the one hole that fell through to the neutral `DefaultFeedFrame` (`FactionFeedFrame.tsx:26`: *"UA feed is undesigned…"*); its design landed in PR #281, so this builds it.

Closes #282.

## What changed
- **`frontend/src/components/feed/UaFeedFrame.tsx`** (new) — a thin, chrome-only, slug-blind wrapper, mirroring `SingularityFeedFrame` (the closest model: an always-pinned-theme faction, inverted from dark to light). Chrome: outer gilt border (`var(--ua-gilt)`, 6px pad, soft brown drop-shadow + inset white hairline) → gold-gradient liner (`linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))`, 3px) → parchment body (`var(--ua-paper)`, 1px brown border, faint radial-dot texture) holding `{children}`. Above the body, an `aria-hidden` masthead: engraved-caps eyebrow "University of Asthmatics" in **Cinzel** at `var(--ua-orange)` (8.5px, .13em tracking) + a gold hairline divider.
- **`frontend/src/components/feed/FactionFeedFrame.tsx`** — register `ua: UaFeedFrame` in `FACTION_FEED_FRAMES`; drop the "UA feed is undesigned / falls through to DefaultFeedFrame" note from the doc comment.
- **`frontend/src/index.css`** — add `--font-faction-engraved: "Cinzel", serif;` alongside the other `--font-faction-*` defs (Cinzel already loads via the `index.html` Google Fonts link).
- **`frontend/src/components/__tests__/factionFeedFrame.test.tsx`** — the dispatch guard now asserts all six frames register (was: five + "ua undesigned").

## Constraints honored
- **Chrome-only** — the frame receives only `children`; card internals (`work`/`critique`/`points`) are out of scope.
- **Always-LIGHT** — styles itself from the `--ua-*` tokens (identical in light and dark blocks of `index.css`); never mutates `data-theme`.
- **No new font / no new color token** — Cinzel already loaded; all `--ua-*` tokens already vendored. No hardcoded hex (brown ink derivatives use `color-mix(... var(--ua-ink) …)`, matching the `signal()` helper pattern in `SingularityFeedFrame`).

## Verify
- A feed item with `context_faction_slug: "ua"` renders the gilt-salon chrome around the event card.
- Toggling dark mode does **not** dim the UA frame (tokens pinned).
- `npm test` → 79 passed; `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGaCDCh7fBZ4AGW5DXqMv3)_