### PR TITLE
fix: duel challenge attaches to the challenger's existing praxis (closes #306)

### DIFF
--- a/backend/routers/duel.py
+++ b/backend/routers/duel.py
@@ -37,10 +37,10 @@ async def issue_challenge_route(
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    """Issue a duel challenge. Body: ``{task_id, opponent_character_id}``."""
+    """Attach a duel to an existing praxis. Body: ``{challenger_praxis_id, opponent_character_id}``."""
     _praxis, duel = await issue_duel_challenge(
         challenger_character_id=character.id,
-        task_id=data.task_id,
+        challenger_praxis_id=data.challenger_praxis_id,
         opponent_character_id=data.opponent_character_id,
         session=session,
         era=CURRENT_ERA,

--- a/backend/schemas/duel.py
+++ b/backend/schemas/duel.py
@@ -5,8 +5,8 @@ from models.duel import DuelStatus
 
 
 class DuelChallengeIn(BaseModel):
-    """Body for POST /duels/challenge — issue a duel challenge."""
-    task_id: int
+    """Body for POST /duels/challenge — attach a duel to an existing praxis."""
+    challenger_praxis_id: int
     opponent_character_id: int
 
 

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -30,7 +30,6 @@ from schemas.duel import DuelOut
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
 from services.praxis import (
-    _check_create_preconditions,
     _count_in_progress_praxes,
     get_praxis,
     is_active_member_of_task,
@@ -72,31 +71,43 @@ async def get_duel_for_praxis(praxis_id: int, session: AsyncSession) -> Optional
 
 async def issue_duel_challenge(
     challenger_character_id: int,
-    task_id: int,
+    challenger_praxis_id: int,
     opponent_character_id: int,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> tuple[Praxis, Duel]:
-    """Issue a duel challenge: create the challenger's praxis + a pending Duel row.
+    """Attach a duel challenge to the challenger's existing in_progress praxis.
 
-    The challenger must meet all create-praxis preconditions (level, bank cap,
-    task eligibility). The opponent must not already have an active praxis for
-    this task (Everymen exempt). The challenger and opponent cannot be the same.
+    The challenger signs up solo first, then attaches an opponent (ADR-0011).
+    This does NOT create a praxis — it loads the challenger's existing one and
+    creates only the pending Duel row pointing at it. The opponent must not
+    already have an active praxis for this task (Everymen exempt); challenger
+    and opponent cannot be the same.
     """
     if challenger_character_id == opponent_character_id:
         raise HTTPException(status_code=400, detail="Cannot challenge yourself.")
 
-    challenger = await session.get(Character, challenger_character_id)
-    if challenger is None:
-        raise HTTPException(status_code=404, detail="Character not found.")
+    challenger_praxis = await get_praxis(challenger_praxis_id, session)
+    if challenger_praxis.created_by_id != challenger_character_id:
+        raise HTTPException(status_code=403, detail="You do not own this praxis.")
+    if challenger_praxis.status != PraxisStatus.in_progress:
+        raise HTTPException(
+            status_code=422,
+            detail="A duel can only start from an in-progress praxis.",
+        )
+    if await get_duel_for_praxis(challenger_praxis_id, session) is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="This praxis is already part of a duel.",
+        )
+
+    task = await session.get(Task, challenger_praxis.task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task no longer exists.")
 
     opponent = await session.get(Character, opponent_character_id)
     if opponent is None:
         raise HTTPException(status_code=404, detail="Opponent character not found.")
-
-    task = await _check_create_preconditions(
-        task_id, PraxisType.solo, challenger_character_id, session, era
-    )
 
     # Opponent eligibility: must not already have an active praxis for this task.
     if await is_active_member_of_task(opponent, task, session):
@@ -114,37 +125,16 @@ async def issue_duel_challenge(
             detail=f"Duels require level {era.duel_level_required}.",
         )
 
-    # Create the challenger's solo praxis.
-    praxis = Praxis(
-        task_id=task_id,
-        type=PraxisType.solo,
-        status=PraxisStatus.in_progress,
-        body_text="",
-        moderation_status=ModerationStatus.visible,
-        created_by_id=challenger_character_id,
-    )
-    session.add(praxis)
-    await session.flush()
-
-    member = PraxisMember(
-        praxis_id=praxis.id,
-        character_id=challenger_character_id,
-        has_submitted=False,
-    )
-    session.add(member)
-    await session.flush()
-
-    # Create the pending Duel row.
+    # Create only the pending Duel row, pointing at the existing praxis.
     duel = Duel(
-        task_id=task_id,
-        challenger_praxis_id=praxis.id,
+        task_id=challenger_praxis.task_id,
+        challenger_praxis_id=challenger_praxis.id,
         opponent_character_id=opponent_character_id,
         status=DuelStatus.pending,
     )
     session.add(duel)
     await session.flush()
 
-    challenger_praxis = await get_praxis(praxis.id, session)
     return challenger_praxis, duel
 
 

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -205,6 +205,24 @@ async def test_vote_updates_author_stats(
 # ---------------------------------------------------------------------------
 
 
+async def _challenge_from_new_praxis(client, headers, task_id, opponent_id):
+    """Sign up solo, then attach a duel to that praxis (ADR-0011 challenge flow).
+
+    Returns ``(challenger_praxis_id, challenge_response)``.
+    """
+    create = await client.post(
+        "/praxes", json={"task_id": task_id, "type": "solo"}, headers=headers
+    )
+    assert create.status_code == 201
+    praxis_id = create.json()["id"]
+    resp = await client.post(
+        "/duels/challenge",
+        json={"challenger_praxis_id": praxis_id, "opponent_character_id": opponent_id},
+        headers=headers,
+    )
+    return praxis_id, resp
+
+
 @pytest.mark.asyncio
 async def test_creating_type_duel_praxis_is_rejected(
     client: AsyncClient,
@@ -238,10 +256,8 @@ async def test_duel_challenge_issue_and_cancel(
 
     # character2 already has level 5 from fixture — meets duel level gate
     # Issue challenge
-    challenge_resp = await client.post(
-        "/duels/challenge",
-        json={"task_id": active_task.id, "opponent_character_id": character.id},
-        headers=auth_headers2,
+    _challenger_praxis_id, challenge_resp = await _challenge_from_new_praxis(
+        client, auth_headers2, active_task.id, character.id
     )
     assert challenge_resp.status_code == 201
     duel = challenge_resp.json()
@@ -285,10 +301,8 @@ async def test_duel_challenge_accept_creates_opponent_praxis(
     await db_session.commit()
 
     # Issue challenge from character2
-    challenge_resp = await client.post(
-        "/duels/challenge",
-        json={"task_id": active_task.id, "opponent_character_id": character.id},
-        headers=auth_headers2,
+    _challenger_praxis_id, challenge_resp = await _challenge_from_new_praxis(
+        client, auth_headers2, active_task.id, character.id
     )
     assert challenge_resp.status_code == 201
     duel_id = challenge_resp.json()["id"]
@@ -308,6 +322,79 @@ async def test_duel_challenge_accept_creates_opponent_praxis(
     get_resp = await client.get(f"/duels/{duel_id}")
     assert get_resp.status_code == 200
     assert get_resp.json()["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_duel_challenge_from_praxis_you_do_not_own_is_forbidden(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Attaching a duel to a praxis you don't own → 403."""
+    # character owns this praxis; character2 tries to duel with it.
+    create = await client.post(
+        "/praxes", json={"task_id": active_task.id, "type": "solo"}, headers=auth_headers
+    )
+    assert create.status_code == 201
+    resp = await client.post(
+        "/duels/challenge",
+        json={
+            "challenger_praxis_id": create.json()["id"],
+            "opponent_character_id": character.id,
+        },
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_duel_challenge_from_submitted_praxis_is_unprocessable(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """A duel can only start from an in_progress praxis → submitted gives 422."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "body_text": "done"},
+        headers=auth_headers2,
+    )
+    assert create.status_code == 201
+    praxis_id = create.json()["id"]
+    submit = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+    assert submit.status_code == 200
+    resp = await client.post(
+        "/duels/challenge",
+        json={"challenger_praxis_id": praxis_id, "opponent_character_id": character.id},
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_duel_challenge_on_already_dueled_praxis_conflicts(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """A second challenge on a praxis already linked to a Duel → 409."""
+    praxis_id, first = await _challenge_from_new_praxis(
+        client, auth_headers2, active_task.id, character.id
+    )
+    assert first.status_code == 201
+    resp = await client.post(
+        "/duels/challenge",
+        json={"challenger_praxis_id": praxis_id, "opponent_character_id": character.id},
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 409
 
 
 @pytest.mark.asyncio
@@ -336,10 +423,8 @@ async def test_vote_on_duel_side_praxis(
     await db_session.commit()
 
     # Issue and accept the duel
-    challenge_resp = await client.post(
-        "/duels/challenge",
-        json={"task_id": active_task.id, "opponent_character_id": character.id},
-        headers=auth_headers2,
+    _challenger_praxis_id, challenge_resp = await _challenge_from_new_praxis(
+        client, auth_headers2, active_task.id, character.id
     )
     assert challenge_resp.status_code == 201
     duel_data = challenge_resp.json()

--- a/docs/adr/0011-duel-is-two-linked-praxes.md
+++ b/docs/adr/0011-duel-is-two-linked-praxes.md
@@ -27,9 +27,12 @@ A duel is **two separate praxes that compete**, joined by a new `Duel` row.
 - **Lifecycle states:** `pending` (challenged, only challenger's praxis exists) →
   `active` (opponent accepted, opponent's praxis created) → `settled` (both
   submitted, voting open). `declined` is terminal.
-- **Cold symmetric challenge.** The challenger's praxis is created `in_progress` at
-  challenge time; both sides then work and `submit` independently, exactly like a solo
-  praxis. No "challenger must finish first" rule.
+- **Cold symmetric challenge.** The challenge **attaches to the challenger's existing
+  `in_progress` praxis** (created at signup), rather than creating one at challenge time.
+  Decline/cancel drops the `Duel` row and the praxis remains a plain `type=solo` praxis
+  (unchanged). The data model (two linked solo praxes + `Duel` row) is identical; only the
+  challenge entry point changes. Both sides then work and `submit` independently, exactly
+  like a solo praxis. No "challenger must finish first" rule.
 - **Decline / cancel → convert to solo.** On decline or challenger-cancel, the `Duel`
   link drops and the challenger's praxis remains as a normal `type=solo` praxis. No
   data loss, no special delete path.

--- a/frontend/src/api/duel.ts
+++ b/frontend/src/api/duel.ts
@@ -19,7 +19,7 @@ export interface DuelOut {
 }
 
 export interface DuelChallengeIn {
-  task_id: number
+  challenger_praxis_id: number
   opponent_character_id: number
 }
 


### PR DESCRIPTION
## What

`POST /duels/challenge` now takes `{challenger_praxis_id, opponent_character_id}` instead of `{task_id, opponent_character_id}`. The intended UX (ADR-0011): sign up solo, then attach an opponent — so the challenge **attaches to an existing `in_progress` praxis** rather than creating a second one.

## Changes
- `schemas/duel.py` — `DuelChallengeIn`: `task_id` → `challenger_praxis_id`.
- `services/duel.py::issue_duel_challenge` — load the challenger praxis; **403** if not owned, **422** if not `in_progress`, **409** if already linked to a non-`declined` Duel (`get_duel_for_praxis`). Derive `task_id` from the praxis. Create only the pending `Duel` row. Kept level / opponent-exists / opponent-not-active / self-challenge guards.
- `routers/duel.py` — body shape + docstring.
- `frontend/src/api/duel.ts` — `DuelChallengeIn` type.
- `docs/adr/0011` — amended the Cold symmetric challenge bullet.

## Tests
`test_votes.py`: existing challenge tests now sign up solo first via a `_challenge_from_new_praxis` helper; new tests cover don't-own → 403, submitted → 422, already-dueled → 409. Full integration suite green locally (Postgres); frontend `tsc` + `vitest` (118) + `build` green.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)