### PR TITLE
Parallelize activity-feed fan-out with per-query sessions (#277)

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Callable
 
 from config import settings
 
@@ -9,6 +9,16 @@ engine = create_async_engine(
 )
 
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+
+def get_session_factory() -> Callable:
+    """FastAPI dependency: returns the session factory used for concurrent sub-queries.
+
+    Injected into routers that need to fan out DB work across independent sessions.
+    Override in tests to provide a factory that reuses the test-transaction session
+    so sub-queries see uncommitted fixture data.
+    """
+    return AsyncSessionLocal
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/backend/routers/activity_feed.py
+++ b/backend/routers/activity_feed.py
@@ -1,12 +1,12 @@
 """Router for the unified activity feed."""
 from dataclasses import asdict
 from datetime import datetime
-from typing import Optional
+from typing import Callable, Optional
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db import get_db
+from db import get_db, get_session_factory
 from dependencies import get_current_character
 from models.character import Character
 from schemas.activity_feed import ActivityFeedResponse
@@ -22,6 +22,7 @@ async def activity_feed(
     limit: int = Query(20, ge=1, le=100),
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
+    session_factory: Callable = Depends(get_session_factory),
 ) -> ActivityFeedResponse:
     """Return a unified, paginated activity feed for the current character."""
     # Unknown filters fall back to "all" in the service (FILTER_QUERIES.get default).
@@ -32,6 +33,7 @@ async def activity_feed(
     dc_response = await get_activity_feed(
         character_id=character.id,
         session=session,
+        session_factory=session_factory,
         feed_filter=filter,
         before_cursor=before_cursor,
         limit=limit,

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -6,13 +6,15 @@ timeline with cursor-based pagination.
 Per SPEC-backend-architecture.md, this service returns dataclasses. The
 router owns the Pydantic schema conversion.
 """
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Callable, Coroutine, Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from db import AsyncSessionLocal
 from game_config import CURRENT_ERA
 from models.character import Character
 from models.comment import Comment, CommentMention
@@ -105,6 +107,20 @@ FILTER_QUERIES: dict[str, set[str]] = {
 }
 
 SUB_QUERY_LIMIT = 50
+
+
+async def _run_with_own_session(
+    coro_factory: Callable[[AsyncSession], Coroutine[Any, Any, Any]],
+    session_factory: Callable,
+) -> Any:
+    """Open a session from session_factory, run coro_factory(session), and close it.
+
+    Each concurrent sub-query gets its own session so they can run safely under
+    asyncio.gather without sharing session state. The factory is injected so tests
+    can substitute one that reuses the test-transaction session.
+    """
+    async with session_factory() as session:
+        return await coro_factory(session)
 
 
 async def _get_related_ids(
@@ -685,150 +701,181 @@ async def _compute_counts(
     character_id: int,
     friend_ids: list[int],
     my_task_ids: list[int],
-    session: AsyncSession,
+    session_factory: Callable,
 ) -> FeedCountsDC:
-    """Compute badge counts for each filter tab using lightweight COUNT queries."""
+    """Compute badge counts for each filter tab.
+
+    Each COUNT query runs in its own session so they can execute concurrently
+    under asyncio.gather.
+    """
 
     async def count_votes_on_mine() -> int:
-        result = await session.execute(
-            select(func.count())
-            .select_from(Vote)
-            .join(Praxis, Vote.praxis_id == Praxis.id)
-            .where(Praxis.created_by_id == character_id)
-        )
-        return result.scalar_one()
+        async with session_factory() as s:
+            result = await s.execute(
+                select(func.count())
+                .select_from(Vote)
+                .join(Praxis, Vote.praxis_id == Praxis.id)
+                .where(Praxis.created_by_id == character_id)
+            )
+            return result.scalar_one()
 
     async def count_friend_completions() -> int:
         if not friend_ids:
             return 0
-        result = await session.execute(
-            select(func.count())
-            .select_from(Praxis)
-            .where(
-                Praxis.created_by_id.in_(friend_ids),
+        async with session_factory() as s:
+            result = await s.execute(
+                select(func.count())
+                .select_from(Praxis)
+                .where(
+                    Praxis.created_by_id.in_(friend_ids),
                     Praxis.status == PraxisStatus.submitted,
+                )
             )
-        )
-        return result.scalar_one()
+            return result.scalar_one()
 
     async def count_friend_signups() -> int:
         if not friend_ids or not my_task_ids:
             return 0
-        result = await session.execute(
-            select(func.count())
-            .select_from(PraxisMember)
-            .join(Praxis, PraxisMember.praxis_id == Praxis.id)
-            .where(
-                PraxisMember.character_id.in_(friend_ids),
-                Praxis.task_id.in_(my_task_ids),
+        async with session_factory() as s:
+            result = await s.execute(
+                select(func.count())
+                .select_from(PraxisMember)
+                .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+                .where(
+                    PraxisMember.character_id.in_(friend_ids),
+                    Praxis.task_id.in_(my_task_ids),
                 )
-        )
-        return result.scalar_one()
+            )
+            return result.scalar_one()
 
     async def count_foe_taunts() -> int:
-        result = await session.execute(
-            select(func.count())
-            .select_from(TauntMessage)
-            .where(TauntMessage.to_character_id == character_id)
-        )
-        return result.scalar_one()
+        async with session_factory() as s:
+            result = await s.execute(
+                select(func.count())
+                .select_from(TauntMessage)
+                .where(TauntMessage.to_character_id == character_id)
+            )
+            return result.scalar_one()
 
-    era_row = await get_current_era_row(session)
+    async def count_foe_completions() -> int:
+        async with session_factory() as s:
+            foe_ids = await _get_related_ids(character_id, RelationshipType.foe, s)
+            if not foe_ids:
+                return 0
+            result = await s.execute(
+                select(func.count())
+                .select_from(Praxis)
+                .where(
+                    Praxis.created_by_id.in_(foe_ids),
+                    Praxis.status == PraxisStatus.submitted,
+                )
+            )
+            return result.scalar_one()
+
+    async def count_praxis_invites() -> int:
+        async with session_factory() as s:
+            result = await s.execute(
+                select(func.count())
+                .select_from(PraxisInvite)
+                .where(PraxisInvite.invitee_id == character_id)
+            )
+            return result.scalar_one()
 
     async def count_invitation_letters() -> int:
-        result = await session.execute(
-            select(func.count())
-            .select_from(InvitationLetter)
-            .where(
-                InvitationLetter.character_id == character_id,
-                InvitationLetter.era_id == era_row.id,
+        async with session_factory() as s:
+            era_row = await get_current_era_row(s)
+            result = await s.execute(
+                select(func.count())
+                .select_from(InvitationLetter)
+                .where(
+                    InvitationLetter.character_id == character_id,
+                    InvitationLetter.era_id == era_row.id,
+                )
             )
-        )
-        return result.scalar_one()
+            return result.scalar_one()
 
     async def count_friend_defections() -> int:
         if not friend_ids:
             return 0
-        result = await session.execute(
-            select(func.count())
-            .select_from(FactionDefectionHistory)
-            .where(
-                FactionDefectionHistory.character_id.in_(friend_ids),
-                FactionDefectionHistory.era_id == era_row.id,
+        async with session_factory() as s:
+            era_row = await get_current_era_row(s)
+            result = await s.execute(
+                select(func.count())
+                .select_from(FactionDefectionHistory)
+                .where(
+                    FactionDefectionHistory.character_id.in_(friend_ids),
+                    FactionDefectionHistory.era_id == era_row.id,
+                )
             )
-        )
-        return result.scalar_one()
+            return result.scalar_one()
 
     async def count_comment_mentions() -> int:
-        result = await session.execute(
-            select(func.count())
-            .select_from(CommentMention)
-            .join(Comment, CommentMention.comment_id == Comment.id)
-            .where(
-                CommentMention.mentioned_character_id == character_id,
-                Comment.is_withdrawn.is_(False),
-                Comment.moderation_status == ModerationStatus.visible,
+        async with session_factory() as s:
+            result = await s.execute(
+                select(func.count())
+                .select_from(CommentMention)
+                .join(Comment, CommentMention.comment_id == Comment.id)
+                .where(
+                    CommentMention.mentioned_character_id == character_id,
+                    Comment.is_withdrawn.is_(False),
+                    Comment.moderation_status == ModerationStatus.visible,
+                )
             )
-        )
-        return result.scalar_one()
-
-    async def count_your_stuff() -> int:
-        """Votes on mine + praxis invites + invitation letters + @mentions."""
-        invite_result = await session.execute(
-            select(func.count())
-            .select_from(PraxisInvite)
-            .where(PraxisInvite.invitee_id == character_id)
-        )
-        invite_count = invite_result.scalar_one()
-        votes_count = await count_votes_on_mine()
-        letters_count = await count_invitation_letters()
-        mentions_count = await count_comment_mentions()
-        return votes_count + invite_count + letters_count + mentions_count
+            return result.scalar_one()
 
     async def count_global() -> int:
-        tasks_result = await session.execute(
-            select(func.count())
-            .select_from(Task)
-            .where(Task.status == TaskStatus.active)
-        )
-        era_result = await session.execute(
-            select(func.count()).select_from(Era)
-        )
-        return tasks_result.scalar_one() + era_result.scalar_one()
+        async with session_factory() as s:
+            tasks_result = await s.execute(
+                select(func.count())
+                .select_from(Task)
+                .where(Task.status == TaskStatus.active)
+            )
+            era_result = await s.execute(
+                select(func.count()).select_from(Era)
+            )
+            return tasks_result.scalar_one() + era_result.scalar_one()
 
     async def count_requests() -> int:
-        result = await session.execute(
-            select(func.count())
-            .select_from(PraxisInvite)
-            .where(
-                PraxisInvite.invitee_id == character_id,
-                PraxisInvite.status == PraxisInviteStatus.pending,
+        async with session_factory() as s:
+            result = await s.execute(
+                select(func.count())
+                .select_from(PraxisInvite)
+                .where(
+                    PraxisInvite.invitee_id == character_id,
+                    PraxisInvite.status == PraxisInviteStatus.pending,
+                )
             )
-        )
-        return result.scalar_one()
+            return result.scalar_one()
 
-    # Run counts sequentially (shared async session)
-    friend_completions_count = await count_friend_completions()
-    friend_signups_count = await count_friend_signups()
-    friend_defections_count = await count_friend_defections()
+    (
+        votes_count,
+        friend_completions_count,
+        friend_signups_count,
+        friend_defections_count,
+        foe_taunts_count,
+        foe_completions_count,
+        invites_count,
+        letters_count,
+        mentions_count,
+        global_count,
+        requests_count,
+    ) = await asyncio.gather(
+        count_votes_on_mine(),
+        count_friend_completions(),
+        count_friend_signups(),
+        count_friend_defections(),
+        count_foe_taunts(),
+        count_foe_completions(),
+        count_praxis_invites(),
+        count_invitation_letters(),
+        count_comment_mentions(),
+        count_global(),
+        count_requests(),
+    )
+
     friends_count = friend_completions_count + friend_signups_count + friend_defections_count
-    foe_ids_for_count = await _get_related_ids(character_id, RelationshipType.foe, session)
-    foe_completions_count = 0
-    if foe_ids_for_count:
-        foe_completions_result = await session.execute(
-            select(func.count())
-            .select_from(Praxis)
-            .where(
-                Praxis.created_by_id.in_(foe_ids_for_count),
-                    Praxis.status == PraxisStatus.submitted,
-            )
-        )
-        foe_completions_count = foe_completions_result.scalar_one()
-    foes_count = await count_foe_taunts() + foe_completions_count
-    your_stuff_count = await count_your_stuff()
-    global_count = await count_global()
-    requests_count = await count_requests()
-
+    foes_count = foe_taunts_count + foe_completions_count
+    your_stuff_count = votes_count + invites_count + letters_count + mentions_count
     all_count = friends_count + foes_count + your_stuff_count + global_count
 
     return FeedCountsDC(
@@ -844,6 +891,7 @@ async def _compute_counts(
 async def get_activity_feed(
     character_id: int,
     session: AsyncSession,
+    session_factory: Callable,
     feed_filter: Optional[str] = None,
     before_cursor: Optional[datetime] = None,
     limit: int = 20,
@@ -852,7 +900,11 @@ async def get_activity_feed(
 
     Args:
         character_id: The character requesting the feed.
-        session: Database session.
+        session: Database session for the pre-fetch phase (friend/foe/task IDs).
+        session_factory: Callable that returns an async session context manager.
+            Each concurrent sub-query gets its own session from this factory.
+            Injected via FastAPI's Depends(get_session_factory); tests override
+            it to reuse the test-transaction session.
         feed_filter: One of "all", "friends", "foes", "your_stuff", "global", "requests".
         before_cursor: ISO datetime cursor for pagination (items before this time).
         limit: Max items to return.
@@ -880,64 +932,95 @@ async def get_activity_feed(
     if needs_my_tasks:
         my_task_ids = await _get_my_task_ids(character_id, session)
 
-    # Build list of coroutines to run in parallel
-    fetch_tasks: list = []
+    # Build per-sub-query coroutine factories; each gets its own session so
+    # they can run concurrently under asyncio.gather without sharing state.
+    fetch_coros: list[Coroutine[Any, Any, list[ActivityFeedItemDC]]] = []
 
     if FEED_ITEM_TYPE_VOTE_ON_MINE in allowed_types:
-        fetch_tasks.append(_fetch_votes_on_mine(character_id, session, before_cursor))
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_votes_on_mine(character_id, s, before_cursor),
+            session_factory,
+        ))
 
     if FEED_ITEM_TYPE_FRIEND_COMPLETION in allowed_types:
-        fetch_tasks.append(_fetch_completions(friend_ids, FEED_ITEM_TYPE_FRIEND_COMPLETION, session, before_cursor))
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_completions(friend_ids, FEED_ITEM_TYPE_FRIEND_COMPLETION, s, before_cursor),
+            session_factory,
+        ))
 
     if FEED_ITEM_TYPE_FOE_TAUNT in allowed_types:
-        fetch_tasks.append(_fetch_foe_taunts(character_id, session, before_cursor))
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_foe_taunts(character_id, s, before_cursor),
+            session_factory,
+        ))
 
     if FEED_ITEM_TYPE_FOE_COMPLETION in allowed_types:
-        fetch_tasks.append(_fetch_completions(foe_ids, FEED_ITEM_TYPE_FOE_COMPLETION, session, before_cursor))
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_completions(foe_ids, FEED_ITEM_TYPE_FOE_COMPLETION, s, before_cursor),
+            session_factory,
+        ))
 
     if FEED_ITEM_TYPE_GLOBAL_TASK in allowed_types:
-        fetch_tasks.append(_fetch_global_tasks(session, before_cursor))
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_global_tasks(s, before_cursor),
+            session_factory,
+        ))
 
     if FEED_ITEM_TYPE_ERA_ANNOUNCEMENT in allowed_types:
-        fetch_tasks.append(_fetch_era_announcements(session, before_cursor))
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_era_announcements(s, before_cursor),
+            session_factory,
+        ))
 
     if FEED_ITEM_TYPE_COLLAB_INVITE in allowed_types:
-        fetch_tasks.append(_fetch_praxis_invites(
-            character_id, PraxisType.collab, FEED_ITEM_TYPE_COLLAB_INVITE,
-            "inviter_character_id", session, before_cursor, pending_only=is_requests_filter,
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_praxis_invites(
+                character_id, PraxisType.collab, FEED_ITEM_TYPE_COLLAB_INVITE,
+                "inviter_character_id", s, before_cursor, pending_only=is_requests_filter,
+            ),
+            session_factory,
         ))
 
     if FEED_ITEM_TYPE_DUEL_CHALLENGE in allowed_types:
-        fetch_tasks.append(_fetch_duel_challenges(
-            character_id, session, before_cursor, pending_only=is_requests_filter,
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_duel_challenges(character_id, s, before_cursor, pending_only=is_requests_filter),
+            session_factory,
         ))
 
     if FEED_ITEM_TYPE_FRIEND_SIGNUP in allowed_types:
-        fetch_tasks.append(_fetch_friend_signups(
-            friend_ids, my_task_ids, session, before_cursor,
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_friend_signups(friend_ids, my_task_ids, s, before_cursor),
+            session_factory,
         ))
 
     if FEED_ITEM_TYPE_INVITATION_LETTER in allowed_types:
-        fetch_tasks.append(_fetch_invitation_letters(
-            character_id, session, before_cursor,
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_invitation_letters(character_id, s, before_cursor),
+            session_factory,
         ))
 
     if FEED_ITEM_TYPE_FRIEND_DEFECTION in allowed_types:
-        fetch_tasks.append(_fetch_friend_defections(
-            friend_ids, session, before_cursor,
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_friend_defections(friend_ids, s, before_cursor),
+            session_factory,
         ))
 
     if FEED_ITEM_TYPE_COMMENT_MENTION in allowed_types:
-        fetch_tasks.append(_fetch_comment_mentions(
-            character_id, session, before_cursor,
+        fetch_coros.append(_run_with_own_session(
+            lambda s: _fetch_comment_mentions(character_id, s, before_cursor),
+            session_factory,
         ))
 
-    # Run all sub-queries (they share the same session, so sequential is safer
-    # with SQLAlchemy async — asyncio.gather can cause issues with shared session)
+    # Run feed fan-out and badge counts concurrently; each sub-query has its own session.
+    gather_results = await asyncio.gather(
+        *fetch_coros,
+        _compute_counts(character_id, friend_ids, my_task_ids, session_factory),
+    )
+    counts: FeedCountsDC = gather_results[-1]
+
     all_items: list[ActivityFeedItemDC] = []
-    for task in fetch_tasks:
-        items = await task
-        all_items.extend(items)
+    for item_list in gather_results[:-1]:
+        all_items.extend(item_list)
 
     # Sort by timestamp descending, slice to limit
     all_items.sort(key=lambda item: item.timestamp, reverse=True)
@@ -947,9 +1030,6 @@ async def get_activity_feed(
     next_cursor = None
     if len(all_items) > limit:
         next_cursor = paginated[-1].timestamp.isoformat()
-
-    # Compute badge counts (separate from pagination)
-    counts = await _compute_counts(character_id, friend_ids, my_task_ids, session)
 
     return ActivityFeedResponseDC(
         items=paginated,

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import NullPool
 
 from config import settings
-from db import get_db
+from db import get_db, get_session_factory
 from main import app
 import models  # noqa: F401 — registers all models on Base.metadata for create_all
 from models.account import Account
@@ -112,6 +112,24 @@ async def db_session(db_connection):
     await session.close()
 
 
+class _ReuseSessionContext:
+    """Null context manager that yields the shared test session without closing it.
+
+    Used by the test session_factory override so that concurrent sub-query sessions
+    (created by ``asyncio.gather`` in the activity-feed service) reuse the same
+    SAVEPOINT-backed session and therefore see uncommitted fixture data.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> AsyncSession:
+        return self._session
+
+    async def __aexit__(self, *args: object) -> None:
+        pass  # Do NOT close; the test fixture owns the session lifecycle.
+
+
 @pytest_asyncio.fixture
 async def client(db_session: AsyncSession):
     """Provide an AsyncClient with the get_db dependency overridden.
@@ -123,13 +141,21 @@ async def client(db_session: AsyncSession):
     test body is still holding (fixtures like ``era``, ``character``, etc.).
     Isolation is preserved by the outer test transaction, which rolls back
     unconditionally at the end of the test.
+
+    Also overrides ``get_session_factory`` so concurrent sub-queries (used by
+    the activity-feed service under ``asyncio.gather``) reuse ``db_session``
+    rather than opening new connections that cannot see uncommitted test data.
     """
 
     async def _override_get_db():
         yield db_session
         await db_session.commit()
 
+    def _override_session_factory():
+        return lambda: _ReuseSessionContext(db_session)
+
     app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_session_factory] = _override_session_factory
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()


### PR DESCRIPTION
Closes #277

## What changed

Replaces the sequential `for task in fetch_tasks: items = await task` loop in `get_activity_feed` with `asyncio.gather`, turning ~22 sequential DB round-trips into concurrent ones. Each sub-query gets its own session/connection from an injected factory, which is exactly what the original comment noted was needed to safely use `asyncio.gather`.

### `backend/services/activity_feed.py`

- **`_run_with_own_session(coro_factory, session_factory)`** — new helper that opens a session from the injected factory, runs the coroutine, and closes it.
- **`get_activity_feed`** — builds coroutine factories for all 12 `_fetch_*` sub-queries and one `_compute_counts` call, then fans them all out with a single `asyncio.gather`. Feed items and badge counts now execute concurrently with each other.
- **`_compute_counts`** — refactored to run all 11 COUNT queries concurrently via `asyncio.gather`. Each count function opens its own session. Removed the old sequential block and the now-redundant `count_your_stuff` aggregator (inlined the sum).
- Both functions accept a `session_factory: Callable` parameter (required, passed from router via DI).

### `backend/db.py`

- **`get_session_factory()`** — new FastAPI dependency that returns `AsyncSessionLocal`. Injected into the router so the factory is overridable in tests without monkeypatching.

### `backend/routers/activity_feed.py`

- Injects `session_factory: Callable = Depends(get_session_factory)` and passes it through to `get_activity_feed`.

### `backend/tests/integration/conftest.py`

- **`_ReuseSessionContext`** — null context manager that yields the shared SAVEPOINT-backed test session without closing it. Allows `asyncio.gather` sub-queries in tests to see uncommitted fixture data (new connections can't, since data is within the test transaction).
- **`client` fixture** — overrides `get_session_factory` to return the reuse factory alongside the existing `get_db` override.

## Test results

```
446 passed in 57.89s
Required test coverage of 80% reached. Total coverage: 84.14%
```

Previously-failing tests now pass:
- `test_activity_feed_shows_votes_on_mine` ✓
- `test_mention_notifies_via_activity_feed` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01H2ZZHg8tRUbnFW6GyTv49H

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2ZZHg8tRUbnFW6GyTv49H)_