### PR TITLE
fix: in_progress praxis is private (member-only) on unsubmit (closes #303)

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from db import get_db
-from dependencies import get_current_character
+from dependencies import get_current_character, get_current_character_optional
 from models.account import Account
 from models.character import Character, CharacterStatus
 from models.relationship import Relationship
@@ -29,7 +29,7 @@ from services.character import (
 )
 from services.era import load_current_era_stats
 from services.media import process_and_save_avatar
-from services.praxis import build_praxis_out
+from services.praxis import build_praxis_out, praxis_visibility_condition
 
 router = APIRouter()
 
@@ -109,11 +109,17 @@ async def get_character_praxes(
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_db),
+    viewer: Optional[Character] = Depends(get_current_character_optional),
 ):
+    # ADR-0024: an in_progress praxis is member-only, so a profile grid shows
+    # another character's drafts only when the viewer is a member.
     result = await session.execute(
         select(Praxis)
         .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
-        .where(Praxis.created_by_id == character_id)
+        .where(
+            Praxis.created_by_id == character_id,
+            praxis_visibility_condition(viewer.id if viewer else None),
+        )
         .order_by(Praxis.created_at.desc())
         .limit(limit)
         .offset(offset)

--- a/backend/routers/comments.py
+++ b/backend/routers/comments.py
@@ -4,11 +4,13 @@ Paths are nested under the target (praxis/task) for create+list and flat under
 /comments for author/flag operations, so the router is registered with no prefix
 (prefixes are embedded in the routes, like the votes router).
 """
-from fastapi import APIRouter, Depends
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import get_current_character
+from dependencies import get_current_character, get_current_character_optional
 from models.character import Character
 from schemas.comment import CommentIn, CommentOut, FlagIn
 from services.comment import (
@@ -19,14 +21,22 @@ from services.comment import (
     list_comments,
     withdraw_comment,
 )
+from services.praxis import can_view_praxis, get_praxis
 
 router = APIRouter()
 
 
 @router.get("/praxes/{praxis_id}/comments", response_model=list[CommentOut])
 async def list_praxis_comments(
-    praxis_id: int, session: AsyncSession = Depends(get_db)
+    praxis_id: int,
+    session: AsyncSession = Depends(get_db),
+    viewer: Optional[Character] = Depends(get_current_character_optional),
 ):
+    # A draft's discussion is member-only too (ADR-0024): mirror the detail 404
+    # so the comments on an in_progress praxis don't leak to non-members.
+    praxis = await get_praxis(praxis_id, session)
+    if not can_view_praxis(viewer, praxis):
+        raise HTTPException(status_code=404, detail="Praxis not found.")
     comments = await list_comments(praxis_id=praxis_id, session=session)
     return [build_comment_out(c) for c in comments]
 

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -44,6 +44,7 @@ from services.praxis import (
     apply_metatask,
     build_praxis_card_out,
     build_praxis_out,
+    can_view_praxis,
     cancel_pending_publish_on_edit,
     create_praxis,
     delete_praxis,
@@ -83,6 +84,7 @@ async def list_praxes_route(
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_db),
+    viewer: Optional[Character] = Depends(get_current_character_optional),
 ):
     praxis_type: Optional[PraxisType] = None
     if type is not None:
@@ -107,6 +109,7 @@ async def list_praxes_route(
         status=praxis_status,
         moderation_status=moderation_status,
         faction=faction,
+        viewer_id=viewer.id if viewer else None,
         limit=limit,
         offset=offset,
     )
@@ -122,7 +125,9 @@ async def get_praxis_route(
     # Route through the service loader so the lazy-on-access publish timeout
     # (ADR-0012) fires on this read path.
     praxis = await get_praxis(praxis_id, session)
-    if praxis.moderation_status == ModerationStatus.hidden:
+    # 404 (not 403) when not viewable — don't reveal existence of hidden or
+    # of another character's in_progress draft (ADR-0024).
+    if not can_view_praxis(viewer, praxis):
         raise HTTPException(status_code=404, detail="Praxis not found.")
     return await build_praxis_out(praxis, session, viewer=viewer)
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -334,6 +334,22 @@ async def get_praxis(
     return praxis
 
 
+def praxis_visibility_condition(viewer_id: Optional[int]):
+    """SQL predicate for who may see a praxis (ADR-0024).
+
+    ``submitted`` praxes are public; an ``in_progress`` praxis is visible only to
+    its members (character-scoped, matching ``_require_member``). Push this into
+    the query so pagination stays honest instead of post-filtering a page.
+    """
+    visible = Praxis.status == PraxisStatus.submitted
+    if viewer_id is not None:
+        member_praxis_ids = select(PraxisMember.praxis_id).where(
+            PraxisMember.character_id == viewer_id
+        )
+        visible = or_(visible, Praxis.id.in_(member_praxis_ids))
+    return visible
+
+
 async def list_praxes(
     session: AsyncSession,
     *,
@@ -343,12 +359,17 @@ async def list_praxes(
     status: Optional[PraxisStatus] = None,
     moderation_status: Optional[str] = None,
     faction: Optional[str] = None,
+    viewer_id: Optional[int] = None,
     limit: int = 50,
     offset: int = 0,
     era: EraConfig = CURRENT_ERA,
 ) -> list[Praxis]:
-    """List praxes with optional filters."""
-    query = select(Praxis)
+    """List praxes with optional filters.
+
+    ``in_progress`` praxes are member-only (ADR-0024): pass ``viewer_id`` to
+    include the viewer's own drafts; everyone else sees only ``submitted``.
+    """
+    query = select(Praxis).where(praxis_visibility_condition(viewer_id))
 
     if faction is not None:
         # Praxis has no faction of its own; it inherits the linked task's faction.
@@ -540,13 +561,32 @@ async def withdraw_praxis(
     if praxis.status == PraxisStatus.in_progress:
         raise HTTPException(status_code=422, detail="Praxis is already in editing mode.")
 
+    # ADR-0024: a *settled* duel side can't simply unsubmit — that would erase a
+    # decided contest. Temporary guard; #307 replaces it with real forfeit
+    # semantics (opponent wins by default, duel stays settled).
+    from services.duel import get_duel_for_praxis
+
+    duel = await get_duel_for_praxis(praxis_id, session)
+    if duel is not None and duel.status == DuelStatus.settled:
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot unsubmit a settled duel side.",
+        )
+
     praxis.status = PraxisStatus.in_progress
     praxis.submit_proposed_at = None
     for member in praxis.members:
         member.has_submitted = False
     await session.flush()
 
-    await recalculate_character_stats(character_id, session, era)
+    # Recalc *every* member: on a collab, co-authors' scores also counted this
+    # praxis while it was submitted, so all of them must drop (the submit paths
+    # already recalc all members — this fixes the prior single-actor under-recalc).
+    era_row = await get_current_era_row(session)
+    for member in praxis.members:
+        await recalculate_character_stats(
+            member.character_id, session, era, era_row=era_row
+        )
     await session.flush()
     return await get_praxis(praxis_id, session)
 
@@ -567,6 +607,25 @@ async def delete_praxis(
         )
     await session.delete(praxis)
     await session.flush()
+
+
+def can_view_praxis(viewer: Optional[Character], praxis: Praxis) -> bool:
+    """Whether ``viewer`` may see ``praxis`` (ADR-0024).
+
+    - ``hidden`` (moderation) → never (mirror the existing hidden branch: 404).
+    - ``submitted`` → public.
+    - ``in_progress`` → members only (character-scoped, matching ``_require_member``;
+      the account-vs-character question in #293 is deliberately not entangled here).
+
+    Reads only always-loaded columns/relationships (``members``), so it stays sync.
+    """
+    if praxis.moderation_status == ModerationStatus.hidden:
+        return False
+    if praxis.status == PraxisStatus.submitted:
+        return True
+    if viewer is None:
+        return False
+    return viewer.id in {member.character_id for member in praxis.members}
 
 
 async def can_flag_praxis(
@@ -1183,6 +1242,7 @@ __all__ = [
     "cancel_pending_publish_on_edit",
     "can_flag_praxis",
     "can_submit_praxis_for_task",
+    "can_view_praxis",
     "create_praxis",
     "delete_praxis",
     "flag_praxis",
@@ -1193,6 +1253,7 @@ __all__ = [
     "kick_member",
     "leave_praxis",
     "list_praxes",
+    "praxis_visibility_condition",
     "moderate_praxis",
     "remove_metatask",
     "respond_to_invite",

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -36,7 +36,7 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction
-from models.praxis import Praxis, PraxisMember, PraxisType
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
 from models.task import Task
 from models.vote import Vote
 from services.auth import create_jwt
@@ -347,15 +347,23 @@ async def signed_up_task2(
 async def praxis_solo(
     db_session: AsyncSession, active_task: Task, character: Character
 ) -> Praxis:
-    """Minimal solo Praxis authored by ``character`` on ``active_task``."""
+    """Minimal *submitted* solo Praxis authored by ``character`` on ``active_task``.
+
+    Submitted (with the creator's PraxisMember row) so it is publicly visible —
+    in_progress praxes are member-only (ADR-0024), and a realistic solo praxis
+    always has its creator as a member.
+    """
     praxis = Praxis(
         task_id=active_task.id,
         created_by_id=character.id,
         type=PraxisType.solo,
+        status=PraxisStatus.submitted,
         title="Solo Praxis",
         body_text="proof",
     )
     db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=praxis.id, character_id=character.id))
     await db_session.commit()
     await db_session.refresh(praxis)
     return praxis

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -220,11 +220,15 @@ async def test_get_character_praxes_returns_list(
     active_task: Task,
 ):
     """GET /characters/{id}/praxes returns seeded praxis entries."""
-    from models.praxis import PraxisType
+    from models.praxis import PraxisStatus, PraxisType
     praxis = Praxis(
         task_id=active_task.id,
         created_by_id=character.id,
         type=PraxisType.solo,
+        # submitted so it's publicly visible on the profile grid (ADR-0024):
+        # in_progress praxes are member-only, and this ORM-seeded row has no
+        # PraxisMember, so it would be filtered out otherwise.
+        status=PraxisStatus.submitted,
         title="My Praxis",
         body_text="Proof here",
     )
@@ -246,12 +250,14 @@ async def test_get_character_praxes_pagination(
     active_task: Task,
 ):
     """GET /characters/{id}/praxes respects limit and offset."""
-    from models.praxis import PraxisType
+    from models.praxis import PraxisStatus, PraxisType
     for index in range(3):
         praxis = Praxis(
             task_id=active_task.id,
             created_by_id=character.id,
             type=PraxisType.solo,
+            # submitted so it's publicly visible (ADR-0024); see returns_list test.
+            status=PraxisStatus.submitted,
             title=f"Praxis {index}",
             body_text="proof",
         )

--- a/backend/tests/integration/test_multi_character.py
+++ b/backend/tests/integration/test_multi_character.py
@@ -361,6 +361,9 @@ async def test_second_life_governs_viewer_flags_on_read(
     assert create.status_code == 201, create.text
     praxis_id = create.json()["id"]
     assert create.json()["created_by_id"] == character.id
+    # Submit so the (non-member) second life can view it — in_progress praxes are
+    # member-only (ADR-0024); the viewer-flag flip is what's under test here.
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
 
     # Viewed as the author (first life): cannot flag your own praxis.
     as_author = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -85,7 +85,8 @@ async def test_get_praxis(
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
 
-    resp = await client.get(f"/praxes/{praxis_id}")
+    # in_progress praxes are member-only (ADR-0024); read as the author-member.
+    resp = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
     assert resp.status_code == 200
     data = resp.json()
     assert data["id"] == praxis_id
@@ -115,7 +116,10 @@ async def test_list_praxes_filter_by_task_id(
     )
     assert create_resp.status_code == 201
 
-    resp = await client.get("/praxes", params={"task_id": active_task.id})
+    # Read as the author-member so the in_progress praxis is visible (ADR-0024).
+    resp = await client.get(
+        "/praxes", params={"task_id": active_task.id}, headers=auth_headers
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert isinstance(data, list)
@@ -186,15 +190,16 @@ async def test_list_praxes_filter_by_faction(
     assert wow_resp.status_code == 201
     wow_praxis_id = wow_resp.json()["id"]
 
-    # Filter to UA — only the UA praxis comes back.
-    ua_list = await client.get("/praxes", params={"faction": "ua"})
+    # Filter to UA — only the UA praxis comes back. Read as the author-member so
+    # the in_progress praxes are visible (ADR-0024).
+    ua_list = await client.get("/praxes", params={"faction": "ua"}, headers=auth_headers)
     assert ua_list.status_code == 200
     ua_ids = {item["id"] for item in ua_list.json()}
     assert ua_praxis_id in ua_ids
     assert wow_praxis_id not in ua_ids
 
     # Filter to Wow — only the Wow praxis comes back.
-    wow_list = await client.get("/praxes", params={"faction": "wow"})
+    wow_list = await client.get("/praxes", params={"faction": "wow"}, headers=auth_headers)
     assert wow_list.status_code == 200
     wow_ids = {item["id"] for item in wow_list.json()}
     assert wow_praxis_id in wow_ids
@@ -1100,6 +1105,8 @@ async def test_get_praxis_can_flag_true_for_level_4_non_author(
     )
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
+    # Submit so the non-author can view it (in_progress is member-only, ADR-0024).
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
 
     # Force character2's level to exactly era.flag_level_required (4)
     result = await db_session.execute(
@@ -1136,6 +1143,8 @@ async def test_get_praxis_can_flag_false_for_level_3_non_author(
     )
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
+    # Submit so the non-author can view it (in_progress is member-only, ADR-0024).
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
 
     # Force character2's level to 3 (one below era.flag_level_required)
     result = await db_session.execute(
@@ -1203,6 +1212,8 @@ async def test_get_praxis_can_flag_false_for_anonymous(
     )
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
+    # Submit so anonymous can view it (in_progress is member-only, ADR-0024).
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
 
     # Hit the detail endpoint without auth headers
     resp = await client.get(f"/praxes/{praxis_id}")
@@ -1501,7 +1512,8 @@ async def test_praxis_card_includes_new_fields(
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
 
-    list_resp = await client.get("/praxes")
+    # Read as the author-member so the in_progress card is visible (ADR-0024).
+    list_resp = await client.get("/praxes", headers=auth_headers)
     assert list_resp.status_code == 200
     cards = list_resp.json()
     card = next((c for c in cards if c["id"] == praxis_id), None)
@@ -1531,7 +1543,8 @@ async def test_submitted_at_set_on_submit(
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
 
-    pre_list = await client.get("/praxes")
+    # Read as the author-member so the in_progress card is visible (ADR-0024).
+    pre_list = await client.get("/praxes", headers=auth_headers)
     pre_card = next(c for c in pre_list.json() if c["id"] == praxis_id)
     assert pre_card["submitted_at"] is None
 
@@ -1562,6 +1575,8 @@ async def test_voter_count_and_score_after_vote(
     )
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
+    # Submit so the praxis is publicly listable (in_progress is member-only, ADR-0024).
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
 
     # character votes 4
     vote_resp = await client.post(

--- a/backend/tests/integration/test_praxis_visibility.py
+++ b/backend/tests/integration/test_praxis_visibility.py
@@ -1,0 +1,238 @@
+"""Integration tests for ADR-0024 — an in_progress praxis is private (member-only).
+
+Covers the four read surfaces routed through ``can_view_praxis`` (detail, list,
+profile, comments), the all-members recalc on collab withdraw, vote preservation
+across unsubmit→resubmit, and the temporary settled-duel-side withdraw guard.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.duel import Duel, DuelStatus
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task
+from services.character_stats import recalculate_character_stats
+
+
+async def _create_solo(client: AsyncClient, task: Task, headers: dict) -> int:
+    """Create an in_progress solo praxis (with the creator's member row) via the API."""
+    resp = await client.post(
+        "/praxes",
+        json={"task_id": task.id, "type": "solo", "title": "Draft"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_in_progress_detail_member_200_nonmember_and_anon_404(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """GET /praxes/{id} of an in_progress praxis: 200 for the member, 404 otherwise."""
+    praxis_id = await _create_solo(client, active_task, auth_headers)
+
+    member = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert member.status_code == 200
+
+    non_member = await client.get(f"/praxes/{praxis_id}", headers=auth_headers2)
+    assert non_member.status_code == 404  # 404, not 403 — don't reveal existence
+
+    anon = await client.get(f"/praxes/{praxis_id}")
+    assert anon.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_hides_others_in_progress_shows_own(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """GET /praxes omits another character's in_progress praxis but includes the viewer's own."""
+    praxis_id = await _create_solo(client, active_task, auth_headers)
+
+    others_view = await client.get("/praxes", headers=auth_headers2)
+    assert praxis_id not in {p["id"] for p in others_view.json()}
+
+    anon_view = await client.get("/praxes")
+    assert praxis_id not in {p["id"] for p in anon_view.json()}
+
+    own_view = await client.get("/praxes", headers=auth_headers)
+    assert praxis_id in {p["id"] for p in own_view.json()}
+
+
+# ---------------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_praxes_hide_others_in_progress_show_own(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """GET /characters/{id}/praxes omits the character's in_progress drafts for non-members."""
+    praxis_id = await _create_solo(client, active_task, auth_headers)
+    path = f"/characters/{character.id}/praxes"
+
+    others_view = await client.get(path, headers=auth_headers2)
+    assert praxis_id not in {p["id"] for p in others_view.json()}
+
+    own_view = await client.get(path, headers=auth_headers)
+    assert praxis_id in {p["id"] for p in own_view.json()}
+
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_comments_on_draft_404_for_nonmember_200_for_member(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """GET /praxes/{id}/comments of a draft is member-only (mirror the detail 404)."""
+    praxis_id = await _create_solo(client, active_task, auth_headers)
+
+    non_member = await client.get(f"/praxes/{praxis_id}/comments", headers=auth_headers2)
+    assert non_member.status_code == 404
+
+    member = await client.get(f"/praxes/{praxis_id}/comments", headers=auth_headers)
+    assert member.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Withdraw semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resubmit_preserves_vote_tally(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Votes survive unsubmit→resubmit (ADR-0007): the tally returns unchanged."""
+    praxis_id = await _create_solo(client, active_task, auth_headers)
+    assert (await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)).status_code == 200
+
+    vote = await client.post(
+        f"/praxes/{praxis_id}/vote", json={"value": 4}, headers=auth_headers2
+    )
+    assert vote.status_code == 200
+    before = await client.get(f"/praxes/{praxis_id}/votes")
+    assert before.json()["total_votes"] == 1
+
+    assert (await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)).status_code == 200
+    assert (await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)).status_code == 200
+
+    after = await client.get(f"/praxes/{praxis_id}/votes")
+    assert after.json()["total_votes"] == 1
+
+
+@pytest.mark.asyncio
+async def test_withdraw_collab_recalculates_every_member(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """Withdrawing a collab recalcs *every* member's score, not just the actor's.
+
+    Regression for the prior single-actor under-recalc: a co-author who did not
+    trigger the withdraw kept a stale, inflated score.
+    """
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.collab,
+        status=PraxisStatus.submitted,
+        title="Team effort",
+        body_text="proof",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            PraxisMember(praxis_id=praxis.id, character_id=character.id, has_submitted=True),
+            PraxisMember(praxis_id=praxis.id, character_id=character2.id, has_submitted=True),
+        ]
+    )
+    await db_session.commit()
+    # Establish scores that reflect the submitted collab for both members.
+    await recalculate_character_stats(character.id, db_session)
+    await recalculate_character_stats(character2.id, db_session)
+    await db_session.commit()
+
+    coauthor_before = (await client.get(f"/characters/{character2.id}")).json()["score"]
+    assert coauthor_before > 0
+
+    # character (a member, but NOT the co-author) reopens the collab.
+    withdraw = await client.post(f"/praxes/{praxis.id}/withdraw", headers=auth_headers)
+    assert withdraw.status_code == 200
+
+    coauthor_after = (await client.get(f"/characters/{character2.id}")).json()["score"]
+    assert coauthor_after < coauthor_before, (
+        "Co-author's score was not recalculated on withdraw — the single-actor "
+        "under-recalc bug is back."
+    )
+
+
+@pytest.mark.asyncio
+async def test_withdraw_settled_duel_side_returns_422(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """Unsubmitting a *settled* duel side is blocked with 422 (temporary; #307 replaces it)."""
+    praxis_id = await _create_solo(client, active_task, auth_headers)
+    assert (await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)).status_code == 200
+
+    db_session.add(
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=praxis_id,
+            opponent_character_id=character2.id,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    assert resp.status_code == 422

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -696,6 +696,7 @@ async def test_my_tasks_with_status_filter(
     resp_submitted = await client.get(
         "/praxes",
         params={"character_id": character2.id, "status": "submitted"},
+        headers=auth_headers2,
     )
     assert resp_submitted.status_code == 200
     submitted_ids = [p["id"] for p in resp_submitted.json()]
@@ -703,10 +704,12 @@ async def test_my_tasks_with_status_filter(
     assert praxis_ids[1] not in submitted_ids
     assert praxis_ids[2] not in submitted_ids
 
-    # status=in_progress returns the remaining two
+    # status=in_progress returns the remaining two. Read as character2 — the owner
+    # (a member) — since in_progress praxes are member-only (ADR-0024).
     resp_ip = await client.get(
         "/praxes",
         params={"character_id": character2.id, "status": "in_progress"},
+        headers=auth_headers2,
     )
     assert resp_ip.status_code == 200
     ip_ids = [p["id"] for p in resp_ip.json()]
@@ -714,10 +717,11 @@ async def test_my_tasks_with_status_filter(
     assert praxis_ids[1] in ip_ids
     assert praxis_ids[2] in ip_ids
 
-    # No status filter returns all three
+    # No status filter returns all three (read as the owner so in_progress shows).
     resp_all = await client.get(
         "/praxes",
         params={"character_id": character2.id},
+        headers=auth_headers2,
     )
     assert resp_all.status_code == 200
     all_ids = [p["id"] for p in resp_all.json()]

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -8,7 +8,7 @@
  * not-found guards live here so archetypes can assume a non-null praxis.
  */
 import type { ComponentType } from 'react'
-import { useParams } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 import { usePraxisDetail } from './praxisDetail/usePraxisDetail'
 import type { PraxisDetailState } from './praxisDetail/usePraxisDetail'
 import { pickVariant } from '../utils/factionDispatch'
@@ -52,6 +52,13 @@ export default function PraxisDetail() {
     </div>
   )
   if (!state.praxis) return <div className="py-8 font-body text-muted">Not found.</div>
+
+  // ADR-0024: the public detail view never renders a draft. Only members reach
+  // here (the API 404s everyone else) — route them to the editor, the sole
+  // surface for in_progress work.
+  if (state.praxis.status === 'in_progress') {
+    return <Navigate to={`/praxes/${state.praxis.id}/edit`} replace />
+  }
 
   const Archetype = pickVariant(ARCHETYPE_BY_SLUG, state.praxis.task_faction_slug, DefaultPraxisDetail)
   return (


### PR DESCRIPTION
Implements **ADR-0024**. Points already dropped on unsubmit (`recalculate_character_stats` counts only submitted praxes); the gap was **unenforced visibility**.

## The seam
`can_view_praxis(viewer, praxis)` + `praxis_visibility_condition(viewer_id)` in `services/praxis.py`: `hidden`→never, `submitted`→public, `in_progress`→members only (character-scoped, matching `_require_member`; deliberately not entangled with #293's account question).

## Four read surfaces routed through it
1. **Detail** `GET /praxes/{id}` → **404** (not 403) when not viewable — mirrors the `hidden` branch, doesn't reveal existence.
2. **List** `GET /praxes` → `WHERE submitted OR viewer-is-member` pushed into the query (viewer via optional dep) so pagination stays honest.
3. **Profile** `GET /characters/{id}/praxes` → same member-or-exclude filter (was the most visible leak).
4. **Comments** `GET /praxes/{id}/comments` → member-or-404, like detail.

## `withdraw_praxis` fixes
- **All-members recalc:** recalc *every* member, not just the actor — a collab co-author kept a stale inflated score (now mirrors the submit paths).
- **Settled-duel guard:** a settled duel side → **422** (temporary; **#307** replaces it with real forfeit). Stays duel-agnostic beyond this guard.

## Frontend
`PraxisDetail` redirects an `in_progress` praxis to `/praxes/:id/edit` (`<Navigate replace>`) — the public view never renders a draft; non-members already 404 at the API.

## Verify (local Postgres)
- **327 backend integration tests pass** (7 new in `test_praxis_visibility.py`: detail/list/profile/comments visibility, all-members collab recalc, vote preservation across resubmit, settled-duel 422).
- Existing tests that read a draft as non-member/anon updated to submit-first or read-as-member; the `praxis_solo` fixture is now a realistic submitted solo praxis with a creator member row.
- `tsc --noEmit` clean, `vitest` 118 passed, `npm run build` green.

Lands before #307 (which turns the 422 guard into forfeit). Closes #303.