### PR TITLE
feat: collab draft in invitee sidebar + edit-praxis description & faction voice (#386, #379, #380)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -339,7 +339,20 @@ async def list_praxes(
         query = query.where(Praxis.task_id == task_id)
 
     if character_id is not None:
-        query = query.where(Praxis.created_by_id == character_id)
+        if status == PraxisStatus.in_progress:
+            # ADR-0013: in-progress praxes are co-owned; surface any member's
+            # active draft, not just the creator's (bank cap already counts
+            # memberships — see _count_in_progress_praxes). Published/authored
+            # lists keep creator semantics below.
+            query = query.where(
+                Praxis.id.in_(
+                    select(PraxisMember.praxis_id).where(
+                        PraxisMember.character_id == character_id
+                    )
+                )
+            )
+        else:
+            query = query.where(Praxis.created_by_id == character_id)
 
     if status is not None:
         query = query.where(Praxis.status == status)

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -571,6 +571,55 @@ async def test_collab_invite_and_accept(
 
 
 @pytest.mark.asyncio
+async def test_collab_draft_visible_to_invitee_active_tasks(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """#386: a joined collaborator sees the shared in_progress draft in their own
+    active-tasks list. ``character_id`` filters by membership (ADR-0013 co-owned
+    draft), not just the creator."""
+    # character2 creates the collab; character is invited and accepts.
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Shared Draft"},
+        headers=auth_headers2,
+    )
+    praxis_id = create_resp.json()["id"]
+    invite_resp = await client.post(
+        f"/praxes/{praxis_id}/invite",
+        json={"invitee_id": character.id},
+        headers=auth_headers2,
+    )
+    invite_id = invite_resp.json()["id"]
+    await client.post(
+        f"/praxes/{praxis_id}/invite/{invite_id}/respond",
+        json={"accept": True},
+        headers=auth_headers,
+    )
+
+    # The invitee (not the creator) still sees the draft in their own list...
+    invitee_list = await client.get(
+        "/praxes",
+        params={"character_id": character.id, "status": "in_progress"},
+        headers=auth_headers,
+    )
+    assert invitee_list.status_code == 200
+    assert praxis_id in [p["id"] for p in invitee_list.json()]
+
+    # ...and so does the creator (membership includes them too).
+    creator_list = await client.get(
+        "/praxes",
+        params={"character_id": character2.id, "status": "in_progress"},
+        headers=auth_headers2,
+    )
+    assert praxis_id in [p["id"] for p in creator_list.json()]
+
+
+@pytest.mark.asyncio
 async def test_collab_invite_decline(
     client: AsyncClient,
     character: Character,

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,11 +7,18 @@ import { factionCssVar, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import FeedBadge from '../feed/FeedBadge'
 import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
+import type { PraxisType } from '../../api/praxis'
 import { useMyCharacterStats } from '../../hooks/useMyCharacterStats'
 import { usePendingRequests } from '../../hooks/usePendingRequests'
 import { useGameConfig } from '../../hooks/useGameConfig'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
+
+const PRAXIS_TYPE_LABEL: Record<PraxisType, string> = {
+  solo: 'Solo',
+  collab: 'Collab',
+  duel: 'Duel',
+}
 
 /**
  * Always-on right sidebar (Style Guide §4.2).
@@ -183,7 +190,7 @@ export default function Sidebar() {
                     {praxis.task_title}
                   </Link>
                 </div>
-                <FeedBadge type="global" label="Solo" />
+                <FeedBadge type="global" label={PRAXIS_TYPE_LABEL[praxis.type]} />
               </div>
             ))}
           </div>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEphemeris.tsx
@@ -171,6 +171,11 @@ export default function EditPraxisEphemeris({ state }: Props) {
             <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 30, lineHeight: 0.96, color: TEXT }}>
               <LapisLastWord text={praxis.task_title} />
             </div>
+            {task?.description && (
+              <div style={{ fontSize: 11, fontStyle: "italic", lineHeight: 1.5, color: MUTED, marginTop: 8 }}>
+                {task.description}
+              </div>
+            )}
             <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 8, flexWrap: "wrap" }}>
               <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 9.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--eph-lapis)", fontWeight: 600 }}>
                 <EphMark size={12} color="var(--eph-lapis)" /> Ephemerists

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisEverymen.tsx
@@ -296,6 +296,11 @@ export default function EditPraxisEverymen({ state }: Props) {
             >
               {praxis.task_title}
             </div>
+            {task?.description && (
+              <div style={{ fontFamily: ACCENT_FONT, fontSize: 13, lineHeight: 1.5, color: MUTED, marginBottom: 8 }}>
+                {task.description}
+              </div>
+            )}
             <TaskMetaInline praxis={praxis} task={task} textColor={RED} />
           </div>
         </div>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPaperCollage.tsx
@@ -34,8 +34,8 @@ interface Props {
 
 const MODE_OPTIONS: Array<{ key: PraxisType; label: string; desc: string }> = [
   { key: "solo", label: "solo", desc: "one set of footprints" },
-  { key: "collab", label: "collab", desc: "in step with others" },
-  { key: "duel", label: "duel", desc: "two paths, one prize" },
+  { key: "collab", label: "w/ friends", desc: "in step with others" },
+  { key: "duel", label: "witch duel", desc: "two paths, one prize" },
 ];
 
 /* ───────── sticker + ivy atoms (inlined from the redesign kit) ───────── */
@@ -388,6 +388,11 @@ export default function EditPraxisPaperCollage({ state }: Props) {
               >
                 {praxis.task_title}
               </div>
+              {task?.description && (
+                <div style={{ fontFamily: cardFont, fontSize: 13, lineHeight: 1.5, color: muted, marginBottom: 8 }}>
+                  {task.description}
+                </div>
+              )}
               <TaskMetaInline praxis={praxis} task={task} textColor={pinkDeep} />
             </div>
 
@@ -697,8 +702,8 @@ export default function EditPraxisPaperCollage({ state }: Props) {
                   ornament: (
                     <Sparkle size={12} color="var(--color-text-on-accent)" />
                   ),
-                  idleLabel: "publish",
-                  busyLabel: "publishing...",
+                  idleLabel: "cast it into the world",
+                  busyLabel: "casting...",
                   style: {
                     display: "inline-flex",
                     alignItems: "center",

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisPunkZine.tsx
@@ -53,19 +53,19 @@ const MODE_OPTIONS: Array<{
 }> = [
   {
     key: "solo",
-    label: "SOLO",
+    label: "LONE WOLF",
     desc: "just me",
     font: "'Permanent Marker', cursive",
   },
   {
     key: "collab",
-    label: "COLLAB",
+    label: "THE GANG",
     desc: "a gang of us",
     font: "'UnifrakturCook', serif",
   },
   {
     key: "duel",
-    label: "D U E L",
+    label: "BEEF",
     desc: "me v. them",
     font: "'Bebas Neue', sans-serif",
   },
@@ -186,6 +186,11 @@ export default function EditPraxisPunkZine({ state }: Props) {
           <div style={{ fontSize: 18, lineHeight: 1.25, marginTop: 6 }}>
             {praxis.task_title}
           </div>
+          {task?.description && (
+            <div style={{ fontSize: 12, lineHeight: 1.45, color: muted, marginTop: 6 }}>
+              {task.description}
+            </div>
+          )}
           <div style={{ marginTop: 8 }}>
             <TaskMetaInline
               praxis={praxis}
@@ -600,8 +605,8 @@ export default function EditPraxisPunkZine({ state }: Props) {
           <PublishButton
             state={state}
             skin={{
-              idleLabel: "xerox & staple",
-              busyLabel: "xeroxing...",
+              idleLabel: "FILE IT & RUN",
+              busyLabel: "running...",
               ornament: (
                 <span
                   aria-hidden

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisStickyNote.tsx
@@ -170,6 +170,11 @@ export default function EditPraxisStickyNote({ state }: Props) {
             </span>
             {praxis.task_title}
           </div>
+          {task?.description && (
+            <div style={{ fontSize: 12, lineHeight: 1.5, color: SLATE, marginTop: 8 }}>
+              {task.description}
+            </div>
+          )}
           <div style={{ marginTop: 8 }}>
             <TaskMetaInline praxis={praxis} task={task} textColor={SLATE} />
           </div>

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisTerminal.tsx
@@ -28,10 +28,10 @@ const MODE_OPTIONS: Array<{ key: PraxisType; flag: string; desc: string }> = [
   { key: "solo", flag: "--solo", desc: "one author. all credit accrues." },
   {
     key: "collab",
-    flag: "--collab",
+    flag: "--networked",
     desc: "fork. multiple authors. all earn full pts.",
   },
-  { key: "duel", flag: "--duel", desc: "pvp. winner-take-all on vote median." },
+  { key: "duel", flag: "--adversarial", desc: "pvp. winner-take-all on vote median." },
 ];
 
 export default function EditPraxisTerminal({ state }: Props) {
@@ -175,6 +175,12 @@ export default function EditPraxisTerminal({ state }: Props) {
               <span style={{ color: dim }}>&gt; </span>
               {praxis.task_title}
             </div>
+            {task?.description && (
+              <div style={{ fontSize: 12, color: dim, lineHeight: 1.5, marginTop: 6, whiteSpace: "pre-wrap" }}>
+                <span style={{ color: accent }}># </span>
+                {task.description}
+              </div>
+            )}
             <div
               style={{
                 display: "flex",
@@ -629,8 +635,8 @@ export default function EditPraxisTerminal({ state }: Props) {
           <PublishButton
             state={state}
             skin={{
-              idleLabel: '$ git commit -m "publish"',
-              busyLabel: "$ committing...",
+              idleLabel: "SEAL & TRANSMIT",
+              busyLabel: "$ transmitting...",
               ornament: (
                 <span
                   aria-hidden

--- a/frontend/src/pages/editPraxis/archetypes/EditPraxisUA.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EditPraxisUA.tsx
@@ -147,6 +147,11 @@ export default function EditPraxisUA({ state }: Props) {
                 <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 20, color: "var(--ua-ink)", lineHeight: 1.15, overflowWrap: "anywhere" }}>
                   {praxis.task_title}
                 </div>
+                {task?.description && (
+                  <div style={{ fontFamily: MONO, fontSize: 10, lineHeight: 1.45, color: "var(--ua-muted)", marginTop: 6, overflowWrap: "anywhere" }}>
+                    {task.description}
+                  </div>
+                )}
                 <div style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: "0.12em", color: "var(--ua-gold)", marginTop: 4 }}>
                   {praxis.task_point_value} pts
                 </div>


### PR DESCRIPTION
Bundles three `ready-for-agent` issues. Ordered so the backend bug lands with its frontend siblings; #388 (e2e infra) is intentionally deferred to its own effort.

## #386 — collab draft missing from invitee's active-tasks sidebar
`list_praxes(character_id=, status=in_progress)` interpreted `character_id` as the **creator** only, so a joined collaborator never saw the shared draft in their sidebar (contradicting ADR-0013 co-ownership).

- Root-cause fix in the one shared function (`services/praxis.py`): for `in_progress`, filter by `PraxisMember` membership; other statuses keep creator semantics, so `CharacterProfile`'s authored list is unchanged. Aligns with the existing `_count_in_progress_praxes` membership convention.
- Sidebar badge now shows the real praxis type instead of a hardcoded `"Solo"`.
- Added `test_collab_draft_visible_to_invitee_active_tasks` (mirrors the `test.fail` on `claude/beautiful-cohen-2fe76b`).

## #379 — task description on the reference slip (all 7 factions)
Every edit-praxis archetype now renders `task.description` under the title, styled to each archetype's own muted voice (`# comment` for Terminal, italic vellum for Ephemeris, etc.). `task` was already in scope via `state.task`.

## #380 — faction voice for snide / singularity / wow mode labels + file verbs
| faction | modes | file verb |
|---|---|---|
| snide | LONE WOLF / THE GANG / BEEF | FILE IT & RUN |
| singularity | `--solo / --networked / --adversarial` | SEAL & TRANSMIT |
| wow | solo / w/ friends / witch duel | cast it into the world |

**Judgment call:** kept singularity's `--` CLI-flag chrome (`[--networked]`) rather than the design table's bare uppercase — the audit flagged only the drifted *words* (collab/duel), not the terminal styling, matching how ephemerists/everymen retained their voice. Trivial to switch to bare uppercase if preferred.

## Verification
This worktree lacks frontend `node_modules/vite` and backend `.venv`/`.env`/Postgres, so `vite build` and the integration suite couldn't run locally. Verified: every edit present on disk, all referenced style vars in scope, Python `ast`-parses. CI (vitest + pytest) covers the rest.

Closes #386
Closes #379
Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)