### PR TITLE
feat: UA gilt-salon fidelity — crest + copy + critique rungs (#372, #373, #374)

### DIFF
--- a/frontend/src/components/__tests__/voteReframes.test.tsx
+++ b/frontend/src/components/__tests__/voteReframes.test.tsx
@@ -72,12 +72,12 @@ describe('EverymenVote renders from registry', () => {
 
 describe('reframeLabel', () => {
   it('labels a value in the task faction vocabulary', () => {
-    expect(reframeLabel('ua', 5)).toBe('Acquired')
+    expect(reframeLabel('ua', 5)).toBe('masterwork')
     expect(reframeLabel('snide', 1)).toBe('meh')
   })
 
   it('resolves the albescent→ua alias', () => {
-    expect(reframeLabel('albescent', 3)).toBe('Hung')
+    expect(reframeLabel('albescent', 3)).toBe('accomplished')
   })
 
   it('falls back to the arabic number when no reframe exists', () => {

--- a/frontend/src/components/cards/TaskCardUA.tsx
+++ b/frontend/src/components/cards/TaskCardUA.tsx
@@ -1,14 +1,16 @@
 import { Link } from "react-router-dom";
 import type { TaskOut } from "../../api/tasks";
 import LevelPill from "../ui/LevelPill";
+import { UACrest, MottoRibbon, UA_FULL_NAME } from "./UACrest";
 
 /**
- * UA — Gilt salon placard (the University of Asthmatics archetype).
- * A small gold-framed acquisition plate on the salon wall: gilt-gradient
- * frame, parchment ground, Marcellus small-caps regalia, burnt-amber accent.
- * Matches the UA praxis-read sheet + UAVote. All colors via --ua-* tokens
- * (never hardcode hex — CLAUDE.md); the salon is always-light, so tokens read
- * identically in both themes.
+ * UA — Gilt salon crest placard (the University of Asthmatics archetype).
+ * A gold-framed acquisition plate on the salon wall, center-composed around the
+ * heraldic crest: masthead ("University of Asthmatics · EST · MMXX"), motto
+ * ribbon, Playfair-italic title, and a "Matriculate" sign-up affordance. The
+ * crest + motto are shared with UAFactionHero (see UACrest.tsx), not re-drawn.
+ * All colors via --ua-* tokens (never hardcode hex — CLAUDE.md); the salon is
+ * always-light, so tokens read identically in both themes.
  */
 
 const REGALIA = "'Marcellus SC', serif";
@@ -23,36 +25,66 @@ interface Props {
 
 export default function TaskCardUA({ task, displayPoints, onSignup }: Props) {
   return (
-    // Gilt frame: gold-leaf gradient border, then the parchment plate.
+    // Gilt frame: gold-leaf gradient border, then the parchment plate, hung with
+    // a slight rotation like a plate on the salon wall.
     <div
       style={{
-        minWidth: 130,
-        maxWidth: 150,
-        flex: "0 1 135px",
-        padding: 3,
+        minWidth: 240,
+        maxWidth: 282,
+        flex: "0 1 264px",
+        padding: 4,
         background: "var(--ua-gilt)",
+        transform: "rotate(-0.6deg)",
         boxShadow:
-          "0 8px 18px color-mix(in srgb, var(--ua-ink) 18%, transparent), inset 0 0 0 1px color-mix(in srgb, white 40%, transparent)",
+          "0 10px 22px color-mix(in srgb, var(--ua-ink) 20%, transparent), inset 0 0 0 1px color-mix(in srgb, white 40%, transparent)",
       }}
     >
       <div
         style={{
           background: "var(--ua-paper)",
+          backgroundImage:
+            "radial-gradient(color-mix(in srgb, var(--ua-ink) 3%, transparent) 1px, transparent 1px)",
+          backgroundSize: "5px 5px",
           border: "1px solid var(--ua-line-soft)",
-          padding: "12px 12px 10px",
+          padding: "18px 20px 14px",
           color: "var(--ua-ink)",
+          textAlign: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
         }}
       >
+        {/* Crest */}
+        <UACrest width={72} height={86} />
+
+        {/* Masthead */}
         <div
-          className="card-meta"
           style={{
             fontFamily: REGALIA,
-            letterSpacing: "0.12em",
-            color: "var(--ua-gold)",
+            fontSize: 10,
+            letterSpacing: "0.16em",
+            textTransform: "uppercase",
+            color: "var(--ua-orange)",
+            marginTop: 8,
           }}
         >
-          UA · {displayPoints} pts
+          {UA_FULL_NAME}
         </div>
+        <div
+          style={{
+            fontFamily: REGALIA,
+            fontSize: 8,
+            letterSpacing: "0.3em",
+            textTransform: "uppercase",
+            color: "var(--ua-muted)",
+            marginBottom: 10,
+          }}
+        >
+          EST · MMXX
+        </div>
+
+        {/* Motto ribbon */}
+        <MottoRibbon fontSize={9} padding="4px 18px" />
 
         <Link
           to={`/tasks/${task.id}`}
@@ -63,9 +95,9 @@ export default function TaskCardUA({ task, displayPoints, onSignup }: Props) {
               fontFamily: DISPLAY,
               fontStyle: "italic",
               fontWeight: 600,
-              fontSize: "var(--text-md)",
+              fontSize: "var(--text-lg)",
               lineHeight: 1.2,
-              margin: "4px 0 6px",
+              margin: "12px 0 6px",
               overflowWrap: "anywhere",
             }}
           >
@@ -76,25 +108,50 @@ export default function TaskCardUA({ task, displayPoints, onSignup }: Props) {
         {task.description && (
           <div
             className="card-description"
-            style={{ fontFamily: SERIF, color: "var(--ua-sub)" }}
+            style={{ fontFamily: SERIF, color: "var(--ua-sub)", marginBottom: 4 }}
           >
             {task.description}
           </div>
         )}
 
+        <div
+          style={{
+            fontFamily: REGALIA,
+            fontSize: 9,
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            color: "var(--ua-gold)",
+            margin: "6px 0 10px",
+          }}
+        >
+          UA · {displayPoints} pts
+        </div>
+
         {onSignup && (
           <button
             onClick={() => onSignup(task.id)}
             className="btn-primary"
-            style={{ fontSize: 7, padding: "2px 8px", marginBottom: 6 }}
+            style={{
+              fontFamily: REGALIA,
+              fontSize: 10,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              padding: "7px 22px",
+              marginBottom: 12,
+              background: "var(--ua-orange)",
+              border: "none",
+            }}
           >
-            sign up
+            Matriculate
           </button>
         )}
 
         <div
           className="card-footer"
-          style={{ borderTop: "1px solid var(--ua-line-soft)" }}
+          style={{
+            width: "100%",
+            borderTop: "1px solid var(--ua-line-soft)",
+          }}
         >
           <LevelPill level={task.level_required} factionSlug="ua" />
           <span

--- a/frontend/src/components/cards/UACrest.tsx
+++ b/frontend/src/components/cards/UACrest.tsx
@@ -1,0 +1,94 @@
+import { useId } from "react";
+
+/**
+ * Shared UA (University of Asthmatics) heraldic atoms — the gilt-salon crest
+ * and motto ribbon that are the faction's locked identity.
+ *
+ * Extracted from UAFactionHero so the crest is drawn once and dropped into
+ * every UA surface that carries it (faction hero, task card, edit-praxis
+ * masthead + commission slip) rather than re-drawn per file. All colors via
+ * --ua-* tokens (never hardcode hex — CLAUDE.md); the salon is always-light,
+ * so tokens read identically in both themes.
+ */
+
+export const UA_FULL_NAME = "University of Asthmatics";
+export const UA_MOTTO = "Ars Longa · Spiritus Brevis";
+
+/** Heraldic crest — a shield with a rising sun and crossed brushes. */
+export function UACrest({ width, height }: { width: number; height: number }) {
+  // Unique clip id per instance — the shield is rendered many times per page
+  // (a card list, the hero, twice in edit-praxis); a shared literal id would
+  // be invalid SVG and risk cross-instance clipping.
+  const clipId = useId();
+  const shield = "M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z";
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 100 120"
+      aria-hidden="true"
+      style={{ display: "block", flexShrink: 0 }}
+    >
+      <defs>
+        <clipPath id={clipId}>
+          <path d={shield} />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipId})`}>
+        <rect x="0" y="0" width="100" height="120" fill="var(--ua-orange)" />
+        <rect x="0" y="60" width="100" height="60" fill="var(--ua-paper-warm)" />
+        <circle cx="50" cy="60" r="15" fill="var(--ua-gold-lt)" />
+        <g stroke="var(--ua-gold-lt)" strokeWidth="2.4" strokeLinecap="round">
+          <line x1="50" y1="60" x2="50" y2="20" />
+          <line x1="50" y1="60" x2="22" y2="30" />
+          <line x1="50" y1="60" x2="78" y2="30" />
+          <line x1="50" y1="60" x2="14" y2="48" />
+          <line x1="50" y1="60" x2="86" y2="48" />
+          <line x1="50" y1="60" x2="34" y2="22" />
+          <line x1="50" y1="60" x2="66" y2="22" />
+        </g>
+        <g transform="translate(50 84)">
+          <g transform="rotate(38)">
+            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill="var(--ua-ink)" />
+            <rect x="-3" y="10" width="6" height="6" fill="var(--ua-gold-pale)" />
+            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill="var(--ua-orange)" />
+          </g>
+          <g transform="rotate(-38)">
+            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill="var(--ua-gold)" />
+            <rect x="-3" y="10" width="6" height="6" fill="var(--ua-gold-pale)" />
+            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill="var(--ua-gold-lt)" />
+          </g>
+        </g>
+      </g>
+      <path d={shield} fill="none" stroke="var(--ua-gold-lt)" strokeWidth="2.5" />
+      <path d={shield} fill="none" stroke="var(--ua-ink)" strokeWidth="0.8" />
+    </svg>
+  );
+}
+
+/** The motto cartouche — a burnt-amber ribbon with notched ends. */
+export function MottoRibbon({
+  fontSize = 11,
+  padding = "5px 26px",
+}: {
+  fontSize?: number;
+  padding?: string;
+}) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "fit-content",
+        background: "var(--ua-orange)",
+        color: "var(--ua-paper-warm)",
+        fontFamily: '"Marcellus", Georgia, serif',
+        fontSize,
+        letterSpacing: "0.1em",
+        padding,
+        clipPath: "polygon(0 0,100% 0,96% 50%,100% 100%,0 100%,4% 50%)",
+      }}
+    >
+      {UA_MOTTO}
+    </div>
+  );
+}

--- a/frontend/src/components/cards/UAFactionHero.tsx
+++ b/frontend/src/components/cards/UAFactionHero.tsx
@@ -1,4 +1,5 @@
 import type { FactionHeroProps } from "../../pages/FactionDetail";
+import { UACrest, MottoRibbon, UA_FULL_NAME } from "./UACrest";
 
 /**
  * UA (University of Asthmatics) faction-page hero — a gilt-salon frontispiece.
@@ -16,19 +17,14 @@ import type { FactionHeroProps } from "../../pages/FactionDetail";
  * Motto + full name are faction constants (not backend fields).
  */
 
-const FULL_NAME = "University of Asthmatics";
-const MOTTO = "Ars Longa · Spiritus Brevis";
-
 // Token shorthands — every value resolves to a --ua-* / --faction-ua-* var.
 const GILT = "var(--ua-gilt)";
 const PAPER = "var(--faction-ua-card-bg)"; // parchment sheet
-const PAPER_WARM = "var(--ua-paper-warm)";
 const INK = "var(--faction-ua-card-text)"; // brown ink — all text
 const ACCENT = "var(--faction-ua-card-accent)"; // burnt amber
 const SUB = "var(--faction-ua-card-muted)"; // secondary serif
 const MUTED = "var(--ua-muted)"; // mono / metadata labels
 const GOLD = "var(--ua-gold)";
-const GOLD_LT = "var(--ua-gold-lt)";
 const GOLD_PALE = "var(--ua-gold-pale)";
 const LINE = "var(--ua-line)"; // hairline borders
 
@@ -40,63 +36,6 @@ const ENGRAVED = '"Marcellus", Georgia, serif';
 // color-mix helper for shades with no dedicated token.
 const ink = (pct: number): string =>
   `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
-
-/** Heraldic crest — a shield with a rising sun and crossed brushes. */
-function UACrest({ width, height }: { width: number; height: number }) {
-  return (
-    <svg
-      width={width}
-      height={height}
-      viewBox="0 0 100 120"
-      aria-hidden="true"
-      style={{ display: "block", flexShrink: 0 }}
-    >
-      <defs>
-        <clipPath id="ua-hero-shield">
-          <path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" />
-        </clipPath>
-      </defs>
-      <g clipPath="url(#ua-hero-shield)">
-        <rect x="0" y="0" width="100" height="120" fill={ACCENT} />
-        <rect x="0" y="60" width="100" height="60" fill={PAPER_WARM} />
-        <circle cx="50" cy="60" r="15" fill={GOLD_LT} />
-        <g stroke={GOLD_LT} strokeWidth="2.4" strokeLinecap="round">
-          <line x1="50" y1="60" x2="50" y2="20" />
-          <line x1="50" y1="60" x2="22" y2="30" />
-          <line x1="50" y1="60" x2="78" y2="30" />
-          <line x1="50" y1="60" x2="14" y2="48" />
-          <line x1="50" y1="60" x2="86" y2="48" />
-          <line x1="50" y1="60" x2="34" y2="22" />
-          <line x1="50" y1="60" x2="66" y2="22" />
-        </g>
-        <g transform="translate(50 84)">
-          <g transform="rotate(38)">
-            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill={INK} />
-            <rect x="-3" y="10" width="6" height="6" fill={GOLD_PALE} />
-            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill={ACCENT} />
-          </g>
-          <g transform="rotate(-38)">
-            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill={GOLD} />
-            <rect x="-3" y="10" width="6" height="6" fill={GOLD_PALE} />
-            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill={GOLD_LT} />
-          </g>
-        </g>
-      </g>
-      <path
-        d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z"
-        fill="none"
-        stroke={GOLD_LT}
-        strokeWidth="2.5"
-      />
-      <path
-        d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z"
-        fill="none"
-        stroke={INK}
-        strokeWidth="0.8"
-      />
-    </svg>
-  );
-}
 
 export default function UAFactionHero({
   name,
@@ -160,7 +99,7 @@ export default function UAFactionHero({
                   marginBottom: 3,
                 }}
               >
-                {FULL_NAME}
+                {UA_FULL_NAME}
               </div>
               {/* eyebrow — engraved metadata */}
               <div
@@ -194,22 +133,8 @@ export default function UAFactionHero({
               </h1>
 
               {/* motto cartouche */}
-              <div
-                style={{
-                  position: "relative",
-                  width: "fit-content",
-                  background: ACCENT,
-                  color: PAPER_WARM,
-                  fontFamily: ENGRAVED,
-                  fontSize: 11,
-                  letterSpacing: "0.1em",
-                  padding: "5px 26px",
-                  clipPath:
-                    "polygon(0 0,100% 0,96% 50%,100% 100%,0 100%,4% 50%)",
-                  marginBottom: 18,
-                }}
-              >
-                {MOTTO}
+              <div style={{ marginBottom: 18 }}>
+                <MottoRibbon />
               </div>
 
               {/* statement */}

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -61,11 +61,11 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
   },
   ua: {
     tiers: [
-      { value: 1, label: 'Noted' },
-      { value: 2, label: 'Sketch' },
-      { value: 3, label: 'Hung' },
-      { value: 4, label: 'Commended' },
-      { value: 5, label: 'Acquired' },
+      { value: 1, label: 'rough sketch' },
+      { value: 2, label: 'study' },
+      { value: 3, label: 'accomplished' },
+      { value: 4, label: 'distinguished' },
+      { value: 5, label: 'masterwork' },
     ],
   },
 }

--- a/frontend/src/copy/__tests__/t.test.ts
+++ b/frontend/src/copy/__tests__/t.test.ts
@@ -33,9 +33,9 @@ describe('t()', () => {
     expect(t('vote.snide.anarchy')).toBe('ANARCHY')
   })
 
-  it('resolves title-case values for UA labels', () => {
-    expect(t('vote.ua.acquired')).toBe('Acquired')
-    expect(t('vote.ua.commended')).toBe('Commended')
+  it('resolves the salon-critique values for UA labels', () => {
+    expect(t('vote.ua.masterwork')).toBe('masterwork')
+    expect(t('vote.ua.distinguished')).toBe('distinguished')
   })
 })
 

--- a/frontend/src/copy/en.ts
+++ b/frontend/src/copy/en.ts
@@ -52,11 +52,11 @@ export const en = {
       verified: "VERIFIED",
     },
     ua: {
-      noted: "Noted",
-      sketch: "Sketch",
-      hung: "Hung",
-      commended: "Commended",
-      acquired: "Acquired",
+      "rough-sketch": "rough sketch",
+      study: "study",
+      accomplished: "accomplished",
+      distinguished: "distinguished",
+      masterwork: "masterwork",
     },
   },
 } as const

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisUA.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisUA.tsx
@@ -20,10 +20,10 @@ import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
   ErrorBanner,
-  TaskMetaInline,
   TitleCounter,
   formatAutosave,
 } from "./shared";
+import { UACrest } from "../../../components/cards/UACrest";
 import {
   BodyPreview,
   BodyTextarea,
@@ -47,9 +47,9 @@ const SERIF = "'EB Garamond', serif";
 const MONO = "'Courier Prime', monospace";
 
 const MODE_OPTIONS: Array<{ key: PraxisType; label: string; desc: string }> = [
-  { key: "solo", label: "Sole", desc: "a sole acquisition" },
-  { key: "collab", label: "Joint", desc: "a joint acquisition" },
-  { key: "duel", label: "Contested", desc: "a contested acquisition" },
+  { key: "solo", label: "Alone", desc: "a sole acquisition" },
+  { key: "collab", label: "Atelier", desc: "a joint acquisition" },
+  { key: "duel", label: "Salon Duel", desc: "a contested acquisition" },
 ];
 
 /** A gilt-framed card — the recurring salon surface for each editor region. */
@@ -108,42 +108,57 @@ export default function EditPraxisUA({ state }: Props) {
           inkColor="var(--ua-gold)"
         />
 
-        {/* Masthead — the acquisition sheet's letterhead */}
+        {/* Masthead — the salon submission sheet's letterhead */}
         <Plate style={{ padding: 0, marginBottom: 26 }}>
+          {/* burnt-amber ribbon — crest + house line */}
           <div
             style={{
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
               gap: 14,
-              padding: "12px 24px",
-              borderBottom: "1px solid var(--ua-line-soft)",
-              background:
-                "linear-gradient(180deg, color-mix(in srgb, var(--ua-gold-pale) 28%, var(--ua-paper)), var(--ua-paper))",
+              padding: "10px 20px",
+              background: "var(--ua-orange)",
             }}
           >
-            <span style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: "0.14em", color: "var(--ua-gold)" }}>
-              University of Asthmatics · The Atelier
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+              <UACrest width={22} height={26} />
+              <span style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: "0.14em", color: "var(--ua-paper-warm)" }}>
+                University of Asthmatics · Salon Submission №{praxis.id}
+              </span>
             </span>
-            <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ua-sub)", fontStyle: "italic" }}>
+            <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ua-paper-warm)", fontStyle: "italic", whiteSpace: "nowrap" }}>
               {state.autosaveAt ? `sketched ${formatAutosave(state.autosaveAt)}` : "unsaved"}
             </span>
           </div>
-          <div style={{ padding: "20px 24px 22px" }}>
-            <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.22em", textTransform: "uppercase", color: "var(--ua-muted)", marginBottom: 8 }}>
-              Preparing an acquisition
-            </div>
-            <h1 style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 600, fontSize: 34, lineHeight: 1.08, color: "var(--ua-ink)", margin: "0 0 6px" }}>
-              re: {praxis.task_title}
+          <div style={{ padding: "22px 24px 22px" }}>
+            <h1 style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 600, fontSize: 50, lineHeight: 1.04, color: "var(--ua-ink)", margin: "0 0 14px" }}>
+              Submit to the Salon
             </h1>
-            <TaskMetaInline praxis={praxis} task={task} textColor="var(--ua-muted)" />
+            {/* red/gold dashed rule */}
+            <div style={{ height: 0, borderTop: "1.5px dashed var(--ua-gold)", marginBottom: 18 }} />
+            {/* commission reference slip — crest, task, points, era mark */}
+            <div style={{ display: "flex", alignItems: "center", gap: 14, border: "1px solid var(--ua-line)", background: "var(--ua-paper-warm)", padding: "12px 16px" }}>
+              <UACrest width={50} height={60} />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--ua-muted)", marginBottom: 4 }}>
+                  Commission · Anno III
+                </div>
+                <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 20, color: "var(--ua-ink)", lineHeight: 1.15, overflowWrap: "anywhere" }}>
+                  {praxis.task_title}
+                </div>
+                <div style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: "0.12em", color: "var(--ua-gold)", marginTop: 4 }}>
+                  {praxis.task_point_value} pts
+                </div>
+              </div>
+            </div>
           </div>
         </Plate>
 
         {/* Mode — engraved plates */}
         {!state.controlsLocked && (
           <div style={{ marginBottom: 24 }}>
-            <RegaliaLabel>The manner of acquisition</RegaliaLabel>
+            <RegaliaLabel>The Hand</RegaliaLabel>
             <ModePicker
               state={state}
               skin={{
@@ -205,7 +220,7 @@ export default function EditPraxisUA({ state }: Props) {
 
         {/* Title */}
         <Plate>
-          <RegaliaLabel>The title of the work</RegaliaLabel>
+          <RegaliaLabel>The Title of the Work</RegaliaLabel>
           <TitleField
             state={state}
             skin={{
@@ -232,7 +247,7 @@ export default function EditPraxisUA({ state }: Props) {
 
         {/* Body — the process */}
         <Plate>
-          <RegaliaLabel>The Process · {state.wordCount} words · markdown</RegaliaLabel>
+          <RegaliaLabel>The Statement · {state.wordCount} words · markdown</RegaliaLabel>
           <BodyTextarea
             state={state}
             skin={{
@@ -269,7 +284,7 @@ export default function EditPraxisUA({ state }: Props) {
 
         {/* The plates — media */}
         <div style={{ marginBottom: 22 }}>
-          <RegaliaLabel>The plates</RegaliaLabel>
+          <RegaliaLabel>The Plate</RegaliaLabel>
           <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "flex-start" }}>
             {state.media.map((item) => {
               const filename = item.file_path.split("/").pop() ?? item.file_path;
@@ -345,8 +360,8 @@ export default function EditPraxisUA({ state }: Props) {
           <PublishButton
             state={state}
             skin={{
-              idleLabel: "File the acquisition",
-              busyLabel: "filing…",
+              idleLabel: "✦ Hang it in the Salon ✦",
+              busyLabel: "hanging…",
               style: {
                 background: "var(--ua-orange)",
                 color: "var(--ua-paper)",
@@ -364,7 +379,7 @@ export default function EditPraxisUA({ state }: Props) {
           <DropButton
             state={state}
             skin={{
-              label: "discard this work",
+              label: "Withdraw Work",
               style: {
                 background: "transparent",
                 border: "none",


### PR DESCRIPTION
Restores the UA gilt-salon **locked identity** the port (PR #361) stripped, and updates the vote vocabulary. Three sibling design-fidelity issues, all UA, one shared atom.

## Changes
- **New shared atom** `UACrest.tsx` — the heraldic crest + motto ribbon, extracted from `UAFactionHero` (which now imports it). Crest clip id uses `useId()` so multiple instances per page are valid SVG.
- **#372 TaskCardUA** — full crest placard: crest, `University of Asthmatics · EST · MMXX` masthead, motto ribbon, Playfair-italic title, **Matriculate** sign-up (keeps `onSignup` contract). Widened to the design's ~282px, center-composed, slight rotation.
- **#373 EditPraxisUA** — crest in the burnt-amber masthead ribbon **and** the commission reference slip; copy aligned to `UA Edit Praxis.dc.html`: title **Submit to the Salon**, sections **The Hand / The Title of the Work / The Statement / The Plate**, modes **Alone / Atelier / Salon Duel**, publish **✦ Hang it in the Salon ✦**, drop **Withdraw Work**. Shared-control wiring unchanged (presentation + labels only).
- **#374 voteReframes** `ua.tiers` → the critique vocabulary: **rough sketch / study / accomplished / distinguished / masterwork**. `UAVote` + praxis-read standing read this single source; copy catalog (`en.ts`) + tests aligned.

## Notes
- All colors via `--ua-*` tokens (no hex — CLAUDE.md).
- **Save sketch** affordance from the design = the existing autosave indicator (`sketched {time}`); not adding a redundant manual button (shared-control wiring unchanged, per acceptance).
- Preview not run — these surfaces need a seeded backend + UA data + auth; validated by `tsc --noEmit` (clean) + vitest (122 pass) + `vite build`.

Closes #372
Closes #373
Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)