### PR TITLE
fix: collab-invite accept — real errors, drop dead modal, document level-lift (closes #318)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,7 +100,11 @@ the link drops and the challenger's praxis stays as a plain solo praxis (**conve
 **Collaboration (collab)**:
 Genuinely shared work on one task: **one** praxis, many `PraxisMember`s, one shared body + media,
 one shared vote pool. Every member is scored off the same star total (through their own faction's
-collab modifier). Contrast **Duel**, which is *not* shared.
+collab modifier). Contrast **Duel**, which is *not* shared. **Invite level-lift** (by design):
+accepting a collab invite lets a **lower-level player** work on a task above their own sign-up
+level — `respond_to_invite` gates the accept only on bank-cap + not-already-submitted, never the
+invitee's level or the task's `level_required`. A qualified creator's invite is the lift; not a
+bypass to be "fixed" (#318).
 
 **Praxis status**:
 The `in_progress → submitted` axis of a praxis. What flips it depends on type — **solo**:

--- a/docs/spec/SPEC-game-rules.md
+++ b/docs/spec/SPEC-game-rules.md
@@ -193,9 +193,10 @@ Each member's score is computed independently using their own faction's collab m
 
 ### Collaboration
 
-- Requires character level ≥ 1 (hardcoded).
+- Requires character level ≥ 1 (hardcoded) **to *create* a collab**.
 - **No participant cap** in Era 1 — any number of characters may join a collaboration.
 - Creator invites other characters. Each accepts or declines via the invite flow.
+- **Level-lift rule (by design):** accepting a collab invite lets a **lower-level player collaborate on a task above their own sign-up level**. `respond_to_invite` gates the accept only on the invitee's **bank cap** and the collab not already being **submitted** — it deliberately does **not** check the invitee's level or the task's `level_required`. An invite is a lift by a qualified creator; this is not a bypass to be "fixed" later.
 - A collab reaches `submitted` status when **all current members** have individually marked `has_submitted = True`.
 - Each member's score is computed independently using their own faction modifiers.
 - Votes are praxis-wide. Members cannot vote on their own collab (account-level anti-self-vote).

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -4,6 +4,7 @@ import type { ActivityFeedItem } from "../../api/activityFeed";
 import { respondToInvite } from "../../api/praxis";
 import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
+import { extractError } from "../../utils/errors";
 import FeedBadge from "./FeedBadge";
 
 interface Props {
@@ -27,32 +28,25 @@ export default function FeedCardCollabInvite({ item }: Props) {
 
   const [status, setStatus] = useState<string | null>(invite_status);
   const [loading, setLoading] = useState(false);
-  // Task-list-full modal state
-  const [showDropModal, setShowDropModal] = useState(false);
-  const [myTasks] = useState<
-    { id: number; task: { id: number; title: string } }[]
-  >([]);
-  const [dropError, setDropError] = useState("");
+  const [acceptError, setAcceptError] = useState("");
 
-  const doAccept = async (drop_task_id?: number) => {
+  const handleAccept = async () => {
     setLoading(true);
+    setAcceptError("");
     try {
       await respondToInvite(praxis_id, invite_id, true);
-      if (drop_task_id) {
-        // Drop task was selected from modal — handled server-side via the task list
-      }
       setStatus("accepted");
-      setShowDropModal(false);
       // New members land on the editor so they can contribute; the editor
       // self-locks if the collab is already submitted (controlsLocked). (#298)
       navigate(`/praxes/${praxis_id}/edit`);
-    } catch {
-      setDropError("Could not accept invite. Please try again.");
+    } catch (err) {
+      // Surface the real backend reason (e.g. 400 "Cannot join a submitted
+      // praxis" after lazy-consensus auto-publish, or 409 bank-full) instead of
+      // a generic swallow. (#318)
+      setAcceptError(extractError(err, "Could not accept invite. Please try again."));
     }
     setLoading(false);
   };
-
-  const handleAccept = () => doAccept();
 
   const handleDecline = async () => {
     setLoading(true);
@@ -68,65 +62,100 @@ export default function FeedCardCollabInvite({ item }: Props) {
   const isPending = status === "pending" || status === null;
 
   return (
-    <>
-      <div style={{ padding: "12px 16px" }}>
-        <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
-          <Link to={`/characters/${inviter_character_id}`}>
-            <div
-              style={{
-                width: 28,
-                height: 28,
-                borderRadius: "50%",
-                background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
-                flexShrink: 0,
-                marginTop: 2,
-              }}
-            />
-          </Link>
+    <div style={{ padding: "12px 16px" }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+        <Link to={`/characters/${inviter_character_id}`}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: "50%",
+              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          />
+        </Link>
 
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              flexWrap: "wrap",
+            }}
+          >
+            <Link
+              to={`/characters/${inviter_character_id}`}
+              className="font-body"
               style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                flexWrap: "wrap",
+                fontSize: 11,
+                fontWeight: 700,
+                color: "var(--color-text-primary)",
+                textDecoration: "none",
               }}
             >
-              <Link
-                to={`/characters/${inviter_character_id}`}
-                className="font-body"
-                style={{
-                  fontSize: 11,
-                  fontWeight: 700,
-                  color: "var(--color-text-primary)",
-                  textDecoration: "none",
-                }}
-              >
-                {item.actor_display_name}
-              </Link>
-              <span
-                className="font-body"
-                style={{ fontSize: 11, color: "var(--color-text-secondary)" }}
-              >
-                invited you to collaborate
-              </span>
-              <FeedBadge type="your_stuff" label="Your Stuff" />
-            </div>
+              {item.actor_display_name}
+            </Link>
             <span
-              className="eyebrow"
-              style={{
-                color: "var(--color-text-tertiary)",
-                display: "block",
-                marginTop: 2,
-              }}
+              className="font-body"
+              style={{ fontSize: 11, color: "var(--color-text-secondary)" }}
             >
-              {relativeTime(item.timestamp)}
+              invited you to collaborate
             </span>
+            <FeedBadge type="your_stuff" label="Your Stuff" />
           </div>
+          <span
+            className="eyebrow"
+            style={{
+              color: "var(--color-text-tertiary)",
+              display: "block",
+              marginTop: 2,
+            }}
+          >
+            {relativeTime(item.timestamp)}
+          </span>
         </div>
+      </div>
 
-        {/* Task detail */}
+      {/* Task detail */}
+      <div
+        style={{
+          marginTop: 10,
+          marginLeft: 38,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: taskColor,
+            flexShrink: 0,
+          }}
+        />
+        <span
+          className="font-body"
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: "var(--color-text-primary)",
+          }}
+        >
+          {task_title}
+        </span>
+        <span className="eyebrow" style={{ color: "var(--color-text-tertiary)" }}>
+          {task_point_value} pts · lvl {task_level_required}
+        </span>
+        <FeedBadge type="collab" label="Collab" />
+      </div>
+
+      {/* Accept/Decline buttons */}
+      {isPending && (
         <div
           style={{
             marginTop: 10,
@@ -134,205 +163,71 @@ export default function FeedCardCollabInvite({ item }: Props) {
             display: "flex",
             alignItems: "center",
             gap: 8,
+            flexWrap: "wrap",
           }}
         >
-          <span
+          <button
+            onClick={handleAccept}
+            disabled={loading}
             style={{
-              width: 8,
-              height: 8,
-              borderRadius: "50%",
-              background: taskColor,
-              flexShrink: 0,
-            }}
-          />
-          <span
-            className="font-body"
-            style={{
-              fontSize: 11,
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
               fontWeight: 700,
-              color: "var(--color-text-primary)",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              background: "var(--badge-collab)",
+              color: "var(--color-text-on-accent)",
+              border: "none",
+              padding: "5px 14px",
+              cursor: loading ? "not-allowed" : "pointer",
             }}
           >
-            {task_title}
-          </span>
-          <span
-            className="eyebrow"
-            style={{ color: "var(--color-text-tertiary)" }}
-          >
-            {task_point_value} pts · lvl {task_level_required}
-          </span>
-          <FeedBadge type="collab" label="Collab" />
-        </div>
-
-        {/* Accept/Decline buttons */}
-        {isPending && (
-          <div
+            Accept
+          </button>
+          <button
+            onClick={handleDecline}
+            disabled={loading}
             style={{
-              marginTop: 10,
-              marginLeft: 38,
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              flexWrap: "wrap",
-            }}
-          >
-            <button
-              onClick={handleAccept}
-              disabled={loading}
-              style={{
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: 9,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
-                background: "var(--badge-collab)",
-                color: "var(--color-text-on-accent)",
-                border: "none",
-                padding: "5px 14px",
-                cursor: loading ? "not-allowed" : "pointer",
-              }}
-            >
-              Accept
-            </button>
-            <button
-              onClick={handleDecline}
-              disabled={loading}
-              style={{
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: 9,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
-                background: "transparent",
-                color: "var(--color-text-secondary)",
-                border: "1px solid var(--color-border)",
-                padding: "5px 14px",
-                cursor: loading ? "not-allowed" : "pointer",
-              }}
-            >
-              Decline
-            </button>
-            {dropError && (
-              <span
-                className="eyebrow"
-                style={{ color: "var(--color-danger)" }}
-              >
-                {dropError}
-              </span>
-            )}
-          </div>
-        )}
-
-        {status === "accepted" && (
-          <div style={{ marginTop: 8, marginLeft: 38 }}>
-            <Link
-              to={`/praxes/${praxis_id}`}
-              className="eyebrow"
-              style={{ color: "var(--badge-collab)", textDecoration: "none" }}
-            >
-              Accepted — view collaboration
-            </Link>
-          </div>
-        )}
-        {status === "declined" && (
-          <div style={{ marginTop: 8, marginLeft: 38 }}>
-            <span
-              className="eyebrow"
-              style={{ color: "var(--color-text-tertiary)" }}
-            >
-              Declined
-            </span>
-          </div>
-        )}
-      </div>
-
-      {/* Task-list-full modal */}
-      {showDropModal && (
-        <div
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 1000,
-            background: "rgba(0,0,0,0.5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: 20,
-          }}
-          onClick={() => setShowDropModal(false)}
-        >
-          <div
-            style={{
-              background: "var(--color-bg-surface)",
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 9,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              background: "transparent",
+              color: "var(--color-text-secondary)",
               border: "1px solid var(--color-border)",
-              padding: "24px",
-              maxWidth: 420,
-              width: "100%",
+              padding: "5px 14px",
+              cursor: loading ? "not-allowed" : "pointer",
             }}
-            onClick={(e) => e.stopPropagation()}
           >
-            <p className="eyebrow" style={{ marginBottom: 8 }}>
-              Task list full
-            </p>
-            <p
-              className="font-body"
-              style={{
-                fontSize: 11,
-                marginBottom: 16,
-                color: "var(--color-text-secondary)",
-              }}
-            >
-              You have 20 in-progress tasks. Drop one to accept this invite:
-            </p>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 6,
-                maxHeight: 260,
-                overflowY: "auto",
-              }}
-            >
-              {myTasks.map((ct) => (
-                <button
-                  key={ct.id}
-                  onClick={() => doAccept(ct.task.id)}
-                  disabled={loading}
-                  style={{
-                    background: "var(--color-bg-surface-alt)",
-                    border: "1px solid var(--color-border)",
-                    padding: "8px 12px",
-                    cursor: "pointer",
-                    textAlign: "left",
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: 10,
-                    color: "var(--color-text-primary)",
-                  }}
-                >
-                  Drop: {ct.task.title}
-                </button>
-              ))}
-            </div>
-            <button
-              onClick={() => setShowDropModal(false)}
-              style={{
-                marginTop: 14,
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: 9,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                background: "transparent",
-                border: "1px solid var(--color-border)",
-                padding: "5px 14px",
-                cursor: "pointer",
-                color: "var(--color-text-secondary)",
-              }}
-            >
-              Cancel
-            </button>
-          </div>
+            Decline
+          </button>
+          {acceptError && (
+            <span className="eyebrow" style={{ color: "var(--color-danger)" }}>
+              {acceptError}
+            </span>
+          )}
         </div>
       )}
-    </>
+
+      {status === "accepted" && (
+        <div style={{ marginTop: 8, marginLeft: 38 }}>
+          <Link
+            to={`/praxes/${praxis_id}`}
+            className="eyebrow"
+            style={{ color: "var(--badge-collab)", textDecoration: "none" }}
+          >
+            Accepted — view collaboration
+          </Link>
+        </div>
+      )}
+      {status === "declined" && (
+        <div style={{ marginTop: 8, marginLeft: 38 }}>
+          <span className="eyebrow" style={{ color: "var(--color-text-tertiary)" }}>
+            Declined
+          </span>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
`FeedCardCollabInvite` swallowed backend errors into a generic *"Could not accept invite"* and carried a **dead stubbed drop-to-accept modal** (`myTasks` was always `[]`). Two live cases hid behind the generic message: the collab **auto-published** (lazy-consensus) before the invitee accepts → 400 *"Cannot join a submitted praxis"*; the invitee's **task bank is full** → 409.

## Changes
- **Surface the real backend message** via `extractError` on accept failure (mirrors the duel card fix #312).
- **Remove the stubbed drop-to-accept modal** and its dead state (`showDropModal`, `myTasks`).
- **Document the level-lift rule** in `SPEC-game-rules.md` §Collaboration + the `CONTEXT.md` glossary: a collab invite deliberately lets a **lower-level player collaborate on a task above their own sign-up level**. `respond_to_invite` gates only bank-cap + submitted-state **by design** — not the invitee's level. Noted so it isn't "fixed" as a bypass later.

## Verify
- `tsc --noEmit` clean (noUnusedLocals would catch leftover modal state), `vitest` 118 passed, `npm run build` green.

Sibling of the duel card fix #312. Closes #318.