### PR TITLE
fix: dirty-check pre-submit save so collab consensus is reachable (#360)

### DIFF
--- a/frontend/src/pages/editPraxis/useEditPraxis.test.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.test.ts
@@ -4,7 +4,31 @@
  * transitions warn: leaving a live duel, or collab→solo dropping co-authors.
  */
 import { describe, it, expect } from "vitest";
-import { modeSwitchPrompt } from "./useEditPraxis";
+import { hasUnsavedEdits, modeSwitchPrompt } from "./useEditPraxis";
+
+/**
+ * Dirty-check gating the pre-submit PUT (#360). persistEdits only fires
+ * updatePraxis when this returns true — on a collab an unconditional PUT
+ * reset every member's has_submitted (ADR-0012), so consensus was never
+ * reachable through the UI.
+ */
+describe("hasUnsavedEdits", () => {
+  it("is false when title and body match the last-persisted values → no PUT on submit", () => {
+    expect(hasUnsavedEdits("Title", "Body", "Title", "Body")).toBe(false);
+  });
+
+  it("is true when the title changed → PUT fires (and resets collab consensus, per ADR-0012)", () => {
+    expect(hasUnsavedEdits("New title", "Body", "Title", "Body")).toBe(true);
+  });
+
+  it("is true when the body changed", () => {
+    expect(hasUnsavedEdits("Title", "New body", "Title", "Body")).toBe(true);
+  });
+
+  it("is true before hydration (refs still null), preserving the old always-save behavior", () => {
+    expect(hasUnsavedEdits("Title", "", null, null)).toBe(true);
+  });
+});
 
 describe("modeSwitchPrompt", () => {
   it("warns that co-authors will be dropped on collab → solo with a crew (#155)", () => {

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -139,6 +139,25 @@ export function modeSwitchPrompt(
   return null;
 }
 
+/**
+ * Dirty-check gate for the pre-submit save (#360).
+ *
+ * On a collab, ANY praxis PUT hard-resets every member's has_submitted
+ * (ADR-0012 — "an edit means we're not done"). If Submit always fired a PUT,
+ * the last member's submit would reset everyone else's, so
+ * all(has_submitted) could never be reached through the UI. Only persist
+ * when the form actually differs from the last-persisted values; a genuine
+ * edit still resets consensus, which is correct per ADR-0012.
+ */
+export function hasUnsavedEdits(
+  title: string,
+  body: string,
+  lastSavedTitle: string | null,
+  lastSavedBody: string | null,
+): boolean {
+  return title !== lastSavedTitle || body !== lastSavedBody;
+}
+
 export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const navigate = useNavigate();
   const { user, refetch, loading: authLoading } = useAuth();
@@ -362,6 +381,18 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       if (autosaveTimerRef.current) {
         clearTimeout(autosaveTimerRef.current);
         autosaveTimerRef.current = null;
+      }
+      // Nothing changed since the last save → skip the PUT entirely (#360).
+      // On a collab the PUT would reset every member's has_submitted.
+      if (
+        !hasUnsavedEdits(
+          title,
+          body,
+          lastSavedTitleRef.current,
+          lastSavedBodyRef.current,
+        )
+      ) {
+        return;
       }
       await updatePraxis(praxisId, { title, body_text: body || undefined });
       lastSavedTitleRef.current = title;


### PR DESCRIPTION
Closes #360

## Bug

A collaboration where every member submitted stayed in edit mode forever. The submit handler (`useEditPraxis.ts` → `publish`) ran `persistEdits(praxisId)` then `submitPraxis(praxisId)`, and `persistEdits` PUT `{title, body_text}` **every time**, dirty or not. On a collab, backend `update_praxis` unconditionally calls `cancel_pending_publish_on_edit`, hard-resetting every member's `has_submitted` (ADR-0012 — "an edit means we're not done"). So Bob's submit reset Alice's, and `all(has_submitted)` was never reachable through the UI.

## Fix (frontend-only, root cause)

`persistEdits` now dirty-checks before PUTting, via a new exported pure helper `hasUnsavedEdits(title, body, lastSavedTitle, lastSavedBody)`. It compares the form state against the hook's existing last-persisted refs (`lastSavedTitleRef` / `lastSavedBodyRef`), which are seeded on hydration with the same `?? ""` normalization the form uses and updated on every autosave/manual save — so the comparison is exact.

- Member agrees with the draft and clicks Submit → no PUT → no reset → their submit can complete consensus.
- Member genuinely edits then submits → PUT fires → consensus resets, correct per ADR-0012.
- `persistEdits` has exactly one caller (the submit path); the Save Draft button was removed in #297 and manual saves go through the debounced autosave, which already dirty-checks. No other caller relies on the unconditional PUT.
- Pre-hydration null refs read as dirty, preserving the old always-save behavior (unreachable in practice since publish requires a non-empty title).

## Test

Added a focused `hasUnsavedEdits` describe block to the existing `useEditPraxis.test.ts` (same pure-function seam pattern as `modeSwitchPrompt`): clean → no PUT, changed title/body → PUT, null refs → PUT.

`npm test -- --run`: 13 files / 132 tests pass. `npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)