### PR TITLE
Retire the vote average; show points-from-votes instead

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,8 +187,7 @@ The **sum** of a praxis's vote values, added flat to score *after* all multiplie
 as *points* (the "73" in a "15 + 73 points" display = base + points-from-votes), never as its
 own noun. Distinct from **voter count** — how many votes were cast (the "45 votes" label). The
 **average** of a praxis's vote values is *not* a domain quantity — a praxis's standing is the sum
-(points-from-votes) and the count, never the mean (SPEC-game-rules: "Not an average"). A vestigial
-display-only `average_value` field still lingers in code, pending its own removal.
+(points-from-votes) and the count, never the mean (SPEC-game-rules: "Not an average").
 _Avoid_: average rating, avg score.
 
 **Vote tally** *(read-model; `services/vote_tally.py`)*:

--- a/backend/routers/votes.py
+++ b/backend/routers/votes.py
@@ -40,17 +40,11 @@ async def get_vote_summary(
     tallies = await tally_votes([praxis_id], session)
     tally = tallies.get(praxis_id)
     total_votes = tally.voter_count if tally else 0
-    average_value = (
-        tally.points_from_votes / tally.voter_count
-        if tally and tally.voter_count > 0
-        else 0.0
-    )
     total_score = float(tally.points_from_votes) if tally else 0.0
 
     return VoteSummary(
         praxis_id=praxis_id,
         total_votes=total_votes,
-        average_value=average_value,
         total_score=total_score,
     )
 

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -92,7 +92,6 @@ class PraxisCardOut(BaseModel):
     submitted_at: Optional[datetime] = None
     member_count: int
     score: float
-    average_value: Optional[float] = None
     voter_count: int = 0
     task_faction_slug: Optional[str] = None
 

--- a/backend/schemas/vote.py
+++ b/backend/schemas/vote.py
@@ -22,7 +22,6 @@ class VoteOut(BaseModel):
 class VoteSummary(BaseModel):
     praxis_id: int
     total_votes: int
-    average_value: float
     total_score: float
 
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -277,10 +277,6 @@ async def build_praxis_card_out(
     tally_map = await tally_votes([praxis.id], session)
     tally = get_tally(tally_map, praxis.id)
     score = float(task_point_value + tally.points_from_votes)
-    average_value = (
-        tally.points_from_votes / tally.voter_count
-        if tally.voter_count > 0 else None
-    )
 
     return PraxisCardOut(
         id=praxis.id,
@@ -299,7 +295,6 @@ async def build_praxis_card_out(
         submitted_at=praxis.submitted_at,
         member_count=len(praxis.members),
         score=score,
-        average_value=average_value,
         voter_count=tally.voter_count,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
     )

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1479,7 +1479,7 @@ async def test_create_praxis_retired_task_allowed_for_ephemerists(
 
 
 # ---------------------------------------------------------------------------
-# PraxisCardOut new fields: task_level_required, average_value, voter_count,
+# PraxisCardOut new fields: task_level_required, voter_count,
 # submitted_at (issue #159)
 # ---------------------------------------------------------------------------
 
@@ -1491,7 +1491,7 @@ async def test_praxis_card_includes_new_fields(
     active_task: Task,
     auth_headers: dict,
 ):
-    """GET /praxes list returns task_level_required, average_value (null), voter_count (0),
+    """GET /praxes list returns task_level_required, voter_count (0),
     and submitted_at (null) for a newly-created in_progress praxis."""
     create_resp = await client.post(
         "/praxes",
@@ -1511,7 +1511,6 @@ async def test_praxis_card_includes_new_fields(
     assert isinstance(card["task_level_required"], int)
     assert card["task_level_required"] == active_task.level_required
 
-    assert card["average_value"] is None
     assert card["voter_count"] == 0
     assert card["submitted_at"] is None
 
@@ -1546,7 +1545,7 @@ async def test_submitted_at_set_on_submit(
 
 
 @pytest.mark.asyncio
-async def test_average_value_and_voter_count_after_vote(
+async def test_voter_count_and_score_after_vote(
     client: AsyncClient,
     character: Character,
     character2: Character,
@@ -1554,7 +1553,7 @@ async def test_average_value_and_voter_count_after_vote(
     auth_headers: dict,
     auth_headers2: dict,
 ):
-    """average_value and voter_count reflect votes cast on the praxis."""
+    """voter_count and score (task points + points-from-votes) reflect votes cast on the praxis."""
     # character2 creates a praxis
     create_resp = await client.post(
         "/praxes",
@@ -1576,8 +1575,7 @@ async def test_average_value_and_voter_count_after_vote(
     card = next(c for c in list_resp.json() if c["id"] == praxis_id)
 
     assert card["voter_count"] == 1
-    assert card["average_value"] is not None
-    assert abs(card["average_value"] - 4.0) < 0.01
+    assert card["score"] == active_task.point_value + 4
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -89,7 +89,6 @@ export interface PraxisCardOut {
   submitted_at: string | null
   member_count: number
   score: number
-  average_value: number | null
   voter_count: number
   task_faction_slug: string | null
 }

--- a/frontend/src/api/votes.ts
+++ b/frontend/src/api/votes.ts
@@ -12,7 +12,6 @@ export interface VoteOut {
 export interface VoteSummary {
   praxis_id: number
   total_votes: number
-  average_value: number
   total_score: number
 }
 

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -12,7 +12,6 @@ import {
   PraxisByline,
   PraxisSeal,
   PraxisStats,
-  VoteUISummary,
   type AdminProps,
 } from "./praxisCard/shared";
 import { usePraxisCard } from "./praxisCard/usePraxisCard";
@@ -58,12 +57,6 @@ function PlaceholderPraxisBody({
   sealLabel?: string;
   titleStyle?: CSSProperties;
 }) {
-  const hero =
-    praxis.average_value !== null && praxis.average_value !== undefined ? (
-      <VoteUISummary praxis={praxis} color={tint} border={tint} />
-    ) : (
-      <PraxisSeal praxis={praxis} color={tint} border={tint} label={sealLabel} />
-    );
   return (
     <>
       <div
@@ -78,7 +71,7 @@ function PlaceholderPraxisBody({
           <PraxisTitle praxis={praxis} style={titleStyle} />
           <PraxisTaskLink praxis={praxis} style={{ color: muted }} />
         </div>
-        {hero}
+        <PraxisSeal praxis={praxis} color={tint} border={tint} label={sealLabel} />
       </div>
       <PraxisStats praxis={praxis} style={{ color: muted, marginTop: 8 }} />
       <PraxisByline praxis={praxis} style={{ color: muted }} />

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -50,7 +50,6 @@ const PRAXIS: PraxisCardOut = {
   submitted_at: "2026-01-02T00:00:00Z",
   member_count: 1,
   score: 4.2,
-  average_value: null,
   voter_count: 0,
   task_faction_slug: "ua",
 };

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -155,64 +155,6 @@ export function PraxisSeal({
   );
 }
 
-/**
- * Slot: compact read-only vote summary — the card hero once the praxis has been
- * rated. Replaces PraxisSeal when average_value is present.
- *
- * Shows the average star rating (1–5) + vote count in a compact badge. Per-faction
- * reframe labels (Concordance, Signal, etc.) are wired per archetype when their
- * designs land; this is the generic fallback that drives the slot.
- */
-export function VoteUISummary({
-  praxis,
-  color,
-  border,
-}: {
-  praxis: PraxisCardOut;
-  color?: string;
-  border?: string;
-}) {
-  if (praxis.average_value === null || praxis.average_value === undefined) return null;
-  return (
-    <div
-      style={{
-        display: "inline-flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        flexShrink: 0,
-        minWidth: 50,
-        padding: "5px 8px",
-        border: `2px solid ${border ?? "currentColor"}`,
-        borderRadius: 4,
-        transform: "rotate(-3deg)",
-        color: color ?? "inherit",
-        lineHeight: 1,
-        gap: 2,
-      }}
-    >
-      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)" }}>
-        {praxis.average_value.toFixed(1)}
-      </span>
-      <span
-        style={{
-          fontSize: 7,
-          letterSpacing: "0.12em",
-          textTransform: "uppercase",
-          opacity: 0.75,
-        }}
-      >
-        ★ avg
-      </span>
-      {praxis.voter_count > 0 && (
-        <span style={{ fontSize: 7, opacity: 0.6 }}>
-          {praxis.voter_count}v
-        </span>
-      )}
-    </div>
-  );
-}
-
 /** Slot: base points + collaboration mode — a compact stat line. */
 export function PraxisStats({
   praxis,

--- a/frontend/src/components/ui/VoteStamps.tsx
+++ b/frontend/src/components/ui/VoteStamps.tsx
@@ -25,12 +25,12 @@ const STAMPS: StampConfig[] = [
 interface Props {
   praxisId: number
   currentValue?: number
-  averageStars?: number | null
+  points?: number | null
   totalVotes?: number
   mode?: 'caster' | 'summary'
 }
 
-export default function VoteStamps({ praxisId, currentValue, averageStars, totalVotes }: Props) {
+export default function VoteStamps({ praxisId, currentValue, points, totalVotes }: Props) {
   const { user, refetch } = useAuth()
   const [selected, setSelected] = useState(currentValue ?? 0)
   const [saving, setSaving] = useState(false)
@@ -110,9 +110,9 @@ export default function VoteStamps({ praxisId, currentValue, averageStars, total
       )}
 
       {/* Summary */}
-      {averageStars != null && (
+      {points != null && (
         <p className="font-body" style={{ fontSize: 9, color: 'var(--color-text-secondary)' }}>
-          {averageStars.toFixed(1)} avg · {totalVotes ?? 0} votes
+          {totalVotes ?? 0} votes · {points} pts
         </p>
       )}
 

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -22,7 +22,7 @@ const TIERS = VOTE_REFRAMES['ephemerists'].tiers;
 export default function EphemeristsVote({
   praxisId,
   currentValue,
-  averageStars,
+  points,
   totalVotes,
 }: VoteUIProps) {
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue);
@@ -104,7 +104,7 @@ export default function EphemeristsVote({
 
       <VoteSummary
         selected={selected}
-        averageStars={averageStars}
+        points={points}
         totalVotes={totalVotes}
         error={error}
         theme={{

--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -26,7 +26,7 @@ const STAMP_SIZE = 40
 
 const TIERS = VOTE_REFRAMES['everymen'].tiers
 
-export default function EverymenVote({ praxisId, currentValue, averageStars, totalVotes }: VoteUIProps) {
+export default function EverymenVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -101,7 +101,7 @@ export default function EverymenVote({ praxisId, currentValue, averageStars, tot
 
       <VoteSummary
         selected={selected}
-        averageStars={averageStars}
+        points={points}
         totalVotes={totalVotes}
         error={error}
         theme={{

--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -32,7 +32,7 @@ const KEY_SIZE = 42
 
 const TIERS = VOTE_REFRAMES['singularity'].tiers
 
-export default function SingularityVote({ praxisId, currentValue, averageStars, totalVotes }: VoteUIProps) {
+export default function SingularityVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -117,7 +117,7 @@ export default function SingularityVote({ praxisId, currentValue, averageStars, 
 
       <VoteSummary
         selected={selected}
-        averageStars={averageStars}
+        points={points}
         totalVotes={totalVotes}
         error={error}
         theme={{

--- a/frontend/src/components/vote/SnideVote.tsx
+++ b/frontend/src/components/vote/SnideVote.tsx
@@ -35,7 +35,7 @@ const SNIDE_VISUALS: Record<number, StampVisual> = {
 
 const TIERS = VOTE_REFRAMES['snide'].tiers
 
-export default function SnideVote({ praxisId, currentValue, averageStars, totalVotes }: VoteUIProps) {
+export default function SnideVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -85,7 +85,7 @@ export default function SnideVote({ praxisId, currentValue, averageStars, totalV
 
       <VoteSummary
         selected={selected}
-        averageStars={averageStars}
+        points={points}
         totalVotes={totalVotes}
         error={error}
         theme={{

--- a/frontend/src/components/vote/UAVote.tsx
+++ b/frontend/src/components/vote/UAVote.tsx
@@ -22,7 +22,7 @@ const TIERS = VOTE_REFRAMES['ua'].tiers
 export default function UAVote({
   praxisId,
   currentValue,
-  averageStars,
+  points,
   totalVotes,
 }: VoteUIProps) {
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
@@ -96,7 +96,7 @@ export default function UAVote({
 
       <VoteSummary
         selected={selected}
-        averageStars={averageStars}
+        points={points}
         totalVotes={totalVotes}
         error={error}
         theme={{

--- a/frontend/src/components/vote/VoteShell.tsx
+++ b/frontend/src/components/vote/VoteShell.tsx
@@ -1,7 +1,7 @@
 /**
  * Shared chrome for per-faction vote UIs. The 1-5 control itself is faction-
  * specific (ink stamps, hearts, …), but the logged-out gate and the
- * average/"voted"/error summary are identical in structure — only their theme
+ * points/"voted"/error summary are identical in structure — only their theme
  * colors differ. These two helpers keep that chrome in one place.
  */
 
@@ -19,16 +19,16 @@ export interface VoteSummaryTheme {
   avgLetterSpacing?: string
 }
 
-/** "Voted N pts", the average display, and the error line — themeable. */
+/** "Voted N pts", the votes/points display, and the error line — themeable. */
 export function VoteSummary({
   selected,
-  averageStars,
+  points,
   totalVotes,
   error,
   theme,
 }: {
   selected: number
-  averageStars?: number | null
+  points?: number | null
   totalVotes?: number
   error: string
   theme: VoteSummaryTheme
@@ -41,7 +41,7 @@ export function VoteSummary({
         </p>
       )}
 
-      {averageStars != null && (
+      {points != null && (
         <p
           className="font-body"
           style={{
@@ -51,10 +51,11 @@ export function VoteSummary({
             letterSpacing: theme.avgLetterSpacing,
           }}
         >
+          {totalVotes ?? 0} votes ·{' '}
           <b style={{ color: theme.accent, fontFamily: theme.accentFont, fontSize: theme.avgFontSize }}>
-            {averageStars.toFixed(1)}
+            {points}
           </b>{' '}
-          avg · {totalVotes ?? 0} votes
+          pts
         </p>
       )}
 

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -17,7 +17,7 @@ import UAVote from './UAVote'
 export interface VoteUIProps {
   praxisId: number
   currentValue?: number
-  averageStars?: number | null
+  points?: number | null
   totalVotes?: number
   mode?: 'caster' | 'summary'
 }

--- a/frontend/src/components/vote/WowVote.tsx
+++ b/frontend/src/components/vote/WowVote.tsx
@@ -41,7 +41,7 @@ function HeartGlyph({ filled, color, size = 30 }: { filled: boolean; color: stri
   )
 }
 
-export default function WowVote({ praxisId, currentValue, averageStars, totalVotes }: VoteUIProps) {
+export default function WowVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -103,7 +103,7 @@ export default function WowVote({ praxisId, currentValue, averageStars, totalVot
 
       <VoteSummary
         selected={selected}
-        averageStars={averageStars}
+        points={points}
         totalVotes={totalVotes}
         error={error}
         theme={{

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -63,7 +63,6 @@ const PRAXIS: PraxisOut = {
 const VOTES: VoteSummary = {
   praxis_id: 1,
   total_votes: 4,
-  average_value: 4.2,
   total_score: 16,
 };
 

--- a/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
@@ -222,7 +222,7 @@ export default function AlbescentPraxisDetail({ state }: { state: PraxisDetailSt
         <VoteUI
           factionSlug={praxis.task_faction_slug}
           praxisId={praxis.id}
-          averageStars={votes?.average_value}
+          points={votes?.total_score}
           totalVotes={votes?.total_votes}
           mode="caster"
         />

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -71,7 +71,7 @@ export default function DefaultPraxisDetail({
         {votes && votes.total_votes > 0 && (
           <div className="text-right shrink-0">
             <div className="font-display italic" style={{ fontSize: 22, color: 'var(--color-text-primary)' }}>
-              {votes.average_value.toFixed(1)}
+              {votes.total_score}
             </div>
             <span className="eyebrow">{votes.total_votes} votes</span>
           </div>
@@ -150,7 +150,7 @@ export default function DefaultPraxisDetail({
         <VoteUI
           factionSlug={praxis.task_faction_slug}
           praxisId={praxis.id}
-          averageStars={votes?.average_value}
+          points={votes?.total_score}
           totalVotes={votes?.total_votes}
         />
       </div>

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -359,7 +359,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
           </div>
           <EphemeristsVote
             praxisId={praxis.id}
-            averageStars={votes?.average_value}
+            points={votes?.total_score}
             totalVotes={votes?.total_votes}
             mode="caster"
           />

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -256,7 +256,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
         <div style={{ marginBottom: 20 }}>
           <EverymenVote
             praxisId={praxis.id}
-            averageStars={votes?.average_value}
+            points={votes?.total_score}
             totalVotes={votes?.total_votes}
             mode="caster"
           />

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -430,7 +430,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
             )}
             <SingularityVote
               praxisId={praxis.id}
-              averageStars={votes?.average_value}
+              points={votes?.total_score}
               totalVotes={votes?.total_votes}
               mode="caster"
             />

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -418,7 +418,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
           </div>
           <SnideVote
             praxisId={praxis.id}
-            averageStars={votes?.average_value}
+            points={votes?.total_score}
             totalVotes={votes?.total_votes}
             mode="caster"
           />

--- a/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
@@ -333,7 +333,7 @@ export default function UAPraxisDetail({ state }: { state: PraxisDetailState }) 
           <VoteUI
             factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
-            averageStars={votes?.average_value}
+            points={votes?.total_score}
             totalVotes={votes?.total_votes}
             mode="caster"
           />

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -432,7 +432,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
             </div>
             <WowVote
               praxisId={praxis.id}
-              averageStars={votes?.average_value}
+              points={votes?.total_score}
               totalVotes={votes?.total_votes}
               mode="caster"
             />

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -70,7 +70,6 @@ const MY_PRAXIS: PraxisCardOut = {
   submitted_at: "2026-01-02T00:00:00Z",
   member_count: 1,
   score: 4.2,
-  average_value: null,
   voter_count: 0,
   task_faction_slug: "snide",
 };


### PR DESCRIPTION
## Summary
- Drops the vestigial `average_value` field from every backend schema/service/router (`VoteSummary`, `PraxisCardOut`, `/praxes/{id}/votes`, `build_praxis_card_out`) — a praxis's standing is the sum of vote points + voter count, never the mean (SPEC-game-rules: "Not an average").
- Frontend vote-summary chrome (`VoteShell`) now reads `"{N} votes · {pts} pts"` instead of `"{avg} avg · {N} votes"`, threaded through `VoteUI`/`VoteStamps` and all 6 per-faction vote components as a renamed `points` prop.
- Praxis cards always show the score seal (`PraxisSeal`) now instead of swapping to an average badge; deleted the now-dead `VoteUISummary`.
- Sequenced after #194 per the issue — that PR landed the vote reframe this one builds on.

## Test plan
- [x] `pytest --cov=. --cov-fail-under=80` — 448 passed, 3 xfailed, 82.87% coverage
- [x] `npx vitest run` — 102 passed
- [x] `npm run build` — clean
- [x] Live-verified against a running server: `average_value` gone from real `/praxes` and `/praxes/{id}/votes` responses; SNIDE praxis-detail page renders `"0 votes · 0 pts"`; praxis card shows the `500 / CASE` seal; no console errors

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)