### PR TITLE
feat: backend for mode-switch rework — dissolve active duels + in-place solo↔collab (#311, #321)

### DIFF
--- a/backend/routers/duel.py
+++ b/backend/routers/duel.py
@@ -95,10 +95,11 @@ async def cancel_challenge_route(
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    """Challenger cancels a pending duel challenge."""
+    """Dissolve a pending or active duel — any participant. Both sides revert to plain solo."""
     duel = await cancel_duel_challenge(
         duel_id=duel_id,
         character_id=character.id,
         session=session,
+        era=CURRENT_ERA,
     )
     return DuelOut.model_validate(duel)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -46,6 +46,7 @@ from services.praxis import (
     build_praxis_out,
     can_view_praxis,
     cancel_pending_publish_on_edit,
+    change_praxis_type,
     create_praxis,
     delete_praxis,
     flag_praxis,
@@ -214,6 +215,28 @@ async def submit_praxis_route(
 ):
     praxis = await submit_praxis(
         praxis_id=praxis_id,
+        character_id=character.id,
+        session=session,
+        era=CURRENT_ERA,
+    )
+    return await build_praxis_out(praxis, session, viewer=character)
+
+
+class PraxisTypeChange(BaseModel):
+    type: PraxisType
+
+
+@router.post("/{praxis_id}/change-type", response_model=PraxisOut)
+async def change_praxis_type_route(
+    praxis_id: int,
+    data: PraxisTypeChange,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Flip a praxis between solo and collab in place (#321) — content/id/media kept."""
+    praxis = await change_praxis_type(
+        praxis_id=praxis_id,
+        new_type=data.type,
         character_id=character.id,
         session=session,
         era=CURRENT_ERA,

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -303,23 +303,40 @@ async def cancel_duel_challenge(
     duel_id: int,
     character_id: int,
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
 ) -> Duel:
-    """Challenger cancels a pending duel challenge.
+    """Dissolve a pending *or* active duel — any participant may (ADR-0011 §Forfeit grill).
 
-    Transitions Duel → declined. Challenger's praxis remains as a plain solo
-    praxis (convert-to-solo).
+    Transitions Duel → declined; both sides remain plain ``type=solo`` praxes
+    (convert-to-solo, no penalty). "If they don't want it to be a duel, it
+    becomes a single task for both parties." An *active* duel may already have a
+    submitted side scored with the duel multiplier, so both participants are
+    recalculated to revert to plain-solo scoring.
     """
     duel = await get_duel(duel_id, session)
 
-    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
-    if challenger_praxis is None or challenger_praxis.created_by_id != character_id:
-        raise HTTPException(status_code=403, detail="Only the challenger can cancel.")
+    if duel.status not in (DuelStatus.pending, DuelStatus.active):
+        raise HTTPException(status_code=400, detail="Duel has already been resolved.")
 
-    if duel.status != DuelStatus.pending:
-        raise HTTPException(status_code=400, detail="Challenge has already been resolved.")
+    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+    challenger_character_id = (
+        challenger_praxis.created_by_id if challenger_praxis is not None else None
+    )
+    if character_id not in (challenger_character_id, duel.opponent_character_id):
+        raise HTTPException(status_code=403, detail="Only a duel participant can end it.")
 
     duel.status = DuelStatus.declined
     duel.declined_at = datetime.now(timezone.utc)
+    await session.flush()
+
+    # An active duel may have a submitted side scored with the duel multiplier;
+    # recalc both participants so they revert to plain-solo scoring.
+    era_row = await get_current_era_row(session)
+    for participant_id in {challenger_character_id, duel.opponent_character_id}:
+        if participant_id is not None:
+            await recalculate_character_stats(
+                participant_id, session, era, era_row=era_row
+            )
     await session.flush()
     return duel
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -608,6 +608,77 @@ async def withdraw_praxis(
     return await get_praxis(praxis_id, session)
 
 
+async def change_praxis_type(
+    praxis_id: int,
+    new_type: PraxisType,
+    character_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Praxis:
+    """Flip a praxis between ``solo`` and ``collab`` in place (#321).
+
+    Preserves content, **id**, and media — never delete+recreate. Guards: the
+    praxis must be ``in_progress``; the actor must be a member; a duel side
+    (it has a live ``Duel`` row) must dissolve the duel first; ``collab``
+    requires ``era.collaboration_level_required``. ``duel`` is not a target here
+    — a duel is a solo praxis + ``Duel`` row (ADR-0011), issued via the challenge
+    endpoint.
+
+    ``collab → solo`` is an intentional **takeover** (grill 2026-07-01): any
+    member may do it and becomes the sole owner — ``created_by_id`` is reassigned
+    to the actor, every other member and pending invite is dropped, content is
+    kept. Trust has stakes.
+    """
+    if new_type not in (PraxisType.solo, PraxisType.collab):
+        raise HTTPException(
+            status_code=400, detail="Can only switch between solo and collab."
+        )
+
+    praxis = await get_praxis(praxis_id, session)
+    _require_member(praxis, character_id, "change the mode of")
+    if praxis.status != PraxisStatus.in_progress:
+        raise HTTPException(
+            status_code=422, detail="Can only change mode while the praxis is in editing."
+        )
+    if praxis.type == new_type:
+        return praxis
+
+    # A duel side is a solo praxis + Duel row; dissolve the duel before switching.
+    from services.duel import get_duel_for_praxis
+
+    if await get_duel_for_praxis(praxis_id, session) is not None:
+        raise HTTPException(
+            status_code=409, detail="End the duel before changing this praxis's mode."
+        )
+
+    if new_type == PraxisType.collab:
+        era_row = await get_current_era_row(session)
+        stats = await get_or_create_stats(session, character_id, era_row.id)
+        if stats.level < era.collaboration_level_required:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Collaborations require level {era.collaboration_level_required}.",
+            )
+        praxis.type = PraxisType.collab
+    else:
+        # collab → solo: the actor takes it over as their own solo praxis.
+        # Mutate the loaded collections so the delete-orphan cascade fires *and*
+        # the returned/serialized praxis reflects the drop (session.delete alone
+        # would leave the selectin-cached collections stale).
+        praxis.type = PraxisType.solo
+        praxis.created_by_id = character_id
+        for member in list(praxis.members):
+            if member.character_id != character_id:
+                praxis.members.remove(member)
+        for invite in list(praxis.invites):
+            if invite.status == PraxisInviteStatus.pending:
+                praxis.invites.remove(invite)
+
+    # in_progress praxes aren't scored, so no stat recalc is needed here.
+    await session.flush()
+    return await get_praxis(praxis_id, session)
+
+
 async def delete_praxis(
     praxis_id: int,
     character_id: int,

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1855,3 +1855,104 @@ async def test_everymen_can_be_invited_despite_active_collab(
         headers=headers_b,
     )
     assert reinvite.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# change-type — solo <-> collab in place (#321)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_change_type_solo_to_collab_preserves_id_and_content(
+    client: AsyncClient,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """solo → collab flips in place: same id, title, and body preserved (#321)."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Keep me", "body_text": "and me"},
+        headers=auth_headers2,
+    )
+    assert create.status_code == 201
+    pid = create.json()["id"]
+
+    resp = await client.post(
+        f"/praxes/{pid}/change-type", json={"type": "collab"}, headers=auth_headers2
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == pid  # same praxis, not a recreate
+    assert body["type"] == "collab"
+    assert body["title"] == "Keep me"
+    assert body["body_text"] == "and me"
+
+
+@pytest.mark.asyncio
+async def test_change_type_collab_to_solo_is_a_takeover(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """collab → solo by a co-author is a takeover: actor becomes sole owner,
+    other members dropped, content kept (grill 2026-07-01, #321)."""
+    # character2 (level 5) creates the collab; content lives on it.
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Shared work"},
+        headers=auth_headers2,
+    )
+    assert create.status_code == 201, create.text
+    pid = create.json()["id"]
+
+    # character joins as a co-author.
+    db_session.add(PraxisMember(praxis_id=pid, character_id=character.id, has_submitted=False))
+    await db_session.commit()
+
+    # character (a non-creator member) takes it over → solo.
+    resp = await client.post(
+        f"/praxes/{pid}/change-type", json={"type": "solo"}, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["type"] == "solo"
+    assert body["title"] == "Shared work"  # content kept
+    assert body["created_by_id"] == character.id  # ownership transferred to the actor
+    member_ids = {m["character_id"] for m in body["members"]}
+    assert member_ids == {character.id}  # co-authors (incl. original creator) dropped
+
+
+@pytest.mark.asyncio
+async def test_change_type_rejects_duel_side(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """A duel side can't switch mode — dissolve the duel first (409)."""
+    from models.duel import Duel, DuelStatus
+
+    create = await client.post(
+        "/praxes", json={"task_id": active_task.id, "type": "solo"}, headers=auth_headers2
+    )
+    assert create.status_code == 201
+    pid = create.json()["id"]
+    db_session.add(Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=pid,
+        opponent_character_id=character.id,
+        status=DuelStatus.pending,
+    ))
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/praxes/{pid}/change-type", json={"type": "collab"}, headers=auth_headers2
+    )
+    assert resp.status_code == 409

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -927,6 +927,53 @@ async def test_duel_detail_returns_both_sides_with_tallies(
 
 
 @pytest.mark.asyncio
+async def test_either_participant_dissolves_active_duel(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    era: Era,
+):
+    """An active (accepted) duel can be dissolved by either participant → declined;
+    both sides revert to plain solo, no penalty (grill 2026-07-01)."""
+    from models.character_stats import CharacterStats
+
+    # Raise the opponent (character) to the duel level so they can accept.
+    stats = (await db_session.execute(
+        select(CharacterStats).where(CharacterStats.character_id == character.id)
+    )).scalar_one()
+    stats.level = 2
+    await db_session.commit()
+
+    _pid, challenge_resp = await _challenge_from_new_praxis(
+        client, auth_headers2, active_task.id, character.id
+    )
+    assert challenge_resp.status_code == 201
+    duel = challenge_resp.json()
+    duel_id = duel["id"]
+
+    accept = await client.post(
+        f"/duels/{duel_id}/respond", json={"accept": True}, headers=auth_headers
+    )
+    assert accept.status_code == 200
+    assert accept.json()["status"] == "active"
+
+    # The OPPONENT (not the challenger) dissolves the active duel.
+    dissolve = await client.post(f"/duels/{duel_id}/cancel", headers=auth_headers)
+    assert dissolve.status_code == 200
+    assert dissolve.json()["status"] == "declined"
+
+    # Both sides are now plain solo praxes (the Duel is unlinked).
+    from services.duel import get_duel_for_praxis
+
+    assert await get_duel_for_praxis(duel["challenger_praxis_id"], db_session) is None
+    assert await get_duel_for_praxis(accept.json()["opponent_praxis_id"], db_session) is None
+
+
+@pytest.mark.asyncio
 async def test_duel_detail_marks_forfeited_side(
     client: AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
Backend prerequisites for the edit-page mode-picker rework (#311 + #321), from the 2026-07-01 grill. Frontend lands in a follow-up PR that closes both issues.

## 1. Dissolve pending *or* active duels (either participant)
`cancel_duel_challenge` now accepts `pending` **and** `active`, by **either** participant (not just the challenger). Sets the `Duel` → `declined`; both sides remain plain `type=solo`, no penalty — "if they don't want it to be a duel, it becomes a single task for both parties." An active duel can have a submitted side scored with the duel multiplier, so both participants are recalculated back to plain-solo scoring. `POST /duels/{id}/cancel` unchanged in shape.

## 2. `POST /praxes/{id}/change-type` — in-place solo↔collab
`change_praxis_type` flips `Praxis.type` between solo and collab **in place**, preserving content, **id**, and media (no delete+recreate). Guards: `in_progress`; member-only; **reject a duel side (409)** — dissolve the duel first; collab requires `collaboration_level_required`. **`collab→solo` is an intentional takeover** (grilled): any member may do it and becomes the **sole owner** — `created_by_id` reassigned to the actor, other members + pending invites dropped, content kept.

## Tests
- Either participant dissolves an active duel → `declined`, both sides unlinked from the Duel.
- `solo→collab` keeps id + title + body; `collab→solo` by a co-author transfers ownership and drops the original creator; a duel side is rejected (409).

Full backend suite green locally (512).

Refs #311, #321
🤖 Generated with [Claude Code](https://claude.com/claude-code)