### PR TITLE
feat: sidebar in-progress tasks by membership + typed badges (#344, #349)

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -79,6 +79,7 @@ router = APIRouter()
 async def list_praxes_route(
     task_id: Optional[int] = None,
     character_id: Optional[int] = None,
+    member_id: Optional[int] = None,
     type: Optional[str] = None,
     status: Optional[str] = None,
     moderation_status: Optional[str] = None,
@@ -107,6 +108,7 @@ async def list_praxes_route(
         session=session,
         task_id=task_id,
         character_id=character_id,
+        member_id=member_id,
         praxis_type=praxis_type,
         status=praxis_status,
         moderation_status=moderation_status,

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -301,6 +301,7 @@ async def list_praxes(
     *,
     task_id: Optional[int] = None,
     character_id: Optional[int] = None,
+    member_id: Optional[int] = None,
     praxis_type: Optional[PraxisType] = None,
     status: Optional[PraxisStatus] = None,
     moderation_status: Optional[str] = None,
@@ -314,6 +315,11 @@ async def list_praxes(
 
     ``in_progress`` praxes are member-only (ADR-0024): pass ``viewer_id`` to
     include the viewer's own drafts; everyone else sees only ``submitted``.
+
+    ``character_id`` filters by authorship (``created_by_id``); ``member_id``
+    filters by *membership* (``PraxisMember``), mirroring
+    :func:`_count_in_progress_praxes` so a membership-based list (the sidebar's
+    in-progress tasks) can never disagree with the slot count.
     """
     query = select(Praxis).where(praxis_visibility_condition(viewer_id))
 
@@ -353,6 +359,17 @@ async def list_praxes(
             )
         else:
             query = query.where(Praxis.created_by_id == character_id)
+
+    if member_id is not None:
+        # Membership filter: any praxis the character holds a PraxisMember row
+        # on, regardless of who created it (accepted collab invites included).
+        query = query.where(
+            Praxis.id.in_(
+                select(PraxisMember.praxis_id).where(
+                    PraxisMember.character_id == member_id
+                )
+            )
+        )
 
     if status is not None:
         query = query.where(Praxis.status == status)

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -620,6 +620,86 @@ async def test_collab_draft_visible_to_invitee_active_tasks(
 
 
 @pytest.mark.asyncio
+async def test_list_praxes_member_id_filters_by_membership(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """#344/#349: ``member_id`` filters by PraxisMember, mirroring the slot count.
+
+    A praxis where the character is a member but NOT the creator shows up;
+    a praxis the character is not a member of does not.
+    """
+    # character2 creates a collab; character is invited and accepts (member, not creator).
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Member Filter Collab"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    collab_id = create_resp.json()["id"]
+    invite_resp = await client.post(
+        f"/praxes/{collab_id}/invite",
+        json={"invitee_id": character.id},
+        headers=auth_headers2,
+    )
+    invite_id = invite_resp.json()["id"]
+    await client.post(
+        f"/praxes/{collab_id}/invite/{invite_id}/respond",
+        json={"accept": True},
+        headers=auth_headers,
+    )
+
+    # character2 also creates a solo praxis (on a second task — one active
+    # membership per task) that character has no membership in.
+    second_task = Task(
+        title="Second Task",
+        description="Another test task",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character2.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(second_task)
+    await db_session.commit()
+    await db_session.refresh(second_task)
+
+    solo_resp = await client.post(
+        "/praxes",
+        json={"task_id": second_task.id, "type": "solo", "title": "Not Yours Solo"},
+        headers=auth_headers2,
+    )
+    assert solo_resp.status_code == 201
+    solo_id = solo_resp.json()["id"]
+
+    # Membership list for character: the joined collab appears...
+    member_list = await client.get(
+        "/praxes",
+        params={"member_id": character.id, "status": "in_progress"},
+        headers=auth_headers,
+    )
+    assert member_list.status_code == 200
+    member_ids = [p["id"] for p in member_list.json()]
+    assert collab_id in member_ids
+    assert solo_id not in member_ids
+
+    # ...and filtering by a non-member's id excludes the praxis even when the
+    # viewer could otherwise see it (character2 is a member of both).
+    non_member_list = await client.get(
+        "/praxes",
+        params={"member_id": character.id, "status": "in_progress"},
+        headers=auth_headers2,
+    )
+    assert non_member_list.status_code == 200
+    assert solo_id not in [p["id"] for p in non_member_list.json()]
+
+
+@pytest.mark.asyncio
 async def test_collab_invite_decline(
     client: AsyncClient,
     character: Character,

--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -139,13 +139,9 @@ test.describe('collaboration lifecycle', () => {
     }
   })
 
-  // KNOWN GAP (bug): useMyActiveTasks -> GET /praxes?character_id= filters on
-  // Praxis.created_by_id (creator), not membership (backend/services/praxis.py:342),
-  // so an invitee who JOINED the draft never sees it in their sidebar. This test
-  // encodes the intended behaviour and is expected to fail until that filter
-  // matches PraxisMember. When it starts passing, remove test.fail().
+  // Fixed (#344/#349): useMyActiveTasks now filters by membership
+  // (GET /praxes?member_id=), so an invitee who JOINED the draft sees it too.
   test('the invitee ALSO sees the shared draft in their active-tasks sidebar', async ({ browser }) => {
-    test.fail()
     const seed = await seedCollabDraft(browser, 'side-b')
     try {
       const page = await seed.bob.ctx.newPage()

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -116,6 +116,7 @@ export interface PraxisVoteIn {
 export async function listPraxes(filters?: {
   task_id?: number
   character_id?: number
+  member_id?: number
   type?: PraxisType
   status?: PraxisStatus
   faction?: string

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -164,11 +164,11 @@ export default function Sidebar() {
 
       {/* ── Active Tasks Panel ── */}
       <div className="sidebar-card">
-        <p className="eyebrow mb-2">Your active tasks</p>
+        <p className="eyebrow mb-2">In progress tasks</p>
 
         {activeTasks.length === 0 ? (
           <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-            No active tasks
+            No in progress tasks
           </p>
         ) : (
           <div className="flex flex-col gap-1.5">
@@ -190,7 +190,10 @@ export default function Sidebar() {
                     {praxis.task_title}
                   </Link>
                 </div>
-                <FeedBadge type="global" label={PRAXIS_TYPE_LABEL[praxis.type]} />
+                <FeedBadge
+                  type={praxis.type === 'solo' ? 'global' : praxis.type}
+                  label={PRAXIS_TYPE_LABEL[praxis.type]}
+                />
               </div>
             ))}
           </div>

--- a/frontend/src/hooks/useMyActiveTasks.ts
+++ b/frontend/src/hooks/useMyActiveTasks.ts
@@ -4,6 +4,9 @@ import { useAuth } from '../auth/AuthContext'
 
 /**
  * Hook to fetch the current character's in-progress praxes.
+ *
+ * Filters by membership (`member_id`), not authorship, so accepted collab
+ * invites appear too — matching the slot count, which also counts memberships.
  * Re-fetches when the authenticated user changes.
  */
 export function useMyActiveTasks() {
@@ -18,7 +21,7 @@ export function useMyActiveTasks() {
       return
     }
     setLoading(true)
-    listPraxes({ character_id: user.character.id, status: 'in_progress' })
+    listPraxes({ member_id: user.character.id, status: 'in_progress' })
       .then((praxes) => setActiveTasks(praxes))
       .catch(() => {})
       .finally(() => setLoading(false))


### PR DESCRIPTION
## Summary

The sidebar's active-tasks bar filtered its list by `created_by_id == you`, but the slot cap (`_count_in_progress_praxes`) counts *membership* (`PraxisMember`). Collabs you were invited to counted against "X/Y slots" but never appeared in the list. This PR makes the list membership-based so the two can never disagree, renames the panel, and colors the per-row type badges.

## Changes

**Backend**
- New `member_id` query param on `GET /praxes` — filters by `PraxisMember` via a subquery in `list_praxes` (service layer; route stays thin), mirroring `_count_in_progress_praxes`.
- The existing `character_id` filter is untouched (zero blast radius on other callers).

**Frontend**
- `useMyActiveTasks` switches from `character_id` to `member_id` → accepted collab invites now appear in the sidebar.
- Panel renamed "Your active tasks" → **"In progress tasks"**; empty state → "No in progress tasks". (Rows already link to `/praxes/:id/edit`, satisfying the edit-link ask.)
- Per-row badge is now colored by `praxis.type`: SOLO (neutral `--badge-global`) / COLLAB (`--badge-collab`) / DUEL (`--badge-duel`) via the existing `FeedBadge` styles — no new hex anywhere.
- Removed `test.fail()` from the Playwright invitee-sidebar collab test (the gap it encoded is now fixed) and updated its stale comment.

**Tests**
- `test_list_praxes_member_id_filters_by_membership`: a praxis where the character is a member but not creator shows up under `member_id`; a praxis they hold no membership in is excluded even when the viewer can see it.

## Verification
- `pytest tests/integration/test_praxes.py` — 63 passed
- `npm test -- --run` — 128 passed (13 files)
- `npx tsc --noEmit` — clean

## Scope note
Accepted collabs only — pending invites stay in the Pending Requests panel (#346, separate issue).

Closes #344
Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)