### PR TITLE
fix: collab members see edit/submit/withdraw on praxis read page (#348)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/isViewerMember.test.ts
+++ b/frontend/src/pages/praxisDetail/__tests__/isViewerMember.test.ts
@@ -1,0 +1,74 @@
+/**
+ * #348 — owner actions are membership-gated, not creator-gated.
+ *
+ * The backend authorizes any praxis MEMBER to edit/submit/withdraw
+ * (ADR-0013 co-ownership, _require_member). isViewerMember mirrors that
+ * guard so an invited collaborator sees the owner actions, while the
+ * creator (always seeded as a member) keeps them on solo/duel praxes.
+ */
+import { describe, it, expect } from "vitest";
+import { isViewerMember } from "../usePraxisDetail";
+import type { PraxisOut, PraxisMemberOut } from "../../../api/praxis";
+
+function member(characterId: number): PraxisMemberOut {
+  return {
+    id: characterId * 10,
+    praxis_id: 1,
+    character_id: characterId,
+    character_display_name: `Character ${characterId}`,
+    has_submitted: false,
+    joined_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function praxis(members: PraxisMemberOut[]): PraxisOut {
+  return {
+    id: 1,
+    task_id: 7,
+    task_title: "Mangrove",
+    task_point_value: 30,
+    task_level_required: 3,
+    task_faction_slug: "ua",
+    type: "collab",
+    status: "in_progress",
+    title: "Reforestation",
+    body_text: "Seedlings planted along the estuary.",
+    moderation_status: "visible",
+    admin_note: null,
+    flagged_at: null,
+    submitted_at: null,
+    submit_proposed_at: null,
+    created_by_id: 3,
+    created_by_display_name: "Ada",
+    created_by_faction_slug: "ua",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    members,
+    invites: [],
+    media_items: [],
+    score: 0,
+    duel_id: null,
+    can_flag: true,
+    applied_metatasks: [],
+  };
+}
+
+describe("isViewerMember (#348)", () => {
+  it("is true for the creator (always seeded as a member)", () => {
+    expect(isViewerMember(praxis([member(3)]), 3)).toBe(true);
+  });
+
+  it("is true for an invited collaborator who is NOT the creator", () => {
+    expect(isViewerMember(praxis([member(3), member(5)]), 5)).toBe(true);
+  });
+
+  it("is false for a non-member viewer", () => {
+    expect(isViewerMember(praxis([member(3), member(5)]), 9)).toBe(false);
+  });
+
+  it("is false when anonymous or praxis not loaded", () => {
+    expect(isViewerMember(praxis([member(3)]), null)).toBe(false);
+    expect(isViewerMember(praxis([member(3)]), undefined)).toBe(false);
+    expect(isViewerMember(null, 3)).toBe(false);
+  });
+});

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -41,6 +41,8 @@ export interface PraxisDetailState {
   duel: DuelDetailOut | null;
 
   // Derived
+  /** True when the viewer is a MEMBER of this praxis (ADR-0013 co-ownership) —
+   *  gates the edit/submit/withdraw actions, matching the backend _require_member guard. */
   isOwner: boolean;
   showAdminBar: boolean;
   // Authenticated viewer character (null when anonymous)
@@ -84,6 +86,22 @@ export interface PraxisDetailState {
   removingMetataskId: number | null;
   handleApplyMetatask: (taskId: number) => Promise<void>;
   handleRemoveMetatask: (taskId: number) => Promise<void>;
+}
+
+/**
+ * Ownership mirrors the backend guard (_require_member): any praxis MEMBER may
+ * edit/submit/withdraw (ADR-0013 co-ownership), not just the creator. The
+ * creator is always seeded as a member, so solo and duel praxes are unchanged;
+ * this only widens collab praxes so invited members see the owner actions (#348).
+ */
+export function isViewerMember(
+  praxis: PraxisOut | null,
+  viewerCharacterId: number | null | undefined,
+): boolean {
+  if (!praxis || viewerCharacterId == null) return false;
+  return praxis.members.some(
+    (member) => member.character_id === viewerCharacterId,
+  );
 }
 
 export function usePraxisDetail(idParam: string | undefined): PraxisDetailState {
@@ -258,8 +276,7 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     }
   };
 
-  const isOwner =
-    !!user?.character && !!praxis && user.character.id === praxis.created_by_id;
+  const isOwner = isViewerMember(praxis, user?.character?.id);
 
   return {
     loading,


### PR DESCRIPTION
## Summary
- Root cause: `isOwner` in `frontend/src/pages/praxisDetail/usePraxisDetail.ts` was creator-only (`user.character.id === praxis.created_by_id`), but the backend authorizes any MEMBER to edit/submit/withdraw (ADR-0013 co-ownership — `update_praxis`/`submit_praxis`/`withdraw_praxis` all guard with `_require_member`). Invited collaborators therefore got a read-only page.
- Fix: repredicate ownership to MEMBERSHIP. New exported pure helper `isViewerMember(praxis, viewerCharacterId)` checks `praxis.members[].character_id`; `isOwner` now delegates to it, mirroring the backend guard exactly.
- The creator is always seeded as a `PraxisMember` on create (`services/praxis.py`), so solo and duel praxes are unchanged — this only widens collab praxes.
- `isOwner` is consumed in exactly one place (`PraxisOwnerActions`, `praxisDetail/shared.tsx`); `change-type` is not in `PraxisOwnerActions` and stays author-only — untouched.

## Tests
- New `frontend/src/pages/praxisDetail/__tests__/isViewerMember.test.ts`: creator-is-member, invited-collaborator, non-member, and anonymous/unloaded cases.
- Full frontend suite: 132 passed (14 files); `tsc --noEmit` clean.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)