### PR TITLE
Build ADR-0010 UI copy catalog (copy/en.ts + t()) (#265)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -908,9 +908,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -925,9 +922,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -942,9 +936,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -959,9 +950,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -976,9 +964,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -993,9 +978,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1010,9 +992,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1027,9 +1006,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1044,9 +1020,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1061,9 +1034,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1078,9 +1048,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,9 +1062,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1112,9 +1076,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/frontend/src/copy/__tests__/t.test.ts
+++ b/frontend/src/copy/__tests__/t.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { t, en } from '../en'
+
+describe('t()', () => {
+  it('resolves a nested key', () => {
+    expect(t('vote.ephemerists.plausible')).toBe('plausible')
+  })
+
+  it('interpolates a {{var}}', () => {
+    expect(t('form.charLimit.reached', { max: 200 })).toBe('200-character limit reached')
+  })
+
+  it('interpolates multiple {{vars}}', () => {
+    expect(t('form.charLimit.approaching', { remaining: 42 })).toBe('42 characters remaining')
+  })
+
+  it('throws on a missing key', () => {
+    // @ts-expect-error — deliberate invalid key for runtime test
+    expect(() => t('vote.ephemerists.nonexistent')).toThrow('[t] missing catalog key')
+  })
+
+  it('throws on a missing interpolation var', () => {
+    expect(() => t('form.charLimit.reached', {})).toThrow('{{max}}')
+  })
+
+  it('resolves a kebab key for multi-word labels', () => {
+    expect(t('vote.everymen.a-start')).toBe('a start')
+    expect(t('vote.snide.not-bad')).toBe('not bad')
+  })
+
+  it('resolves preserved-case values for all-caps labels', () => {
+    expect(t('vote.singularity.verified')).toBe('VERIFIED')
+    expect(t('vote.snide.anarchy')).toBe('ANARCHY')
+  })
+
+  it('resolves title-case values for UA labels', () => {
+    expect(t('vote.ua.acquired')).toBe('Acquired')
+    expect(t('vote.ua.commended')).toBe('Commended')
+  })
+})
+
+describe('en catalog shape', () => {
+  const FACTION_SLUGS = ['ephemerists', 'everymen', 'wow', 'snide', 'singularity', 'ua'] as const
+  const EXPECTED_TIER_COUNT = 5
+
+  it('has a vote entry for every registered faction', () => {
+    for (const slug of FACTION_SLUGS) {
+      expect(en.vote).toHaveProperty(slug)
+    }
+  })
+
+  it('has exactly 5 tier entries per faction', () => {
+    for (const slug of FACTION_SLUGS) {
+      const tiers = Object.keys(en.vote[slug])
+      expect(tiers).toHaveLength(EXPECTED_TIER_COUNT)
+    }
+  })
+
+  it('has non-empty string values for every tier', () => {
+    for (const slug of FACTION_SLUGS) {
+      for (const value of Object.values(en.vote[slug])) {
+        expect(typeof value).toBe('string')
+        expect(value.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('has the form.charLimit keys referenced by ADR-0010', () => {
+    expect(en.form.charLimit).toHaveProperty('reached')
+    expect(en.form.charLimit).toHaveProperty('approaching')
+  })
+
+  it('has the praxis.charLimit.terminal key referenced by ADR-0010', () => {
+    expect(en.praxis.charLimit).toHaveProperty('terminal')
+  })
+})

--- a/frontend/src/copy/en.ts
+++ b/frontend/src/copy/en.ts
@@ -1,0 +1,92 @@
+// ponytail: i18next upgrade path — replace the `en` const + `t()` body with
+// `import i18n from 'i18next'; export const t = i18n.t.bind(i18n)` keeping all
+// key strings and {{var}} syntax unchanged (they are i18next-native by design).
+
+export const en = {
+  form: {
+    charLimit: {
+      approaching: "{{remaining}} characters remaining",
+      reached: "{{max}}-character limit reached",
+    },
+  },
+  praxis: {
+    charLimit: {
+      approaching: "{{remaining}} characters left — make them count",
+      terminal: "{{max}} characters — your proof is complete. No more words.",
+    },
+  },
+  vote: {
+    ephemerists: {
+      apocryphal: "apocryphal",
+      disputed: "disputed",
+      plausible: "plausible",
+      corroborated: "corroborated",
+      canonical: "canonical",
+    },
+    everymen: {
+      "a-start": "a start",
+      solid: "solid",
+      good: "good",
+      excellent: "excellent",
+      legendary: "legendary",
+    },
+    wow: {
+      "a-start": "a start",
+      solid: "solid",
+      good: "good",
+      excellent: "excellent",
+      legendary: "legendary",
+    },
+    snide: {
+      meh: "meh",
+      "not-bad": "not bad",
+      rad: "rad",
+      sick: "sick",
+      anarchy: "ANARCHY",
+    },
+    singularity: {
+      noise: "NOISE",
+      weak: "WEAK",
+      signal: "SIGNAL",
+      clear: "CLEAR",
+      verified: "VERIFIED",
+    },
+    ua: {
+      noted: "Noted",
+      sketch: "Sketch",
+      hung: "Hung",
+      commended: "Commended",
+      acquired: "Acquired",
+    },
+  },
+} as const
+
+type DotPaths<T, P extends string = ''> = T extends string
+  ? P
+  : {
+      [K in keyof T & string]: DotPaths<
+        T[K],
+        P extends '' ? K : `${P}.${K}`
+      >
+    }[keyof T & string]
+
+export type CatalogKey = DotPaths<typeof en>
+
+export function t(key: CatalogKey, vars?: Record<string, string | number>): string {
+  const parts = (key as string).split('.')
+  let node: unknown = en
+  for (const part of parts) {
+    if (typeof node !== 'object' || node === null) {
+      throw new Error(`[t] missing catalog key: "${key}"`)
+    }
+    node = (node as Record<string, unknown>)[part]
+  }
+  if (typeof node !== 'string') {
+    throw new Error(`[t] missing catalog key: "${key}"`)
+  }
+  if (!vars) return node
+  return node.replace(/\{\{(\w+)\}\}/g, (_, name: string) => {
+    if (Object.prototype.hasOwnProperty.call(vars, name)) return String(vars[name])
+    throw new Error(`[t] missing interpolation var "{{${name}}}" for key "${key}"`)
+  })
+}


### PR DESCRIPTION
Closes #265

## What changed

**New: `frontend/src/copy/en.ts`**

The typed copy catalog specified in ADR-0010, finally implemented. Two exports:

- **`en`** — `as const` nested object with three namespaces:
  - `form.charLimit` — `approaching` / `reached` messages (ADR-0010 trigger)
  - `praxis.charLimit` — `approaching` / `terminal` messages (more whimsical; ADR-0010 example key)
  - `vote.*` — all six faction tier vocabularies keyed in lowercase/kebab (`vote.ephemerists.plausible`, `vote.snide.not-bad`, etc.)
- **`t(key, vars?)`** — dotted-key lookup + `{{var}}` interpolation. Throws loudly on a missing key or missing interpolation var. A `ponytail:` comment marks the i18next upgrade path (ADR-0010 Consequences).
- **`CatalogKey`** — union type of all valid dot-paths derived from `typeof en` via `DotPaths<T>`. Passing an invalid key to `t()` is a TypeScript error — satisfies the "typed-key guarantee" acceptance criterion without any new runtime dependency.

**New: `frontend/src/copy/__tests__/t.test.ts`**

13 tests covering:
- Key resolution (nested, kebab, title-case, all-caps)
- `{{var}}` interpolation
- Loud failure on missing key (runtime `Error`)
- Loud failure on missing interpolation var
- Catalog shape invariants: every registered faction slug has exactly 5 non-empty tiers, ADR-0010 keys are present

## How #194's label→labelKey migration works after this

When #194 (vote reframe registry, PR #285) merges, swapping `label: 'plausible'` to `labelKey: 'vote.ephemerists.plausible'` is one-line-per-tier mechanical: the registry shape already has `label`; change the key name and resolve with `t(labelKey)`. No structural change to `voteReframes.ts`.

## Test results

```
Test Files  8 passed (8)
     Tests  92 passed (92)
```

Zero new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_013A94c83qAxGqXo25N64qhp

---
_Generated by [Claude Code](https://claude.ai/code/session_013A94c83qAxGqXo25N64qhp)_