### PR TITLE
feat: read-oriented duel detail endpoint for the praxis read page (closes #308)

### DIFF
--- a/backend/routers/duel.py
+++ b/backend/routers/duel.py
@@ -1,17 +1,20 @@
 """Duel router — challenge flow for two-linked-praxes duels (ADR-0011)."""
 
+from typing import Optional
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import get_current_character
+from dependencies import get_current_character, get_current_character_optional
 from game_config import CURRENT_ERA
 from models.character import Character
-from schemas.duel import DuelChallengeIn, DuelOut, DuelRespondIn
+from schemas.duel import DuelChallengeIn, DuelDetailOut, DuelOut, DuelRespondIn
 from schemas.praxis import PraxisOut
 from services.duel import (
     cancel_duel_challenge,
     get_duel,
+    get_duel_detail,
     issue_duel_challenge,
     list_pending_duel_challenges_for_character,
     respond_to_duel_challenge,
@@ -46,6 +49,17 @@ async def issue_challenge_route(
         era=CURRENT_ERA,
     )
     return DuelOut.model_validate(duel)
+
+
+@router.get("/{duel_id}/detail", response_model=DuelDetailOut)
+async def get_duel_detail_route(
+    duel_id: int,
+    viewer: Optional[Character] = Depends(get_current_character_optional),
+    session: AsyncSession = Depends(get_db),
+):
+    """Read-oriented duel view for the praxis read page: both sides' display
+    info + live vote points + ``viewer_is_participant`` in one round trip (#308)."""
+    return await get_duel_detail(duel_id, viewer, session)
 
 
 @router.get("/{duel_id}", response_model=DuelOut)

--- a/backend/schemas/duel.py
+++ b/backend/schemas/duel.py
@@ -27,3 +27,30 @@ class DuelOut(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class DuelSideOut(BaseModel):
+    """One side of a duel, shaped for the read page (#308).
+
+    Display metadata + live vote points only — never the praxis body. A
+    forfeited / unsubmitted side still renders (name, avatar) but ``is_submitted``
+    is False; its body stays behind the normal in_progress 404 (ADR-0024).
+    """
+    praxis_id: Optional[int]
+    character_id: int
+    display_name: str
+    faction_slug: str
+    avatar_url: str
+    points_from_votes: int
+    is_submitted: bool
+
+
+class DuelDetailOut(BaseModel):
+    """Read-oriented duel view: both sides' display info + tallies in one call."""
+    id: int
+    task_id: int
+    status: DuelStatus
+    forfeited_by_character_id: Optional[int]
+    challenger: DuelSideOut
+    opponent: DuelSideOut
+    viewer_is_participant: bool

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -26,8 +26,9 @@ from models.praxis import (
     PraxisType,
 )
 from models.task import Task
-from schemas.duel import DuelOut
+from schemas.duel import DuelDetailOut, DuelOut, DuelSideOut
 from services.character_stats import recalculate_character_stats
+from services.vote_tally import get_tally, tally_votes
 from services.era import get_current_era_row, get_or_create_stats
 from services.praxis import (
     _count_in_progress_praxes,
@@ -67,6 +68,73 @@ async def get_duel_for_praxis(praxis_id: int, session: AsyncSession) -> Optional
         )
     )
     return result.scalar_one_or_none()
+
+
+async def get_duel_detail(
+    duel_id: int,
+    viewer: Optional[Character],
+    session: AsyncSession,
+) -> DuelDetailOut:
+    """Read-oriented duel view for the praxis read page (#308).
+
+    Returns both sides' display info + live vote points in one round trip, plus
+    ``viewer_is_participant`` (account-level, mirroring #309) which drives the
+    opponent-side anti-vote UI. Never returns a praxis body — a forfeited or
+    unsubmitted side still renders name/avatar but ``is_submitted`` is False.
+    """
+    duel = await get_duel(duel_id, session)
+
+    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+    opponent_praxis = (
+        await session.get(Praxis, duel.opponent_praxis_id)
+        if duel.opponent_praxis_id is not None
+        else None
+    )
+    challenger_character = (
+        await session.get(Character, challenger_praxis.created_by_id)
+        if challenger_praxis is not None
+        else None
+    )
+    opponent_character = await session.get(Character, duel.opponent_character_id)
+
+    praxis_ids = [
+        pid
+        for pid in (duel.challenger_praxis_id, duel.opponent_praxis_id)
+        if pid is not None
+    ]
+    tallies = await tally_votes(praxis_ids, session)
+
+    def _side(character: Optional[Character], praxis: Optional[Praxis], praxis_id: Optional[int]) -> DuelSideOut:
+        return DuelSideOut(
+            praxis_id=praxis_id,
+            character_id=character.id if character is not None else 0,
+            display_name=character.display_name if character is not None else "",
+            faction_slug=(character.faction_slug or "na") if character is not None else "na",
+            avatar_url=character.avatar_url if character is not None else "",
+            points_from_votes=(
+                get_tally(tallies, praxis_id).points_from_votes if praxis_id is not None else 0
+            ),
+            is_submitted=praxis is not None and praxis.status == PraxisStatus.submitted,
+        )
+
+    participant_account_ids = {
+        character.account_id
+        for character in (challenger_character, opponent_character)
+        if character is not None
+    }
+    viewer_is_participant = (
+        viewer is not None and viewer.account_id in participant_account_ids
+    )
+
+    return DuelDetailOut(
+        id=duel.id,
+        task_id=duel.task_id,
+        status=duel.status,
+        forfeited_by_character_id=duel.forfeited_by_character_id,
+        challenger=_side(challenger_character, challenger_praxis, duel.challenger_praxis_id),
+        opponent=_side(opponent_character, opponent_praxis, duel.opponent_praxis_id),
+        viewer_is_participant=viewer_is_participant,
+    )
 
 
 async def issue_duel_challenge(

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -842,3 +842,127 @@ async def test_ban_forfeits_settled_duels(
         [challenger_praxis], character, CURRENT_ERA, db_session
     )
     assert contribs[challenger_pid].duel_multiplier == win
+
+
+# ---------------------------------------------------------------------------
+# Read-oriented duel detail (#308) — GET /duels/{id}/detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duel_detail_returns_both_sides_with_tallies(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Settled-duel detail: both sides' display info + live vote points in one call.
+
+    ``viewer_is_participant`` is True for a side's account, False for a third
+    party and for anonymous. No praxis body is ever included.
+    """
+    from models.duel import Duel, DuelStatus
+    from services.auth import create_jwt
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_pid,
+        opponent_character_id=character2.id,
+        opponent_praxis_id=opponent_pid,
+        status=DuelStatus.settled,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    # A non-participant third party votes on the challenger side.
+    third = Account(email="duel_detail_voter@example.com")
+    db_session.add(third)
+    await db_session.flush()
+    third_char = Character(
+        account_id=third.id,
+        username="duel_detail_voter",
+        display_name="DD Voter",
+        faction_slug="ua",
+    )
+    db_session.add(third_char)
+    await db_session.flush()
+    db_session.add(CharacterStats(
+        character_id=third_char.id, era_id=era.id, score=100,
+        all_time_score=100, level=3, votes_spent_this_era=0,
+    ))
+    await db_session.commit()
+    third_headers = {"Authorization": f"Bearer {create_jwt(third.id)}"}
+    assert (await client.post(
+        f"/praxes/{challenger_pid}/vote", json={"value": 4}, headers=third_headers
+    )).status_code == 200
+
+    resp = await client.get(f"/duels/{duel.id}/detail", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "settled"
+    assert body["forfeited_by_character_id"] is None
+    assert body["viewer_is_participant"] is True
+    assert body["challenger"]["character_id"] == character.id
+    assert body["challenger"]["display_name"] == character.display_name
+    assert body["challenger"]["is_submitted"] is True
+    assert body["challenger"]["points_from_votes"] > 0
+    assert body["opponent"]["character_id"] == character2.id
+    assert body["opponent"]["points_from_votes"] == 0
+    assert "body_text" not in body["challenger"]  # never leak the praxis body
+
+    # Third party and anonymous are not participants.
+    assert (await client.get(
+        f"/duels/{duel.id}/detail", headers=third_headers
+    )).json()["viewer_is_participant"] is False
+    anon = await client.get(f"/duels/{duel.id}/detail")
+    assert anon.status_code == 200
+    assert anon.json()["viewer_is_participant"] is False
+
+
+@pytest.mark.asyncio
+async def test_duel_detail_marks_forfeited_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    era: Era,
+):
+    """A forfeited duel: winner renders fully, thrown side marked unsubmitted, no body leak."""
+    from models.duel import Duel, DuelStatus
+    from services.praxis import withdraw_praxis
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_pid,
+        opponent_character_id=character2.id,
+        opponent_praxis_id=opponent_pid,
+        status=DuelStatus.settled,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    # character2 forfeits by unsubmitting their side; commit so the API view sees it.
+    await withdraw_praxis(opponent_pid, character2.id, db_session)
+    await db_session.commit()
+
+    resp = await client.get(f"/duels/{duel.id}/detail")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "settled"
+    assert body["forfeited_by_character_id"] == character2.id
+    assert body["challenger"]["is_submitted"] is True
+    assert body["opponent"]["is_submitted"] is False
+    assert body["opponent"]["display_name"] == character2.display_name
+    assert "body_text" not in body["opponent"]

--- a/frontend/src/api/duel.ts
+++ b/frontend/src/api/duel.ts
@@ -27,6 +27,26 @@ export interface DuelRespondIn {
   accept: boolean
 }
 
+export interface DuelSideOut {
+  praxis_id: number | null
+  character_id: number
+  display_name: string
+  faction_slug: string
+  avatar_url: string
+  points_from_votes: number
+  is_submitted: boolean
+}
+
+export interface DuelDetailOut {
+  id: number
+  task_id: number
+  status: DuelStatus
+  forfeited_by_character_id: number | null
+  challenger: DuelSideOut
+  opponent: DuelSideOut
+  viewer_is_participant: boolean
+}
+
 // ---------------------------------------------------------------------------
 // API functions
 // ---------------------------------------------------------------------------
@@ -38,6 +58,11 @@ export async function issueChallenge(data: DuelChallengeIn): Promise<DuelOut> {
 
 export async function getDuel(duelId: number): Promise<DuelOut> {
   const { data } = await api.get<DuelOut>(`/duels/${duelId}`)
+  return data
+}
+
+export async function getDuelDetail(duelId: number): Promise<DuelDetailOut> {
+  const { data } = await api.get<DuelDetailOut>(`/duels/${duelId}/detail`)
   return data
 }
 


### PR DESCRIPTION
## What

The read-page duel cross-link (design D1 / build F3) needs opponent display data + live vote tallies that `DuelOut` (ids only) doesn't carry. Adds `GET /duels/{id}/detail` returning both sides + tallies in **one round trip**.

## Response (`DuelDetailOut`)
- `status`, `forfeited_by_character_id`
- `challenger` / `opponent` (`DuelSideOut`): `praxis_id`, `character_id`, `display_name`, `faction_slug`, `avatar_url`, `points_from_votes`, `is_submitted`
- `viewer_is_participant` — account-level (mirrors #309), drives the opponent-side anti-vote UI (B4)

## Notes
- **No body leak by construction**: the endpoint returns only side metadata + tallies, never the praxis body. A forfeited / unsubmitted / banned side still renders name + avatar with `is_submitted=False`; its body stays behind the normal `in_progress` 404 (ADR-0024).
- Reuses `tally_votes` for points and reads display fields straight off `Character`. Optional viewer (`get_current_character_optional`) so the public read page can call it anonymously.
- `frontend/src/api/duel.ts` — `getDuelDetail` + `DuelDetailOut` / `DuelSideOut` types.

## Tests
`test_votes.py`: settled-duel detail returns both sides with tallies, `viewer_is_participant` True for a side / False for third-party + anon, no `body_text` in the payload; forfeited duel marks the thrown side `is_submitted=False` and surfaces `forfeited_by_character_id`. Full backend suite green (507); frontend `tsc` + `vitest` (118) + `build` green.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)