### PR TITLE
feat: edit-page duel challenge + in-place solo↔collab switch (closes #311, #321, #294)

### DIFF
--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -45,6 +45,8 @@ async def get_game_config() -> GameConfigOut:
     return GameConfigOut(
         era_name=CURRENT_ERA.name,
         level_thresholds=list(CURRENT_ERA.level_thresholds),
+        duel_level_required=CURRENT_ERA.duel_level_required,
+        collaboration_level_required=CURRENT_ERA.collaboration_level_required,
         max_task_signups=CURRENT_ERA.max_task_signups,
         vote_budget_base=CURRENT_ERA.vote_budget_base,
         vote_budget_multiplier=CURRENT_ERA.vote_budget_multiplier,

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -26,6 +26,7 @@ from schemas.praxis import (
     PraxisCreate,
     PraxisInviteCreate,
     PraxisOut,
+    PraxisTypeChange,
     PraxisUpdate,
     PraxisVoteIn,
 )
@@ -46,6 +47,7 @@ from services.praxis import (
     build_praxis_out,
     can_view_praxis,
     cancel_pending_publish_on_edit,
+    change_praxis_type,
     create_praxis,
     delete_praxis,
     flag_praxis,
@@ -165,6 +167,24 @@ async def update_praxis_route(
     praxis = await update_praxis(
         praxis_id=praxis_id,
         data=data,
+        character_id=character.id,
+        session=session,
+        era=CURRENT_ERA,
+    )
+    return await build_praxis_out(praxis, session, viewer=character)
+
+
+@router.post("/{praxis_id}/change-type", response_model=PraxisOut)
+async def change_praxis_type_route(
+    praxis_id: int,
+    data: PraxisTypeChange,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Flip a praxis between solo and collab in place (#321), preserving content/media."""
+    praxis = await change_praxis_type(
+        praxis_id=praxis_id,
+        new_type=data.type,
         character_id=character.id,
         session=session,
         era=CURRENT_ERA,

--- a/backend/schemas/game_config.py
+++ b/backend/schemas/game_config.py
@@ -29,6 +29,8 @@ class LevelProfileOut(BaseModel):
 class GameConfigOut(BaseModel):
     era_name: str
     level_thresholds: list[int]
+    duel_level_required: int
+    collaboration_level_required: int
     max_task_signups: int
     vote_budget_base: int
     vote_budget_multiplier: float

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -110,6 +110,12 @@ class PraxisUpdate(BaseModel):
     body_text: Optional[str] = None
 
 
+class PraxisTypeChange(BaseModel):
+    """Body for the in-place solo↔collab mode switch (#321)."""
+
+    type: PraxisType
+
+
 class PraxisInviteCreate(BaseModel):
     invitee_id: int
 

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -163,6 +163,12 @@ async def issue_duel_challenge(
             status_code=422,
             detail="A duel can only start from an in-progress praxis.",
         )
+    # A duel side is a solo praxis (ADR-0011); duel and collab are mutually exclusive.
+    if challenger_praxis.type != PraxisType.solo:
+        raise HTTPException(
+            status_code=422,
+            detail="Only a solo praxis can issue a duel challenge.",
+        )
     if await get_duel_for_praxis(challenger_praxis_id, session) is not None:
         raise HTTPException(
             status_code=409,

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -545,6 +545,86 @@ async def update_praxis(
     return await get_praxis(praxis_id, session)
 
 
+async def change_praxis_type(
+    praxis_id: int,
+    new_type: PraxisType,
+    character_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> Praxis:
+    """Flip a praxis between solo and collab in place, preserving id/content/media (#321).
+
+    A collab is just a ``type=solo`` praxis + members; recreation is unnecessary
+    and destructive (the old flow ``delete_praxis`` + ``create_praxis`` discarded
+    the draft). This flips ``Praxis.type`` instead.
+
+    Guards:
+    - Only the author may change mode.
+    - Praxis must be ``in_progress``.
+    - Target must be solo or collab — duels are issued via the challenge endpoint
+      (ADR-0011), never a direct type change.
+    - solo → collab requires ``era.collaboration_level_required``.
+    - A duel side (a solo praxis linked by a live Duel row) cannot change type.
+
+    solo → collab flips the type; collab → solo drops every non-author member and
+    any pending invites (the caller confirms this loss first).
+    """
+    if new_type not in (PraxisType.solo, PraxisType.collab):
+        raise HTTPException(
+            status_code=400,
+            detail="Only solo and collab modes can be switched in place; duels use the challenge endpoint (ADR-0011).",
+        )
+
+    praxis = await get_praxis(praxis_id, session)
+    if praxis.created_by_id != character_id:
+        raise HTTPException(status_code=403, detail="Only the author can change the praxis mode.")
+    if praxis.status != PraxisStatus.in_progress:
+        raise HTTPException(status_code=422, detail="Only an in-progress praxis can change mode.")
+
+    # A duel side is a solo praxis linked by a Duel row; never let it morph.
+    duel_result = await session.execute(
+        select(Duel.id).where(
+            or_(
+                Duel.challenger_praxis_id == praxis_id,
+                Duel.opponent_praxis_id == praxis_id,
+            ),
+            Duel.status.in_([DuelStatus.pending, DuelStatus.active, DuelStatus.settled]),
+        )
+    )
+    if duel_result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="This praxis is part of a duel and cannot change mode.",
+        )
+
+    if praxis.type == new_type:
+        return praxis
+
+    if new_type == PraxisType.collab:
+        era_row = await get_current_era_row(session)
+        stats = await get_or_create_stats(session, character_id, era_row.id)
+        if stats.level < era.collaboration_level_required:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Collaborations require level {era.collaboration_level_required}.",
+            )
+    else:
+        # collab → solo: drop everyone but the author + any pending invites.
+        # delete-orphan cascades the row DELETEs (see models/praxis.py).
+        for member in list(praxis.members):
+            if member.character_id != character_id:
+                praxis.members.remove(member)
+        for invite in list(praxis.invites):
+            if invite.status == PraxisInviteStatus.pending:
+                praxis.invites.remove(invite)
+
+    praxis.type = new_type
+    await session.flush()
+    # A type change is a structural edit — reset any collab pending-publish window.
+    await cancel_pending_publish_on_edit(praxis, session, era)
+    return await get_praxis(praxis_id, session)
+
+
 async def withdraw_praxis(
     praxis_id: int,
     character_id: int,

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -981,6 +981,117 @@ async def test_solo_submit_opens_no_window(
 
 
 # ---------------------------------------------------------------------------
+# Change type (in-place solo↔collab, #321)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_change_type_solo_to_collab_preserves_content(
+    client: AsyncClient,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """solo → collab keeps the same id, title, and body (no delete+recreate).
+
+    Actor is character2 (level 5) to clear the collaboration level gate.
+    """
+    create_resp = await client.post(
+        "/praxes",
+        json={
+            "task_id": active_task.id,
+            "type": "solo",
+            "title": "Keep me",
+            "body_text": "draft body",
+        },
+        headers=auth_headers2,
+    )
+    praxis_id = create_resp.json()["id"]
+
+    resp = await client.post(
+        f"/praxes/{praxis_id}/change-type",
+        json={"type": "collab"},
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == praxis_id
+    assert data["type"] == "collab"
+    assert data["title"] == "Keep me"
+    assert data["body_text"] == "draft body"
+
+
+@pytest.mark.asyncio
+async def test_change_type_collab_to_solo_drops_members_keeps_content(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """collab → solo drops the co-author but preserves id/title (author = level-5 character2)."""
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    resp = await client.post(
+        f"/praxes/{praxis_id}/change-type",
+        json={"type": "solo"},
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == praxis_id
+    assert data["type"] == "solo"
+    assert {m["character_id"] for m in data["members"]} == {character2.id}
+
+
+@pytest.mark.asyncio
+async def test_change_type_to_duel_rejected(
+    client: AsyncClient,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """Duels are issued via the challenge endpoint, not a direct type change."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "x"},
+        headers=auth_headers2,
+    )
+    praxis_id = create_resp.json()["id"]
+    resp = await client.post(
+        f"/praxes/{praxis_id}/change-type",
+        json={"type": "duel"},
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_collab_cannot_issue_duel_challenge(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """A duel side must be solo (ADR-0011) — a collab praxis can't challenge."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "crew"},
+        headers=auth_headers2,
+    )
+    collab_id = create_resp.json()["id"]
+    resp = await client.post(
+        "/duels/challenge",
+        json={"challenger_praxis_id": collab_id, "opponent_character_id": character.id},
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
 # Moderation
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/api/gameConfig.ts
+++ b/frontend/src/api/gameConfig.ts
@@ -30,6 +30,8 @@ export interface LevelProfile {
 export interface GameConfigOut {
   era_name: string
   level_thresholds: number[]
+  duel_level_required: number
+  collaboration_level_required: number
   max_task_signups: number
   vote_budget_base: number
   vote_budget_multiplier: number

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -149,6 +149,12 @@ export async function deletePraxis(id: number): Promise<void> {
   await api.delete(`/praxes/${id}`)
 }
 
+/** Flip a praxis between solo and collab in place, preserving id/content/media (#321). */
+export async function changePraxisType(id: number, type: PraxisType): Promise<PraxisOut> {
+  const { data } = await api.post<PraxisOut>(`/praxes/${id}/change-type`, { type })
+  return data
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle transitions
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
@@ -227,10 +227,10 @@ export default function EditPraxisEphemeris({ state }: Props) {
         )}
 
         {/* invite (collab / duel) */}
-        {state.showCollabInvite && !(praxis.type === "duel" && state.duelSlotFull) && (
+        {state.showInviteBox && (
           <div style={{ marginBottom: 28 }}>
-            <FieldLabel meta={praxis.type === "duel" ? "name the disputant" : "name the co-witness"}>
-              {praxis.type === "duel" ? "IN DISPUTE WITH" : "IN CONCORD WITH"}
+            <FieldLabel meta={state.duelMode ? "name the disputant" : "name the co-witness"}>
+              {state.duelMode ? "IN DISPUTE WITH" : "IN CONCORD WITH"}
             </FieldLabel>
             <InviteSearch
               state={state}

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
@@ -22,6 +22,7 @@ import {
   BodyPreview,
   BodyTextarea,
   DropButton,
+  InviteSearch,
   ModePicker,
   PublishButton,
   TitleField,
@@ -376,11 +377,8 @@ export default function EditPraxisEverymen({ state }: Props) {
           </div>
         )}
 
-        {/* Collab / duel invite */}
-        {state.showCollabInvite &&
-          !(praxis.type === "duel" && state.duelSlotFull) && (
-            <InviteBlock state={state} />
-          )}
+        {/* Collab invite / duel challenge */}
+        {state.showInviteBox && <InviteBlock state={state} />}
 
         {/* The job (headline) */}
         <div style={{ marginBottom: 28 }}>
@@ -714,7 +712,8 @@ function ExistingProof({ state }: { state: EditPraxisState }) {
 }
 
 function InviteBlock({ state }: { state: EditPraxisState }) {
-  const praxis = state.praxis!;
+  // Delegates to the shared InviteSearch so collab-invite and duel-challenge (#311)
+  // behaviour stay identical across archetypes; the crew-frame chrome stays bespoke.
   return (
     <div
       style={{
@@ -725,115 +724,23 @@ function InviteBlock({ state }: { state: EditPraxisState }) {
       }}
     >
       <FieldLabel>
-        {praxis.type === "duel" ? "YOUR OPPONENT" : "THE CREW ROSTER"}
+        {state.duelMode ? "YOUR OPPONENT" : "THE CREW ROSTER"}
       </FieldLabel>
-      <div
-        style={{
-          display: "flex",
-          gap: 8,
-          flexWrap: "wrap",
-          marginBottom: 10,
+      <InviteSearch
+        state={state}
+        skin={{
+          fontFamily: BODY_FONT,
+          inputBg: CREAM,
+          inputColor: INK,
+          inputBorder: `1.5px solid ${INK}`,
+          dropdownBg: PAPER,
+          dropdownBorder: `1.5px solid ${INK}`,
+          acceptedBg: OLIVE,
+          acceptedColor: CREAM,
+          pendingColor: PAPER_TEXT,
+          placeholder: "search by name or @handle",
         }}
-      >
-        {praxis.members
-          .filter((m) => m.character_id !== state.currentCharacterId)
-          .map((member) => (
-            <span
-              key={member.id}
-              style={{
-                background: OLIVE,
-                color: CREAM,
-                fontFamily: BODY_FONT,
-                fontSize: 11,
-                fontWeight: 700,
-                padding: "3px 10px",
-              }}
-            >
-              {member.character_display_name}
-            </span>
-          ))}
-        {praxis.invites
-          .filter((invite) => invite.status === "pending")
-          .map((invite) => (
-            <span
-              key={invite.id}
-              style={{
-                background: "transparent",
-                border: `1px dashed ${INK}`,
-                color: PAPER_TEXT,
-                fontFamily: BODY_FONT,
-                fontSize: 11,
-                padding: "3px 10px",
-              }}
-            >
-              {invite.invitee_display_name}{" "}
-              <span style={{ fontStyle: "italic", color: MUTED }}>
-                · pending
-              </span>
-            </span>
-          ))}
-      </div>
-      <div style={{ position: "relative" }}>
-        <input
-          type="text"
-          value={state.inviteQuery}
-          onChange={(event) => state.setInviteQuery(event.target.value)}
-          placeholder="search by name or @handle"
-          style={{
-            width: "100%",
-            fontFamily: BODY_FONT,
-            fontSize: 13,
-            padding: "9px 12px",
-            background: CREAM,
-            color: INK,
-            border: `1.5px solid ${INK}`,
-            outline: "none",
-          }}
-          onFocus={() => {
-            if (state.inviteResults.length > 0) state.setInviteOpen(true);
-          }}
-          onBlur={() => setTimeout(() => state.setInviteOpen(false), 200)}
-        />
-        {state.inviteOpen && (
-          <div
-            style={{
-              position: "absolute",
-              top: "100%",
-              left: 0,
-              right: 0,
-              zIndex: 10,
-              background: PAPER,
-              border: `1.5px solid ${INK}`,
-              boxShadow: `4px 4px 0 ${INK}`,
-              maxHeight: 220,
-              overflowY: "auto",
-            }}
-          >
-            {state.inviteResults.map((character) => (
-              <button
-                key={character.id}
-                type="button"
-                disabled={state.inviting}
-                onMouseDown={() => void state.sendInvite(character)}
-                style={{
-                  display: "block",
-                  width: "100%",
-                  padding: "9px 12px",
-                  background: "transparent",
-                  border: "none",
-                  cursor: state.inviting ? "wait" : "pointer",
-                  textAlign: "left",
-                  fontFamily: BODY_FONT,
-                  fontSize: 12,
-                  color: PAPER_TEXT,
-                }}
-              >
-                {character.display_name}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+      />
     </div>
   );
 }

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
@@ -448,8 +448,7 @@ export default function EditPraxisPaperCollage({ state }: Props) {
             )}
 
             {/* Invite */}
-            {state.showCollabInvite &&
-              !(praxis.type === "duel" && state.duelSlotFull) && (
+            {state.showInviteBox && (
                 <div
                   style={{
                     ...notepadPanel,
@@ -458,7 +457,7 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                   }}
                 >
                   <span style={{ ...eyebrowStyle, marginBottom: 10 }}>
-                    ↳ {praxis.type === "duel" ? "racing" : "walking together"}
+                    ↳ {state.duelMode ? "racing" : "walking together"}
                   </span>
                   <InviteSearch
                     state={state}

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
@@ -271,8 +271,7 @@ export default function EditPraxisPunkZine({ state }: Props) {
         )}
 
         {/* Invite */}
-        {state.showCollabInvite &&
-          !(praxis.type === "duel" && state.duelSlotFull) && (
+        {state.showInviteBox && (
             <div
               style={{
                 marginBottom: 22,
@@ -285,7 +284,7 @@ export default function EditPraxisPunkZine({ state }: Props) {
                 className="eyebrow"
                 style={{ color: hot, display: "block", marginBottom: 8 }}
               >
-                {praxis.type === "duel" ? "✗ THE OPPOSITION ✗" : "WHO ELSE"}
+                {state.duelMode ? "✗ THE OPPOSITION ✗" : "WHO ELSE"}
               </span>
               <InviteSearch
                 state={state}
@@ -294,10 +293,9 @@ export default function EditPraxisPunkZine({ state }: Props) {
                   inputBg: surface,
                   inputColor: ink,
                   inputBorder: `2px dashed ${accentDeep}`,
-                  placeholder:
-                    praxis.type === "duel"
-                      ? "@ who are you fighting?"
-                      : "@ who else?",
+                  placeholder: state.duelMode
+                    ? "@ who are you fighting?"
+                    : "@ who else?",
                   pillBg: lightBg,
                   acceptedBg: accentDeep,
                   acceptedColor: "var(--color-text-on-accent)",

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
@@ -261,8 +261,7 @@ export default function EditPraxisStickyNote({ state }: Props) {
         )}
 
         {/* Invite */}
-        {state.showCollabInvite &&
-          !(praxis.type === "duel" && state.duelSlotFull) && (
+        {state.showInviteBox && (
             <div
               style={{
                 background: STICKY_PAPER,
@@ -280,7 +279,7 @@ export default function EditPraxisStickyNote({ state }: Props) {
                   marginBottom: 6,
                 }}
               >
-                ↳ {praxis.type === "duel" ? "me v." : "who else?"}
+                ↳ {state.duelMode ? "me v." : "who else?"}
               </div>
               <InviteSearch
                 state={state}

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
@@ -259,8 +259,7 @@ export default function EditPraxisTerminal({ state }: Props) {
         )}
 
         {/* Invite */}
-        {state.showCollabInvite &&
-          !(praxis.type === "duel" && state.duelSlotFull) && (
+        {state.showInviteBox && (
             <div style={{ marginBottom: 22 }}>
               <div style={{ fontSize: 10, color: dim, marginBottom: 8 }}>
                 <span style={{ color: term }}>$ </span>wz praxis invite

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -63,23 +63,29 @@ export function InviteSearch({
                 }}
               >
                 ⚔ {state.duel?.opponent.display_name ?? "opponent"}{" "}
-                <em>· challenged</em>
-                <button
-                  type="button"
-                  onClick={() => void state.cancelDuel()}
-                  aria-label="cancel challenge"
-                  style={{
-                    background: "transparent",
-                    border: "none",
-                    color: "inherit",
-                    cursor: "pointer",
-                    fontSize: 14,
-                    lineHeight: 1,
-                    padding: 0,
-                  }}
-                >
-                  ×
-                </button>
+                <em>
+                  · {state.duel?.status === "active" ? "accepted" : "challenged"}
+                </em>
+                {/* Only a pending challenge can be withdrawn (backend forbids
+                    cancelling an accepted duel). */}
+                {(state.duel == null || state.duel.status === "pending") && (
+                  <button
+                    type="button"
+                    onClick={() => void state.cancelDuel()}
+                    aria-label="cancel challenge"
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      color: "inherit",
+                      cursor: "pointer",
+                      fontSize: 14,
+                      lineHeight: 1,
+                      padding: 0,
+                    }}
+                  >
+                    ×
+                  </button>
+                )}
               </span>
             )
           : [

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -36,52 +36,103 @@ export function InviteSearch({
   skin: InviteSearchSkin;
 }) {
   const praxis = state.praxis!;
+  // Duel mode reuses this same box as a one-opponent challenge picker (#311):
+  // picking issues a challenge; once attached, the opponent shows as a chip and
+  // the search input is hidden (a duel has exactly one opponent).
+  const duelMode = state.duelMode;
+  const challengeAttached = duelMode && praxis.duel_id != null;
+  const onPick = duelMode ? state.sendChallenge : state.sendInvite;
   return (
     <div>
       <div
         style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}
       >
-        {praxis.members
-          .filter((member) => member.character_id !== state.currentCharacterId)
-          .map((member) => (
-            <span
-              key={member.id}
-              style={{
-                fontFamily: skin.fontFamily,
-                fontSize: 11,
-                padding: "4px 10px",
-                background: skin.acceptedBg ?? "var(--color-success)",
-                color: skin.acceptedColor ?? "var(--color-text-on-accent)",
-              }}
-            >
-              {member.character_display_name}
-            </span>
-          ))}
-        {praxis.invites
-          .filter((invite) => invite.status === "pending")
-          .map((invite) => (
-            <span
-              key={invite.id}
-              style={{
-                fontFamily: skin.fontFamily,
-                fontSize: 11,
-                padding: "4px 10px",
-                background: skin.pendingBg ?? "transparent",
-                color: skin.pendingColor ?? "inherit",
-                border: "1px dashed currentColor",
-              }}
-            >
-              {invite.invitee_display_name} <em>· pending</em>
-            </span>
-          ))}
+        {duelMode
+          ? challengeAttached && (
+              <span
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  fontFamily: skin.fontFamily,
+                  fontSize: 11,
+                  padding: "4px 10px",
+                  background: skin.pendingBg ?? "transparent",
+                  color: skin.pendingColor ?? "inherit",
+                  border: "1px dashed currentColor",
+                }}
+              >
+                ⚔ {state.duel?.opponent.display_name ?? "opponent"}{" "}
+                <em>· challenged</em>
+                <button
+                  type="button"
+                  onClick={() => void state.cancelDuel()}
+                  aria-label="cancel challenge"
+                  style={{
+                    background: "transparent",
+                    border: "none",
+                    color: "inherit",
+                    cursor: "pointer",
+                    fontSize: 14,
+                    lineHeight: 1,
+                    padding: 0,
+                  }}
+                >
+                  ×
+                </button>
+              </span>
+            )
+          : [
+              ...praxis.members
+                .filter(
+                  (member) => member.character_id !== state.currentCharacterId,
+                )
+                .map((member) => (
+                  <span
+                    key={`m-${member.id}`}
+                    style={{
+                      fontFamily: skin.fontFamily,
+                      fontSize: 11,
+                      padding: "4px 10px",
+                      background: skin.acceptedBg ?? "var(--color-success)",
+                      color: skin.acceptedColor ?? "var(--color-text-on-accent)",
+                    }}
+                  >
+                    {member.character_display_name}
+                  </span>
+                )),
+              ...praxis.invites
+                .filter((invite) => invite.status === "pending")
+                .map((invite) => (
+                  <span
+                    key={`i-${invite.id}`}
+                    style={{
+                      fontFamily: skin.fontFamily,
+                      fontSize: 11,
+                      padding: "4px 10px",
+                      background: skin.pendingBg ?? "transparent",
+                      color: skin.pendingColor ?? "inherit",
+                      border: "1px dashed currentColor",
+                    }}
+                  >
+                    {invite.invitee_display_name} <em>· pending</em>
+                  </span>
+                )),
+            ]}
       </div>
+      {!challengeAttached && (
       <div style={{ position: "relative" }}>
         <input
           type="text"
           value={state.inviteQuery}
           onChange={(event) => state.setInviteQuery(event.target.value)}
-          placeholder={skin.placeholder ?? "search player name or @handle"}
-          aria-label="search players to invite"
+          placeholder={
+            skin.placeholder ??
+            (duelMode
+              ? "search an opponent to challenge"
+              : "search player name or @handle")
+          }
+          aria-label={duelMode ? "search an opponent" : "search players to invite"}
           style={{
             width: "100%",
             fontFamily: skin.fontFamily,
@@ -118,7 +169,7 @@ export function InviteSearch({
                 key={character.id}
                 type="button"
                 disabled={state.inviting}
-                onMouseDown={() => void state.sendInvite(character)}
+                onMouseDown={() => void onPick(character)}
                 style={{
                   display: "flex",
                   alignItems: "center",
@@ -155,6 +206,7 @@ export function InviteSearch({
           </div>
         )}
       </div>
+      )}
     </div>
   );
 }
@@ -439,9 +491,20 @@ export function ModePicker<O extends { key: PraxisType }>({
   return (
     <div style={skin.containerStyle}>
       {skin.options
-        .filter((option) => skin.allowedModes.includes(option.key))
+        .filter((option) =>
+          // Duel isn't in task.allowed_modes (it's issued via challenge, ADR-0011);
+          // it's gated on the viewer's level instead (#311). Hide, don't disable.
+          option.key === "duel"
+            ? state.duelChipVisible
+            : skin.allowedModes.includes(option.key),
+        )
         .map((option, index) => {
-          const active = praxis.type === option.key;
+          // A duel side stays type='solo' + duel_id, so the duel chip's active
+          // state is driven by duelMode, not praxis.type.
+          const active =
+            option.key === "duel"
+              ? state.duelMode
+              : praxis.type === option.key && !state.duelMode;
           const disabled =
             state.modeIsLocked || state.switchingMode !== null;
           if (state.modeIsLocked && !active) return null;

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -155,8 +155,8 @@ export function TaskMetaInline({
       <span>{factionName(slug)}</span>
       {task && <span>· {task.point_value} pts</span>}
       {task && showLevelPill && <LevelPill level={task.level_required} />}
-      {praxis.type !== "solo" && (
-        <span>· {praxis.type === "duel" ? "duel" : "collab"}</span>
+      {(praxis.type === "collab" || praxis.duel_id != null) && (
+        <span>· {praxis.duel_id != null ? "duel" : "collab"}</span>
       )}
     </span>
   );

--- a/frontend/src/pages/editPraxis/useEditPraxis.test.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.test.ts
@@ -1,26 +1,27 @@
 /**
- * Guards the mode-switch confirm logic behind #155: once a second member joins,
- * the picker must stay usable (confirm-then-drop), not silently lock.
+ * Mode-switch confirm logic. Switches are now in-place (#321 solo↔collab, #311
+ * duel), so the draft is always preserved — only genuinely destructive
+ * transitions warn: leaving a live duel, or collab→solo dropping co-authors.
  */
 import { describe, it, expect } from "vitest";
 import { modeSwitchPrompt } from "./useEditPraxis";
 
 describe("modeSwitchPrompt", () => {
-  it("does not lock once a second member joins — it offers a confirm (#155)", () => {
-    // A non-null prompt means the switch proceeds after confirm, not a hard block.
-    expect(modeSwitchPrompt(2, true)).not.toBeNull();
-    expect(modeSwitchPrompt(3, false)).not.toBeNull();
+  it("warns that co-authors will be dropped on collab → solo with a crew (#155)", () => {
+    expect(modeSwitchPrompt("solo", "collab", 2, false)).toMatch(/co-authors/i);
   });
 
-  it("warns that co-authors will be dropped when collaborators have joined", () => {
-    expect(modeSwitchPrompt(2, false)).toMatch(/co-authors/i);
+  it("warns that the duel is cancelled when leaving a live duel", () => {
+    expect(modeSwitchPrompt("collab", "solo", 1, true)).toMatch(/duel/i);
+    expect(modeSwitchPrompt("solo", "solo", 1, true)).toMatch(/duel/i);
   });
 
-  it("warns about discarding an unsaved solo draft", () => {
-    expect(modeSwitchPrompt(1, true)).toMatch(/discard/i);
+  it("does not warn when re-selecting duel while dueling", () => {
+    expect(modeSwitchPrompt("duel", "solo", 1, true)).toBeNull();
   });
 
-  it("proceeds without a confirm for an empty solo praxis", () => {
-    expect(modeSwitchPrompt(1, false)).toBeNull();
+  it("proceeds silently for a lossless switch (solo → collab, or solo crew)", () => {
+    expect(modeSwitchPrompt("collab", "solo", 1, false)).toBeNull();
+    expect(modeSwitchPrompt("solo", "collab", 1, false)).toBeNull();
   });
 });

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -141,7 +141,7 @@ export function modeSwitchPrompt(
 
 export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const navigate = useNavigate();
-  const { user, refetch } = useAuth();
+  const { user, refetch, loading: authLoading } = useAuth();
 
   // ---- Core state ----
   const [praxis, setPraxis] = useState<PraxisOut | null>(null);
@@ -185,11 +185,22 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   // ---- Initial load ----
   useEffect(() => {
     if (!idParam) return;
+    // Wait for auth to resolve before the membership guard — otherwise a
+    // still-loading `user` would bounce to the read page, which redirects
+    // in_progress praxes right back here (infinite loop).
+    if (authLoading) return;
     const praxisId = parseInt(idParam, 10);
     setLoading(true);
     getPraxis(praxisId)
       .then(async (loaded) => {
-        if (user?.character?.id !== loaded.created_by_id) {
+        // A collab is co-owned — any member may edit (ADR-0013), not just the
+        // creator. Gating on created_by_id looped non-creator members between
+        // this page and the read page's in_progress → edit redirect.
+        const viewerId = user?.character?.id;
+        const isMember =
+          viewerId != null &&
+          loaded.members.some((member) => member.character_id === viewerId);
+        if (!isMember) {
           navigate(`/praxes/${idParam}`, { replace: true });
           return;
         }
@@ -218,7 +229,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       })
       .catch(() => setError("Couldn't load this praxis."))
       .finally(() => setLoading(false));
-  }, [idParam, user, navigate]);
+  }, [idParam, user, authLoading, navigate]);
 
   // ---- Duel gating: level required + the viewer's foes (surfaced first) ----
   useEffect(() => {

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   applyMetatask,
-  createPraxis,
+  changePraxisType,
   deletePraxis,
   deletePraxisMedia,
   getPraxis,
@@ -24,6 +24,14 @@ import {
   type PraxisOut,
   type PraxisType,
 } from "../../api/praxis";
+import {
+  cancelChallenge,
+  getDuelDetail,
+  issueChallenge,
+  type DuelDetailOut,
+} from "../../api/duel";
+import { getGameConfig } from "../../api/gameConfig";
+import { listRelationships } from "../../api/relationships";
 import { getTask, type TaskOut } from "../../api/tasks";
 import { listCharacters, type CharacterOut } from "../../api/characters";
 import { listMetatasks } from "../../api/metaTasks";
@@ -59,7 +67,7 @@ export interface EditPraxisState {
   switchingMode: PraxisType | null;
   changeMode: (next: PraxisType) => Promise<void>;
 
-  // Invites (collab/duel)
+  // Invites (collab) / challenge (duel) — shared search box
   inviteQuery: string;
   setInviteQuery: (value: string) => void;
   inviteResults: CharacterOut[];
@@ -67,6 +75,12 @@ export interface EditPraxisState {
   setInviteOpen: (value: boolean) => void;
   inviting: boolean;
   sendInvite: (character: CharacterOut) => Promise<void>;
+
+  // Duel challenge (#311) — selecting duel attaches a challenge to this praxis;
+  // the praxis stays type='solo' and gains a duel_id.
+  duel: DuelDetailOut | null;
+  sendChallenge: (character: CharacterOut) => Promise<void>;
+  cancelDuel: () => Promise<void>;
 
   // Metatasks
   metaTasks: TaskOut[];
@@ -87,9 +101,13 @@ export interface EditPraxisState {
   isPublished: boolean;
   controlsLocked: boolean;
   modeIsLocked: boolean;
-  showCollabInvite: boolean;
+  /** Show the invite/challenge box: collab members, or an open duel pane. */
+  showInviteBox: boolean;
   showMetatasks: boolean;
-  duelSlotFull: boolean;
+  /** The duel chip is selected (a challenge is attached or the pane is open). */
+  duelMode: boolean;
+  /** The duel chip is available to this viewer (level ≥ duel_level_required). */
+  duelChipVisible: boolean;
 
   // Identity helpers
   currentCharacterId: number | null;
@@ -101,20 +119,22 @@ const AUTOSAVE_DEBOUNCE_MS = 2000;
  * Decide whether switching to a new mode needs a confirm, and with what prompt.
  * Returns the message to confirm, or null to proceed silently.
  *
- * A mode switch tears down and recreates the praxis (see `performModeSwitch`),
- * so the destructive cases warn first instead of locking the control (#155):
- *  - co-authors present  → they'll be dropped
- *  - else unsaved draft  → it'll be discarded
+ * Mode switches are now in-place (#321 solo↔collab, #311 duel), so the draft is
+ * always preserved — only genuinely destructive transitions warn:
+ *  - leaving a pending/active duel  → the challenge is cancelled
+ *  - collab → solo with co-authors  → they're dropped (content stays)
  */
 export function modeSwitchPrompt(
+  next: PraxisType,
+  currentType: PraxisType,
   memberCount: number,
-  hasDraftContent: boolean,
+  inDuel: boolean,
 ): string | null {
-  if (memberCount > 1) {
-    return "Switching mode will drop the collaboration — your co-authors will be removed and the current draft replaced. Continue?";
+  if (inDuel && next !== "duel") {
+    return "Switching mode will cancel your duel challenge. Continue?";
   }
-  if (hasDraftContent) {
-    return "Changing mode will discard your current draft (title, body, media, metatasks). Continue?";
+  if (next === "solo" && currentType === "collab" && memberCount > 1) {
+    return "Switching to solo will remove your co-authors — your draft stays. Continue?";
   }
   return null;
 }
@@ -146,6 +166,12 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const [inviting, setInviting] = useState(false);
 
   const [switchingMode, setSwitchingMode] = useState<PraxisType | null>(null);
+
+  // Duel challenge (#311)
+  const [duelPaneOpen, setDuelPaneOpen] = useState(false);
+  const [duel, setDuel] = useState<DuelDetailOut | null>(null);
+  const [duelLevelRequired, setDuelLevelRequired] = useState<number | null>(null);
+  const [foeIds, setFoeIds] = useState<Set<number>>(new Set());
 
   const [autosaveAt, setAutosaveAt] = useState<Date | null>(null);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
@@ -193,6 +219,44 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       .catch(() => setError("Couldn't load this praxis."))
       .finally(() => setLoading(false));
   }, [idParam, user, navigate]);
+
+  // ---- Duel gating: level required + the viewer's foes (surfaced first) ----
+  useEffect(() => {
+    getGameConfig()
+      .then((cfg) => setDuelLevelRequired(cfg.duel_level_required))
+      .catch(() => {
+        /* non-fatal; chip stays hidden until known */
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!user?.character) return;
+    listRelationships({ type: "foe", status: "active" })
+      .then((rels) => setFoeIds(new Set(rels.map((r) => r.to_character_id))))
+      .catch(() => {
+        /* foes-first ordering is a nicety; ignore failures */
+      });
+  }, [user?.character?.id]);
+
+  // ---- Duel detail (opponent chip + status) whenever this praxis is a duel side ----
+  useEffect(() => {
+    const duelId = praxis?.duel_id ?? null;
+    if (duelId == null) {
+      setDuel(null);
+      return;
+    }
+    let cancelled = false;
+    getDuelDetail(duelId)
+      .then((d) => {
+        if (!cancelled) setDuel(d);
+      })
+      .catch(() => {
+        /* non-fatal */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [praxis?.duel_id]);
 
   // ---- Debounced autosave for title + body ----
   useEffect(() => {
@@ -343,40 +407,79 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   }, [praxis, navigate]);
 
   // ---- Mode switching ----
-  const hasDraftContent = useCallback((): boolean => {
-    if (title.trim().length > 0) return true;
-    if (body.trim().length > 0) return true;
-    if (media.length > 0) return true;
-    if (appliedMetatasks.size > 0) return true;
-    return false;
-  }, [title, body, media, appliedMetatasks]);
-
-  const performModeSwitch = useCallback(
+  const changeMode = useCallback(
     async (next: PraxisType) => {
       if (!praxis) return;
+
+      // Duel is not a type flip — it reveals the challenge box (#311). The praxis
+      // stays type='solo' and only gains a duel_id once an opponent is picked.
+      if (next === "duel") {
+        if (praxis.duel_id != null) return; // already dueling
+        // A duel side must be solo (ADR-0011). Coming from collab drops the crew.
+        if (praxis.type === "collab") {
+          if (
+            praxis.members.length > 1 &&
+            !window.confirm(
+              "Switching to a duel will remove your co-authors — your draft stays. Continue?",
+            )
+          ) {
+            return;
+          }
+          setError("");
+          setSwitchingMode("solo");
+          try {
+            const updated = await changePraxisType(praxis.id, "solo");
+            setPraxis(updated);
+            setMedia(updated.media_items);
+          } catch (err) {
+            setError(extractError(err, "Could not change mode."));
+            setSwitchingMode(null);
+            return;
+          }
+          setSwitchingMode(null);
+        }
+        setDuelPaneOpen(true);
+        return;
+      }
+
+      // next is solo|collab. Clicking the current mode with no duel open is a no-op.
+      const inDuel = praxis.duel_id != null;
+      if (!inDuel && next === praxis.type) {
+        setDuelPaneOpen(false);
+        return;
+      }
+
+      const prompt = modeSwitchPrompt(
+        next,
+        praxis.type,
+        praxis.members.length,
+        inDuel,
+      );
+      if (prompt && !window.confirm(prompt)) return;
+
       setError("");
       setSwitchingMode(next);
       try {
-        const taskId = praxis.task_id;
-        await deletePraxis(praxis.id);
-        const fresh = await createPraxis({ task_id: taskId, type: next });
-        navigate(`/praxes/${fresh.id}/edit`, { replace: true });
+        if (inDuel && praxis.duel_id != null) {
+          await cancelChallenge(praxis.duel_id);
+        }
+        // During a duel the praxis type is already 'solo', so switching to solo
+        // just reloads; any real solo↔collab flip goes through change-type in place.
+        const updated =
+          next === praxis.type
+            ? await getPraxis(praxis.id)
+            : await changePraxisType(praxis.id, next);
+        setPraxis(updated);
+        setMedia(updated.media_items);
+        setDuelPaneOpen(false);
+        setDuel(null);
       } catch (err) {
         setError(extractError(err, "Could not change mode."));
+      } finally {
         setSwitchingMode(null);
       }
     },
-    [praxis, navigate],
-  );
-
-  const changeMode = useCallback(
-    async (next: PraxisType) => {
-      if (!praxis || praxis.type === next) return;
-      const prompt = modeSwitchPrompt(praxis.members.length, hasDraftContent());
-      if (prompt && !window.confirm(prompt)) return;
-      await performModeSwitch(next);
-    },
-    [praxis, hasDraftContent, performModeSwitch],
+    [praxis],
   );
 
   // ---- Invite search (debounced via input change handler in caller, but
@@ -409,6 +512,13 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
             !memberIds.has(c.id) &&
             !pendingInviteIds.has(c.id),
         );
+        // In duel mode, surface the viewer's foes first (soft ordering; anyone
+        // eligible can still be challenged).
+        if (praxis.duel_id == null && duelPaneOpen && foeIds.size > 0) {
+          filtered.sort(
+            (a, b) => Number(foeIds.has(b.id)) - Number(foeIds.has(a.id)),
+          );
+        }
         setInviteResults(filtered);
         setInviteOpen(filtered.length > 0);
       } catch {
@@ -420,7 +530,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     return () => {
       cancelled = true;
     };
-  }, [inviteQuery, praxis, user]);
+  }, [inviteQuery, praxis, user, duelPaneOpen, foeIds]);
 
   const sendInvite = useCallback(
     async (character: CharacterOut) => {
@@ -444,6 +554,48 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     },
     [praxis],
   );
+
+  // ---- Duel challenge (#311): pick an opponent, cancel a pending challenge ----
+  const sendChallenge = useCallback(
+    async (character: CharacterOut) => {
+      if (!praxis) return;
+      setInviting(true);
+      setError("");
+      setInviteQuery("");
+      setInviteOpen(false);
+      setInviteResults([]);
+      try {
+        await issueChallenge({
+          challenger_praxis_id: praxis.id,
+          opponent_character_id: character.id,
+        });
+        // Reload so the praxis carries its new duel_id; the effect fetches detail.
+        const refreshed = await getPraxis(praxis.id);
+        setPraxis(refreshed);
+      } catch (err) {
+        setError(
+          extractError(err, `Could not challenge ${character.display_name}.`),
+        );
+      } finally {
+        setInviting(false);
+      }
+    },
+    [praxis],
+  );
+
+  const cancelDuel = useCallback(async () => {
+    if (!praxis?.duel_id) return;
+    setError("");
+    try {
+      await cancelChallenge(praxis.duel_id);
+      const refreshed = await getPraxis(praxis.id);
+      setPraxis(refreshed);
+      setDuel(null);
+      setDuelPaneOpen(false);
+    } catch (err) {
+      setError(extractError(err, "Could not cancel the challenge."));
+    }
+  }, [praxis]);
 
   // ---- Metatasks ----
   const toggleMetatask = useCallback(
@@ -482,21 +634,21 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   // Locked only once sealed/moderated — co-authors no longer lock the picker;
   // switching with members joined confirms-then-drops instead (#155).
   const modeIsLocked = controlsLocked;
-  const duelSlotFull = !!(
-    praxis &&
-    praxis.type === "duel" &&
-    praxis.members.length +
-      praxis.invites.filter((i) => i.status === "pending").length >=
-      2
-  );
-  const showCollabInvite =
+  // A duel side stays type='solo' + a duel_id (ADR-0011); the chip is "selected"
+  // once a challenge is attached or the viewer has opened the challenge pane.
+  const duelMode = !!praxis && (praxis.duel_id != null || duelPaneOpen);
+  const viewerLevel = user?.character?.level ?? 0;
+  const duelChipVisible =
     !controlsLocked &&
-    !!praxis &&
-    (praxis.type === "collab" || praxis.type === "duel");
+    duelLevelRequired != null &&
+    viewerLevel >= duelLevelRequired;
+  const showInviteBox =
+    !controlsLocked && !!praxis && (praxis.type === "collab" || duelMode);
   const showMetatasks =
     !controlsLocked &&
     !!praxis &&
     praxis.type === "solo" &&
+    !duelMode &&
     metaTasks.length > 0;
 
   const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0;
@@ -530,6 +682,10 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     inviting,
     sendInvite,
 
+    duel,
+    sendChallenge,
+    cancelDuel,
+
     metaTasks,
     appliedMetatasks,
     applyingMetatask,
@@ -545,9 +701,10 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     isPublished: !!isPublished,
     controlsLocked,
     modeIsLocked,
-    showCollabInvite,
+    showInviteBox,
     showMetatasks,
-    duelSlotFull,
+    duelMode,
+    duelChipVisible,
 
     currentCharacterId: user?.character?.id ?? null,
   };

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -449,6 +449,16 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
         return;
       }
 
+      // Only a *pending* challenge can be cancelled (the backend forbids
+      // unilaterally cancelling an accepted duel). Once the opponent has
+      // accepted, the challenger can't switch away.
+      if (inDuel && duel && duel.status !== "pending") {
+        setError(
+          "This duel is already underway — it can't be cancelled from here.",
+        );
+        return;
+      }
+
       const prompt = modeSwitchPrompt(
         next,
         praxis.type,
@@ -479,7 +489,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
         setSwitchingMode(null);
       }
     },
-    [praxis],
+    [praxis, duel],
   );
 
   // ---- Invite search (debounced via input change handler in caller, but


### PR DESCRIPTION
Edit-page mode picker rework. #311 and #321 both replace the old delete+recreate `performModeSwitch`, so they land together (as the issues request).

## #321 — solo↔collab switch preserves content
- New `POST /praxes/{id}/change-type` flips `Praxis.type` in place, preserving id/title/body/media (no more delete+recreate). `collab→solo` drops non-author members + pending invites; guards `in_progress`, collab level, and duel sides.
- The mode picker points at this instead of delete+recreate.

## #311 — wire the duel chip to the real challenge flow (closes #294)
- Selecting **duel** reveals a challenge box (shared `InviteSearch` in duel mode); picking an opponent issues a real challenge. The praxis stays `type=solo` and gains a `duel_id`; the opponent renders as a pending chip with × to cancel.
- Duel chip hidden below `duel_level_required` (now exposed via `/game-config`); metatasks + collab invite hidden in duel mode; foes surfaced first in the search.
- Everymen's bespoke invite block now delegates to the shared control.
- Backend guard: a duel side must be `type=solo` (ADR-0011) — enforced in `issue_duel_challenge`.
- Cancel is gated to **pending** duels (the merged backend can't cancel an accepted one); an accepted duel shows an "accepted" chip with no ×.

## Tests
`511` backend + `118` frontend tests pass; `tsc` clean; production build succeeds. New coverage: change-type (both directions + duel-reject), collab-can't-challenge guard, `modeSwitchPrompt`.

The read-page duel cross-link (#313) is a separate PR (independent, read-page-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)