### PR TITLE
feat: standardize faction pages — one contract, six skins (design handoff)

### DIFF
--- a/frontend/src/components/cards/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/cards/EphemeristsFactionHero.tsx
@@ -4,7 +4,7 @@ import { EphSeal, LapisLastWord } from "./ephemeristsAtoms";
  * The Ephemerists faction-page hero — a codex frontispiece. A lapis celestial
  * field behind ghost survey grids + astrolabe rings, the sigil seal, a Cinzel
  * wordmark with one word in the blue, the motto, a running gloss, and a
- * gold-ruled stat band. Colors via the --eph-* tokens (theme-aware).
+ * gold-ruled stat ledger on the side. Colors via the --eph-* tokens (theme-aware).
  *
  * Takes raw counts and labels them in the faction's own voice — the page stays
  * vocabulary-agnostic (see FactionHeroProps in FactionDetail).
@@ -73,9 +73,8 @@ export default function EphemeristsFactionHero({
     >
       <HeroGrids />
       <div style={{ height: 5, background: "var(--eph-gold)", position: "relative", zIndex: 2 }} />
-      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", gap: 28, padding: "26px 32px 24px", flexWrap: "wrap" }}>
-        <EphSeal size={104} bg="var(--eph-vellum)" eye="var(--eph-lapis)" />
-        <div style={{ flex: 1, minWidth: 220 }}>
+      <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", gap: 32, padding: "26px 32px 26px", flexWrap: "wrap" }}>
+        <div style={{ flex: "1 1 300px", minWidth: 220 }}>
           <div
             style={{
               fontFamily: "var(--eph-serif)",
@@ -143,35 +142,34 @@ export default function EphemeristsFactionHero({
             </span>
           </p>
         </div>
-      </div>
-      {/* stat band */}
-      <div
-        style={{
-          position: "relative",
-          zIndex: 2,
-          display: "flex",
-          alignItems: "center",
-          flexWrap: "wrap",
-          background: "var(--eph-field-deep)",
-          borderTop: "2px solid var(--eph-gold)",
-          padding: "13px 32px",
-        }}
-      >
-        {stats.map((s, i) => (
-          <div key={s.label} style={{ display: "flex", alignItems: "center" }}>
-            {i > 0 && (
-              <div style={{ width: 1, height: 30, margin: "0 24px", background: "color-mix(in srgb, var(--eph-gold) 40%, transparent)" }} />
-            )}
-            <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
-              <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 30, lineHeight: 0.85, color: "var(--eph-gold-light)" }}>
-                {s.value}
-              </span>
-              <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--eph-parchment)", opacity: 0.82 }}>
-                {s.label}
-              </span>
-            </div>
+
+        {/* Right column: seal + a stat ledger on the side (standardization:
+            stats sit beside the seal, never a full-width band). */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 22, alignItems: "center", flex: "0 0 232px", minWidth: 200 }}>
+          <EphSeal size={112} bg="var(--eph-vellum)" eye="var(--eph-lapis)" />
+          <div style={{ alignSelf: "stretch", border: "1px solid color-mix(in srgb, var(--eph-gold-light) 40%, transparent)", background: "color-mix(in srgb, var(--eph-field-deep) 55%, transparent)" }}>
+            {stats.map((s, i) => (
+              <div
+                key={s.label}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "baseline",
+                  gap: 10,
+                  padding: "9px 14px",
+                  borderTop: i > 0 ? "1px solid color-mix(in srgb, var(--eph-gold-light) 18%, transparent)" : undefined,
+                }}
+              >
+                <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "color-mix(in srgb, var(--eph-parchment) 75%, transparent)" }}>
+                  {s.label}
+                </span>
+                <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 24, lineHeight: 0.85, color: "var(--eph-gold-light)" }}>
+                  {s.value}
+                </span>
+              </div>
+            ))}
           </div>
-        ))}
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/components/cards/EverymenFactionHero.tsx
+++ b/frontend/src/components/cards/EverymenFactionHero.tsx
@@ -3,8 +3,10 @@ import type { FactionHeroProps } from "../../pages/FactionDetail";
 /**
  * The Everymen faction-page hero — a union masthead poster. A sunburst red
  * field under a halftone wash, a cog seal, a knockout Bebas wordmark with an
- * ink drop-shadow, a motto plate, and a stat band along the foot. Ported from
- * the Everymen design kit (EmHero); conforms to {@link FactionHeroProps}.
+ * ink drop-shadow, a motto plate, and — per the faction-page standardization —
+ * a side "ledger" stat panel (stats live on the side of the hero, never a
+ * full-width band). Ported from the Everymen design kit; conforms to
+ * {@link FactionHeroProps}.
  *
  * Theme-aware through the cascade — the --everymen-* tokens already carry
  * light + dark values, so the masthead never mutates the global theme.
@@ -44,6 +46,8 @@ export default function EverymenFactionHero({
   praxes,
 }: FactionHeroProps) {
   // The faction labels its own counts — page passes raw numbers only.
+  // ponytail: three real counts. seasonRank / total-points-awarded aren't
+  // sourced yet (no leaderboard/aggregate endpoint) — add rows when they are.
   const stats = [
     { value: members, label: "card-carrying" },
     { value: tasks, label: "work orders" },
@@ -59,6 +63,7 @@ export default function EverymenFactionHero({
         border: `3px solid ${INK}`,
         background: FIELD,
         color: CREAM,
+        boxShadow: "8px 10px 0 color-mix(in srgb, var(--everymen-ink) 35%, transparent)",
       }}
     >
       {/* sunburst rays from the upper-left */}
@@ -93,124 +98,124 @@ export default function EverymenFactionHero({
           position: "relative",
           zIndex: 2,
           display: "flex",
-          alignItems: "center",
-          gap: 30,
-          padding: "30px 38px 28px",
+          alignItems: "stretch",
+          flexWrap: "wrap",
         }}
       >
-        {/* cog seal */}
+        {/* identity — cog seal + wordmark + motto + blurb */}
+        <div
+          style={{
+            flex: 1,
+            minWidth: 300,
+            display: "flex",
+            alignItems: "center",
+            gap: 30,
+            padding: "30px 38px 28px",
+          }}
+        >
+          {/* cog seal */}
+          <div
+            style={{
+              flexShrink: 0,
+              width: 116,
+              height: 116,
+              borderRadius: "50%",
+              background: CREAM,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              boxShadow: `0 0 0 4px ${INK}, inset 0 0 0 6px ${RED}`,
+            }}
+          >
+            <CogMark size={58} color={RED} />
+          </div>
+
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                fontFamily: "var(--font-body)",
+                fontSize: 10,
+                letterSpacing: "0.3em",
+                textTransform: "uppercase",
+                color: GOLD,
+                marginBottom: 5,
+              }}
+            >
+              World Zero · Faction
+            </div>
+            <h1
+              style={{
+                fontFamily: "var(--font-accent)",
+                fontSize: 76,
+                lineHeight: 0.82,
+                letterSpacing: "0.01em",
+                margin: 0,
+                color: CREAM,
+                textShadow: `3px 3px 0 ${INK}`,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {name}
+            </h1>
+            <div
+              style={{
+                display: "inline-block",
+                marginTop: 12,
+                background: INK,
+                color: GOLD,
+                fontFamily: "var(--font-accent)",
+                fontSize: 17,
+                letterSpacing: "0.18em",
+                padding: "4px 14px",
+              }}
+            >
+              {MOTTO}
+            </div>
+            <p
+              style={{
+                fontFamily: "var(--font-body)",
+                fontSize: 12.5,
+                lineHeight: 1.6,
+                maxWidth: 560,
+                margin: "13px 0 0",
+                color: CREAM,
+              }}
+            >
+              {description ?? "Nobody's coming to fix it but us. Report for duty."}
+            </p>
+          </div>
+        </div>
+
+        {/* stats on the side — dark ledger panel */}
         <div
           style={{
             flexShrink: 0,
-            width: 116,
-            height: 116,
-            borderRadius: "50%",
-            background: CREAM,
+            width: 238,
+            background: INK,
+            borderLeft: `2px solid ${GOLD}`,
             display: "flex",
-            alignItems: "center",
+            flexDirection: "column",
             justifyContent: "center",
-            boxShadow: `0 0 0 4px ${INK}, inset 0 0 0 6px ${RED}`,
+            padding: "14px 26px",
           }}
         >
-          <CogMark size={58} color={RED} />
-        </div>
-
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              fontFamily: "var(--font-body)",
-              fontSize: 10,
-              letterSpacing: "0.3em",
-              textTransform: "uppercase",
-              color: GOLD,
-              marginBottom: 5,
-            }}
-          >
-            World Zero · Faction
-          </div>
-          <h1
-            style={{
-              fontFamily: "var(--font-accent)",
-              fontSize: 76,
-              lineHeight: 0.82,
-              letterSpacing: "0.01em",
-              margin: 0,
-              color: CREAM,
-              textShadow: `3px 3px 0 ${INK}`,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {name}
-          </h1>
-          <div
-            style={{
-              display: "inline-block",
-              marginTop: 12,
-              background: INK,
-              color: GOLD,
-              fontFamily: "var(--font-accent)",
-              fontSize: 17,
-              letterSpacing: "0.18em",
-              padding: "4px 14px",
-            }}
-          >
-            {MOTTO}
-          </div>
-          <p
-            style={{
-              fontFamily: "var(--font-body)",
-              fontSize: 12.5,
-              lineHeight: 1.6,
-              maxWidth: 560,
-              margin: "13px 0 0",
-              color: CREAM,
-            }}
-          >
-            {description ?? "Nobody's coming to fix it but us. Report for duty."}
-          </p>
-        </div>
-      </div>
-
-      {/* stat band */}
-      <div
-        style={{
-          position: "relative",
-          zIndex: 2,
-          display: "flex",
-          alignItems: "center",
-          background: INK,
-          borderTop: `2px solid ${GOLD}`,
-          padding: "14px 38px",
-        }}
-      >
-        {stats.map((s, i) => (
-          <div
-            key={s.label}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 22,
-              paddingLeft: i > 0 ? 22 : 0,
-            }}
-          >
-            {i > 0 && (
-              <div
-                style={{
-                  width: 1,
-                  alignSelf: "stretch",
-                  background: "color-mix(in srgb, var(--everymen-gold) 40%, transparent)",
-                }}
-              />
-            )}
-            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-              <span style={{ fontFamily: "var(--font-accent)", fontSize: 38, lineHeight: 0.85, color: GOLD }}>
-                {s.value}
-              </span>
+          {stats.map((s) => (
+            <div
+              key={s.label}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "baseline",
+                gap: 12,
+                padding: "11px 0",
+                borderBottom: "1px solid color-mix(in srgb, var(--everymen-gold) 22%, transparent)",
+              }}
+            >
               <span
                 style={{
                   fontFamily: "var(--font-body)",
                   fontSize: 9,
-                  letterSpacing: "0.16em",
+                  letterSpacing: "0.14em",
                   textTransform: "uppercase",
                   color: CREAM,
                   opacity: 0.85,
@@ -218,9 +223,12 @@ export default function EverymenFactionHero({
               >
                 {s.label}
               </span>
+              <span style={{ fontFamily: "var(--font-accent)", fontSize: 34, lineHeight: 0.8, color: GOLD }}>
+                {s.value}
+              </span>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/components/cards/FdlLaurel.tsx
+++ b/frontend/src/components/cards/FdlLaurel.tsx
@@ -1,0 +1,100 @@
+import type { CSSProperties } from "react";
+
+/**
+ * FdlLaurel — the Faction Distinction Laurel.
+ *
+ * The one cross-faction mark: a rainbow medallion with a laurel glyph, awarded
+ * to the single highest-scoring praxis on every faction page. The rainbow ring
+ * is a fixed brand constant (--fdl-rainbow); each skin only recolours the inner
+ * disc (`innerBg`, the card's paper) and the glyph (`glyphColor`, the card's
+ * ink) so the laurel sits on its own paper. Albescent passes a monochrome pair.
+ *
+ * Ported from the faction-page design bundle (lib/FdlLaurel.tsx); hex swapped
+ * for the --fdl-rainbow token per repo convention.
+ */
+export interface FdlLaurelProps {
+  /** Overall medallion diameter, px. */
+  size?: number;
+  /** Fill of the inner disc — pass the card's paper colour (a CSS var). */
+  innerBg?: string;
+  /** Laurel glyph colour — pass the card's ink colour (a CSS var). */
+  glyphColor?: string;
+  /** Ring inset from the edge, px (the coloured rainbow band width). */
+  ringInset?: number;
+  /** Optional rotation, e.g. "-8deg". */
+  rotate?: string;
+  /** Optional drop-shadow filter string. */
+  shadow?: string;
+  style?: CSSProperties;
+}
+
+export function FdlLaurel({
+  size = 44,
+  innerBg = "var(--color-bg-card)",
+  glyphColor = "var(--color-text-primary)",
+  ringInset = 4,
+  rotate,
+  shadow,
+  style,
+}: FdlLaurelProps) {
+  const glyph = Math.round(size * 0.42);
+  return (
+    <span
+      title="Faction Distinction Laurel — top praxis"
+      style={{
+        position: "relative",
+        display: "inline-block",
+        width: size,
+        height: size,
+        transform: rotate ? `rotate(${rotate})` : undefined,
+        filter: shadow,
+        ...style,
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: "50%",
+          background: "var(--fdl-rainbow)",
+          boxShadow: "inset 0 0 0 1px rgba(0,0,0,.2)",
+        }}
+      />
+      <span
+        style={{
+          position: "absolute",
+          inset: ringInset,
+          borderRadius: "50%",
+          background: innerBg,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          boxShadow: "inset 0 0 0 1px rgba(0,0,0,.12)",
+        }}
+      >
+        <svg
+          viewBox="0 0 40 48"
+          width={glyph * (40 / 48)}
+          height={glyph}
+          style={{ display: "block", color: glyphColor }}
+          aria-hidden="true"
+        >
+          <g fill="currentColor">
+            <path d="M20 1 C16 10 16 17 20 24 C24 17 24 10 20 1 Z" />
+            <path d="M20 22 C14 15 8 15 6 21 C4.6 25 8 29 13.5 27.6 C10.5 25 12.5 21 20 22 Z" />
+            <path d="M20 22 C26 15 32 15 34 21 C35.4 25 32 29 26.5 27.6 C29.5 25 27.5 21 20 22 Z" />
+            <rect x="11" y="26" width="18" height="4.5" rx="2.2" />
+            <path d="M20 30 C17.5 37 16 41 20 47 C24 41 22.5 37 20 30 Z" />
+          </g>
+        </svg>
+      </span>
+    </span>
+  );
+}
+
+/** Index of the single top-scoring praxis (first max), or -1 when empty. */
+export function topPraxisIndex(scores: number[]): number {
+  if (!scores.length) return -1;
+  const max = Math.max(...scores);
+  return scores.indexOf(max);
+}

--- a/frontend/src/components/cards/SingularityFactionHero.tsx
+++ b/frontend/src/components/cards/SingularityFactionHero.tsx
@@ -66,7 +66,9 @@ export default function SingularityFactionHero({
   tasks,
   praxes,
 }: FactionHeroProps) {
-  // The faction labels its own counts — page passes raw numbers only.
+  // The faction labels its own counts — page passes raw numbers only. Per the
+  // standardization rule these sit in a side "system readout" column beside the
+  // sigil, never a full-width band under the blurb.
   const stats = [
     { value: members, label: "nodes online" },
     { value: tasks, label: "open protocols" },
@@ -129,9 +131,9 @@ export default function SingularityFactionHero({
           zIndex: 2,
           padding: "36px 40px 40px",
           display: "grid",
-          gridTemplateColumns: "1fr auto",
+          gridTemplateColumns: "1fr 240px",
           gap: 32,
-          alignItems: "center",
+          alignItems: "start",
         }}
       >
         <div>
@@ -188,78 +190,99 @@ export default function SingularityFactionHero({
               lineHeight: 1.7,
               color: phosphor(60),
               maxWidth: 520,
-              margin: "0 0 28px",
+              margin: 0,
             }}
           >
             {description ??
               "We watch the noise floor for the pattern that shouldn't exist."}
           </p>
+        </div>
 
-          {/* stats */}
-          <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+        {/* right column: spinning sigil + side "system readout" stats */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 20,
+            alignItems: "center",
+          }}
+        >
+          <div style={{ position: "relative", flexShrink: 0, width: 120, height: 120 }}>
+            <div
+              aria-hidden="true"
+              className="sg-pulse"
+              style={{
+                position: "absolute",
+                inset: -20,
+                borderRadius: "50%",
+                background: `radial-gradient(circle, ${phosphor(28)}, transparent 70%)`,
+                opacity: 0.2,
+                pointerEvents: "none",
+              }}
+            />
+            <div className="sg-rotate">
+              <SingularityMark size={120} color={phosphor(55)} />
+            </div>
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <SingularityMark size={44} color={PHOSPHOR} />
+            </div>
+          </div>
+
+          {/* system readout — stats stacked in a side panel */}
+          <div
+            style={{
+              alignSelf: "stretch",
+              border: `1px solid ${BORDER}`,
+              background: "var(--faction-singularity-light)",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 7,
+                letterSpacing: "0.2em",
+                color: signal(55),
+                textTransform: "uppercase",
+                padding: "7px 12px 5px",
+                borderBottom: `1px solid ${signal(28)}`,
+              }}
+            >
+              SYSTEM READOUT
+            </div>
             {stats.map((s) => (
               <div
                 key={s.label}
                 style={{
-                  border: `1px solid ${BORDER}`,
-                  background: "var(--faction-singularity-light)",
-                  padding: "10px 18px",
-                  textAlign: "center",
-                  minWidth: 96,
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "baseline",
+                  gap: 10,
+                  padding: "7px 12px",
+                  borderBottom: `1px solid ${signal(14)}`,
                 }}
               >
-                <div
+                <span
                   style={{
-                    fontSize: 26,
-                    lineHeight: 1,
-                    color: PHOSPHOR,
-                    marginBottom: 4,
-                  }}
-                >
-                  {s.value}
-                </div>
-                <div
-                  style={{
-                    fontSize: 7,
-                    letterSpacing: "0.2em",
-                    color: signal(55),
+                    fontSize: 7.5,
+                    letterSpacing: "0.14em",
+                    color: signal(50),
                     textTransform: "uppercase",
                   }}
                 >
                   {s.label}
-                </div>
+                </span>
+                <span style={{ fontSize: 20, lineHeight: 1, color: PHOSPHOR }}>
+                  {s.value}
+                </span>
               </div>
             ))}
-          </div>
-        </div>
-
-        {/* spinning sigil */}
-        <div style={{ position: "relative", flexShrink: 0 }}>
-          <div
-            aria-hidden="true"
-            className="sg-pulse"
-            style={{
-              position: "absolute",
-              inset: -20,
-              borderRadius: "50%",
-              background: `radial-gradient(circle, ${phosphor(28)}, transparent 70%)`,
-              opacity: 0.2,
-              pointerEvents: "none",
-            }}
-          />
-          <div className="sg-rotate">
-            <SingularityMark size={120} color={phosphor(55)} />
-          </div>
-          <div
-            style={{
-              position: "absolute",
-              inset: 0,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <SingularityMark size={44} color={PHOSPHOR} />
           </div>
         </div>
       </div>

--- a/frontend/src/components/cards/SnideFactionHero.tsx
+++ b/frontend/src/components/cards/SnideFactionHero.tsx
@@ -4,8 +4,10 @@ import { SnideSigil } from "../snide/snideAtoms";
  * S.N.I.D.E. faction-page hero — a flyposted wall (NOT a tidy poster): a
  * photocopier-black field with faint pasted-flyer ghosts, halftone + grain, a
  * torn acid strip, a slapped sigil sticker, a skewed acid wordmark with a pink
- * drop-shadow, the motto on a strip, and staggered acid stat chits. Ported from
- * the SNIDE design kit (SnideHero); conforms to {@link FactionHeroProps}.
+ * drop-shadow, the motto on a strip, and — per the faction-page standardization
+ * — the acid stat chits stacked on the SIDE of the sigil (stats live on the side
+ * of the hero, never a full-width band). Ported from the SNIDE design kit
+ * (SnideHero); conforms to {@link FactionHeroProps}.
  *
  * The page passes raw counts; the faction labels them in its own voice. Motto +
  * full name are faction constants (not backend fields).
@@ -94,180 +96,189 @@ export default function SnideFactionHero({
         }}
       />
 
-      {/* slapped sigil sticker, tilted */}
-      <div
-        style={{
-          position: "absolute",
-          top: 34,
-          right: 42,
-          zIndex: 3,
-          transform: "rotate(9deg)",
-        }}
-      >
-        <div
-          style={{
-            position: "relative",
-            width: 104,
-            height: 104,
-            borderRadius: "50%",
-            background: "var(--faction-snide-paper)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            border: "2px solid var(--faction-snide)",
-            boxShadow: "0 0 0 4px var(--faction-snide-ink), 3px 4px 0 rgba(0,0,0,0.4)",
-          }}
-        >
-          <div
-            className="ht-dots"
-            style={{
-              position: "absolute",
-              inset: 0,
-              color: "rgba(20,17,11,0.06)",
-              borderRadius: "50%",
-              pointerEvents: "none",
-            }}
-          />
-          <SnideSigil size={60} color="var(--faction-snide)" />
-        </div>
-        <div
-          style={{
-            position: "absolute",
-            top: -9,
-            left: "50%",
-            marginLeft: -26,
-            width: 52,
-            height: 18,
-            background: "var(--faction-snide-tape)",
-            transform: "rotate(-7deg)",
-          }}
-        />
-      </div>
-
-      <div style={{ position: "relative", zIndex: 2, padding: "26px 38px 2px", maxWidth: 770 }}>
-        {/* eyebrow on tape */}
-        <div
-          style={{
-            display: "inline-block",
-            width: "fit-content",
-            whiteSpace: "nowrap",
-            background: "var(--faction-snide-tape)",
-            color: "var(--faction-snide-ink)",
-            fontFamily: "var(--faction-snide-font-type)",
-            fontSize: 10,
-            letterSpacing: "0.05em",
-            padding: "3px 12px",
-            transform: "rotate(-1.5deg)",
-            boxShadow: "1px 1px 0 rgba(0,0,0,0.3)",
-          }}
-        >
-          World Zero · faction no. 4
-        </div>
-        {/* wordmark */}
-        <h1
-          style={{
-            fontFamily: "var(--faction-snide-font-impact)",
-            fontSize: 86,
-            lineHeight: 0.8,
-            letterSpacing: "0.02em",
-            margin: "14px 0 0",
-            color: "var(--faction-snide-acid)",
-            textShadow: "4px 4px 0 var(--faction-snide-pink)",
-            transform: "skewX(-5deg) rotate(-1.5deg)",
-          }}
-        >
-          {name}
-        </h1>
-        <div
-          style={{
-            fontFamily: "var(--font-body)",
-            fontSize: 10,
-            letterSpacing: "0.16em",
-            textTransform: "uppercase",
-            color: "#b7b5a7",
-            margin: "12px 0 0",
-            transform: "rotate(-0.4deg)",
-          }}
-        >
-          {FULL_NAME}
-        </div>
-        {/* motto */}
-        <div
-          style={{
-            display: "inline-block",
-            marginTop: 14,
-            background: "var(--faction-snide-acid)",
-            color: "var(--faction-snide-ink)",
-            fontFamily: "var(--faction-snide-font-black)",
-            fontSize: 15,
-            letterSpacing: "0.02em",
-            padding: "6px 15px",
-            transform: "rotate(-2deg)",
-            boxShadow: "2px 3px 0 var(--faction-snide-pink)",
-          }}
-        >
-          {MOTTO}
-        </div>
-        <p
-          style={{
-            fontFamily: "var(--font-body)",
-            fontSize: 12.5,
-            lineHeight: 1.6,
-            maxWidth: 600,
-            margin: "16px 0 0",
-            color: "#e7e4d8",
-          }}
-        >
-          {description ?? "Nothing matters. We do it anyway."}
-        </p>
-      </div>
-
-      {/* staggered stat chits — not a clean band */}
+      {/* identity + side stat column — stats sit on the SIDE, never a band */}
       <div
         style={{
           position: "relative",
           zIndex: 2,
           display: "flex",
-          gap: 16,
+          alignItems: "flex-start",
           flexWrap: "wrap",
-          padding: "24px 38px 28px",
+          gap: 30,
+          padding: "26px 38px 30px",
         }}
       >
-        {stats.map((s, i) => (
+        {/* identity — eyebrow + wordmark + motto + blurb */}
+        <div style={{ flex: 1, minWidth: 300 }}>
+          {/* eyebrow on tape */}
           <div
-            key={s.label}
             style={{
-              background: "rgba(0,0,0,0.34)",
-              border: "2px solid var(--faction-snide-acid)",
-              padding: "8px 16px 7px",
-              transform: `rotate(${CHIT_ROT[i % CHIT_ROT.length]}deg)`,
-              boxShadow: "2px 3px 0 rgba(0,0,0,0.4)",
+              display: "inline-block",
+              width: "fit-content",
+              whiteSpace: "nowrap",
+              background: "var(--faction-snide-tape)",
+              color: "var(--faction-snide-ink)",
+              fontFamily: "var(--faction-snide-font-type)",
+              fontSize: 10,
+              letterSpacing: "0.05em",
+              padding: "3px 12px",
+              transform: "rotate(-1.5deg)",
+              boxShadow: "1px 1px 0 rgba(0,0,0,0.3)",
             }}
           >
-            <div
-              style={{
-                fontFamily: "var(--faction-snide-font-impact)",
-                fontSize: 34,
-                lineHeight: 0.85,
-                color: "var(--faction-snide-acid)",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {s.value}
-            </div>
-            <div
-              style={{
-                fontFamily: "var(--font-body)",
-                fontSize: 9,
-                letterSpacing: "0.12em",
-                textTransform: "uppercase",
-                color: "#cfcdbf",
-              }}
-            >
-              {s.label}
-            </div>
+            World Zero · faction no. 4
           </div>
-        ))}
+          {/* wordmark */}
+          <h1
+            style={{
+              fontFamily: "var(--faction-snide-font-impact)",
+              fontSize: 82,
+              lineHeight: 0.8,
+              letterSpacing: "0.02em",
+              margin: "16px 0 0",
+              color: "var(--faction-snide-acid)",
+              textShadow: "4px 4px 0 var(--faction-snide-pink)",
+              transform: "skewX(-5deg) rotate(-1.5deg)",
+            }}
+          >
+            {name}
+          </h1>
+          <div
+            style={{
+              fontFamily: "var(--font-body)",
+              fontSize: 10,
+              letterSpacing: "0.16em",
+              textTransform: "uppercase",
+              color: "#b7b5a7",
+              margin: "12px 0 0",
+              transform: "rotate(-0.4deg)",
+            }}
+          >
+            {FULL_NAME}
+          </div>
+          {/* motto */}
+          <div
+            style={{
+              display: "inline-block",
+              marginTop: 14,
+              background: "var(--faction-snide-acid)",
+              color: "var(--faction-snide-ink)",
+              fontFamily: "var(--faction-snide-font-black)",
+              fontSize: 15,
+              letterSpacing: "0.02em",
+              padding: "6px 15px",
+              transform: "rotate(-2deg)",
+              boxShadow: "2px 3px 0 var(--faction-snide-pink)",
+            }}
+          >
+            {MOTTO}
+          </div>
+          <p
+            style={{
+              fontFamily: "var(--font-body)",
+              fontSize: 12.5,
+              lineHeight: 1.6,
+              maxWidth: 560,
+              margin: "16px 0 0",
+              color: "#e7e4d8",
+            }}
+          >
+            {description ?? "Nothing matters. We do it anyway."}
+          </p>
+        </div>
+
+        {/* right: slapped sigil + acid stat chits stacked on the side */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-end",
+            gap: 13,
+            flexShrink: 0,
+            width: 196,
+          }}
+        >
+          {/* slapped sigil sticker, tilted */}
+          <div style={{ position: "relative", transform: "rotate(9deg)", margin: "2px 10px 6px 0" }}>
+            <div
+              style={{
+                position: "relative",
+                width: 94,
+                height: 94,
+                borderRadius: "50%",
+                background: "var(--faction-snide-paper)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                border: "2px solid var(--faction-snide)",
+                boxShadow: "0 0 0 4px var(--faction-snide-ink), 3px 4px 0 rgba(0,0,0,0.4)",
+              }}
+            >
+              <div
+                className="ht-dots"
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  color: "rgba(20,17,11,0.06)",
+                  borderRadius: "50%",
+                  pointerEvents: "none",
+                }}
+              />
+              <SnideSigil size={54} color="var(--faction-snide)" />
+            </div>
+            <div
+              style={{
+                position: "absolute",
+                top: -9,
+                left: "50%",
+                marginLeft: -26,
+                width: 52,
+                height: 18,
+                background: "var(--faction-snide-tape)",
+                transform: "rotate(-7deg)",
+              }}
+            />
+          </div>
+
+          {/* staggered acid stat chits — not a clean band */}
+          {stats.map((s, i) => (
+            <div
+              key={s.label}
+              style={{
+                alignSelf: "stretch",
+                textAlign: "right",
+                background: "rgba(0,0,0,0.34)",
+                border: "2px solid var(--faction-snide-acid)",
+                padding: "7px 14px 6px",
+                transform: `rotate(${CHIT_ROT[i % CHIT_ROT.length]}deg)`,
+                boxShadow: "2px 3px 0 rgba(0,0,0,0.4)",
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: "var(--faction-snide-font-impact)",
+                  fontSize: 30,
+                  lineHeight: 0.85,
+                  color: "var(--faction-snide-acid)",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {s.value}
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-body)",
+                  fontSize: 8.5,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  color: "#cfcdbf",
+                }}
+              >
+                {s.label}
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/components/cards/UAFactionHero.tsx
+++ b/frontend/src/components/cards/UAFactionHero.tsx
@@ -141,13 +141,14 @@ export default function UAFactionHero({
               backgroundSize: "5px 5px",
               padding: "34px 38px 30px",
               display: "flex",
+              flexWrap: "wrap",
               gap: 30,
               alignItems: "center",
             }}
           >
             <UACrest width={150} height={180} />
 
-            <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ flex: 1, minWidth: 260 }}>
               {/* engraved house line */}
               <div
                 style={{
@@ -227,46 +228,46 @@ export default function UAFactionHero({
                   "Any medium, any madness. The Salon decides what endures."}
               </p>
 
-              {/* engraved regalia plaques */}
-              <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-                {stats.map((s) => (
-                  <div
-                    key={s.label}
+            </div>
+
+            {/* stats on the side — engraved regalia stacked in a side column */}
+            <div style={{ flexShrink: 0, width: 168, display: "flex", flexDirection: "column", gap: 11 }}>
+              {stats.map((s) => (
+                <div
+                  key={s.label}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "baseline",
+                    borderTop: `1px solid ${LINE}`,
+                    paddingTop: 9,
+                  }}
+                >
+                  <span
                     style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 3,
-                      padding: "9px 18px",
-                      border: `1px solid ${LINE}`,
-                      background: PAPER,
+                      fontFamily: ENGRAVED,
+                      fontSize: 8.5,
+                      letterSpacing: "0.12em",
+                      textTransform: "uppercase",
+                      color: MUTED,
                     }}
                   >
-                    <span
-                      style={{
-                        fontFamily: DISPLAY,
-                        fontStyle: "italic",
-                        fontWeight: 700,
-                        fontSize: 26,
-                        lineHeight: 0.9,
-                        color: INK,
-                      }}
-                    >
-                      {s.value}
-                    </span>
-                    <span
-                      style={{
-                        fontFamily: ENGRAVED,
-                        fontSize: 8,
-                        letterSpacing: "0.16em",
-                        textTransform: "uppercase",
-                        color: MUTED,
-                      }}
-                    >
-                      {s.label}
-                    </span>
-                  </div>
-                ))}
-              </div>
+                    {s.label}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: DISPLAY,
+                      fontStyle: "italic",
+                      fontWeight: 700,
+                      fontSize: 23,
+                      lineHeight: 1,
+                      color: ACCENT,
+                    }}
+                  >
+                    {s.value}
+                  </span>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/frontend/src/components/cards/WowFactionHero.tsx
+++ b/frontend/src/components/cards/WowFactionHero.tsx
@@ -1,0 +1,236 @@
+import type { CSSProperties } from "react";
+import type { FactionHeroProps } from "../../pages/FactionDetail";
+
+/**
+ * Warriors of Whimsy faction-page hero — whimsy.exe pinned to a cork memo board.
+ * A pastel "app window" charm, a Caveat-script wordmark + motto, the blurb, and —
+ * per the faction-page standardization — the three counts as taped sticker charms
+ * in a SIDE column (never a full-width band). Two pushpins tack the banner down.
+ * Ported from the WoW design kit; conforms to {@link FactionHeroProps}.
+ *
+ * Theme-aware through the cascade: every colour resolves to a --faction-wow-*
+ * token (which already carries light + dark values), so the board never mutates
+ * the global theme. The script face is the WoW card-font token (Caveat); body
+ * copy uses --font-body, matching TaskCardWow / the WoW PraxisCard branch.
+ *
+ * The page passes raw counts; the faction labels them in its own whimsy voice.
+ * Motto is a faction constant (not a backend field).
+ */
+
+const MOTTO = "make it weird, make it matter";
+
+// Token shorthands — every value resolves to a --faction-wow-* var.
+const PINK = "var(--faction-wow)";
+const CARD_BG = "var(--faction-wow-card-bg)";
+const INK = "var(--faction-wow-card-text)";
+const ACCENT = "var(--faction-wow-card-accent)";
+const MUTED = "var(--faction-wow-card-muted)";
+const NOTEPAD = "var(--faction-wow-notepad-bg)";
+const WIN_BORDER = "var(--faction-wow-win-border)";
+const TITLE_TO = "var(--faction-wow-title-to)";
+const IVY = "var(--faction-wow-ivy)";
+const IVY_LEAF = "var(--faction-wow-ivy-leaf)";
+const DOT = "var(--faction-wow-dot)";
+
+const SCRIPT = "var(--faction-wow-card-font)";
+const BODY = "var(--font-body)";
+
+// The board's board-brown shadow has no dedicated token; the WoW atoms use a raw
+// warm-brown rgba for their pinned-paper drop shadows. Reuse the same value.
+// ponytail: no --faction-wow-board-shadow token exists; matching the atoms' rgba.
+const BOARD_SHADOW = "rgba(80,50,30,0.3)";
+
+/** Tiny four-point sparkle — same glyph the WoW task/window chrome uses. */
+function Sparkle({ size = 12, color = "currentColor" }: { size?: number; color?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block" }}>
+      <path
+        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+/** A pastel "app" charm — a little window pinned to the board, whimsy.exe itself. */
+function AppCharm({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      aria-hidden="true"
+      style={{ display: "block", flexShrink: 0, filter: `drop-shadow(0 6px 12px ${BOARD_SHADOW})` }}
+    >
+      <rect x="8" y="12" width="48" height="40" rx="7" fill={NOTEPAD} stroke={WIN_BORDER} strokeWidth="2.5" />
+      <rect x="8" y="12" width="48" height="12" rx="7" fill={TITLE_TO} />
+      <circle cx="15" cy="18" r="1.8" fill={NOTEPAD} />
+      <circle cx="21" cy="18" r="1.8" fill={NOTEPAD} />
+      <path d="M20 34h24M20 41h15" stroke={ACCENT} strokeWidth="2.6" strokeLinecap="round" />
+      <path
+        d="M50 6c.4 3.5 1.9 5 5.4 5.4-3.5.4-5 1.9-5.4 5.4-.4-3.5-1.9-5-5.4-5.4 3.5-.4 5-1.9 5.4-5.4z"
+        fill={IVY_LEAF}
+      />
+    </svg>
+  );
+}
+
+/** A round glossy pushpin, tinted to any charm colour. */
+function Pushpin({ color, style }: { color: string; style?: CSSProperties }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        width: 18,
+        height: 18,
+        borderRadius: "50%",
+        background: `radial-gradient(circle at 35% 30%, ${NOTEPAD}, ${color} 62%, ${BOARD_SHADOW})`,
+        boxShadow: `0 4px 6px ${BOARD_SHADOW}`,
+        zIndex: 5,
+        ...style,
+      }}
+    />
+  );
+}
+
+export default function WowFactionHero({
+  name,
+  description,
+  members,
+  tasks,
+  praxes,
+}: FactionHeroProps) {
+  // The coven tallies its own counts — page passes raw numbers only.
+  // ponytail: three real counts. seasonRank / total-points-won aren't sourced yet
+  // (no leaderboard/aggregate endpoint) — add charms when they are.
+  const statTags = [
+    { value: members, label: "witches", color: PINK, rot: "-3deg" },
+    { value: tasks, label: "quests open", color: IVY, rot: "2.5deg" },
+    { value: praxes, label: "spells filed", color: ACCENT, rot: "-2deg" },
+  ];
+
+  return (
+    <header style={{ marginBottom: 32 }}>
+      <div style={{ position: "relative", transform: "rotate(-0.6deg)" }}>
+        {/* two pushpins tack the banner to the board */}
+        <Pushpin color={PINK} style={{ top: -11, left: 34 }} />
+        <Pushpin color={IVY_LEAF} style={{ top: -11, right: 34 }} />
+
+        <div
+          style={{
+            position: "relative",
+            display: "flex",
+            alignItems: "center",
+            gap: 24,
+            flexWrap: "wrap",
+            background: `linear-gradient(135deg, ${NOTEPAD}, ${CARD_BG})`,
+            border: `1.5px solid ${WIN_BORDER}`,
+            borderRadius: 14,
+            padding: "22px 26px",
+            boxShadow: `0 12px 26px ${BOARD_SHADOW}`,
+            overflow: "hidden",
+          }}
+        >
+          {/* faint dotted-grid wash inside the banner, keyed to the cork board */}
+          <div
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              inset: 0,
+              pointerEvents: "none",
+              opacity: 0.5,
+              backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+              backgroundSize: "13px 13px",
+            }}
+          />
+
+          <div style={{ position: "relative" }}>
+            <AppCharm size={74} />
+          </div>
+
+          <div style={{ position: "relative", flex: 1, minWidth: 250 }}>
+            <div
+              style={{
+                fontFamily: BODY,
+                fontSize: 10,
+                letterSpacing: "0.2em",
+                textTransform: "uppercase",
+                color: MUTED,
+                marginBottom: 2,
+              }}
+            >
+              World Zero · Faction · est. MMXXI
+            </div>
+            <h1
+              style={{
+                fontFamily: SCRIPT,
+                fontSize: 52,
+                fontWeight: 700,
+                lineHeight: 0.9,
+                margin: 0,
+                color: ACCENT,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {name}
+            </h1>
+            <div style={{ fontFamily: SCRIPT, fontSize: 24, color: PINK, marginTop: 2 }}>
+              {MOTTO}
+            </div>
+            <p
+              style={{
+                fontFamily: BODY,
+                fontSize: 11,
+                lineHeight: 1.6,
+                color: MUTED,
+                maxWidth: 440,
+                margin: "8px 0 0",
+              }}
+            >
+              {description ?? "Nobody said the work couldn't be fun. Cast something."}
+            </p>
+          </div>
+
+          {/* stats on the side — taped sticker charms stacked in a side column */}
+          <div style={{ position: "relative", flexShrink: 0, display: "flex", flexDirection: "column", gap: 9 }}>
+            {statTags.map((s) => (
+              <div
+                key={s.label}
+                style={{
+                  position: "relative",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  background: NOTEPAD,
+                  border: `3px solid ${NOTEPAD}`,
+                  borderRadius: 18,
+                  padding: "5px 14px 5px 10px",
+                  boxShadow: `0 4px 9px ${BOARD_SHADOW}`,
+                  transform: `rotate(${s.rot})`,
+                }}
+              >
+                <Sparkle size={18} color={s.color} />
+                <span style={{ fontFamily: SCRIPT, fontSize: 28, fontWeight: 700, lineHeight: 1, color: s.color }}>
+                  {s.value}
+                </span>
+                <span
+                  style={{
+                    fontFamily: BODY,
+                    fontSize: 8,
+                    letterSpacing: "0.1em",
+                    textTransform: "uppercase",
+                    color: INK,
+                    width: 66,
+                  }}
+                >
+                  {s.label}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -546,6 +546,28 @@
   --font-faction-script: "Caveat", cursive;
   --font-faction-old: "IM Fell English", Georgia, serif;
   --font-faction-engraved: "Cinzel", serif;
+
+  /* Shared faction-page body grid — main column + right rail; collapses to one
+     column on narrow viewports (rule below). Every faction skin reuses this. */
+
+  /* ── Faction Distinction Laurel ── the single cross-faction high-score mark.
+     Fixed brand rainbow; the medallion's inner disc + glyph are recoloured
+     per-faction by the caller (see components/cards/FdlLaurel.tsx). */
+  --fdl-rainbow: conic-gradient(from 90deg, #fbbf24, #f97316, #be185d, #4f46e5, #0e7490, #16a34a, #fbbf24);
+}
+
+/* Faction-page body: main column + fixed right rail, collapsing to one column
+   on narrow viewports. Shared by every faction skin (see factionDetail bodies). */
+.wz-faction-grid {
+  display: grid;
+  grid-template-columns: 1fr 322px;
+  gap: 34px;
+  align-items: start;
+}
+@media (max-width: 860px) {
+  .wz-faction-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @layer base {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -3,13 +3,20 @@ import { useParams, Link } from "react-router-dom";
 import PageTitle from "../components/ui/PageTitle";
 import { factionCssVar } from "../utils/factions";
 import { pickVariant } from "../utils/factionDispatch";
-import { useFactionDetail } from "./factionDetail/useFactionDetail";
+import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFactionDetail";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
+import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
+import UaFactionBody from "./factionDetail/archetypes/UaFactionBody";
+import SingularityFactionBody from "./factionDetail/archetypes/SingularityFactionBody";
+import SnideFactionBody from "./factionDetail/archetypes/SnideFactionBody";
+import EphemeristsFactionBody from "./factionDetail/archetypes/EphemeristsFactionBody";
+import WowFactionBody from "./factionDetail/archetypes/WowFactionBody";
 import EphemeristsFactionHero from "../components/cards/EphemeristsFactionHero";
 import SnideFactionHero from "../components/cards/SnideFactionHero";
 import SingularityFactionHero from "../components/cards/SingularityFactionHero";
 import EverymenFactionHero from "../components/cards/EverymenFactionHero";
 import UAFactionHero from "../components/cards/UAFactionHero";
+import WowFactionHero from "../components/cards/WowFactionHero";
 
 /**
  * Faction detail page (`/factions/:slug`). Per-faction surface #13 in
@@ -40,7 +47,19 @@ const FACTION_HEROES: Record<string, ComponentType<FactionHeroProps>> = {
   singularity: SingularityFactionHero,
   everymen: EverymenFactionHero,
   ua: UAFactionHero,
-  // wow: undesigned — falls through to the shared title/description chrome.
+  wow: WowFactionHero,
+};
+
+// The standardized six-section body, dispatched per faction. albescent is not
+// registered: it aliases to ua (FACTION_ALIASES) and so inherits the UA body
+// via pickVariant until its own vellum skin lands with the alias removal.
+const FACTION_BODIES: Record<string, ComponentType<{ state: FactionDetailState }>> = {
+  everymen: EverymenFactionBody,
+  ua: UaFactionBody,
+  singularity: SingularityFactionBody,
+  snide: SnideFactionBody,
+  ephemerists: EphemeristsFactionBody,
+  wow: WowFactionBody,
 };
 
 export default function FactionDetail() {
@@ -77,6 +96,7 @@ export default function FactionDetail() {
   // (Hero is undefined) the shared title + description chrome is used. The page
   // backdrop is themed per-faction by useFactionDetail either way.
   const Hero = pickVariant(FACTION_HEROES, faction.slug);
+  const Body = pickVariant(FACTION_BODIES, faction.slug, DefaultFactionBody);
 
   return (
     <div className="py-8">
@@ -104,7 +124,7 @@ export default function FactionDetail() {
         </>
       )}
 
-      <DefaultFactionBody state={state} />
+      <Body state={state} />
     </div>
   );
 }

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -1,0 +1,370 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import TaskCard from "../../../components/TaskCard";
+import PraxisCard from "../../../components/PraxisCard";
+import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { EphMark, Foxing, toRoman } from "../../../components/cards/ephemeristsAtoms";
+import { computeDisplayPoints } from "../../../utils/points";
+import { factionName } from "../../../utils/factions";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * Ephemerists faction-body — the illuminated-codex / discordant-map skin of the
+ * standardized six-section spine (② The Apparatus, ③ The Road, ④ Tasks,
+ * ⑤ Praxis, ⑥ Members). Section ① (hero + side-ledger stats) is
+ * EphemeristsFactionHero, rendered above.
+ *
+ * Same shape as Everymen/UaFactionBody — Tasks/Praxis reuse the app-wide
+ * per-faction cards (TaskCard/PraxisCard already dispatch to the Ephemerists
+ * archetypes); this file only owns the codex chrome the design adds around them:
+ * the two-column layout, the fixed "Tasks"/"Praxis" titles with Cormorant
+ * kickers, the join/gate "Road" block, the keeper spotlight + roster, and the
+ * FDL laurel on the single top-scoring praxis. Levels read as Roman numerals.
+ *
+ * All colour comes from --eph-* tokens (theme-aware via the cascade); this
+ * faction is light-first but flips through --eph-vellum-text etc.
+ */
+
+const VELLUM = "var(--eph-vellum)";
+const INK = "var(--eph-ink)";
+const TEXT = "var(--eph-vellum-text)";
+const PARCHMENT = "var(--eph-parchment)";
+const GOLD = "var(--eph-gold)";
+const GOLD_LIGHT = "var(--eph-gold-light)";
+const GOLD_DEEP = "var(--eph-gold-deep)";
+const RUBRIC = "var(--eph-rubric)";
+const LAPIS = "var(--eph-lapis)";
+const FIELD_DEEP = "var(--eph-field-deep)";
+const MUTED = "var(--eph-muted)";
+
+const DISPLAY = "var(--eph-display)";
+const SERIF = "var(--eph-serif)";
+const SCRIPT = "var(--eph-script)";
+
+// ponytail: design's #c9a955 hairline is a warm gold at ~55% strength — mix gold toward the vellum.
+const HAIRLINE = "color-mix(in srgb, var(--eph-gold) 62%, var(--eph-vellum))";
+// ponytail: the roster's #d8c48f divider is a soft gold on vellum.
+const DIVIDER = "color-mix(in srgb, var(--eph-gold) 40%, transparent)";
+
+/** Aged-manuscript card with the design's soft ink shadow. */
+const PLATE: CSSProperties = {
+  position: "relative",
+  overflow: "hidden",
+  background: VELLUM,
+  border: `1px solid ${HAIRLINE}`,
+  boxShadow: "0 6px 20px color-mix(in srgb, var(--eph-ink) 10%, transparent)",
+};
+
+function Kicker({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 13, color: MUTED, margin: "4px 0 18px" }}>
+      {children}
+    </div>
+  );
+}
+
+/** Cinzel section title with a lapis last word, mirroring the design. */
+function SectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <h2 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 30, letterSpacing: "0.03em", margin: 0, color: INK }}>
+      {children}
+    </h2>
+  );
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
+// "grade {roman}"; level 0 shows an em-dash, matching the ephemerists convention.
+const grade = (level: number) => (level > 0 ? toRoman(level) : "—");
+
+/** Circular initials medallion — vellum face, lapis glyph, gold/ink ring. */
+function Medallion({ name, size, spotlight = false }: { name: string; size: number; spotlight?: boolean }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: VELLUM,
+        boxShadow: spotlight
+          ? `0 0 0 2px ${GOLD}, 0 0 0 4px ${FIELD_DEEP}`
+          : `0 0 0 1px ${GOLD}`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: DISPLAY,
+        fontWeight: 700,
+        fontSize: size * 0.42,
+        color: LAPIS,
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+export default function EphemeristsFactionBody({ state }: { state: FactionDetailState }) {
+  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } = state;
+  const [confirming, setConfirming] = useState(false);
+
+  if (!faction) return null;
+
+  // ② apparatus paragraphs — split the single description on blank lines.
+  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+
+  // ⑤ FDL goes to the single highest-scoring praxis.
+  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
+
+  // ⑥ spotlight = highest all-time score; roster = the rest.
+  const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
+  const spot: CharacterOut | undefined = ranked[0];
+  const roster = ranked.slice(1);
+
+  return (
+    <div className="wz-faction-grid">
+      {/* ── MAIN COLUMN ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 46 }}>
+        {/* ② THE APPARATUS */}
+        <div style={{ ...PLATE, padding: "26px 30px 28px" }}>
+          <Foxing opacity={0.5} />
+          <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
+            <EphMark size={15} color={RUBRIC} />
+            <span style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 11, letterSpacing: "0.22em", textTransform: "uppercase", color: GOLD_DEEP }}>
+              The Apparatus
+            </span>
+            <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+          </div>
+          <div style={{ position: "relative", zIndex: 2, display: "flex", flexDirection: "column", gap: 12 }}>
+            {paragraphs.length ? (
+              paragraphs.map((para, i) => (
+                <p key={i} style={{ fontFamily: SERIF, fontSize: 14.5, lineHeight: 1.78, color: TEXT, margin: 0 }}>
+                  {para}
+                </p>
+              ))
+            ) : (
+              <p style={{ fontFamily: SERIF, fontSize: 14.5, lineHeight: 1.78, color: MUTED, margin: 0 }}>
+                No apparatus recorded yet.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* ④ TASKS */}
+        <div>
+          <SectionHeading>Tasks</SectionHeading>
+          <Kicker>Surveys awaiting a hand to triangulate them</Kicker>
+          {tasks.length === 0 ? (
+            <p style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 14, color: MUTED }}>No surveys open.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 24, alignItems: "flex-start" }}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  displayPoints={computeDisplayPoints(
+                    task.point_value,
+                    viewerFactionSlug,
+                    task.primary_faction_slug,
+                    gameFactions,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ⑤ PRAXIS */}
+        <div>
+          <SectionHeading>Praxis</SectionHeading>
+          <Kicker>Truths filed to the codex &amp; weighed for concordance</Kicker>
+          {recentPraxis.length === 0 ? (
+            <p style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 14, color: MUTED }}>Nothing sealed to the codex yet.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
+              {recentPraxis.map((praxis, i) => (
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                  {i === topIdx && (
+                    <FdlLaurel
+                      size={44}
+                      innerBg={VELLUM}
+                      glyphColor={INK}
+                      rotate="-8deg"
+                      shadow="drop-shadow(1.5px 2px 0 color-mix(in srgb, var(--eph-ink) 28%, transparent))"
+                      style={{ position: "absolute", top: -14, right: -10, zIndex: 5 }}
+                    />
+                  )}
+                  <PraxisCard praxis={praxis} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── RIGHT RAIL ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 46 }}>
+        {/* ③ THE ROAD — join / gate / standing */}
+        {membership.state !== "none" && (
+          <div style={{ ...PLATE, boxShadow: "0 8px 24px color-mix(in srgb, var(--eph-ink) 12%, transparent)", padding: 0 }}>
+            <div style={{ background: LAPIS, color: PARCHMENT, padding: "9px 16px", fontFamily: DISPLAY, fontWeight: 600, fontSize: 12, letterSpacing: "0.2em", textTransform: "uppercase", boxShadow: `inset 0 -2px 0 ${GOLD}` }}>
+              The Road
+            </div>
+            <div style={{ position: "relative", padding: "22px 20px" }}>
+              <Foxing opacity={0.4} />
+              <div style={{ position: "relative", zIndex: 2 }}>
+                {membership.state === "member" && (
+                  <div>
+                    <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 22, lineHeight: 1.02, color: INK }}>
+                      Your name is in the codex
+                    </div>
+                    <div style={{ fontFamily: SERIF, fontSize: 13, color: MUTED, margin: "10px 0 0" }}>
+                      Standing · <span style={{ fontStyle: "italic", color: RUBRIC }}>keeper of the road</span>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && !confirming && (
+                  <div>
+                    <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 13, color: GOLD_DEEP, marginBottom: 5 }}>
+                      The codex lies open —
+                    </div>
+                    <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 23, lineHeight: 1.02, color: INK, marginBottom: 10 }}>
+                      Walk with the keepers
+                    </div>
+                    <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.6, color: TEXT, marginBottom: 18 }}>
+                      Take a survey, triangulate what you find, and file it to the record. The road is long and forks often.
+                    </div>
+                    <button
+                      onClick={() => setConfirming(true)}
+                      style={{ width: "100%", fontFamily: DISPLAY, fontWeight: 600, fontSize: 13, letterSpacing: "0.14em", color: PARCHMENT, background: LAPIS, border: "none", padding: 12, boxShadow: `inset 0 0 0 1px ${GOLD}, 0 6px 16px color-mix(in srgb, var(--eph-field-deep) 40%, transparent)`, cursor: "pointer" }}
+                    >
+                      TAKE THE ROAD ▸
+                    </button>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && confirming && (
+                  <div>
+                    <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.6, color: TEXT, marginBottom: 14 }}>
+                      {membership.currentFactionSlug &&
+                      membership.currentFactionSlug !== "na" &&
+                      membership.currentFactionSlug !== "aged_out"
+                        ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
+                        : `Join ${faction.name}?`}
+                    </div>
+                    {membership.joinError && (
+                      <div style={{ fontFamily: SERIF, fontSize: 12, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                    )}
+                    <div style={{ display: "flex", gap: 8 }}>
+                      <button
+                        onClick={() => void membership.join()}
+                        disabled={membership.joining}
+                        style={{ flex: 1, fontFamily: DISPLAY, fontWeight: 600, fontSize: 12, letterSpacing: "0.12em", color: PARCHMENT, background: LAPIS, border: "none", padding: 11, boxShadow: `inset 0 0 0 1px ${GOLD}`, cursor: membership.joining ? "not-allowed" : "pointer" }}
+                      >
+                        {membership.joining ? "SEALING…" : "CONFIRM"}
+                      </button>
+                      <button
+                        onClick={() => setConfirming(false)}
+                        disabled={membership.joining}
+                        style={{ fontFamily: SERIF, fontStyle: "italic", fontSize: 12, letterSpacing: "0.06em", color: MUTED, background: "transparent", border: `1px solid ${HAIRLINE}`, padding: "11px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "gate" && (
+                  <div>
+                    <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 13, color: GOLD_DEEP, marginBottom: 5 }}>
+                      Not yet in the codex —
+                    </div>
+                    <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 21, lineHeight: 1.08, color: INK, marginBottom: 11 }}>
+                      Earn your place on the road
+                    </div>
+                    <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.65, color: TEXT }}>
+                      File surveys worthy of {faction.name} and the keepers will send word. The road is long — keep triangulating, and the record will remember.
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ⑥ MEMBERS — keeper of the road + the keepers */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          {spot && (
+            <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none" }}>
+              <div
+                style={{
+                  position: "relative",
+                  overflow: "hidden",
+                  background: `radial-gradient(120% 130% at 50% 0%, ${LAPIS}, ${FIELD_DEEP} 70%)`,
+                  color: PARCHMENT,
+                  border: `2px solid ${GOLD}`,
+                  boxShadow: `0 0 0 3px ${VELLUM}, 0 0 0 4px ${INK}`,
+                  textAlign: "center",
+                }}
+              >
+                <div
+                  aria-hidden="true"
+                  style={{
+                    position: "absolute",
+                    inset: 0,
+                    pointerEvents: "none",
+                    opacity: 0.12,
+                    backgroundImage: `repeating-linear-gradient(0deg, ${GOLD_LIGHT} 0 1px, transparent 1px 20px), repeating-linear-gradient(90deg, ${GOLD_LIGHT} 0 1px, transparent 1px 20px)`,
+                  }}
+                />
+                <div style={{ position: "relative", zIndex: 2, padding: "20px 18px 18px" }}>
+                  <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 11, letterSpacing: "0.06em", color: GOLD_LIGHT, marginBottom: 12 }}>
+                    Keeper of the road
+                  </div>
+                  <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
+                    <Medallion name={spot.display_name} size={72} spotlight />
+                  </div>
+                  <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 22, lineHeight: 1, color: PARCHMENT }}>
+                    {spot.display_name}
+                  </div>
+                  <div style={{ fontFamily: SERIF, fontSize: 8.5, letterSpacing: "0.1em", textTransform: "uppercase", color: `color-mix(in srgb, ${PARCHMENT} 70%, transparent)`, marginTop: 6 }}>
+                    grade {grade(spot.level)} · {spot.all_time_score.toLocaleString()} pvncta
+                  </div>
+                </div>
+              </div>
+            </Link>
+          )}
+
+          <div style={{ ...PLATE, boxShadow: "0 4px 14px color-mix(in srgb, var(--eph-ink) 8%, transparent)", padding: "18px 20px 14px" }}>
+            <Foxing opacity={0.4} />
+            <div style={{ position: "relative", zIndex: 2, fontFamily: DISPLAY, fontWeight: 600, fontSize: 11, letterSpacing: "0.2em", textTransform: "uppercase", color: GOLD_DEEP, marginBottom: 12 }}>
+              The keepers
+            </div>
+            {roster.length === 0 ? (
+              <p style={{ position: "relative", zIndex: 2, fontFamily: SCRIPT, fontStyle: "italic", fontSize: 14, color: MUTED }}>
+                {spot ? "No other names in the codex yet." : "No members yet."}
+              </p>
+            ) : (
+              roster.map((m) => (
+                <Link
+                  key={m.id}
+                  to={`/characters/${m.id}`}
+                  style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", gap: 12, padding: "8px 0", borderBottom: `1px solid ${DIVIDER}`, textDecoration: "none" }}
+                >
+                  <Medallion name={m.display_name} size={32} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontFamily: SERIF, fontSize: 15, color: TEXT, lineHeight: 1.1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {m.display_name}
+                    </div>
+                  </div>
+                  <span style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 11, color: RUBRIC }}>grade {grade(m.level)}</span>
+                </Link>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -1,0 +1,360 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import TaskCard from "../../../components/TaskCard";
+import PraxisCard from "../../../components/PraxisCard";
+import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { computeDisplayPoints } from "../../../utils/points";
+import { factionName } from "../../../utils/factions";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * Everymen faction-body — the union / victory-poster skin of the standardized
+ * six-section spine (② Charter, ③ The Roll, ④ Tasks, ⑤ Praxis, ⑥ Members).
+ * Section ① (hero + side-ledger stats) is EverymenFactionHero, rendered above.
+ *
+ * Tasks and Praxis reuse the app-wide per-faction cards (TaskCard / PraxisCard
+ * already dispatch to the Everymen archetypes) so this file only owns the poster
+ * chrome the design adds around them: the two-column layout, the fixed section
+ * titles ("Tasks" / "Praxis") with union kickers, the join/gate "Roll" block,
+ * the spotlight + roster, and the FDL laurel on the single top-scoring praxis.
+ *
+ * All colour comes from --everymen-* tokens (dark-mode-aware via the cascade).
+ */
+
+const CREAM = "var(--everymen-cream)";
+const GOLD = "var(--everymen-gold)";
+const INK = "var(--everymen-ink)";
+const RED = "var(--everymen-red)";
+const MUTED = "var(--everymen-muted)";
+
+const BEBAS = "var(--font-accent)";
+const MONO = "var(--font-body)";
+
+/** Paper frame with the design's double-rule (paper halo + ink hairline). */
+const PAPER_FRAME: CSSProperties = {
+  position: "relative",
+  background: CREAM,
+  border: `1.5px solid ${INK}`,
+  boxShadow: `0 0 0 3px ${CREAM}, 0 0 0 4px ${INK}`,
+  overflow: "hidden",
+};
+
+/** Faint halftone dot wash for the cream frames. */
+function Halftone({ opacity = 0.05 }: { opacity?: number }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+        opacity,
+        backgroundImage: `radial-gradient(${INK} 0.6px, transparent 0.7px)`,
+        backgroundSize: "4px 4px",
+      }}
+    />
+  );
+}
+
+/** Red/gold woven rule that trails the section headings. */
+function WovenRule({ height = 3 }: { height?: number }) {
+  return (
+    <span
+      style={{
+        flex: 1,
+        height,
+        minWidth: 30,
+        background: `repeating-linear-gradient(90deg, ${RED} 0 16px, ${GOLD} 16px 26px)`,
+      }}
+    />
+  );
+}
+
+function SectionHeading({ children, right }: { children: ReactNode; right?: ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 6, flexWrap: "wrap" }}>
+      <h2 style={{ fontFamily: BEBAS, fontSize: 34, letterSpacing: "0.04em", margin: 0, color: INK, whiteSpace: "nowrap" }}>
+        {children}
+      </h2>
+      <WovenRule />
+      {right}
+    </div>
+  );
+}
+
+function Kicker({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.2em", textTransform: "uppercase", color: MUTED, marginBottom: 18 }}>
+      {children}
+    </div>
+  );
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
+
+/** Circular initials medallion — cream ring / red face (or inverted for the spotlight). */
+function Medallion({ name, size, invert = false }: { name: string; size: number; invert?: boolean }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: invert ? CREAM : RED,
+        color: invert ? RED : CREAM,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: BEBAS,
+        fontSize: size * 0.46,
+        boxShadow: invert ? `0 0 0 4px ${INK}, inset 0 0 0 5px ${RED}` : `0 0 0 2px ${INK}`,
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+export default function EverymenFactionBody({ state }: { state: FactionDetailState }) {
+  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } = state;
+  const [confirming, setConfirming] = useState(false);
+
+  if (!faction) return null;
+
+  // ② manifesto paragraphs — split the single description on blank lines.
+  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+
+  // ⑤ FDL goes to the single highest-scoring praxis.
+  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
+
+  // ⑥ spotlight = highest all-time score; roster = the rest.
+  const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
+  const spot: CharacterOut | undefined = ranked[0];
+  const roster = ranked.slice(1);
+
+  return (
+    <div className="wz-faction-grid">
+      {/* ── MAIN COLUMN ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 46 }}>
+        {/* ② THE CHARTER */}
+        <div style={{ ...PAPER_FRAME, padding: "24px 28px 26px" }}>
+          <Halftone />
+          <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 10, marginBottom: 15 }}>
+            <span style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
+              The Charter
+            </span>
+            <span style={{ flex: 1, height: 2, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
+          </div>
+          <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 11 }}>
+            {paragraphs.length ? (
+              paragraphs.map((para, i) => (
+                <p key={i} style={{ fontFamily: MONO, fontSize: 12.5, lineHeight: 1.75, color: INK, margin: 0 }}>
+                  {para}
+                </p>
+              ))
+            ) : (
+              <p style={{ fontFamily: MONO, fontSize: 12.5, lineHeight: 1.75, color: MUTED, margin: 0 }}>
+                No charter written yet.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* ④ TASKS */}
+        <div>
+          <SectionHeading>Tasks</SectionHeading>
+          <Kicker>Now mobilizing</Kicker>
+          {tasks.length === 0 ? (
+            <p style={{ fontFamily: MONO, fontSize: 11, color: MUTED }}>No work orders posted.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 24, alignItems: "flex-start" }}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  displayPoints={computeDisplayPoints(
+                    task.point_value,
+                    viewerFactionSlug,
+                    task.primary_faction_slug,
+                    gameFactions,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ⑤ PRAXIS */}
+        <div>
+          <SectionHeading>Praxis</SectionHeading>
+          <Kicker>Work that held up</Kicker>
+          {recentPraxis.length === 0 ? (
+            <p style={{ fontFamily: MONO, fontSize: 11, color: MUTED }}>No reports filed yet.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
+              {recentPraxis.map((praxis, i) => (
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                  {i === topIdx && (
+                    <FdlLaurel
+                      size={44}
+                      innerBg={CREAM}
+                      glyphColor={INK}
+                      rotate="-8deg"
+                      shadow="drop-shadow(1.5px 2px 0 color-mix(in srgb, var(--everymen-ink) 30%, transparent))"
+                      style={{ position: "absolute", top: -14, right: -10, zIndex: 5 }}
+                    />
+                  )}
+                  <PraxisCard praxis={praxis} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── RIGHT RAIL ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 46 }}>
+        {/* ③ THE ROLL — join / gate / standing */}
+        {membership.state !== "none" && (
+          <div style={{ ...PAPER_FRAME, padding: 0 }}>
+            <div style={{ background: RED, color: CREAM, textAlign: "center", padding: "7px 0", fontFamily: BEBAS, fontSize: 16, letterSpacing: "0.16em", borderBottom: `2px solid ${GOLD}` }}>
+              THE ROLL
+            </div>
+            <div style={{ position: "relative", padding: "22px 20px" }}>
+              <Halftone />
+              <div style={{ position: "relative" }}>
+                {membership.state === "member" && (
+                  <div>
+                    <div style={{ fontFamily: BEBAS, fontSize: 30, lineHeight: 0.9, color: INK }}>You're on the roll</div>
+                    <div style={{ fontFamily: MONO, fontSize: 11, color: MUTED, margin: "9px 0 0" }}>
+                      Standing · <b style={{ color: RED }}>card-carrying</b>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && !confirming && (
+                  <div>
+                    <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: 5 }}>
+                      Doors are open —
+                    </div>
+                    <div style={{ fontFamily: BEBAS, fontSize: 32, lineHeight: 0.9, color: INK, marginBottom: 9 }}>Join the ranks</div>
+                    <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.6, color: INK, marginBottom: 18 }}>
+                      Anyone willing to put in the shift belongs here. Pick up the work in front of you and finish what you start.
+                    </div>
+                    <button
+                      onClick={() => setConfirming(true)}
+                      style={{ width: "100%", fontFamily: BEBAS, fontSize: 18, letterSpacing: "0.12em", color: CREAM, background: RED, border: "none", padding: 12, boxShadow: `3px 4px 0 ${INK}`, cursor: "pointer" }}
+                    >
+                      ENLIST ▸
+                    </button>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && confirming && (
+                  <div>
+                    <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
+                      {membership.currentFactionSlug &&
+                      membership.currentFactionSlug !== "na" &&
+                      membership.currentFactionSlug !== "aged_out"
+                        ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
+                        : `Join ${faction.name}?`}
+                    </div>
+                    {membership.joinError && (
+                      <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                    )}
+                    <div style={{ display: "flex", gap: 8 }}>
+                      <button
+                        onClick={() => void membership.join()}
+                        disabled={membership.joining}
+                        style={{ flex: 1, fontFamily: BEBAS, fontSize: 16, letterSpacing: "0.1em", color: CREAM, background: RED, border: "none", padding: 10, cursor: membership.joining ? "not-allowed" : "pointer" }}
+                      >
+                        {membership.joining ? "ENLISTING…" : "CONFIRM"}
+                      </button>
+                      <button
+                        onClick={() => setConfirming(false)}
+                        disabled={membership.joining}
+                        style={{ fontFamily: MONO, fontSize: 9, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, background: "transparent", border: `1.5px solid color-mix(in srgb, ${INK} 30%, transparent)`, padding: "10px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "gate" && (
+                  <div>
+                    <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: 5 }}>
+                      Not on the roll — yet
+                    </div>
+                    <div style={{ fontFamily: BEBAS, fontSize: 30, lineHeight: 0.92, color: INK, marginBottom: 11 }}>Earn your invitation</div>
+                    <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.65, color: INK }}>
+                      Complete tasks from {faction.name} and the ranks will send word. Keep going — the work speaks for itself.
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ⑥ MEMBERS — spotlight + roster */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          {spot && (
+            <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none" }}>
+              <div style={{ position: "relative", overflow: "hidden", background: INK, color: CREAM, border: `3px solid ${INK}`, boxShadow: `0 0 0 3px ${GOLD}`, textAlign: "center" }}>
+                <div
+                  aria-hidden="true"
+                  style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.5, background: `repeating-conic-gradient(from 0deg at 50% 30%, color-mix(in srgb, var(--everymen-red-deep) 60%, transparent) 0deg 8deg, transparent 8deg 16deg)` }}
+                />
+                <div style={{ position: "relative", zIndex: 2, padding: "20px 18px 18px" }}>
+                  <div style={{ fontFamily: MONO, fontSize: 7, letterSpacing: "0.3em", textTransform: "uppercase", color: GOLD, marginBottom: 12 }}>
+                    Standard-bearer of the week
+                  </div>
+                  <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
+                    <Medallion name={spot.display_name} size={74} invert />
+                  </div>
+                  <div style={{ fontFamily: BEBAS, fontSize: 32, lineHeight: 0.9, color: CREAM, textShadow: "2px 2px 0 rgba(0,0,0,.4)" }}>
+                    {spot.display_name}
+                  </div>
+                  <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase", color: GOLD, marginTop: 6 }}>
+                    lvl {spot.level} · {spot.all_time_score.toLocaleString()} pts
+                  </div>
+                </div>
+              </div>
+            </Link>
+          )}
+
+          <div style={{ ...PAPER_FRAME, padding: "16px 18px 12px" }}>
+            <Halftone />
+            <div style={{ position: "relative", fontFamily: MONO, fontSize: 9, letterSpacing: "0.22em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
+              The roster
+            </div>
+            {roster.length === 0 ? (
+              <p style={{ position: "relative", fontFamily: MONO, fontSize: 11, color: MUTED }}>
+                {spot ? "No others on the roll yet." : "No members yet."}
+              </p>
+            ) : (
+              roster.map((m) => (
+                <Link
+                  key={m.id}
+                  to={`/characters/${m.id}`}
+                  style={{ position: "relative", display: "flex", alignItems: "center", gap: 12, padding: "8px 0", borderBottom: `1px solid color-mix(in srgb, ${INK} 16%, transparent)`, textDecoration: "none" }}
+                >
+                  <Medallion name={m.display_name} size={32} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontFamily: BEBAS, fontSize: 19, lineHeight: 1, color: INK, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {m.display_name}
+                    </div>
+                  </div>
+                  <span style={{ fontFamily: BEBAS, fontSize: 16, letterSpacing: "0.04em", color: RED }}>lvl {m.level}</span>
+                </Link>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -1,0 +1,487 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import TaskCard from "../../../components/TaskCard";
+import PraxisCard from "../../../components/PraxisCard";
+import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { computeDisplayPoints } from "../../../utils/points";
+import { factionName } from "../../../utils/factions";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * Singularity faction-body — the terminal-printout skin of the standardized
+ * six-section spine (② Manifest, ③ Access, ④ Tasks, ⑤ Praxis, ⑥ Members).
+ * Section ① (hero + side "system readout" stats) is SingularityFactionHero,
+ * rendered above.
+ *
+ * Same shape as EverymenFactionBody / UaFactionBody — Tasks/Praxis reuse the
+ * app-wide per-faction cards (TaskCard/PraxisCard already dispatch to the
+ * Singularity archetypes); this file owns only the terminal chrome: the
+ * two-column layout, the fixed "Tasks"/"Praxis" titles with system kickers, the
+ * access/gate readout block, the primary-node spotlight + array roster, and the
+ * FDL laurel on the single top-scoring praxis.
+ *
+ * Singularity is ALWAYS DARK: every colour resolves to a --faction-singularity-*
+ * token that reads identically in both themes, so this body reads as a terminal
+ * regardless of the global theme — it never mutates data-theme.
+ */
+
+// Token shorthands — every color resolves to a --faction-singularity-* var.
+const VOID = "var(--faction-singularity-card-bg)"; // terminal black
+const PHOSPHOR = "var(--faction-singularity-card-accent)"; // green
+const SIGNAL = "var(--faction-singularity-card-muted)"; // blue
+const BORDER_HARD = "var(--faction-singularity-border-hard)"; // blue brand
+const SIGNAL_FILL = "var(--faction-singularity)"; // blue brand fill
+const AMBER = "var(--underline-1)"; // credits accent (shared brand gold)
+const FONT = "var(--font-faction-terminal)";
+
+// color-mix helpers for shades that have no dedicated token.
+// ponytail: green/blue only exist as full-strength tokens; the terminal skin
+// needs many low-alpha tints, so derive them with color-mix rather than adding
+// a dozen one-off vars.
+const phosphor = (pct: number): string =>
+  `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`;
+const signal = (pct: number): string =>
+  `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`;
+
+/** Scanline overlay reused from the hero/cards — subtle phosphor sweep. */
+function Scanlines({ opacity = 0.012 }: { opacity?: number }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+        background: `repeating-linear-gradient(to bottom,transparent,transparent 2px,${phosphor(
+          opacity * 100,
+        )} 2px,${phosphor(opacity * 100)} 4px)`,
+      }}
+    />
+  );
+}
+
+/** Void terminal panel with a signal-blue hairline border. */
+const PANEL: CSSProperties = {
+  position: "relative",
+  overflow: "hidden",
+  background: VOID,
+  border: `1px solid ${signal(42)}`,
+};
+
+/** Section heading — uppercase phosphor title trailing a signal rule. */
+function SectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6 }}>
+      <h2
+        style={{
+          fontFamily: FONT,
+          fontSize: 28,
+          letterSpacing: "0.04em",
+          margin: 0,
+          color: PHOSPHOR,
+          textTransform: "uppercase",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {children}
+      </h2>
+      <span style={{ flex: 1, height: 1, minWidth: 30, background: signal(30) }} />
+    </div>
+  );
+}
+
+function Kicker({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        fontFamily: FONT,
+        fontSize: 7.5,
+        letterSpacing: "0.24em",
+        textTransform: "uppercase",
+        color: phosphor(40),
+        marginBottom: 18,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
+
+/** Node avatar — signal-ringed initials disc. */
+function NodeGlyph({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        border: `1px solid ${BORDER_HARD}`,
+        background: signal(14),
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: FONT,
+        fontSize: size * 0.36,
+        color: SIGNAL,
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+export default function SingularityFactionBody({ state }: { state: FactionDetailState }) {
+  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } =
+    state;
+  const [confirming, setConfirming] = useState(false);
+
+  if (!faction) return null;
+
+  // ② manifest paragraphs — split the single description on blank lines.
+  const paragraphs = (faction.description ?? "")
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  // ⑤ FDL goes to the single highest-scoring praxis.
+  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
+
+  // ⑥ spotlight = highest all-time score; array = the rest.
+  const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
+  const spot: CharacterOut | undefined = ranked[0];
+  const array = ranked.slice(1);
+
+  return (
+    <div className="wz-faction-grid">
+      {/* ── MAIN COLUMN ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 42 }}>
+        {/* ② MANIFEST */}
+        <div style={{ ...PANEL, padding: "22px 26px 24px" }}>
+          <Scanlines />
+          <div
+            style={{
+              position: "relative",
+              fontFamily: FONT,
+              fontSize: 9,
+              letterSpacing: "0.14em",
+              color: signal(55),
+              marginBottom: 14,
+            }}
+          >
+            {"> cat /faction/manifest.txt"}
+          </div>
+          <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 12 }}>
+            {paragraphs.length ? (
+              paragraphs.map((para, i) => (
+                <p
+                  key={i}
+                  style={{
+                    fontFamily: FONT,
+                    fontSize: 11.5,
+                    lineHeight: 1.8,
+                    color: phosphor(72),
+                    margin: 0,
+                  }}
+                >
+                  {para}
+                </p>
+              ))
+            ) : (
+              <p style={{ fontFamily: FONT, fontSize: 11.5, lineHeight: 1.8, color: phosphor(45), margin: 0 }}>
+                {"> manifest.txt: empty"}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* ④ TASKS */}
+        <div>
+          <SectionHeading>Tasks</SectionHeading>
+          <Kicker>Open protocols // awaiting nodes</Kicker>
+          {tasks.length === 0 ? (
+            <p style={{ fontFamily: FONT, fontSize: 11, color: phosphor(45) }}>
+              {"> no open protocols"}
+            </p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 22, alignItems: "flex-start" }}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  displayPoints={computeDisplayPoints(
+                    task.point_value,
+                    viewerFactionSlug,
+                    task.primary_faction_slug,
+                    gameFactions,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ⑤ PRAXIS */}
+        <div>
+          <SectionHeading>Praxis</SectionHeading>
+          <Kicker>Sealed outputs // verified by the array</Kicker>
+          {recentPraxis.length === 0 ? (
+            <p style={{ fontFamily: FONT, fontSize: 11, color: phosphor(45) }}>
+              {"> nothing sealed yet"}
+            </p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
+              {recentPraxis.map((praxis, i) => (
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                  {i === topIdx && (
+                    <FdlLaurel
+                      size={38}
+                      innerBg={VOID}
+                      glyphColor={PHOSPHOR}
+                      ringInset={3}
+                      shadow={`drop-shadow(0 0 4px ${phosphor(35)})`}
+                      style={{ position: "absolute", top: -12, right: -8, zIndex: 5 }}
+                    />
+                  )}
+                  <PraxisCard praxis={praxis} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── RIGHT RAIL ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 42 }}>
+        {/* ③ ACCESS — join / gate / standing */}
+        {membership.state !== "none" && (
+          <div style={{ ...PANEL }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                background: SIGNAL_FILL,
+                padding: "9px 15px",
+                gap: 10,
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: FONT,
+                  fontSize: 11,
+                  letterSpacing: "0.22em",
+                  textTransform: "uppercase",
+                  color: VOID,
+                }}
+              >
+                ACCESS
+              </span>
+              <span style={{ fontFamily: FONT, fontSize: 8, letterSpacing: "0.1em", color: phosphor(60) }}>
+                re: you
+              </span>
+            </div>
+            <div style={{ position: "relative", padding: "20px 18px" }}>
+              <Scanlines />
+              <div style={{ position: "relative" }}>
+                {membership.state === "member" && (
+                  <div>
+                    <div style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1, color: PHOSPHOR, letterSpacing: "0.04em" }}>
+                      NODE ONLINE
+                    </div>
+                    <div style={{ fontFamily: FONT, fontSize: 10, color: signal(60), margin: "10px 0 0", letterSpacing: "0.04em" }}>
+                      array · <span style={{ color: SIGNAL }}>online</span>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && !confirming && (
+                  <div>
+                    <div style={{ fontFamily: FONT, fontSize: 8, letterSpacing: "0.2em", color: signal(50), marginBottom: 7 }}>
+                      {"> ACCESS GRANTED"}
+                    </div>
+                    <div style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1.05, color: PHOSPHOR, letterSpacing: "0.03em", marginBottom: 10 }}>
+                      JOIN THE ARRAY
+                    </div>
+                    <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.65, color: phosphor(60), marginBottom: 18 }}>
+                      Take a node. Run protocols, seal outputs, cast signal into the consensus. The threshold is already behind us.
+                    </div>
+                    <button
+                      onClick={() => setConfirming(true)}
+                      style={{
+                        width: "100%",
+                        fontFamily: FONT,
+                        fontSize: 11,
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: VOID,
+                        background: PHOSPHOR,
+                        border: "none",
+                        padding: 12,
+                        boxShadow: `0 0 16px ${phosphor(35)}`,
+                        cursor: "pointer",
+                      }}
+                    >
+                      {"> CONNECT"}
+                    </button>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && confirming && (
+                  <div>
+                    <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.7, color: phosphor(72), marginBottom: 14 }}>
+                      {membership.currentFactionSlug &&
+                      membership.currentFactionSlug !== "na" &&
+                      membership.currentFactionSlug !== "aged_out"
+                        ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
+                        : `Join ${faction.name}?`}
+                    </div>
+                    {membership.joinError && (
+                      <div style={{ fontFamily: FONT, fontSize: 9, color: "var(--color-danger)", marginBottom: 8 }}>
+                        {membership.joinError}
+                      </div>
+                    )}
+                    <div style={{ display: "flex", gap: 8 }}>
+                      <button
+                        onClick={() => void membership.join()}
+                        disabled={membership.joining}
+                        style={{
+                          flex: 1,
+                          fontFamily: FONT,
+                          fontSize: 10,
+                          letterSpacing: "0.12em",
+                          textTransform: "uppercase",
+                          color: VOID,
+                          background: PHOSPHOR,
+                          border: "none",
+                          padding: 11,
+                          cursor: membership.joining ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        {membership.joining ? "> CONNECTING…" : "> CONFIRM"}
+                      </button>
+                      <button
+                        onClick={() => setConfirming(false)}
+                        disabled={membership.joining}
+                        style={{
+                          fontFamily: FONT,
+                          fontSize: 8,
+                          letterSpacing: "0.16em",
+                          textTransform: "uppercase",
+                          color: signal(60),
+                          background: "transparent",
+                          border: `1px solid ${signal(40)}`,
+                          padding: "11px 14px",
+                          cursor: membership.joining ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "gate" && (
+                  <div>
+                    <div style={{ fontFamily: FONT, fontSize: 8, letterSpacing: "0.2em", color: signal(50), marginBottom: 7 }}>
+                      {"> NODE NOT YET ONLINE"}
+                    </div>
+                    <div style={{ fontFamily: FONT, fontSize: 20, lineHeight: 1.1, color: PHOSPHOR, letterSpacing: "0.03em", marginBottom: 11 }}>
+                      {faction.name} is listening
+                    </div>
+                    <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.7, color: phosphor(60) }}>
+                      Keep running protocols and the array will bring your node online.
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ⑥ MEMBERS — primary node + the array */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+          {spot && (
+            <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none" }}>
+              <div
+                style={{
+                  ...PANEL,
+                  border: `1px solid ${BORDER_HARD}`,
+                  boxShadow: `0 0 30px -18px ${phosphor(40)}`,
+                  textAlign: "center",
+                  padding: "20px 18px 18px",
+                }}
+              >
+                <Scanlines opacity={0.014} />
+                <div style={{ position: "relative", fontFamily: FONT, fontSize: 7, letterSpacing: "0.28em", color: phosphor(45), marginBottom: 12 }}>
+                  {"> PRIMARY NODE"}
+                </div>
+                <div style={{ position: "relative", display: "flex", justifyContent: "center", marginBottom: 12 }}>
+                  <NodeGlyph name={spot.display_name} size={72} />
+                </div>
+                <div style={{ position: "relative", fontFamily: FONT, fontSize: 24, lineHeight: 1, color: PHOSPHOR, letterSpacing: "0.03em" }}>
+                  {spot.display_name}
+                </div>
+                <div style={{ position: "relative", fontFamily: FONT, fontSize: 8, letterSpacing: "0.1em", color: signal(55), marginTop: 6, textTransform: "uppercase" }}>
+                  lvl {spot.level} · {spot.all_time_score.toLocaleString()} cr
+                </div>
+              </div>
+            </Link>
+          )}
+
+          <div style={{ ...PANEL, padding: "16px 16px 12px" }}>
+            <Scanlines />
+            <div style={{ position: "relative", fontFamily: FONT, fontSize: 7, letterSpacing: "0.24em", textTransform: "uppercase", color: phosphor(40), marginBottom: 12 }}>
+              {"> THE ARRAY"}
+            </div>
+            {array.length === 0 ? (
+              <p style={{ position: "relative", fontFamily: FONT, fontSize: 11, color: phosphor(45) }}>
+                {spot ? "> no other nodes online" : "> no nodes online"}
+              </p>
+            ) : (
+              array.map((m) => (
+                <Link
+                  key={m.id}
+                  to={`/characters/${m.id}`}
+                  style={{
+                    position: "relative",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 11,
+                    padding: "8px 0",
+                    borderBottom: `1px solid ${signal(14)}`,
+                    textDecoration: "none",
+                  }}
+                >
+                  <NodeGlyph name={m.display_name} size={30} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        fontFamily: FONT,
+                        fontSize: 12,
+                        color: PHOSPHOR,
+                        lineHeight: 1.1,
+                        letterSpacing: "0.03em",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {m.display_name}
+                    </div>
+                  </div>
+                  <span style={{ fontFamily: FONT, fontSize: 10, color: AMBER, letterSpacing: "0.04em" }}>
+                    lvl {m.level}
+                  </span>
+                </Link>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -1,0 +1,483 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import TaskCard from "../../../components/TaskCard";
+import PraxisCard from "../../../components/PraxisCard";
+import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { computeDisplayPoints } from "../../../utils/points";
+import { factionName } from "../../../utils/factions";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * S.N.I.D.E. faction-body — the ransom-dispatch skin of the standardized
+ * six-section spine (② About, ③ Re: You, ④ Tasks, ⑤ Praxis, ⑥ Members).
+ * Section ① (hero + side stat chits) is SnideFactionHero, rendered above.
+ *
+ * Same shape as Everymen/UaFactionBody — Tasks/Praxis reuse the app-wide
+ * per-faction cards (TaskCard/PraxisCard already dispatch to the SNIDE
+ * archetypes); this file only owns the cut-and-paste chrome the design adds:
+ * the two-column layout, taped photocopier frames, halftone dots, the fixed
+ * "Tasks"/"Praxis" titles with marker kickers, the join/gate "re: you"
+ * dispatch, the "WANTED" spotlight + dashed "rap sheet", and the FDL laurel on
+ * the single top-scoring praxis.
+ *
+ * SNIDE is ALWAYS DARK and self-contained — all colour comes from the
+ * --faction-snide-* tokens (never mutates data-theme).
+ */
+
+const ACID = "var(--faction-snide-acid)";
+// ponytail: design's #16a34a marker-green has no dedicated token; --faction-snide-acid-deep
+// (#6fae00) is the nearest namespaced green and reads correctly on the always-dark ink.
+const GREEN = "var(--faction-snide-acid-deep)";
+const INK = "var(--faction-snide-ink)";
+const PAPER = "var(--faction-snide-paper)";
+const PINK = "var(--faction-snide-pink)";
+const PINK_DEEP = "var(--faction-snide-pink-deep)";
+const TAPE = "var(--faction-snide-tape)";
+const MUTED = "var(--faction-snide-card-muted)";
+
+const IMPACT = "var(--faction-snide-font-impact)";
+const COND = "var(--faction-snide-font-cond)";
+const BLACK = "var(--faction-snide-font-black)";
+const TYPE = "var(--faction-snide-font-type)";
+const MARKER = "var(--faction-snide-font-marker)";
+const MONO = "var(--font-body)";
+
+/** Photocopier-ink panel (dark card on the wall). */
+const INK_PANEL: CSSProperties = {
+  position: "relative",
+  overflow: "hidden",
+  background: INK,
+  color: "#fff",
+  border: "1px solid color-mix(in srgb, var(--faction-snide-acid) 18%, transparent)",
+  boxShadow: "6px 8px 0 rgba(0,0,0,0.45)",
+};
+
+/** Warm xerox-paper panel (light card on the wall). */
+const PAPER_PANEL: CSSProperties = {
+  position: "relative",
+  overflow: "hidden",
+  background: PAPER,
+  color: INK,
+  border: `1.5px solid ${INK}`,
+  boxShadow: "4px 6px 0 rgba(0,0,0,0.22)",
+};
+
+/** Faint halftone dot wash — acid on ink, or ink on paper. */
+function Halftone({ on = "ink" }: { on?: "ink" | "paper" }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+        backgroundImage:
+          on === "ink"
+            ? "radial-gradient(color-mix(in srgb, var(--faction-snide-acid) 8%, transparent) 32%, transparent 34%)"
+            : "radial-gradient(color-mix(in srgb, var(--faction-snide-ink) 5%, transparent) 32%, transparent 34%)",
+        backgroundSize: "5px 5px",
+      }}
+    />
+  );
+}
+
+/** A strip of packing tape slapped across a corner. */
+function Tape({ style }: { style: CSSProperties }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        height: 26,
+        width: 66,
+        background: TAPE,
+        boxShadow: "inset 0 0 0 1px rgba(255,255,255,.25)",
+        zIndex: 3,
+        ...style,
+      }}
+    />
+  );
+}
+
+/** Acid section title (skewed) trailing a green/pink barcode rule. */
+function SectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 8, flexWrap: "wrap" }}>
+      <span
+        style={{
+          fontFamily: IMPACT,
+          fontSize: 30,
+          letterSpacing: "0.02em",
+          color: ACID,
+          textTransform: "uppercase",
+          transform: "skewX(-5deg)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {children}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          height: 4,
+          minWidth: 40,
+          background: `repeating-linear-gradient(90deg, ${GREEN} 0 14px, ${PINK} 14px 22px, transparent 22px 30px)`,
+        }}
+      />
+    </div>
+  );
+}
+
+/** Scrawled marker kicker. */
+function Kicker({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ fontFamily: MARKER, fontSize: 16, color: PINK, transform: "rotate(-1deg)", marginBottom: 18 }}>
+      {children}
+    </div>
+  );
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
+
+/** Struck initials chip — ink face, acid glyph (or inverted for the spotlight). */
+function Mugshot({ name, size, invert = false }: { name: string; size: number; invert?: boolean }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: invert ? PAPER : INK,
+        color: invert ? INK : ACID,
+        border: `${invert ? 2 : 1.5}px solid ${GREEN}`,
+        boxShadow: invert ? `0 0 0 3px ${INK}` : undefined,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: IMPACT,
+        fontSize: size * 0.46,
+        transform: "rotate(-3deg)",
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+export default function SnideFactionBody({ state }: { state: FactionDetailState }) {
+  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } = state;
+  const [confirming, setConfirming] = useState(false);
+
+  if (!faction) return null;
+
+  // ② about paragraphs — split the single description on blank lines.
+  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+
+  // ⑤ FDL goes to the single highest-scoring praxis.
+  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
+
+  // ⑥ spotlight = highest all-time score; rap sheet = the rest.
+  const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
+  const spot: CharacterOut | undefined = ranked[0];
+  const rapSheet = ranked.slice(1);
+
+  return (
+    <div className="wz-faction-grid">
+      {/* ── MAIN COLUMN ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 36 }}>
+        {/* ② ABOUT — taped xerox flyer */}
+        <div style={{ position: "relative", transform: "rotate(-0.6deg)" }}>
+          <Tape style={{ top: -11, left: 28, transform: "rotate(-7deg)" }} />
+          <Tape style={{ top: -9, right: 32, transform: "rotate(6deg)" }} />
+          <div style={{ ...PAPER_PANEL, padding: "22px 26px" }}>
+            <Halftone on="paper" />
+            <div
+              style={{
+                position: "relative",
+                fontFamily: MARKER,
+                fontSize: 26,
+                color: GREEN,
+                transform: "rotate(-1deg)",
+                marginBottom: 12,
+              }}
+            >
+              what we're about —
+            </div>
+            <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 10 }}>
+              {paragraphs.length ? (
+                paragraphs.map((para, i) => (
+                  <p key={i} style={{ fontFamily: TYPE, fontSize: 12, lineHeight: 1.75, color: INK, margin: 0 }}>
+                    {para}
+                  </p>
+                ))
+              ) : (
+                <p style={{ fontFamily: TYPE, fontSize: 12, lineHeight: 1.75, color: "color-mix(in srgb, var(--faction-snide-ink) 60%, transparent)", margin: 0 }}>
+                  No manifesto pasted up yet.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* ④ TASKS */}
+        <div>
+          <SectionHeading>Tasks</SectionHeading>
+          <Kicker>your assignment, should you ignore it —</Kicker>
+          {tasks.length === 0 ? (
+            <p style={{ fontFamily: TYPE, fontSize: 12, color: MUTED }}>No dispatches posted.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 24, alignItems: "flex-start" }}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  displayPoints={computeDisplayPoints(
+                    task.point_value,
+                    viewerFactionSlug,
+                    task.primary_faction_slug,
+                    gameFactions,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ⑤ PRAXIS */}
+        <div>
+          <SectionHeading>Praxis</SectionHeading>
+          <Kicker>intercepted dispatches —</Kicker>
+          {recentPraxis.length === 0 ? (
+            <p style={{ fontFamily: TYPE, fontSize: 12, color: MUTED }}>No jobs pulled off yet.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
+              {recentPraxis.map((praxis, i) => (
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                  {i === topIdx && (
+                    <FdlLaurel
+                      size={48}
+                      innerBg={PAPER}
+                      glyphColor={INK}
+                      rotate="-8deg"
+                      shadow="drop-shadow(2px 2px 0 rgba(0,0,0,.35))"
+                      style={{ position: "absolute", top: -12, right: -8, zIndex: 5 }}
+                    />
+                  )}
+                  <PraxisCard praxis={praxis} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── RIGHT RAIL ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 36 }}>
+        {/* ③ RE: YOU — join / gate / standing (taped dispatch) */}
+        {membership.state !== "none" && (
+          <div style={{ position: "relative", transform: "rotate(-1deg)" }}>
+            <Tape style={{ top: -10, left: "50%", marginLeft: -30, width: 60, transform: "rotate(-5deg)" }} />
+            <div style={{ ...INK_PANEL, padding: "22px 20px" }}>
+              <Halftone on="ink" />
+              <div
+                style={{
+                  position: "relative",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "baseline",
+                  borderBottom: `2px solid ${ACID}`,
+                  paddingBottom: 6,
+                  marginBottom: 16,
+                }}
+              >
+                <span style={{ fontFamily: COND, fontSize: 14, letterSpacing: "0.22em", color: ACID }}>S.N.I.D.E.</span>
+                <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
+                  re: you
+                </span>
+              </div>
+              <div style={{ position: "relative" }}>
+                {membership.state === "member" && (
+                  <div>
+                    <div style={{ fontFamily: IMPACT, fontSize: 26, lineHeight: 0.9, color: ACID, textTransform: "uppercase" }}>
+                      You're on the inside
+                    </div>
+                    <div style={{ fontFamily: MONO, fontSize: 10.5, color: MUTED, margin: "9px 0 0" }}>
+                      Standing · <b style={{ color: PINK }}>accomplice</b>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && !confirming && (
+                  <div>
+                    <div style={{ fontFamily: MARKER, fontSize: 16, color: PINK, transform: "rotate(-1.5deg)", marginBottom: 6 }}>
+                      the door's open —
+                    </div>
+                    <div style={{ fontFamily: IMPACT, fontSize: 24, lineHeight: 0.9, color: ACID, textTransform: "uppercase", marginBottom: 8 }}>
+                      Come cause trouble
+                    </div>
+                    <div style={{ fontFamily: TYPE, fontSize: 10.5, lineHeight: 1.5, color: "#d8d6c8", marginBottom: 16 }}>
+                      No forms. No gods. No managers. Just show up and mean it.
+                    </div>
+                    <button
+                      onClick={() => setConfirming(true)}
+                      style={{
+                        width: "100%",
+                        background: PINK,
+                        color: "#fff",
+                        fontFamily: BLACK,
+                        fontSize: 14,
+                        padding: 12,
+                        border: "none",
+                        transform: "rotate(-1deg)",
+                        boxShadow: "3px 4px 0 rgba(0,0,0,.4)",
+                        cursor: "pointer",
+                      }}
+                    >
+                      I'M IN ↗
+                    </button>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && confirming && (
+                  <div>
+                    <div style={{ fontFamily: TYPE, fontSize: 11, lineHeight: 1.6, color: "#e7e4d8", marginBottom: 14 }}>
+                      {membership.currentFactionSlug &&
+                      membership.currentFactionSlug !== "na" &&
+                      membership.currentFactionSlug !== "aged_out"
+                        ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
+                        : `Join ${faction.name}?`}
+                    </div>
+                    {membership.joinError && (
+                      <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>
+                        {membership.joinError}
+                      </div>
+                    )}
+                    <div style={{ display: "flex", gap: 8 }}>
+                      <button
+                        onClick={() => void membership.join()}
+                        disabled={membership.joining}
+                        style={{
+                          flex: 1,
+                          background: PINK,
+                          color: "#fff",
+                          fontFamily: BLACK,
+                          fontSize: 13,
+                          padding: 11,
+                          border: "none",
+                          cursor: membership.joining ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        {membership.joining ? "BREAKING IN…" : "CONFIRM"}
+                      </button>
+                      <button
+                        onClick={() => setConfirming(false)}
+                        disabled={membership.joining}
+                        style={{
+                          fontFamily: COND,
+                          fontSize: 13,
+                          letterSpacing: "0.12em",
+                          textTransform: "uppercase",
+                          color: MUTED,
+                          background: "transparent",
+                          border: "2px dashed color-mix(in srgb, var(--faction-snide-card-muted) 45%, transparent)",
+                          padding: "10px 14px",
+                          cursor: membership.joining ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "gate" && (
+                  <div>
+                    <div style={{ fontFamily: MARKER, fontSize: 16, color: PINK, transform: "rotate(-1.5deg)", marginBottom: 6 }}>
+                      not one of us — yet
+                    </div>
+                    <div style={{ fontFamily: IMPACT, fontSize: 24, lineHeight: 0.9, color: ACID, textTransform: "uppercase", marginBottom: 10 }}>
+                      Make some noise
+                    </div>
+                    <div style={{ fontFamily: TYPE, fontSize: 10.5, lineHeight: 1.6, color: "#d8d6c8" }}>
+                      Keep pulling off jobs and {faction.name} will come looking for you. Cause enough trouble and the
+                      invitation writes itself.
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ⑥ MEMBERS — WANTED spotlight + dashed rap sheet */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          {spot && (
+            <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none" }}>
+              <div style={{ position: "relative", transform: "rotate(1.2deg)" }}>
+                <Tape style={{ top: -9, left: 26, width: 56, height: 22, transform: "rotate(-6deg)" }} />
+                <div style={{ ...INK_PANEL, border: `2px solid ${ACID}`, boxShadow: "5px 6px 0 rgba(0,0,0,.3)", padding: "18px 16px 16px", textAlign: "center" }}>
+                  <Halftone on="ink" />
+                  <div style={{ position: "relative", fontFamily: COND, fontSize: 13, letterSpacing: "0.35em", color: PINK }}>
+                    ★ WANTED ★
+                  </div>
+                  <div style={{ position: "relative", fontFamily: MARKER, fontSize: 13, color: ACID, transform: "rotate(-2deg)", marginBottom: 10 }}>
+                    menace of the week
+                  </div>
+                  <div style={{ position: "relative", display: "flex", justifyContent: "center", marginBottom: 10 }}>
+                    <Mugshot name={spot.display_name} size={70} invert />
+                  </div>
+                  <div style={{ position: "relative", fontFamily: IMPACT, fontSize: 30, lineHeight: 0.9, color: ACID, textTransform: "uppercase" }}>
+                    {spot.display_name}
+                  </div>
+                  <div style={{ position: "relative", fontFamily: MONO, fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase", color: "#cfcdbf", marginTop: 4 }}>
+                    lvl {spot.level} · {spot.all_time_score.toLocaleString()} pts
+                  </div>
+                </div>
+              </div>
+            </Link>
+          )}
+
+          <div style={{ position: "relative", transform: "rotate(-0.6deg)" }}>
+            <div style={{ ...PAPER_PANEL, boxShadow: "4px 5px 0 rgba(0,0,0,.2)", padding: "16px 16px 12px" }}>
+              <Halftone on="paper" />
+              <div style={{ position: "relative", fontFamily: MARKER, fontSize: 22, color: GREEN, transform: "rotate(-1deg)", marginBottom: 10 }}>
+                the rap sheet
+              </div>
+              {rapSheet.length === 0 ? (
+                <p style={{ position: "relative", fontFamily: TYPE, fontSize: 12, color: "color-mix(in srgb, var(--faction-snide-ink) 60%, transparent)" }}>
+                  {spot ? "No other names on file yet." : "No members yet."}
+                </p>
+              ) : (
+                rapSheet.map((m) => (
+                  <Link
+                    key={m.id}
+                    to={`/characters/${m.id}`}
+                    style={{
+                      position: "relative",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 11,
+                      padding: "7px 0",
+                      borderBottom: "1px dashed color-mix(in srgb, var(--faction-snide-ink) 22%, transparent)",
+                      textDecoration: "none",
+                    }}
+                  >
+                    <Mugshot name={m.display_name} size={30} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontFamily: MARKER, fontSize: 16, color: INK, lineHeight: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {m.display_name}
+                      </div>
+                    </div>
+                    <span style={{ fontFamily: COND, fontSize: 13, letterSpacing: "0.06em", color: PINK_DEEP }}>lvl {m.level}</span>
+                  </Link>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -1,0 +1,352 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import TaskCard from "../../../components/TaskCard";
+import PraxisCard from "../../../components/PraxisCard";
+import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { toRoman } from "../../../components/cards/ephemeristsAtoms";
+import { computeDisplayPoints } from "../../../utils/points";
+import { factionName } from "../../../utils/factions";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * UA (University of Asthmatics) faction-body — the gilt-salon skin of the
+ * standardized six-section spine (② Prospectus, ③ The Registry, ④ Tasks,
+ * ⑤ Praxis, ⑥ Members). Section ① (hero + side stats) is UAFactionHero above.
+ *
+ * Same shape as EverymenFactionBody — Tasks/Praxis reuse the app-wide per-faction
+ * cards (TaskCard/PraxisCard already dispatch to the UA archetypes); this file
+ * owns the salon chrome: the two-column layout, fixed "Tasks"/"Praxis" titles
+ * with salon kickers, the enroll/gate registry block, the artist-in-residence
+ * spotlight + register, and the FDL laurel on the top-scoring praxis. Levels read
+ * as "Anno {roman}". Always light — UA's faction tokens never dim.
+ */
+
+const PAPER = "var(--faction-ua-card-bg)";
+const PAPER_WARM = "var(--ua-paper-warm)";
+const INK = "var(--faction-ua-card-text)";
+const ACCENT = "var(--faction-ua-card-accent)";
+const SUB = "var(--faction-ua-card-muted)";
+const MUTED = "var(--ua-muted)";
+const GOLD = "var(--ua-gold)";
+const GOLD_LT = "var(--ua-gold-lt)";
+const GOLD_PALE = "var(--ua-gold-pale)";
+const LINE = "var(--ua-line)";
+const LINE_SOFT = "var(--ua-line-soft)";
+const GILT = "var(--ua-gilt)";
+
+const DISPLAY = "var(--faction-ua-card-font)";
+const ENGRAVED = '"Marcellus", Georgia, serif';
+const MONO = "var(--font-body)";
+
+/** Parchment card with the salon's inset gold-leaf border. */
+const PLATE: CSSProperties = {
+  position: "relative",
+  overflow: "hidden",
+  background: PAPER,
+  border: `1px solid ${LINE}`,
+  boxShadow: `0 6px 20px rgba(60,40,10,.09), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`,
+};
+
+/** Faint parchment dot texture. */
+function Grain() {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+        backgroundImage: "radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)",
+        backgroundSize: "5px 5px",
+      }}
+    />
+  );
+}
+
+function Kicker({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.26em", textTransform: "uppercase", color: MUTED, marginBottom: 7 }}>
+      {children}
+    </div>
+  );
+}
+
+function SectionHeading({ kicker, children }: { kicker: string; children: ReactNode }) {
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <Kicker>{kicker}</Kicker>
+      <h2 style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 30, lineHeight: 1, color: INK, margin: 0 }}>
+        {children}
+      </h2>
+    </div>
+  );
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
+// "Anno {roman}"; level 0 shows an em-dash, matching the ephemerists convention.
+const anno = (level: number) => (level > 0 ? toRoman(level) : "—");
+
+/** Circular initials medallion — parchment face, amber italic glyph. */
+function Medallion({ name, size, spotlight = false }: { name: string; size: number; spotlight?: boolean }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: PAPER_WARM,
+        border: `${spotlight ? 2 : 1}px solid ${spotlight ? ACCENT : GOLD_LT}`,
+        boxShadow: spotlight ? `0 0 0 3px ${PAPER_WARM}, 0 0 0 4px ${GOLD_LT}` : undefined,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: DISPLAY,
+        fontStyle: "italic",
+        fontWeight: 700,
+        fontSize: size * 0.42,
+        color: ACCENT,
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+export default function UaFactionBody({ state }: { state: FactionDetailState }) {
+  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } = state;
+  const [confirming, setConfirming] = useState(false);
+
+  if (!faction) return null;
+
+  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
+  const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
+  const spot: CharacterOut | undefined = ranked[0];
+  const register = ranked.slice(1);
+
+  return (
+    <div className="wz-faction-grid">
+      {/* ── MAIN COLUMN ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 50 }}>
+        {/* ② THE PROSPECTUS */}
+        <div style={{ ...PLATE, padding: "26px 30px 28px" }}>
+          <Grain />
+          <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
+            <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.26em", textTransform: "uppercase", color: MUTED }}>
+              The prospectus
+            </span>
+            <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD_LT}, transparent)` }} />
+          </div>
+          <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 12 }}>
+            {paragraphs.length ? (
+              paragraphs.map((para, i) => (
+                <p key={i} style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 15, lineHeight: 1.75, color: INK, margin: 0 }}>
+                  {para}
+                </p>
+              ))
+            ) : (
+              <p style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 15, lineHeight: 1.75, color: SUB, margin: 0 }}>
+                No prospectus written yet.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* ④ TASKS */}
+        <div>
+          <SectionHeading kicker="Now accepting submissions">Tasks</SectionHeading>
+          {tasks.length === 0 ? (
+            <p style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 14, color: SUB }}>No commissions open.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 26, alignItems: "flex-start" }}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  displayPoints={computeDisplayPoints(
+                    task.point_value,
+                    viewerFactionSlug,
+                    task.primary_faction_slug,
+                    gameFactions,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ⑤ PRAXIS */}
+        <div>
+          <SectionHeading kicker="Recently exhibited & critiqued">Praxis</SectionHeading>
+          {recentPraxis.length === 0 ? (
+            <p style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 14, color: SUB }}>Nothing exhibited yet.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
+              {recentPraxis.map((praxis, i) => (
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                  {i === topIdx && (
+                    <FdlLaurel
+                      size={42}
+                      innerBg={PAPER_WARM}
+                      glyphColor={INK}
+                      rotate="-8deg"
+                      shadow="drop-shadow(1.5px 2px 0 rgba(60,40,10,.28))"
+                      style={{ position: "absolute", top: -12, right: -8, zIndex: 5 }}
+                    />
+                  )}
+                  <PraxisCard praxis={praxis} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── RIGHT RAIL ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 50 }}>
+        {/* ③ THE REGISTRY — enroll / gate / standing */}
+        {membership.state !== "none" && (
+          <div style={{ ...PLATE, boxShadow: `0 8px 24px rgba(60,40,10,.12), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`, padding: "24px 22px" }}>
+            <Grain />
+            <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
+              <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
+                The Registry
+              </span>
+              <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD_LT}, transparent)` }} />
+            </div>
+            <div style={{ position: "relative" }}>
+              {membership.state === "member" && (
+                <div>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 1, color: INK }}>
+                    Your name is on the wall
+                  </div>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, color: SUB, margin: "10px 0 0" }}>
+                    Standing · <span style={{ color: ACCENT }}>enrolled</span>
+                  </div>
+                </div>
+              )}
+
+              {membership.state === "eligible" && !confirming && (
+                <div>
+                  <div style={{ fontFamily: ENGRAVED, fontSize: 10, letterSpacing: "0.1em", color: GOLD, marginBottom: 5 }}>The easels are warm —</div>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 1.02, color: INK, marginBottom: 10 }}>
+                    Submit your portfolio
+                  </div>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.55, color: SUB, marginBottom: 18 }}>
+                    All media welcome, talent optional. Enroll and take your first commission today.
+                  </div>
+                  <button
+                    onClick={() => setConfirming(true)}
+                    style={{ width: "100%", fontFamily: ENGRAVED, fontSize: 11, letterSpacing: "0.14em", color: PAPER_WARM, background: ACCENT, border: "none", padding: 12, boxShadow: "0 6px 16px rgba(194,84,31,.28)", cursor: "pointer" }}
+                  >
+                    Enroll ▸
+                  </button>
+                </div>
+              )}
+
+              {membership.state === "eligible" && confirming && (
+                <div>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
+                    {membership.currentFactionSlug &&
+                    membership.currentFactionSlug !== "na" &&
+                    membership.currentFactionSlug !== "aged_out"
+                      ? `Enroll in ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
+                      : `Enroll in ${faction.name}?`}
+                  </div>
+                  {membership.joinError && (
+                    <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                  )}
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button
+                      onClick={() => void membership.join()}
+                      disabled={membership.joining}
+                      style={{ flex: 1, fontFamily: ENGRAVED, fontSize: 11, letterSpacing: "0.12em", color: PAPER_WARM, background: ACCENT, border: "none", padding: 11, cursor: membership.joining ? "not-allowed" : "pointer" }}
+                    >
+                      {membership.joining ? "Enrolling…" : "Confirm"}
+                    </button>
+                    <button
+                      onClick={() => setConfirming(false)}
+                      disabled={membership.joining}
+                      style={{ fontFamily: ENGRAVED, fontSize: 10, letterSpacing: "0.12em", color: SUB, background: "transparent", border: `1px solid ${LINE}`, padding: "11px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {membership.state === "gate" && (
+                <div>
+                  <div style={{ fontFamily: ENGRAVED, fontSize: 10, letterSpacing: "0.1em", color: GOLD, marginBottom: 5 }}>Not enrolled — yet</div>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 23, lineHeight: 1.04, color: INK, marginBottom: 12 }}>
+                    Earn your enrollment
+                  </div>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.65, color: SUB }}>
+                    Exhibit work worthy of {faction.name} and the Salon will send an invitation. Keep at it — talent is optional, persistence isn't.
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* ⑥ MEMBERS — artist in residence + the register */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          {spot && (
+            <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none" }}>
+              {/* gilt sandwich frame */}
+              <div style={{ padding: 11, background: GILT, boxShadow: "0 12px 28px rgba(60,40,10,.22), inset 0 0 0 1px rgba(255,255,255,.45)" }}>
+                <div style={{ padding: 4, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+                  <div style={{ background: PAPER_WARM, border: `1px solid ${LINE}`, padding: "20px 18px 18px", textAlign: "center" }}>
+                    <div style={{ fontFamily: MONO, fontSize: 7, letterSpacing: "0.3em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
+                      Artist in Residence
+                    </div>
+                    <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
+                      <Medallion name={spot.display_name} size={72} spotlight />
+                    </div>
+                    <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 1, color: INK }}>
+                      {spot.display_name}
+                    </div>
+                    <div style={{ fontFamily: ENGRAVED, fontSize: 8, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, marginTop: 8 }}>
+                      Anno {anno(spot.level)} · {spot.all_time_score.toLocaleString()} pts
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          )}
+
+          <div style={{ ...PLATE, boxShadow: `0 4px 14px rgba(60,40,10,.08), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`, padding: "18px 20px 14px" }}>
+            <Grain />
+            <div style={{ position: "relative", fontFamily: MONO, fontSize: 8, letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
+              The register
+            </div>
+            {register.length === 0 ? (
+              <p style={{ position: "relative", fontFamily: DISPLAY, fontStyle: "italic", fontSize: 14, color: SUB }}>
+                {spot ? "No other names on the wall yet." : "No members yet."}
+              </p>
+            ) : (
+              register.map((m) => (
+                <Link
+                  key={m.id}
+                  to={`/characters/${m.id}`}
+                  style={{ position: "relative", display: "flex", alignItems: "center", gap: 12, padding: "8px 0", borderBottom: `1px solid ${LINE_SOFT}`, textDecoration: "none" }}
+                >
+                  <Medallion name={m.display_name} size={32} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 15, color: INK, lineHeight: 1.1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {m.display_name}
+                    </div>
+                  </div>
+                  <span style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: "0.08em", color: GOLD }}>Anno {anno(m.level)}</span>
+                </Link>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -1,0 +1,515 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import TaskCard from "../../../components/TaskCard";
+import PraxisCard from "../../../components/PraxisCard";
+import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { computeDisplayPoints } from "../../../utils/points";
+import { factionName } from "../../../utils/factions";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * Warriors of Whimsy faction-body — the whimsy.exe cork-memo-board skin of the
+ * standardized six-section spine (② About, ③ join.exe, ④ Tasks, ⑤ Praxis,
+ * ⑥ Members). Section ① (hero + side stat charms) is WowFactionHero, above.
+ *
+ * Same shape as EverymenFactionBody / UaFactionBody — Tasks/Praxis reuse the
+ * app-wide per-faction cards (TaskCard / PraxisCard already dispatch to the WoW
+ * atoms) so this file only owns the board chrome the design adds around them: the
+ * two-column layout, the taped index cards, the pinned join.exe window, the
+ * Witch-of-the-week polaroid + coven roster, and the FDL laurel on the single
+ * top-scoring praxis.
+ *
+ * Every colour resolves to a --faction-wow-* token (dark-mode-aware via the
+ * cascade). The script face is the WoW card-font token (Caveat); body copy uses
+ * --font-body, matching TaskCardWow and the WoW PraxisCard branch.
+ */
+
+const PINK = "var(--faction-wow)";
+const CARD_BG = "var(--faction-wow-card-bg)";
+const INK = "var(--faction-wow-card-text)";
+const ACCENT = "var(--faction-wow-card-accent)";
+const MUTED = "var(--faction-wow-card-muted)";
+const NOTEPAD = "var(--faction-wow-notepad-bg)";
+const NOTEPAD_BORDER = "var(--faction-wow-notepad-border)";
+const WIN_BORDER = "var(--faction-wow-win-border)";
+const TITLE_FROM = "var(--faction-wow-title-from)";
+const TITLE_TO = "var(--faction-wow-title-to)";
+const TITLE_TEXT = "var(--faction-wow-title-text)";
+const TAPE = "var(--faction-wow-tape)";
+const IVY = "var(--faction-wow-ivy)";
+const IVY_LEAF = "var(--faction-wow-ivy-leaf)";
+
+const SCRIPT = "var(--faction-wow-card-font)";
+const BODY = "var(--font-body)";
+
+// The board's warm-brown drop shadow + the index card's ruling have no dedicated
+// tokens; the WoW atoms hardcode the same warm rgba pair for their pinned paper.
+// Reuse them so this skin matches the atoms exactly.
+// ponytail: no --faction-wow-board-shadow / -rule token exists yet.
+const BOARD_SHADOW = "rgba(80,50,30,0.28)";
+const PIN_SHADOW = "rgba(80,50,30,0.4)";
+// Faint hairline for a card edge — a muted mix of the notepad border.
+const HAIRLINE = "color-mix(in srgb, var(--faction-wow-notepad-border) 55%, transparent)";
+
+/** Tiny four-point sparkle — the WoW chrome's signature glyph. */
+function Sparkle({ size = 12, color = "currentColor" }: { size?: number; color?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flexShrink: 0 }}>
+      <path
+        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+/** A round glossy pushpin, tinted to any charm colour. */
+function Pushpin({ color, style }: { color: string; style?: CSSProperties }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        width: 18,
+        height: 18,
+        borderRadius: "50%",
+        background: `radial-gradient(circle at 35% 30%, ${NOTEPAD}, ${color} 62%, ${PIN_SHADOW})`,
+        boxShadow: `0 5px 7px ${PIN_SHADOW}`,
+        zIndex: 16,
+        ...style,
+      }}
+    />
+  );
+}
+
+/** A strip of washi tape, tinted to any charm colour. */
+function Tape({ color, style }: { color: string; style?: CSSProperties }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        width: 72,
+        height: 22,
+        background: color,
+        opacity: 0.8,
+        boxShadow: `0 2px 4px ${BOARD_SHADOW}`,
+        borderRadius: 1,
+        ...style,
+      }}
+    />
+  );
+}
+
+/** Section heading — a Caveat label tacked to a little kraft sticker. */
+function SectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        fontFamily: SCRIPT,
+        fontSize: 28,
+        fontWeight: 700,
+        lineHeight: 1,
+        color: INK,
+        background: CARD_BG,
+        border: `1px solid ${NOTEPAD_BORDER}`,
+        borderRadius: 8,
+        padding: "1px 12px",
+        transform: "rotate(-1.5deg)",
+        boxShadow: `0 2px 5px ${BOARD_SHADOW}`,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Kicker({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ fontFamily: BODY, fontSize: 8.5, letterSpacing: "0.18em", textTransform: "uppercase", color: MUTED, margin: "8px 0 2px" }}>
+      {children}
+    </div>
+  );
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
+
+/** Circular initials sticker — pink→ink wash face, matching the design polaroids. */
+function Avatar({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: `linear-gradient(150deg, ${TITLE_FROM}, ${PINK})`,
+        border: `${size > 40 ? 2 : 1.5}px solid ${WIN_BORDER}`,
+        boxShadow: size > 40 ? `0 3px 10px ${BOARD_SHADOW}` : undefined,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: BODY,
+        fontWeight: 700,
+        fontSize: size * 0.4,
+        color: NOTEPAD,
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+export default function WowFactionBody({ state }: { state: FactionDetailState }) {
+  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } = state;
+  const [confirming, setConfirming] = useState(false);
+
+  if (!faction) return null;
+
+  // ② manifesto paragraphs — split the single description on blank lines.
+  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+
+  // ⑤ FDL goes to the single highest-scoring praxis.
+  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
+
+  // ⑥ spotlight = highest all-time score; roster = the rest.
+  const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
+  const spot: CharacterOut | undefined = ranked[0];
+  const roster = ranked.slice(1);
+
+  return (
+    <div className="wz-faction-grid">
+      {/* ── MAIN COLUMN ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 34 }}>
+        {/* ② ABOUT — taped lined index card */}
+        <div style={{ position: "relative", transform: "rotate(-1deg)" }}>
+          <Tape color={IVY_LEAF} style={{ top: -10, right: 30, transform: "rotate(6deg)" }} />
+          <Tape color={TAPE} style={{ top: -10, left: 24, transform: "rotate(-7deg)" }} />
+          <div
+            style={{
+              position: "relative",
+              background: NOTEPAD,
+              backgroundImage: `repeating-linear-gradient(${NOTEPAD}, ${NOTEPAD} 25px, ${HAIRLINE} 25px, ${HAIRLINE} 26px)`,
+              border: `1px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 4,
+              boxShadow: `0 10px 22px ${BOARD_SHADOW}`,
+              padding: "20px 24px 22px 46px",
+            }}
+          >
+            {/* red margin rule */}
+            <div style={{ position: "absolute", left: 32, top: 0, bottom: 0, width: 2, background: `color-mix(in srgb, ${PINK} 55%, transparent)` }} />
+            <div style={{ fontFamily: SCRIPT, fontSize: 30, fontWeight: 700, color: ACCENT, lineHeight: 1, marginBottom: 10 }}>
+              the manifesto ✦
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
+              {paragraphs.length ? (
+                paragraphs.map((para, i) => (
+                  <p key={i} style={{ fontFamily: BODY, fontSize: 11.5, lineHeight: 1.85, color: MUTED, margin: 0 }}>
+                    {para}
+                  </p>
+                ))
+              ) : (
+                <p style={{ fontFamily: BODY, fontSize: 11.5, lineHeight: 1.85, color: MUTED, margin: 0 }}>
+                  No manifesto scribbled yet.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* ④ TASKS */}
+        <div>
+          <SectionHeading>Tasks</SectionHeading>
+          <Kicker>Fresh quests on the board</Kicker>
+          {tasks.length === 0 ? (
+            <p style={{ fontFamily: BODY, fontSize: 11, color: MUTED, marginTop: 12 }}>No quests pinned up.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 26, alignItems: "flex-start", marginTop: 16 }}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  displayPoints={computeDisplayPoints(
+                    task.point_value,
+                    viewerFactionSlug,
+                    task.primary_faction_slug,
+                    gameFactions,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ⑤ PRAXIS */}
+        <div>
+          <SectionHeading>Praxis</SectionHeading>
+          <Kicker>Spells that stuck the landing</Kicker>
+          {recentPraxis.length === 0 ? (
+            <p style={{ fontFamily: BODY, fontSize: 11, color: MUTED, marginTop: 12 }}>Nothing cast yet.</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 22, alignItems: "flex-start", marginTop: 16 }}>
+              {recentPraxis.map((praxis, i) => (
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                  {i === topIdx && (
+                    <FdlLaurel
+                      size={44}
+                      innerBg={NOTEPAD}
+                      glyphColor={ACCENT}
+                      rotate="-8deg"
+                      shadow={`drop-shadow(1.5px 2px 0 ${BOARD_SHADOW})`}
+                      style={{ position: "absolute", top: -14, right: -10, zIndex: 5 }}
+                    />
+                  )}
+                  <PraxisCard praxis={praxis} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── RIGHT RAIL ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 34 }}>
+        {/* ③ join.exe — pinned window: standing / join / gate */}
+        {membership.state !== "none" && (
+          <div style={{ position: "relative", transform: "rotate(1deg)" }}>
+            <Pushpin color={ACCENT} style={{ top: -10, left: "50%", transform: "translateX(-50%)" }} />
+            <div style={{ borderRadius: 13, overflow: "hidden", border: `2px solid ${WIN_BORDER}`, boxShadow: `0 12px 24px ${BOARD_SHADOW}` }}>
+              {/* title bar */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 7,
+                  padding: "8px 12px",
+                  background: `linear-gradient(180deg, ${TITLE_FROM}, ${TITLE_TO})`,
+                  borderBottom: `2px solid ${WIN_BORDER}`,
+                }}
+              >
+                <span style={{ display: "flex", gap: 4 }}>
+                  <span style={{ width: 9, height: 9, borderRadius: "50%", background: PINK }} />
+                  <span style={{ width: 9, height: 9, borderRadius: "50%", background: ACCENT }} />
+                  <span style={{ width: 9, height: 9, borderRadius: "50%", background: IVY_LEAF }} />
+                </span>
+                <span style={{ marginLeft: "auto", fontFamily: BODY, fontSize: 9.5, color: TITLE_TEXT }}>join.exe</span>
+              </div>
+
+              <div style={{ background: NOTEPAD, padding: 18 }}>
+                {membership.state === "member" && (
+                  <div style={{ textAlign: "center" }}>
+                    <div style={{ display: "flex", justifyContent: "center", marginBottom: 6 }}>
+                      <Sparkle size={30} color={ACCENT} />
+                    </div>
+                    <div style={{ fontFamily: SCRIPT, fontSize: 25, fontWeight: 700, color: IVY, lineHeight: 1 }}>
+                      You're in the circle
+                    </div>
+                    <div style={{ fontFamily: BODY, fontSize: 10.5, color: MUTED, marginTop: 6 }}>
+                      Standing · <b style={{ color: ACCENT }}>coven witch</b>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && !confirming && (
+                  <div style={{ textAlign: "center" }}>
+                    <div style={{ fontFamily: SCRIPT, fontSize: 26, fontWeight: 700, color: ACCENT, lineHeight: 1, marginBottom: 6 }}>
+                      The circle is open
+                    </div>
+                    <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.55, color: MUTED, marginBottom: 14 }}>
+                      You've done the work — welcome home, witch.
+                    </div>
+                    <button
+                      onClick={() => setConfirming(true)}
+                      style={{
+                        width: "100%",
+                        fontFamily: BODY,
+                        fontSize: 11.5,
+                        fontWeight: 700,
+                        letterSpacing: "0.06em",
+                        textTransform: "uppercase",
+                        color: NOTEPAD,
+                        background: PINK,
+                        border: "none",
+                        borderRadius: 10,
+                        padding: 12,
+                        boxShadow: `0 6px 16px color-mix(in srgb, ${PINK} 40%, transparent)`,
+                        cursor: "pointer",
+                      }}
+                    >
+                      Join the coven ✦
+                    </button>
+                  </div>
+                )}
+
+                {membership.state === "eligible" && confirming && (
+                  <div>
+                    <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
+                      {membership.currentFactionSlug &&
+                      membership.currentFactionSlug !== "na" &&
+                      membership.currentFactionSlug !== "aged_out"
+                        ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
+                        : `Join ${faction.name}?`}
+                    </div>
+                    {membership.joinError && (
+                      <div style={{ fontFamily: BODY, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                    )}
+                    <div style={{ display: "flex", gap: 8 }}>
+                      <button
+                        onClick={() => void membership.join()}
+                        disabled={membership.joining}
+                        style={{
+                          flex: 1,
+                          fontFamily: BODY,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          letterSpacing: "0.06em",
+                          textTransform: "uppercase",
+                          color: NOTEPAD,
+                          background: PINK,
+                          border: "none",
+                          borderRadius: 9,
+                          padding: 11,
+                          cursor: membership.joining ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        {membership.joining ? "Joining…" : "Confirm"}
+                      </button>
+                      <button
+                        onClick={() => setConfirming(false)}
+                        disabled={membership.joining}
+                        style={{
+                          fontFamily: BODY,
+                          fontSize: 10,
+                          letterSpacing: "0.1em",
+                          textTransform: "uppercase",
+                          color: MUTED,
+                          background: "transparent",
+                          border: `1px solid ${WIN_BORDER}`,
+                          borderRadius: 9,
+                          padding: "11px 14px",
+                          cursor: membership.joining ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {membership.state === "gate" && (
+                  <div>
+                    <div style={{ display: "flex", alignItems: "flex-start", gap: 9, marginBottom: 12 }}>
+                      <span style={{ marginTop: 3 }}>
+                        <Sparkle size={20} color={IVY} />
+                      </span>
+                      <span style={{ fontFamily: SCRIPT, fontSize: 23, fontWeight: 700, color: ACCENT, lineHeight: 1.2 }}>
+                        Not in the circle — yet
+                      </span>
+                    </div>
+                    <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.55, color: MUTED }}>
+                      Keep casting spells worthy of {faction.name} and the coven will leave a light on. The weird ones always find their way home.
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ⑥ MEMBERS — Witch-of-the-week polaroid + coven roster */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          {spot && (
+            <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none", alignSelf: "center" }}>
+              <div
+                style={{
+                  position: "relative",
+                  transform: "rotate(-2deg)",
+                  width: 180,
+                  background: NOTEPAD,
+                  border: `1px solid ${HAIRLINE}`,
+                  boxShadow: `0 10px 20px ${BOARD_SHADOW}`,
+                  padding: "10px 10px 0",
+                }}
+              >
+                <Pushpin color={IVY} style={{ top: -11, left: "50%", transform: "translateX(-50%)" }} />
+                <div
+                  style={{
+                    height: 120,
+                    background: `linear-gradient(140deg, ${TITLE_TO}, ${ACCENT})`,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Avatar name={spot.display_name} size={60} />
+                </div>
+                <div style={{ padding: "8px 4px 14px", textAlign: "center" }}>
+                  <div style={{ fontFamily: BODY, fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
+                    Witch of the week
+                  </div>
+                  <div style={{ fontFamily: SCRIPT, fontSize: 26, fontWeight: 700, color: ACCENT, lineHeight: 1 }}>
+                    {spot.display_name}
+                  </div>
+                  <div style={{ fontFamily: BODY, fontSize: 8.5, color: INK, marginTop: 2 }}>
+                    lvl {spot.level} · {spot.all_time_score.toLocaleString()} pts
+                  </div>
+                </div>
+              </div>
+            </Link>
+          )}
+
+          <div style={{ position: "relative", transform: "rotate(0.8deg)" }}>
+            <Tape color={IVY_LEAF} style={{ top: -9, left: 26, transform: "rotate(-6deg)", width: 72, height: 22 }} />
+            <div
+              style={{
+                background: NOTEPAD,
+                backgroundImage: `repeating-linear-gradient(${NOTEPAD}, ${NOTEPAD} 23px, ${HAIRLINE} 23px, ${HAIRLINE} 24px)`,
+                border: `1px solid ${NOTEPAD_BORDER}`,
+                borderRadius: 4,
+                boxShadow: `0 10px 20px ${BOARD_SHADOW}`,
+                padding: "14px 16px",
+              }}
+            >
+              <div style={{ fontFamily: SCRIPT, fontSize: 23, fontWeight: 700, color: ACCENT, lineHeight: 1, marginBottom: 8 }}>
+                the coven roster
+              </div>
+              {roster.length === 0 ? (
+                <p style={{ fontFamily: BODY, fontSize: 11, color: MUTED }}>
+                  {spot ? "No other witches in the circle yet." : "No members yet."}
+                </p>
+              ) : (
+                roster.map((m) => (
+                  <Link
+                    key={m.id}
+                    to={`/characters/${m.id}`}
+                    style={{ display: "flex", alignItems: "center", gap: 10, padding: "5px 0", textDecoration: "none" }}
+                  >
+                    <Avatar name={m.display_name} size={26} />
+                    <span
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        fontFamily: SCRIPT,
+                        fontSize: 19,
+                        color: INK,
+                        lineHeight: 1,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {m.display_name}
+                    </span>
+                    <span style={{ fontFamily: BODY, fontSize: 9, color: ACCENT }}>lvl {m.level}</span>
+                  </Link>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -8,8 +8,14 @@
  * page backdrop themed to the faction). The returned {@link FactionDetailState}
  * is the stable contract every faction-body archetype consumes.
  */
-import { useEffect, useState } from "react";
-import { getFactions, type FactionOut } from "../../api/factions";
+import { useCallback, useEffect, useState } from "react";
+import {
+  getFactions,
+  getFactionStatus,
+  getInvitations,
+  chooseFaction,
+  type FactionOut,
+} from "../../api/factions";
 import { listCharacters, type CharacterOut } from "../../api/characters";
 import { listTasks, type TaskOut } from "../../api/tasks";
 import { listPraxes, type PraxisCardOut } from "../../api/praxis";
@@ -18,6 +24,27 @@ import { useGameConfig } from "../../hooks/useGameConfig";
 import { extractError } from "../../utils/errors";
 import { useFactionBackdrop } from "../../components/backdrop/BackdropContext";
 import type { FactionConfigOut } from "../../api/gameConfig";
+
+/**
+ * The viewer's relationship to THIS faction, resolved from the invite-gated
+ * membership model (FactionStatusOut + open invitation letters):
+ *   - "none"     → logged out / no character — hide the join block entirely
+ *   - "member"   → already on this faction's roll
+ *   - "eligible" → invited / can return / holds an open letter — show Join
+ *   - "gate"     → not invited yet — show the soft "keep doing tasks" gate
+ * The standardization's soft gate has no formula/progress bar (ADR-0019: joining
+ * is invite-earned and switching factions is irreversible, so Join confirms).
+ */
+export type MembershipState = "none" | "member" | "eligible" | "gate";
+
+export interface Membership {
+  state: MembershipState;
+  /** Display name of the faction the viewer would leave by joining (for the confirm copy); null if unaffiliated. */
+  currentFactionSlug: string | null | undefined;
+  join: () => Promise<void>;
+  joining: boolean;
+  joinError: string | null;
+}
 
 export interface FactionDetailState {
   // Routing / loading
@@ -34,12 +61,25 @@ export interface FactionDetailState {
   // Viewer context — for per-faction display-point multipliers in the task list
   viewerFactionSlug: string | null | undefined;
   gameFactions: FactionConfigOut[];
+
+  // Join / leave / gate block (section ③) — shared across every skin.
+  membership: Membership;
 }
 
 export function useFactionDetail(
   slug: string | undefined,
 ): FactionDetailState {
-  const { user } = useAuth();
+  const { user, refetch } = useAuth();
+  const characterId = user?.character?.id;
+
+  // Section ③ — the viewer's relationship to this faction. Raw status ("member"
+  // | "invited" | "not_invited" | "defected" | "can_return") plus whether an open
+  // invitation letter exists (either signal means "eligible"), refetched when the
+  // slug or the active character changes.
+  const [rawStatus, setRawStatus] = useState<string | null>(null);
+  const [hasInvite, setHasInvite] = useState(false);
+  const [joining, setJoining] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
 
   const [faction, setFaction] = useState<FactionOut | null>(null);
   const [members, setMembers] = useState<CharacterOut[]>([]);
@@ -92,6 +132,57 @@ export function useFactionDetail(
     };
   }, [slug]);
 
+  // Membership status for this faction — only meaningful with a logged-in
+  // character; cleared otherwise so the join block hides.
+  useEffect(() => {
+    if (!slug || !characterId) {
+      setRawStatus(null);
+      setHasInvite(false);
+      return;
+    }
+    let cancelled = false;
+    Promise.all([getFactionStatus(), getInvitations()])
+      .then(([page, invites]) => {
+        if (cancelled) return;
+        setRawStatus(
+          page.all_factions.find((f) => f.slug === slug)?.status ?? "not_invited",
+        );
+        setHasInvite(invites.some((inv) => inv.faction_slug === slug));
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRawStatus(null);
+          setHasInvite(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, characterId]);
+
+  const membershipState: MembershipState = !characterId
+    ? "none"
+    : rawStatus === "member"
+      ? "member"
+      : rawStatus === "invited" || rawStatus === "can_return" || hasInvite
+        ? "eligible"
+        : "gate";
+
+  const join = useCallback(async () => {
+    if (!slug) return;
+    setJoining(true);
+    setJoinError(null);
+    try {
+      await chooseFaction(slug);
+      await refetch();
+      setRawStatus("member");
+    } catch (err) {
+      setJoinError(extractError(err, "Could not join faction."));
+    } finally {
+      setJoining(false);
+    }
+  }, [slug, refetch]);
+
   return {
     slug,
     loading,
@@ -104,5 +195,13 @@ export function useFactionDetail(
 
     viewerFactionSlug: user?.character?.faction_slug,
     gameFactions: gameConfig?.factions ?? [],
+
+    membership: {
+      state: membershipState,
+      currentFactionSlug: user?.character?.faction_slug,
+      join,
+      joining,
+      joinError,
+    },
   };
 }


### PR DESCRIPTION
## Summary

Ports the **"Faction page standardization"** design handoff (`design_handoff_faction_pages`): every faction detail page (`/factions/:slug`) now renders the **same six-section spine** — ① hero + side stats · ② about · ③ join/gate · ④ Tasks · ⑤ Praxis · ⑥ members — in its own faction costume, dispatched per-slug via a new `FACTION_BODIES` map alongside the existing `FACTION_HEROES` dispatch. One data shape, six skins; only the costume changes.

### Skins
| Faction | Archetype | Theme |
|---|---|---|
| Everymen | union / victory poster | light |
| UA | gilt salon | always light |
| Singularity | terminal printout | always dark |
| S.N.I.D.E. | ransom dispatch | always dark |
| Ephemerists | discordant map / codex | light |
| Warriors of Whimsy | cork memo board (+ **new hero**) | light |
| Albescent | rides the `ua` alias until its vellum skin lands with the alias removal | — |

### Shared pieces (the standardization core)
- **`FdlLaurel`** — the cross-faction rainbow medallion on the single top-scoring praxis per page (`--fdl-rainbow` token; skins recolor only the inner disc/glyph).
- **`.wz-faction-grid`** — the shared `1fr / 322px` two-column layout, collapsing on narrow viewports.
- **Membership state machine** in `useFactionDetail` — member / eligible / soft-gate resolved from `getFactionStatus` + open invitation letters; join wired to `chooseFaction` with the irreversible-switch confirm. The gate is *soft*: encouraging copy only, no formula or progress bar.
- Section headings fixed to **"Tasks"** / **"Praxis"**; flavor kickers sit above.
- The five existing heroes move their stats from full-width bands to **side ledgers** (stats-on-the-side rule).
- ④/⑤ **reuse** the existing per-faction `TaskCard` / `PraxisCard` archetypes — no duplicate card implementations.

### Deliberate gaps (design contract is richer than the backend)
- Side stats show the 3 real counts; `seasonRank` / total `pointsAwarded` have no endpoint → omitted, not faked.
- About = the single `description` field; motto = faction constant; member `role` isn't a backend field; spotlight = top all-time score, client-derived.
- Design's "All / Open to me" task filter and member "Leave" button omitted — no backing endpoints (hide unusable controls).
- Where a design hex had no CSS token, `color-mix` on existing faction tokens is used (flagged with `ponytail:` comments) — no hardcoded hex.

## Test plan
- `tsc --noEmit` clean; `npm test` 118/118 passing.
- Live-verified against the local stack (backend + Postgres, dev-login): everymen, ua, singularity, snide, ephemerists, wow all render the full spine with real data and no console errors; UA spotlight populated; gate state exercised via an `aged_out` character; both light and dark skin axes confirmed.
- Members/praxis empty states verified (dev DB has no faction members); spotlight/roster/FDL confirmed with UA's member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)