### PR TITLE
Retire stale 'graduated from UA' prompt on Factions page (closes #295)

### DIFF
--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -69,9 +69,10 @@ export default function Factions() {
     return entry?.status ?? STATUS_NOT_INVITED
   }
 
-  const needsFactionChoice =
-    character?.faction_slug === AGED_OUT_SLUG ||
-    character?.faction_slug === NA_SLUG
+  // Unaffiliated = no faction to lose, so no "can't rejoin" warning on join.
+  const isUnaffiliated =
+    character?.faction_slug === NA_SLUG ||
+    character?.faction_slug === AGED_OUT_SLUG
 
   const handleJoin = async (slug: string) => {
     setJoining(true)
@@ -119,26 +120,6 @@ export default function Factions() {
 
       {error && (
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2 mb-4">{error}</p>
-      )}
-
-      {/* Graduation prompt for aged_out / na characters */}
-      {character && needsFactionChoice && (
-        <div
-          className="sidebar-card mb-6"
-          style={{
-            padding: '20px 24px',
-            borderLeft: '4px solid var(--color-warning)',
-            background: 'var(--color-warning-light)',
-          }}
-        >
-          <p className="font-display italic" style={{ fontSize: 16, color: 'var(--color-text-primary)', marginBottom: 6 }}>
-            You've graduated from UA — choose your faction below.
-          </p>
-          <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
-            Each faction has unique modifiers and abilities. Choose wisely — you can defect later, but you
-            won't be able to rejoin most factions once you leave.
-          </p>
-        </div>
       )}
 
       {/* Invitation letters — collapsible; each card also surfaces its own prompt below */}
@@ -200,7 +181,7 @@ export default function Factions() {
       {/* Logged-out hint */}
       {!character && (
         <p className="font-body text-sm text-muted mb-6">
-          Factions are chosen at level 3. Until then, you start in UA.
+          Everyone starts unaffiliated. Earn an invitation through task work to join a faction.
         </p>
       )}
 
@@ -211,17 +192,16 @@ export default function Factions() {
           const isDefected = status === STATUS_DEFECTED
           const canReturn = status === STATUS_CAN_RETURN
           const hasInvitationLetter = Boolean(invitationBySlug[f.slug])
-          // Any signal that the player is welcome here: explicit status,
-          // an open invitation letter, or the graduation moment.
+          // Any signal that the player is welcome here: explicit status or an
+          // open invitation letter (invite-gated per ADR-0019).
           const canJoin =
             status === STATUS_INVITED ||
             canReturn ||
-            hasInvitationLetter ||
-            (needsFactionChoice && status !== STATUS_DEFECTED && status !== STATUS_MEMBER)
+            hasInvitationLetter
           const isConfirming = confirmSlug === f.slug
 
           // Derive card-level props from page state
-          // "eligible" is passed when the character can join (via invitation, return, or graduation)
+          // "eligible" is passed when the character can join (via invitation or return)
           const cardStatus = isConfirming
             ? status
             : status === STATUS_CAN_RETURN
@@ -263,7 +243,7 @@ export default function Factions() {
                     }}
                   >
                     <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)', marginBottom: 8 }}>
-                      {needsFactionChoice
+                      {isUnaffiliated
                         ? `Join ${f.name}?`
                         : `Join ${f.name}? You won't be able to rejoin ${factionName(character?.faction_slug)} after leaving.`
                       }
@@ -339,7 +319,7 @@ export default function Factions() {
               </Link>
 
               {/* Not-invited hint */}
-              {character && status === STATUS_NOT_INVITED && !needsFactionChoice && (
+              {character && status === STATUS_NOT_INVITED && (
                 <p className="font-body" style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginTop: 6, fontStyle: 'italic' }}>
                   Complete tasks from this faction to unlock an invitation.
                 </p>


### PR DESCRIPTION
## What

The Factions page still ran the retired UA forced-graduation flow. This removes it.

## Root cause

Per [ADR-0019](docs/adr/0019-characters-start-unaffiliated-invite-gated-factions.md), characters are **born unaffiliated** (`na`) and faction membership is **invite-gated**; "Everyone starts in UA" and the `aged_out` forced-graduation mechanic are fully retired. The backend already dropped the logic (regression guard in `test_character_stats.py` documents the removed `check_faction_graduation`). Only the frontend was stale.

`Factions.tsx` showed **"You've graduated from UA — choose your faction below"** to any `na`/`aged_out` character (a born-unaffiliated character was never in UA), and — worse — treated `needsFactionChoice` as license to join *any* faction, a false affordance the invite-gated backend rejects.

## Changes (frontend-only, `Factions.tsx`)

- Delete the graduation prompt block.
- `canJoin` now flows purely from invite status (`invited` / `can_return` / open letter).
- Show the "Complete tasks from this faction to unlock an invitation" hint to unaffiliated players too — that's exactly how they earn a faction under ADR-0019 (previously it was hidden from them).
- Rewrite the logged-out hint from "Factions are chosen at level 3, you start in UA" to the unaffiliated-start model.
- Keep the no-rejoin warning suppressed for the unaffiliated via a renamed `isUnaffiliated`.

Net: 11 insertions, 31 deletions.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)