### PR TITLE
feat: Albescent sealed placeholder at /factions/albescent (#394)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import CharacterProfile from './pages/CharacterProfile'
 import Leaderboard from './pages/Leaderboard'
 import Factions from './pages/Factions'
 import FactionDetail from './pages/FactionDetail'
+import AlbescentSecretPlaceholder from './pages/AlbescentSecretPlaceholder'
 import Updates from './pages/Updates'
 import Praxes from './pages/Praxes'
 import Admin from './pages/Admin'
@@ -59,6 +60,11 @@ export default function App() {
         />
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/factions" element={<Factions />} />
+        {/* Albescent is sealed: outsiders get an in-world dead end, not the
+            faction page. Static segment outranks `:slug`, so this intercepts.
+            TODO(#390): gate on account.albescent_revealed — show real faction
+            page once revealed. */}
+        <Route path="/factions/albescent" element={<AlbescentSecretPlaceholder />} />
         <Route path="/factions/:slug" element={<FactionDetail />} />
         <Route
           path="/updates"

--- a/frontend/src/pages/AlbescentSecretPlaceholder.tsx
+++ b/frontend/src/pages/AlbescentSecretPlaceholder.tsx
@@ -1,0 +1,85 @@
+/**
+ * Albescent "sealed" placeholder (#394). What an outsider sees at
+ * `/factions/albescent` — deliberately NOT a 404, an in-world dead end.
+ * Styled in the Albescent "Register" idiom (ADR-0017 / #231): always-light
+ * vellum, near-black ink, Cormorant Garamond italic, quiet mono label, faint
+ * fleur-de-lis glyph. Albescent surfaces never dim in dark mode — the
+ * `--faction-albescent-*` tokens carry identical values in both themes.
+ */
+const BG = 'var(--faction-albescent-card-bg)'
+const INK = 'var(--faction-albescent-card-text)'
+const FONT = 'var(--faction-albescent-card-font)'
+const MONO = 'var(--font-body)'
+
+/** A translucent wash of Albescent ink at the given opacity percentage. */
+const ink = (percent: number): string => `color-mix(in srgb, ${INK} ${percent}%, transparent)`
+
+function FleurMark({ size = 56 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 40 48"
+      width={size * (40 / 48)}
+      height={size}
+      style={{ display: 'block', color: ink(22) }}
+      aria-hidden="true"
+    >
+      <g fill="currentColor">
+        <path d="M20 1 C16 10 16 17 20 24 C24 17 24 10 20 1 Z" />
+        <path d="M20 22 C14 15 8 15 6 21 C4.6 25 8 29 13.5 27.6 C10.5 25 12.5 21 20 22 Z" />
+        <path d="M20 22 C26 15 32 15 34 21 C35.4 25 32 29 26.5 27.6 C29.5 25 27.5 21 20 22 Z" />
+        <rect x="11" y="26" width="18" height="4.5" rx="2.2" />
+        <path d="M20 30 C17.5 37 16 41 20 47 C24 41 22.5 37 20 30 Z" />
+      </g>
+    </svg>
+  )
+}
+
+export default function AlbescentSecretPlaceholder() {
+  return (
+    <div
+      className="flex items-center justify-center"
+      style={{ minHeight: '70vh', fontFamily: MONO }}
+    >
+      <div
+        className="text-center"
+        style={{
+          background: BG,
+          border: `1px solid ${ink(12)}`,
+          color: INK,
+          maxWidth: 520,
+          width: '100%',
+          padding: '64px 48px',
+        }}
+      >
+        <div className="flex justify-center" style={{ marginBottom: 28 }}>
+          <FleurMark />
+        </div>
+        <div
+          style={{
+            fontFamily: MONO,
+            fontSize: 8,
+            letterSpacing: '0.28em',
+            textTransform: 'uppercase',
+            color: ink(30),
+            marginBottom: 20,
+          }}
+        >
+          — no such account —
+        </div>
+        <p
+          style={{
+            fontFamily: FONT,
+            fontStyle: 'italic',
+            fontSize: 30,
+            lineHeight: 1.25,
+            color: INK,
+            margin: 0,
+          }}
+        >
+          You know not what you seek.
+        </p>
+        <div style={{ height: 1, width: 64, margin: '28px auto 0', background: ink(16) }} />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `frontend/src/pages/AlbescentSecretPlaceholder.tsx`: the "sealed" page an outsider hits at a gated Albescent surface — **"You know not what you seek."** — deliberately an in-world dead end, not a 404. Register idiom (ADR-0017 / #231): always-light vellum card, near-black ink, Cormorant Garamond italic headline, quiet uppercase mono label ("— no such account —"), faint fleur-de-lis SVG glyph, hairline rule.
- Wiring: static `/factions/albescent` route in `App.tsx`, placed ahead of `/factions/:slug`. React Router ranks static segments above params, so it unconditionally intercepts before `FactionDetail` renders — the smallest possible wiring, no wrapper or slug check inside FactionDetail needed. `TODO(#390)` comment at the route marks where the `account.albescent_revealed` gate will swap in the real faction page.

## Design notes
- No hardcoded hex: all color via `--faction-albescent-card-bg/-text/-font` + `--font-body`; ink washes via `color-mix(in srgb, <ink> N%, transparent)`.
- The albescent tokens carry identical values in `:root` and `[data-theme="dark"]` (index.css), so the vellum stays light in dark mode — Albescent is always-light per ADR-0017.
- Tailwind utilities (`flex items-center justify-center`, `text-center`) used for layout, matching repo idiom; visual styling inline like the other Albescent surfaces.

## Verification
- `npm test -- --run`: 13 files / 128 tests pass.
- `npx tsc --noEmit`: clean.

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)