### PR TITLE
feat: read-page duel cross-link (closes #313)

### DIFF
--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -21,6 +21,7 @@ import WowPraxisDetail from './praxisDetail/archetypes/WowPraxisDetail'
 import UAPraxisDetail from './praxisDetail/archetypes/UAPraxisDetail'
 import AlbescentPraxisDetail from './praxisDetail/archetypes/AlbescentPraxisDetail'
 import CommentThread from '../components/comments/CommentThread'
+import DuelCrossLink from './praxisDetail/DuelCrossLink'
 
 /**
  * Per-faction praxis-read archetype map. Keyed by task faction slug.
@@ -63,6 +64,9 @@ export default function PraxisDetail() {
   const Archetype = pickVariant(ARCHETYPE_BY_SLUG, state.praxis.task_faction_slug, DefaultPraxisDetail)
   return (
     <>
+      {/* Duel cross-link is neutral chrome above every archetype (#313); one
+          shared faction-tokened widget, per the grilled #310 decision. */}
+      {state.duel && <DuelCrossLink praxis={state.praxis} duel={state.duel} />}
       <Archetype state={state} />
       {/* Comments are neutral chrome below every archetype (ADR-0006); a thread
           renders on a visible praxis only. Mounted at the dispatcher so it covers

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -1,0 +1,160 @@
+/**
+ * DuelCrossLink — the read-page duel surface (#313), one shared faction-tokened
+ * component dropped below every praxis-read archetype (per the grilled #310
+ * decision: a mechanism, not a per-faction identity statement). It inherits the
+ * opponent's faction tokens so it reads native inside any archetype.
+ *
+ * Lifecycle states (ADR-0011, designs in #310):
+ *  - active   (accepted, pre-settle): a "⚔ Dueling [opponent]" marker only — no
+ *              tally (voting isn't open; the opponent may be unsubmitted).
+ *  - settled  (both submitted): live points-from-votes tally on both sides, who's
+ *              ahead (floats with the votes, never frozen), and a cross-link.
+ *  - forfeited (opponent unsubmitted/banned, #307): "won by default" on the
+ *              winner / "you forfeited" for the thrower; the thrown-side link
+ *              404s gracefully (it's a plain link, so it never breaks this page).
+ */
+import type { CSSProperties } from "react";
+import { Link } from "react-router-dom";
+import { factionCssVar, factionName } from "../../utils/factions";
+import { mediaUrl } from "../../utils/media";
+import type { PraxisOut } from "../../api/praxis";
+import type { DuelDetailOut, DuelSideOut } from "../../api/duel";
+
+function OpponentBadge({ side }: { side: DuelSideOut }) {
+  const border = factionCssVar(side.faction_slug, "border");
+  const soft = factionCssVar(side.faction_slug, "light");
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+      {side.avatar_url ? (
+        <img
+          src={mediaUrl(side.avatar_url)}
+          alt=""
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: "50%",
+            objectFit: "cover",
+            border: `1px solid ${border}`,
+          }}
+        />
+      ) : (
+        <span
+          aria-hidden
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: "50%",
+            background: soft,
+            border: `1px solid ${border}`,
+          }}
+        />
+      )}
+      <span>
+        <strong>{side.display_name}</strong>
+        <span style={{ opacity: 0.7 }}> · {factionName(side.faction_slug)}</span>
+      </span>
+    </span>
+  );
+}
+
+export default function DuelCrossLink({
+  praxis,
+  duel,
+}: {
+  praxis: PraxisOut;
+  duel: DuelDetailOut;
+}) {
+  const isChallenger = praxis.id === duel.challenger.praxis_id;
+  const me: DuelSideOut = isChallenger ? duel.challenger : duel.opponent;
+  const foe: DuelSideOut = isChallenger ? duel.opponent : duel.challenger;
+
+  const accent = factionCssVar(foe.faction_slug);
+  const soft = factionCssVar(foe.faction_slug, "light");
+
+  const wrapper: CSSProperties = {
+    maxWidth: "42rem",
+    margin: "16px 0",
+    padding: "12px 16px",
+    borderLeft: `3px solid ${accent}`,
+    background: soft,
+    fontFamily: "var(--font-body)",
+    fontSize: "var(--text-sm)",
+    color: "var(--color-text)",
+  };
+
+  const forfeited = duel.forfeited_by_character_id != null;
+
+  // active: marker only.
+  if (duel.status === "active" && !forfeited) {
+    return (
+      <div style={wrapper}>
+        <span style={{ fontWeight: 700 }}>⚔ Dueling {foe.display_name}</span>
+      </div>
+    );
+  }
+
+  // forfeited: won-by-default / you-forfeited. The foe link 404s if the thrown
+  // side was withdrawn — a plain <Link>, so clicking it 404s without breaking us.
+  if (forfeited) {
+    const iForfeited = duel.forfeited_by_character_id === me.character_id;
+    return (
+      <div style={wrapper}>
+        {iForfeited ? (
+          <span>You forfeited this duel.</span>
+        ) : (
+          <span>
+            <strong>⚔ Won by default</strong> — {foe.display_name} forfeited
+            {foe.praxis_id != null && (
+              <>
+                {" "}
+                (
+                <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
+                  their entry
+                </Link>
+                )
+              </>
+            )}
+            .
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // settled: live tally + cross-link.
+  const diff = me.points_from_votes - foe.points_from_votes;
+  const standing =
+    diff === 0 ? "Tied" : diff > 0 ? "You're ahead" : "You're behind";
+  return (
+    <div style={wrapper}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <span>
+          <span style={{ fontWeight: 700 }}>⚔ Duel</span> vs{" "}
+          {foe.praxis_id != null ? (
+            <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
+              <OpponentBadge side={foe} />
+            </Link>
+          ) : (
+            <OpponentBadge side={foe} />
+          )}
+        </span>
+        <span style={{ whiteSpace: "nowrap" }}>
+          <strong>{me.points_from_votes}</strong>
+          <span style={{ opacity: 0.6 }}> — </span>
+          <strong>{foe.points_from_votes}</strong>
+        </span>
+      </div>
+      <div style={{ marginTop: 4, fontSize: "var(--text-xs)", opacity: 0.85 }}>
+        {standing} · live — the winner floats with the votes until era reset.
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/praxisDetail/__tests__/DuelCrossLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/DuelCrossLink.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * DuelCrossLink lifecycle guard (#313): active shows a marker only; settled
+ * shows the live tally + cross-link; forfeited shows won-by-default / you-forfeited.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import DuelCrossLink from "../DuelCrossLink";
+import type { PraxisOut } from "../../../api/praxis";
+import type { DuelDetailOut, DuelSideOut, DuelStatus } from "../../../api/duel";
+
+const ME: DuelSideOut = {
+  praxis_id: 10,
+  character_id: 1,
+  display_name: "Alice",
+  faction_slug: "ua",
+  avatar_url: "",
+  points_from_votes: 12,
+  is_submitted: true,
+};
+const FOE: DuelSideOut = {
+  praxis_id: 20,
+  character_id: 2,
+  display_name: "Bob",
+  faction_slug: "wow",
+  avatar_url: "",
+  points_from_votes: 7,
+  is_submitted: true,
+};
+
+// The read page always renders "my" side; id matches the challenger praxis.
+const PRAXIS = { id: 10 } as PraxisOut;
+
+function duel(over: Partial<DuelDetailOut>): DuelDetailOut {
+  return {
+    id: 5,
+    task_id: 7,
+    status: "settled" as DuelStatus,
+    forfeited_by_character_id: null,
+    challenger: ME,
+    opponent: FOE,
+    viewer_is_participant: false,
+    ...over,
+  };
+}
+
+function text(d: DuelDetailOut): string {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <DuelCrossLink praxis={PRAXIS} duel={d} />
+    </MemoryRouter>,
+  );
+  return html.replace(/<[^>]*>/g, "");
+}
+
+describe("DuelCrossLink", () => {
+  it("active: shows a marker only, no tally", () => {
+    const t = text(duel({ status: "active" }));
+    expect(t).toMatch(/Dueling Bob/);
+    expect(t).not.toMatch(/ahead|behind/i);
+  });
+
+  it("settled: shows the live tally and who's ahead", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <DuelCrossLink praxis={PRAXIS} duel={duel({})} />
+      </MemoryRouter>,
+    );
+    expect(html).toMatch(/href="\/praxes\/20"/); // cross-link to opponent
+    const t = html.replace(/<[^>]*>/g, "");
+    expect(t).toMatch(/ahead/i); // 12 > 7
+    expect(t).toMatch(/12/);
+    expect(t).toMatch(/7/);
+  });
+
+  it("forfeited by the opponent: won by default", () => {
+    const t = text(duel({ forfeited_by_character_id: FOE.character_id }));
+    expect(t).toMatch(/Won by default/i);
+    expect(t).toMatch(/Bob forfeited/);
+  });
+
+  it("forfeited by me: you forfeited", () => {
+    const t = text(duel({ forfeited_by_character_id: ME.character_id }));
+    expect(t).toMatch(/You forfeited/i);
+  });
+});

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -76,6 +76,7 @@ function state(): PraxisDetailState {
     fetchError: null,
     votes: VOTES,
     voters: [],
+    duel: null,
     isOwner: false,
     showAdminBar: false,
     user: null,

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -53,7 +53,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
   if (!praxis) return null
 
   const sealedDate = praxis.submitted_at ?? praxis.created_at
-  const modeLabel = praxis.type === 'collab' ? 'COLLAB' : praxis.type === 'duel' ? 'DUEL' : 'SOLO'
+  const modeLabel = praxis.type === 'collab' ? 'COLLAB' : 'SOLO'
 
   return (
     <div
@@ -185,7 +185,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
               {praxis.created_by_display_name || `#${praxis.created_by_id}`}
             </Link>
             <div style={{ fontSize: 9, letterSpacing: '0.06em', color: 'var(--everymen-muted)', marginTop: 3 }}>
-              {praxis.type === 'collab' ? 'all hands' : praxis.type === 'duel' ? 'head to head' : 'one pair of hands'}
+              {praxis.type === 'collab' ? 'all hands' : 'one pair of hands'}
             </div>
           </div>
           {/* base points from the task */}

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -35,10 +35,10 @@ const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
 const BODY = 'var(--font-body)' // Courier Prime
 const ON_ACCENT = 'var(--color-text-on-accent)'
 
-/** Party-voiced label for the filing mode. */
+/** Party-voiced label for the filing mode. A duel side is a solo praxis
+ * (ADR-0011) — its duel context is shown by the shared DuelCrossLink, not here. */
 function modeVoice(type: string): string {
   if (type === 'collab') return 'cast together'
-  if (type === 'duel') return 'cast in a duel'
   return 'filed solo'
 }
 

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -20,6 +20,7 @@ import {
   type PraxisOut,
 } from "../../api/praxis";
 import { getVotes, getVoters, type VoteSummary, type VoterDetail } from "../../api/votes";
+import { getDuelDetail, type DuelDetailOut } from "../../api/duel";
 import { useAuth } from "../../auth/AuthContext";
 import { useAdminMode } from "../../auth/AdminModeContext";
 import { moderatePraxis } from "../../api/admin";
@@ -36,6 +37,8 @@ export interface PraxisDetailState {
   // Entities
   votes: VoteSummary | null;
   voters: VoterDetail[];
+  /** Duel detail when this praxis is one side of a duel (#313); null otherwise. */
+  duel: DuelDetailOut | null;
 
   // Derived
   isOwner: boolean;
@@ -90,6 +93,7 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
   const [praxis, setPraxis] = useState<PraxisOut | null>(null);
   const [votes, setVotes] = useState<VoteSummary | null>(null);
   const [voters, setVoters] = useState<VoterDetail[]>([]);
+  const [duel, setDuel] = useState<DuelDetailOut | null>(null);
   const [metatasks, setMetatasks] = useState<TaskOut[]>([]);
   const [metataskLoading, setMetataskLoading] = useState(false);
   const [metataskError, setMetataskError] = useState<string | null>(null);
@@ -143,6 +147,26 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
       )
       .finally(() => setLoading(false));
   }, [idParam]);
+
+  // Fetch duel detail in one round trip whenever this praxis is a duel side (#313).
+  useEffect(() => {
+    const duelId = praxis?.duel_id ?? null;
+    if (duelId == null) {
+      setDuel(null);
+      return;
+    }
+    let cancelled = false;
+    getDuelDetail(duelId)
+      .then((d) => {
+        if (!cancelled) setDuel(d);
+      })
+      .catch(() => {
+        /* non-fatal — the page still renders without the cross-link */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [praxis?.duel_id]);
 
   useEffect(() => {
     if (!praxis) return;
@@ -244,6 +268,7 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
 
     votes,
     voters,
+    duel,
 
     user,
 


### PR DESCRIPTION
One shared faction-tokened `DuelCrossLink`, mounted once in the praxis-read dispatcher (per the grilled #310 decision — a mechanism, not a per-faction identity statement, so no 7-archetype bundle). Fed by `praxis.duel_id` → `getDuelDetail` (from #308) in one round trip.

## States (ADR-0011, designs #310)
- **active** (accepted, pre-settle): a "⚔ Dueling [opponent]" marker only — no tally (voting isn't open; the opponent may be unsubmitted).
- **settled**: live points-from-votes tally on both sides, who's ahead (floats with the votes, never frozen), and a cross-link to the opponent's praxis.
- **forfeited** (#307): "won by default — [opponent] forfeited" on the winner / "you forfeited" for the thrower; the thrown-side link 404s gracefully (a plain link, so it never breaks the page).

Also removes now-dead `praxis.type === 'duel'` label branches in the Wow/Everymen read archetypes (a duel side is `type=solo`).

## Tests
`122` frontend tests pass (incl. a new `DuelCrossLink` lifecycle test covering all three states); `tsc` clean; build succeeds.

Branches off `main` and is independent of the edit-page PR (#356) — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)