### PR TITLE
feat: make Sidebar pending invites/challenges actionable (closes #319)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -123,11 +123,13 @@ export default function Sidebar() {
             {pendingRequests.map((item, index) => {
               const isCollab = item.type === 'collab_invite'
               return (
-                <div
+                <Link
                   key={`${item.type}-${index}`}
+                  to="/updates?filter=requests"
                   className="flex items-center gap-2 py-1.5"
                   style={{
                     borderTop: index > 0 ? '1px dashed var(--color-border)' : undefined,
+                    textDecoration: 'none',
                   }}
                 >
                   <div
@@ -146,7 +148,7 @@ export default function Sidebar() {
                       {isCollab ? 'Collab Invite' : 'Duel Challenge'}
                     </span>
                   </div>
-                </div>
+                </Link>
               )
             })}
           </div>

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { getActivityFeed, type ActivityFeedItem, type FeedCounts } from '../api/activityFeed'
 import PageTitle from '../components/ui/PageTitle'
 import FeedCardRouter from '../components/feed/FeedCardRouter'
@@ -33,9 +34,16 @@ function getCount(filter: FeedFilter, counts: FeedCounts): number {
 }
 
 export default function Updates() {
+  const [searchParams] = useSearchParams()
   const [items, setItems] = useState<ActivityFeedItem[]>([])
   const [counts, setCounts] = useState<FeedCounts>({ all: 0, friends: 0, foes: 0, your_stuff: 0, global_count: 0, requests: 0 })
-  const [filter, setFilter] = useState<FeedFilter>('All')
+  // Deep-link the initial tab from ?filter=<api value> (e.g. Sidebar → Requests).
+  const [filter, setFilter] = useState<FeedFilter>(() => {
+    const apiFilter = searchParams.get('filter')
+    return (Object.keys(FILTER_API_MAP) as FeedFilter[]).find(
+      (name) => FILTER_API_MAP[name] === apiFilter,
+    ) ?? 'All'
+  })
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [nextCursor, setNextCursor] = useState<string | null>(null)


### PR DESCRIPTION
## What
The Sidebar "Pending Requests" panel rendered invites/challenges as display-only labels — the invitee had to hunt for the matching card in the feed. Now each item is **one click** from being actioned.

## Changes
- `Sidebar.tsx` — each pending-request row is a `Link` to `/updates?filter=requests` (the accept/decline cards live in the feed's Requests tab).
- `Updates.tsx` — initial tab reads from the `?filter=<api value>` query param (lazy `useState` initializer, reverse of `FILTER_API_MAP`), defaulting to `All`. So the Sidebar link deep-links straight to Requests.

Minimal per the issue ("link the item to the requests view; don't rebuild the accept/decline card in the sidebar"). tsc + vitest (118) + build green.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)