### PR TITLE
feat: InviteSearch pre-filters players already active on the task (closes #320)

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -38,13 +38,23 @@ router = APIRouter()
 async def list_characters(
     search: Optional[str] = None,
     faction: Optional[str] = None,
+    exclude_active_task_id: Optional[int] = None,
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_db),
 ):
-    """List all active characters. Optionally filter by name or faction."""
+    """List all active characters. Optionally filter by name or faction.
+
+    ``exclude_active_task_id`` hides players already active on that task (invite
+    search pre-filter, #320).
+    """
     rows = await list_characters_for_viewer(
-        session, search=search, faction_slug=faction, limit=limit, offset=offset
+        session,
+        search=search,
+        faction_slug=faction,
+        exclude_active_task_id=exclude_active_task_id,
+        limit=limit,
+        offset=offset,
     )
     return [build_character_out(character, stats) for character, stats in rows]
 

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -12,7 +12,7 @@ from models.account import Account
 from models.character import Character, CharacterStatus
 from models.character_stats import CharacterStats
 from models.invitation_letter import InvitationLetter
-from models.praxis import ModerationStatus, Praxis, PraxisStatus
+from models.praxis import ModerationStatus, Praxis, PraxisMember, PraxisStatus
 from models.task import Task
 from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
 from services.era import get_current_era_row, get_current_era_row_safe, get_or_create_stats
@@ -473,10 +473,20 @@ async def list_characters_for_viewer(
     *,
     search: Optional[str] = None,
     faction_slug: Optional[str] = None,
+    exclude_active_task_id: Optional[int] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[tuple[Character, CharacterStats | None]]:
-    """List active characters with current-era stats. Optional name/faction filters."""
+    """List active characters with current-era stats. Optional name/faction filters.
+
+    ``exclude_active_task_id`` drops characters who already hold an active
+    (in_progress or submitted) praxis membership for that task — so the invite
+    search doesn't surface players the backend would 409 (#320). Everymen are
+    never excluded (Double Dipper perk: they may hold multiple memberships per
+    task), mirroring :func:`services.praxis.is_active_member_of_task`.
+    """
+    from services.praxis import EVERYMEN_FACTION_SLUG
+
     era_row = await get_current_era_row_safe(session)
     era_id = era_row.id if era_row else None
 
@@ -492,6 +502,21 @@ async def list_characters_for_viewer(
         )
     if faction_slug:
         query = query.where(Character.faction_slug == faction_slug)
+    if exclude_active_task_id is not None:
+        active_member_ids = (
+            select(PraxisMember.character_id)
+            .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+            .where(
+                Praxis.task_id == exclude_active_task_id,
+                Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.submitted]),
+            )
+        )
+        query = query.where(
+            or_(
+                Character.faction_slug == EVERYMEN_FACTION_SLUG,
+                Character.id.notin_(active_member_ids),
+            )
+        )
     query = (
         query.order_by(CharacterStats.score.desc().nulls_last())
         .limit(limit)

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -163,6 +163,32 @@ async def test_list_characters_faction_no_match(client: AsyncClient, character: 
 
 
 @pytest.mark.asyncio
+async def test_list_characters_excludes_players_active_on_task(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """exclude_active_task_id hides players already active on that task (#320)."""
+    # character2 signs up solo on the task → active member for it.
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo"},
+        headers=auth_headers2,
+    )
+    assert create.status_code == 201
+
+    resp = await client.get(
+        "/characters", params={"exclude_active_task_id": active_task.id}
+    )
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert character2.id not in ids  # active on the task → hidden
+    assert character.id in ids  # not active → still listed
+
+
+@pytest.mark.asyncio
 async def test_list_characters_limit_offset(
     client: AsyncClient, character: Character, character2: Character
 ):

--- a/frontend/src/api/characters.ts
+++ b/frontend/src/api/characters.ts
@@ -25,7 +25,13 @@ export interface CharacterUpdate {
   location?: string
 }
 
-export async function listCharacters(params?: { search?: string; faction?: string; limit?: number }): Promise<CharacterOut[]> {
+export async function listCharacters(params?: {
+  search?: string
+  faction?: string
+  /** Hide players already active on this task (invite-search pre-filter, #320). */
+  exclude_active_task_id?: number
+  limit?: number
+}): Promise<CharacterOut[]> {
   const { data } = await api.get<CharacterOut[]>('/characters', { params })
   return data
 }

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -391,7 +391,11 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     let cancelled = false;
     void (async () => {
       try {
-        const results = await listCharacters({ search: inviteQuery, limit: 8 });
+        const results = await listCharacters({
+          search: inviteQuery,
+          exclude_active_task_id: praxis.task_id,
+          limit: 8,
+        });
         if (cancelled) return;
         const memberIds = new Set(praxis.members.map((m) => m.character_id));
         const pendingInviteIds = new Set(


### PR DESCRIPTION
## What
The edit-page invite search filtered out yourself, current members, and pending invitees — but not players **already active on the task**. The backend rejects those with a 409, so the inviter only learned after clicking.

## Why backend, not client-side
`in_progress` praxes are member-only visible (ADR-0024), so the client can't enumerate who's active on a task. Per the issue's fallback, the search endpoint is widened instead.

## Changes
- `GET /characters` — new optional `exclude_active_task_id`. `list_characters_for_viewer` drops characters holding an `in_progress`/`submitted` membership for that task, **exempting Everymen** (Double Dipper perk), exactly mirroring `services.praxis.is_active_member_of_task`.
- `frontend/src/api/characters.ts` + `useEditPraxis.ts` — invite search passes the praxis's `task_id` as `exclude_active_task_id`.

## Tests
`test_characters.py`: a player active on the task is hidden from the results; a non-active player still appears. Full backend suite green (508); frontend tsc + vitest (118) + build green.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)