### PR TITLE
Shared useRespondToRequest hook + actionable sidebar Pending Requests; fix duel-accept from feed

### DIFF
--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
-import { respondToInvite } from "../../api/praxis";
+import { useRespondToRequest } from "../../hooks/useRespondToRequest";
 import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
-import { extractError } from "../../utils/errors";
 import FeedBadge from "./FeedBadge";
 
 interface Props {
@@ -13,53 +11,31 @@ interface Props {
 
 export default function FeedCardCollabInvite({ item }: Props) {
   const {
-    invite_id,
     praxis_id,
     task_title,
     task_point_value,
     task_faction_slug,
     task_level_required,
-    invite_status,
     inviter_character_id,
   } = item.payload;
   const taskColor = factionColor(task_faction_slug);
   const actorColor = factionColor(item.actor_faction_slug);
   const navigate = useNavigate();
 
-  const [status, setStatus] = useState<string | null>(invite_status);
-  const [loading, setLoading] = useState(false);
-  const [acceptError, setAcceptError] = useState("");
+  const { accept, decline, loading, status, error } = useRespondToRequest(item);
 
   const handleAccept = async () => {
-    setLoading(true);
-    setAcceptError("");
-    try {
-      await respondToInvite(praxis_id, invite_id, true);
-      setStatus("accepted");
+    const result = await accept();
+    if (result.ok) {
       // New members land on the editor so they can contribute; the editor
       // self-locks if the collab is already submitted (controlsLocked). (#298)
-      navigate(`/praxes/${praxis_id}/edit`);
-    } catch (err) {
-      // Surface the real backend reason (e.g. 400 "Cannot join a submitted
-      // praxis" after lazy-consensus auto-publish, or 409 bank-full) instead of
-      // a generic swallow. (#318)
-      setAcceptError(extractError(err, "Could not accept invite. Please try again."));
+      navigate(`/praxes/${result.praxisId ?? praxis_id}/edit`);
     }
-    setLoading(false);
   };
 
-  const handleDecline = async () => {
-    setLoading(true);
-    try {
-      await respondToInvite(praxis_id, invite_id, false);
-      setStatus("declined");
-    } catch {
-      /* swallow */
-    }
-    setLoading(false);
-  };
+  const handleDecline = () => decline();
 
-  const isPending = status === "pending" || status === null;
+  const isPending = status === "pending";
 
   return (
     <div style={{ padding: "12px 16px" }}>
@@ -202,9 +178,9 @@ export default function FeedCardCollabInvite({ item }: Props) {
           >
             Decline
           </button>
-          {acceptError && (
+          {error && (
             <span className="eyebrow" style={{ color: "var(--color-danger)" }}>
-              {acceptError}
+              {error}
             </span>
           )}
         </div>

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
-import { respondToInvite } from "../../api/praxis";
+import { useRespondToRequest } from "../../hooks/useRespondToRequest";
 import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
@@ -11,58 +11,49 @@ interface Props {
 }
 
 export default function FeedCardDuelChallenge({ item }: Props) {
+  // Duel payload carries duel_id / challenger_praxis_id / duel_status — NOT
+  // the collab invite_id / praxis_id / invite_status fields. The shared hook
+  // owns the endpoint switch (#346).
   const {
-    invite_id,
-    praxis_id,
+    challenger_praxis_id,
     task_title,
     task_point_value,
     task_faction_slug,
-    invite_status,
     challenger_character_id,
   } = item.payload;
   const taskColor = factionColor(task_faction_slug);
   const actorColor = factionColor(item.actor_faction_slug);
   const navigate = useNavigate();
 
-  const [status, setStatus] = useState<string | null>(invite_status);
-  const [loading, setLoading] = useState(false);
-  // Task-list-full modal state
+  const { accept, decline, loading, status, error } = useRespondToRequest(item);
+  // Task-list-full modal state — dormant skeleton, wired by #322/#314.
   const [showDropModal, setShowDropModal] = useState(false);
   const [myTasks] = useState<
     { id: number; task: { id: number; title: string } }[]
   >([]);
-  const [dropError, setDropError] = useState("");
 
   const doAccept = async (drop_task_id?: number) => {
-    setLoading(true);
-    try {
-      await respondToInvite(praxis_id, invite_id, true);
+    const result = await accept();
+    if (result.ok) {
       if (drop_task_id) {
         // Drop task was selected from modal — handled server-side via the task list
       }
-      setStatus("accepted");
       setShowDropModal(false);
-      navigate(`/praxes/${praxis_id}`);
-    } catch {
-      setDropError("Could not accept duel. Please try again.");
+      // Accepting creates the opponent's fresh praxis server-side — land the
+      // responder on its editor so they can start working (mirrors collab).
+      navigate(
+        result.praxisId
+          ? `/praxes/${result.praxisId}/edit`
+          : `/praxes/${challenger_praxis_id}`,
+      );
     }
-    setLoading(false);
   };
 
   const handleAccept = () => doAccept();
 
-  const handleDecline = async () => {
-    setLoading(true);
-    try {
-      await respondToInvite(praxis_id, invite_id, false);
-      setStatus("declined");
-    } catch {
-      /* swallow */
-    }
-    setLoading(false);
-  };
+  const handleDecline = () => decline();
 
-  const isPending = status === "pending" || status === null;
+  const isPending = status === "pending";
 
   return (
     <>
@@ -209,12 +200,12 @@ export default function FeedCardDuelChallenge({ item }: Props) {
             >
               Decline
             </button>
-            {dropError && (
+            {error && (
               <span
                 className="eyebrow"
                 style={{ color: "var(--color-danger)" }}
               >
-                {dropError}
+                {error}
               </span>
             )}
           </div>
@@ -223,7 +214,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
         {status === "accepted" && (
           <div style={{ marginTop: 8, marginLeft: 38 }}>
             <Link
-              to={`/praxes/${praxis_id}`}
+              to={`/praxes/${challenger_praxis_id}`}
               className="eyebrow"
               style={{ color: "var(--badge-duel)", textDecoration: "none" }}
             >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../auth/AuthContext'
 import { getActivityFeed, type ActivityFeedItem } from '../../api/activityFeed'
@@ -10,6 +10,7 @@ import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
 import type { PraxisType } from '../../api/praxis'
 import { useMyCharacterStats } from '../../hooks/useMyCharacterStats'
 import { usePendingRequests } from '../../hooks/usePendingRequests'
+import { useRespondToRequest } from '../../hooks/useRespondToRequest'
 import { useGameConfig } from '../../hooks/useGameConfig'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
@@ -28,9 +29,9 @@ export default function Sidebar() {
   const { user } = useAuth()
   const character = user?.character
 
-  const { activeTasks } = useMyActiveTasks()
+  const { activeTasks, refetch: refetchActiveTasks } = useMyActiveTasks()
   const { votesReceived } = useMyCharacterStats(character?.id)
-  const { pendingRequests } = usePendingRequests()
+  const { pendingRequests, refetch: refetchPendingRequests } = usePendingRequests()
   const gameConfig = useGameConfig()
   const [globalActivity, setGlobalActivity] = useState<ActivityFeedItem[]>([])
 
@@ -127,37 +128,19 @@ export default function Sidebar() {
             Pending Requests · {pendingRequests.length}
           </p>
           <div className="flex flex-col gap-1.5">
-            {pendingRequests.map((item, index) => {
-              const isCollab = item.type === 'collab_invite'
-              return (
-                <Link
-                  key={`${item.type}-${index}`}
-                  to="/updates?filter=requests"
-                  className="flex items-center gap-2 py-1.5"
-                  style={{
-                    borderTop: index > 0 ? '1px dashed var(--color-border)' : undefined,
-                    textDecoration: 'none',
-                  }}
-                >
-                  <div
-                    className="shrink-0 rounded-full"
-                    style={{
-                      width: 24,
-                      height: 24,
-                      background: `linear-gradient(135deg, ${factionCssVar(item.actor_faction_slug, 'light')}, ${factionCssVar(item.actor_faction_slug)})`,
-                    }}
-                  />
-                  <div className="flex-1 min-w-0">
-                    <span className="font-body block" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)' }}>
-                      {item.actor_display_name}
-                    </span>
-                    <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-                      {isCollab ? 'Collab Invite' : 'Duel Challenge'}
-                    </span>
-                  </div>
-                </Link>
-              )
-            })}
+            {pendingRequests.map((item, index) => (
+              <PendingRequestRow
+                key={`${item.type}-${index}`}
+                item={item}
+                isFirst={index === 0}
+                onResolved={() => {
+                  // An accepted collab/duel becomes an in-progress praxis —
+                  // refresh both panels so the request moves bars (#346).
+                  refetchPendingRequests()
+                  refetchActiveTasks()
+                }}
+              />
+            ))}
           </div>
         </div>
       )}
@@ -288,5 +271,112 @@ export default function Sidebar() {
         Propose a Task
       </Link>
     </aside>
+  )
+}
+
+const REQUEST_BUTTON_BASE: CSSProperties = {
+  fontFamily: "'Courier Prime', monospace",
+  fontSize: 8,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  padding: '3px 8px',
+}
+
+/**
+ * One actionable row in the Pending Requests panel: accept/decline inline via
+ * the shared request hook (#346) — same logic the feed cards use.
+ */
+function PendingRequestRow({
+  item,
+  isFirst,
+  onResolved,
+}: {
+  item: ActivityFeedItem
+  isFirst: boolean
+  onResolved: () => void
+}) {
+  const isCollab = item.type === 'collab_invite'
+  const actorId = isCollab
+    ? item.payload.inviter_character_id
+    : item.payload.challenger_character_id
+  const badgeVar = isCollab ? 'var(--badge-collab)' : 'var(--badge-duel)'
+  const { accept, decline, loading, error } = useRespondToRequest(item)
+
+  const respond = async (action: typeof accept) => {
+    const result = await action()
+    if (result.ok) onResolved()
+  }
+
+  return (
+    <div
+      className="py-1.5"
+      style={{ borderTop: !isFirst ? '1px dashed var(--color-border)' : undefined }}
+    >
+      <div className="flex items-center gap-2">
+        <Link to={`/characters/${actorId}`} className="shrink-0">
+          <div
+            className="rounded-full"
+            style={{
+              width: 24,
+              height: 24,
+              background: `linear-gradient(135deg, ${factionCssVar(item.actor_faction_slug, 'light')}, ${factionCssVar(item.actor_faction_slug)})`,
+            }}
+          />
+        </Link>
+        <div className="flex-1 min-w-0">
+          <Link
+            to={`/characters/${actorId}`}
+            className="font-body block truncate"
+            style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+          >
+            {item.actor_display_name}
+          </Link>
+          <Link
+            to="/updates?filter=requests"
+            className="eyebrow block"
+            style={{ color: 'var(--color-text-tertiary)', textDecoration: 'none' }}
+          >
+            {isCollab ? 'Collab Invite' : 'Duel Challenge'}
+          </Link>
+        </div>
+      </div>
+      <div className="flex items-center gap-1.5" style={{ marginTop: 4, marginLeft: 32 }}>
+        <button
+          onClick={() => respond(accept)}
+          disabled={loading}
+          style={{
+            ...REQUEST_BUTTON_BASE,
+            background: badgeVar,
+            color: 'var(--color-text-on-accent)',
+            border: 'none',
+            cursor: loading ? 'not-allowed' : 'pointer',
+          }}
+        >
+          Accept
+        </button>
+        <button
+          onClick={() => respond(decline)}
+          disabled={loading}
+          style={{
+            ...REQUEST_BUTTON_BASE,
+            background: 'transparent',
+            color: 'var(--color-text-secondary)',
+            border: '1px solid var(--color-border)',
+            cursor: loading ? 'not-allowed' : 'pointer',
+          }}
+        >
+          Decline
+        </button>
+      </div>
+      {error && (
+        <span
+          className="eyebrow block"
+          style={{ color: 'var(--color-danger)', marginTop: 3, marginLeft: 32 }}
+        >
+          {error}
+        </span>
+      )}
+    </div>
   )
 }

--- a/frontend/src/hooks/__tests__/useRespondToRequest.test.ts
+++ b/frontend/src/hooks/__tests__/useRespondToRequest.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The endpoint switch that broke duel-accept (#346): duel challenges must hit
+ * POST /duels/:id/respond with payload.duel_id, NOT the collab invite
+ * endpoint with (undefined, undefined). Guards the dispatch + the per-type
+ * status field normalization.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import {
+  respondToRequest,
+  requestStatusOf,
+  normalizeRequestStatus,
+} from '../useRespondToRequest'
+import { respondToInvite } from '../../api/praxis'
+import { respondToChallenge } from '../../api/duel'
+
+vi.mock('../../api/praxis', () => ({ respondToInvite: vi.fn() }))
+vi.mock('../../api/duel', () => ({ respondToChallenge: vi.fn() }))
+
+const feedItem = (type: string, payload: Record<string, unknown>): ActivityFeedItem => ({
+  type,
+  timestamp: '2026-07-03T00:00:00Z',
+  actor_display_name: 'Rival',
+  actor_faction_slug: 'snide',
+  actor_avatar_url: null,
+  payload,
+  context_faction_slug: null,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('respondToRequest dispatch', () => {
+  it('routes collab_invite to the praxis invite endpoint and returns the shared praxis', async () => {
+    const item = feedItem('collab_invite', { praxis_id: 7, invite_id: 42, invite_status: 'pending' })
+    const praxisId = await respondToRequest(item, true)
+    expect(respondToInvite).toHaveBeenCalledWith(7, 42, true)
+    expect(respondToChallenge).not.toHaveBeenCalled()
+    expect(praxisId).toBe(7)
+  })
+
+  it('routes duel_challenge to the duel respond endpoint with duel_id (the #346 bug)', async () => {
+    vi.mocked(respondToChallenge).mockResolvedValue({ opponent_praxis_id: 99 } as never)
+    const item = feedItem('duel_challenge', {
+      duel_id: 5,
+      challenger_praxis_id: 11,
+      duel_status: 'pending',
+    })
+    const praxisId = await respondToRequest(item, true)
+    expect(respondToChallenge).toHaveBeenCalledWith(5, { accept: true })
+    expect(respondToInvite).not.toHaveBeenCalled()
+    // The fresh opponent praxis created by the accept, not the challenger's.
+    expect(praxisId).toBe(99)
+  })
+
+  it('declines a duel via the same endpoint with accept: false', async () => {
+    vi.mocked(respondToChallenge).mockResolvedValue({ opponent_praxis_id: null } as never)
+    const item = feedItem('duel_challenge', { duel_id: 5, duel_status: 'pending' })
+    const praxisId = await respondToRequest(item, false)
+    expect(respondToChallenge).toHaveBeenCalledWith(5, { accept: false })
+    expect(praxisId).toBeNull()
+  })
+
+  it('rejects non-request feed items', async () => {
+    const item = feedItem('era_announcement', {})
+    await expect(respondToRequest(item, true)).rejects.toThrow(/not a respondable/i)
+  })
+})
+
+describe('status normalization', () => {
+  it('reads invite_status for collabs and duel_status for duels', () => {
+    expect(requestStatusOf(feedItem('collab_invite', { invite_status: 'pending' }))).toBe('pending')
+    expect(requestStatusOf(feedItem('duel_challenge', { duel_status: 'pending' }))).toBe('pending')
+    // A duel card must not read the (absent) collab field and look pending forever.
+    expect(requestStatusOf(feedItem('duel_challenge', { duel_status: 'declined' }))).toBe('declined')
+  })
+
+  it('maps duel active/settled to accepted', () => {
+    expect(normalizeRequestStatus('active')).toBe('accepted')
+    expect(normalizeRequestStatus('settled')).toBe('accepted')
+    expect(normalizeRequestStatus('accepted')).toBe('accepted')
+  })
+
+  it('treats missing status as pending', () => {
+    expect(normalizeRequestStatus(null)).toBe('pending')
+    expect(normalizeRequestStatus(undefined)).toBe('pending')
+  })
+})

--- a/frontend/src/hooks/usePendingRequests.ts
+++ b/frontend/src/hooks/usePendingRequests.ts
@@ -1,17 +1,18 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { getActivityFeed, type ActivityFeedItem } from '../api/activityFeed'
 import { useAuth } from '../auth/AuthContext'
 
 /**
  * Hook to fetch pending collab invites and duel challenges.
- * Re-fetches when the authenticated user changes.
+ * Re-fetches when the authenticated user changes; `refetch` lets callers
+ * refresh after responding to a request (#346).
  */
 export function usePendingRequests() {
   const { user } = useAuth()
   const [pendingRequests, setPendingRequests] = useState<ActivityFeedItem[]>([])
   const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
+  const refetch = useCallback(() => {
     if (!user) {
       setPendingRequests([])
       setLoading(false)
@@ -24,5 +25,9 @@ export function usePendingRequests() {
       .finally(() => setLoading(false))
   }, [user])
 
-  return { pendingRequests, loading } as const
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  return { pendingRequests, loading, refetch } as const
 }

--- a/frontend/src/hooks/useRespondToRequest.ts
+++ b/frontend/src/hooks/useRespondToRequest.ts
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import type { ActivityFeedItem } from '../api/activityFeed'
+import { respondToInvite } from '../api/praxis'
+import { respondToChallenge } from '../api/duel'
+import { extractError } from '../utils/errors'
+
+/**
+ * Shared accept/decline logic for the two request-shaped feed items
+ * (#346, #393). Collab invites and duel challenges hit DIFFERENT backend
+ * endpoints with different payload fields — this hook is the single place
+ * that knows the switch, so the feed cards and the sidebar Pending Requests
+ * panel can't drift apart again (the drift previously broke duel-accept:
+ * the duel card read collab fields and called the collab endpoint with
+ * `undefined` ids).
+ */
+
+export type RequestResponseStatus = 'pending' | 'accepted' | 'declined'
+
+/**
+ * Collapse the per-type raw status into the three states the UI cares about.
+ * Collab invites report 'accepted'; duels report 'active' (and later
+ * 'settled') once accepted.
+ */
+export function normalizeRequestStatus(
+  raw: string | null | undefined,
+): RequestResponseStatus {
+  if (raw === null || raw === undefined || raw === 'pending') return 'pending'
+  if (raw === 'declined') return 'declined'
+  return 'accepted'
+}
+
+/** Read the item's current status from the right payload field per type. */
+export function requestStatusOf(item: ActivityFeedItem): RequestResponseStatus {
+  const raw =
+    item.type === 'duel_challenge'
+      ? item.payload.duel_status
+      : item.payload.invite_status
+  return normalizeRequestStatus(raw)
+}
+
+/**
+ * Dispatch the response to the right endpoint for the item type.
+ *
+ * Returns the praxis the responder should land on after accepting: the
+ * shared collab praxis, or the fresh opponent praxis a duel-accept creates
+ * server-side. Null when declining a duel (no praxis is created).
+ */
+export async function respondToRequest(
+  item: ActivityFeedItem,
+  accept: boolean,
+): Promise<number | null> {
+  switch (item.type) {
+    case 'collab_invite': {
+      const { praxis_id, invite_id } = item.payload
+      await respondToInvite(praxis_id, invite_id, accept)
+      return praxis_id
+    }
+    case 'duel_challenge': {
+      const duel = await respondToChallenge(item.payload.duel_id, { accept })
+      return duel.opponent_praxis_id
+    }
+    default:
+      throw new Error(`Not a respondable request type: ${item.type}`)
+  }
+}
+
+export interface RespondResult {
+  ok: boolean
+  /** Praxis to navigate to after a successful accept (null on decline/failure). */
+  praxisId: number | null
+}
+
+export function useRespondToRequest(item: ActivityFeedItem) {
+  const [status, setStatus] = useState<RequestResponseStatus>(() =>
+    requestStatusOf(item),
+  )
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const respond = async (acceptRequest: boolean): Promise<RespondResult> => {
+    setLoading(true)
+    setError('')
+    try {
+      const praxisId = await respondToRequest(item, acceptRequest)
+      setStatus(acceptRequest ? 'accepted' : 'declined')
+      return { ok: true, praxisId }
+    } catch (err) {
+      // Surface the real backend reason (e.g. 400 "Cannot join a submitted
+      // praxis" after lazy-consensus auto-publish, or 409 bank-full) instead
+      // of a generic swallow. (#318)
+      const noun = item.type === 'duel_challenge' ? 'duel' : 'invite'
+      const verb = acceptRequest ? 'accept' : 'decline'
+      setError(extractError(err, `Could not ${verb} ${noun}. Please try again.`))
+      return { ok: false, praxisId: null }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const accept = () => respond(true)
+  const decline = () => respond(false)
+
+  return { accept, decline, loading, status, error } as const
+}


### PR DESCRIPTION
## What

The accept/reject logic was inline-duplicated in `FeedCardCollabInvite.tsx` and `FeedCardDuelChallenge.tsx`, and the duplication produced a live bug: the duel card destructured `invite_id`/`praxis_id`/`invite_status` — fields that don't exist in the duel-challenge payload (which carries `duel_id`/`challenger_praxis_id`/`duel_status`) — and called `respondToInvite(undefined, undefined, ...)`. Accepting a duel from the feed was broken.

### Changes

- **`frontend/src/hooks/useRespondToRequest.ts` (new)** — single owner of the endpoint switch: `collab_invite` → `respondToInvite(praxis_id, invite_id, accept)`; `duel_challenge` → `respondToChallenge(duel_id, { accept })`. Returns `{ accept, decline, loading, status, error }`. Per-type raw statuses normalize to `pending / accepted / declined` (duel `active`/`settled` count as accepted). Accept resolves with the praxis to land on: the shared collab praxis, or the fresh opponent praxis the duel-accept creates server-side.
- **Both feed cards** now use the hook. The duel card reads its real payload fields; on accept it navigates to the new opponent-praxis editor (mirrors the collab flow). The dormant drop-modal skeleton (`showDropModal`, `myTasks`, `doAccept(drop_task_id?)`) is intentionally left in place for #322/#314.
- **Sidebar Pending Requests panel** is now actionable: compact Accept/Decline buttons per row (badge-colored per request type, CSS vars only), actor name links to their profile, and a successful response refetches pending requests **and** active tasks so an accepted collab/duel appears in the in-progress bar immediately. `usePendingRequests` now exposes `refetch`.
- **Test** — `useRespondToRequest.test.ts` guards the type-switch dispatch (the exact #346 bug shape) and status normalization.

No backend changes — request feed items already carry the needed IDs.

### Verification

- `npm test -- --run`: 135 tests / 14 files green (7 new)
- `tsc --noEmit` clean, `npm run build` green

Closes #346
Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)