### PR TITLE
docs: land ADR-0027 (Albescent secrecy) + ADR-0028 (Task Crown)

### DIFF
--- a/docs/adr/0027-albescent-is-a-secret-society.md
+++ b/docs/adr/0027-albescent-is-a-secret-society.md
@@ -1,0 +1,67 @@
+# Albescent is a secret society, revealed by a sticky per-account flag
+
+Albescent is a **distinct faction**, not a visual alias of UA (see #232). Its
+*existence as a faction* is a **secret**: hidden from an account until that
+account has, at some point, had a character who joined Albescent. Two visibility
+tiers, and a reveal trigger that is deliberately sticky.
+
+## The two tiers
+
+**Always visible to everyone (no gate).** Albescent characters/players, their
+tasks, and their praxis cards/pages render with Albescent's *own* full identity
+(name, skin, everything) wherever they legitimately appear. The distinctive
+Albescent look is public — outsiders are meant to *see* Albescent members and
+not know what faction that is.
+
+**Hidden until reveal (the secret).** The faction-*listing* surfaces conceal
+Albescent's existence:
+- not listed on the faction-cards grid (`Factions.tsx`),
+- the detail page (`/factions/albescent`) shows a **"You know not what you
+  seek"** placeholder (issue #394), not the real page and not a 404,
+- not a pennant in the filter strip (`FilterFactionTabs` / `GET /factions`),
+- no description, roster, or lore anywhere.
+
+## Reveal trigger — sticky, account-collective
+
+The reveal fires when the account **has ever had a character who is / was a
+member of Albescent**. It is **monotonic**: once revealed, always revealed —
+age-out, death, or switching active character never re-hide it. "Once the secret
+is out, it's out."
+
+Implemented as a sticky `albescent_revealed: bool` (default `False`) on the
+`Account` model, flipped `True` at the join site (`defect_to_faction` when the
+target is Albescent) and never unset. Account-collective (consistent with
+ADR-0021), O(1) to read (the account is already loaded for auth), and — because
+it is *not* derived from live character membership — it survives age-out/death.
+
+This reveal gate is **distinct from ADR-0021 join-eligibility** (level 8 + full
+coverage). The flow is: eligibility → invitation → **join** → reveal. Receiving
+the invitation does **not** reveal; only *having had a member character* does.
+
+## Considered Options
+
+- **Alias Albescent to UA (the pre-#232 status quo).** Rejected — Albescent is
+  its own faction; masking it as UA erases a first-class identity and makes the
+  secret a lie rather than a mystery.
+- **Derive "revealed" from current character membership.** Rejected — a revealed
+  secret must stay revealed after the member ages out or dies; live membership is
+  non-monotonic. The sticky flag is the point.
+- **Hide Albescent members/tasks/praxis too (full concealment).** Rejected — the
+  intended experience is that you *see* Albescent members and cannot look the
+  faction up. Concealing members as well removes the mystery.
+- **404 the faction page pre-reveal.** Rejected — a 404 reads as "no such
+  faction," which both leaks (a real slug 404s differently than a typo) and kills
+  the mystery. The "You know not what you seek" wall is deliberate.
+
+## Consequences
+
+- The faction-listing endpoints (`GET /factions`, `GET /factions/status`,
+  `GET /factions/{slug}`) become **account-aware** and exclude Albescent unless
+  the account is revealed. `GET /factions` is currently unauthenticated — it must
+  learn the current account.
+- The join site (`defect_to_faction`) gains a side effect (flip the flag) on top
+  of the #395 eligibility guard — both land in the same block.
+- A one-column migration adds `account.albescent_revealed`.
+- Composes with #232 (first-class identity), #394 (the placeholder wall), and is
+  blocked by #395 (join-eligibility enforcement, so an ineligible join can't
+  wrongly trip the reveal).

--- a/docs/adr/0028-task-crown-replaces-faction-distinction-laurel.md
+++ b/docs/adr/0028-task-crown-replaces-faction-distinction-laurel.md
@@ -1,0 +1,52 @@
+# ADR-0028 — The Task Crown replaces the Faction Distinction Laurel
+
+**Status:** Accepted
+**Date:** 2026-07-03
+**Supersedes:** the cross-task "faction champion" semantics of the Faction Distinction Laurel (`FdlLaurel` / `topPraxisIndex`)
+**Relates to:** #354 (this mark), #390 / Albescent secrecy ([ADR-0027](0027-albescent-is-a-secret-society.md) — the revealed Albescent faction page carries the Task Crown like the other six)
+
+## Context
+
+A single cross-faction mark shipped as the **Faction Distinction Laurel** (`FdlLaurel`, a rainbow
+medallion + laurel glyph). It crowned *one* praxis per faction page — the faction's single
+highest-scoring recent praxis, **across all its tasks**, first-max-wins, no ties, faction-page only.
+
+Issue #354 ("fleur de lis on top scoring praxis for any task") asks for a mark with a **different
+unit**: the top-scoring praxis **per task**, shown **everywhere a praxis card appears**, with
+**co-champion ties all crowned**. Reusing the same glyph for both rules is a semantic collision — the
+same emblem would mean "faction champion" on one surface and "task leader" on another.
+
+## Decision
+
+**One mark, one meaning: "top-scoring submitted praxis for its task."** The cross-task faction-champion
+concept is retired. `FdlLaurel` / `topPraxisIndex` are removed; the six faction bodies stop computing a
+single champion and instead render the per-task mark on each recent-praxis card that leads its own task.
+
+- **Name:** the **Task Crown**. Component `TaskCrown`; backend field `is_top_for_task: bool`.
+- **Glyph:** an actual **fleur-de-lis (⚜)** inside the existing rainbow ring (`--fdl-rainbow`), skin-aware
+  inner disc + glyph recolor per faction — i.e. swap the laurel glyph in the current medallion, keep the ring.
+- **Rule (fully permissive, live):**
+  - Crown the highest-score *submitted* praxis for its task, recomputed each read (like `score` itself).
+  - Only `submitted` praxes compete (`in_progress` aren't scored). Since a task's base points are equal
+    across its praxes, "top score" reduces to most vote-points.
+  - **Ties → all tied praxes crowned** (co-champions), including the zero-vote case: a fresh multi-entry
+    task is one big tie until votes differentiate.
+  - **A sole entrant is crowned by default.** No minimum-submissions and no minimum-vote threshold. This
+    makes the crown common at "everywhere" scope; that ubiquity is accepted — the mark is honest ("leads
+    its task"), scarcity emerges as votes accumulate, and a threshold would add config + a "why isn't mine
+    crowned?" support surface for marginal noise reduction.
+
+**Surfaces:** everywhere a praxis card appears (feed, profile, praxis detail, task detail) plus the
+faction pages. The corner-stamp slot already exists on the shared `PraxisCard` (`praxisCard/shared.tsx`)
+and on the praxis-detail hero.
+
+**Backend:** stamp `is_top_for_task` on `PraxisCardOut` **and** `PraxisOut`, computed via a per-task max
+over vote-points (window function / grouped subquery), **not** per-card in the build loop (avoid N+1).
+
+## Consequences
+
+- The faction page can show several crowns (co-champions) or, occasionally, none of the shown cards if
+  none happens to lead its own task — busier than the old guaranteed single laurel, accepted.
+- The revealed Albescent faction page (ADR-0027 / #232) carries the Task Crown like the other six.
+- The `FdlLaurel` visual asset survives only as the base medallion for `TaskCrown` (glyph swapped); the
+  old naming (`Fdl`, "laurel", `topPraxisIndex`) is retired to avoid the stale cross-task meaning.


### PR DESCRIPTION
The 2026-07-03 grill sessions wrote these ADRs on session branches (claude/busy-bun-c4fc16, claude/happy-dubinsky-7818cc) but never landed them. Issues #390, #395, and #354 cite them as spec — landing docs-only so the builds can reference them.

- ADR-0027: Albescent is a secret society (sticky per-account reveal)
- ADR-0028: Task Crown replaces the Faction Distinction Laurel

🤖 Generated with [Claude Code](https://claude.com/claude-code)