### PR TITLE
fix: collab-invite accept lands on the editor, not the read page (closes #298)

### DIFF
--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -43,7 +43,9 @@ export default function FeedCardCollabInvite({ item }: Props) {
       }
       setStatus("accepted");
       setShowDropModal(false);
-      navigate(`/praxes/${praxis_id}`);
+      // New members land on the editor so they can contribute; the editor
+      // self-locks if the collab is already submitted (controlsLocked). (#298)
+      navigate(`/praxes/${praxis_id}/edit`);
     } catch {
       setDropError("Could not accept invite. Please try again.");
     }


### PR DESCRIPTION
## What
Accepting a collab invite from the activity feed navigated to `/praxes/{id}` (the read / "completed" screen), so a new contributor couldn't tell they could contribute.

## Fix
`FeedCardCollabInvite.tsx` `doAccept` now navigates to `/praxes/{id}/edit`. The editor self-locks if the collab is already submitted (`controlsLocked`), so this is safe even post-submit. Scope is just the nav target (the deeper collab-logic review is separate). The sibling duel card has the same bug, fixed on the duel side by #312.

## Verify
- `npx tsc --noEmit` clean.

Closes #298.