### PR TITLE
fix: account-scope flag guards — anti-self-flag + anti-gang (closes #328)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -628,6 +628,33 @@ def can_view_praxis(viewer: Optional[Character], praxis: Praxis) -> bool:
     return viewer.id in {member.character_id for member in praxis.members}
 
 
+async def _praxis_author_account_id(
+    praxis: Praxis, session: AsyncSession
+) -> Optional[int]:
+    """The account that owns ``praxis``'s author (created_by is usually loaded)."""
+    author = praxis.created_by
+    if author is None and praxis.created_by_id is not None:
+        author = await session.get(Character, praxis.created_by_id)
+    return author.account_id if author is not None else None
+
+
+async def _account_already_flagged(
+    praxis_id: int, account_id: int, session: AsyncSession
+) -> bool:
+    """True if any character on ``account_id`` already flagged this praxis (#328 anti-gang).
+
+    Joins ``Flag.flagged_by → Character.account_id`` so no ``flagged_by_account_id``
+    column / migration is needed.
+    """
+    result = await session.execute(
+        select(Flag.id)
+        .join(Character, Character.id == Flag.flagged_by)
+        .where(Flag.praxis_id == praxis_id, Character.account_id == account_id)
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
 async def can_flag_praxis(
     viewer: Optional[Character],
     praxis: Praxis,
@@ -636,14 +663,19 @@ async def can_flag_praxis(
 ) -> bool:
     """Return True if ``viewer`` may flag ``praxis``.
 
-    Mirrors the rules enforced in :func:`flag_praxis`:
+    Mirrors the rules enforced in :func:`flag_praxis` so the ``can_flag`` UI flag
+    hides the control exactly when the action would 403/409 (#328):
     - Viewer must be authenticated (anonymous viewers cannot flag).
+    - Viewer's **account** cannot own the praxis author (account-scoped anti-self-flag).
+    - Viewer's **account** must not already have a flag on this praxis (anti-gang).
     - Viewer must be at or above ``era.flag_level_required`` in the current era.
-    - Viewer cannot flag a praxis they authored (character-level check).
     """
     if viewer is None:
         return False
-    if viewer.id == praxis.created_by_id:
+    author_account_id = await _praxis_author_account_id(praxis, session)
+    if author_account_id is not None and author_account_id == viewer.account_id:
+        return False
+    if await _account_already_flagged(praxis.id, viewer.account_id, session):
         return False
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, viewer.id, era_row.id)
@@ -792,10 +824,19 @@ async def flag_praxis(
     """Flag a praxis for moderation review. Requires ``era.flag_level_required`` or above."""
     praxis = await get_praxis(praxis_id, session)
 
-    # Self-flag is always rejected with its own error message so the caller
-    # sees a clearer reason than a generic level failure.
-    if flagged_by.id == praxis.created_by_id:
+    # Account-scoped anti-self-flag (#328): no account can flag its own work
+    # across lives — mirror the account-level anti-self-vote shape. Own message
+    # so the caller sees a clearer reason than a generic level failure.
+    author_account_id = await _praxis_author_account_id(praxis, session)
+    if author_account_id is not None and author_account_id == flagged_by.account_id:
         raise HTTPException(status_code=403, detail="Cannot flag your own praxis.")
+
+    # Account-scoped uniqueness (#328): one flag per account per praxis — a second
+    # life can't stack a second flag to gang up on a third-party praxis.
+    if await _account_already_flagged(praxis.id, flagged_by.account_id, session):
+        raise HTTPException(
+            status_code=409, detail="Your account has already flagged this praxis."
+        )
 
     if not await can_flag_praxis(flagged_by, praxis, session, era):
         raise HTTPException(

--- a/backend/tests/integration/test_flag_account_scope.py
+++ b/backend/tests/integration/test_flag_account_scope.py
@@ -1,0 +1,148 @@
+"""#328 — account-scoped flag guards (anti-self-flag + anti-gang).
+
+A second life is an independent identity except for account-scoped anti-cheat
+guards. Flagging is now account-scoped like voting: no account can flag its own
+work across lives, and no account can stack more than one flag on a praxis.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character, CharacterStatus
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction
+from models.task import Task
+from services.auth import create_jwt
+
+FLAG_LEVEL = CURRENT_ERA.flag_level_required
+
+
+async def _seed_life(
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    *,
+    username: str,
+    level: int = FLAG_LEVEL,
+) -> Character:
+    ch = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username.title(),
+        faction_slug="ua",
+        status=CharacterStatus.active,
+    )
+    db_session.add(ch)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(character_id=ch.id, era_id=era.id, level=level, votes_spent_this_era=0)
+    )
+    await db_session.commit()
+    await db_session.refresh(ch)
+    return ch
+
+
+async def _submit_solo(client: AsyncClient, task: Task, headers: dict) -> int:
+    create = await client.post(
+        "/praxes",
+        json={"task_id": task.id, "type": "solo", "title": "Work"},
+        headers=headers,
+    )
+    assert create.status_code == 201, create.text
+    praxis_id = create.json()["id"]
+    assert (await client.post(f"/praxes/{praxis_id}/submit", headers=headers)).status_code == 200
+    return praxis_id
+
+
+async def _carry(client: AsyncClient, character_id: int, headers: dict) -> None:
+    resp = await client.post(
+        "/me/active-character", json={"character_id": character_id}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def _set_level(db_session: AsyncSession, character: Character, era: Era, level: int) -> None:
+    stats = (
+        await db_session.execute(
+            select(CharacterStats).where(
+                CharacterStats.character_id == character.id,
+                CharacterStats.era_id == era.id,
+            )
+        )
+    ).scalar_one()
+    stats.level = level
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_sibling_cannot_flag_own_accounts_praxis(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """Puppet B flagging puppet A's praxis (same account) → 403."""
+    praxis_id = await _submit_solo(client, active_task, auth_headers)  # puppet A's work
+    puppet_b = await _seed_life(db_session, account, era, username="puppetb")
+
+    await _carry(client, puppet_b.id, auth_headers)
+    resp = await client.post(
+        f"/praxes/{praxis_id}/flag", params={"reason": "sockpuppet self-flag"}, headers=auth_headers
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_account_flag_uniqueness_and_non_sibling_still_allowed(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    account2: Account,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """One flag per account (anti-gang): a sibling → 409; a non-sibling → still 200."""
+    target_pid = await _submit_solo(client, active_task, auth_headers2)  # third-party praxis
+
+    # account1: puppet A (character, bumped to flag level) + puppet B.
+    await _set_level(db_session, character, era, FLAG_LEVEL)
+    puppet_b = await _seed_life(db_session, account, era, username="puppetb")
+
+    # Puppet A registers the account's one legitimate flag.
+    await _carry(client, character.id, auth_headers)
+    first = await client.post(
+        f"/praxes/{target_pid}/flag", params={"reason": "genuine concern here"}, headers=auth_headers
+    )
+    assert first.status_code == 200
+
+    # Puppet B (same account) tries to stack a second flag → 409.
+    await _carry(client, puppet_b.id, auth_headers)
+    gang = await client.post(
+        f"/praxes/{target_pid}/flag", params={"reason": "piling on here"}, headers=auth_headers
+    )
+    assert gang.status_code == 409
+
+    # A non-sibling on a different account is unaffected → 200.
+    account3 = Account(email="third-flagger@example.com")
+    db_session.add(account3)
+    await db_session.flush()
+    non_sibling = await _seed_life(db_session, account3, era, username="nonsibling")
+    ns_headers = {"Authorization": f"Bearer {create_jwt(account3.id)}"}
+    assert non_sibling.id  # seeded
+    ns_flag = await client.post(
+        f"/praxes/{target_pid}/flag", params={"reason": "independent concern"}, headers=ns_headers
+    )
+    assert ns_flag.status_code == 200

--- a/backend/tests/integration/test_multi_character.py
+++ b/backend/tests/integration/test_multi_character.py
@@ -343,33 +343,34 @@ async def test_second_life_governs_viewer_flags_on_read(
     db_session: AsyncSession,
     account: Account,
     character: Character,
+    character2: Character,
     era: Era,
     faction_ua: Faction,
     active_task: Task,
     auth_headers: dict,
+    auth_headers2: dict,
 ):
-    """The optional viewer resolver (public detail reads) also honours the carried
-    life: ``can_flag`` on the *first* life's own praxis flips to True once the
-    second life is carried (a life may flag a sibling's praxis; anti-self-flag is
-    character-scoped today — see #328)."""
-    # First life authors a praxis while it is still the only (newest) active life.
+    """The optional viewer resolver (public detail reads) honours the carried life.
+
+    ``can_flag`` on a *third-party* praxis flips with the carried life's **level**
+    (a character-scoped gate). The target must be on a different account because
+    account-scoped anti-self-flag (#328) forbids flagging a sibling's praxis.
+    """
+    # A different account (character2) authors + submits the praxis.
     create = await client.post(
         "/praxes",
-        json={"task_id": active_task.id, "type": "solo", "title": "First life work"},
-        headers=auth_headers,
+        json={"task_id": active_task.id, "type": "solo", "title": "Rival work"},
+        headers=auth_headers2,
     )
     assert create.status_code == 201, create.text
     praxis_id = create.json()["id"]
-    assert create.json()["created_by_id"] == character.id
-    # Submit so the (non-member) second life can view it — in_progress praxes are
-    # member-only (ADR-0024); the viewer-flag flip is what's under test here.
-    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+    assert (await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)).status_code == 200
 
-    # Viewed as the author (first life): cannot flag your own praxis.
-    as_author = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
-    assert as_author.json()["can_flag"] is False
+    # First life (character) is level 0 — below the flag level → can_flag False.
+    as_first = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert as_first.json()["can_flag"] is False
 
-    # Carry a second life at/above the flag level, then view again.
+    # Carry a second life at/above the flag level; can_flag flips to True.
     second = await _add_character(
         db_session, account, era, username="secondlife",
         level=CURRENT_ERA.flag_level_required,
@@ -382,7 +383,7 @@ async def test_second_life_governs_viewer_flags_on_read(
     as_second = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
     assert as_second.json()["can_flag"] is True, (
         "Optional viewer resolver ignored the carried life: can_flag should reflect "
-        "the second life (a non-author) once it is carried."
+        "the carried second life's level once it is carried."
     )
 
 


### PR DESCRIPTION
Sock-puppet hardening (sibling of #293 / ADR-0025). Voting is account-scoped already (`vote.py`); flagging was only **character**-scoped, so a player could switch to puppet B and flag puppet A's praxis, or stack flags from multiple lives to gang up on a rival.

## Changes (`services/praxis.py`)
- **Account-scoped anti-self-flag** — `flag_praxis` + `can_flag_praxis` reject when the flagger's **account** owns the praxis author (`author.account_id == flagger.account_id`), not just the same character → **403**. Mirrors the vote rule's shape.
- **Account-scoped uniqueness (anti-gang)** — one flag per **account** per praxis; a second life stacking a flag → **409**. Implemented by joining `Flag.flagged_by → Character.account_id` — **no new column / migration**.
- `can_flag` reflects both new rejections so the UI hides the control exactly when the action would 403/409.

## Verify (local Postgres)
- New `test_flag_account_scope.py`: puppet B → **403** on a sibling's praxis; a sibling → **409** on an already-flagged third-party praxis; a non-sibling → **200**.
- The #293 optional-viewer test now distinguishes the two lives by **level** on a different-account praxis (a life can no longer flag its sibling's work).
- Full integration suite: **329 passed**.

Anti-cheat half of ADR-0025; sibling of #293. Closes #328.