### PR TITLE
feat: live @mention autocomplete in the comment composer (closes #229)

### DIFF
--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -3,7 +3,7 @@ import re
 from typing import Optional
 
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.sql import Select, false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -436,7 +436,14 @@ async def list_characters_for_viewer(
 
     query = _character_stats_era_join(era_id)
     if search:
-        query = query.where(Character.username.ilike(f"%{search}%"))
+        # Match on handle OR display name so "@Mol" surfaces "Molly" (@mollusk).
+        # The inserted mention is still @username; display_name only *matches*.
+        query = query.where(
+            or_(
+                Character.username.ilike(f"%{search}%"),
+                Character.display_name.ilike(f"%{search}%"),
+            )
+        )
     if faction_slug:
         query = query.where(Character.faction_slug == faction_slug)
     query = (

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -126,6 +126,22 @@ async def test_list_characters_search_by_username(
 
 
 @pytest.mark.asyncio
+async def test_list_characters_search_by_display_name(
+    client: AsyncClient, character: Character, character2: Character
+):
+    """Search matches display_name, not just username (#229 — powers @mention typeahead).
+
+    character2's display_name is "Other Character"; its username ("othercharacter")
+    has no space, so this substring only matches via display_name.
+    """
+    resp = await client.get("/characters", params={"search": "Other Character"})
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert character2.id in ids
+    assert character.id not in ids
+
+
+@pytest.mark.asyncio
 async def test_list_characters_filter_by_faction(
     client: AsyncClient, character: Character, character2: Character
 ):

--- a/frontend/src/components/comments/__tests__/useMentionAutocomplete.test.ts
+++ b/frontend/src/components/comments/__tests__/useMentionAutocomplete.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { getActiveMention, insertMention } from '../useMentionAutocomplete'
+
+describe('getActiveMention', () => {
+  it('detects a token at input start', () => {
+    expect(getActiveMention('@mo', 3)).toEqual({ query: 'mo', start: 0, end: 3 })
+  })
+
+  it('detects a token after whitespace', () => {
+    expect(getActiveMention('hi @mo', 6)).toEqual({ query: 'mo', start: 3, end: 6 })
+  })
+
+  it('does NOT trigger on an email (@ preceded by a non-space)', () => {
+    expect(getActiveMention('email@x', 7)).toBeNull()
+    expect(getActiveMention('a@bob', 5)).toBeNull()
+  })
+
+  it('returns an empty query for a bare "@" (caller suppresses the fetch)', () => {
+    expect(getActiveMention('hi @', 4)).toEqual({ query: '', start: 3, end: 4 })
+  })
+
+  it('returns null when the caret is not inside a mention', () => {
+    expect(getActiveMention('hi bob', 6)).toBeNull()
+    expect(getActiveMention('', 0)).toBeNull()
+  })
+
+  it('spans the whole token when the caret sits mid-token', () => {
+    // caret after "mol" but the token continues to "molly"
+    expect(getActiveMention('@molly', 4)).toEqual({ query: 'molly', start: 0, end: 6 })
+  })
+
+  it('stops the token at non-token chars', () => {
+    expect(getActiveMention('@mo! rest', 3)).toEqual({ query: 'mo', start: 0, end: 3 })
+  })
+})
+
+describe('insertMention', () => {
+  it('replaces the token with "@username " and puts the caret after it', () => {
+    const active = getActiveMention('hi @mo', 6)!
+    expect(insertMention('hi @mo', active, 'molly')).toEqual({
+      next: 'hi @molly ',
+      caret: 10,
+    })
+  })
+
+  it('preserves text after the replaced token', () => {
+    const active = getActiveMention('see @mo now', 6)!
+    const { next, caret } = insertMention('see @mo now', active, 'molly')
+    expect(next).toBe('see @molly  now')
+    // caret lands right after "@molly " (before the original trailing text)
+    expect(next.slice(0, caret)).toBe('see @molly ')
+  })
+})

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -11,6 +11,7 @@ import type { ComponentType } from 'react'
 import { Link } from 'react-router-dom'
 import type { CharacterOut } from '../../api/auth'
 import type { CommentMention, CommentOut } from '../../api/comments'
+import { MentionDropdown, useMentionAutocomplete } from './useMentionAutocomplete'
 
 export interface CommentRowProps {
   mode: 'row'
@@ -109,27 +110,45 @@ export function ComposerControls({
   text?: string
 }) {
   const disabled = submitting || value.trim().length === 0
+  const mention = useMentionAutocomplete(value, onChange)
   return (
     <div>
-      <textarea
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder="Write a comment… type @ to mention someone"
-        rows={2}
-        disabled={submitting}
-        style={{
-          width: '100%',
-          resize: 'vertical',
-          background: bg,
-          color: text,
-          border: `1px solid ${accent}`,
-          borderRadius: 6,
-          padding: '8px 10px',
-          font: 'inherit',
-          fontFamily: 'inherit',
-          boxSizing: 'border-box',
-        }}
-      />
+      <div style={{ position: 'relative' }}>
+        <textarea
+          ref={mention.textareaRef}
+          value={value}
+          onChange={mention.handleChange}
+          onKeyDown={mention.handleKeyDown}
+          onBlur={mention.close}
+          placeholder="Write a comment… type @ to mention someone"
+          rows={2}
+          disabled={submitting}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={mention.open}
+          aria-controls="mention-listbox"
+          aria-activedescendant={mention.activeOptionId}
+          style={{
+            width: '100%',
+            resize: 'vertical',
+            background: bg,
+            color: text,
+            border: `1px solid ${accent}`,
+            borderRadius: 6,
+            padding: '8px 10px',
+            font: 'inherit',
+            fontFamily: 'inherit',
+            boxSizing: 'border-box',
+          }}
+        />
+        {mention.open && (
+          <MentionDropdown
+            results={mention.results}
+            highlight={mention.highlight}
+            onPick={mention.pick}
+          />
+        )}
+      </div>
       <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 6 }}>
         <button
           onClick={onSubmit}

--- a/frontend/src/components/comments/useMentionAutocomplete.tsx
+++ b/frontend/src/components/comments/useMentionAutocomplete.tsx
@@ -1,0 +1,240 @@
+/**
+ * Live @mention typeahead for the comment composer (#229).
+ *
+ * Reuses the existing search endpoint (`listCharacters`, backed by
+ * `GET /characters?search=`) and renders below the textarea. Neutral chrome
+ * (ADR-0006 keeps the thread container neutral; a transient popup is not an
+ * enumerated faction surface) — per-row identity comes from `FactionAvatar`.
+ *
+ * The pure token helpers (`getActiveMention`, `insertMention`) are exported so
+ * the fiddly detection + caret math can be unit-tested without React/network.
+ */
+import { useCallback, useRef, useState } from 'react'
+import type React from 'react'
+import { listCharacters, type CharacterOut } from '../../api/characters'
+import { useAuth } from '../../auth/AuthContext'
+import FactionAvatar from '../avatar/FactionAvatar'
+
+// Token charset matches the backend MENTION_RE ([A-Za-z0-9_]).
+const TOKEN_CHAR = /[A-Za-z0-9_]/
+const WHITESPACE = /\s/
+const DEBOUNCE_MS = 200
+const RESULT_LIMIT = 8
+
+export interface ActiveMention {
+  /** Text between '@' and the token end (empty for a bare '@'). */
+  query: string
+  /** Index of the '@'. */
+  start: number
+  /** Index just past the token (exclusive) — the replace range is [start, end). */
+  end: number
+}
+
+/**
+ * The @mention token the caret currently sits inside, or null. The '@' must be
+ * at input start or preceded by whitespace, so `email@x` never triggers.
+ */
+export function getActiveMention(value: string, caret: number): ActiveMention | null {
+  let runStart = caret
+  while (runStart > 0 && TOKEN_CHAR.test(value[runStart - 1])) runStart--
+  const atIndex = runStart - 1
+  if (atIndex < 0 || value[atIndex] !== '@') return null
+  const before = atIndex > 0 ? value[atIndex - 1] : ''
+  if (before !== '' && !WHITESPACE.test(before)) return null
+  let end = caret
+  while (end < value.length && TOKEN_CHAR.test(value[end])) end++
+  return { query: value.slice(atIndex + 1, end), start: atIndex, end }
+}
+
+/** Replace the active token with `@username ` (trailing space); return new value + caret. */
+export function insertMention(
+  value: string,
+  active: ActiveMention,
+  username: string,
+): { next: string; caret: number } {
+  const inserted = `@${username} `
+  const next = value.slice(0, active.start) + inserted + value.slice(active.end)
+  return { next, caret: active.start + inserted.length }
+}
+
+export function useMentionAutocomplete(
+  value: string,
+  onChange: (value: string) => void,
+) {
+  const { user } = useAuth()
+  const selfId = user?.character?.id ?? null
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const activeRef = useRef<ActiveMention | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const [results, setResults] = useState<CharacterOut[]>([])
+  const [open, setOpen] = useState(false)
+  const [highlight, setHighlight] = useState(0)
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setResults([])
+    activeRef.current = null
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+  }, [])
+
+  const evaluate = useCallback(
+    (nextValue: string, caret: number) => {
+      const active = getActiveMention(nextValue, caret)
+      activeRef.current = active
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      // Bare '@' (no chars yet) shows nothing; fire at >=1 char.
+      if (!active || active.query.length < 1) {
+        setOpen(false)
+        setResults([])
+        return
+      }
+      debounceRef.current = setTimeout(() => {
+        listCharacters({ search: active.query, limit: RESULT_LIMIT })
+          .then((chars) => {
+            const filtered = chars.filter((c) => c.id !== selfId)
+            setResults(filtered)
+            setHighlight(0)
+            setOpen(filtered.length > 0)
+          })
+          .catch(() => {
+            setOpen(false)
+            setResults([])
+          })
+      }, DEBOUNCE_MS)
+    },
+    [selfId],
+  )
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const nextValue = event.target.value
+      const caret = event.target.selectionStart ?? nextValue.length
+      onChange(nextValue)
+      evaluate(nextValue, caret)
+    },
+    [onChange, evaluate],
+  )
+
+  const pick = useCallback(
+    (username: string) => {
+      const active = activeRef.current
+      if (!active) return
+      const { next, caret } = insertMention(value, active, username)
+      onChange(next)
+      close()
+      // Restore focus + caret after the controlled re-render.
+      requestAnimationFrame(() => {
+        const el = textareaRef.current
+        if (el) {
+          el.focus()
+          el.setSelectionRange(caret, caret)
+        }
+      })
+    },
+    [value, onChange, close],
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!open || results.length === 0) return
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault()
+          setHighlight((h) => (h + 1) % results.length)
+          break
+        case 'ArrowUp':
+          event.preventDefault()
+          setHighlight((h) => (h - 1 + results.length) % results.length)
+          break
+        case 'Enter':
+        case 'Tab':
+          event.preventDefault()
+          pick(results[highlight].username)
+          break
+        case 'Escape':
+          event.preventDefault()
+          close()
+          break
+      }
+    },
+    [open, results, highlight, pick, close],
+  )
+
+  const activeOptionId =
+    open && results[highlight] ? `mention-option-${results[highlight].id}` : undefined
+
+  return {
+    textareaRef,
+    open,
+    results,
+    highlight,
+    activeOptionId,
+    handleChange,
+    handleKeyDown,
+    pick,
+    close,
+  }
+}
+
+/** Neutral-chrome dropdown rendered below the textarea (full-width). */
+export function MentionDropdown({
+  results,
+  highlight,
+  onPick,
+}: {
+  results: CharacterOut[]
+  highlight: number
+  onPick: (username: string) => void
+}) {
+  return (
+    <ul
+      id="mention-listbox"
+      role="listbox"
+      style={{
+        position: 'absolute',
+        top: '100%',
+        left: 0,
+        right: 0,
+        margin: '4px 0 0',
+        padding: 4,
+        listStyle: 'none',
+        background: 'var(--color-surface-scrim)',
+        border: '1px solid var(--color-border-strong)',
+        borderRadius: 6,
+        boxShadow: '0 6px 20px rgba(0, 0, 0, 0.15)',
+        maxHeight: 240,
+        overflowY: 'auto',
+        zIndex: 30,
+      }}
+    >
+      {results.map((character, index) => (
+        <li
+          key={character.id}
+          id={`mention-option-${character.id}`}
+          role="option"
+          aria-selected={index === highlight}
+          // preventDefault on mousedown keeps textarea focus so the click still inserts.
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onPick(character.username)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '6px 8px',
+            borderRadius: 4,
+            cursor: 'pointer',
+            background: index === highlight ? 'var(--color-border)' : 'transparent',
+          }}
+        >
+          <FactionAvatar character={character} size="sm" />
+          <span style={{ fontWeight: 600, color: 'var(--color-text-primary)' }}>
+            {character.display_name}
+          </span>
+          <span style={{ color: 'var(--color-text-secondary)', fontSize: 12 }}>
+            @{character.username}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}


### PR DESCRIPTION
## What
The type-ahead UX deferred from the comment build (#167). Typing `@mo` in any comment composer shows a debounced dropdown of matching active characters. Plain-text mentions + on-submit resolution + linkify are unchanged (ADR-0006).

## Backend (2 lines + test)
Widen `list_characters_for_viewer` search from username-only to `or_(username ILIKE, display_name ILIKE)`, so `@Mol` surfaces **Molly** (`@mollusk`). The inserted handle is still `@username`; display_name only *matches*. No new endpoint. Test: `GET /characters?search="Other Character"` matches via display_name.

## Frontend
Added **once** inside `ComposerControls` (`shared.tsx`) — every faction voice inherits it, no voice component touched:
- `useMentionAutocomplete` hook + neutral `MentionDropdown` (new `useMentionAutocomplete.tsx`). Reuses `listCharacters({ search, limit: 8 })` + `FactionAvatar`.
- Dropdown renders **below the textarea** (full-width, `position: relative` wrapper), **neutral chrome** (`--color-surface-scrim`/`-border-strong`/`-text-*`) — not per-faction.
- **Trigger:** `@token` at input start or after whitespace (so `email@x` never fires); charset `[A-Za-z0-9_]` matching backend `MENTION_RE`. Fires at ≥1 char, debounced 200ms, self excluded.
- **Keyboard:** Up/Down highlight; Enter/Tab insert (`preventDefault`); Esc closes. Enter is otherwise a plain newline (composer submits via button), so no conflict.
- **Insert:** replaces the active `@partial` with `@username `; caret lands after it.
- **a11y:** `role="listbox"`/`role="option"`, `aria-activedescendant`, `aria-expanded`/`aria-controls`.

## Verify
- Backend: `py_compile` + `pytest --collect-only` clean; new display_name test added.
- `npx tsc --noEmit` clean; `vitest run` — 118 passed (9 new for the pure token/caret logic); `npm run build` green.

## Out of scope (per issue)
Caret-anchored positioning, per-faction dropdown theming, any change to mention resolution/linkify/notify.

Closes #229.