### PR TITLE
fix: block voting on either side of a duel you're in (closes #309)

### DIFF
--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -52,6 +52,31 @@ async def cast_or_update_vote(
     if author is not None and author.account_id == voter.account_id:
         raise HTTPException(status_code=403, detail="Cannot vote on your own praxis.")
 
+    # Duel anti-participation (#309): a duel participant — any life on their
+    # account — cannot rate EITHER side of a duel they're in, not just their own.
+    # Account-level anti-self-vote above only blocks the participant's own side.
+    from services.duel import get_duel_for_praxis
+
+    duel = await get_duel_for_praxis(praxis.id, session)
+    if duel is not None:
+        challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+        challenger = (
+            await session.get(Character, challenger_praxis.created_by_id)
+            if challenger_praxis is not None
+            else None
+        )
+        opponent = await session.get(Character, duel.opponent_character_id)
+        participant_account_ids = {
+            participant.account_id
+            for participant in (challenger, opponent)
+            if participant is not None
+        }
+        if voter.account_id in participant_account_ids:
+            raise HTTPException(
+                status_code=403,
+                detail="Cannot vote on a duel you're a participant in.",
+            )
+
     result = await session.execute(
         select(Vote).where(
             Vote.praxis_id == praxis.id,

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -541,3 +541,112 @@ async def test_anti_self_vote_fallback_allows_unrelated_voter(
     assert vote.value == 3
     assert vote.voter_character_id == character2.id
     assert vote.praxis_id == praxis_solo.id
+
+
+# ---------------------------------------------------------------------------
+# Duel anti-participation (#309) — a participant cannot rate either side.
+# ---------------------------------------------------------------------------
+
+
+async def _create_and_submit_solo(
+    client: AsyncClient, task: Task, headers: dict
+) -> int:
+    create = await client.post(
+        "/praxes",
+        json={"task_id": task.id, "type": "solo", "title": "Duel side"},
+        headers=headers,
+    )
+    assert create.status_code == 201, create.text
+    praxis_id = create.json()["id"]
+    submit = await client.post(f"/praxes/{praxis_id}/submit", headers=headers)
+    assert submit.status_code == 200, submit.text
+    return praxis_id
+
+
+@pytest.mark.asyncio
+async def test_duel_participant_cannot_vote_on_either_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A duel participant (any life on their account) cannot rate either side (403)."""
+    from models.duel import Duel, DuelStatus
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
+    db_session.add(
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=challenger_pid,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=opponent_pid,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.commit()
+
+    # Challenger's account voting on the OPPONENT's side — the gap this fixes.
+    on_opponent = await client.post(
+        f"/praxes/{opponent_pid}/vote", json={"value": 1}, headers=auth_headers
+    )
+    assert on_opponent.status_code == 403
+
+    # Opponent's account voting on the CHALLENGER's side — symmetric.
+    on_challenger = await client.post(
+        f"/praxes/{challenger_pid}/vote", json={"value": 1}, headers=auth_headers2
+    )
+    assert on_challenger.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_participant_can_vote_on_duel_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua,
+    auth_headers: dict,
+):
+    """A third party who isn't in the duel can still rate a duel side (200)."""
+    from models.duel import Duel, DuelStatus
+    from services.auth import create_jwt
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    db_session.add(
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=challenger_pid,
+            opponent_character_id=character2.id,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.commit()
+
+    # A fresh third account/character — not a participant in the duel.
+    third = Account(email="third@example.com")
+    db_session.add(third)
+    await db_session.flush()
+    third_char = Character(
+        account_id=third.id,
+        username="thirdchar",
+        display_name="Third Char",
+        faction_slug="ua",
+    )
+    db_session.add(third_char)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(character_id=third_char.id, era_id=era.id, votes_spent_this_era=0)
+    )
+    await db_session.commit()
+    third_headers = {"Authorization": f"Bearer {create_jwt(third.id)}"}
+
+    resp = await client.post(
+        f"/praxes/{challenger_pid}/vote", json={"value": 4}, headers=third_headers
+    )
+    assert resp.status_code == 200

--- a/docs/spec/SPEC-game-rules.md
+++ b/docs/spec/SPEC-game-rules.md
@@ -206,7 +206,7 @@ Each member's score is computed independently using their own faction's collab m
 - Max participants: `era.max_duel_participants` (Era 1: 2).
 - Creator invites one opponent. Opponent accepts or declines.
 - Votes are **per-member** (`praxis_member_id` required). Voters may vote for one or both members — each is a separate `Vote` row.
-- Duel participants cannot vote on their own duel at the **account level** (a voter cannot use any of their characters to rate either side of a duel they participate in). Account-level anti-self-vote is enforced per-praxis in `services/vote.py` (a voter cannot rate a side authored by any character on their account). _Note: this blocks the participant's own side; blocking a participant from rating the **opponent's** side is not yet enforced — tracked separately._
+- Duel participants cannot vote on **either side** of a duel they're in, at the **account level** — a voter cannot use any of their characters to rate the challenger's *or* the opponent's side. Enforced per-praxis in `services/vote.py`: the account-level anti-self-vote blocks the participant's own side, and when the target praxis is a duel side, the vote is additionally rejected (403) if the voter's account owns either side of that duel (#309).
 - Winner is determined by the highest `total_stars` across each member's votes.
 
 ### Duel outcome multipliers (Era 1)
@@ -362,7 +362,7 @@ Items flagged ⚠️ above, consolidated for engineering:
 1. ~~Enforce task signup level gate (`character.level ≥ task.level_required` on praxis creation).~~ — ✅ **done** (`services/praxis.py::_check_create_preconditions`).
 2. Remove `task_submit_level_gap` from `EraConfig` and any references.
 3. ~~Add `max_collab_participants` to `EraConfig`~~ — **removed**. Era 1 collaborations are unlimited. Do not add this field.
-4. ~~Switch duel anti-self-vote from character-level to account-level (same behavior as solo/collab).~~ — ✅ **done** (account-level anti-self-vote per-praxis in `services/vote.py`; see the duel note in §Duels for the residual opponent-side scope).
+4. ~~Switch duel anti-self-vote from character-level to account-level (same behavior as solo/collab).~~ — ✅ **done** (account-level anti-self-vote per-praxis in `services/vote.py`; opponent-side blocking landed in #309 — a participant cannot rate either side of their duel).
 5. ~~Vote budget on-read recomputation: compute `votes_available = vote_budget_base + floor(multiplier × score) − votes_spent_this_era` fresh on every read. Replace stored running counter with stored `votes_spent_this_era` only.~~ — ✅ **done** (`services/scoring.py::compute_votes_available`; stored column is `votes_spent_this_era`).
 6. ~~Snide tie rule: opponent gets **own** faction's `duel_loss_modifier`, not Snide's. Update `compute_duel_multiplier`.~~ — ✅ **done** (`services/scoring.py::compute_duel_multiplier`).
 7. Second character level gate: raise from 3 → **4**. Gate the Albescent faction choice for new characters behind "account has at least one character at level 8 who has completed at least one task from each faction."


### PR DESCRIPTION
## What
Account-level anti-self-vote only blocked a participant's **own** side — a duel participant could still rate their **opponent's** side (dump 1-star votes to tank them once dueling goes live).

## Fix
`services/vote.py` `cast_or_update_vote`: when the target praxis is a side of a `Duel` (`get_duel_for_praxis`), reject with **403** if the voter's **account** owns either side (challenger or opponent), not just the side being rated. Non-participants are unaffected. Spec §Duel caveat removed.

## Verify (local Postgres)
- New tests: a participant → **403** on both the opponent's and their own side; a fresh third-party non-participant → **200** on a duel side.
- Full integration suite: **329 passed**.

Closes #309.