### PR TITLE
Build the level-up pop-up (Field Stamp) + level_profiles config

### DIFF
--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -19,7 +19,14 @@ Each era defines:
   - Taunt templates: the faction-flavored trash talk between foes
   - Game rules: task limits, vote budget formula, level thresholds, reset behavior
 """
-from game_config import EraConfig, FactionConfig, TaskDef
+from game_config import (
+    EraConfig,
+    FactionConfig,
+    LevelProfile,
+    LevelUnlock,
+    LevelUnlockKind,
+    TaskDef,
+)
 
 
 # =============================================================================
@@ -164,6 +171,30 @@ ERA_N_TAUNT_TEMPLATES: dict[str, dict[str, list[str]]] = {
 
 
 # =============================================================================
+# LEVEL PROFILES
+# =============================================================================
+# Rank + unlocks shown by the level-up pop-up, indexed by level like
+# level_thresholds (index 0 = start state, never shown). Every "ability"
+# unlock must match a real gate constant above at that same level — don't
+# invent one. "sense" unlocks are pure whimsy, no mechanics required.
+
+ERA_N_LEVEL_PROFILES = (
+    LevelProfile(rank="", unlocks=()),  # index 0 = start state, never shown
+    # TODO: One LevelProfile per real level. Example:
+    #
+    # LevelProfile(
+    #     rank="Your Rank Title",
+    #     unlocks=(
+    #         LevelUnlock(LevelUnlockKind.ability, "Ability name",
+    #                     "One sentence describing the unlocked capability."),
+    #         LevelUnlock(LevelUnlockKind.sense, "Curious sense name",
+    #                     "One sentence of whimsical flavor, no mechanics."),
+    #     ),
+    # ),
+)
+
+
+# =============================================================================
 # ERA DEFINITION
 # =============================================================================
 # Combine everything above into a single EraConfig instance.
@@ -222,5 +253,6 @@ ERA_N = EraConfig(
 
     factions=ERA_N_FACTIONS,
     tasks=ERA_N_TASKS,
+    level_profiles=ERA_N_LEVEL_PROFILES,
     taunt_templates=ERA_N_TAUNT_TEMPLATES,
 )

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -4,7 +4,14 @@ Era 1 — the founding era of World Zero.
 This file is the complete, self-contained configuration for Era 1.
 Everything needed to start this era lives here: factions, tasks, taunts, and rules.
 """
-from game_config import EraConfig, FactionConfig, TaskDef
+from game_config import (
+    EraConfig,
+    FactionConfig,
+    LevelProfile,
+    LevelUnlock,
+    LevelUnlockKind,
+    TaskDef,
+)
 
 
 # =============================================================================
@@ -461,6 +468,107 @@ ERA_1_TAUNT_TEMPLATES: dict[str, dict[str, list[str]]] = {
 
 
 # =============================================================================
+# LEVEL PROFILES
+# =============================================================================
+# Rank + unlocks announced by the level-up pop-up ("Field Stamp", #244/#287).
+# Indexed by level, same convention as level_thresholds. Grounded ability
+# entries are checked against the real gate constants below them; sense
+# entries are pure whimsy. Bot-drafted copy — Molly may revise later
+# (config-only, no code change).
+#
+# NOTE: issue #287's table paired level 3 with "choose a faction"
+# (`faction_graduation_level`), but that field is DORMANT (see game_config.py)
+# and `services/faction_service.py::defect_to_faction` has no level check at
+# all — faction choice is gated purely by invitation, not by level. Dropped
+# from the grounded abilities below rather than citing a gate that isn't
+# actually enforced.
+
+ERA_1_LEVEL_PROFILES = (
+    LevelProfile(rank="", unlocks=()),  # index 0 = start state, never shown
+    LevelProfile(
+        rank="Trailhead",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "Sign up for a task",
+                        "Pick a task from the board and begin your first praxis."),
+            LevelUnlock(LevelUnlockKind.ability, "Start a collaboration",
+                        "Pool a task with other questers and split the work."),
+            LevelUnlock(LevelUnlockKind.sense, "Notice the paths already worn",
+                        "Well-trodden ground hums faintly underfoot. You'll learn to trust it."),
+        ),
+    ),
+    LevelProfile(
+        rank="Ranger",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "Challenge a duel",
+                        "Stake reputation against another quester and settle it in the field."),
+            LevelUnlock(LevelUnlockKind.ability, "Leave a comment",
+                        "Weigh in on any praxis with a word of your own."),
+            LevelUnlock(LevelUnlockKind.ability, "See retired tasks",
+                        "The archive opens — browse tasks the board has since retired."),
+            LevelUnlock(LevelUnlockKind.sense, "Read weather a day early",
+                        "Clouds tell you their plans before the sky commits to them."),
+        ),
+    ),
+    LevelProfile(
+        rank="Surveyor",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "Propose a task",
+                        "Draft a task of your own and submit it to the board."),
+            LevelUnlock(LevelUnlockKind.ability, "See pending tasks",
+                        "Watch proposals move through review before they go live."),
+            LevelUnlock(LevelUnlockKind.sense, "Sense a shortcut before taking it",
+                        "Some routes simply feel correct. You've started to notice which."),
+        ),
+    ),
+    LevelProfile(
+        rank="Warden",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "Flag a praxis",
+                        "Send questionable praxis to moderation review."),
+            LevelUnlock(LevelUnlockKind.ability, "Create a second character",
+                        "Start a new character on this account, independent of this one."),
+            LevelUnlock(LevelUnlockKind.sense, "Hear a lie land wrong",
+                        "Untrue words ring a half-step flat. Useful, if unsettling."),
+        ),
+    ),
+    LevelProfile(
+        rank="Voyager",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.sense, "Taste distance in the air",
+                        "Far-off places have a flavor. You're close enough now to notice."),
+        ),
+    ),
+    LevelProfile(
+        rank="Chronicler",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "Propose a metatask",
+                        "Draft a task built for your whole faction to apply to."),
+            LevelUnlock(LevelUnlockKind.sense, "Remember a place you've never been",
+                        "Certain rooms feel already-visited. You've stopped questioning it."),
+        ),
+    ),
+    LevelProfile(
+        rank="Luminary",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "Apply your faction's metatasks",
+                        "Take on the metatasks your faction has published."),
+            LevelUnlock(LevelUnlockKind.sense, "Hold three plans at once without confusion",
+                        "Your mind now files contingencies the way it once filed excuses."),
+        ),
+    ),
+    LevelProfile(
+        rank="Paragon",
+        unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "Start an Albescent character",
+                        "Unlock /Albescent as a starting faction for a future character."),
+            LevelUnlock(LevelUnlockKind.sense, "See the underline before it's drawn",
+                        "You've read enough field stamps to know how this sentence ends."),
+        ),
+    ),
+)
+
+
+# =============================================================================
 # ERA DEFINITION
 # =============================================================================
 
@@ -499,6 +607,7 @@ ERA_1 = EraConfig(
     reset_all_time_score=False,
     factions=ERA_1_FACTIONS,
     tasks=ERA_1_TASKS,
+    level_profiles=ERA_1_LEVEL_PROFILES,
     taunt_templates=ERA_1_TAUNT_TEMPLATES,
     # Ephemerists' Task Vision perk: they may create praxes on retired tasks.
     allow_praxis_on_retired_task_factions=frozenset({"ephemerists"}),

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -7,6 +7,27 @@ owns the rules themselves. Changing CURRENT_ERA is the one lever that
 switches all live game mechanics.
 """
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class LevelUnlockKind(str, Enum):
+    """Whether a level unlock is a rules-backed capability or pure flavor."""
+    ability = "ability"   # rules-backed capability, must match a real gate constant
+    sense = "sense"        # whimsical flavor, no mechanics
+
+
+@dataclass(frozen=True)
+class LevelUnlock:
+    kind: LevelUnlockKind
+    name: str
+    desc: str
+
+
+@dataclass(frozen=True)
+class LevelProfile:
+    """Rank title + unlocks announced by the level-up pop-up at a given level."""
+    rank: str
+    unlocks: tuple[LevelUnlock, ...]
 
 
 @dataclass(frozen=True)
@@ -107,6 +128,10 @@ class EraConfig:
 
     # Task definitions for this era
     tasks: tuple = ()                # tuple[TaskDef, ...]
+
+    # Rank + unlocks shown by the level-up pop-up, indexed by level like
+    # level_thresholds (index 0 = start state, never shown).
+    level_profiles: tuple = ()       # tuple[LevelProfile, ...]
 
     # Taunt templates for this era
     taunt_templates: dict = field(default_factory=dict)  # faction slug → trigger → templates

--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -1,7 +1,12 @@
 from fastapi import APIRouter
 
 from game_config import CURRENT_ERA
-from schemas.game_config import FactionConfigOut, GameConfigOut
+from schemas.game_config import (
+    FactionConfigOut,
+    GameConfigOut,
+    LevelProfileOut,
+    LevelUnlockOut,
+)
 
 router = APIRouter()
 
@@ -26,6 +31,17 @@ async def get_game_config() -> GameConfigOut:
         for faction in CURRENT_ERA.factions.values()
     ]
 
+    level_profiles = [
+        LevelProfileOut(
+            rank=profile.rank,
+            unlocks=[
+                LevelUnlockOut(kind=unlock.kind.value, name=unlock.name, desc=unlock.desc)
+                for unlock in profile.unlocks
+            ],
+        )
+        for profile in CURRENT_ERA.level_profiles
+    ]
+
     return GameConfigOut(
         era_name=CURRENT_ERA.name,
         level_thresholds=list(CURRENT_ERA.level_thresholds),
@@ -33,4 +49,5 @@ async def get_game_config() -> GameConfigOut:
         vote_budget_base=CURRENT_ERA.vote_budget_base,
         vote_budget_multiplier=CURRENT_ERA.vote_budget_multiplier,
         factions=factions,
+        level_profiles=level_profiles,
     )

--- a/backend/schemas/game_config.py
+++ b/backend/schemas/game_config.py
@@ -15,6 +15,17 @@ class FactionConfigOut(BaseModel):
     duel_loss_modifier: float
 
 
+class LevelUnlockOut(BaseModel):
+    kind: str
+    name: str
+    desc: str
+
+
+class LevelProfileOut(BaseModel):
+    rank: str
+    unlocks: list[LevelUnlockOut]
+
+
 class GameConfigOut(BaseModel):
     era_name: str
     level_thresholds: list[int]
@@ -22,3 +33,4 @@ class GameConfigOut(BaseModel):
     vote_budget_base: int
     vote_budget_multiplier: float
     factions: list[FactionConfigOut]
+    level_profiles: list[LevelProfileOut]

--- a/backend/tests/integration/test_game_config.py
+++ b/backend/tests/integration/test_game_config.py
@@ -21,3 +21,9 @@ async def test_get_game_config_returns_current_era(client: AsyncClient):
     assert len(data["factions"]) == len(CURRENT_ERA.factions)
     slugs = {faction["slug"] for faction in data["factions"]}
     assert slugs == set(CURRENT_ERA.factions.keys())
+
+    # level_profiles serialized index-aligned with level_thresholds.
+    assert len(data["level_profiles"]) == len(CURRENT_ERA.level_profiles)
+    served_level_1 = data["level_profiles"][1]
+    assert served_level_1["rank"] == CURRENT_ERA.level_profiles[1].rank
+    assert served_level_1["unlocks"][0]["kind"] in {"ability", "sense"}

--- a/backend/tests/unit/test_level_profiles.py
+++ b/backend/tests/unit/test_level_profiles.py
@@ -1,0 +1,63 @@
+import pytest
+
+from game_config import ERA_1, LevelUnlockKind
+
+GATE_ATTRS = [
+    "collaboration_level_required",
+    "duel_level_required",
+    "comment_level_required",
+    "level_to_see_retired_tasks",
+    "level_to_propose_task",
+    "level_to_see_pending_tasks",
+    "flag_level_required",
+    "second_character_level_required",
+    "level_to_propose_metatask",
+    "metatask_apply_level",
+    "albescent_level_required",
+]
+
+
+def _ability_names(level: int) -> set[str]:
+    return {
+        unlock.name
+        for unlock in ERA_1.level_profiles[level].unlocks
+        if unlock.kind == LevelUnlockKind.ability
+    }
+
+
+def test_level_profiles_index_aligned_with_thresholds():
+    assert len(ERA_1.level_profiles) == len(ERA_1.level_thresholds)
+
+
+def test_level_0_is_a_placeholder_never_shown():
+    assert ERA_1.level_profiles[0].unlocks == ()
+
+
+@pytest.mark.parametrize("level", range(1, len(ERA_1.level_thresholds)))
+def test_every_real_level_has_a_rank_and_an_unlock(level):
+    profile = ERA_1.level_profiles[level]
+    assert profile.rank
+    assert len(profile.unlocks) >= 1
+
+
+@pytest.mark.parametrize("gate_attr", GATE_ATTRS)
+def test_grounded_ability_sits_at_its_gate_constants_level(gate_attr):
+    """Each capability gate must have a matching ability unlock at that exact level."""
+    gate_level = getattr(ERA_1, gate_attr)
+    assert _ability_names(gate_level), f"no ability unlock at level {gate_level} for {gate_attr}"
+
+
+def test_level_5_has_no_hard_gate_sense_only():
+    """Level 5 has no EraConfig gate; the spec doc's 'promote level-0 tasks' is
+    aspirational and unimplemented, so the profile is whimsy-only."""
+    kinds = {unlock.kind for unlock in ERA_1.level_profiles[5].unlocks}
+    assert kinds == {LevelUnlockKind.sense}
+
+
+def test_faction_choice_is_not_a_grounded_ability_anywhere():
+    """faction_graduation_level is DORMANT (services/faction_service.py has no
+    level check on faction choice) — it must not be cited as a grounded gate."""
+    for profile in ERA_1.level_profiles:
+        for unlock in profile.unlocks:
+            if unlock.kind == LevelUnlockKind.ability:
+                assert "choose" not in unlock.name.lower()

--- a/frontend/src/api/gameConfig.ts
+++ b/frontend/src/api/gameConfig.ts
@@ -14,6 +14,19 @@ export interface FactionConfigOut {
   duel_loss_modifier: number
 }
 
+export type LevelUnlockKind = 'ability' | 'sense'
+
+export interface LevelUnlock {
+  kind: LevelUnlockKind
+  name: string
+  desc: string
+}
+
+export interface LevelProfile {
+  rank: string
+  unlocks: LevelUnlock[]
+}
+
 export interface GameConfigOut {
   era_name: string
   level_thresholds: number[]
@@ -21,6 +34,7 @@ export interface GameConfigOut {
   vote_budget_base: number
   vote_budget_multiplier: number
   factions: FactionConfigOut[]
+  level_profiles: LevelProfile[]
 }
 
 export async function getGameConfig(): Promise<GameConfigOut> {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth/AuthContext'
 import NavBar from './NavBar'
 import { BackdropProvider } from './backdrop/BackdropContext'
 import FactionBackdrop from './backdrop/FactionBackdrop'
+import LevelUpWatcher from './LevelUpWatcher'
 import Sidebar from './layout/Sidebar'
 
 export default function Layout({ children }: { children: ReactNode }) {
@@ -25,6 +26,7 @@ export default function Layout({ children }: { children: ReactNode }) {
     <BackdropProvider>
     <div className="min-h-screen flex flex-col relative">
       <FactionBackdrop />
+      <LevelUpWatcher />
 
       <NavBar />
 

--- a/frontend/src/components/LevelUpPopup.tsx
+++ b/frontend/src/components/LevelUpPopup.tsx
@@ -1,0 +1,241 @@
+import { useEffect } from 'react'
+import type { CSSProperties } from 'react'
+import type { LevelUnlock } from '../api/gameConfig'
+
+/**
+ * LevelUpPopup — World Zero "Field Stamp" level-up popup (design: docs/design/level-up/).
+ * Self-contained inline-styled modal, matching EverymenVote / the feed modals.
+ */
+
+const RAINBOW = [
+  'var(--underline-1)', // amber
+  'var(--underline-2)', // magenta
+  'var(--underline-3)', // indigo
+  'var(--underline-4)', // teal
+  'var(--underline-5)', // green
+  'var(--underline-6)', // red
+]
+
+const INK = 'var(--color-text-primary)'
+const PAPER = 'var(--color-bg-page)'
+const MUTED = 'var(--color-text-secondary)'
+const FAINT = 'var(--color-text-tertiary)'
+const BORDER = 'var(--color-border-strong)'
+const FONT_DISPLAY = 'var(--font-display)'
+const FONT_BODY = 'var(--font-body)'
+
+function RainbowText({ text, fontSize = 34 }: { text: string; fontSize?: number }) {
+  let i = 0
+  return (
+    <h1
+      style={{
+        fontFamily: FONT_DISPLAY,
+        fontStyle: 'italic',
+        fontWeight: 500,
+        lineHeight: 1.15,
+        fontSize,
+        color: INK,
+        margin: 0,
+      }}
+    >
+      {[...text].map((ch, idx) => {
+        if (ch === ' ') {
+          return <span key={idx} style={{ display: 'inline-block', width: '0.3em' }} />
+        }
+        const color = RAINBOW[i++ % RAINBOW.length]
+        return (
+          <span key={idx} style={{ borderBottom: `4px solid ${color}`, paddingBottom: 2 }}>
+            {ch}
+          </span>
+        )
+      })}
+    </h1>
+  )
+}
+
+function RainbowRule({ style }: { style?: CSSProperties }) {
+  return (
+    <div style={{ display: 'flex', width: '100%', height: 4, borderRadius: 2, overflow: 'hidden', ...style }}>
+      {RAINBOW.map((c, idx) => (
+        <span key={idx} style={{ flex: 1, background: c }} />
+      ))}
+    </div>
+  )
+}
+
+function SealStamp({ level, sealRing = 'rainbow' }: { level: number; sealRing?: 'rainbow' | 'ink' }) {
+  const ringBg =
+    sealRing === 'ink'
+      ? INK
+      : 'conic-gradient(from -60deg,' +
+        RAINBOW.map((c, idx) => `${c} ${idx * 60}deg ${(idx + 1) * 60}deg`).join(',') +
+        ')'
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 18 }}>
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderRadius: '50%',
+          padding: 6,
+          transform: 'rotate(-7deg)',
+          background: ringBg,
+        }}
+      >
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: '50%',
+            background: PAPER,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: `inset 0 0 0 2px ${PAPER}, inset 0 0 0 3px ${INK}`,
+          }}
+        >
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontFamily: FONT_BODY, fontSize: 8, letterSpacing: '0.24em', color: INK }}>
+              LVL
+            </div>
+            <div style={{ fontFamily: FONT_DISPLAY, fontStyle: 'italic', fontSize: 38, lineHeight: 0.85, color: INK }}>
+              {level}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AbilityRow({ ability, color }: { ability: LevelUnlock; color: string }) {
+  const isSense = ability.kind === 'sense'
+  return (
+    <div style={{ display: 'flex', gap: 13, textAlign: 'left', alignItems: 'flex-start', marginBottom: 15 }}>
+      <span style={{ fontSize: 15, lineHeight: 1.1, flex: 'none', width: 18, textAlign: 'center', color }}>
+        {isSense ? '✦' : '■'}
+      </span>
+      <div>
+        <div style={{ fontFamily: FONT_BODY, fontSize: 7, letterSpacing: '0.18em', textTransform: 'uppercase', color: FAINT, marginBottom: 3 }}>
+          {isSense ? 'A curious sense' : 'New ability'}
+        </div>
+        <div style={{ fontFamily: FONT_DISPLAY, fontStyle: 'italic', fontSize: 16, lineHeight: 1.2, color: INK }}>
+          {ability.name}
+        </div>
+        {ability.desc && (
+          <div style={{ fontFamily: FONT_BODY, fontSize: 9, lineHeight: 1.55, color: MUTED, marginTop: 3 }}>
+            {ability.desc}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export interface LevelUpPopupProps {
+  level: number
+  rank: string
+  abilities: LevelUnlock[]
+  onContinue: () => void
+  continueLabel?: string
+  sealRing?: 'rainbow' | 'ink'
+  dimBackdrop?: boolean
+}
+
+export default function LevelUpPopup({
+  level,
+  rank,
+  abilities,
+  onContinue,
+  continueLabel = 'Continue',
+  sealRing = 'rainbow',
+  dimBackdrop = true,
+}: LevelUpPopupProps) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onContinue()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onContinue])
+
+  const card = (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        width: 372,
+        maxWidth: '100%',
+        boxSizing: 'border-box',
+        background: PAPER,
+        border: `1px solid ${BORDER}`,
+        borderRadius: 12,
+        padding: '30px 28px 24px',
+        boxShadow: '0 18px 46px -14px rgba(26,18,9,0.5)',
+        textAlign: 'center',
+        fontFamily: FONT_BODY,
+      }}
+    >
+      <SealStamp level={level} sealRing={sealRing} />
+
+      <p style={{ fontFamily: FONT_BODY, fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.15em', color: FAINT, margin: '0 0 4px' }}>
+        Level Reached
+      </p>
+      <RainbowText text={rank} />
+
+      <RainbowRule style={{ margin: '14px 0 16px' }} />
+
+      <div style={{ fontFamily: FONT_BODY, fontSize: 8, letterSpacing: '0.2em', textTransform: 'uppercase', color: FAINT, marginBottom: 14 }}>
+        Now Unlocked
+      </div>
+
+      {abilities.map((ab, idx) => (
+        <AbilityRow key={idx} ability={ab} color={RAINBOW[idx % RAINBOW.length]} />
+      ))}
+
+      <button
+        type="button"
+        autoFocus
+        onClick={onContinue}
+        style={{
+          marginTop: 20,
+          width: '100%',
+          fontFamily: FONT_BODY,
+          textTransform: 'uppercase',
+          letterSpacing: '0.12em',
+          fontSize: 11,
+          padding: '0.6rem 1.4rem',
+          border: 'none',
+          background: INK,
+          color: PAPER,
+          cursor: 'pointer',
+          transition: 'opacity 150ms',
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.85')}
+        onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+      >
+        {continueLabel}
+      </button>
+    </div>
+  )
+
+  if (!dimBackdrop) return card
+
+  return (
+    <div
+      onClick={onContinue}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        zIndex: 1000,
+        background: 'radial-gradient(ellipse at 50% 42%, rgba(26,18,9,0.30), rgba(26,18,9,0.66))',
+      }}
+    >
+      <div onClick={(e) => e.stopPropagation()}>{card}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/LevelUpWatcher.tsx
+++ b/frontend/src/components/LevelUpWatcher.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react'
+import { useAuth } from '../auth/AuthContext'
+import { useGameConfig } from '../hooks/useGameConfig'
+import LevelUpPopup from './LevelUpPopup'
+
+const STORAGE_PREFIX = 'wz:lastSeenLevel:'
+
+export function lastSeenLevelKey(characterId: number): string {
+  return `${STORAGE_PREFIX}${characterId}`
+}
+
+export interface LevelDiff {
+  levelsToAnnounce: number[]
+  nextStored: number
+}
+
+/**
+ * Pure diff between the last-seen level and the current one.
+ * `stored === null` means "never observed this character before" -> seed
+ * silently. A drop (era reset) leaves `nextStored` at the old high-water
+ * mark, so re-climbing stays silent until it's exceeded again.
+ */
+export function diffLevel(stored: number | null, current: number): LevelDiff {
+  if (stored === null) return { levelsToAnnounce: [], nextStored: current }
+  if (current <= stored) return { levelsToAnnounce: [], nextStored: stored }
+  const levelsToAnnounce: number[] = []
+  for (let level = stored + 1; level <= current; level++) levelsToAnnounce.push(level)
+  return { levelsToAnnounce, nextStored: current }
+}
+
+/** Mounted once in Layout. Detects level-ups via a per-character localStorage
+ * diff (score only changes from others voting, so there's no in-the-moment
+ * event) and queues one Field Stamp popup per level crossed. */
+export default function LevelUpWatcher() {
+  const { user } = useAuth()
+  const config = useGameConfig()
+  const [queue, setQueue] = useState<number[]>([])
+  const character = user?.character ?? null
+
+  useEffect(() => {
+    if (!character) return
+    const key = lastSeenLevelKey(character.id)
+    const raw = localStorage.getItem(key)
+    const stored = raw === null ? null : Number(raw)
+    const { levelsToAnnounce, nextStored } = diffLevel(stored, character.level)
+    if (nextStored !== stored) localStorage.setItem(key, String(nextStored))
+    if (levelsToAnnounce.length > 0) setQueue((prev) => [...prev, ...levelsToAnnounce])
+  }, [character?.id, character?.level])
+
+  if (!config || queue.length === 0) return null
+
+  const level = queue[0]
+  const profile = config.level_profiles[level]
+  if (!profile) return null
+
+  return (
+    <LevelUpPopup
+      level={level}
+      rank={profile.rank}
+      abilities={profile.unlocks}
+      onContinue={() => setQueue((prev) => prev.slice(1))}
+    />
+  )
+}

--- a/frontend/src/components/__tests__/levelUpWatcher.test.ts
+++ b/frontend/src/components/__tests__/levelUpWatcher.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Level-up detection is a pure per-character localStorage diff (#287) — no
+ * in-the-moment event exists, since score only rises when others vote. This
+ * guards the diff logic directly; no DOM/jsdom is set up in this repo (see
+ * vite.config.ts), so localStorage wiring itself is exercised by inspection.
+ */
+import { describe, it, expect } from 'vitest'
+import { diffLevel, lastSeenLevelKey } from '../LevelUpWatcher'
+
+describe('diffLevel', () => {
+  it('seeds silently on first observation (no popup, but commits current level)', () => {
+    expect(diffLevel(null, 3)).toEqual({ levelsToAnnounce: [], nextStored: 3 })
+  })
+
+  it('fires on a single-level increase', () => {
+    expect(diffLevel(2, 3)).toEqual({ levelsToAnnounce: [3], nextStored: 3 })
+  })
+
+  it('queues every level crossed in order on a multi-level jump', () => {
+    expect(diffLevel(2, 5)).toEqual({ levelsToAnnounce: [3, 4, 5], nextStored: 5 })
+  })
+
+  it('does nothing on a drop (era reset) and keeps the old high-water mark', () => {
+    expect(diffLevel(5, 3)).toEqual({ levelsToAnnounce: [], nextStored: 5 })
+  })
+
+  it('does nothing when the level is unchanged', () => {
+    expect(diffLevel(3, 3)).toEqual({ levelsToAnnounce: [], nextStored: 3 })
+  })
+})
+
+describe('lastSeenLevelKey', () => {
+  it('namespaces the storage key per character id, so switching characters never mixes state', () => {
+    expect(lastSeenLevelKey(1)).not.toBe(lastSeenLevelKey(2))
+  })
+})


### PR DESCRIPTION
Closes #287.

## Summary
- Authors `level_profiles` as era config: `LevelUnlockKind`/`LevelUnlock`/`LevelProfile` dataclasses on `EraConfig`, values in `eras/era_1.py` (levels 0–8, index-aligned with `level_thresholds`), served on the existing `GET /game-config` endpoint (no new endpoint).
- Ports the vendored design (`docs/design/level-up/LevelUpPopup.jsx`) to `frontend/src/components/LevelUpPopup.tsx`: typed props, stripped hex fallbacks (all 8 tokens confirmed in `index.css`), Escape-to-dismiss + autofocused Continue, no focus trap.
- Adds `LevelUpWatcher.tsx`, mounted once in `Layout`: detects level-ups via a per-character `localStorage` diff (score only rises when *others* vote, so there's no in-the-moment event), seeds silently on first observation, queues one popup per level crossed, and eager-commits so a mid-popup refetch can't re-enqueue. A drop (era reset) leaves the old high-water mark in place — re-climbing stays silent until it's exceeded again (accepted limitation per the issue).
- Fills in the `LEVEL PROFILES` section of `eras/_template.py` so a future era doesn't silently ship with an empty `level_profiles`.

## Deviation from the issue
The issue's level-3 row paired "choose a faction" with `faction_graduation_level`. That field is marked **DORMANT** in `game_config.py`, and `services/faction_service.py::defect_to_faction` / `can_join_faction` have **no level check at all** — faction choice is gated purely by invitation (ADR-0022), not by level. Citing it would violate the issue's own grounding requirement ("must match the real gate constants... do not invent"), so it's dropped. Level 3 keeps its two other real gates: propose a task (`level_to_propose_task`) and see pending tasks (`level_to_see_pending_tasks`). Left a comment in `era_1.py` explaining the discrepancy in place.

Also independently verified the issue's "level 5 has no hard gate" claim against `SPEC-game-rules.md`'s conflicting "vote to promote level-0 tasks" — confirmed no `promote` logic exists anywhere in services, so the issue's version is correct and level 5 is sense-only.

Rank titles + sense copy are bot-drafted per the issue ("Molly revises later, config-only").

## Test plan
- [x] Backend: `pytest --cov=. --cov-fail-under=80` → 471 passed, 3 xfailed, 82.97% coverage
- [x] New `test_level_profiles.py`: index alignment with `level_thresholds`, every real level has a rank + ≥1 unlock, every grounded ability sits at its gate constant's real level, level 5 is sense-only, faction choice is never cited as a grounded ability
- [x] `test_game_config.py` extended: `level_profiles` served correctly on `/game-config`
- [x] Frontend: `npm test` → 108 passed, including new `levelUpWatcher.test.ts` (seed-silently, single/multi-level fire, drop-does-nothing, per-character key namespacing)
- [x] `npx tsc --noEmit` clean on all touched/new files (one pre-existing unrelated failure in `archetypeSlots.test.tsx` — flagged as a separate follow-up task, not touched here)
- [x] `npm run build` succeeds
- [x] Manual verification via preview: dev-login, rolled back `localStorage` lastSeenLevel, reloaded — popup fired with exact grounded copy for levels 3→4 in sequence, autofocus confirmed on Continue, Escape dismissed correctly, eager-commit confirmed (localStorage already at new level before the queue drained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)