### PR TITLE
fix: active character is the actor for every write path (closes #293)

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -8,9 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
 from models.account import Account, AccountStatus
-from models.character import Character, CharacterStatus
+from models.character import Character
 from models.roles import AccountRole, Role
 from services.auth import decode_jwt, get_current_account
+from services.character import resolve_active_character
 
 _OPTIONAL_BEARER = HTTPBearer(auto_error=False)
 
@@ -19,20 +20,13 @@ async def get_current_character(
     account: Account = Depends(get_current_account),
     session: AsyncSession = Depends(get_db),
 ) -> Character:
-    """Return the first active character for the authenticated account.
+    """Return the account's active (carried) character — the actor for every write path.
 
+    Honours ``account.active_character_id`` (the life the player is currently
+    carrying); falls back to the most-recently-created active character.
     Raises 403 if the account has no active character yet.
     """
-    result = await session.execute(
-        select(Character)
-        .where(
-            Character.account_id == account.id,
-            Character.status == CharacterStatus.active,
-        )
-        .order_by(Character.created_at)
-        .limit(1)
-    )
-    character = result.scalar_one_or_none()
+    character = await resolve_active_character(account, session)
     if character is None:
         raise HTTPException(
             status_code=403,
@@ -76,16 +70,7 @@ async def get_current_character_optional(
     if account is None or account.status != AccountStatus.active:
         return None
 
-    char_result = await session.execute(
-        select(Character)
-        .where(
-            Character.account_id == account.id,
-            Character.status == CharacterStatus.active,
-        )
-        .order_by(Character.created_at)
-        .limit(1)
-    )
-    return char_result.scalar_one_or_none()
+    return await resolve_active_character(account, session)
 
 
 async def require_admin(

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -126,19 +126,12 @@ async def get_character_praxes(
 async def upload_avatar(
     character_id: int,
     file: UploadFile = File(...),
-    account: Account = Depends(get_current_account),
+    current_character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    character = await session.scalar(
-        select(Character).where(
-            Character.id == character_id,
-            Character.status == CharacterStatus.active,
-        )
-    )
-    if character is None:
-        raise HTTPException(status_code=404, detail="Character not found.")
-    if character.account_id != account.id:
+    if current_character.id != character_id:
         raise HTTPException(status_code=403, detail="Cannot update another character's avatar.")
+    character = current_character
     character.avatar_url = await process_and_save_avatar(file, character_id)
     await session.flush()
     await session.refresh(character)

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -532,18 +532,22 @@ async def test_upload_avatar_wrong_owner(
 
 
 @pytest.mark.asyncio
-async def test_upload_avatar_not_found(
+async def test_upload_avatar_not_active_character(
     client: AsyncClient,
     auth_headers: dict,
 ):
-    """Uploading an avatar for a nonexistent character returns 404."""
+    """Uploading to an id that isn't the caller's active character returns 403.
+
+    The avatar guard is identity-based, matching edit/delete (ADR-0025): a
+    mismatched id (here, a nonexistent one) is rejected as 403, not 404.
+    """
     jpeg_bytes = _make_jpeg_bytes()
     resp = await client.post(
         "/characters/99999/avatar",
         files={"file": ("avatar.jpg", jpeg_bytes, "image/jpeg")},
         headers=auth_headers,
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_multi_character.py
+++ b/backend/tests/integration/test_multi_character.py
@@ -11,11 +11,11 @@ Covers two readings of "a second character":
 Each test asserts the *intended* behaviour (the second character acts as itself),
 so any broken write path shows up as a failing test rather than a silent no-op.
 
-Known gap under test: every write endpoint resolves the acting character through
-``dependencies.get_current_character``, which returns the **oldest active
-character by created_at** and ignores ``account.active_character_id``. The
-same-account-second-life tests below therefore pin down whether switching the
-carried life actually governs task signup, collaboration, and profile edits.
+Active character is the actor (ADR-0025): every write endpoint resolves the acting
+character through ``dependencies.get_current_character``, which honours
+``account.active_character_id`` (falling back to the newest active character). The
+same-account-second-life tests below pin down that switching the carried life
+actually governs task signup, collaboration, profile edits, and viewer flags.
 """
 import pytest
 from httpx import AsyncClient
@@ -197,20 +197,9 @@ async def test_other_account_character_cannot_edit_someone_elses_profile(
 # B. Same-account second life (the multi-life surface)
 # ===========================================================================
 
-# Known gap: write endpoints resolve the actor via
-# ``dependencies.get_current_character``, which returns the OLDEST active
-# character and ignores ``account.active_character_id``. So after switching the
-# carried life, task signup / collaboration / profile edits still act as the
-# account's first life. The three tests below assert the *intended* behaviour and
-# are marked xfail(strict=True) — when the resolver is fixed to honour the carried
-# life, they will xpass and force these markers to be removed.
-_CARRIED_LIFE_NOT_HONOURED = pytest.mark.xfail(
-    reason=(
-        "get_current_character ignores account.active_character_id, so write "
-        "paths act as the account's first life rather than the carried second life."
-    ),
-    strict=True,
-)
+# Write endpoints resolve the actor via ``dependencies.get_current_character``,
+# which now honours ``account.active_character_id`` (ADR-0025). So after switching
+# the carried life, task signup / collaboration / profile edits act as *that* life.
 
 
 @pytest.mark.asyncio
@@ -254,7 +243,6 @@ async def test_second_life_views_own_profile(
     assert resp.json()["id"] == second.id
 
 
-@_CARRIED_LIFE_NOT_HONOURED
 @pytest.mark.asyncio
 async def test_second_life_signs_up_for_task_as_itself(
     client: AsyncClient,
@@ -291,7 +279,6 @@ async def test_second_life_signs_up_for_task_as_itself(
     assert member_ids == [second.id]
 
 
-@_CARRIED_LIFE_NOT_HONOURED
 @pytest.mark.asyncio
 async def test_second_life_edits_own_profile(
     client: AsyncClient,
@@ -323,7 +310,79 @@ async def test_second_life_edits_own_profile(
     assert after.json()["bio"] == "Second life bio"
 
 
-@_CARRIED_LIFE_NOT_HONOURED
+@pytest.mark.asyncio
+async def test_second_life_carried_cannot_edit_sibling_first_life(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """Carrying the second life must NOT unlock editing a *sibling* life on the
+    same account — profile edits stay carried-character-only (ADR-0025 decision 3)."""
+    second = await _add_character(db_session, account, era, username="secondlife", level=5)
+    await client.post(
+        "/me/active-character",
+        json={"character_id": second.id},
+        headers=auth_headers,
+    )
+
+    resp = await client.put(
+        f"/characters/{character.id}",
+        json={"display_name": "Hijacked sibling"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_second_life_governs_viewer_flags_on_read(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """The optional viewer resolver (public detail reads) also honours the carried
+    life: ``can_flag`` on the *first* life's own praxis flips to True once the
+    second life is carried (a life may flag a sibling's praxis; anti-self-flag is
+    character-scoped today — see #328)."""
+    # First life authors a praxis while it is still the only (newest) active life.
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "First life work"},
+        headers=auth_headers,
+    )
+    assert create.status_code == 201, create.text
+    praxis_id = create.json()["id"]
+    assert create.json()["created_by_id"] == character.id
+
+    # Viewed as the author (first life): cannot flag your own praxis.
+    as_author = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert as_author.json()["can_flag"] is False
+
+    # Carry a second life at/above the flag level, then view again.
+    second = await _add_character(
+        db_session, account, era, username="secondlife",
+        level=CURRENT_ERA.flag_level_required,
+    )
+    await client.post(
+        "/me/active-character",
+        json={"character_id": second.id},
+        headers=auth_headers,
+    )
+    as_second = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert as_second.json()["can_flag"] is True, (
+        "Optional viewer resolver ignored the carried life: can_flag should reflect "
+        "the second life (a non-author) once it is carried."
+    )
+
+
 @pytest.mark.asyncio
 async def test_second_life_collaborates_on_praxis(
     client: AsyncClient,


### PR DESCRIPTION
## What

Every write path (task signup, collab accept, votes, profile edit, avatar) and viewer-relative read flag resolved the acting character via `get_current_character` / `get_current_character_optional`, which picked the **oldest active** character and ignored `account.active_character_id`. Meanwhile `/auth/me` (via `resolve_active_character`) already reflects the **carried** life. Result: after switching lives, writes acted as the wrong character.

## Change

- Route **both** `get_current_character` and `get_current_character_optional` through `resolve_active_character` — the active (carried) character is now the single actor/viewer seam for all 43 write sites and the public detail read flags.
- Accept the fallback flip **oldest→newest** (no migration) — it matches what `/auth/me` already shows (ADR-0025 decision 2).
- Convert the avatar-upload guard from an account-wide check to the same **carried-character-only** identity guard used by edit/delete, so all three profile mutations are consistent (decision 3).

## Tests

- Drop the 3 `xfail(strict=True)` markers in `test_multi_character.py` — the carried-life signup / profile-edit / collab tests now pass.
- Add `test_second_life_carried_cannot_edit_sibling_first_life` (403 guard stays) and `test_second_life_governs_viewer_flags_on_read` (optional resolver honours the carried life).

Anti-self-vote stays account-scoped (unchanged). Account-scoped anti-self-**flag** hardening is spun out to #328.

Implements ADR-0025. Closes #293.