### PR TITLE
Fix broken portraits on FieldDesk (closes #296)

### DIFF
--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth/AuthContext'
 import { getMyCharacters, setActiveCharacter } from '../api/me'
 import type { CharacterOut } from '../api/auth'
 import CredentialCard from '../components/CredentialCard'
+import { mediaUrl } from '../utils/media'
 
 /**
  * FieldDesk roster — the authenticated account home (#274). "Whose shoes today?":
@@ -53,7 +54,7 @@ export default function FieldDesk() {
         {active && (
           <div style={pillStyle}>
             {active.avatar_url ? (
-              <img src={active.avatar_url} alt={active.display_name} style={pillAvatar} />
+              <img src={mediaUrl(active.avatar_url)} alt={active.display_name} style={pillAvatar} />
             ) : (
               <span style={{ ...pillAvatar, display: 'inline-block' }} />
             )}
@@ -91,7 +92,7 @@ export default function FieldDesk() {
                 factionSlug={life.faction_slug}
                 level={life.level}
                 score={life.score}
-                avatarUrl={life.avatar_url}
+                avatarUrl={mediaUrl(life.avatar_url)}
                 rotation={TILTS[index % TILTS.length]}
               />
             </button>


### PR DESCRIPTION
## What

Portraits were broken on the FieldDesk "choose your identity" page (`Whose shoes today?`).

## Root cause

Frontend bug, not backend. The backend serves media as **relative paths**; every avatar in the app is rendered via `mediaUrl()` to prefix the API base URL. FieldDesk was the one page rendering the **raw** `avatar_url`, so the browser resolved it against the frontend origin and 404'd.

Two call sites fixed:
- Top pill — `active.avatar_url`
- Roster cards — `life.avatar_url` passed into `CredentialCard`

## Why not fix inside CredentialCard

`CredentialCard` is deliberately URL-agnostic: its other caller (`CreateCharacter`) passes a `blob:` preview URL that must render raw. Wrapping inside the component would break that preview. Fix belongs at the callers.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)