### PR TITLE
feat: sticky duel forfeit — unsubmit / ban -> opponent wins by default (closes #307)

### DIFF
--- a/backend/alembic/versions/0010_duel_forfeited_by.py
+++ b/backend/alembic/versions/0010_duel_forfeited_by.py
@@ -1,0 +1,35 @@
+"""Sticky duel forfeit — add ``duel.forfeited_by_character_id`` (ADR-0011 §Forfeit, #307).
+
+Nullable FK → ``character.id``. Set when a settled duel side unsubmits or its
+owner is banned; the opponent then wins by default and the duel stays settled.
+
+Idempotent (like 0006): the squashed baseline ``create_all`` reflects the
+current ORM, so on a fresh DB the column already exists and ``ADD COLUMN IF
+NOT EXISTS`` is a no-op. On an existing DB it adds the column.
+
+Revision ID: 0010_duel_forfeited_by
+Revises: 0009_account_active_character
+Create Date: 2026-07-01
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010_duel_forfeited_by"
+down_revision: Union[str, None] = "0009_account_active_character"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text(
+        "ALTER TABLE duel ADD COLUMN IF NOT EXISTS forfeited_by_character_id"
+        " INTEGER REFERENCES character(id)"
+    ))
+
+
+def downgrade() -> None:
+    op.execute(sa.text(
+        "ALTER TABLE duel DROP COLUMN IF EXISTS forfeited_by_character_id"
+    ))

--- a/backend/models/duel.py
+++ b/backend/models/duel.py
@@ -53,6 +53,12 @@ class Duel(CreatedAtMixin, Base):
     declined_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # Set when a *settled* duel is forfeited (unsubmit or ban). Sticky: the
+    # opponent wins by default, the duel stays settled, and resubmitting does
+    # not restore the contest (ADR-0011 §Forfeit, #307).
+    forfeited_by_character_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("character.id"), nullable=True
+    )
 
     challenger_praxis: Mapped["Praxis"] = relationship(
         "Praxis", foreign_keys=[challenger_praxis_id], lazy="selectin"

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -393,12 +393,58 @@ async def update_character(
     return character
 
 
-async def soft_delete_character(character_id: int, session: AsyncSession) -> None:
+async def soft_delete_character(
+    character_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> None:
     character = await get_character_by_id(character_id, session)
     if character is None:
         raise HTTPException(status_code=404, detail="Character not found.")
     character.status = CharacterStatus.banned
+
+    # ADR-0011 §Forfeit (#307): a ban forfeits every *settled* duel the banned
+    # character is a side of — the opponent wins by default. Sticky: leave duels
+    # already forfeited untouched. Recalc the winners so their win modifier lands
+    # (the banned side's own score is never read, so we don't recalc it).
+    from models.duel import Duel, DuelStatus
+    from services.character_stats import recalculate_character_stats
+
+    own_praxis_ids = select(Praxis.id).where(Praxis.created_by_id == character_id)
+    duels = (await session.execute(
+        select(Duel).where(
+            Duel.status == DuelStatus.settled,
+            Duel.forfeited_by_character_id.is_(None),
+            or_(
+                Duel.opponent_character_id == character_id,
+                Duel.challenger_praxis_id.in_(own_praxis_ids),
+            ),
+        )
+    )).scalars().all()
+
+    winner_ids: set[int] = set()
+    for duel in duels:
+        duel.forfeited_by_character_id = character_id
+        challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+        challenger_character_id = (
+            challenger_praxis.created_by_id if challenger_praxis else None
+        )
+        winner_id = (
+            duel.opponent_character_id
+            if challenger_character_id == character_id
+            else challenger_character_id
+        )
+        if winner_id is not None:
+            winner_ids.add(winner_id)
     await session.flush()
+
+    if winner_ids:
+        era_row = await get_current_era_row(session)
+        for winner_id in winner_ids:
+            await recalculate_character_stats(
+                winner_id, session, era, era_row=era_row
+            )
+        await session.flush()
 
 
 def _character_stats_era_join(era_id: int | None) -> Select:

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -556,23 +556,35 @@ async def withdraw_praxis(
     Votes are preserved but stop contributing to score until resubmitted via
     ``submit_praxis``. For collabs/duels, member submission flags are reset so
     the full group must re-submit.
+
+    Unsubmitting a *settled* duel side forfeits the contest (ADR-0011 §Forfeit):
+    the opponent wins by default, the duel stays ``settled``, and the forfeit is
+    permanent — resubmitting does not restore it.
     """
     praxis = await get_praxis(praxis_id, session)
     _require_member(praxis, character_id, "reopen")
     if praxis.status == PraxisStatus.in_progress:
         raise HTTPException(status_code=422, detail="Praxis is already in editing mode.")
 
-    # ADR-0024: a *settled* duel side can't simply unsubmit — that would erase a
-    # decided contest. Temporary guard; #307 replaces it with real forfeit
-    # semantics (opponent wins by default, duel stays settled).
+    # ADR-0011 §Forfeit (#307): unsubmitting a *settled* duel side forfeits the
+    # contest. Mark the forfeit (first one sticks) and recalc the winner below so
+    # their guaranteed-win modifier lands immediately.
     from services.duel import get_duel_for_praxis
 
     duel = await get_duel_for_praxis(praxis_id, session)
+    forfeit_winner_character_id: Optional[int] = None
     if duel is not None and duel.status == DuelStatus.settled:
-        raise HTTPException(
-            status_code=422,
-            detail="Cannot unsubmit a settled duel side.",
+        if duel.forfeited_by_character_id is None:
+            duel.forfeited_by_character_id = character_id
+        winner_praxis_id = (
+            duel.opponent_praxis_id
+            if duel.challenger_praxis_id == praxis_id
+            else duel.challenger_praxis_id
         )
+        if winner_praxis_id is not None:
+            winner_praxis = await session.get(Praxis, winner_praxis_id)
+            if winner_praxis is not None:
+                forfeit_winner_character_id = winner_praxis.created_by_id
 
     praxis.status = PraxisStatus.in_progress
     praxis.submit_proposed_at = None
@@ -587,6 +599,10 @@ async def withdraw_praxis(
     for member in praxis.members:
         await recalculate_character_stats(
             member.character_id, session, era, era_row=era_row
+        )
+    if forfeit_winner_character_id is not None:
+        await recalculate_character_stats(
+            forfeit_winner_character_id, session, era, era_row=era_row
         )
     await session.flush()
     return await get_praxis(praxis_id, session)

--- a/backend/services/praxis_scoring.py
+++ b/backend/services/praxis_scoring.py
@@ -176,15 +176,26 @@ async def compute_contributions(
                 character_faction, task_faction, era,
                 collaboration_mode=COLLABORATION_MODE_SOLO,
             )
-            own_pts = own_tally.points_from_votes
-            opp_pts = opp_tally.points_from_votes
-            duel_multiplier = compute_duel_multiplier(
-                character_faction,
-                opponent_faction,
-                is_winner=own_pts > opp_pts,
-                is_tied=own_pts == opp_pts,
-                era=era,
-            )
+            if duel.forfeited_by_character_id is not None:
+                # ADR-0011 §Forfeit: the opponent wins by default; vote tallies
+                # don't decide the outcome. The forfeiter takes the loss modifier.
+                duel_multiplier = compute_duel_multiplier(
+                    character_faction,
+                    opponent_faction,
+                    is_winner=character.id != duel.forfeited_by_character_id,
+                    is_tied=False,
+                    era=era,
+                )
+            else:
+                own_pts = own_tally.points_from_votes
+                opp_pts = opp_tally.points_from_votes
+                duel_multiplier = compute_duel_multiplier(
+                    character_faction,
+                    opponent_faction,
+                    is_winner=own_pts > opp_pts,
+                    is_tied=own_pts == opp_pts,
+                    era=era,
+                )
 
         else:
             # Plain solo praxis

--- a/backend/tests/integration/test_praxis_visibility.py
+++ b/backend/tests/integration/test_praxis_visibility.py
@@ -212,7 +212,7 @@ async def test_withdraw_collab_recalculates_every_member(
 
 
 @pytest.mark.asyncio
-async def test_withdraw_settled_duel_side_returns_422(
+async def test_withdraw_settled_duel_side_forfeits(
     client: AsyncClient,
     db_session: AsyncSession,
     character: Character,
@@ -220,19 +220,26 @@ async def test_withdraw_settled_duel_side_returns_422(
     active_task: Task,
     auth_headers: dict,
 ):
-    """Unsubmitting a *settled* duel side is blocked with 422 (temporary; #307 replaces it)."""
+    """Unsubmitting a *settled* duel side forfeits it (ADR-0011 §Forfeit, #307).
+
+    No 422: the withdraw succeeds, the duel stays ``settled``, and the actor is
+    recorded as the forfeiter.
+    """
     praxis_id = await _create_solo(client, active_task, auth_headers)
     assert (await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)).status_code == 200
 
-    db_session.add(
-        Duel(
-            task_id=active_task.id,
-            challenger_praxis_id=praxis_id,
-            opponent_character_id=character2.id,
-            status=DuelStatus.settled,
-        )
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=praxis_id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.settled,
     )
+    db_session.add(duel)
     await db_session.commit()
 
     resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
-    assert resp.status_code == 422
+    assert resp.status_code == 200
+
+    await db_session.refresh(duel)
+    assert duel.status == DuelStatus.settled
+    assert duel.forfeited_by_character_id == character.id

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -735,3 +735,110 @@ async def test_non_participant_can_vote_on_duel_side(
         f"/praxes/{challenger_pid}/vote", json={"value": 4}, headers=third_headers
     )
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Duel forfeit (#307) — unsubmit / ban → opponent wins by default (ADR-0011)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forfeit_by_unsubmit_gives_opponent_win_regardless_of_votes(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    era: Era,
+):
+    """Unsubmitting a settled duel side forfeits it: the opponent scores the win
+    modifier (not the 1.0x tie), the forfeiter the loss modifier, votes ignored;
+    resubmitting does not restore the contest (ADR-0011 §Forfeit)."""
+    from game_config import CURRENT_ERA
+    from models.duel import Duel, DuelStatus
+    from services.praxis import get_praxis, withdraw_praxis
+    from services.praxis_scoring import compute_contributions
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
+    db_session.add(Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_pid,
+        opponent_character_id=character2.id,
+        opponent_praxis_id=opponent_pid,
+        status=DuelStatus.settled,
+    ))
+    await db_session.commit()
+
+    win = CURRENT_ERA.factions[character.faction_slug].duel_win_modifier
+    loss = CURRENT_ERA.factions[character.faction_slug].duel_loss_modifier
+
+    # No votes cast on either side → without forfeit this is a 1.0x tie for both.
+    # character2 forfeits by unsubmitting their side.
+    await withdraw_praxis(opponent_pid, character2.id, db_session)
+
+    challenger_praxis = await get_praxis(challenger_pid, db_session)
+    contribs = await compute_contributions(
+        [challenger_praxis], character, CURRENT_ERA, db_session
+    )
+    assert contribs[challenger_pid].duel_multiplier == win
+
+    # Resubmit does not restore: the forfeiter keeps the loss modifier and the
+    # opponent keeps the win modifier.
+    assert (await client.post(f"/praxes/{opponent_pid}/submit", headers=auth_headers2)).status_code == 200
+    opponent_praxis = await get_praxis(opponent_pid, db_session)
+    contribs_loser = await compute_contributions(
+        [opponent_praxis], character2, CURRENT_ERA, db_session
+    )
+    assert contribs_loser[opponent_pid].duel_multiplier == loss
+    contribs_winner = await compute_contributions(
+        [challenger_praxis], character, CURRENT_ERA, db_session
+    )
+    assert contribs_winner[challenger_pid].duel_multiplier == win
+
+
+@pytest.mark.asyncio
+async def test_ban_forfeits_settled_duels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    era: Era,
+):
+    """Banning a character forfeits their settled duels; the opponent wins by default."""
+    from game_config import CURRENT_ERA
+    from models.duel import Duel, DuelStatus
+    from services.character import soft_delete_character
+    from services.praxis import get_praxis
+    from services.praxis_scoring import compute_contributions
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_pid,
+        opponent_character_id=character2.id,
+        opponent_praxis_id=opponent_pid,
+        status=DuelStatus.settled,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    # Ban character2 (the opponent side).
+    await soft_delete_character(character2.id, db_session)
+    await db_session.refresh(duel)
+    assert duel.status == DuelStatus.settled
+    assert duel.forfeited_by_character_id == character2.id
+
+    # The challenger (still active) wins by default.
+    win = CURRENT_ERA.factions[character.faction_slug].duel_win_modifier
+    challenger_praxis = await get_praxis(challenger_pid, db_session)
+    contribs = await compute_contributions(
+        [challenger_praxis], character, CURRENT_ERA, db_session
+    )
+    assert contribs[challenger_pid].duel_multiplier == win

--- a/docs/adr/0011-duel-is-two-linked-praxes.md
+++ b/docs/adr/0011-duel-is-two-linked-praxes.md
@@ -41,6 +41,24 @@ A duel is **two separate praxes that compete**, joined by a new `Duel` row.
   always-live-on-read scoring model; there is no per-duel voting window or freeze. The
   duel win/loss multiplier is applied per side at scoring time from the current tally.
 
+### Forfeit
+
+Once a duel is `settled`, backing out of it forfeits the contest rather than reopening it.
+
+- **Triggers.** Unsubmitting a `settled` duel side (`withdraw_praxis`), or the ban /
+  soft-delete of a side's character (`soft_delete_character`), forfeits that side.
+- **Opponent wins by default.** The forfeiter takes their faction **loss** modifier; the
+  opponent takes their **win** modifier. Vote tallies no longer decide the outcome — the
+  duel-side scoring branch reads `Duel.forfeited_by_character_id` and skips the tally
+  comparison. The winner is scored even if the forfeited side is now `in_progress` or the
+  forfeiter is banned.
+- **Sticky.** `forfeited_by_character_id` is recorded on the first forfeit and never
+  overwritten; the duel **stays `settled`**. Resubmitting the thrown side does not restore
+  the contest — the forfeiter keeps the loss modifier on resubmit.
+- **No body leak.** A forfeited-by-unsubmit side is `in_progress`, so its read link 404s
+  for non-members exactly like any editing praxis (ADR-0024); read surfaces show only
+  "forfeited — won by default".
+
 ## Consequences
 
 - Scoring must determine "is this praxis a side of a duel?" via the `Duel` table

--- a/docs/spec/SPEC-game-rules.md
+++ b/docs/spec/SPEC-game-rules.md
@@ -209,6 +209,7 @@ Each member's score is computed independently using their own faction's collab m
 - Votes are **per-member** (`praxis_member_id` required). Voters may vote for one or both members — each is a separate `Vote` row.
 - Duel participants cannot vote on **either side** of a duel they're in, at the **account level** — a voter cannot use any of their characters to rate the challenger's *or* the opponent's side. Enforced per-praxis in `services/vote.py`: the account-level anti-self-vote blocks the participant's own side, and when the target praxis is a duel side, the vote is additionally rejected (403) if the voter's account owns either side of that duel (#309).
 - Winner is determined by the highest `total_stars` across each member's votes.
+- **Forfeit (sticky).** Unsubmitting a `settled` duel side, or having your character banned, forfeits the contest: the opponent wins by default — win/loss faction modifiers apply and vote tallies are ignored — and the duel stays `settled`. Recorded once in `Duel.forfeited_by_character_id`; resubmitting does not restore the contest (ADR-0011 §Forfeit). Scored in `services/praxis_scoring.py::compute_contributions`; triggered by `withdraw_praxis` / `soft_delete_character`.
 
 ### Duel outcome multipliers (Era 1)
 


### PR DESCRIPTION
## What

Per grill: backing out of a **settled** duel forfeits it rather than reopening it. Unsubmitting a settled side, or a ban, hands the opponent a **win by default** (faction win/loss modifiers, votes ignored). The duel **stays `settled`** and the forfeit is **permanent** — resubmitting does not restore the contest.

## Changes
- **Model + migration** — `Duel.forfeited_by_character_id` (nullable FK → `character.id`); idempotent Alembic `0010_duel_forfeited_by`.
- `services/praxis.py::withdraw_praxis` — replaces the temporary #303 422 guard: on a settled duel side, record the forfeiter (first one sticks), keep status `settled`, and recalc the winner so their guaranteed win lands immediately.
- `services/character.py::soft_delete_character` — a ban forfeits every settled duel the banned character is a side of; recalc the winners.
- `services/praxis_scoring.py::compute_contributions` — duel branch honors `forfeited_by_character_id`: opponent → win modifier, forfeiter → loss modifier, tally ignored. Winner is scored even when the thrown side is `in_progress` / the forfeiter is banned.
- `docs/adr/0011` §Forfeit + `docs/spec/SPEC-game-rules.md` §Duel.

## Tests
- `test_praxis_visibility.py` — the old `returns_422` test becomes `..._forfeits` (200, stays settled, forfeiter recorded).
- `test_votes.py` — forfeit-by-unsubmit gives the opponent the win modifier over a 1.0× tie regardless of votes and resubmit doesn't restore; ban forfeits settled duels.

Full backend suite green locally (505); migration chain 0001→0010 applies cleanly on a fresh DB.

## Note
Sequenced **before #308** (read-oriented duel data), which surfaces `forfeited_by_character_id` — this PR introduces that column. (Plan had #308 first; reordered to avoid #308 adding a column this PR owns.)

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)