### PR TITLE
refactor: single sign-up eligibility predicate (fix can_submit drift) (closes #330)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -4,7 +4,9 @@ Handles all three praxis types: solo, collab, and duel.
 Replaces the old services/submission.py and services/collaboration.py.
 """
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Optional
 
 from fastapi import HTTPException
@@ -406,6 +408,87 @@ async def list_praxes(
     return praxes
 
 
+class SignupDenialReason(str, Enum):
+    """Why the type-agnostic sign-up gates reject a claim (ADR-0008)."""
+
+    below_level = "below_level"
+    task_status_closed = "task_status_closed"
+    already_active_member = "already_active_member"
+    bank_full = "bank_full"
+
+
+@dataclass(frozen=True)
+class SignupEligibility:
+    """Result of :func:`evaluate_signup`. ``reason`` is set iff ``allowed`` is False."""
+
+    allowed: bool
+    reason: Optional[SignupDenialReason] = None
+
+
+async def evaluate_signup(
+    character: Optional[Character],
+    task: Task,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> SignupEligibility:
+    """The single sign-up predicate — true iff ``create_praxis``'s **type-agnostic**
+    gates would accept (ADR-0008). Owns the four gates every claim shares: level,
+    retired/pending faction carve-out, active-member, and the task-bank cap. The
+    mode-specific gates (duel-via-challenge, collab level) stay in
+    :func:`allowed_praxis_modes` and are applied by :func:`_check_create_preconditions`.
+
+    Anonymous viewers are never eligible (``allowed=False``, no ``reason``).
+    """
+    if character is None:
+        return SignupEligibility(allowed=False)
+
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, character.id, era_row.id)
+
+    if stats.level < task.level_required:
+        return SignupEligibility(False, SignupDenialReason.below_level)
+
+    if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
+        return SignupEligibility(False, SignupDenialReason.task_status_closed)
+    if task.status == TaskStatus.pending and character.faction_slug not in era.allow_praxis_on_pending_task_factions:
+        return SignupEligibility(False, SignupDenialReason.task_status_closed)
+
+    if await is_active_member_of_task(character, task, session):
+        return SignupEligibility(False, SignupDenialReason.already_active_member)
+
+    in_progress_count = await _count_in_progress_praxes(character.id, session)
+    if in_progress_count >= era.max_task_signups:
+        return SignupEligibility(False, SignupDenialReason.bank_full)
+
+    return SignupEligibility(allowed=True)
+
+
+def _signup_denial_to_http(
+    reason: Optional[SignupDenialReason], task: Task, era: EraConfig
+) -> HTTPException:
+    """Map a :class:`SignupDenialReason` to the route error it has always raised."""
+    if reason == SignupDenialReason.below_level:
+        return HTTPException(
+            status_code=403, detail=f"This task requires level {task.level_required}."
+        )
+    if reason == SignupDenialReason.task_status_closed:
+        detail = (
+            "This task is retired and is not open for new praxes."
+            if task.status == TaskStatus.retired
+            else "This task is pending and is not open for new praxes."
+        )
+        return HTTPException(status_code=403, detail=detail)
+    if reason == SignupDenialReason.already_active_member:
+        return HTTPException(
+            status_code=409, detail="You have already submitted a praxis for this task."
+        )
+    # bank_full (and the anonymous/None fallback, which create_praxis never hits).
+    return HTTPException(
+        status_code=400,
+        detail=f"Task bank is full ({era.max_task_signups} in-progress praxes). Complete or withdraw one first.",
+    )
+
+
 async def _check_create_preconditions(
     task_id: int,
     praxis_type: PraxisType,
@@ -418,45 +501,25 @@ async def _check_create_preconditions(
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found.")
 
-    era_row = await get_current_era_row(session)
-    stats = await get_or_create_stats(session, character_id, era_row.id)
-
-    if stats.level < task.level_required:
-        raise HTTPException(
-            status_code=403,
-            detail=f"This task requires level {task.level_required}.",
-        )
-
-    # One-praxis-per-task gate (with Everymen Double Dipper carve-out).
-    # Uses the same helper that powers the ``can_submit_praxis`` flag on the
-    # task detail response so the rule is single-sourced.
     character = await session.get(Character, character_id)
     if character is None:
         raise HTTPException(status_code=404, detail="Character not found.")
 
-    if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
-        raise HTTPException(
-            status_code=403,
-            detail="This task is retired and is not open for new praxes.",
-        )
-    if task.status == TaskStatus.pending and character.faction_slug not in era.allow_praxis_on_pending_task_factions:
-        raise HTTPException(
-            status_code=403,
-            detail="This task is pending and is not open for new praxes.",
-        )
+    # Type-agnostic gates: level, retired/pending, active-member, bank cap — one
+    # predicate, so the can_submit_praxis flag can't drift from enforcement.
+    eligibility = await evaluate_signup(character, task, session, era)
+    if not eligibility.allowed:
+        raise _signup_denial_to_http(eligibility.reason, task, era)
 
-    if not await can_submit_praxis_for_task(character, task, session, era):
-        raise HTTPException(
-            status_code=409,
-            detail="You have already submitted a praxis for this task.",
-        )
-
+    # Mode-specific gates stay here (single-sourced via allowed_praxis_modes).
     if praxis_type == PraxisType.duel:
         raise HTTPException(
             status_code=400,
             detail="Duels are issued via the challenge endpoint, not direct praxis creation (ADR-0011).",
         )
 
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, character_id, era_row.id)
     allowed = allowed_praxis_modes(character, stats.level, era)
     if praxis_type not in allowed:
         _denial: dict[PraxisType, str] = {
@@ -467,12 +530,6 @@ async def _check_create_preconditions(
             detail=_denial.get(praxis_type, "Praxis mode not available."),
         )
 
-    in_progress_count = await _count_in_progress_praxes(character_id, session)
-    if in_progress_count >= era.max_task_signups:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Task bank is full ({era.max_task_signups} in-progress praxes). Complete or withdraw one first.",
-        )
     return task
 
 
@@ -728,34 +785,15 @@ async def can_submit_praxis_for_task(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> bool:
-    """Return True if ``character`` passes every signup gate for ``task``.
+    """Return True iff ``create_praxis``'s type-agnostic gates would accept — the
+    truthful ``can_submit_praxis`` flag on ``TaskOut`` (ADR-0008).
 
-    Mirrors all guards enforced in :func:`_check_create_preconditions` so the
-    frontend ``can_submit_praxis`` flag on ``TaskOut`` is always truthful:
-    - Anonymous viewers → False.
-    - Character level below ``task.level_required`` → False.
-    - Task is retired/pending and character's faction is not in the
-      ``allow_praxis_on_retired/pending_task_factions`` carve-out → False.
-    - Character already holds an active ``PraxisMember`` row (authored *or*
-      joined via collab invite) on a non-deleted praxis for this task → False.
-      The Everymen faction (Double Dipper perk) is exempt from this last gate
-      only — level and task-status gates still apply to everyone.
+    Derives from :func:`evaluate_signup`, so it covers every shared gate: level,
+    retired/pending faction carve-out, active-member (Everymen Double-Dipper
+    exempt), **and the task-bank cap** — the last was previously omitted here,
+    which made the sign-up button lie once a character's bank was full.
     """
-    if character is None:
-        return False
-
-    era_row = await get_current_era_row(session)
-    stats = await get_or_create_stats(session, character.id, era_row.id)
-
-    if stats.level < task.level_required:
-        return False
-
-    if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
-        return False
-    if task.status == TaskStatus.pending and character.faction_slug not in era.allow_praxis_on_pending_task_factions:
-        return False
-
-    return not await is_active_member_of_task(character, task, session)
+    return (await evaluate_signup(character, task, session, era)).allowed
 
 
 def allowed_praxis_modes(
@@ -1286,6 +1324,7 @@ __all__ = [
     "can_view_praxis",
     "create_praxis",
     "delete_praxis",
+    "evaluate_signup",
     "flag_praxis",
     "get_praxis",
     "invite_to_praxis",
@@ -1298,6 +1337,8 @@ __all__ = [
     "moderate_praxis",
     "remove_metatask",
     "respond_to_invite",
+    "SignupDenialReason",
+    "SignupEligibility",
     "submit_praxis",
     "update_praxis",
     "withdraw_praxis",

--- a/backend/tests/integration/test_signup_eligibility.py
+++ b/backend/tests/integration/test_signup_eligibility.py
@@ -1,0 +1,136 @@
+"""#330 — the single sign-up eligibility predicate (evaluate_signup).
+
+The predicate is the test surface (ADR-0008): one place asserts each denial
+reason, and the regression pins the can_submit_praxis flag to the bank cap it
+previously omitted.
+"""
+from dataclasses import replace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.era import Era
+from models.faction import Faction
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from services.praxis import (
+    SignupDenialReason,
+    can_submit_praxis_for_task,
+    evaluate_signup,
+)
+
+
+async def _seed_in_progress_praxis(
+    db_session: AsyncSession, character: Character, task: Task
+) -> None:
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="wip",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=praxis.id, character_id=character.id))
+    await db_session.commit()
+
+
+async def _make_task(
+    db_session: AsyncSession,
+    character: Character,
+    *,
+    level_required: int = 0,
+    status: TaskStatus = TaskStatus.active,
+) -> Task:
+    task = Task(
+        title="Extra Task",
+        description="",
+        point_value=5,
+        level_required=level_required,
+        status=status,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(task)
+    await db_session.commit()
+    await db_session.refresh(task)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_evaluate_signup_allowed(
+    db_session: AsyncSession, character: Character, active_task: Task, era: Era, faction_ua: Faction
+):
+    result = await evaluate_signup(character, active_task, db_session)
+    assert result.allowed is True
+    assert result.reason is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_signup_anonymous_not_allowed(
+    db_session: AsyncSession, active_task: Task, era: Era, faction_ua: Faction
+):
+    result = await evaluate_signup(None, active_task, db_session)
+    assert result.allowed is False
+
+
+@pytest.mark.asyncio
+async def test_evaluate_signup_below_level(
+    db_session: AsyncSession, character: Character, era: Era, faction_ua: Faction
+):
+    hard_task = await _make_task(db_session, character, level_required=5)
+    result = await evaluate_signup(character, hard_task, db_session)
+    assert result.allowed is False
+    assert result.reason is SignupDenialReason.below_level
+
+
+@pytest.mark.asyncio
+async def test_evaluate_signup_task_status_closed(
+    db_session: AsyncSession, character: Character, era: Era, faction_ua: Faction
+):
+    retired = await _make_task(db_session, character, status=TaskStatus.retired)
+    result = await evaluate_signup(character, retired, db_session)
+    assert result.allowed is False
+    assert result.reason is SignupDenialReason.task_status_closed
+
+
+@pytest.mark.asyncio
+async def test_evaluate_signup_already_active_member(
+    db_session: AsyncSession, character: Character, active_task: Task, era: Era, faction_ua: Faction
+):
+    await _seed_in_progress_praxis(db_session, character, active_task)
+    result = await evaluate_signup(character, active_task, db_session)
+    assert result.allowed is False
+    assert result.reason is SignupDenialReason.already_active_member
+
+
+@pytest.mark.asyncio
+async def test_evaluate_signup_bank_full(
+    db_session: AsyncSession, character: Character, active_task: Task, era: Era, faction_ua: Faction
+):
+    # One in-progress praxis on active_task; evaluate a DIFFERENT task with cap=1
+    # so the bank-cap gate (not active-member) is the one that fires.
+    await _seed_in_progress_praxis(db_session, character, active_task)
+    other = await _make_task(db_session, character)
+    capped = replace(CURRENT_ERA, max_task_signups=1)
+    result = await evaluate_signup(character, other, db_session, capped)
+    assert result.allowed is False
+    assert result.reason is SignupDenialReason.bank_full
+
+
+@pytest.mark.asyncio
+async def test_can_submit_flag_false_when_bank_full(
+    db_session: AsyncSession, character: Character, active_task: Task, era: Era, faction_ua: Faction
+):
+    """Regression: the can_submit_praxis flag now reflects the bank cap.
+
+    Before #330 the flag omitted the bank cap, so a full-bank character got
+    can_submit_praxis=True and the sign-up button lied.
+    """
+    await _seed_in_progress_praxis(db_session, character, active_task)
+    other = await _make_task(db_session, character)
+    capped = replace(CURRENT_ERA, max_task_signups=1)
+    assert await can_submit_praxis_for_task(character, other, db_session, capped) is False


### PR DESCRIPTION
The sign-up rule was authored **twice** and had drifted: `can_submit_praxis_for_task` (the UI flag) omitted the **task-bank cap** that `create_praxis` enforces, so a full-bank character saw a sign-up button that then **400'd** on click. (CLAUDE.md: hide unusable controls.)

## Fix (ADR-0008 — one deep predicate)
- **`evaluate_signup(character, task, session, era) -> SignupEligibility`** owns the four **type-agnostic** gates: level, retired/pending faction carve-out, active-member, and the bank cap. Returns a structured `SignupDenialReason` (`below_level | task_status_closed | already_active_member | bank_full`).
- **`_check_create_preconditions`** calls it and maps `reason -> HTTPException`, preserving today's exact status codes + messages; the **mode-specific** gates (duel-via-challenge, collab level) stay in `allowed_praxis_modes`.
- **`can_submit_praxis_for_task`** now returns `evaluate_signup(...).allowed`, so `TaskOut.can_submit_praxis` includes the bank cap and stops lying.

## Boundary (per issue)
Mode gates stay in `allowed_praxis_modes` (already single-sourced + unit-tested); `eligible_for_current_user`/metatask eligibility and the task-404 stay where they are.

## Verify (local Postgres)
- New `test_signup_eligibility.py`: one assertion per `SignupDenialReason` + a **regression** that `can_submit_praxis` is False when the bank is full (uses `dataclasses.replace(CURRENT_ERA, max_task_signups=1)` to avoid seeding 20 praxes).
- Existing gate messages/status codes unchanged; full suite **338 passed**.

Closes #330.