### PR TITLE
feat: faction filter strip in canonical rainbow order (#352)

### DIFF
--- a/frontend/src/components/ui/FilterFactionTabs.tsx
+++ b/frontend/src/components/ui/FilterFactionTabs.tsx
@@ -1,5 +1,8 @@
 import type { FactionOut } from "../../api/factions";
-import { factionCssVar } from "../../utils/factions";
+import {
+  factionCssVar,
+  sortFactionsByRainbowOrder,
+} from "../../utils/factions";
 
 /**
  * Faction filter — Diagonal Banner Tabs (Style Guide §5.3).
@@ -20,7 +23,7 @@ export default function FilterFactionTabs({
   return (
     <div className="flex gap-1 items-center">
       <span className="eyebrow">faction:</span>
-      {factions.map((faction) => {
+      {sortFactionsByRainbowOrder(factions).map((faction) => {
         const active = value === faction.slug;
         return (
           <button

--- a/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
+++ b/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  FACTION_RAINBOW_ORDER,
+  sortFactionsByRainbowOrder,
+} from "../factions";
+
+describe("sortFactionsByRainbowOrder", () => {
+  it("orders known factions into canonical rainbow order", () => {
+    const shuffled = [
+      { slug: "wow" },
+      { slug: "singularity" },
+      { slug: "everymen" },
+      { slug: "ephemerists" },
+      { slug: "albescent" },
+      { slug: "ua" },
+      { slug: "snide" },
+    ];
+    expect(sortFactionsByRainbowOrder(shuffled).map((f) => f.slug)).toEqual([
+      ...FACTION_RAINBOW_ORDER,
+    ]);
+  });
+
+  it("sorts unknown slugs last, preserving their relative order", () => {
+    const factions = [
+      { slug: "mystery_b" },
+      { slug: "wow" },
+      { slug: "mystery_a" },
+      { slug: "everymen" },
+    ];
+    expect(sortFactionsByRainbowOrder(factions).map((f) => f.slug)).toEqual([
+      "everymen",
+      "wow",
+      "mystery_b",
+      "mystery_a",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const factions = [{ slug: "wow" }, { slug: "everymen" }];
+    sortFactionsByRainbowOrder(factions);
+    expect(factions.map((f) => f.slug)).toEqual(["wow", "everymen"]);
+  });
+});

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -119,3 +119,33 @@ export function factionName(slug: string | null | undefined): string {
 export function getAllFactions(): FactionConfig[] {
   return Object.values(factionRegistry);
 }
+
+/**
+ * Canonical rainbow display order for faction strips/pennants (issue #352):
+ * Everymen → UA → S.N.I.D.E. → Ephemerists → Singularity → Albescent → Warriors of Whimsy.
+ */
+export const FACTION_RAINBOW_ORDER: readonly string[] = [
+  "everymen",
+  "ua",
+  "snide",
+  "ephemerists",
+  "singularity",
+  "albescent",
+  "wow",
+];
+
+/**
+ * Sort factions into canonical rainbow order without mutating the input.
+ * Unknown slugs sort last, preserving their relative (arrival) order.
+ */
+export function sortFactionsByRainbowOrder<T extends { slug: string }>(
+  factions: T[],
+): T[] {
+  const rankOf = (slug: string): number => {
+    const index = FACTION_RAINBOW_ORDER.indexOf(slug);
+    return index === -1 ? FACTION_RAINBOW_ORDER.length : index;
+  };
+  return [...factions].sort(
+    (first, second) => rankOf(first.slug) - rankOf(second.slug),
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `FACTION_RAINBOW_ORDER` (canonical pennant order: Everymen → UA → S.N.I.D.E. → Ephemerists → Singularity → Albescent → Warriors of Whimsy) and a reusable `sortFactionsByRainbowOrder()` helper to `frontend/src/utils/factions.ts`.
- `FilterFactionTabs` now sorts whatever `GET /factions` returns through that helper before rendering pennants.
- Unknown slugs sort last with their arrival order preserved (stable sort, input not mutated). Whether albescent appears in the set is out of scope (#390) — we just order what arrives.
- Reorder only: no recoloring, no hardcoded hex.

## Tests
- New `frontend/src/utils/__tests__/factionRainbowOrder.test.ts` covering canonical ordering, unknown-slug tail ordering, and non-mutation.
- Full frontend suite: 131 passed (14 files).

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)