### PR TITLE
chore: remove vestigial newFiles staging in editPraxis (closes #325)

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
@@ -13,7 +13,7 @@ import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
-import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
 import { Breadcrumb, ErrorBanner, formatAutosave } from "./shared";
 import {
   BodyPreview,
@@ -309,7 +309,7 @@ export default function EditPraxisEphemeris({ state }: Props) {
 
         {/* the evidence */}
         <div style={{ marginBottom: 30 }}>
-          <FieldLabel meta={`${state.media.length + state.newFiles.length} pinned`}>THE EVIDENCE</FieldLabel>
+          <FieldLabel meta={`${state.media.length} pinned`}>THE EVIDENCE</FieldLabel>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 16, marginBottom: 14 }}>
             {state.media.map((item, index) => {
               const filename = item.file_path.split("/").pop() ?? item.file_path;
@@ -331,16 +331,6 @@ export default function EditPraxisEphemeris({ state }: Props) {
                 </Specimen>
               );
             })}
-            {state.newFiles.map((file, index) => (
-              <Specimen
-                key={index}
-                rotation={[1.8, -2.4, 1.2, -1.6][index % 4]}
-                caption={file.name}
-                onRemove={() => state.removeNewFile(index)}
-              >
-                <MediaArt art={mediaArtKeysFromFile(file)} />
-              </Specimen>
-            ))}
           </div>
           <FilePicker
             state={state}

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
@@ -11,7 +11,7 @@ import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import type { MediaItemOut } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
-import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
   ErrorBanner,
@@ -151,7 +151,7 @@ export default function EditPraxisEverymen({ state }: Props) {
 
   const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const reportNo = String(praxis.id).padStart(4, "0");
-  const totalProof = state.newFiles.length + state.media.length;
+  const totalProof = state.media.length;
 
   return (
     <div
@@ -498,15 +498,6 @@ export default function EditPraxisEverymen({ state }: Props) {
               alignItems: "flex-start",
             }}
           >
-            {state.newFiles.map((file, index) => (
-              <ProofSlip
-                key={index}
-                caption={file.name}
-                onRemove={() => state.removeNewFile(index)}
-              >
-                <MediaArt art={mediaArtKeysFromFile(file)} />
-              </ProofSlip>
-            ))}
             <button
               type="button"
               onClick={() => fileRef.current?.click()}

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
@@ -7,7 +7,7 @@ import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
-import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
   ErrorBanner,
@@ -570,7 +570,7 @@ export default function EditPraxisPaperCollage({ state }: Props) {
             <div style={{ ...notepadPanel, marginBottom: 18 }}>
               <span style={{ ...eyebrowStyle, marginBottom: 12 }}>
                 scraps &amp; specimens ·{" "}
-                {state.media.length + state.newFiles.length} pasted
+                {state.media.length} pasted
               </span>
               <div style={{ display: "flex", flexWrap: "wrap", gap: 14 }}>
                 {state.media.map((item) => {
@@ -611,18 +611,6 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                     </MediaTile>
                   );
                 })}
-                {state.newFiles.map((file, index) => (
-                  <MediaTile
-                    key={index}
-                    caption={file.name}
-                    borderColor={notepadBorder}
-                    tileBg={notepadBg}
-                    removeColor={pink}
-                    onRemove={() => state.removeNewFile(index)}
-                  >
-                    <MediaArt art={mediaArtKeysFromFile(file)} />
-                  </MediaTile>
-                ))}
               </div>
               <div style={{ marginTop: 14 }}>
                 <FilePicker

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
@@ -7,7 +7,7 @@ import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
-import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
   ErrorBanner,
@@ -524,72 +524,6 @@ export default function EditPraxisPunkZine({ state }: Props) {
           >
             ↳ glue in proof · photos / audio / receipts
           </span>
-          <div
-            style={{
-              display: "flex",
-              gap: 14,
-              flexWrap: "wrap",
-              marginBottom: 8,
-            }}
-          >
-            {state.newFiles.map((file, index) => (
-              <div
-                key={index}
-                style={{
-                  position: "relative",
-                  border: `2px solid ${accentDeep}`,
-                  padding: 6,
-                  background: surface,
-                  transform: `rotate(${index % 2 ? 2 : -2.4}deg)`,
-                  boxShadow: `2px 2px 0 ${accentDeep}`,
-                }}
-              >
-                <div
-                  style={{
-                    width: 140,
-                    height: 100,
-                    overflow: "hidden",
-                    filter: "contrast(1.15)",
-                  }}
-                >
-                  <MediaArt art={mediaArtKeysFromFile(file)} />
-                </div>
-                <div
-                  style={{
-                    fontSize: 9,
-                    marginTop: 4,
-                    color: accentDeep,
-                    fontStyle: "italic",
-                  }}
-                >
-                  FIG. {state.media.length + index + 1} · {file.name}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => state.removeNewFile(index)}
-                  aria-label={`Remove ${file.name}`}
-                  style={{
-                    position: "absolute",
-                    top: -8,
-                    right: -8,
-                    width: 22,
-                    height: 22,
-                    background: lightBg,
-                    border: `2px solid ${ink}`,
-                    color: ink,
-                    fontSize: 12,
-                    fontWeight: 700,
-                    cursor: "pointer",
-                    lineHeight: 1,
-                    padding: 0,
-                    borderRadius: "50%",
-                  }}
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
           <FilePicker
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
@@ -5,7 +5,7 @@
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
-import { mediaArtKeysFromFile, pickArtKey } from "../blocks/useMediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
   ErrorBanner,
@@ -476,16 +476,6 @@ export default function EditPraxisStickyNote({ state }: Props) {
               </PolaroidStickie>
             );
           })}
-          {state.newFiles.map((file, index) => (
-            <PolaroidStickie
-              key={index}
-              rotation={index % 2 ? -2.5 : 2.2}
-              caption={file.name}
-              onRemove={() => state.removeNewFile(index)}
-            >
-              <MediaArt art={mediaArtKeysFromFile(file)} />
-            </PolaroidStickie>
-          ))}
           <FilePicker
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
@@ -486,7 +486,7 @@ export default function EditPraxisTerminal({ state }: Props) {
               background: "rgba(37,99,235,.04)",
             }}
           >
-            {state.media.length === 0 && state.newFiles.length === 0 ? (
+            {state.media.length === 0 ? (
               <div
                 style={{
                   fontSize: 11,
@@ -554,41 +554,6 @@ export default function EditPraxisTerminal({ state }: Props) {
                     </div>
                   );
                 })}
-                {state.newFiles.map((file, index) => (
-                  <div
-                    key={index}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 12,
-                      padding: "6px 10px",
-                      background: "rgba(74,222,128,.06)",
-                      border: `1px dashed ${accent}`,
-                      fontSize: 11,
-                      color: term,
-                    }}
-                  >
-                    <span style={{ color: accent }}>[staged]</span>
-                    <span style={{ flex: 1 }}>{file.name}</span>
-                    <span style={{ color: dim, fontSize: 9 }}>
-                      {(file.size / 1024 / 1024).toFixed(1)}MB
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => state.removeNewFile(index)}
-                      style={{
-                        background: "transparent",
-                        color: "#f87171",
-                        border: "none",
-                        cursor: "pointer",
-                        fontFamily: "inherit",
-                        fontSize: 10,
-                      }}
-                    >
-                      rm
-                    </button>
-                  </div>
-                ))}
               </div>
             )}
             <FilePicker

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -51,10 +51,8 @@ export interface EditPraxisState {
 
   // Media
   media: MediaItemOut[];
-  newFiles: File[];
   fileError: string;
   handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  removeNewFile: (index: number) => void;
   removeMedia: (item: MediaItemOut) => Promise<void>;
 
   // Mode switching
@@ -131,7 +129,6 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [media, setMedia] = useState<MediaItemOut[]>([]);
-  const [newFiles, setNewFiles] = useState<File[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
@@ -270,10 +267,6 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     [idParam],
   );
 
-  const removeNewFile = useCallback((index: number) => {
-    setNewFiles((previous) => previous.filter((_, i) => i !== index));
-  }, []);
-
   const removeMedia = useCallback(
     async (item: MediaItemOut) => {
       if (!idParam) return;
@@ -298,13 +291,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       await updatePraxis(praxisId, { title, body_text: body || undefined });
       lastSavedTitleRef.current = title;
       lastSavedBodyRef.current = body;
-      for (const file of newFiles) {
-        const uploaded = await uploadPraxisMedia(praxisId, file);
-        setMedia((previous) => [...previous, uploaded]);
-      }
-      setNewFiles([]);
     },
-    [title, body, newFiles],
+    [title, body],
   );
 
   const publish = useCallback(async () => {
@@ -359,10 +347,9 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     if (title.trim().length > 0) return true;
     if (body.trim().length > 0) return true;
     if (media.length > 0) return true;
-    if (newFiles.length > 0) return true;
     if (appliedMetatasks.size > 0) return true;
     return false;
-  }, [title, body, media, newFiles, appliedMetatasks]);
+  }, [title, body, media, appliedMetatasks]);
 
   const performModeSwitch = useCallback(
     async (next: PraxisType) => {
@@ -524,10 +511,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     wordCount,
 
     media,
-    newFiles,
     fileError,
     handleFileChange,
-    removeNewFile,
     removeMedia,
 
     switchingMode,


### PR DESCRIPTION
## What
Since #297 (PR #316), media uploads immediately on selection in `handleFileChange`, so the `newFiles` staging array in `useEditPraxis.ts` is never populated — the whole staging path is dead code.

## Change
`useEditPraxis.ts`: remove `newFiles`/`setNewFiles`/`removeNewFile`, the `persistEdits` upload loop + `setNewFiles([])`, the `hasDraftContent` `newFiles` branch, and the `newFiles`/`removeNewFile` interface + return fields.

6 edit archetypes (Ephemeris, Everymen, PaperCollage, PunkZine, StickyNote, Terminal): remove each `state.newFiles.map(...)` staged-preview block, the `+ state.newFiles.length` in the pinned/pasted/evidence counts, and the now-unused `mediaArtKeysFromFile` imports. (Gazette had no staging block.)

## Verify
- `npx tsc --noEmit` clean (noUnusedLocals would catch any orphaned import/local).
- `vitest run` — 109 passed.
- `npm run build` — green.

Closes #325.