### PR TITLE
feat: praxis-card hero = earned points (base + votes), replacing the placeholder seal (#375)

### DIFF
--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -6,11 +6,10 @@ import SnideMasthead from "./cards/SnideMasthead";
 import { EphMark, Foxing } from "./cards/ephemeristsAtoms";
 import {
   AdminOverlay,
-  PraxisContent,
   PraxisTitle,
   PraxisTaskLink,
   PraxisByline,
-  PraxisSeal,
+  PraxisScoreHero,
   PraxisStats,
   type AdminProps,
 } from "./praxisCard/shared";
@@ -23,38 +22,32 @@ interface Props {
 
 /**
  * Each faction's praxis card owns a bespoke frame. The content inside is
- * composed from the shared structural slots in ./praxisCard/shared (an archetype
- * may rearrange them; today every archetype uses the default PraxisContent
- * composition). Admin moderation + the optimistic local praxis come from
- * usePraxisCard; the frame is selected by task faction via pickVariant.
+ * composed from the shared structural slots in ./praxisCard/shared via the local
+ * `PraxisBody` composition (an archetype may rearrange the slots). Admin
+ * moderation + the optimistic local praxis come from usePraxisCard; the frame is
+ * selected by task faction via pickVariant.
  */
 export type ArchetypeProps = { praxis: PraxisCardOut; adminProps: AdminProps };
 
 // ─── Per-faction archetypes ───────────────────────────────────────────────────
 
 /**
- * Shared interim content body for every faction's praxis card: title + task link
- * on the left, the score "seal" (hero) on the right, then a points/mode line and
- * the byline. Each faction's own frame wraps this; tint / muted / sealLabel carry
- * the faction voice (e.g. snide "case", ephemerists "concord", singularity
- * "verified").
- *
- * ponytail: the seal is a placeholder hero showing the computed score. The fully
- * designed per-faction cards — and the vote-reframe summary (Concordance, Signal,
- * heart/ink ramps) that replaces the seal — supersede this once the design and
- * the rating/level/date API fields land. See docs/adr/0005.
+ * Shared content body for every faction's praxis card: title + task link on the
+ * left, the score hero (`{base} + {votes}` points) on the right, then a
+ * points/mode line and the byline. Each faction's own frame wraps this; tint /
+ * muted carry the faction voice via the frame's accent tokens. The hero shows
+ * earned points (task base + points-from-votes, ADR-0014) — not a rating, not an
+ * average, not a voter count (#375, Molly's call).
  */
-function PlaceholderPraxisBody({
+function PraxisBody({
   praxis,
   tint,
   muted,
-  sealLabel = "sealed",
   titleStyle,
 }: {
   praxis: PraxisCardOut;
   tint: string;
   muted: string;
-  sealLabel?: string;
   titleStyle?: CSSProperties;
 }) {
   return (
@@ -71,7 +64,7 @@ function PlaceholderPraxisBody({
           <PraxisTitle praxis={praxis} style={titleStyle} />
           <PraxisTaskLink praxis={praxis} style={{ color: muted }} />
         </div>
-        <PraxisSeal praxis={praxis} color={tint} border={tint} label={sealLabel} />
+        <PraxisScoreHero praxis={praxis} color={tint} border={tint} />
       </div>
       <PraxisStats praxis={praxis} style={{ color: muted, marginTop: 8 }} />
       <PraxisByline praxis={praxis} style={{ color: muted }} />
@@ -126,7 +119,7 @@ function UAPraxisCard({ praxis, adminProps }: ArchetypeProps) {
           Acquisition · filed
         </div>
         <AdminOverlay {...adminProps} />
-        <PlaceholderPraxisBody
+        <PraxisBody
           praxis={praxis}
           tint={factionCssVar("ua", "card-accent")}
           muted={factionCssVar("ua", "card-muted")}
@@ -169,7 +162,7 @@ function EverymenPraxisCard({ praxis, adminProps }: ArchetypeProps) {
         }}
       />
       <AdminOverlay {...adminProps} />
-      <PlaceholderPraxisBody
+      <PraxisBody
         praxis={praxis}
         tint={factionCssVar("everymen", "card-accent")}
         muted={factionCssVar("everymen", "card-muted")}
@@ -243,7 +236,7 @@ function WowPraxisCard({ praxis, adminProps }: ArchetypeProps) {
           }}
         />
         <AdminOverlay {...adminProps} />
-        <PlaceholderPraxisBody
+        <PraxisBody
           praxis={praxis}
           tint={factionCssVar("wow", "card-accent")}
           muted={factionCssVar("wow", "card-muted")}
@@ -297,11 +290,10 @@ function SnidePraxisCard({ praxis, adminProps }: ArchetypeProps) {
       <div className="snide-tape" style={{ top: -10, left: 22, transform: "rotate(-8deg)" }} />
       <SnideMasthead subtitle="evidence locker" />
       <AdminOverlay {...adminProps} />
-      <PlaceholderPraxisBody
+      <PraxisBody
         praxis={praxis}
         tint={factionCssVar("snide", "card-accent")}
         muted={factionCssVar("snide", "card-muted")}
-        sealLabel="case"
       />
     </div>
   );
@@ -358,11 +350,10 @@ function EphemeristsPraxisCard({ praxis, adminProps }: ArchetypeProps) {
       </div>
       <div style={{ position: "relative", zIndex: 2, padding: "10px 14px 14px" }}>
         <AdminOverlay {...adminProps} />
-        <PlaceholderPraxisBody
+        <PraxisBody
           praxis={praxis}
           tint="var(--eph-rubric)"
           muted="var(--eph-muted)"
-          sealLabel="concord"
           titleStyle={{ fontFamily: "var(--eph-display)", color: "var(--eph-vellum-text)" }}
         />
       </div>
@@ -494,11 +485,10 @@ function SingularityPraxisCard({ praxis, adminProps }: ArchetypeProps) {
           />
         </div>
         <AdminOverlay {...adminProps} />
-        <PlaceholderPraxisBody
+        <PraxisBody
           praxis={praxis}
           tint="var(--faction-singularity-card-text)"
           muted="var(--faction-singularity-card-muted)"
-          sealLabel="verified"
         />
       </div>
       <SingularityHoles />
@@ -526,9 +516,10 @@ export function DefaultPraxisCard({ praxis, adminProps }: ArchetypeProps) {
       }}
     >
       <AdminOverlay {...adminProps} />
-      <PraxisContent
+      <PraxisBody
         praxis={praxis}
-        metaStyle={{ color: factionCssVar(slug, "card-muted") }}
+        tint={factionCssVar(slug, "card-accent")}
+        muted={factionCssVar(slug, "card-muted")}
       />
     </div>
   );

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -6,23 +6,13 @@ import type { PraxisCardOut } from "../../api/praxis";
  * Praxis-card shared building blocks.
  *
  * Each faction's praxis card owns a bespoke FRAME (tilted memo, ruled paper,
- * scrap collage, torn evidence, vellum leaf, terminal, gazette…) but the
- * CONTENT inside used to be a single monolithic `PraxisContent`, so the cards
- * "read flat" below the chrome (SPEC §1 #2). These exports break the content
- * into independently-placeable structural slots — `PraxisTitle`,
- * `PraxisTaskLink`, `PraxisByline` — so an archetype can arrange (or replace)
- * its own content layout instead of only re-coloring one fixed block.
- *
- * `PraxisContent` is the DEFAULT composition of those slots, byte-identical to
- * the original; archetypes that want the standard layout keep calling it, and
- * the dispatch stays a true per-faction dispatch rather than chrome-only.
+ * scrap collage, torn evidence, vellum leaf, terminal, gazette…). The CONTENT
+ * inside is broken into independently-placeable structural slots — `PraxisTitle`,
+ * `PraxisTaskLink`, `PraxisScoreHero`, `PraxisStats`, `PraxisByline` — so an
+ * archetype can arrange them (via the shared `PraxisBody` composition in
+ * PraxisCard.tsx) instead of only re-coloring one fixed block. The dispatch stays
+ * a true per-faction dispatch rather than chrome-only.
  */
-
-export interface ContentProps {
-  praxis: PraxisCardOut;
-  titleStyle?: CSSProperties;
-  metaStyle?: CSSProperties;
-}
 
 /** Slot: the praxis title, linked to the praxis detail page. */
 export function PraxisTitle({
@@ -101,25 +91,25 @@ export function PraxisByline({
 }
 
 /**
- * Slot: the score "seal" — the hero of a completed praxis, a stamped badge
- * showing the vote-weighted score instead of the buried byline number.
- *
- * ponytail: placeholder hero, shows the computed `score`; the canonical
- * per-faction cards replace it with the faction's vote reframe (Concordance,
- * heart ramp, ink stamps) at the rated tier — swap out when those land.
+ * Slot: the score hero — a completed praxis's earned-points readout, stamped as
+ * `{base} + {votes}`: the task's base points plus the points scored FROM votes
+ * (ADR-0014 merit = `task base + points_from_votes`, so vote-points =
+ * `score - task_point_value`). This is a points sum, never a 1–5 rating or an
+ * average. `voter_count` (a people-count) is deliberately not shown — the second
+ * number is vote *points*, per Molly's #375 call.
  */
-export function PraxisSeal({
+export function PraxisScoreHero({
   praxis,
   color,
   border,
-  label = "sealed",
 }: {
   praxis: PraxisCardOut;
   color?: string;
   border?: string;
-  label?: string;
 }) {
   if (praxis.score === null || praxis.score === undefined) return null;
+  const base = praxis.task_point_value;
+  const votePoints = Math.max(0, Math.round(praxis.score - base));
   return (
     <div
       style={{
@@ -128,8 +118,8 @@ export function PraxisSeal({
         alignItems: "center",
         justifyContent: "center",
         flexShrink: 0,
-        minWidth: 50,
-        padding: "5px 8px",
+        minWidth: 54,
+        padding: "6px 10px",
         border: `2px solid ${border ?? "currentColor"}`,
         borderRadius: 4,
         transform: "rotate(-3deg)",
@@ -137,19 +127,21 @@ export function PraxisSeal({
         lineHeight: 1,
       }}
     >
-      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)" }}>
-        {praxis.score.toFixed(0)}
+      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)", whiteSpace: "nowrap" }}>
+        {base}
+        <span style={{ opacity: 0.55, margin: "0 2px" }}>+</span>
+        {votePoints}
       </span>
       <span
         style={{
           fontSize: 7,
-          letterSpacing: "0.18em",
+          letterSpacing: "0.16em",
           textTransform: "uppercase",
           marginTop: 3,
           opacity: 0.8,
         }}
       >
-        {label}
+        pts + votes
       </span>
     </div>
   );
@@ -188,21 +180,6 @@ export function PraxisStats({
         </>
       )}
     </div>
-  );
-}
-
-/**
- * Default content composition — title, task link, byline. Visually identical to
- * the pre-refactor `PraxisContent`. An archetype that wants a different content
- * structure composes the slots above directly instead of calling this.
- */
-export function PraxisContent({ praxis, titleStyle, metaStyle }: ContentProps) {
-  return (
-    <>
-      <PraxisTitle praxis={praxis} style={titleStyle} />
-      <PraxisTaskLink praxis={praxis} style={metaStyle} />
-      <PraxisByline praxis={praxis} style={metaStyle} />
-    </>
   );
 }
 


### PR DESCRIPTION
Every faction's praxis card wrapped its faithful bespoke frame (UA gilt plate, Snide torn-evidence, Wow scrap collage, …) around the **same** `PlaceholderPraxisBody` whose hero was a generic rotated `PraxisSeal` score number — so the cards "read flat" and the design's per-faction reframe was missing everywhere.

## Molly's product call (resolving #375's premise error)
The audit assumed `PraxisCardOut.score` was a 0–5 rating to reframe into "rough sketch → masterwork". It isn't — `score` is **Merit** (ADR-0014: `task base + points_from_votes`), a points sum. There's no tier to reframe.

Per Molly: the hero shows **"X points + Y votes"**, where *votes* = **the points scored by votes** (not the voter count):
- `X` = `task_point_value` (base)
- `Y` = `score − task_point_value` (points from votes) — the classic **`15 + 73`**

## Changes
- `praxisCard/shared.tsx`: `PraxisSeal` → **`PraxisScoreHero`** — a stamped `{base} + {votePoints}` labeled "pts + votes". No average, no 1–5 rating, no `voter_count`.
- `PlaceholderPraxisBody` → **`PraxisBody`**, now the real body for all six faction archetypes **and** `DefaultPraxisCard` (previously the plain `PraxisContent` slab).
- Removed the now-dead `PraxisContent` / `ContentProps`.
- Existing per-faction frames unchanged; `--faction-*` tokens only (no hex).

## Flagged
- **Excerpt/body preview OMITTED.** `PraxisCardOut` exposes `title` but no body snippet; adding an `excerpt` is a backend change (out of this frontend scope). Flagging per the issue rather than inventing a field.
- `voteReframes.ts` tier words are **not** used on the card (there's no rating to map); they remain the source for the vote *widget* + praxis-read standing (which do have a 1–5).

Verification: `tsc --noEmit` clean; vitest 122 pass (incl. the content-slot invariant across all archetypes).

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)