### PR TITLE
docs: vendor join designs + albescent kit from the design system

### DIFF
--- a/docs/design/albescent-kit/Albescent Edit Praxis.dc.html
+++ b/docs/design/albescent-kit/Albescent Edit Praxis.dc.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@1,400;1,700&display=swap" rel="stylesheet">
+<script src="./ds-base.js"></script>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #f7f4ee; }
+  a { color: inherit; text-decoration: none; }
+  ::selection { background: rgba(28,28,26,0.10); }
+  input::placeholder, textarea::placeholder { color: rgba(28,28,26,0.26); font-style: italic; }
+  input:focus, textarea:focus { border-color: rgba(28,28,26,0.5) !important; }
+</style>
+</helmet>
+
+<svg width="0" height="0" style="position:absolute;" aria-hidden="true">
+  <symbol id="al-mark" viewBox="0 0 20 20">
+    <circle cx="10" cy="10" r="8.6" fill="none" stroke="#1c1c1a" stroke-width="0.44" opacity="0.18"/>
+    <circle cx="10" cy="10" r="4.7" fill="none" stroke="#1c1c1a" stroke-width="0.76" opacity="0.5"/>
+    <line x1="15.2" y1="10" x2="17.8" y2="10" stroke="#1c1c1a" stroke-width="0.76"/>
+    <line x1="10" y1="15.2" x2="10" y2="17.8" stroke="#1c1c1a" stroke-width="0.76"/>
+    <line x1="4.8" y1="10" x2="2.2" y2="10" stroke="#1c1c1a" stroke-width="0.76"/>
+    <line x1="10" y1="4.8" x2="10" y2="2.2" stroke="#1c1c1a" stroke-width="0.76"/>
+    <circle cx="10" cy="10" r="0.88" fill="#1c1c1a"/>
+  </symbol>
+</svg>
+
+<div style="min-height:100vh;background-color:#f7f4ee;background-image:radial-gradient(ellipse 72% 58% at 50% 38%, rgba(255,255,255,0.58) 0%, transparent 100%), repeating-linear-gradient(to bottom, transparent 0 27px, rgba(0,0,0,0.016) 27px 28px);font-family:'Courier Prime',monospace;color:#1c1c1a;">
+
+  <!-- NAV -->
+  <nav style="position:relative;z-index:10;display:flex;align-items:center;gap:28px;padding:14px 32px;background:rgba(247,244,238,0.92);backdrop-filter:blur(8px);border-bottom:1px solid rgba(0,0,0,0.055);">
+    <span style="font-family:'Lora',Georgia,serif;font-style:italic;font-weight:700;font-size:22px;line-height:1;border-bottom:3px solid;padding-bottom:2px;border-image:linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1;">World Zero</span>
+    <div style="display:flex;gap:20px;flex:1;">
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:rgba(28,28,26,0.35);">Home</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:rgba(28,28,26,0.35);">Tasks</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:rgba(28,28,26,0.72);border-bottom:1px solid rgba(28,28,26,0.42);padding-bottom:3px;">The Register</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:rgba(28,28,26,0.35);">Players</a>
+      <a href="#" style="font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:rgba(28,28,26,0.35);">Factions</a>
+    </div>
+    <div style="display:flex;align-items:center;gap:14px;font-family:'Courier Prime',monospace;font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:rgba(28,28,26,0.35);">
+      <span style="border:1px solid rgba(0,0,0,0.10);padding:5px 11px;">Keeper Vane</span>
+      <span style="border:1px solid rgba(0,0,0,0.10);padding:5px 11px;cursor:pointer;">Leave</span>
+    </div>
+  </nav>
+
+  <!-- BREADCRUMBS -->
+  <div style="position:relative;z-index:5;max-width:780px;margin:0 auto;padding:20px 32px 0;font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:.16em;text-transform:uppercase;color:rgba(28,28,26,0.28);">
+    <a href="#">The Register</a> &nbsp;/&nbsp; <a href="#">Tend the Archive in Silence</a> &nbsp;/&nbsp; <span style="color:rgba(28,28,26,0.55);">File an Account</span>
+  </div>
+
+  <!-- SHEET -->
+  <div style="position:relative;z-index:5;max-width:780px;margin:0 auto;padding:22px 32px 90px;">
+    <div style="position:relative;background:#ffffff;border:1px solid rgba(0,0,0,0.10);box-shadow:0 2px 18px rgba(0,0,0,0.055),0 1px 3px rgba(0,0,0,0.04);padding:40px 46px 44px;">
+      <div style="position:absolute;inset:6px;border:1px solid rgba(0,0,0,0.055);pointer-events:none;"></div>
+
+      <!-- masthead -->
+      <div style="position:relative;display:flex;align-items:center;justify-content:space-between;gap:14px;padding-bottom:18px;border-bottom:1px solid rgba(0,0,0,0.07);">
+        <span style="display:inline-flex;align-items:center;gap:9px;font-family:'Courier Prime',monospace;font-size:8.5px;letter-spacing:.24em;text-transform:uppercase;color:rgba(28,28,26,0.3);">
+          <svg viewBox="0 0 20 20" style="width:13px;height:13px;display:block;"><use href="#al-mark"></use></svg>
+          Albescent · Account № XV
+        </span>
+        <span style="font-family:'Courier Prime',monospace;font-size:7.5px;letter-spacing:.16em;text-transform:uppercase;color:rgba(28,28,26,0.26);border-bottom:1px solid rgba(28,28,26,0.18);padding-bottom:1px;">unfiled draft</span>
+      </div>
+
+      <!-- title -->
+      <h1 style="position:relative;font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:300;font-size:62px;line-height:1.0;color:#1c1c1a;margin:26px 0 8px;">File an Account</h1>
+      <p style="position:relative;font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:300;font-size:16px;line-height:1.5;color:rgba(28,28,26,0.5);max-width:480px;margin-bottom:30px;">A returned task is entered into the Register as a plain account — no more than was done. The keepers will bear witness; you need not persuade them.</p>
+
+      <!-- reference slip -->
+      <div style="position:relative;display:flex;gap:16px;align-items:center;border:1px solid rgba(0,0,0,0.07);background:#faf9f7;padding:15px 18px;margin-bottom:34px;">
+        <svg viewBox="0 0 20 20" style="width:38px;height:38px;flex-shrink:0;"><use href="#al-mark"></use></svg>
+        <div style="flex:1;min-width:0;">
+          <div style="font-family:'Courier Prime',monospace;font-size:7.5px;letter-spacing:.2em;text-transform:uppercase;color:rgba(28,28,26,0.3);margin-bottom:5px;">Returning · Ref. XV</div>
+          <div style="font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:400;font-size:24px;line-height:1.05;color:#1c1c1a;margin-bottom:7px;">Tend the Archive in Silence</div>
+          <div style="display:flex;align-items:center;gap:14px;font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.08em;color:rgba(28,28,26,0.4);">
+            <span>Third House</span>
+            <span style="color:rgba(28,28,26,0.18);">·</span>
+            <span>40 pts on return</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- THE MANNER -->
+      <div style="position:relative;margin-bottom:32px;">
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:13px;">
+          <span style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.26em;text-transform:uppercase;color:rgba(28,28,26,0.3);white-space:nowrap;">The Manner</span>
+          <span style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:13px;color:rgba(28,28,26,0.4);white-space:nowrap;">how was it attended?</span>
+          <span style="flex:1;height:1px;background:rgba(0,0,0,0.07);"></span>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px;">
+          <sc-for list="{{ manners }}" as="m" hint-placeholder-count="3">
+            <sc-if value="{{ m.on }}" hint-placeholder-val="{{ false }}"><button onClick="{{ m.onClick }}" style="cursor:pointer;text-align:left;padding:14px 16px;background:#1c1c1a;color:#f7f4ee;border:1px solid #1c1c1a;transition:all 160ms;width:100%;">
+              <div style="font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:400;font-size:22px;line-height:1;">{{ m.name }}</div>
+              <div style="font-family:'Courier Prime',monospace;font-size:7.5px;letter-spacing:.06em;margin-top:6px;opacity:.7;">{{ m.sub }}</div>
+            </button></sc-if>
+            <sc-if value="{{ m.off }}" hint-placeholder-val="{{ true }}"><button onClick="{{ m.onClick }}" style="cursor:pointer;text-align:left;padding:14px 16px;background:#ffffff;color:#1c1c1a;border:1px solid rgba(0,0,0,0.12);transition:all 160ms;width:100%;">
+              <div style="font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:400;font-size:22px;line-height:1;">{{ m.name }}</div>
+              <div style="font-family:'Courier Prime',monospace;font-size:7.5px;letter-spacing:.06em;margin-top:6px;opacity:.7;">{{ m.sub }}</div>
+            </button>
+          </sc-for>
+        </div>
+      </div>
+
+      <!-- THE ACCOUNT -->
+      <div style="position:relative;margin-bottom:32px;">
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:13px;">
+          <span style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.26em;text-transform:uppercase;color:rgba(28,28,26,0.3);white-space:nowrap;">The Account</span>
+          <span style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:13px;color:rgba(28,28,26,0.4);white-space:nowrap;">{{ accountMeta }}</span>
+          <span style="flex:1;height:1px;background:rgba(0,0,0,0.07);"></span>
+        </div>
+        <textarea value="{{ accountValue }}" onChange="{{ onAccount }}" rows="7" placeholder="Set down what was done, one line at a time. Leave nothing out; add nothing in." style="width:100%;resize:vertical;border:1px solid rgba(0,0,0,0.10);background:#fffefb;font-family:'Cormorant Garamond',serif;font-size:18px;line-height:1.75;color:#1c1c1a;padding:16px 18px;outline:none;background-image:repeating-linear-gradient(to bottom,transparent 0 30px,rgba(0,0,0,0.03) 30px 31px);"></textarea>
+      </div>
+
+      <!-- THE CLOSING LINE -->
+      <div style="position:relative;margin-bottom:36px;">
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:13px;">
+          <span style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.26em;text-transform:uppercase;color:rgba(28,28,26,0.3);white-space:nowrap;">The Closing Line</span>
+          <span style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:13px;color:rgba(28,28,26,0.4);white-space:nowrap;">the one line the Register keeps</span>
+          <span style="flex:1;height:1px;background:rgba(0,0,0,0.07);"></span>
+        </div>
+        <input value="{{ closingValue }}" onChange="{{ onClosing }}" placeholder="what remains, now that it is done" style="width:100%;border:none;border-bottom:1px solid rgba(0,0,0,0.18);background:transparent;font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:400;font-size:26px;color:#1c1c1a;padding:4px 2px 10px;outline:none;" />
+      </div>
+
+      <!-- FILE BAR -->
+      <div style="position:relative;border-top:1px solid rgba(0,0,0,0.07);padding-top:24px;display:flex;align-items:center;gap:16px;flex-wrap:wrap;">
+        <sc-if value="{{ notFiled }}" hint-placeholder-val="{{ true }}"><button onClick="{{ onFile }}" style="cursor:pointer;border:1px solid #1c1c1a;background:#ffffff;color:#1c1c1a;font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:500;font-size:20px;letter-spacing:.02em;padding:12px 30px;white-space:nowrap;transition:all 200ms;">{{ fileLabel }}</button></sc-if><sc-if value="{{ filed }}" hint-placeholder-val="{{ false }}"><button onClick="{{ onFile }}" style="cursor:pointer;border:1px solid #1c1c1a;background:#1c1c1a;color:#f7f4ee;font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:500;font-size:20px;letter-spacing:.02em;padding:12px 30px;white-space:nowrap;transition:all 200ms;">{{ fileLabel }}</button></sc-if>
+        <button style="cursor:pointer;border:1px solid rgba(0,0,0,0.12);background:transparent;color:rgba(28,28,26,0.5);font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:.12em;text-transform:uppercase;padding:14px 18px;">Keep as draft</button>
+        <sc-if value="{{ dropCold }}" hint-placeholder-val="{{ true }}"><button onClick="{{ onDrop }}" style="cursor:pointer;border:1px solid rgba(0,0,0,0.12);background:transparent;color:rgba(28,28,26,0.5);font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:.12em;text-transform:uppercase;padding:14px 18px;transition:all 160ms;">{{ dropLabel }}</button></sc-if><sc-if value="{{ dropHot }}" hint-placeholder-val="{{ false }}"><button onClick="{{ onDrop }}" style="cursor:pointer;border:1px solid rgba(154,47,47,0.5);background:transparent;color:#9a2f2f;font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:.12em;text-transform:uppercase;padding:14px 18px;transition:all 160ms;">{{ dropLabel }}</button></sc-if>
+      </div>
+
+    </div>
+  </div>
+
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:844,&quot;height&quot;:1180}}">
+class Component extends DCLogic {
+  constructor() {
+    super();
+    this.MANNERS = [
+      { id: "alone",      name: "Alone",        sub: "no witness present" },
+      { id: "observed",   name: "Observed",     sub: "a keeper looked on" },
+      { id: "confidence", name: "In Confidence", sub: "told to one only" },
+    ];
+    this.WITNESS = [
+      { label: "Unseeing",  fill: "rgba(0,0,0,0.16)" },
+      { label: "Glimpsed",  fill: "rgba(0,0,0,0.30)" },
+      { label: "Witnessed", fill: "rgba(0,0,0,0.48)" },
+      { label: "Verified",  fill: "rgba(0,0,0,0.66)" },
+      { label: "Inscribed", fill: "rgba(0,0,0,0.84)" },
+    ];
+    this.state = { manner: "alone", account: "", closing: "", filed: false, dropArmed: false, dropped: false };
+  }
+
+  setManner(id) { this.setState({ manner: id, filed: false }); }
+  onAccount(e) { this.setState({ account: e.target.value, filed: false }); }
+  onClosing(e) { this.setState({ closing: e.target.value.slice(0, 90), filed: false }); }
+  file() { this.setState({ filed: !this.state.filed, dropArmed: false, dropped: false }); }
+  drop() {
+    if (this.state.dropped) { this.setState({ dropped: false, dropArmed: false }); return; }
+    if (this.state.dropArmed) { this.setState({ dropped: true, dropArmed: false, filed: false }); }
+    else { this.setState({ dropArmed: true }); }
+  }
+
+  renderVals() {
+    const { manner, account, closing, filed, dropArmed, dropped } = this.state;
+    const lines = account.split("\n").filter(l => l.trim()).length;
+
+    const manners = this.MANNERS.map((m) => {
+      const on = manner === m.id;
+      return {
+        name: m.name,
+        sub: m.sub,
+        on: on,
+        off: !on,
+        onClick: () => this.setManner(m.id),
+      };
+    });
+
+    return {
+      manners,
+      accountValue: account,
+      closingValue: closing,
+      accountMeta: lines + (lines === 1 ? " line set down" : " lines set down"),
+      onAccount: (e) => this.onAccount(e),
+      onClosing: (e) => this.onClosing(e),
+      onFile: () => this.file(),
+      onDrop: () => this.drop(),
+      fileLabel: filed ? "✓ Entered into the Register" : "Enter into the Register",
+      notFiled: !filed,
+      dropLabel: dropped ? "Withdrawn" : dropArmed ? "Confirm — withdraw" : "Withdraw",
+      dropHot: (dropArmed || dropped),
+      dropCold: !(dropArmed || dropped),
+      statusText: dropped ? "withdrawn from the Register" : filed ? "filed · awaiting witness" : "Not yet",
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/albescent-kit/Albescent Faction Page.html
+++ b/docs/design/albescent-kit/Albescent Faction Page.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>World Zero — Albescent</title>
+<link rel="stylesheet" href="albescent.css">
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background: #f7f4ee;
+    color: #1c1c1a;
+    font-family: "Courier Prime", "Courier New", monospace;
+    min-height: 100vh;
+  }
+  a { color: inherit; text-decoration: none; }
+
+  .wordmark {
+    font-family: "Lora", Georgia, serif;
+    font-style: italic;
+    font-weight: 700;
+    font-size: 22px;
+    line-height: 1;
+    color: #1c1c1a;
+    border-bottom: 3px solid;
+    padding-bottom: 2px;
+    border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1;
+  }
+
+  .nav-links { display:flex; gap:20px; flex:1; }
+  .nav-links a {
+    font-family: var(--al-mono);
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(28,28,26,0.35);
+    padding-bottom: 3px;
+    transition: color 120ms;
+  }
+  .nav-links a.active {
+    color: rgba(28,28,26,0.72);
+    border-bottom: 1px solid rgba(28,28,26,0.42);
+  }
+  .nav-links a:hover { color: rgba(28,28,26,0.58); }
+
+  .nav-ctl {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    font-family: var(--al-mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(28,28,26,0.35);
+  }
+  .nav-box {
+    border: 1px solid var(--al-border);
+    padding: 5px 11px;
+    cursor: pointer;
+    transition: background 120ms;
+  }
+  .nav-box:hover { background: rgba(0,0,0,0.04); }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="albescent-cards.jsx"></script>
+<script type="text/babel" src="albescent-faction.jsx"></script>
+</head>
+<body>
+
+<div class="al-backdrop"></div>
+
+<!-- ── Nav ── -->
+<nav class="al-nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a>
+    <a href="#">Tasks</a>
+    <a href="#">Praxis</a>
+    <a href="#">Players</a>
+    <a href="Albescent Faction Page.html" class="active">Factions</a>
+    <a href="#">Updates</a>
+    <a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Keeper</span>
+    <span id="nav-badge-mount"></span>
+    <span class="nav-box">Leave</span>
+  </div>
+</nav>
+
+<!-- ── Page ── -->
+<div class="al-page">
+
+  <!-- hero -->
+  <div id="hero"></div>
+
+  <!-- open tasks -->
+  <div class="al-section">
+    <h2>Open Tasks</h2>
+    <span class="rule"></span>
+    <span class="count">3 open</span>
+  </div>
+  <div class="al-task-grid" id="tasks"></div>
+
+  <!-- the record -->
+  <div class="al-section">
+    <h2>The Record</h2>
+    <span class="rule"></span>
+    <a href="#" style="font-size:8px;letter-spacing:0.14em;color:rgba(28,28,26,0.3);">
+      view all →
+    </a>
+  </div>
+  <div class="al-dispatch-layout">
+    <div id="record"></div>
+    <div id="witness"></div>
+  </div>
+
+  <!-- isolated asset states -->
+  <div class="al-assets">
+    <div style="font-family:var(--al-mono);font-size:10px;letter-spacing:0.24em;text-transform:uppercase;color:rgba(28,28,26,0.3);margin-bottom:6px;">
+      Faction Assets — Isolated States
+    </div>
+    <p style="font-size:8.5px;line-height:1.65;color:rgba(28,28,26,0.38);max-width:600px;margin:0 0 20px;font-family:var(--al-mono);">
+      Reusable components shown on their own for review. Everything above is these same pieces composed into the live page.
+    </p>
+    <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:14px;">
+
+      <div class="al-acard">
+        <div class="h">Nav badge</div>
+        <div id="a-badge"></div>
+        <div class="cap">Marks the viewer's faction in the top bar</div>
+      </div>
+
+      <div class="al-acard">
+        <div class="h">Albescent Mark — faction sigil</div>
+        <div id="a-sigil"></div>
+        <div class="cap">Surveyor's cross-hair · scales 12–120px</div>
+      </div>
+
+      <div class="al-acard">
+        <div class="h">Witness marks — 1 through 5</div>
+        <div id="a-witness"></div>
+        <div class="cap">Unseeing · Glimpsed · Witnessed · Verified · Inscribed</div>
+      </div>
+
+      <div class="al-acard">
+        <div class="h">Task card — Vellum archetype</div>
+        <div id="a-card"></div>
+        <div class="cap">Full card for the faction page · 224px</div>
+      </div>
+
+    </div>
+  </div>
+
+</div><!-- /.al-page -->
+
+<script type="text/babel">
+const {
+  AlHero, AlNavBadge, AlActivityCard, AlWitnessWidget,
+  AlbescentCard, AlbescentMark,
+  AL_ACTIVITY, AL_TASKS, AL_WITNESS,
+} = window;
+
+/* ── Hero ── */
+ReactDOM.createRoot(document.getElementById("hero")).render(
+  <AlHero
+    name="Albescent"
+    motto="The Work Is the Way"
+    blurb="We exist outside the leaderboard. We have no rank, no color, no record in the system that matters. Every task undertaken is an act of devotion with no audience — returned quietly, without signature, before anyone thought to look."
+    stats={[
+      { value:"47",       label:"Keepers"  },
+      { value:"312",      label:"Returned" },
+      { value:"Unranked", label:"By design" },
+    ]}
+  />
+);
+
+/* ── Nav badge ── */
+ReactDOM.createRoot(document.getElementById("nav-badge-mount")).render(<AlNavBadge/>);
+
+/* ── Task cards ── */
+ReactDOM.createRoot(document.getElementById("tasks")).render(
+  <React.Fragment>
+    {AL_TASKS.map(t => <AlbescentCard key={t.title} {...t}/>)}
+  </React.Fragment>
+);
+
+/* ── Record feed — first 4 ── */
+ReactDOM.createRoot(document.getElementById("record")).render(
+  <React.Fragment>
+    {AL_ACTIVITY.slice(0,4).map(item => <AlActivityCard key={item.id} item={item}/>)}
+  </React.Fragment>
+);
+
+/* ── Witness widget ── */
+ReactDOM.createRoot(document.getElementById("witness")).render(
+  <AlWitnessWidget
+    taskId="archive-silence"
+    taskLabel="Tend the Archive in Silence"
+    baseDist={[0, 1, 8, 14, 9]}
+  />
+);
+
+/* ── Isolated asset states ── */
+ReactDOM.createRoot(document.getElementById("a-badge")).render(<AlNavBadge/>);
+
+ReactDOM.createRoot(document.getElementById("a-sigil")).render(
+  <div style={{display:"flex",gap:16,alignItems:"center"}}>
+    {[14, 22, 36, 54].map(s => <AlbescentMark key={s} size={s}/>)}
+  </div>
+);
+
+const WITNESS_SHADES = [
+  "rgba(0,0,0,0.16)","rgba(0,0,0,0.30)","rgba(0,0,0,0.48)",
+  "rgba(0,0,0,0.66)","rgba(0,0,0,0.84)",
+];
+ReactDOM.createRoot(document.getElementById("a-witness")).render(
+  <div style={{display:"flex",gap:10,alignItems:"flex-start"}}>
+    {AL_WITNESS.map((s, i) => {
+      const shade = WITNESS_SHADES[i];
+      const filled = i <= 2; /* show first 3 as filled for illustration */
+      return (
+        <div key={s.v} style={{display:"flex",flexDirection:"column",alignItems:"center",gap:6}}>
+          <div style={{
+            width:28,height:28,borderRadius:"50%",
+            border:`1.5px solid ${shade}`,
+            background: filled ? shade : "transparent",
+            display:"flex",alignItems:"center",justifyContent:"center",
+          }}>
+            {i===2&&<div style={{width:7,height:7,borderRadius:"50%",background:"#fff"}}/>}
+          </div>
+          <span style={{fontSize:5.5,letterSpacing:"0.06em",textAlign:"center",color:"rgba(28,28,26,0.3)",fontFamily:"var(--al-mono)"}}>
+            {s.label}
+          </span>
+        </div>
+      );
+    })}
+  </div>
+);
+
+ReactDOM.createRoot(document.getElementById("a-card")).render(
+  <AlbescentCard
+    title="Tend the Archive in Silence"
+    description="Retrieve, restore, and return. No record of your work need remain."
+    level={3}
+    points={40}
+  />
+);
+</script>
+</body>
+</html>

--- a/docs/design/albescent-kit/Albescent Task Card Explorations.html
+++ b/docs/design/albescent-kit/Albescent Task Card Explorations.html
@@ -1,0 +1,675 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Albescent — Task Card Explorations</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400;1,500&family=Courier+Prime:ital,wght@0,400;1,400&family=Lora:ital,wght@1,400;1,700&display=swap" rel="stylesheet">
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --color-bg-page: #f7f4ee;
+      --color-text-primary: #1a1209;
+      --color-text-secondary: #6b6050;
+      --color-text-tertiary: #9b8e7d;
+      --font-body: "Courier Prime", "Courier New", monospace;
+      --font-display: "Lora", Georgia, serif;
+      --al-font: "Cormorant Garamond", Georgia, serif;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--color-bg-page);
+      font-family: var(--font-body);
+      color: var(--color-text-primary);
+      min-height: 100vh;
+    }
+    @keyframes al-breathe {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.6; }
+    }
+  </style>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+
+const { useState } = React;
+
+/* ═══════════════════════════════════════════════════
+   SAMPLE TASK DATA
+═══════════════════════════════════════════════════ */
+const TASK = {
+  title: "Tend the archive in silence",
+  description: "Retrieve, restore, and return. No record of your work need remain.",
+  level: 3,
+  points: 40
+};
+
+/* ═══════════════════════════════════════════════════
+   ALBESCENT MARK
+   Surveyor's cross-hair: outer ring · inner ring ·
+   4 cardinal ticks · center dot.
+   Precise, purposeful, sacred-geometric.
+═══════════════════════════════════════════════════ */
+function AlbescentMark({ size = 20, color = "#1c1c1a", breathe = false, opacity = 1 }) {
+  const c = size / 2;
+  const rO = size * 0.43; // outer ring
+  const rI = size * 0.235; // inner ring
+  const rD = size * 0.044; // center dot
+  const tS = rI + size * 0.025; // tick start (just outside inner ring)
+  const tE = tS + size * 0.13; // tick end
+
+  const line = (deg) => {
+    const a = deg * Math.PI / 180;
+    return {
+      x1: c + tS * Math.cos(a), y1: c + tS * Math.sin(a),
+      x2: c + tE * Math.cos(a), y2: c + tE * Math.sin(a)
+    };
+  };
+
+  return (
+    <svg
+      width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none"
+      style={{
+        display: "block", flexShrink: 0, opacity,
+        animation: breathe ? "al-breathe 5s ease-in-out infinite" : "none"
+      }}>
+      
+      <circle cx={c} cy={c} r={rO} stroke={color} strokeWidth={size * 0.022} opacity={0.18} />
+      <circle cx={c} cy={c} r={rI} stroke={color} strokeWidth={size * 0.038} opacity={0.5} />
+      {[0, 90, 180, 270].map((deg, i) => {
+        const { x1, y1, x2, y2 } = line(deg);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={size * 0.038} />;
+      })}
+      <circle cx={c} cy={c} r={rD} fill={color} />
+    </svg>);
+
+}
+
+/* ═══════════════════════════════════════════════════
+   WAX SEAL  (used in Card III)
+═══════════════════════════════════════════════════ */
+function WaxSeal({ size = 32 }) {
+  const c = size / 2;
+  const r = size * 0.44;
+  const ri = r * 0.72;
+  const rm = r * 0.38;
+  const tr = r * 0.48;
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none">
+      <circle cx={c} cy={c} r={r} fill="rgba(0,0,0,0.055)" stroke="rgba(0,0,0,0.12)" strokeWidth={0.7} />
+      <circle cx={c} cy={c} r={ri} stroke="rgba(0,0,0,0.08)" strokeWidth={0.5} fill="none" />
+      <circle cx={c} cy={c} r={rm} stroke="rgba(0,0,0,0.14)" strokeWidth={0.5} fill="none" />
+      {[0, 90, 180, 270].map((d, i) => {
+        const a = d * Math.PI / 180;
+        return (
+          <line key={i}
+          x1={c + rm * Math.cos(a)} y1={c + rm * Math.sin(a)}
+          x2={c + tr * Math.cos(a)} y2={c + tr * Math.sin(a)}
+          stroke="rgba(0,0,0,0.14)" strokeWidth={0.7} />);
+
+
+      })}
+      <circle cx={c} cy={c} r={2.5} fill="rgba(0,0,0,0.24)" />
+    </svg>);
+
+}
+
+/* ═══════════════════════════════════════════════════
+   I · VELLUM
+   Pure white correspondence card. Centered sigil,
+   hairline border, Cormorant italic title.
+   CTA: "acknowledge" — language fits the order.
+═══════════════════════════════════════════════════ */
+function CardVellum({ title, description, level, points }) {
+  const [ack, setAck] = useState(false);
+  return (
+    <div style={{
+      width: 204,
+      background: "#fff",
+      border: "1px solid rgba(0,0,0,0.09)",
+      boxShadow: "0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)",
+      padding: "22px 18px 16px",
+      fontFamily: "var(--al-font)"
+    }}>
+      {/* Centered sigil */}
+      <div style={{ display: "flex", justifyContent: "center", marginBottom: 14 }}>
+        <AlbescentMark size={20} breathe />
+      </div>
+
+      {/* Top rule */}
+      <div style={{ height: 1, background: "rgba(0,0,0,0.07)", marginBottom: 12 }} />
+
+      {/* Eyebrow */}
+      <div style={{
+        fontSize: 6, letterSpacing: "0.32em", textTransform: "uppercase",
+        color: "rgba(0,0,0,0.26)", fontFamily: "var(--font-body)", marginBottom: 9
+      }}>Albescent</div>
+
+      {/* Title */}
+      <div style={{
+        fontSize: 17, fontStyle: "italic", fontWeight: 300,
+        lineHeight: 1.28, color: "#1c1c1a", marginBottom: 10
+      }}>{title}</div>
+
+      {/* Description */}
+      <div style={{
+        fontSize: 7.5, color: "rgba(28,28,26,0.42)", lineHeight: 1.6,
+        fontFamily: "var(--font-body)", marginBottom: 14
+      }}>{description}</div>
+
+      {/* CTA */}
+      <div style={{ marginBottom: 13 }}>
+        <button
+          onClick={() => setAck((a) => !a)}
+          style={{
+            background: "none", border: "none", padding: 0, cursor: "pointer",
+            fontSize: 7, letterSpacing: "0.22em", textTransform: "uppercase",
+            color: ack ? "rgba(0,0,0,0.55)" : "rgba(0,0,0,0.35)",
+            fontFamily: "var(--font-body)",
+            borderBottom: `1px solid ${ack ? "rgba(0,0,0,0.45)" : "rgba(0,0,0,0.18)"}`,
+            paddingBottom: 1, transition: "all 250ms ease"
+          }}>
+          {ack ? "acknowledged" : "acknowledge"}</button>
+      </div>
+
+      {/* Footer */}
+      <div style={{
+        borderTop: "1px solid rgba(0,0,0,0.07)", paddingTop: 10,
+        display: "flex", justifyContent: "space-between", alignItems: "center"
+      }}>
+        <span style={{
+          fontSize: 6.5, letterSpacing: "0.2em", textTransform: "uppercase",
+          color: "rgba(0,0,0,0.24)", fontFamily: "var(--font-body)"
+        }}>Lvl {level}</span>
+        <span style={{ fontSize: 14, fontWeight: 300, color: "rgba(28,28,26,0.5)" }}>
+          {points}<span style={{ fontSize: 6.5, marginLeft: 3, letterSpacing: "0.1em", textTransform: "uppercase", fontFamily: "var(--font-body)" }}>pts</span>
+        </span>
+      </div>
+    </div>);
+
+}
+
+/* ═══════════════════════════════════════════════════
+   II · PALIMPSEST
+   Warm white, ruled lines, faint ghost text of past
+   tasks showing through. The surface persists.
+   Left margin rule (barely visible).
+═══════════════════════════════════════════════════ */
+function CardPalimpsest({ title, description, level, points }) {
+  const ghosts = [
+  "transcribe the morning observations",
+  "walk the perimeter at dusk",
+  "index the unmarked volumes",
+  "verify the catalogue entry",
+  "seal and store before departing",
+  "attend the hour without speaking",
+  "count the objects without touching"];
+
+
+  return (
+    <div style={{
+      width: 200,
+      background: "#faf9f7",
+      border: "1px solid rgba(0,0,0,0.08)",
+      padding: "14px 16px 13px",
+      position: "relative",
+      fontFamily: "var(--al-font)",
+      overflow: "hidden",
+      backgroundImage: "repeating-linear-gradient(to bottom, transparent, transparent 18px, rgba(0,0,0,0.026) 18px, rgba(0,0,0,0.026) 19px)"
+    }}>
+      {/* Ghost text layer */}
+      <div style={{
+        position: "absolute", inset: 0, padding: "14px 16px",
+        pointerEvents: "none", overflow: "hidden"
+      }}>
+        {ghosts.map((g, i) =>
+        <div key={i} style={{
+          fontSize: 10, lineHeight: "18px", fontStyle: "italic", fontWeight: 300,
+          color: "rgba(0,0,0,0.046)",
+          transform: i % 2 ? "translateX(4px)" : "none"
+        }}>{g}</div>
+        )}
+      </div>
+
+      {/* Left margin rule */}
+      <div style={{
+        position: "absolute", left: 26, top: 0, bottom: 0,
+        width: 1, background: "rgba(0,0,0,0.04)"
+      }} />
+
+      {/* Foreground content */}
+      <div style={{ position: "relative", zIndex: 1, paddingLeft: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 11 }}>
+          <AlbescentMark size={11} />
+          <span style={{
+            fontSize: 5.5, letterSpacing: "0.32em", textTransform: "uppercase",
+            color: "rgba(0,0,0,0.2)", fontFamily: "var(--font-body)"
+          }}>Albescent</span>
+        </div>
+
+        <div style={{
+          fontSize: 16.5, fontStyle: "italic", fontWeight: 300,
+          lineHeight: 1.3, color: "#1a1a18", marginBottom: 9
+        }}>{title}</div>
+
+        <div style={{
+          fontSize: 7.5, color: "rgba(28,28,26,0.44)", lineHeight: 1.58,
+          fontFamily: "var(--font-body)", marginBottom: 12
+        }}>{description}</div>
+
+        <div style={{
+          display: "flex", justifyContent: "space-between", alignItems: "center",
+          borderTop: "1px solid rgba(0,0,0,0.06)", paddingTop: 8
+        }}>
+          {/* Roman numeral level */}
+          <span style={{
+            fontSize: 8, letterSpacing: "0.16em",
+            color: "rgba(0,0,0,0.22)", fontFamily: "var(--al-font)",
+            fontWeight: 300
+          }}>III</span>
+          <span style={{ fontSize: 14, fontWeight: 300, color: "rgba(28,28,26,0.46)" }}>{points}</span>
+        </div>
+      </div>
+    </div>);
+
+}
+
+/* ═══════════════════════════════════════════════════
+   III · THE SEALED
+   "Eyes of the Order only." Dispatch header,
+   visible title, description withheld (sealed bars).
+   Wax seal mark in corner.
+═══════════════════════════════════════════════════ */
+function CardSealed({ title, description, level, points }) {
+  return (
+    <div style={{
+      width: 204,
+      background: "#fff",
+      border: "1px solid rgba(0,0,0,0.1)",
+      fontFamily: "var(--al-font)",
+      overflow: "hidden"
+    }}>
+      {/* Header band */}
+      <div style={{
+        padding: "7px 14px",
+        borderBottom: "1px solid rgba(0,0,0,0.07)",
+        background: "rgba(0,0,0,0.018)",
+        display: "flex", justifyContent: "space-between", alignItems: "center"
+      }}>
+        <span style={{
+          fontSize: 5.5, letterSpacing: "0.32em", textTransform: "uppercase",
+          color: "rgba(0,0,0,0.22)", fontFamily: "var(--font-body)"
+        }}>Eyes of the Order</span>
+        <AlbescentMark size={10} />
+      </div>
+
+      <div style={{ padding: "16px 14px 14px" }}>
+        {/* Sub-label */}
+        <div style={{
+          fontSize: 6.5, letterSpacing: "0.2em", textTransform: "uppercase",
+          color: "rgba(0,0,0,0.18)", fontFamily: "var(--font-body)", marginBottom: 8
+        }}>Dispatch · Sealed</div>
+
+        {/* Title — visible */}
+        <div style={{
+          fontSize: 17, fontStyle: "italic", fontWeight: 300,
+          lineHeight: 1.28, color: "#1a1a18", marginBottom: 12
+        }}>{title}</div>
+
+        {/* Sealed description area */}
+        <div style={{ position: "relative", marginBottom: 14, minHeight: 38, overflow: "hidden" }}>
+          {/* Ghost text beneath */}
+          <div style={{
+            fontSize: 7.5, color: "rgba(0,0,0,0.055)", lineHeight: 1.58,
+            fontFamily: "var(--font-body)", userSelect: "none"
+          }}>{description}</div>
+          {/* Overlay redaction bars */}
+          <div style={{
+            position: "absolute", inset: 0,
+            display: "flex", flexDirection: "column",
+            justifyContent: "space-evenly", padding: "1px 0"
+          }}>
+            {[94, 80, 60].map((w, i) =>
+            <div key={i} style={{
+              height: 3.5, width: `${w}%`,
+              background: "rgba(0,0,0,0.048)", borderRadius: 0.5
+            }} />
+            )}
+          </div>
+        </div>
+
+        {/* Footer: level + wax seal */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end" }}>
+          <div style={{
+            fontSize: 5.5, letterSpacing: "0.24em", textTransform: "uppercase",
+            color: "rgba(0,0,0,0.2)", fontFamily: "var(--font-body)", lineHeight: 1.9
+          }}>
+            <div>Lvl {level}</div>
+            <div style={{ color: "rgba(0,0,0,0.13)", fontSize: 5 }}>Sealed</div>
+          </div>
+          <WaxSeal size={32} />
+        </div>
+      </div>
+    </div>);
+
+}
+
+/* ═══════════════════════════════════════════════════
+   IV · CARTOUCHE
+   Outer border + inset inner border, all centered.
+   Architectural, monumental, Roman-inscription feel.
+   Double-rule dividers. Everything aligned to center.
+═══════════════════════════════════════════════════ */
+function CardCartouche({ title, description, level, points }) {
+  return (
+    <div style={{
+      width: 200,
+      background: "#fff",
+      border: "1px solid rgba(0,0,0,0.12)",
+      padding: 8,
+      fontFamily: "var(--al-font)"
+    }}>
+      <div style={{
+        border: "1px solid rgba(0,0,0,0.07)",
+        padding: "20px 14px 16px",
+        display: "flex", flexDirection: "column",
+        alignItems: "center", textAlign: "center",
+        gap: 10
+      }}>
+        <AlbescentMark size={22} breathe />
+
+        <div style={{
+          fontSize: 5.5, letterSpacing: "0.42em", textTransform: "uppercase",
+          color: "rgba(0,0,0,0.22)", fontFamily: "var(--font-body)"
+        }}>Albescent</div>
+
+        {/* Divider rule */}
+        <div style={{ width: "38%", height: 1, background: "rgba(0,0,0,0.09)" }} />
+
+        <div style={{
+          fontSize: 17, fontStyle: "italic", fontWeight: 300,
+          lineHeight: 1.28, color: "#1a1a18"
+        }}>{title}</div>
+
+        <div style={{
+          fontSize: 7.5, color: "rgba(28,28,26,0.38)",
+          lineHeight: 1.55, fontFamily: "var(--font-body)"
+        }}>{description}</div>
+
+        {/* Divider rule */}
+        <div style={{ width: "38%", height: 1, background: "rgba(0,0,0,0.09)" }} />
+
+        <div style={{ display: "flex", gap: 14, alignItems: "center" }}>
+          <span style={{
+            fontSize: 6, letterSpacing: "0.22em", textTransform: "uppercase",
+            color: "rgba(0,0,0,0.24)", fontFamily: "var(--font-body)"
+          }}>Lvl {level}</span>
+          <span style={{ fontSize: 7, color: "rgba(0,0,0,0.14)", fontFamily: "var(--font-body)" }}>·</span>
+          <span style={{ fontSize: 14.5, fontWeight: 300, color: "rgba(28,28,26,0.48)" }}>
+            {points}<span style={{ fontSize: 6.5, marginLeft: 3, fontFamily: "var(--font-body)", letterSpacing: "0.1em", textTransform: "uppercase" }}>pts</span>
+          </span>
+        </div>
+      </div>
+    </div>);
+
+}
+
+/* ═══════════════════════════════════════════════════
+   V · TABULA RASA
+   Nearly blank at rest — large faint watermark sigil,
+   all text nearly invisible. Hover: everything gently
+   emerges. The task exists whether seen or not.
+   (Hover the card to reveal.)
+═══════════════════════════════════════════════════ */
+function CardTabulaRasa({ title, description, level, points }) {
+  const [hov, setHov] = useState(false);
+
+  return (
+    <div
+      onMouseEnter={() => setHov(true)}
+      onMouseLeave={() => setHov(false)}
+      style={{
+        width: 200,
+        background: "#fff",
+        border: "1px solid rgba(0,0,0,0.08)",
+        boxShadow: hov ?
+        "0 6px 28px rgba(0,0,0,0.08)" :
+        "0 1px 6px rgba(0,0,0,0.04)",
+        padding: "20px 18px 16px",
+        fontFamily: "var(--al-font)",
+        position: "relative", overflow: "hidden",
+        transition: "box-shadow 600ms ease",
+        cursor: "default"
+      }}>
+      
+      {/* Watermark sigil — large, centered */}
+      <div style={{
+        position: "absolute", top: "50%", left: "50%",
+        transform: "translate(-50%, -50%)",
+        opacity: hov ? 0.04 : 0.11,
+        transition: "opacity 800ms ease",
+        pointerEvents: "none"
+      }}>
+        <AlbescentMark size={120} />
+      </div>
+
+      <div style={{ position: "relative", zIndex: 1 }}>
+        {/* Eyebrow + mark */}
+        <div style={{
+          display: "flex", justifyContent: "space-between", alignItems: "center",
+          marginBottom: 12,
+          opacity: hov ? 0.38 : 0.13,
+          transition: "opacity 500ms ease"
+        }}>
+          <span style={{
+            fontSize: 5.5, letterSpacing: "0.32em", textTransform: "uppercase",
+            color: "#1c1c1a", fontFamily: "var(--font-body)"
+          }}>Albescent</span>
+          <AlbescentMark size={11} />
+        </div>
+
+        {/* Title */}
+        <div style={{
+          fontSize: 17, fontStyle: "italic", fontWeight: 300,
+          lineHeight: 1.28, marginBottom: 10,
+          color: hov ? "#1a1a18" : "rgba(28,28,26,0.18)",
+          transition: "color 600ms ease"
+        }}>{title}</div>
+
+        {/* Description */}
+        <div style={{
+          fontSize: 7.5, lineHeight: 1.58, fontFamily: "var(--font-body)",
+          marginBottom: 14,
+          color: hov ? "rgba(28,28,26,0.42)" : "rgba(28,28,26,0.03)",
+          transition: "color 750ms ease"
+        }}>{description}</div>
+
+        {/* Footer */}
+        <div style={{
+          borderTop: "1px solid rgba(0,0,0,0.06)", paddingTop: 10,
+          display: "flex", justifyContent: "space-between", alignItems: "center",
+          opacity: hov ? 0.55 : 0.1,
+          transition: "opacity 500ms ease"
+        }}>
+          <span style={{
+            fontSize: 6.5, letterSpacing: "0.2em", textTransform: "uppercase",
+            color: "#1c1c1a", fontFamily: "var(--font-body)"
+          }}>Lvl {level}</span>
+          <span style={{ fontSize: 14, fontWeight: 300 }}>
+            {points}<span style={{ fontSize: 6.5, marginLeft: 3, letterSpacing: "0.1em", textTransform: "uppercase", fontFamily: "var(--font-body)" }}>pts</span>
+          </span>
+        </div>
+      </div>
+    </div>);
+
+}
+
+/* ═══════════════════════════════════════════════════
+   PAGE
+═══════════════════════════════════════════════════ */
+const CARDS = [
+{
+  id: "vellum",
+  name: "I · Vellum",
+  sub: "Pure white correspondence. Centered sigil, hairline border. CTA: acknowledge.",
+  C: CardVellum
+},
+{
+  id: "palimpsest",
+  name: "II · Palimpsest",
+  sub: "Past tasks show through the current. The surface persists; the task does not.",
+  C: CardPalimpsest
+},
+{
+  id: "sealed",
+  name: "III · The Sealed",
+  sub: "Eyes of the Order only. Title visible, description withheld by the faction.",
+  C: CardSealed
+},
+{
+  id: "cartouche",
+  name: "IV · Cartouche",
+  sub: "Double-frame, centered, architectural. Like a Roman inscription. Monumental.",
+  C: CardCartouche
+},
+{
+  id: "rasa",
+  name: "V · Tabula Rasa",
+  sub: "Hover to reveal. Present whether seen or not — the task exists for itself.",
+  C: CardTabulaRasa
+}];
+
+
+function App() {
+  return (
+    <div style={{ minHeight: "100vh", padding: "52px 48px 80px" }}>
+
+      {/* ── Page header ── */}
+      <div style={{ maxWidth: 1240, margin: "0 auto 56px" }}>
+        <div style={{
+          fontSize: 8.5, letterSpacing: "0.32em", textTransform: "uppercase",
+          color: "var(--color-text-tertiary)", fontFamily: "var(--font-body)", marginBottom: 12
+        }}>
+          World Zero · Faction Design · Task Card Exploration
+        </div>
+        <h1 style={{
+          fontFamily: "var(--font-display)", fontStyle: "italic",
+          fontSize: 34, fontWeight: 700, color: "var(--color-text-primary)",
+          marginBottom: 10, lineHeight: 1.1
+        }}>Albescent</h1>
+        <p style={{
+          fontSize: 10, color: "var(--color-text-secondary)",
+          lineHeight: 1.8, maxWidth: 540, fontFamily: "var(--font-body)"
+        }}>
+          A sacred secret society. Color: white. Aesthetic: minimalist. Philosophy: tasking for
+          its own sake — not competition, not accumulation, not record. Five archetype directions
+          for the task card. <strong style="font-weight:400;color:var(--color-text-primary)">Vellum (I) is the selected direction</strong> &mdash;
+          now Albescent&rsquo;s task card in the World Zero design system.
+        </p>
+      </div>
+
+      {/* ── Five cards ── */}
+      <div style={{
+        maxWidth: 1240, margin: "0 auto",
+        display: "flex", flexWrap: "wrap", gap: 44, alignItems: "flex-start"
+      }}>
+        {CARDS.map(({ id, name, sub, C }) => {
+        const selected = id === "vellum";
+        return (
+        <div key={id} style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+            <div style={{ position: "relative" }}>
+              {selected &&
+              <div style={{
+                position: "absolute", top: -11, left: -7, zIndex: 2,
+                display: "inline-flex", alignItems: "center", gap: 5,
+                background: "#1c1c1a", color: "#fff",
+                fontSize: 6.5, letterSpacing: "0.22em", textTransform: "uppercase",
+                fontFamily: "var(--font-body)", padding: "4px 9px"
+              }}>✓ Going with this</div>}
+              <div style={{
+                outline: selected ? "1px solid rgba(28,28,26,0.5)" : "none",
+                outlineOffset: selected ? 9 : 0
+              }}>
+                <C {...TASK} />
+              </div>
+            </div>
+            <div style={{ maxWidth: 204 }}>
+              <div style={{
+              fontSize: 9, fontFamily: "var(--font-body)", letterSpacing: "0.1em",
+              textTransform: "uppercase", color: selected ? "var(--color-text-primary)" : "var(--color-text-tertiary)", marginBottom: 5
+            }}>{name}{selected && " — selected"}</div>
+              <div style={{
+              fontSize: 8.5, color: "var(--color-text-secondary)",
+              lineHeight: 1.65, fontFamily: "var(--font-body)"
+            }}>{sub}</div>
+            </div>
+          </div>
+        );
+        })}
+      </div>
+
+      {/* ── Design notes ── */}
+      <div style={{
+        maxWidth: 1240, margin: "64px auto 0",
+        paddingTop: 36, borderTop: "1px solid rgba(0,0,0,0.08)"
+      }}>
+        <div style={{
+          fontSize: 7.5, letterSpacing: "0.3em", textTransform: "uppercase",
+          color: "var(--color-text-tertiary)", fontFamily: "var(--font-body)", marginBottom: 24
+        }}>Design Notes</div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 28 }}>
+          {[
+          {
+            label: "Faction Font",
+            val: "Cormorant Garamond · Light Italic",
+            note: "Ultra-thin high-contrast serif. Sacred, devotional quality. Fully distinct from all 7 existing faction fonts."
+          },
+          {
+            label: "Color System",
+            val: "Monochromatic — no faction hue",
+            note: "White card, near-black type only. Albescent refuses the rainbow palette. The absence of color is the statement."
+          },
+          {
+            label: "Sigil",
+            val: "Surveyor's cross-hair mark",
+            note: "Outer ring · inner ring · 4 cardinal ticks · center dot. Precise and purposeful without aggression."
+          },
+          {
+            label: "CTA Language",
+            val: "Acknowledge, not Join",
+            note: "The faction doesn't recruit — it receives. Dispatch language fits: acknowledge, attend, receive, return."
+          }].
+          map(({ label, val, note }) =>
+          <div key={label} style={{ paddingTop: 14, borderTop: "1px solid rgba(0,0,0,0.07)" }}>
+              <div style={{
+              fontSize: 7, letterSpacing: "0.24em", textTransform: "uppercase",
+              color: "var(--color-text-tertiary)", fontFamily: "var(--font-body)", marginBottom: 6
+            }}>{label}</div>
+              <div style={{
+              fontSize: 10, color: "var(--color-text-primary)",
+              fontFamily: "var(--font-body)", marginBottom: 6
+            }}>{val}</div>
+              <div style={{
+              fontSize: 8.5, color: "var(--color-text-secondary)",
+              lineHeight: 1.65, fontFamily: "var(--font-body)"
+            }}>{note}</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+    </div>);
+
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/design/albescent-kit/Albescent Task Detail.dc.html
+++ b/docs/design/albescent-kit/Albescent Task Detail.dc.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="stylesheet" href="../../styles.css">
+<script src="../../_ds_bundle.js"></script>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body { background: #f4f3f0; }
+  a { color: inherit; text-decoration: none; }
+  .al-link:hover { color: #1c1c1a !important; }
+  .al-body p { font-family:'Cormorant Garamond',serif; font-size:20px; line-height:1.62; color:#2a2a27; margin:0 0 16px; }
+  .al-body p:last-child { margin-bottom:0; }
+  .al-body em { font-style:italic; color:#1c1c1a; }
+  .al-body a { color:#1c1c1a; border-bottom:1px solid rgba(28,28,26,0.4); }
+</style>
+</helmet>
+
+<div style="min-height:100vh;font-family:'Courier Prime',monospace;color:#1c1c1a;position:relative;background:#f4f3f0;">
+
+  <!-- NAV -->
+  <nav style="position:relative;z-index:10;display:flex;align-items:center;gap:30px;padding:16px 40px;background:rgba(244,243,240,0.88);backdrop-filter:blur(8px);border-bottom:1px solid rgba(0,0,0,0.08);">
+    <span style="font-family:'Lora',serif;font-style:italic;font-weight:600;font-size:25px;line-height:1;border-bottom:3px solid;border-image:linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1;padding-bottom:2px;">World Zero</span>
+    <div style="display:flex;gap:22px;flex:1;">
+      <a class="al-link" href="#" style="font-size:11px;letter-spacing:0.13em;text-transform:uppercase;color:rgba(28,28,26,0.45);">Tasks</a>
+      <a class="al-link" href="#" style="font-size:11px;letter-spacing:0.13em;text-transform:uppercase;color:#1c1c1a;border-bottom:2px solid #1c1c1a;padding-bottom:2px;">Correspondence</a>
+      <a class="al-link" href="#" style="font-size:11px;letter-spacing:0.13em;text-transform:uppercase;color:rgba(28,28,26,0.45);">Praxes</a>
+      <a class="al-link" href="#" style="font-size:11px;letter-spacing:0.13em;text-transform:uppercase;color:rgba(28,28,26,0.45);">Register</a>
+    </div>
+    <span style="display:inline-flex;align-items:center;gap:8px;font-family:'Cormorant Garamond',serif;font-style:italic;font-size:14px;letter-spacing:0.04em;color:rgba(28,28,26,0.6);">— admitted, in confidence</span>
+  </nav>
+
+  <!-- PAGE -->
+  <div style="position:relative;z-index:5;max-width:880px;margin:0 auto;padding:26px 40px 96px;">
+    <div style="font-size:10px;letter-spacing:0.16em;text-transform:uppercase;color:rgba(28,28,26,0.4);margin-bottom:24px;">
+      <a class="al-link" href="#">Tasks</a><span style="opacity:0.5;margin:0 8px;">/</span><span>Albescent</span><span style="opacity:0.5;margin:0 8px;">/</span><span style="color:#1c1c1a;">{{ task.title }}</span>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:34px;">
+
+      <!-- HERO — the letter -->
+      <div style="background:#fdfdfc;border:1px solid rgba(0,0,0,0.1);box-shadow:0 2px 24px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04);padding:54px 60px 48px;text-align:center;">
+        <div style="display:flex;justify-content:center;margin-bottom:24px;">
+          <svg width="44" height="44" viewBox="0 0 44 44" fill="none">
+            <circle cx="22" cy="22" r="19" stroke="#1c1c1a" stroke-width="1" opacity="0.18"/>
+            <circle cx="22" cy="22" r="10.3" stroke="#1c1c1a" stroke-width="1.7" opacity="0.5"/>
+            <line x1="32.3" y1="22" x2="38" y2="22" stroke="#1c1c1a" stroke-width="1.7"/>
+            <line x1="6" y1="22" x2="11.7" y2="22" stroke="#1c1c1a" stroke-width="1.7"/>
+            <line x1="22" y1="32.3" x2="22" y2="38" stroke="#1c1c1a" stroke-width="1.7"/>
+            <line x1="22" y1="6" x2="22" y2="11.7" stroke="#1c1c1a" stroke-width="1.7"/>
+            <circle cx="22" cy="22" r="1.9" fill="#1c1c1a"/>
+          </svg>
+        </div>
+        <div style="font-size:9px;letter-spacing:0.34em;text-transform:uppercase;color:rgba(28,28,26,0.45);margin-bottom:6px;">Albescent</div>
+        <div style="font-size:8px;letter-spacing:0.28em;text-transform:uppercase;color:rgba(28,28,26,0.3);margin-bottom:26px;">Correspondence №{{ task.no }} · in confidence</div>
+        <div style="width:54px;height:1px;background:rgba(0,0,0,0.12);margin:0 auto 26px;"></div>
+        <h1 style="font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:500;font-size:46px;line-height:1.16;color:#1c1c1a;margin:0 auto 22px;max-width:560px;overflow-wrap:anywhere;">{{ task.title }}</h1>
+        <div style="width:54px;height:1px;background:rgba(0,0,0,0.12);margin:0 auto 28px;"></div>
+        <div style="display:flex;justify-content:center;gap:48px;flex-wrap:wrap;">
+          <div>
+            <div style="font-size:8px;letter-spacing:0.22em;text-transform:uppercase;color:rgba(28,28,26,0.4);margin-bottom:6px;">Standing</div>
+            <div style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:22px;color:#1c1c1a;">Lvl {{ task.level }}</div>
+          </div>
+          <div style="border-left:1px solid rgba(0,0,0,0.1);"></div>
+          <div>
+            <div style="font-size:8px;letter-spacing:0.22em;text-transform:uppercase;color:rgba(28,28,26,0.4);margin-bottom:6px;">Worth</div>
+            <div style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:22px;color:#1c1c1a;">{{ task.points }} pts</div>
+          </div>
+          <div style="border-left:1px solid rgba(0,0,0,0.1);"></div>
+          <div>
+            <div style="font-size:8px;letter-spacing:0.22em;text-transform:uppercase;color:rgba(28,28,26,0.4);margin-bottom:6px;">Witnessed</div>
+            <div style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:22px;color:#1c1c1a;">31 times</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA bar -->
+      <div style="display:flex;align-items:center;gap:18px;flex-wrap:wrap;background:#fdfdfc;border:1px solid rgba(0,0,0,0.1);box-shadow:0 1px 3px rgba(0,0,0,0.04);padding:16px 22px;">
+        <sc-if value="{{ notSigned }}" hint-placeholder-val="{{ true }}"><button onClick="{{ onSign }}" style="cursor:pointer;font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:0.22em;text-transform:uppercase;color:#1c1c1a;background:transparent;border:1px solid #1c1c1a;padding:13px 26px;">Acknowledge</button></sc-if><sc-if value="{{ signed }}" hint-placeholder-val="{{ false }}"><button onClick="{{ onSign }}" style="cursor:pointer;font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:0.22em;text-transform:uppercase;color:#fdfdfc;background:#1c1c1a;border:1px solid #1c1c1a;padding:13px 26px;">✓ Taken in confidence</button></sc-if>
+        <div style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:15px;color:rgba(28,28,26,0.55);">{{ signNote }}</div>
+        <div style="margin-left:auto;font-size:8px;letter-spacing:0.18em;text-transform:uppercase;color:rgba(28,28,26,0.4);">44 taken · 31 inscribed · 4.3 credence</div>
+      </div>
+
+      <!-- THE ASK (user-written body) -->
+      <div>
+        <div style="display:flex;align-items:center;gap:14px;margin-bottom:16px;">
+          <h2 style="font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:600;font-size:22px;margin:0;color:#1c1c1a;white-space:nowrap;">The Ask</h2>
+          <span style="flex:1;height:1px;background:rgba(0,0,0,0.08);"></span>
+          <span style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:13px;color:rgba(28,28,26,0.45);">in the hand of The Archivist</span>
+        </div>
+        <div class="al-body" style="background:#fdfdfc;border:1px solid rgba(0,0,0,0.1);box-shadow:0 1px 3px rgba(0,0,0,0.04);padding:34px 40px;max-width:640px;">
+          <p>Spend one ordinary day attending to a single small thing the world has agreed not to see — the way a stranger holds a door a half-second too long, a repair someone made and never mentioned, a kindness performed for <em>no audience</em>.</p>
+          <p>Choose nothing in advance; let the day present the thing to you. When you notice it, stay with it a moment longer than is comfortable. Then write it down in the fewest words that keep it true.</p>
+          <p>Inscribe it in the register, unsigned. Claim nothing. To witness is enough — that is the whole of the practice. <a href="#">— the full correspondence ↗</a></p>
+        </div>
+      </div>
+
+      <!-- THE REGISTER (completions) -->
+      <div>
+        <div style="display:flex;align-items:center;gap:14px;margin-bottom:20px;">
+          <h2 style="font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:600;font-size:22px;margin:0;color:#1c1c1a;white-space:nowrap;">Inscribed in the Register</h2>
+          <span style="flex:1;height:1px;background:rgba(0,0,0,0.08);"></span>
+          <span style="font-family:'Cormorant Garamond',serif;font-style:italic;font-size:13px;color:rgba(28,28,26,0.45);">{{ praxisCount }} accounts returned</span>
+        </div>
+        <div style="display:flex;flex-wrap:wrap;gap:30px 24px;align-items:flex-start;">
+          <sc-for list="{{ praxis }}" as="p" hint-placeholder-count="3">
+            <div style="position:relative;padding-top:22px;">
+              <sc-if value="{{ p.top }}" hint-placeholder-val="{{ true }}">
+                <div style="position:absolute;top:0;left:50%;transform:translateX(-50%);z-index:3;display:inline-flex;align-items:center;gap:6px;white-space:nowrap;background:#1c1c1a;color:#fdfdfc;font-family:'Cormorant Garamond',serif;font-style:italic;font-size:13px;letter-spacing:0.04em;padding:3px 14px;"><span style="font-size:13px;line-height:1;">⚜</span> most witnessed</div>
+              </sc-if>
+              <x-import component-from-global-scope="WorldZeroDesignSystem_019e22.FactionPraxisCard" faction="albescent" dc-props="{{ p }}" hint-size="224px,240px"></x-import>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <!-- THE REGISTER SPEAKS (discussion) -->
+      <div>
+        <div style="display:flex;align-items:center;gap:14px;margin-bottom:20px;">
+          <h2 style="font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:600;font-size:22px;margin:0;color:#1c1c1a;white-space:nowrap;">In the Margin</h2>
+          <span style="flex:1;height:1px;background:rgba(0,0,0,0.08);"></span>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:18px;max-width:680px;">
+          <sc-for list="{{ comments }}" as="c" hint-placeholder-count="2">
+            <x-import component-from-global-scope="WorldZeroDesignSystem_019e22.FactionCommentBox" faction="albescent" dc-props="{{ c }}" hint-size="100%,86px"></x-import>
+          </sc-for>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<template id="__bundler_thumbnail"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect width="200" height="200" fill="#e8e6e1"/><circle cx="100" cy="100" r="34" fill="none" stroke="#1c1c1a" stroke-width="5"/><line x1="100" y1="50" x2="100" y2="66" stroke="#1c1c1a" stroke-width="5"/><line x1="100" y1="134" x2="100" y2="150" stroke="#1c1c1a" stroke-width="5"/><line x1="50" y1="100" x2="66" y2="100" stroke="#1c1c1a" stroke-width="5"/><line x1="134" y1="100" x2="150" y2="100" stroke="#1c1c1a" stroke-width="5"/><circle cx="100" cy="100" r="6" fill="#1c1c1a"/></svg></template></x-dc>
+<script type="text/x-dc" data-dc-script>
+class Component extends DCLogic {
+  state = { signed: false };
+
+  avatar(seed) {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><rect width="80" height="80" fill="#e8e6e1"/><text x="50%" y="60%" font-size="30" text-anchor="middle" fill="#1c1c1a" font-family="Georgia,serif" font-style="italic">' + seed + '</text></svg>';
+    return 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
+  }
+
+  markTop(list) {
+    let bi = 0;
+    list.forEach((p, i) => { if (p.rating > list[bi].rating) bi = i; });
+    return list.map((p, i) => ({ ...p, top: i === bi }));
+  }
+
+  renderVals() {
+    const signed = this.state.signed;
+    const praxis = this.markTop([
+      { task: "Notice What No One Did", finding: "The parking meter", author: "The Archivist", excerpt: "A man refilled a stranger's meter and walked on without looking back. I was the only one who saw.", rating: 5, marks: 26, points: 35, level: 3 },
+      { task: "Notice What No One Did", finding: "The mended fence", author: "M.", excerpt: "Someone repaired the gap in the school fence overnight. No note, no name. Children pass through it daily.", rating: 4, marks: 14, points: 35, level: 3 },
+      { task: "Notice What No One Did", finding: "The held elevator", author: "A Witness", excerpt: "She held the door for a man still three floors away, by the stairs. He never knew she waited.", rating: 4, marks: 11, points: 35, level: 3 },
+    ]);
+    return {
+      task: { title: "Notice What No One Else Did", no: "0089", points: 35, level: 3 },
+      praxis,
+      praxisCount: praxis.length,
+      comments: [
+        { name: "The Archivist", meta: "proposed · 3w ago", body: "I watched a man refill a stranger's parking meter and walk on without looking back. @Quietly is right — some things are diminished by being told.", avatar: this.avatar("A") },
+        { name: "Quietly", meta: "2d ago", body: "And yet here we are, telling. Gently. Only to each other.", avatar: this.avatar("Q") },
+      ],
+      signed,
+      signLabel: signed ? "✓ Taken in confidence" : "Acknowledge",
+      signBg: signed ? "#1c1c1a" : "transparent",
+      signColor: signed ? "#fdfdfc" : "#1c1c1a",
+      signNote: signed ? "you carry it now. quietly." : "no portfolio. no announcement.",
+      notSigned: !signed,
+      onSign: () => this.setState((s) => ({ signed: !s.signed })),
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/albescent-kit/Albescent Updates.html
+++ b/docs/design/albescent-kit/Albescent Updates.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>World Zero — The Record · Albescent</title>
+<link rel="stylesheet" href="albescent.css">
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background: #f7f4ee;
+    color: #1c1c1a;
+    font-family: "Courier Prime", "Courier New", monospace;
+    min-height: 100vh;
+  }
+  a { color: inherit; text-decoration: none; }
+
+  .wordmark {
+    font-family: "Lora", Georgia, serif;
+    font-style: italic; font-weight: 700;
+    font-size: 22px; line-height: 1;
+    color: #1c1c1a;
+    border-bottom: 3px solid; padding-bottom: 2px;
+    border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1;
+  }
+  .nav-links { display: flex; gap: 20px; flex: 1; }
+  .nav-links a {
+    font-family: var(--al-mono); font-size: 10px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: rgba(28,28,26,0.35); padding-bottom: 3px;
+    transition: color 120ms;
+  }
+  .nav-links a.active {
+    color: rgba(28,28,26,0.72);
+    border-bottom: 1px solid rgba(28,28,26,0.42);
+  }
+  .nav-links a:hover { color: rgba(28,28,26,0.58); }
+  .nav-ctl {
+    display: flex; align-items: center; gap: 14px;
+    font-family: var(--al-mono); font-size: 10px;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    color: rgba(28,28,26,0.35);
+  }
+  .nav-box {
+    border: 1px solid var(--al-border);
+    padding: 5px 11px; cursor: pointer;
+    transition: background 120ms;
+  }
+  .nav-box:hover { background: rgba(0,0,0,0.04); }
+
+  .crumbs {
+    position: relative; z-index: 5;
+    max-width: 1100px; margin: 0 auto;
+    padding: 18px 32px 0;
+    font-family: var(--al-mono);
+    font-size: 9px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: rgba(28,28,26,0.28);
+  }
+  .crumbs a:hover { color: rgba(28,28,26,0.55); }
+
+  .rec-layout { display: grid; grid-template-columns: 1fr 268px; gap: 30px; align-items: start; }
+  @media (max-width: 880px) { .rec-layout { grid-template-columns: 1fr; } }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="albescent-cards.jsx"></script>
+<script type="text/babel" src="albescent-faction.jsx"></script>
+</head>
+<body>
+
+<div class="al-backdrop"></div>
+
+<nav class="al-nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a>
+    <a href="Albescent Faction Page.html">Tasks</a>
+    <a href="Albescent Faction Page.html">Praxis</a>
+    <a href="#">Players</a>
+    <a href="Albescent Faction Page.html">Factions</a>
+    <a href="Albescent Updates.html" class="active">Updates</a>
+    <a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Keeper</span>
+    <span id="nav-badge"></span>
+    <span class="nav-box">Leave</span>
+  </div>
+</nav>
+
+<div class="crumbs">
+  <a href="Albescent Faction Page.html">Factions</a>
+  &nbsp;/&nbsp;
+  <a href="Albescent Faction Page.html">Albescent</a>
+  &nbsp;/&nbsp;
+  <span style="color:rgba(28,28,26,0.55)">The Record</span>
+</div>
+
+<div class="al-page" data-screen-label="Albescent · The Record">
+  <div class="rec-layout">
+
+    <div>
+      <!-- masthead -->
+      <div style="padding-bottom:22px;margin-bottom:18px;border-bottom:1px solid rgba(0,0,0,0.07);">
+        <div style="font-family:var(--al-mono);font-size:7.5px;letter-spacing:0.28em;text-transform:uppercase;color:rgba(28,28,26,0.22);margin-bottom:9px;">
+          Albescent · the standing record · fourth season
+        </div>
+        <div style="font-family:var(--al-font);font-style:italic;font-weight:300;font-size:40px;line-height:1;color:rgba(28,28,26,0.82);margin-bottom:7px;">
+          The Record
+        </div>
+        <div style="height:1px;width:56px;background:rgba(0,0,0,0.12);margin-bottom:13px;"></div>
+        <p style="font-family:var(--al-mono);font-size:8.5px;line-height:1.7;color:rgba(28,28,26,0.4);max-width:440px;margin:0;">
+          Everything the faction has attended, kept in order. Acknowledged, attended,
+          returned, witnessed — entered quietly, without ceremony, whether or not
+          anyone is reading.
+        </p>
+      </div>
+
+      <div class="al-sheet">
+        <div style="padding:22px 26px 26px;" id="feed"></div>
+      </div>
+    </div>
+
+    <!-- quiet aside -->
+    <aside style="position:sticky;top:24px;">
+      <div class="al-sheet">
+        <div style="padding:24px 22px;display:flex;flex-direction:column;align-items:center;text-align:center;">
+          <div class="al-breathe" style="margin-bottom:16px;"><span id="aside-mark"></span></div>
+          <div style="font-family:var(--al-font);font-style:italic;font-weight:300;font-size:19px;line-height:1.3;color:rgba(28,28,26,0.6);margin-bottom:10px;">
+            No trace need remain.
+          </div>
+          <div style="font-family:var(--al-mono);font-size:7.5px;letter-spacing:0.06em;line-height:1.7;color:rgba(28,28,26,0.36);">
+            The Record exists for those who keep it, not for those who watch.
+            Entries are never ranked, never compared, never scored against another.
+          </div>
+        </div>
+      </div>
+      <div id="counts" style="margin-top:14px;"></div>
+    </aside>
+
+  </div>
+</div>
+
+<script type="text/babel">
+const { AlActivityFeed, AL_ACTIVITY, AlNavBadge, AlbescentMark } = window;
+
+ReactDOM.createRoot(document.getElementById("nav-badge")).render(<AlNavBadge/>);
+ReactDOM.createRoot(document.getElementById("aside-mark")).render(<AlbescentMark size={48} breathe/>);
+
+ReactDOM.createRoot(document.getElementById("feed")).render(
+  <AlActivityFeed items={AL_ACTIVITY}/>
+);
+
+/* small tally of kinds */
+function Counts() {
+  const kinds = ["acknowledged","attended","returned","witnessed"];
+  const tally = kinds.map(k => ({ k, n: AL_ACTIVITY.filter(i => i.kind === k).length }));
+  const shade = { acknowledged:"rgba(28,28,26,0.28)", attended:"rgba(28,28,26,0.46)", returned:"rgba(28,28,26,0.64)", witnessed:"rgba(28,28,26,0.82)" };
+  return (
+    <div className="al-sheet">
+      <div style={{padding:"18px 22px",fontFamily:"var(--al-mono)"}}>
+        <div style={{fontSize:7,letterSpacing:"0.26em",textTransform:"uppercase",color:"rgba(28,28,26,0.24)",marginBottom:13}}>This season</div>
+        {tally.map(t => (
+          <div key={t.k} style={{display:"flex",alignItems:"center",justifyContent:"space-between",padding:"6px 0",borderBottom:"1px solid rgba(0,0,0,0.045)"}}>
+            <span style={{display:"inline-flex",alignItems:"center",gap:8}}>
+              <span style={{width:7,height:7,borderRadius:"50%",background:shade[t.k]}}/>
+              <span style={{fontSize:8,letterSpacing:"0.14em",textTransform:"uppercase",color:"rgba(28,28,26,0.5)"}}>{t.k}</span>
+            </span>
+            <span style={{fontFamily:"var(--al-font)",fontStyle:"italic",fontSize:16,color:"rgba(28,28,26,0.55)"}}>{t.n}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+ReactDOM.createRoot(document.getElementById("counts")).render(<Counts/>);
+</script>
+</body>
+</html>

--- a/docs/design/albescent-kit/README.md
+++ b/docs/design/albescent-kit/README.md
@@ -1,0 +1,26 @@
+# Albescent design kit — vendored for issue #232 (first-class Albescent identity)
+
+Vendored 2026-07-03. Two sources, two freshness tiers:
+
+1. **Canonical (cloud, FRESH — fetch these first):** the cloud "World Zero Design
+   System" project (`019e221c-7853-7530-a934-7d3b2b7c8b43`) holds the
+   restructured, contract-aligned React components under
+   `components/factions/albescent/`:
+   `AlbescentTaskCard.jsx`, `AlbescentPraxisCard.jsx`, `AlbescentPraxisRow.jsx`,
+   `AlbescentEditPraxis.jsx`, `AlbescentAvatar.jsx`, `AlbescentNavBadge.jsx`,
+   `AlbescentSigil.jsx` (+ `.d.ts` prop contracts). If you have DesignSync
+   access, read those. They consume the root contract JSONs
+   (`task-card-contract.json`, `praxis-card-contract.json`,
+   `edit-praxis-contract.json`).
+
+2. **Fallback (this directory, 2026-06-26 export of the deprecated `templates/`
+   tier):** the files here carry the same *visual identity* (vellum
+   correspondence: always-light, near-black ink, Cormorant Garamond, quiet
+   fleur/laurel marks, "bear witness", no points logged on the feed) but predate
+   the 2026-07-02 contract restructure — e.g. they don't surface `votePoints`.
+   Where they disagree with a contract slot, the contract wins.
+
+Also relevant, already in the repo: `AlbescentComment` voice
+(`frontend/src/components/comments/voices/`), the Albescent praxis-READ page
+(#231/#358, `AlbescentPraxisDetail`), the `--faction-albescent-*` tokens in
+`index.css`, and the join letter in `docs/design/join/Albescent Join Screen.html`.

--- a/docs/design/albescent-kit/albescent-cards.jsx
+++ b/docs/design/albescent-kit/albescent-cards.jsx
@@ -1,0 +1,159 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — Atoms + Task Card
+   Shared visual vocabulary for all Albescent surfaces.
+
+   Physical archetype: VELLUM CORRESPONDENCE — pure white,
+   Cormorant Garamond italic, surveyor's mark sigil, hairline
+   borders. The card speaks in a whisper.
+
+   Atoms exported:    AlbescentMark
+   Task card exported: AlbescentCard (window.AlbescentCard)
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Witness scale ── */
+const AL_WITNESS = [
+  { v:1, label:"Unseeing"  },
+  { v:2, label:"Glimpsed"  },
+  { v:3, label:"Witnessed" },
+  { v:4, label:"Verified"  },
+  { v:5, label:"Inscribed" },
+];
+
+const alDistTotal = d => d.reduce((a,b) => a+b, 0);
+const alDistAvg   = d => {
+  const t = alDistTotal(d);
+  return t ? d.reduce((a,c,i) => a+c*(i+1), 0) / t : 0;
+};
+const alStanding = avg => AL_WITNESS[Math.max(0, Math.min(4, Math.round(avg)-1))];
+
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT MARK — the surveyor's cross-hair sigil
+   Outer ring (18% opacity) · inner ring (50%) ·
+   4 cardinal tick marks · filled center dot.
+   ════════════════════════════════════════════════════════════════ */
+function AlbescentMark({ size = 20, color = "#1c1c1a", breathe = false, opacity = 1 }) {
+  const c  = size / 2;
+  const rO = size * 0.43;    /* outer ring */
+  const rI = size * 0.235;   /* inner ring */
+  const rD = size * 0.044;   /* center dot */
+  const tS = rI + size * 0.025;   /* tick start — just past inner ring */
+  const tE = tS + size * 0.13;    /* tick end */
+
+  const tick = (deg) => {
+    const a = deg * Math.PI / 180;
+    return {
+      x1: c + tS * Math.cos(a), y1: c + tS * Math.sin(a),
+      x2: c + tE * Math.cos(a), y2: c + tE * Math.sin(a),
+    };
+  };
+
+  return (
+    <svg
+      width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none"
+      style={{
+        display: "block", flexShrink: 0, opacity,
+        animation: breathe ? "al-breathe 5.5s ease-in-out infinite" : "none",
+      }}
+    >
+      <circle cx={c} cy={c} r={rO} stroke={color} strokeWidth={size*0.022} opacity={0.18}/>
+      <circle cx={c} cy={c} r={rI} stroke={color} strokeWidth={size*0.038} opacity={0.5}/>
+      {[0, 90, 180, 270].map((deg, i) => {
+        const { x1, y1, x2, y2 } = tick(deg);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={size*0.038}/>;
+      })}
+      <circle cx={c} cy={c} r={rD} fill={color}/>
+    </svg>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT TASK CARD — Vellum archetype
+   Full-sized version for the faction page task grid.
+   224px wide. Shows in the global task list at a smaller size
+   via FactionTaskCard (the base DS component).
+   ════════════════════════════════════════════════════════════════ */
+function AlbescentCard({ title, description, level, points, onAcknowledge }) {
+  const [ack, setAck] = React.useState(false);
+
+  return (
+    <div style={{
+      width: 224,
+      background: "#fff",
+      border: "1px solid rgba(0,0,0,0.09)",
+      boxShadow: "0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)",
+      padding: "24px 20px 18px",
+      fontFamily: "var(--al-font)",
+    }}>
+      {/* Centered sigil */}
+      <div style={{ display:"flex", justifyContent:"center", marginBottom:16 }}>
+        <AlbescentMark size={20} breathe/>
+      </div>
+
+      {/* Top rule */}
+      <div style={{ height:1, background:"rgba(0,0,0,0.07)", marginBottom:13 }}/>
+
+      {/* Eyebrow */}
+      <div style={{
+        fontSize:6, letterSpacing:"0.32em", textTransform:"uppercase",
+        color:"rgba(0,0,0,0.24)", fontFamily:"var(--al-mono)", marginBottom:10,
+      }}>Albescent</div>
+
+      {/* Title */}
+      <div style={{
+        fontSize:18, fontStyle:"italic", fontWeight:300,
+        lineHeight:1.28, color:"#1c1c1a", marginBottom:11,
+      }}>{title}</div>
+
+      {/* Description */}
+      {description && (
+        <div style={{
+          fontSize:7.5, color:"rgba(28,28,26,0.42)", lineHeight:1.6,
+          fontFamily:"var(--al-mono)", marginBottom:16,
+          overflow:"hidden", display:"-webkit-box",
+          WebkitLineClamp:3, WebkitBoxOrient:"vertical",
+        }}>{description}</div>
+      )}
+
+      {/* CTA */}
+      <div style={{ marginBottom:14 }}>
+        <button
+          onClick={() => { setAck(a => !a); onAcknowledge?.(); }}
+          style={{
+            background:"none", border:"none", padding:0, cursor:"pointer",
+            fontSize:7, letterSpacing:"0.22em", textTransform:"uppercase",
+            color: ack ? "rgba(0,0,0,0.55)" : "rgba(0,0,0,0.32)",
+            fontFamily:"var(--al-mono)",
+            borderBottom:`1px solid ${ack ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.16)"}`,
+            paddingBottom:1, transition:"all 250ms ease",
+          }}
+        >{ack ? "acknowledged" : "acknowledge"}</button>
+      </div>
+
+      {/* Footer */}
+      <div style={{
+        borderTop:"1px solid rgba(0,0,0,0.07)", paddingTop:11,
+        display:"flex", justifyContent:"space-between", alignItems:"center",
+      }}>
+        <span style={{
+          fontSize:6.5, letterSpacing:"0.2em", textTransform:"uppercase",
+          color:"rgba(0,0,0,0.22)", fontFamily:"var(--al-mono)",
+        }}>Lvl {level}</span>
+        <span style={{ fontSize:14, fontWeight:300, color:"rgba(28,28,26,0.48)" }}>
+          {points}
+          <span style={{
+            fontSize:6.5, marginLeft:3, letterSpacing:"0.1em",
+            textTransform:"uppercase", fontFamily:"var(--al-mono)",
+          }}>pts</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AlbescentMark, AlbescentCard,
+  AL_WITNESS, alDistTotal, alDistAvg, alStanding,
+});

--- a/docs/design/albescent-kit/albescent-faction.jsx
+++ b/docs/design/albescent-kit/albescent-faction.jsx
@@ -1,0 +1,421 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — Faction page components + activity feed
+   Hero · Activity Cards · Witness Widget · Nav Badge · Data.
+   Uses albescent-cards.jsx atoms. Exports on window.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Activity data ── */
+const AL_ACTIVITY = [
+  {
+    id:"a1", actor:"Keeper Vane", house:"Third House",
+    action:"returned", time:"1d ago",
+    task:"Tend the Archive in Silence", taskId:"archive-silence",
+    refNo:"XIV", credits:40, kind:"returned",
+    note:"All volumes restored and indexed. No record of passage remains.",
+  },
+  {
+    id:"a2", actor:"Keeper Orin", house:"First House",
+    action:"witnessed", time:"2d ago",
+    task:"Walk the Perimeter at Dusk", taskId:"perimeter-dusk",
+    refNo:"XI", credits:20, kind:"witnessed",
+    note:"Movement confirmed. The circuit holds.",
+  },
+  {
+    id:"a3", actor:"Keeper Sel", house:"Second House",
+    action:"acknowledged", time:"3d ago",
+    task:"Index the Unmarked Volumes", taskId:"index-unmarked",
+    refNo:"XVII", credits:0, kind:"acknowledged",
+    note:"Task received. No further acknowledgment.",
+  },
+  {
+    id:"a4", actor:"Keeper Marsh", house:"Fourth House",
+    action:"returned", time:"5d ago",
+    task:"Seal and Store Before Departing", taskId:"seal-store",
+    refNo:"IX", credits:30, kind:"returned",
+    note:"Storage completed per protocol. Departed before light.",
+  },
+  {
+    id:"a5", actor:"Keeper Vane", house:"Third House",
+    action:"attended", time:"6d ago",
+    task:"Count the Objects Without Touching", taskId:"count-objects",
+    refNo:"XXI", credits:0, kind:"attended",
+    note:"Forty-three objects accounted for. None disturbed.",
+  },
+  {
+    id:"a6", actor:"Keeper Orin", house:"First House",
+    action:"witnessed", time:"1w ago",
+    task:"Tend the Archive in Silence", taskId:"archive-silence",
+    refNo:"XIV", credits:40, kind:"witnessed",
+    note:"Signal: Inscribed. Twelve keepers in accord.",
+  },
+];
+
+const AL_TASKS = [
+  {
+    title:"Tend the Archive in Silence",
+    description:"Retrieve, restore, and return. No record of your work need remain.",
+    level:3, points:40,
+  },
+  {
+    title:"Walk the Perimeter at Dusk",
+    description:"Complete the circuit before darkness settles. Do not mark the path.",
+    level:2, points:20,
+  },
+  {
+    title:"Index the Unmarked Volumes",
+    description:"Catalogue what has not been named. Add only what is necessary.",
+    level:4, points:60,
+  },
+];
+
+const ACTION_KIND = {
+  acknowledged: { label:"acknowledged", shade:"rgba(28,28,26,0.28)" },
+  attended:     { label:"attended",     shade:"rgba(28,28,26,0.46)" },
+  returned:     { label:"returned",     shade:"rgba(28,28,26,0.64)" },
+  witnessed:    { label:"witnessed",    shade:"rgba(28,28,26,0.82)" },
+};
+
+/* ════════════════════════════════════════════════════════════════
+   AL NAV BADGE — faction membership indicator for the nav bar
+   ════════════════════════════════════════════════════════════════ */
+function AlNavBadge() {
+  const { AlbescentMark } = window;
+  return (
+    <div style={{
+      display:"inline-flex", alignItems:"center", gap:7,
+      border:"1px solid rgba(0,0,0,0.12)",
+      background:"rgba(255,255,255,0.6)",
+      padding:"4px 10px",
+    }}>
+      <AlbescentMark size={11}/>
+      <span style={{
+        fontFamily:"var(--al-mono)", fontSize:8,
+        letterSpacing:"0.18em", textTransform:"uppercase",
+        color:"rgba(28,28,26,0.55)",
+      }}>Albescent</span>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL HERO — faction page masthead
+   Meditative and still. No terminal boot-up, no dramatic chrome.
+   Just the name, the mark, and the purpose.
+   ════════════════════════════════════════════════════════════════ */
+function AlHero({ name, motto, blurb, stats }) {
+  const { AlbescentMark } = window;
+  return (
+    <div className="al-sheet" style={{ marginBottom:32, overflow:"hidden" }}>
+
+      {/* Faint background watermark */}
+      <div style={{
+        position:"absolute", top:"50%", left:"62%",
+        transform:"translate(-50%,-50%)",
+        pointerEvents:"none", zIndex:0,
+        opacity:0.03,
+      }}>
+        <AlbescentMark size={220}/>
+      </div>
+
+      <div style={{
+        position:"relative", zIndex:2,
+        padding:"44px 48px 50px",
+        display:"grid", gridTemplateColumns:"1fr auto",
+        gap:56, alignItems:"center",
+      }}>
+        <div>
+          {/* Pre-title eyebrow */}
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:7.5,
+            letterSpacing:"0.28em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)", marginBottom:18, lineHeight:1.9,
+          }}>
+            <div>Faction · {name}</div>
+            <div>Fourth Season · Active</div>
+            <div>Unranked · By design</div>
+          </div>
+
+          {/* Faction name */}
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:76, lineHeight:0.92,
+            color:"#1c1c1a", marginBottom:16,
+            letterSpacing:"-0.015em",
+          }}>{name}</div>
+
+          {/* Motto */}
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:9,
+            letterSpacing:"0.34em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.28)", marginBottom:20,
+          }}>{motto}</div>
+
+          {/* Blurb */}
+          <p style={{
+            fontFamily:"var(--al-mono)", fontSize:9.5, lineHeight:1.74,
+            color:"rgba(28,28,26,0.46)", maxWidth:490, marginBottom:30,
+          }}>{blurb}</p>
+
+          {/* Stats */}
+          <div style={{ display:"flex", gap:28, flexWrap:"wrap" }}>
+            {stats.map(s => (
+              <div key={s.label} style={{
+                paddingTop:12,
+                borderTop:"1px solid rgba(0,0,0,0.07)",
+                minWidth:80,
+              }}>
+                <div style={{
+                  fontFamily:"var(--al-font)", fontStyle:"italic",
+                  fontWeight:300, fontSize:28, lineHeight:1,
+                  color:"rgba(28,28,26,0.68)", marginBottom:5,
+                }}>{s.value}</div>
+                <div style={{
+                  fontFamily:"var(--al-mono)", fontSize:7,
+                  letterSpacing:"0.2em", textTransform:"uppercase",
+                  color:"rgba(28,28,26,0.26)",
+                }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Large mark — slowly breathing */}
+        <div className="al-breathe" style={{ flexShrink:0 }}>
+          <AlbescentMark size={106}/>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL ACTIVITY CARD — record feed item
+   Styled like a formal logbook entry: quiet, precise, no color.
+   ════════════════════════════════════════════════════════════════ */
+function AlActivityCard({ item }) {
+  const ak = ACTION_KIND[item.kind] || ACTION_KIND.acknowledged;
+  return (
+    <div className="al-activity-card" style={{ fontFamily:"var(--al-mono)" }}>
+
+      {/* Actor row */}
+      <div style={{
+        display:"flex", justifyContent:"space-between",
+        alignItems:"flex-start", gap:12, marginBottom:7,
+      }}>
+        <div>
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:14, lineHeight:1.2,
+            color:"rgba(28,28,26,0.72)", marginBottom:2,
+          }}>{item.actor}</div>
+          <div style={{
+            fontSize:7, letterSpacing:"0.16em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.26)",
+          }}>{item.house}</div>
+        </div>
+        <div style={{ display:"flex", alignItems:"center", gap:10, flexShrink:0 }}>
+          <span style={{
+            fontSize:6.5, letterSpacing:"0.18em", textTransform:"uppercase",
+            color:ak.shade, borderBottom:`1px solid ${ak.shade}`, paddingBottom:1,
+          }}>{ak.label}</span>
+          <span style={{
+            fontSize:7, letterSpacing:"0.06em",
+            color:"rgba(28,28,26,0.2)",
+          }}>{item.time}</span>
+        </div>
+      </div>
+
+      {/* Task name */}
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontWeight:300, fontSize:12.5, lineHeight:1.3,
+        color:"rgba(28,28,26,0.6)", marginBottom:5,
+      }}>{item.task}</div>
+
+      {/* Meta row */}
+      <div style={{
+        display:"flex", gap:12, alignItems:"center",
+        flexWrap:"wrap", marginBottom: item.note ? 5 : 0,
+      }}>
+        <span style={{ fontSize:7, letterSpacing:"0.12em", color:"rgba(28,28,26,0.24)" }}>
+          Ref. {item.refNo}
+        </span>
+        {item.credits > 0 && (
+          <span style={{ fontSize:7, letterSpacing:"0.1em", color:"rgba(28,28,26,0.32)" }}>
+            {item.credits} pts
+          </span>
+        )}
+      </div>
+
+      {item.note && (
+        <div style={{
+          fontSize:8, fontStyle:"italic", fontFamily:"var(--al-font)",
+          color:"rgba(28,28,26,0.36)", lineHeight:1.5,
+        }}>{item.note}</div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL WITNESS WIDGET — consensus witness for the faction page
+   Grayscale 1-5 circle marks: Unseeing → Inscribed.
+   No colors — Albescent refuses the palette.
+   ════════════════════════════════════════════════════════════════ */
+function AlWitnessWidget({ taskId, taskLabel, baseDist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const key = "al-witness-" + taskId;
+  const [my, setMy] = React.useState(0);
+
+  React.useEffect(() => {
+    try {
+      const v = +localStorage.getItem(key);
+      if (v >= 1 && v <= 5) setMy(v);
+    } catch(e) {}
+  }, [key]);
+
+  const cast = v => {
+    const nv = my === v ? 0 : v;
+    setMy(nv);
+    try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch(e) {}
+  };
+
+  const live = baseDist.map((c, i) => c + (my === i+1 ? 1 : 0));
+  const avg  = alDistAvg(live);
+  const total = alDistTotal(live);
+  const st   = alStanding(avg);
+
+  const shades = [
+    "rgba(0,0,0,0.16)",
+    "rgba(0,0,0,0.30)",
+    "rgba(0,0,0,0.48)",
+    "rgba(0,0,0,0.66)",
+    "rgba(0,0,0,0.84)",
+  ];
+
+  return (
+    <div style={{
+      border:"1px solid rgba(0,0,0,0.09)",
+      background:"#fff",
+      padding:"22px 24px",
+      fontFamily:"var(--al-mono)",
+    }}>
+      {/* Header */}
+      <div style={{
+        fontSize:7, letterSpacing:"0.26em", textTransform:"uppercase",
+        color:"rgba(28,28,26,0.24)", marginBottom:8,
+      }}>Bear Witness</div>
+
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontWeight:300, fontSize:13.5, color:"rgba(28,28,26,0.52)",
+        lineHeight:1.38, marginBottom:20,
+      }}>
+        How completely was this task attended?<br/>
+        <span style={{ color:"rgba(28,28,26,0.7)" }}>{taskLabel}</span>
+      </div>
+
+      {/* 5 circle marks */}
+      <div style={{ display:"flex", gap:8, marginBottom:14 }}>
+        {AL_WITNESS.map((s, i) => {
+          const shade = shades[i];
+          const on    = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{
+              display:"flex", flexDirection:"column",
+              alignItems:"center", gap:7, flex:1,
+            }}>
+              <button
+                onClick={() => cast(s.v)}
+                style={{
+                  width:32, height:32, borderRadius:"50%", cursor:"pointer",
+                  border:`1.5px solid ${shade}`,
+                  background: on ? shade : "transparent",
+                  display:"flex", alignItems:"center", justifyContent:"center",
+                  padding:0, transition:"all 200ms ease",
+                }}
+              >
+                {picked && (
+                  <div style={{
+                    width:8, height:8, borderRadius:"50%", background:"#fff",
+                  }}/>
+                )}
+              </button>
+              <span style={{
+                fontSize:5.5, letterSpacing:"0.06em", textAlign:"center",
+                color:"rgba(28,28,26,0.28)", lineHeight:1.35,
+              }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Consensus readout */}
+      <div style={{
+        display:"flex", justifyContent:"space-between", alignItems:"center",
+        paddingTop:13, borderTop:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        <span style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:17, color:"rgba(28,28,26,0.58)",
+        }}>{st.label}</span>
+        <span style={{
+          fontSize:8, letterSpacing:"0.12em",
+          color:"rgba(28,28,26,0.26)",
+        }}>{total} keepers</span>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   AL ACTIVITY FEED — full updates page version with filters
+   ════════════════════════════════════════════════════════════════ */
+function AlActivityFeed({ items }) {
+  const [filter, setFilter] = React.useState("all");
+  const FILTERS = [
+    { id:"all",          name:"All" },
+    { id:"acknowledged", name:"Acknowledged" },
+    { id:"attended",     name:"Attended" },
+    { id:"returned",     name:"Returned" },
+    { id:"witnessed",    name:"Witnessed" },
+  ];
+  const rows = items.filter(i => filter === "all" || i.kind === filter);
+
+  return (
+    <div>
+      <div style={{ display:"flex", gap:6, marginBottom:20, flexWrap:"wrap" }}>
+        {FILTERS.map(f => {
+          const on = filter === f.id;
+          return (
+            <button key={f.id} onClick={() => setFilter(f.id)} style={{
+              fontFamily:"var(--al-mono)", fontSize:7.5,
+              letterSpacing:"0.14em", textTransform:"uppercase",
+              padding:"4px 10px", cursor:"pointer",
+              border:`1px solid ${on ? "rgba(0,0,0,0.28)" : "rgba(0,0,0,0.1)"}`,
+              background: on ? "rgba(28,28,26,0.07)" : "transparent",
+              color: on ? "rgba(28,28,26,0.65)" : "rgba(28,28,26,0.36)",
+              transition:"all 120ms",
+            }}>{f.name}</button>
+          );
+        })}
+      </div>
+      {rows.map(item => <AlActivityCard key={item.id} item={item}/>)}
+      {rows.length === 0 && (
+        <div style={{
+          padding:"24px 0", fontSize:13, fontStyle:"italic",
+          fontFamily:"var(--al-font)", color:"rgba(28,28,26,0.26)",
+        }}>No entries match this filter.</div>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AL_ACTIVITY, AL_TASKS, ACTION_KIND,
+  AlNavBadge, AlHero, AlActivityCard, AlWitnessWidget, AlActivityFeed,
+});

--- a/docs/design/albescent-kit/albescent-praxis.jsx
+++ b/docs/design/albescent-kit/albescent-praxis.jsx
@@ -1,0 +1,572 @@
+/* ════════════════════════════════════════════════════════════════
+   ALBESCENT — The Register (Praxis surfaces)
+   A returned task is a filed account the faction now witnesses.
+   The 1–5 rating becomes THE WITNESS SCALE — a presence ramp
+   (unseeing → glimpsed → witnessed → verified → inscribed)
+   that measures how completely the task was attended.
+
+   Two surfaces:
+     · RegisterIndex — the ledger of returned accounts + witness
+     · EntryRead     — one returned account in full, with casting
+
+   Uses albescent-cards.jsx atoms. Data + helpers on window.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── dataset ── */
+const AL_PRAXES = [
+  {
+    id:        "archive-silence",
+    refNo:     "XIV",
+    task:      "Tend the Archive in Silence",
+    status:    "witnessed",
+    keeper:    "Keeper Vane",
+    house:     "Third House",
+    timestamp: "2026.04.21 // dawn",
+    credits:   40,
+    output:    "All volumes restored. The shelves hold their sequence without my name in them.",
+    account: [
+      "Arrived before the cataloguers. Worked from the east wing inward, restoring the displaced volumes to their documented positions. Did not open any that were sealed.",
+      "Found three volumes with damaged spines. Wrapped them without notation — they will be found by whoever is meant to find them.",
+      "Departed by the rear passage before the morning shift arrived. Left no note.",
+    ],
+    dist: [0, 1, 8, 14, 9],
+  },
+  {
+    id:        "perimeter-dusk",
+    refNo:     "XI",
+    task:      "Walk the Perimeter at Dusk",
+    status:    "witnessed",
+    keeper:    "Keeper Orin",
+    house:     "First House",
+    timestamp: "2026.04.18 // dusk",
+    credits:   20,
+    output:    "The circuit holds. Three missing posts replaced before the light failed.",
+    account: [
+      "Walked the full eastern perimeter beginning at the point where the light first dims. Completed the circuit in forty-one minutes.",
+      "Three boundary posts were missing from the northern quadrant. Replaced them from materials kept in the groundskeeper storage.",
+      "Returned by the same route. Nothing disturbed.",
+    ],
+    dist: [0, 2, 5, 8, 4],
+  },
+  {
+    id:        "seal-store",
+    refNo:     "IX",
+    task:      "Seal and Store Before Departing",
+    status:    "returned",
+    keeper:    "Keeper Marsh",
+    house:     "Fourth House",
+    timestamp: "2026.04.19 // before light",
+    credits:   30,
+    output:    "Stored. Departed. No trace visible from the road.",
+    account: [
+      "Completed sealing of the eastern archive annex using the wax from the cabinet — verified seal integrity before leaving.",
+      "Checked the facade from the road before departing. No light. No sign. Left before the hour changed.",
+    ],
+    dist: [1, 3, 7, 4, 1],
+  },
+  {
+    id:        "count-objects",
+    refNo:     "XXI",
+    task:      "Count the Objects Without Touching",
+    status:    "witnessed",
+    keeper:    "Keeper Vane",
+    house:     "Third House",
+    timestamp: "2026.04.20 // midday",
+    credits:   25,
+    output:    "Forty-three objects accounted for. None disturbed.",
+    account: [
+      "Entered the reading room at the appointed hour. Counted all objects on the central table by visual inspection only. Forty-three.",
+      "One object appeared to have moved since the last count. It had not — the shadow deceived. Counted again from the doorway. Forty-three.",
+      "Departed without confirming the count to anyone present.",
+    ],
+    dist: [0, 0, 3, 8, 5],
+  },
+];
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS BAR — mini grayscale histogram for index rows
+   ════════════════════════════════════════════════════════════════ */
+function WitnessBar({ dist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const total = alDistTotal(dist);
+  const avg   = alDistAvg(dist);
+  const st    = alStanding(avg);
+  const max   = Math.max(1, ...dist);
+  const shades = ["rgba(0,0,0,0.14)","rgba(0,0,0,0.28)","rgba(0,0,0,0.44)","rgba(0,0,0,0.62)","rgba(0,0,0,0.80)"];
+
+  return (
+    <div style={{ display:"flex", alignItems:"center", gap:10 }}>
+      <div style={{ display:"flex", alignItems:"flex-end", gap:2, height:22 }}>
+        {AL_WITNESS.map((s, i) => (
+          <div key={s.v} style={{
+            width:5,
+            height: Math.max(2, (dist[i] / max) * 22),
+            background: shades[i],
+            opacity: dist[i] ? 0.88 : 0.12,
+          }}/>
+        ))}
+      </div>
+      <div>
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:13.5, lineHeight:1,
+          color:"rgba(28,28,26,0.55)", marginBottom:2,
+        }}>{st.label}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7,
+          letterSpacing:"0.1em", color:"rgba(28,28,26,0.28)",
+        }}>{total} witnesses</div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   REGISTER ROW — single row in the praxis index
+   ════════════════════════════════════════════════════════════════ */
+function RegisterRow({ p, href }) {
+  return (
+    <a href={href} style={{
+      display:"grid",
+      gridTemplateColumns:"56px 1fr auto 20px",
+      alignItems:"center", gap:14,
+      padding:"12px 0", textDecoration:"none", color:"inherit",
+      borderBottom:"1px solid rgba(0,0,0,0.055)",
+      transition:"background 150ms",
+    }}
+    onMouseEnter={e => e.currentTarget.style.background="rgba(0,0,0,0.016)"}
+    onMouseLeave={e => e.currentTarget.style.background="transparent"}>
+
+      {/* Ref + status */}
+      <div style={{ textAlign:"right" }}>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7.5,
+          color:"rgba(28,28,26,0.30)", letterSpacing:"0.1em",
+        }}>Ref. {p.refNo}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:6,
+          color:"rgba(28,28,26,0.2)", letterSpacing:"0.12em",
+          textTransform:"uppercase", marginTop:2,
+        }}>{p.status}</div>
+      </div>
+
+      {/* Task name + keeper */}
+      <div>
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:15.5, lineHeight:1.2,
+          color:"rgba(28,28,26,0.72)", marginBottom:3,
+        }}>{p.task}</div>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:7.5,
+          color:"rgba(28,28,26,0.30)", letterSpacing:"0.04em",
+        }}>
+          {p.keeper} · {p.house}
+          <span style={{ marginLeft:8, color:"rgba(28,28,26,0.18)" }}>
+            {p.timestamp.split("//")[0].trim()}
+          </span>
+        </div>
+      </div>
+
+      {/* Witness consensus mini-bar */}
+      <WitnessBar dist={p.dist}/>
+
+      {/* Arrow */}
+      <span style={{ color:"rgba(28,28,26,0.22)", fontSize:11 }}>›</span>
+    </a>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   REGISTER INDEX — the full praxis index component
+   ════════════════════════════════════════════════════════════════ */
+function RegisterIndex({ praxes, hrefFor }) {
+  const [filter, setFilter] = React.useState("all");
+  const { alDistAvg, alDistTotal } = window;
+
+  const FILTERS = [
+    { id:"all",      name:"All returned" },
+    { id:"verified", name:"Highly witnessed" },
+    { id:"recent",   name:"This season" },
+  ];
+
+  const totalWitnesses = praxes.reduce((a, p) => a + alDistTotal(p.dist), 0);
+
+  const rows = praxes.filter(p => {
+    if (filter === "all")      return true;
+    if (filter === "verified") return alDistAvg(p.dist) >= 3.5;
+    return true;
+  });
+
+  return (
+    <React.Fragment>
+      {/* Masthead */}
+      <div style={{
+        display:"flex", justifyContent:"space-between",
+        alignItems:"flex-start", gap:16,
+        paddingBottom:22, marginBottom:20,
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        <div>
+          <div style={{
+            fontFamily:"var(--al-mono)", fontSize:7.5,
+            letterSpacing:"0.28em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)", marginBottom:9,
+          }}>Albescent · witnessed accounts · fourth season</div>
+          <div style={{
+            fontFamily:"var(--al-font)", fontStyle:"italic",
+            fontWeight:300, fontSize:36, lineHeight:1.0,
+            color:"rgba(28,28,26,0.8)", marginBottom:6,
+          }}>The Register</div>
+          <div style={{ height:1, width:56, background:"rgba(0,0,0,0.12)", marginBottom:13 }}/>
+          <p style={{
+            fontFamily:"var(--al-mono)", fontSize:8.5, lineHeight:1.65,
+            color:"rgba(28,28,26,0.4)", maxWidth:440, margin:0,
+          }}>
+            Tasks returned by the keepers. Each entry is a completed account —
+            no more, no less. Cast your witness on any you have observed.
+          </p>
+        </div>
+        <div style={{ display:"flex", gap:24, flexShrink:0 }}>
+          {[{ v:praxes.length, l:"returned" },{ v:totalWitnesses, l:"witnesses" }].map(s => (
+            <div key={s.l} style={{ textAlign:"right" }}>
+              <div style={{
+                fontFamily:"var(--al-font)", fontStyle:"italic",
+                fontWeight:300, fontSize:32, lineHeight:1,
+                color:"rgba(28,28,26,0.6)",
+              }}>{s.v}</div>
+              <div style={{
+                fontFamily:"var(--al-mono)", fontSize:7,
+                letterSpacing:"0.16em", color:"rgba(28,28,26,0.28)", marginTop:3,
+              }}>{s.l}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div style={{ display:"flex", gap:6, marginBottom:16, flexWrap:"wrap" }}>
+        {FILTERS.map(f => {
+          const on = filter === f.id;
+          return (
+            <button key={f.id} onClick={() => setFilter(f.id)} style={{
+              fontFamily:"var(--al-mono)", fontSize:7.5, letterSpacing:"0.14em",
+              textTransform:"uppercase", padding:"4px 10px", cursor:"pointer",
+              border:`1px solid ${on ? "rgba(0,0,0,0.28)" : "rgba(0,0,0,0.1)"}`,
+              background: on ? "rgba(28,28,26,0.07)" : "transparent",
+              color: on ? "rgba(28,28,26,0.65)" : "rgba(28,28,26,0.36)",
+              transition:"all 120ms",
+            }}>{f.name}</button>
+          );
+        })}
+        <span style={{
+          fontSize:7, color:"rgba(28,28,26,0.22)",
+          letterSpacing:"0.14em", marginLeft:6, alignSelf:"center",
+        }}>{rows.length}/{praxes.length}</span>
+      </div>
+
+      {/* Column headers */}
+      <div style={{
+        display:"grid", gridTemplateColumns:"56px 1fr auto 20px",
+        gap:14, paddingBottom:8, marginBottom:2,
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+      }}>
+        {["Ref", "Account", "Witnesses", ""].map((h, i) => (
+          <div key={i} style={{
+            fontFamily:"var(--al-mono)", fontSize:6.5,
+            letterSpacing:"0.22em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.22)",
+            textAlign: i === 2 ? "right" : "left",
+          }}>{h}</div>
+        ))}
+      </div>
+
+      {/* Rows */}
+      <div>
+        {rows.map(p => <RegisterRow key={p.id} p={p} href={hrefFor(p)}/>)}
+        {rows.length === 0 && (
+          <div style={{
+            padding:"28px 0", fontSize:14, fontStyle:"italic",
+            fontFamily:"var(--al-font)", color:"rgba(28,28,26,0.26)",
+          }}>No entries match this filter.</div>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS METER — grayscale distribution + standing label
+   ════════════════════════════════════════════════════════════════ */
+function WitnessMeter({ dist }) {
+  const { alDistAvg, alDistTotal, alStanding, AL_WITNESS } = window;
+  const total = alDistTotal(dist);
+  const avg   = alDistAvg(dist);
+  const st    = alStanding(avg);
+  const max   = Math.max(1, ...dist);
+  const shades = ["rgba(0,0,0,0.84)","rgba(0,0,0,0.66)","rgba(0,0,0,0.48)","rgba(0,0,0,0.30)","rgba(0,0,0,0.16)"];
+
+  return (
+    <div>
+      <div style={{ display:"flex", alignItems:"baseline", gap:10, marginBottom:10 }}>
+        <span style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:38, lineHeight:0.9,
+          color:"rgba(28,28,26,0.65)",
+        }}>{st.label}</span>
+        <div style={{
+          fontFamily:"var(--al-mono)", fontSize:8,
+          letterSpacing:"0.12em", color:"rgba(28,28,26,0.30)",
+        }}>{total} witnesses · avg {avg.toFixed(1)}</div>
+      </div>
+
+      <div style={{ display:"flex", flexDirection:"column", gap:6, marginTop:14 }}>
+        {AL_WITNESS.slice().reverse().map((s, i) => {
+          const realIdx = 4 - i;
+          const count   = dist[realIdx];
+          return (
+            <div key={s.v} style={{ display:"flex", alignItems:"center", gap:10 }}>
+              <span style={{
+                width:62, textAlign:"right",
+                fontFamily:"var(--al-mono)", fontSize:7.5,
+                letterSpacing:"0.06em", color:"rgba(28,28,26,0.38)",
+              }}>{s.label}</span>
+              <div style={{
+                flex:1, height:10,
+                background:"rgba(0,0,0,0.04)",
+                border:"1px solid rgba(0,0,0,0.07)",
+                position:"relative", overflow:"hidden",
+              }}>
+                <div style={{
+                  position:"absolute", inset:0,
+                  width:`${(count / max) * 100}%`,
+                  background: shades[i],
+                  opacity: count ? 0.88 : 0,
+                  transition:"width 400ms ease",
+                }}/>
+              </div>
+              <span style={{
+                width:18, fontFamily:"var(--al-mono)", fontSize:9,
+                color:"rgba(28,28,26,0.50)", textAlign:"right",
+              }}>{count}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WITNESS CASTER — interactive witness casting (with meter)
+   Persists to localStorage. Albescent's equivalent of SignalCaster.
+   ════════════════════════════════════════════════════════════════ */
+function WitnessCaster({ praxisId, baseDist }) {
+  const { alDistAvg, alDistTotal, AL_WITNESS } = window;
+  const key = "al-witness-" + praxisId;
+  const [my, setMy] = React.useState(0);
+
+  React.useEffect(() => {
+    try { const v = +localStorage.getItem(key); if (v>=1&&v<=5) setMy(v); } catch(e) {}
+  }, [key]);
+
+  const cast = v => {
+    const nv = my === v ? 0 : v;
+    setMy(nv);
+    try { nv ? localStorage.setItem(key, String(nv)) : localStorage.removeItem(key); } catch(e) {}
+  };
+
+  const live = baseDist.map((c, i) => c + (my === i+1 ? 1 : 0));
+  const shades = ["rgba(0,0,0,0.16)","rgba(0,0,0,0.30)","rgba(0,0,0,0.48)","rgba(0,0,0,0.66)","rgba(0,0,0,0.84)"];
+
+  return (
+    <div>
+      <WitnessMeter dist={live}/>
+
+      <div style={{ height:1, background:"rgba(0,0,0,0.07)", margin:"18px 0 14px" }}/>
+
+      <div style={{
+        fontFamily:"var(--al-mono)", fontSize:7, letterSpacing:"0.26em",
+        textTransform:"uppercase", color:"rgba(28,28,26,0.24)", marginBottom:6,
+      }}>Bear Witness</div>
+
+      <div style={{
+        fontFamily:"var(--al-font)", fontStyle:"italic",
+        fontSize:12, color:"rgba(28,28,26,0.4)", marginBottom:16, lineHeight:1.4,
+      }}>How completely was this task attended?</div>
+
+      <div style={{ display:"flex", gap:8, flexWrap:"wrap" }}>
+        {AL_WITNESS.map((s, i) => {
+          const shade  = shades[i];
+          const on     = my >= s.v;
+          const picked = my === s.v;
+          return (
+            <div key={s.v} style={{ display:"flex", flexDirection:"column", alignItems:"center", gap:6 }}>
+              <button onClick={() => cast(s.v)} style={{
+                width:34, height:34, borderRadius:"50%", cursor:"pointer",
+                border:`1.5px solid ${shade}`,
+                background: on ? shade : "transparent",
+                display:"flex", alignItems:"center", justifyContent:"center",
+                padding:0, transition:"all 200ms ease",
+              }}>
+                {picked && <div style={{ width:8, height:8, borderRadius:"50%", background:"#fff" }}/>}
+              </button>
+              <span style={{
+                fontSize:5.5, letterSpacing:"0.06em",
+                textAlign:"center", color:"rgba(28,28,26,0.28)",
+                fontFamily:"var(--al-mono)",
+              }}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{
+        marginTop:14, fontSize:8.5, lineHeight:1.55,
+        fontStyle:"italic", fontFamily:"var(--al-font)",
+        color: my ? "rgba(28,28,26,0.58)" : "rgba(28,28,26,0.26)",
+      }}>
+        {my
+          ? `Witnessed as ${AL_WITNESS[my-1].label}. ${alDistTotal(live)} keepers now in accord.`
+          : "You have not yet cast your witness."}
+        {my > 0 && (
+          <span onClick={() => cast(my)} style={{
+            marginLeft:8, cursor:"pointer",
+            color:"rgba(28,28,26,0.42)",
+            borderBottom:"1px solid rgba(28,28,26,0.2)",
+          }}>amend</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ENTRY READ — full single-account view (main column)
+   ════════════════════════════════════════════════════════════════ */
+function EntryRead({ p }) {
+  const { AlbescentMark } = window;
+
+  return (
+    <div style={{ fontFamily:"var(--al-mono)", color:"#1c1c1a", position:"relative" }}>
+
+      {/* Header band */}
+      <div style={{
+        display:"flex", alignItems:"center",
+        justifyContent:"space-between", gap:14,
+        padding:"10px 24px",
+        borderBottom:"1px solid rgba(0,0,0,0.07)",
+        background:"rgba(0,0,0,0.012)",
+      }}>
+        <span style={{
+          display:"inline-flex", alignItems:"center", gap:9,
+          fontSize:9, letterSpacing:"0.22em", textTransform:"uppercase",
+          color:"rgba(28,28,26,0.28)",
+        }}>
+          <AlbescentMark size={12}/>
+          Albescent · Ref. {p.refNo}
+        </span>
+        <span style={{
+          fontSize:7, letterSpacing:"0.16em", textTransform:"uppercase",
+          color:"rgba(28,28,26,0.26)",
+          borderBottom:"1px solid rgba(28,28,26,0.18)", paddingBottom:1,
+        }}>{p.status}</span>
+      </div>
+
+      <div style={{ padding:"28px 24px 32px" }}>
+
+        {/* Task name */}
+        <h1 style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:48, lineHeight:1.05,
+          color:"#1c1c1a", margin:"0 0 14px",
+        }}>{p.task}</h1>
+
+        {/* Output quote */}
+        <div style={{
+          fontFamily:"var(--al-font)", fontStyle:"italic",
+          fontWeight:300, fontSize:14.5, lineHeight:1.55,
+          color:"rgba(28,28,26,0.52)",
+          borderLeft:"2px solid rgba(0,0,0,0.09)",
+          paddingLeft:14, marginBottom:22,
+        }}>{p.output}</div>
+
+        {/* Byline */}
+        <div style={{
+          display:"flex", alignItems:"center", gap:14,
+          paddingBottom:20, marginBottom:6,
+          borderBottom:"1px solid rgba(0,0,0,0.06)",
+        }}>
+          <div style={{
+            width:36, height:36, borderRadius:"50%", flexShrink:0,
+            border:"1px solid rgba(0,0,0,0.12)",
+            background:"rgba(0,0,0,0.03)",
+            display:"flex", alignItems:"center", justifyContent:"center",
+            fontFamily:"var(--al-font)", fontSize:13, fontStyle:"italic",
+            color:"rgba(28,28,26,0.45)",
+          }}>K</div>
+          <div>
+            <div style={{
+              fontFamily:"var(--al-font)", fontStyle:"italic",
+              fontWeight:300, fontSize:14, color:"rgba(28,28,26,0.7)",
+            }}>{p.keeper}</div>
+            <div style={{
+              fontSize:7.5, color:"rgba(28,28,26,0.34)",
+              letterSpacing:"0.06em",
+            }}>{p.house} · {p.timestamp}</div>
+          </div>
+          <div style={{ marginLeft:"auto", textAlign:"right", flexShrink:0 }}>
+            <div style={{
+              fontFamily:"var(--al-font)", fontStyle:"italic",
+              fontWeight:300, fontSize:28, lineHeight:1,
+              color:"rgba(28,28,26,0.55)",
+            }}>{p.credits}</div>
+            <div style={{
+              fontFamily:"var(--al-mono)", fontSize:7,
+              letterSpacing:"0.14em", color:"rgba(28,28,26,0.26)", marginTop:2,
+            }}>pts returned</div>
+          </div>
+        </div>
+
+        {/* Account section divider */}
+        <div style={{ display:"flex", alignItems:"center", gap:10, margin:"18px 0 12px" }}>
+          <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+          <span style={{
+            fontSize:7, letterSpacing:"0.24em", textTransform:"uppercase",
+            color:"rgba(28,28,26,0.2)", whiteSpace:"nowrap",
+            fontFamily:"var(--al-mono)",
+          }}>Account</span>
+          <div style={{ height:1, flex:1, background:"rgba(0,0,0,0.06)" }}/>
+        </div>
+
+        {/* Account lines */}
+        <div style={{ marginBottom:8 }}>
+          {p.account.map((line, i) => (
+            <div key={i} style={{
+              fontSize:9, lineHeight:1.8, color:"rgba(28,28,26,0.58)",
+              paddingLeft:26, position:"relative", marginBottom:4,
+              fontFamily:"var(--al-mono)",
+            }}>
+              <span style={{
+                position:"absolute", left:0,
+                color:"rgba(28,28,26,0.2)", fontSize:7.5,
+              }}>{String(i).padStart(2,"0")}</span>
+              {line}
+            </div>
+          ))}
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   EXPORTS
+   ════════════════════════════════════════════════════════════════ */
+Object.assign(window, {
+  AL_PRAXES,
+  RegisterIndex, RegisterRow,
+  WitnessBar, WitnessMeter, WitnessCaster,
+  EntryRead,
+});

--- a/docs/design/albescent-kit/albescent.css
+++ b/docs/design/albescent-kit/albescent.css
@@ -1,0 +1,208 @@
+/* ══════════════════════════════════════════════════════════════
+   ALBESCENT — World Zero faction
+   A sacred secret society. They task for the sake of tasking:
+   not competition, not accumulation, not record. The faction
+   exists outside the leaderboard; it refuses the rainbow palette;
+   it leaves no trace. Every task is an act of devotion with no
+   audience.
+
+   Physical card archetype: VELLUM CORRESPONDENCE — pure white
+   cotton paper, hairline borders, Cormorant Garamond italic,
+   a surveyor's mark as the only sigil. The card whispers.
+
+   Style: MINIMAL · SACRED · SILENT · PRECISE · WHITE
+   The signature artifact is THE MARK: a surveyor's cross-hair
+   sigil that asks only: where are you, exactly?
+
+   TOKEN MODEL: Albescent is always light — no dark mode flip.
+   White is the card surface in both themes. Near-black ink is
+   all text. No faction hue anywhere.
+   ══════════════════════════════════════════════════════════════ */
+
+@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400;1,500&family=Courier+Prime:ital,wght@0,400;1,400&family=Lora:ital,wght@1,400;1,700&display=swap");
+
+:root {
+  /* ── Core palette ── */
+  --al-surface:       #ffffff;
+  --al-surface-warm:  #faf9f7;
+  --al-text:          #1c1c1a;
+  --al-text-muted:    rgba(28, 28, 26, 0.44);
+  --al-text-faint:    rgba(28, 28, 26, 0.22);
+  --al-ink:           rgba(28, 28, 26, 0.72);
+
+  /* ── Structural ── */
+  --al-border:        rgba(0, 0, 0, 0.10);
+  --al-border-faint:  rgba(0, 0, 0, 0.055);
+  --al-border-rule:   rgba(0, 0, 0, 0.07);
+  --al-shadow:        0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04);
+
+  /* ── Typography ── */
+  --al-font: "Cormorant Garamond", Georgia, serif;
+  --al-mono: "Courier Prime", "Courier New", monospace;
+
+  /* ── Card contract — mirrors --faction-albescent-card-* ── */
+  --faction-albescent-card-bg:     #ffffff;
+  --faction-albescent-card-text:   #1c1c1a;
+  --faction-albescent-card-accent: rgba(28, 28, 26, 0.72);
+  --faction-albescent-card-muted:  rgba(28, 28, 26, 0.42);
+  --faction-albescent-card-font:   var(--al-font);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ALBESCENT BACKDROP
+   Near-white cream with barely-visible ruled paper lines.
+   Not a dramatic backdrop — a surface already present,
+   whether anyone looks or not.
+   ══════════════════════════════════════════════════════════════ */
+.al-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: #f7f4ee;
+  background-image:
+    radial-gradient(ellipse 72% 58% at 50% 38%,
+      rgba(255, 255, 255, 0.58) 0%, transparent 100%),
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 27px,
+      rgba(0, 0, 0, 0.016) 27px 28px);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANIMATIONS — everything slow, deliberate, no urgency
+   ══════════════════════════════════════════════════════════════ */
+@keyframes al-breathe { 0%,100%{ opacity:1; }        50%{ opacity:0.58; }        }
+@keyframes al-drift   { 0%,100%{ transform:scale(1); } 50%{ transform:scale(1.016); } }
+
+@media (prefers-reduced-motion: no-preference) {
+  .al-breathe { animation: al-breathe 5.5s ease-in-out infinite; }
+  .al-drift   { animation: al-drift   14s  ease-in-out infinite; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHARED LAYOUT — nav
+   ══════════════════════════════════════════════════════════════ */
+.al-nav {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  padding: 14px 32px;
+  background: rgba(247, 244, 238, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--al-border-faint);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SHEET — the primary white surface
+   ══════════════════════════════════════════════════════════════ */
+.al-sheet {
+  position: relative;
+  background: var(--al-surface);
+  border: 1px solid var(--al-border);
+  box-shadow: var(--al-shadow);
+}
+/* subtle inset architectural border */
+.al-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 1px solid var(--al-border-faint);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   PAGE
+   ══════════════════════════════════════════════════════════════ */
+.al-page {
+  position: relative;
+  z-index: 5;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 28px 32px 80px;
+}
+
+/* section heading with flanking rules */
+.al-section {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 38px 0 16px;
+}
+.al-section h2 {
+  font-family: var(--al-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--al-text-faint);
+  white-space: nowrap;
+  margin: 0;
+  font-weight: 400;
+}
+.al-section .rule  { flex: 1; height: 1px; background: var(--al-border-rule); }
+.al-section .count {
+  font-family: var(--al-mono);
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--al-text-faint);
+  white-space: nowrap;
+}
+
+/* task card grid */
+.al-task-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+/* two-col record/witness layout */
+.al-dispatch-layout {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  .al-dispatch-layout { grid-template-columns: 1fr; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ACTIVITY RECORD
+   ══════════════════════════════════════════════════════════════ */
+.al-activity-card {
+  border-bottom: 1px solid var(--al-border-faint);
+  padding: 14px 0;
+}
+.al-activity-card:last-child { border-bottom: none; }
+
+/* ══════════════════════════════════════════════════════════════
+   ASSET SHOWCASE
+   ══════════════════════════════════════════════════════════════ */
+.al-assets {
+  margin-top: 52px;
+  padding-top: 24px;
+  border-top: 1px solid var(--al-border-faint);
+}
+.al-acard {
+  border: 1px solid var(--al-border-faint);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 14px 16px;
+}
+.al-acard .h {
+  font-family: var(--al-mono);
+  font-size: 7px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--al-text-faint);
+  margin-bottom: 12px;
+}
+.al-acard .cap {
+  font-family: var(--al-mono);
+  font-size: 7.5px;
+  letter-spacing: 0.06em;
+  color: var(--al-text-faint);
+  margin-top: 10px;
+}

--- a/docs/design/join/Albescent Join Screen.html
+++ b/docs/design/join/Albescent Join Screen.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Choose Your Faction · Albescent</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="albescent.css" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400;1,500&family=Courier+Prime:ital,wght@0,400;1,400&display=swap" />
+<style>
+  html, body { margin: 0; }
+  body { background: #f7f4ee; color: var(--al-text); font-family: var(--al-mono); min-height: 100vh; }
+  a { color: inherit; text-decoration: none; }
+  .al-nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 22px; padding: 14px 32px;
+    background: rgba(247,244,238,0.9); backdrop-filter: blur(8px); border-bottom: 1px solid var(--al-border-faint); }
+  .wordmark { font-family: "Lora", Georgia, serif; font-style: italic; font-weight: 700; font-size: 22px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 20px; flex: 1; }
+  .nav-links a { font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(28,28,26,0.35); }
+  .nav-box { border: 1px solid var(--al-border); padding: 5px 11px; font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; }
+  .page { position: relative; z-index: 5; max-width: 1120px; margin: 0 auto; padding: 40px 32px 80px; }
+  .kicker { font-family: var(--al-mono); font-size: 8px; letter-spacing: 0.28em; text-transform: uppercase; color: rgba(28,28,26,0.3); margin-bottom: 26px; text-align: center; }
+  .layout { display: grid; grid-template-columns: 1fr 300px; gap: 34px; align-items: start; }
+  @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+  .chooser { display: flex; flex-direction: column; gap: 8px; }
+  .fchip { display: flex; align-items: center; gap: 13px; padding: 12px 14px; border: 1px solid var(--al-border-faint);
+    background: #fff; cursor: pointer; text-align: left; width: 100%; transition: transform 100ms; }
+  .fchip:hover { transform: translateX(2px); }
+  .fchip.sel { border-color: var(--al-text); }
+  .fchip .dot { width: 24px; height: 24px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 2px rgba(255,255,255,0.2); }
+  .fchip .nm { display: block; font-family: var(--al-font); font-style: italic; font-size: 16px; color: var(--al-text); line-height: 1.1; }
+  .fchip .ds { display: block; font-family: var(--al-mono); font-size: 7px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(28,28,26,0.4); margin-top: 3px; }
+  .fchip .arrow { margin-left: auto; font-size: 12px; color: rgba(28,28,26,0.35); }
+  .chooser-note { font-family: var(--al-mono); font-size: 8px; line-height: 1.7; color: rgba(28,28,26,0.36); margin-top: 10px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div class="al-backdrop"></div>
+<nav class="al-nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="#">Praxis</a><a href="#">Players</a>
+    <a href="Albescent Faction Page.dc.html">Factions</a><a href="#">Updates</a>
+  </div>
+  <span class="nav-box">Leave</span>
+</nav>
+<div class="page"><div id="root"></div></div>
+
+<script type="text/babel">
+const { AlbescentSigil } = window.WorldZeroDesignSystem_019e22;
+
+// ── the join contract for Albescent (join-contract.json shape) ──
+const DATA = {
+  slug: "albescent", name: "Albescent", archetype: "vellum correspondence",
+  recruit: {
+    kicker: "A hand is extended —",
+    headline: "Take up the work",
+    pitch: "Albescent is an unranked order that keeps what others let slip. Attend the quiet duties, return them well, and leave no trace of yourself in the work. There is no leaderboard here worth minding.",
+    terms: [
+      { label: "toll of entry", value: "one duty, quietly kept" },
+      { label: "required skills", value: "none — only care" },
+      { label: "expected output", value: "accounts, entered plainly" },
+      { label: "standing", value: "unranked, by design" },
+    ],
+    perks: [
+      "A record that survives the keeper",
+      "Duties that ask nothing back",
+      "Your account, witnessed and inscribed",
+    ],
+    cta: { join: "Accept the order", joined: "You are of the Order" },
+  },
+  viewer: {
+    state: "prospective", eligible: true,
+    requirement: {
+      summary: "Attend, and be seen attending",
+      detail: "Keep taking up the quiet duties and returning them well. The Order extends its hand to those who tend the record without needing to be thanked.",
+      have: 2, needed: 3, unit: "duties returned",
+    },
+  },
+  social: { memberCount: 88, recentJoiners: [ { name: "Orin", initial: "O" }, { name: "Sel", initial: "S" }, { name: "Marsh", initial: "M" } ] },
+};
+
+const FACTIONS = [
+  { slug: "ua", name: "UA", color: "#c2541f", tagline: "the gilt salon" },
+  { slug: "wow", name: "Warriors of Whimsy", color: "#be185d", tagline: "a little magic" },
+  { slug: "snide", name: "S.N.I.D.E.", color: "#16a34a", tagline: "gleeful disorder" },
+  { slug: "ephemerists", name: "The Ephemerists", color: "#1d4f6e", tagline: "the long road" },
+  { slug: "singularity", name: "Singularity", color: "#2563eb", tagline: "the signal" },
+  { slug: "everymen", name: "The Everymen", color: "#c1272d", tagline: "the common good" },
+  { slug: "albescent", name: "Albescent", color: "#1c1c1a", tagline: "quiet witness" },
+];
+
+// ── the recruitment letter — a standing correspondence ──
+function AlRecruit({ data }) {
+  const [joined, setJoined] = React.useState(data.viewer.state === "member");
+  const eligible = data.viewer.eligible;
+  const r = data.recruit, req = data.viewer.requirement;
+  const serif = { fontFamily: "var(--al-font)", fontStyle: "italic", fontWeight: 300 };
+  const mono = { fontFamily: "var(--al-mono)" };
+  return (
+    <div style={{ position: "relative", maxWidth: 620, background: "#fff", border: "1px solid rgba(0,0,0,0.1)", boxShadow: "0 2px 24px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)", overflow: "hidden" }}>
+      <div style={{ position: "absolute", inset: 6, border: "1px solid rgba(0,0,0,0.055)", pointerEvents: "none" }} />
+      <div style={{ position: "relative", padding: "40px 46px 44px", textAlign: "center" }}>
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 20 }}>
+          <AlbescentSigil size={44} />
+        </div>
+        <div style={{ ...mono, fontSize: 9, letterSpacing: "0.34em", textTransform: "uppercase", color: "rgba(28,28,26,0.45)", marginBottom: 6 }}>Albescent</div>
+        <div style={{ ...mono, fontSize: 8, letterSpacing: "0.28em", textTransform: "uppercase", color: "rgba(28,28,26,0.3)", marginBottom: 24 }}>Faction no. 7 · enlistment · in confidence</div>
+        <div style={{ width: 54, height: 1, background: "rgba(0,0,0,0.12)", margin: "0 auto 24px" }} />
+        <div style={{ ...mono, fontSize: 8, letterSpacing: "0.2em", textTransform: "uppercase", color: "rgba(28,28,26,0.3)", marginBottom: 10 }}>{r.kicker}</div>
+        <h1 style={{ ...serif, fontWeight: 500, fontSize: 46, lineHeight: 1.05, color: "var(--al-text)", margin: "0 0 16px" }}>{r.headline}</h1>
+        <p style={{ ...serif, fontWeight: 400, fontSize: 17, lineHeight: 1.6, color: "rgba(28,28,26,0.6)", maxWidth: 440, margin: "0 auto 6px" }}>{r.pitch}</p>
+      </div>
+
+      {/* terms slip */}
+      <div style={{ position: "relative", margin: "0 46px", borderTop: "1px solid rgba(0,0,0,0.07)", padding: "22px 0 4px", textAlign: "left" }}>
+        <div style={{ ...mono, fontSize: 7, letterSpacing: "0.22em", textTransform: "uppercase", color: "rgba(28,28,26,0.3)", marginBottom: 14 }}>The terms, plainly</div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "2px 26px" }}>
+          {r.terms.map((t) => (
+            <div key={t.label} style={{ borderBottom: "1px solid rgba(0,0,0,0.055)", padding: "8px 0" }}>
+              <div style={{ ...mono, fontSize: 7, letterSpacing: "0.14em", textTransform: "uppercase", color: "rgba(28,28,26,0.38)" }}>{t.label}</div>
+              <div style={{ ...serif, fontSize: 18, color: "var(--al-text)", marginTop: 2 }}>{t.value}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop: 14, display: "flex", flexWrap: "wrap", gap: "4px 16px" }}>
+          {r.perks.map((p) => (
+            <div key={p} style={{ ...serif, fontSize: 14, color: "rgba(28,28,26,0.55)" }}>— {p}</div>
+          ))}
+        </div>
+      </div>
+
+      {/* enlist state */}
+      <div style={{ position: "relative", padding: "26px 46px 40px" }}>
+        {joined ? (
+          <div style={{ ...serif, fontSize: 22, color: "var(--al-text)", textAlign: "center" }}>{r.cta.joined}</div>
+        ) : eligible ? (
+          <div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap", justifyContent: "center" }}>
+            <button onClick={() => setJoined(true)} style={{ cursor: "pointer", border: "1px solid #1c1c1a", background: "#1c1c1a", color: "#f7f4ee", ...serif, fontWeight: 500, fontSize: 20, padding: "12px 30px" }}>{r.cta.join}</button>
+            <span style={{ ...serif, fontSize: 15, color: "rgba(28,28,26,0.5)" }}>you need not persuade us.</span>
+          </div>
+        ) : (
+          <div style={{ border: "1px solid rgba(0,0,0,0.09)", background: "#faf9f7", padding: "18px 20px" }}>
+            <div style={{ ...serif, fontSize: 22, color: "var(--al-text)", marginBottom: 6 }}>{req.summary}</div>
+            <div style={{ ...mono, fontSize: 9, lineHeight: 1.75, color: "rgba(28,28,26,0.5)", marginBottom: 12 }}>{req.detail}</div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <div style={{ flex: 1, height: 6, background: "rgba(0,0,0,0.06)", position: "relative" }}>
+                <div style={{ position: "absolute", inset: 0, width: `${(req.have / req.needed) * 100}%`, background: "rgba(28,28,26,0.55)" }} />
+              </div>
+              <span style={{ ...mono, fontSize: 8, letterSpacing: "0.08em", color: "rgba(28,28,26,0.44)", whiteSpace: "nowrap" }}>{req.have} / {req.needed} {req.unit}</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WrongPoster({ faction }) {
+  return (
+    <div style={{ maxWidth: 620, background: "#fff", border: "1px dashed rgba(0,0,0,0.14)", padding: "40px 40px", color: "rgba(28,28,26,0.5)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+        <span style={{ width: 22, height: 22, borderRadius: "50%", background: faction.color }} />
+        <div style={{ fontFamily: "var(--al-font)", fontStyle: "italic", fontWeight: 300, fontSize: 24, color: "var(--al-text)" }}>{faction.name} · enlistment</div>
+      </div>
+      <p style={{ fontFamily: "var(--al-mono)", fontSize: 9.5, lineHeight: 1.75, margin: "0 0 14px" }}>Each faction keeps its own recruitment surface. This is where the {faction.name} enlistment — "{faction.tagline}" — would stand. But you are reading Albescent's correspondence.</p>
+      <div style={{ fontFamily: "var(--al-font)", fontStyle: "italic", fontSize: 15, color: "var(--al-text)" }}>a quieter door, but yours to choose →</div>
+    </div>
+  );
+}
+
+function JoinPage() {
+  const [sel, setSel] = React.useState("albescent");
+  const current = FACTIONS.find((f) => f.slug === sel);
+  return (
+    <div>
+      <div className="kicker">World Zero · Enlistment · Choose Your Faction</div>
+      <div className="layout">
+        <div>{sel === "albescent" ? <AlRecruit data={DATA} /> : <WrongPoster faction={current} />}</div>
+        <div>
+          <div style={{ fontFamily: "var(--al-mono)", fontSize: 7.5, letterSpacing: "0.22em", textTransform: "uppercase", color: "rgba(28,28,26,0.3)", marginBottom: 10 }}>All factions</div>
+          <div className="chooser">
+            {FACTIONS.map((f) => (
+              <button key={f.slug} className={"fchip" + (sel === f.slug ? " sel" : "")} onClick={() => setSel(f.slug)}>
+                <span className="dot" style={{ background: f.color }} />
+                <span><span className="nm">{f.name}</span><span className="ds">{f.tagline}</span></span>
+                <span className="arrow">{sel === f.slug ? "•" : "→"}</span>
+              </button>
+            ))}
+          </div>
+          <p className="chooser-note">Selecting a faction opens its recruitment surface. Each faction keeps its own enlistment treatment — the shared chooser rail is the only common chrome.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<JoinPage />);
+</script>
+</body>
+</html>

--- a/docs/design/join/Ephemerists Join Screen.html
+++ b/docs/design/join/Ephemerists Join Screen.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Choose Your Faction · The Ephemerists</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="ephemerists.css" />
+<style>
+  html, body { margin: 0; }
+  body { background: var(--eph-vellum); color: var(--color-text-primary); font-family: var(--font-faction-codex); min-height: 100vh; }
+  a { color: inherit; text-decoration: none; }
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 22px; padding: 14px 34px;
+    background: var(--color-nav-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 25px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 20px; flex: 1; }
+  .nav-links a { font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-ctl { display: flex; align-items: center; gap: 14px; }
+  .nav-box { border: 1px solid var(--color-border-strong); padding: 6px 12px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-primary); }
+  .page { position: relative; z-index: 5; max-width: 1160px; margin: 0 auto; padding: 40px 34px 80px; }
+  .kicker { font-family: var(--font-faction-codex); font-style: italic; font-size: 12px; letter-spacing: 0.14em; color: var(--eph-muted); margin-bottom: 26px; text-align: center; }
+  .layout { display: grid; grid-template-columns: 1fr 320px; gap: 34px; align-items: start; }
+  @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+  .chooser { display: flex; flex-direction: column; gap: 8px; }
+  .fchip { display: flex; align-items: center; gap: 13px; padding: 11px 14px; border: 1px solid var(--eph-gold-deep);
+    background: color-mix(in srgb, var(--eph-vellum) 70%, transparent); cursor: pointer; text-align: left; font-family: var(--font-faction-codex); width: 100%; transition: transform 100ms; }
+  .fchip:hover { transform: translateX(2px); }
+  .fchip.sel { border-color: var(--eph-lapis); box-shadow: 3px 3px 0 var(--eph-lapis); }
+  .fchip .dot { width: 28px; height: 28px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 2px rgba(255,255,255,0.2); }
+  .fchip .nm { display: block; font-family: var(--font-faction-engraved); font-weight: 700; font-size: 13px; color: var(--eph-vellum-text); }
+  .fchip .ds { display: block; font-size: 9.5px; font-style: italic; color: var(--eph-muted); margin-top: 2px; }
+  .fchip .arrow { margin-left: auto; font-size: 14px; color: var(--eph-muted); }
+  .fchip.sel .arrow { color: var(--eph-lapis); }
+  .chooser-note { font-size: 10px; line-height: 1.6; font-style: italic; color: var(--eph-muted); margin-top: 10px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div class="eph-backdrop"></div>
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="#">Praxis</a><a href="#">Players</a>
+    <a href="Ephemerists Faction Page.dc.html">Factions</a><a href="#">Updates</a>
+  </div>
+  <div class="nav-ctl">
+    <button class="nav-box" id="theme-toggle" style="background:none;cursor:pointer;font:inherit;">Dark</button>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+<div class="page"><div id="root"></div></div>
+
+<script type="text/babel">
+const { EphemeristsSigil } = window.WorldZeroDesignSystem_019e22;
+
+// ── the join contract for the Ephemerists (join-contract.json shape) ──
+const DATA = {
+  slug: "ephemerists", name: "The Ephemerists", archetype: "illuminated codex",
+  recruit: {
+    kicker: "the codex lies open —",
+    headline: "Walk with the keepers",
+    pitch: "The Ephemerists are World Zero's cartographers of the impermanent. There are no members here, only keepers of the road. Take a survey, triangulate what you find, and file the truth before the world revises it.",
+    terms: [
+      { label: "toll of entry", value: "one truth, filed by hand" },
+      { label: "required skills", value: "none — only a steady eye" },
+      { label: "expected output", value: "surveys, sealed as praxis" },
+      { label: "season rank", value: "#5 · the road is long" },
+    ],
+    perks: [
+      "A codex that outlives the thing recorded",
+      "Surveys that turn a walk into a finding",
+      "Your praxis, sealed and weighed by the concordance",
+    ],
+    cta: { join: "Take the road ▸", joined: "✦ your name is in the codex" },
+  },
+  viewer: {
+    state: "prospective", eligible: true,
+    requirement: {
+      summary: "One survey away from the codex",
+      detail: "File a single triangulated finding and the codex opens. Keep walking — the record is made in the doing.",
+      have: 2, needed: 3, unit: "surveys filed",
+    },
+  },
+  social: { memberCount: 642, recentJoiners: [ { name: "Corvin", initial: "C" }, { name: "Lune", initial: "L" }, { name: "Bram", initial: "B" } ] },
+};
+
+const FACTIONS = [
+  { slug: "ua", name: "UA", color: "#c2541f", tagline: "the gilt salon" },
+  { slug: "wow", name: "Warriors of Whimsy", color: "#be185d", tagline: "a little magic" },
+  { slug: "snide", name: "S.N.I.D.E.", color: "#16a34a", tagline: "gleeful disorder" },
+  { slug: "ephemerists", name: "The Ephemerists", color: "#1d4f6e", tagline: "the long road" },
+  { slug: "singularity", name: "Singularity", color: "#2563eb", tagline: "the signal" },
+  { slug: "everymen", name: "The Everymen", color: "#c1272d", tagline: "the common good" },
+  { slug: "albescent", name: "Albescent", color: "#1c1c1a", tagline: "quiet witness" },
+];
+
+// ── the recruitment frontispiece — a codex leaf pinned open ──
+function EphRecruit({ data }) {
+  const [joined, setJoined] = React.useState(data.viewer.state === "member");
+  const eligible = data.viewer.eligible;
+  const r = data.recruit;
+  const req = data.viewer.requirement;
+  return (
+    <div style={{ position: "relative", maxWidth: 640, border: "2px solid var(--eph-gold)", background: "radial-gradient(120% 140% at 82% 0%, var(--eph-lapis), var(--eph-lapis-deep) 60%, #05131c 100%)", color: "var(--eph-parchment)", boxShadow: "0 0 0 3px var(--eph-vellum), 0 0 0 4px var(--eph-ink), 0 18px 44px rgba(20,40,50,.35)", overflow: "hidden" }}>
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.12, backgroundImage: "repeating-linear-gradient(0deg,var(--eph-parchment) 0 1px,transparent 1px 26px),repeating-linear-gradient(90deg,var(--eph-parchment) 0 1px,transparent 1px 26px)" }} />
+      <div style={{ height: 5, background: "var(--eph-gold)" }} />
+      <div style={{ position: "relative", padding: "30px 36px 34px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 18 }}>
+          <EphemeristsSigil size={22} color="var(--eph-gold-light)" />
+          <span style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 600, fontSize: 13, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--eph-gold-light)" }}>The Ephemerists</span>
+          <span style={{ marginLeft: "auto", fontFamily: "var(--font-faction-codex)", fontStyle: "italic", fontSize: 10, color: "rgba(241,232,207,.6)" }}>faction no. 5 · enlistment</span>
+        </div>
+        <div style={{ fontFamily: "var(--font-faction-codex)", fontStyle: "italic", fontSize: 13, color: "var(--eph-gold-light)", marginBottom: 6 }}>{r.kicker}</div>
+        <h1 style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 800, fontSize: 44, lineHeight: 0.94, margin: 0, color: "var(--eph-parchment)", textShadow: "2px 2px 0 var(--eph-lapis-deep)" }}>{r.headline}</h1>
+        <p style={{ fontFamily: "var(--font-faction-codex)", fontSize: 13, lineHeight: 1.65, color: "rgba(241,232,207,.9)", margin: "14px 0 0", maxWidth: 500 }}>{r.pitch}</p>
+
+        {/* the terms slip — a vellum leaf laid over the codex */}
+        <div style={{ position: "relative", background: "var(--eph-vellum)", color: "var(--eph-vellum-text)", padding: "16px 18px 18px", marginTop: 22, boxShadow: "0 6px 20px rgba(0,0,0,.35)", border: "1px solid var(--eph-ink)" }}>
+          <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 9, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--eph-rubric)", marginBottom: 10 }}>the toll, abbreviated</div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "4px 18px" }}>
+            {r.terms.map((t) => (
+              <div key={t.label} style={{ borderBottom: "1px dashed color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)", padding: "6px 0" }}>
+                <div style={{ fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--eph-muted)" }}>{t.label}</div>
+                <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 14, color: "var(--eph-vellum-text)", marginTop: 2 }}>{t.value}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: "4px 14px" }}>
+            {r.perks.map((p) => (
+              <div key={p} style={{ fontFamily: "var(--font-faction-codex)", fontSize: 10.5, color: "var(--eph-muted)", display: "flex", alignItems: "baseline", gap: 6 }}>
+                <span style={{ color: "var(--eph-lapis)" }}>✦</span>{p}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* the enlist state */}
+        <div style={{ marginTop: 22 }}>
+          {joined ? (
+            <div style={{ display: "inline-block", background: "var(--eph-gold)", color: "var(--eph-ink)", fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 15, letterSpacing: "0.08em", padding: "13px 24px" }}>{r.cta.joined}</div>
+          ) : eligible ? (
+            <div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+              <button onClick={() => setJoined(true)} style={{ cursor: "pointer", background: "var(--eph-gold)", color: "var(--eph-ink)", border: "1px solid var(--eph-gold-light)", fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 15, letterSpacing: "0.1em", padding: "14px 26px", boxShadow: "0 6px 16px rgba(20,50,70,.4)" }}>{r.cta.join}</button>
+              <span style={{ fontFamily: "var(--font-faction-codex)", fontStyle: "italic", fontSize: 12, color: "rgba(241,232,207,.7)" }}>the road forks often — that's the point.</span>
+            </div>
+          ) : (
+            <div style={{ background: "rgba(20,40,50,.4)", border: "1px solid rgba(212,171,85,.4)", padding: "16px 18px" }}>
+              <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 17, color: "var(--eph-gold-light)", marginBottom: 6 }}>{req.summary}</div>
+              <div style={{ fontFamily: "var(--font-faction-codex)", fontSize: 12.5, lineHeight: 1.6, color: "rgba(241,232,207,.85)", marginBottom: 12 }}>{req.detail}</div>
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <div style={{ flex: 1, height: 8, background: "rgba(241,232,207,.15)", position: "relative" }}>
+                  <div style={{ position: "absolute", inset: 0, width: `${(req.have / req.needed) * 100}%`, background: "var(--eph-gold)" }} />
+                </div>
+                <span style={{ fontFamily: "var(--font-faction-codex)", fontSize: 10, color: "var(--eph-gold-light)", whiteSpace: "nowrap" }}>{req.have} / {req.needed} {req.unit}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WrongPoster({ faction }) {
+  return (
+    <div style={{ maxWidth: 640, background: "color-mix(in srgb, var(--eph-vellum) 70%, transparent)", border: "2px dashed var(--eph-gold-deep)", padding: "40px 32px", color: "var(--eph-muted)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+        <span style={{ width: 26, height: 26, borderRadius: "50%", background: faction.color }} />
+        <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 24, color: "var(--eph-vellum-text)" }}>{faction.name} · enlistment</div>
+      </div>
+      <p style={{ fontFamily: "var(--font-faction-codex)", fontSize: 13, lineHeight: 1.6, margin: "0 0 16px" }}>
+        Each faction owns its own recruitment surface. This is where the {faction.name} poster — "{faction.tagline}" — would open. But you are reading the Ephemerists' codex.
+      </p>
+      <div style={{ fontFamily: "var(--font-faction-codex)", fontStyle: "italic", fontSize: 15, color: "var(--eph-rubric)" }}>a different road, but yours to choose →</div>
+    </div>
+  );
+}
+
+function JoinPage() {
+  const [sel, setSel] = React.useState("ephemerists");
+  const current = FACTIONS.find((f) => f.slug === sel);
+  return (
+    <div>
+      <div className="kicker">World Zero · Enlistment · Choose Your Faction</div>
+      <div className="layout">
+        <div>{sel === "ephemerists" ? <EphRecruit data={DATA} /> : <WrongPoster faction={current} />}</div>
+        <div>
+          <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 700, fontSize: 9.5, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--eph-rubric)", marginBottom: 10 }}>All factions</div>
+          <div className="chooser">
+            {FACTIONS.map((f) => (
+              <button key={f.slug} className={"fchip" + (sel === f.slug ? " sel" : "")} onClick={() => setSel(f.slug)}>
+                <span className="dot" style={{ background: f.color }} />
+                <span><span className="nm">{f.name}</span><span className="ds">{f.tagline}</span></span>
+                <span className="arrow">{sel === f.slug ? "✦" : "→"}</span>
+              </button>
+            ))}
+          </div>
+          <p className="chooser-note">Selecting a faction opens its recruitment surface. Each faction owns its own enlistment treatment — the shared chooser rail is the only common chrome.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<JoinPage />);
+const tog = document.getElementById("theme-toggle");
+tog.addEventListener("click", () => {
+  const dark = document.documentElement.getAttribute("data-theme") === "dark";
+  document.documentElement.setAttribute("data-theme", dark ? "light" : "dark");
+  tog.textContent = dark ? "Dark" : "Light";
+});
+</script>
+</body>
+</html>

--- a/docs/design/join/Everymen Join Screen.html
+++ b/docs/design/join/Everymen Join Screen.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Choose Your Faction</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="everymen.css" />
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body { background: var(--everymen-paper); color: var(--color-text-primary); font-family: var(--font-body); min-height: 100vh; }
+  a { color: inherit; text-decoration: none; }
+
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 30px; padding: 16px 34px;
+    background: var(--color-nav-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 25px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 22px; flex: 1; }
+  .nav-links a { font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--color-text-tertiary); padding-bottom: 3px; }
+  .nav-ctl { display: flex; align-items: center; gap: 16px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-box { border: 1px solid var(--color-border-strong); padding: 6px 12px; color: var(--color-text-primary); }
+  .nav-toggle { background: none; border: none; cursor: pointer; font: inherit; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); padding: 0; }
+  .nav-toggle:hover { color: var(--color-text-primary); }
+
+  .page { position: relative; z-index: 5; max-width: 1180px; margin: 0 auto; padding: 30px 34px 70px; }
+  .intro { text-align: center; margin-bottom: 28px; }
+  .intro .k { font-size: 11px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--everymen-red); }
+  .intro h1 { font-family: var(--font-accent); font-size: 52px; letter-spacing: 0.03em; margin: 6px 0 8px; color: var(--color-text-primary); }
+  .intro p { font-size: 13px; line-height: 1.6; color: var(--color-text-secondary); max-width: 540px; margin: 0 auto; }
+
+  .layout { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 26px; align-items: start; }
+  @media (max-width: 920px) { .layout { grid-template-columns: 1fr; } }
+
+  .recruit { position: relative; }
+
+  .chooser { display: flex; flex-direction: column; gap: 14px; }
+  .chooser .lbl { font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .factions { display: flex; flex-direction: column; gap: 9px; }
+  .fchip { display: flex; align-items: center; gap: 13px; padding: 12px 15px; border: 1px solid var(--color-border);
+    background: var(--color-bg-surface); border-radius: var(--radius-md,10px); cursor: pointer; text-align: left;
+    font-family: var(--font-body); width: 100%; transition: all 130ms; }
+  .fchip:hover { border-color: var(--color-border-strong); transform: translateX(2px); }
+  .fchip.sel { border-color: var(--everymen-ink); box-shadow: 0 0 0 2px var(--everymen-red); }
+  .fchip .dot { width: 30px; height: 30px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 2px rgba(255,255,255,0.25); }
+  .fchip .nm { display: block; font-size: 13px; font-weight: 700; color: var(--color-text-primary); line-height: 1.2; }
+  .fchip .ds { display: block; font-size: 10px; letter-spacing: 0.04em; color: var(--color-text-tertiary); margin-top: 3px; }
+  .fchip .arrow { margin-left: auto; font-size: 15px; color: var(--color-text-tertiary); }
+
+  .note { font-size: 10.5px; line-height: 1.6; color: var(--color-text-tertiary); margin-top: 4px; }
+  .note b { color: var(--everymen-red); }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="everymen-cards.jsx"></script>
+<script type="text/babel" src="everymen-faction.jsx"></script>
+<script type="text/babel" src="everymen-join.jsx"></script>
+</head>
+<body>
+<div class="em-backdrop"></div>
+
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="#">Praxis</a><a href="#">Players</a>
+    <a href="Everymen Faction Page.html">Factions</a><a href="Everymen Updates Page.html">Updates</a><a href="#">Admin</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Mod</span>
+    <button class="nav-toggle" id="theme-toggle">Dark</button>
+    <span>Pixie</span>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+
+<div class="page">
+  <div class="intro">
+    <div class="k">World Zero · Enlistment</div>
+    <h1>CHOOSE YOUR FACTION</h1>
+    <p>Eight ways to make your mark. This choice shapes your tasks, your people, and how your work gets seen. Take your time — then pick up the load.</p>
+  </div>
+
+  <div class="layout">
+    <div class="recruit" id="recruit"></div>
+    <div class="chooser">
+      <span class="lbl">All factions</span>
+      <div class="factions" id="factions"></div>
+      <p class="note">Showing the <b>Everymen</b> recruitment bill. Selecting another faction would swap this poster for theirs — each faction owns its own enlistment treatment.</p>
+    </div>
+  </div>
+</div>
+
+<script type="text/babel">
+  const { RecruitPoster } = window;
+
+  const FACTIONS = [
+    { c: "#7c3aed", nm: "Untitled Anonymous", ds: "Mystery · misdirection" },
+    { c: "#ca8a04", nm: "The Analog", ds: "Craft · the physical world" },
+    { c: "#be185d", nm: "Gestalt", ds: "Systems · the big picture" },
+    { c: "#16a34a", nm: "S.N.I.D.E.", ds: "Wit · sharp edges" },
+    { c: "#0e7490", nm: "The Journeymen", ds: "Mastery · the long road" },
+    { c: "#2563eb", nm: "Singularity", ds: "Futures · acceleration" },
+    { c: "#c2410c", nm: "UA Masters", ds: "Legacy · the inner circle" },
+    { c: "var(--everymen-red)", nm: "The Everymen", ds: "Graft · down-to-earth", em: true },
+  ];
+
+  function Chooser() {
+    const [sel, setSel] = React.useState("The Everymen");
+    return (
+      <React.Fragment>
+        {FACTIONS.map((f) => (
+          <button key={f.nm} className={"fchip" + (sel === f.nm ? " sel" : "")} onClick={() => setSel(f.nm)}>
+            <span className="dot" style={{ background: f.c }}></span>
+            <span>
+              <span className="nm">{f.nm}</span>
+              <span className="ds">{f.ds}</span>
+            </span>
+            <span className="arrow">{sel === f.nm ? "●" : "→"}</span>
+          </button>
+        ))}
+      </React.Fragment>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById("recruit")).render(<RecruitPoster />);
+  ReactDOM.createRoot(document.getElementById("factions")).render(<Chooser />);
+
+  const tog = document.getElementById("theme-toggle");
+  tog.addEventListener("click", () => {
+    const dark = document.documentElement.getAttribute("data-theme") === "dark";
+    document.documentElement.setAttribute("data-theme", dark ? "light" : "dark");
+    tog.textContent = dark ? "Dark" : "Light";
+  });
+</script>
+</body>
+</html>

--- a/docs/design/join/README.md
+++ b/docs/design/join/README.md
@@ -1,0 +1,41 @@
+# Join / recruitment designs — vendored from the World Zero Design System
+
+Vendored 2026-07-03 from the cloud "World Zero Design System" Claude Design project
+(projectId `019e221c-7853-7530-a934-7d3b2b7c8b43`). These feed the join-flow work:
+issue #347 (membership moves to the faction detail page), #395 (Albescent
+invitation entry flow), and the ready-for-human design issue #243 (faction
+invitation letter pop-ups).
+
+## What's here
+
+- `join-contract.json` — the canonical join/recruitment data contract (fetched
+  fresh 2026-07-03). One shape, seven skins. Its `viewer` sub-shape is shared
+  with `faction-contract.json` so one resolver drives both the full enlistment
+  screen and the in-page join block on a faction page.
+- `Albescent Join Screen.html` — "Take up the work" correspondence letter
+  (contract-shaped, fresh). **This is the invitation card #395 uses.**
+- `Warriors of Whimsy Join Screen.html` — join.exe pinned corkboard flyer
+  (contract-shaped, fresh).
+- `SNIDE Join Screen.html` — ransom-note recruitment demand. ⚠️ STALE ROSTER:
+  its inline `FACTIONS` list predates the faction renames (Gestalt/Journeymen/
+  UA Masters) and it does not consume the join contract. The *poster itself*
+  (SnideRecruitPoster) is the canonical SNIDE treatment; ignore its chooser rail.
+
+- `Everymen Join Screen.html` — union enlistment poster (from the 2026-06-26
+  local export of the cloud project; may lag the cloud copy slightly).
+
+## Not vendored (exist in the cloud project, fetch if needed)
+
+- `templates/ephemerists/Ephemerists Join Screen.html`
+- `templates/singularity/Singularity Join Screen.html`
+
+Same pattern as the above: one in-voice recruit poster per faction rendering
+from the join contract, plus a shared chooser rail. For repo builds, compose the
+faction's established repo archetype (task-card / faction-hero atoms) with the
+contract fields if the vendored file isn't available.
+
+## Design gap (flagged for #200 / #243)
+
+There is **no UA Join Screen** in the design system — UA is the only faction
+without a recruitment/enlistment design. The UA join popup needs a design round
+(gilt-salon "letter of matriculation") before UA's join flow can match the others.

--- a/docs/design/join/README.md
+++ b/docs/design/join/README.md
@@ -23,11 +23,10 @@ invitation letter pop-ups).
 
 - `Everymen Join Screen.html` — union enlistment poster (from the 2026-06-26
   local export of the cloud project; may lag the cloud copy slightly).
-
-## Not vendored (exist in the cloud project, fetch if needed)
-
-- `templates/ephemerists/Ephemerists Join Screen.html`
-- `templates/singularity/Singularity Join Screen.html`
+- `Ephemerists Join Screen.html` — codex-leaf frontispiece "Walk with the
+  keepers" (contract-shaped, fresh).
+- `Singularity Join Screen.html` — terminal enlist printout "JOIN THE ARRAY"
+  (contract-shaped, fresh, always-dark).
 
 Same pattern as the above: one in-voice recruit poster per faction rendering
 from the join contract, plus a shared chooser rail. For repo builds, compose the

--- a/docs/design/join/SNIDE Join Screen.html
+++ b/docs/design/join/SNIDE Join Screen.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Choose Your Faction · S.N.I.D.E.</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="snide.css" />
+<style>
+  html, body { margin: 0; }
+  body { background: #efece3; color: var(--color-text-primary); font-family: var(--font-body); min-height: 100vh; }
+  [data-theme="dark"] body { background: #141310; }
+  a { color: inherit; text-decoration: none; }
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 30px; padding: 16px 34px;
+    background: var(--color-nav-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 25px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 22px; flex: 1; }
+  .nav-links a { font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-ctl { display: flex; align-items: center; gap: 16px; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); }
+  .nav-box { border: 1px solid var(--color-border-strong); padding: 6px 12px; color: var(--color-text-primary); }
+  .nav-toggle { background: none; border: none; cursor: pointer; font: inherit; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-text-tertiary); padding: 0; }
+
+  .page { position: relative; z-index: 5; max-width: 1180px; margin: 0 auto; padding: 40px 34px 80px; }
+
+  .kicker { font-family: var(--f-cond); font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase;
+    color: var(--color-text-tertiary); margin-bottom: 28px; text-align: center; }
+  .layout { display: grid; grid-template-columns: 1fr 340px; gap: 34px; align-items: start; }
+  @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+
+  /* faction chooser (neutral right-side chrome) */
+  .chooser { display: flex; flex-direction: column; gap: 8px; }
+  .fchip { display: flex; align-items: center; gap: 13px; padding: 11px 14px;
+    border: 1px solid var(--color-border); background: var(--color-bg-surface); cursor: pointer;
+    text-align: left; font-family: var(--font-body); width: 100%; transition: transform 100ms; }
+  .fchip:hover { border-color: var(--color-border-strong); transform: translateX(2px); }
+  .fchip.sel { border-color: var(--snide-green); box-shadow: 3px 3px 0 var(--snide-green); }
+  .fchip .dot { width: 28px; height: 28px; border-radius: 50%; flex-shrink: 0; }
+  .fchip .nm { display: block; font-size: 12px; font-weight: 700; color: var(--color-text-primary); }
+  .fchip .ds { display: block; font-size: 9.5px; color: var(--color-text-tertiary); margin-top: 2px; }
+  .fchip .arrow { margin-left: auto; font-size: 14px; color: var(--color-text-tertiary); }
+  .fchip.sel .arrow { color: var(--snide-green); font-family: var(--f-marker); }
+  .chooser-note { font-size: 10px; line-height: 1.6; color: var(--color-text-tertiary); margin-top: 10px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="snide-cards.jsx"></script>
+<script type="text/babel" src="snide-faction.jsx"></script>
+<script type="text/babel">
+const { Ransom, SnideSigil } = window;
+
+/* SNIDE ransom-note recruitment demand */
+function SnideRecruitPoster({ onJoin }) {
+  const [joined, setJoined] = React.useState(false);
+  const ink = "var(--ink)";
+  const TORN_TOP = "polygon(0 100%,3% 0,7% 70%,11% 10%,15% 80%,19% 20%,23% 90%,27% 5%,31% 75%,35% 15%,39% 95%,43% 20%,47% 70%,51% 0,55% 85%,59% 20%,63% 80%,67% 10%,71% 90%,75% 20%,79% 80%,83% 5%,87% 70%,91% 20%,95% 85%,100% 0,100% 100%)";
+  const TORN_BOT = "polygon(0 0,100% 0,97% 100%,93% 30%,89% 90%,85% 10%,81% 80%,77% 20%,73% 100%,68% 25%,63% 85%,58% 10%,53% 90%,48% 20%,43% 80%,38% 5%,33% 95%,28% 25%,23% 80%,18% 10%,13% 90%,8% 20%,4% 75%,0 10%)";
+
+  const FACTS = [
+    { label: "membership fee", val: "none (we're broke)" },
+    { label: "required skills", val: "none (we're serious)" },
+    { label: "expected output", val: "whatever. honestly." },
+    { label: "season rank", val: "last. always last." },
+  ];
+
+  return (
+    <div style={{ position: "relative", maxWidth: 600 }}>
+      {/* outer demand envelope — photocopier black */}
+      <div style={{ position: "relative", background: ink, padding: "28px 28px 32px", overflow: "hidden",
+        boxShadow: "8px 10px 0 rgba(0,0,0,0.35)", transform: "rotate(-1deg)" }}>
+        <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(182,255,46,0.06)", pointerEvents: "none" }} />
+        <div style={{ position: "absolute", inset: 0, filter: "url(#snide-grain)", opacity: 0.35, mixBlendMode: "screen", pointerEvents: "none" }} />
+
+        {/* torn acid strip top */}
+        <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: 8, background: "var(--acid)", clipPath: TORN_BOT }} />
+        {/* torn acid strip bottom */}
+        <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: 8, background: "var(--acid)", clipPath: TORN_TOP }} />
+
+        {/* masthead */}
+        <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+            <SnideSigil size={22} color="var(--acid)" />
+            <span style={{ fontFamily: "var(--f-cond)", fontSize: 15, letterSpacing: "0.18em", color: "var(--acid)" }}>S.N.I.D.E.</span>
+          </div>
+          <span style={{ fontFamily: "var(--font-body)", fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: "#6b6d60" }}>official demand · do not ignore</span>
+        </div>
+
+        {/* the demand */}
+        <div style={{ position: "relative", marginBottom: 18 }}>
+          <div style={{ fontFamily: "var(--f-marker)", fontSize: 14, color: "var(--pink)", marginBottom: 10, transform: "rotate(-1deg)" }}>attention: you — yes, you</div>
+          <div style={{ marginBottom: 12 }}><Ransom text="WE NEED YOU" size={34} /></div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 12, lineHeight: 1.6, color: "#d4d0c0", marginTop: 14, maxWidth: 480 }}>
+            The Society for Nihilistic Intent &amp; Disruptive Efforts is expanding operations.
+            This is not an invitation. It's more of a strongly-worded suggestion.
+            <span style={{ fontFamily: "var(--f-marker)", color: "var(--pink)", fontSize: 14, marginLeft: 5 }}>join us, or don't — see if we care.</span>
+          </div>
+        </div>
+
+        {/* cream "terms" slip taped over the demand */}
+        <div style={{ position: "relative", background: "var(--paper)", color: ink, padding: "14px 16px 16px",
+          transform: "rotate(1.2deg)", boxShadow: "3px 4px 0 rgba(0,0,0,0.35)", marginBottom: 22 }}>
+          <div className="ht-dots" style={{ position: "absolute", inset: 0, color: "rgba(20,17,11,0.05)", pointerEvents: "none" }} />
+          <div className="tape" style={{ top: -9, left: "50%", marginLeft: -28, width: 56, height: 17, transform: "rotate(-3deg)" }} />
+          <div style={{ position: "relative", fontFamily: "var(--f-type)", fontSize: 10.5, letterSpacing: "0.02em", color: "#3a342a", marginBottom: 3, textTransform: "uppercase", letterSpacing: "0.12em" }}>terms &amp; conditions (abbreviated)</div>
+          <div style={{ position: "relative", display: "grid", gridTemplateColumns: "1fr 1fr", gap: "4px 16px", marginTop: 10 }}>
+            {FACTS.map(f => (
+              <div key={f.label} style={{ borderBottom: "1px dashed rgba(20,17,11,0.2)", paddingBottom: 6, paddingTop: 6 }}>
+                <div style={{ fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "#8a7c6a" }}>{f.label}</div>
+                <div style={{ fontFamily: "var(--f-cond)", fontSize: 15, color: ink, marginTop: 2 }}>{f.val}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ position: "relative", marginTop: 12, fontFamily: "var(--f-marker)", fontSize: 13, color: "var(--snide-accent)", transform: "rotate(-1deg)" }}>by clicking below you agree to nothing in particular</div>
+        </div>
+
+        {/* CTA */}
+        <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap" }}>
+          {!joined ? (
+            <button onClick={() => { setJoined(true); if (onJoin) onJoin(); }} style={{
+              cursor: "pointer", background: "var(--pink)", color: "#fff",
+              border: "2px solid #fff", fontFamily: "var(--f-black)", fontSize: 20,
+              letterSpacing: "0.04em", padding: "15px 28px", transform: "rotate(-1.5deg)",
+              boxShadow: "5px 6px 0 rgba(0,0,0,0.5)" }}>★ YEAH I'M IN ★</button>
+          ) : (
+            <div style={{ background: "var(--snide-green)", color: "#fff", fontFamily: "var(--f-black)",
+              fontSize: 20, letterSpacing: "0.04em", padding: "15px 28px", transform: "rotate(-1.5deg)",
+              boxShadow: "5px 6px 0 rgba(0,0,0,0.5)" }}>✓ WELCOME TO THE CHAOS</div>
+          )}
+          <div style={{ fontFamily: "var(--f-marker)", fontSize: 13, color: "#8a9080", transform: "rotate(-1deg)" }}>
+            {joined ? "we never doubted you (we did)" : "or don't. this poster self-destructs in 9 minutes."}
+          </div>
+        </div>
+      </div>
+      {/* tape corners on the outer poster */}
+      <div className="tape" style={{ top: -9, left: 22, width: 60, height: 20, transform: "rotate(-9deg)" }} />
+      <div className="tape" style={{ top: -7, right: 38, width: 60, height: 20, transform: "rotate(7deg)" }} />
+    </div>
+  );
+}
+
+const FACTIONS = [
+  { c: "#7c3aed", nm: "Untitled Anonymous",  ds: "Mystery · misdirection" },
+  { c: "#ca8a04", nm: "The Analog",          ds: "Craft · the physical world" },
+  { c: "#be185d", nm: "Gestalt",             ds: "Systems · the big picture" },
+  { c: "#16a34a", nm: "S.N.I.D.E.",          ds: "Wit · sharp edges" },
+  { c: "#0e7490", nm: "The Journeymen",      ds: "Mastery · the long road" },
+  { c: "#2563eb", nm: "Singularity",         ds: "Futures · acceleration" },
+  { c: "#c2410c", nm: "UA Masters",          ds: "Legacy · the inner circle" },
+];
+
+/* wrong-faction decoy poster (grey-toned placeholder) */
+function WrongPoster({ name }) {
+  return (
+    <div style={{ maxWidth: 600, background: "var(--color-bg-surface)", border: "2px dashed var(--color-border-strong)",
+      padding: "40px 32px", color: "var(--color-text-tertiary)", fontFamily: "var(--font-body)" }}>
+      <div style={{ fontFamily: "var(--f-cond)", fontSize: 28, letterSpacing: "0.08em", color: "var(--color-text-secondary)", marginBottom: 12 }}>
+        {name.toUpperCase()} RECRUITMENT POSTER
+      </div>
+      <p style={{ fontSize: 12, lineHeight: 1.6, margin: "0 0 20px" }}>
+        Each faction owns its enlistment treatment. This is where the {name} poster would live.
+        But you're here, looking at S.N.I.D.E.'s page.
+      </p>
+      <div style={{ fontFamily: "var(--f-marker)", fontSize: 18, color: "var(--pink)", transform: "rotate(-1.5deg)" }}>
+        wrong choice, but it's your life →
+      </div>
+    </div>
+  );
+}
+
+function JoinPage() {
+  const [sel, setSel] = React.useState("S.N.I.D.E.");
+  return (
+    <div>
+      <div className="kicker">World Zero · Enlistment · Choose Your Faction</div>
+      <div className="layout">
+        <div>
+          {sel === "S.N.I.D.E." ? <SnideRecruitPoster /> : <WrongPoster name={sel} />}
+        </div>
+        <div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: 9.5, letterSpacing: "0.16em", textTransform: "uppercase",
+            color: "var(--color-text-tertiary)", marginBottom: 10 }}>All factions</div>
+          <div className="chooser">
+            {FACTIONS.map(f => (
+              <button key={f.nm} className={"fchip" + (sel === f.nm ? " sel" : "")} onClick={() => setSel(f.nm)}>
+                <span className="dot" style={{ background: f.c, boxShadow: "inset 0 0 0 2px rgba(255,255,255,0.2)" }} />
+                <span><span className="nm">{f.nm}</span><span className="ds">{f.ds}</span></span>
+                <span className="arrow">{sel === f.nm ? "★" : "→"}</span>
+              </button>
+            ))}
+          </div>
+          <p className="chooser-note">Selecting a faction shows its recruitment poster. Each faction owns its own enlistment treatment — swapping to another faction would replace the S.N.I.D.E. ransom note with theirs.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<JoinPage />);
+const tog = document.getElementById("theme-toggle");
+tog.addEventListener("click", () => {
+  const dark = document.documentElement.getAttribute("data-theme") === "dark";
+  document.documentElement.setAttribute("data-theme", dark ? "light" : "dark");
+  tog.textContent = dark ? "Dark" : "Light";
+});
+</script>
+</head>
+<body>
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <filter id="snide-grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch" result="n"/><feColorMatrix in="n" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 -1.7 1.05"/></filter>
+  <filter id="snide-spray"><feTurbulence type="fractalNoise" baseFrequency="0.62" numOctaves="2" seed="4" result="t"/><feDisplacementMap in="SourceGraphic" in2="t" scale="3.4" xChannelSelector="R" yChannelSelector="G"/></filter>
+</defs></svg>
+<div class="snide-backdrop"></div>
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="#">Praxis</a>
+    <a href="#">Players</a><a href="SNIDE Faction Page.dc.html">Factions</a><a href="#">Updates</a>
+  </div>
+  <div class="nav-ctl">
+    <span class="nav-box">Mod</span>
+    <button class="nav-toggle" id="theme-toggle">Dark</button>
+    <span class="nav-box">Logout</span>
+  </div>
+</nav>
+<div class="page"><div id="root"></div></div>
+</body>
+</html>

--- a/docs/design/join/Singularity Join Screen.html
+++ b/docs/design/join/Singularity Join Screen.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Choose Your Faction · Singularity</title>
+<link rel="stylesheet" href="../../styles.css" />
+<link rel="stylesheet" href="singularity.css" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" />
+<style>
+  html, body { margin: 0; }
+  body { background: #07090c; color: var(--sg-phosphor); font-family: var(--sg-mono); min-height: 100vh; }
+  a { color: inherit; text-decoration: none; }
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 24px; padding: 14px 32px;
+    background: rgba(5,15,8,0.92); backdrop-filter: blur(10px); border-bottom: 1px solid var(--sg-border); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 500; font-size: 24px; line-height: 1; color: var(--sg-phosphor);
+    border-bottom: 3px solid; padding-bottom: 2px; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; }
+  .nav-links { display: flex; gap: 20px; flex: 1; }
+  .nav-links a { font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(96,165,250,0.45); }
+  .nav-box { border: 1px solid var(--sg-border); padding: 5px 11px; font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--sg-phosphor); }
+  .page { position: relative; z-index: 5; max-width: 1160px; margin: 0 auto; padding: 40px 32px 80px; }
+  .kicker { font-size: 8px; letter-spacing: 0.28em; text-transform: uppercase; color: rgba(74,222,128,0.5); margin-bottom: 26px; text-align: center; }
+  .layout { display: grid; grid-template-columns: 1fr 320px; gap: 34px; align-items: start; }
+  @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+  .chooser { display: flex; flex-direction: column; gap: 8px; }
+  .fchip { display: flex; align-items: center; gap: 13px; padding: 11px 14px; border: 1px solid var(--sg-border);
+    background: var(--sg-void); cursor: pointer; text-align: left; width: 100%; transition: transform 100ms; }
+  .fchip:hover { transform: translateX(2px); border-color: var(--sg-border-hard); }
+  .fchip.sel { border-color: var(--sg-phosphor); box-shadow: 0 0 14px rgba(74,222,128,0.2); }
+  .fchip .dot { width: 26px; height: 26px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 2px rgba(255,255,255,0.15); }
+  .fchip .nm { display: block; font-size: 12px; letter-spacing: 0.04em; color: var(--sg-phosphor); }
+  .fchip .ds { display: block; font-size: 8px; letter-spacing: 0.06em; color: rgba(96,165,250,0.5); margin-top: 3px; text-transform: uppercase; }
+  .fchip .arrow { margin-left: auto; font-size: 13px; color: rgba(96,165,250,0.5); }
+  .fchip.sel .arrow { color: var(--sg-phosphor); }
+  .chooser-note { font-size: 8.5px; line-height: 1.7; color: rgba(96,165,250,0.4); margin-top: 10px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<div class="sg-backdrop"></div>
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="#">Praxis</a><a href="#">Players</a>
+    <a href="Singularity Faction Page.dc.html">Factions</a><a href="#">Updates</a>
+  </div>
+  <span class="nav-box">Logout</span>
+</nav>
+<div class="page"><div id="root"></div></div>
+
+<script type="text/babel">
+const { SingularitySigil } = window.WorldZeroDesignSystem_019e22;
+
+// ── the join contract for Singularity (join-contract.json shape) ──
+const DATA = {
+  slug: "singularity", name: "Singularity", archetype: "terminal printout",
+  recruit: {
+    kicker: "> ACCESS GRANTED",
+    headline: "JOIN THE ARRAY",
+    pitch: "Singularity is the faction that thinks the future already happened and everyone else is buffering. Take a node, run protocols, seal outputs, and cast signal into the consensus until the pattern verifies.",
+    terms: [
+      { label: "membership fee", value: "none · bring compute" },
+      { label: "required skills", value: "none · only rigor" },
+      { label: "expected output", value: "sealed, verified protocols" },
+      { label: "season rank", value: "#4 · arrays online" },
+    ],
+    perks: [
+      "A consensus array that verifies your work",
+      "Protocols that turn noise into signal",
+      "Your praxis, sealed and cast on by the array",
+    ],
+    cta: { join: "> CONNECT", joined: "◈ NODE ONLINE" },
+  },
+  viewer: {
+    state: "prospective", eligible: true,
+    requirement: {
+      summary: "One protocol from access",
+      detail: "Seal a single verified output and the array opens your node. Keep casting — access is earned in signal, not application.",
+      have: 3, needed: 4, unit: "protocols sealed",
+    },
+  },
+  social: { memberCount: 894, recentJoiners: [ { name: "Cipher", initial: "C" }, { name: "Echo", initial: "E" }, { name: "Wren", initial: "W" } ] },
+};
+
+const FACTIONS = [
+  { slug: "ua", name: "UA", color: "#c2541f", tagline: "the gilt salon" },
+  { slug: "wow", name: "Warriors of Whimsy", color: "#be185d", tagline: "a little magic" },
+  { slug: "snide", name: "S.N.I.D.E.", color: "#16a34a", tagline: "gleeful disorder" },
+  { slug: "ephemerists", name: "The Ephemerists", color: "#1d4f6e", tagline: "the long road" },
+  { slug: "singularity", name: "Singularity", color: "#2563eb", tagline: "the signal" },
+  { slug: "everymen", name: "The Everymen", color: "#c1272d", tagline: "the common good" },
+  { slug: "albescent", name: "Albescent", color: "#1c1c1a", tagline: "quiet witness" },
+];
+
+// ── the recruitment printout — a terminal boot slip ──
+function SgRecruit({ data }) {
+  const [joined, setJoined] = React.useState(data.viewer.state === "member");
+  const eligible = data.viewer.eligible;
+  const r = data.recruit, req = data.viewer.requirement;
+  return (
+    <div style={{ position: "relative", maxWidth: 640, background: "#050f08", border: "1px solid #2563eb", boxShadow: "0 0 0 1px rgba(37,99,235,0.12), 0 24px 60px -28px rgba(0,0,0,0.85), 0 0 40px -20px rgba(74,222,128,0.06)", overflow: "hidden" }}>
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", background: "repeating-linear-gradient(to bottom,transparent,transparent 2px,rgba(74,222,128,0.014) 2px,rgba(74,222,128,0.014) 4px)" }} />
+      <div style={{ display: "flex", alignItems: "center", gap: 10, background: "var(--sg-signal)", padding: "9px 16px" }}>
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: "#fff", opacity: 0.9 }} />
+        <span style={{ fontSize: 10, letterSpacing: "0.2em", color: "rgba(255,255,255,0.92)", textTransform: "uppercase" }}>singularity@worldzero:~$ ./enlist</span>
+      </div>
+      <div style={{ position: "relative", padding: "30px 34px 34px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
+          <SingularitySigil size={20} color="#4ade80" />
+          <span style={{ fontSize: 10, letterSpacing: "0.2em", textTransform: "uppercase", color: "#4ade80" }}>Singularity</span>
+          <span style={{ marginLeft: "auto", fontSize: 8, letterSpacing: "0.1em", color: "rgba(96,165,250,0.5)" }}>faction no. 6 · enlistment</span>
+        </div>
+        <div style={{ fontSize: 8, letterSpacing: "0.2em", color: "rgba(96,165,250,0.55)", marginBottom: 8 }}>{r.kicker}</div>
+        <h1 style={{ fontSize: 42, lineHeight: 1.02, letterSpacing: "0.03em", margin: 0, color: "#4ade80" }}>{r.headline}<span style={{ display: "inline-block", width: 10, height: 32, background: "#4ade80", marginLeft: 5, verticalAlign: "middle" }} /></h1>
+        <p style={{ fontSize: 11, lineHeight: 1.75, color: "rgba(74,222,128,0.6)", margin: "14px 0 0", maxWidth: 500 }}>{r.pitch}</p>
+
+        {/* terms slip */}
+        <div style={{ position: "relative", border: "1px solid rgba(37,99,235,0.4)", background: "rgba(37,99,235,0.06)", padding: "16px 18px 18px", marginTop: 22 }}>
+          <div style={{ fontSize: 7, letterSpacing: "0.2em", textTransform: "uppercase", color: "rgba(74,222,128,0.45)", marginBottom: 11 }}>&gt; cat terms.txt</div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "4px 18px" }}>
+            {r.terms.map((t) => (
+              <div key={t.label} style={{ borderBottom: "1px solid rgba(37,99,235,0.18)", padding: "6px 0" }}>
+                <div style={{ fontSize: 7, letterSpacing: "0.14em", textTransform: "uppercase", color: "rgba(96,165,250,0.5)" }}>{t.label}</div>
+                <div style={{ fontSize: 13, color: "#86efac", marginTop: 3 }}>{t.value}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: "4px 14px" }}>
+            {r.perks.map((p) => (
+              <div key={p} style={{ fontSize: 9, color: "rgba(74,222,128,0.55)", display: "flex", alignItems: "baseline", gap: 6 }}><span style={{ color: "var(--sg-signal-bright)" }}>◈</span>{p}</div>
+            ))}
+          </div>
+        </div>
+
+        {/* enlist state */}
+        <div style={{ marginTop: 22 }}>
+          {joined ? (
+            <div style={{ display: "inline-block", background: "#4ade80", color: "#050f08", fontSize: 13, letterSpacing: "0.14em", textTransform: "uppercase", padding: "13px 24px" }}>{r.cta.joined}</div>
+          ) : eligible ? (
+            <div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+              <button onClick={() => setJoined(true)} style={{ cursor: "pointer", background: "#4ade80", color: "#050f08", border: "none", fontFamily: "var(--sg-mono)", fontSize: 13, letterSpacing: "0.14em", textTransform: "uppercase", padding: "14px 26px", boxShadow: "0 0 16px rgba(74,222,128,0.35)" }}>{r.cta.join}</button>
+              <span style={{ fontSize: 9, color: "rgba(96,165,250,0.6)" }}>the threshold is already behind us.</span>
+            </div>
+          ) : (
+            <div style={{ border: "1px solid rgba(37,99,235,0.4)", background: "rgba(37,99,235,0.06)", padding: "16px 18px" }}>
+              <div style={{ fontSize: 16, color: "#4ade80", marginBottom: 6 }}>{req.summary}</div>
+              <div style={{ fontSize: 10, lineHeight: 1.7, color: "rgba(74,222,128,0.6)", marginBottom: 12 }}>{req.detail}</div>
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <div style={{ flex: 1, height: 8, background: "rgba(37,99,235,0.18)", position: "relative" }}>
+                  <div style={{ position: "absolute", inset: 0, width: `${(req.have / req.needed) * 100}%`, background: "#4ade80" }} />
+                </div>
+                <span style={{ fontSize: 8, color: "rgba(96,165,250,0.6)", whiteSpace: "nowrap", letterSpacing: "0.08em" }}>{req.have}/{req.needed} {req.unit}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WrongPoster({ faction }) {
+  return (
+    <div style={{ maxWidth: 640, background: "var(--sg-void)", border: "1px dashed var(--sg-border-hard)", padding: "40px 32px", color: "rgba(96,165,250,0.55)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+        <span style={{ width: 24, height: 24, borderRadius: "50%", background: faction.color }} />
+        <div style={{ fontSize: 22, color: "var(--sg-phosphor)", textTransform: "uppercase", letterSpacing: "0.04em" }}>{faction.name} · enlistment</div>
+      </div>
+      <p style={{ fontSize: 10, lineHeight: 1.7, margin: "0 0 16px" }}>Each faction owns its own recruitment surface. This is where the {faction.name} enlistment — "{faction.tagline}" — would render. But you're on Singularity's terminal.</p>
+      <div style={{ fontSize: 11, color: "var(--sg-signal-bright)", letterSpacing: "0.06em" }}>&gt; switch nodes, but choose deliberately →</div>
+    </div>
+  );
+}
+
+function JoinPage() {
+  const [sel, setSel] = React.useState("singularity");
+  const current = FACTIONS.find((f) => f.slug === sel);
+  return (
+    <div>
+      <div className="kicker">World Zero · Enlistment · Choose Your Faction</div>
+      <div className="layout">
+        <div>{sel === "singularity" ? <SgRecruit data={DATA} /> : <WrongPoster faction={current} />}</div>
+        <div>
+          <div style={{ fontSize: 8, letterSpacing: "0.2em", textTransform: "uppercase", color: "rgba(74,222,128,0.45)", marginBottom: 10 }}>&gt; all factions</div>
+          <div className="chooser">
+            {FACTIONS.map((f) => (
+              <button key={f.slug} className={"fchip" + (sel === f.slug ? " sel" : "")} onClick={() => setSel(f.slug)}>
+                <span className="dot" style={{ background: f.color }} />
+                <span><span className="nm">{f.name}</span><span className="ds">{f.tagline}</span></span>
+                <span className="arrow">{sel === f.slug ? "◈" : "›"}</span>
+              </button>
+            ))}
+          </div>
+          <p className="chooser-note">Selecting a faction opens its recruitment surface. Each faction owns its own enlistment treatment — the shared chooser rail is the only common chrome.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<JoinPage />);
+document.documentElement.setAttribute("data-theme", "dark");
+</script>
+</body>
+</html>

--- a/docs/design/join/Warriors of Whimsy Join Screen.html
+++ b/docs/design/join/Warriors of Whimsy Join Screen.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>World Zero — Choose Your Faction · Warriors of Whimsy</title>
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  html, body { margin: 0; }
+  body { min-height: 100vh; font-family: var(--font-body); color: var(--gestalt-ink);
+    background: var(--gestalt-panel-bg);
+    background-image: radial-gradient(40% 36% at 4% 6%, var(--gestalt-pink-lt), transparent 70%), radial-gradient(42% 38% at 98% 96%, var(--gestalt-title-from), transparent 70%); }
+  a { color: inherit; text-decoration: none; }
+  button { font: inherit; cursor: pointer; }
+
+  .nav { position: relative; z-index: 10; display: flex; align-items: center; gap: 26px; padding: 14px 30px;
+    background: var(--gestalt-nav-bg, rgba(255,255,255,0.7)); backdrop-filter: blur(8px); border-bottom: 1px solid var(--gestalt-border-soft); }
+  .wordmark { font-family: var(--font-display); font-style: italic; font-weight: 600; font-size: 22px; line-height: 1;
+    border-bottom: 3px solid; border-image: linear-gradient(90deg,#fbbf24,#be185d,#4f46e5,#0e7490,#16a34a,#f97316) 1; padding-bottom: 2px; }
+  .nav-links { display: flex; gap: 18px; flex: 1; }
+  .nav-links a { font-size: 10px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--gestalt-label); }
+  .nav-links a.active { color: var(--gestalt-ink); }
+  .nav-toggle { background: none; border: none; letter-spacing: 0.12em; text-transform: uppercase; font-size: 10px; color: var(--gestalt-label); }
+
+  .page { position: relative; z-index: 5; max-width: 1160px; margin: 0 auto; padding: 40px 30px 80px; }
+  .kicker { font-family: var(--font-body); font-size: 10px; letter-spacing: 0.3em; text-transform: uppercase; color: var(--gestalt-label); margin-bottom: 26px; text-align: center; }
+  .layout { display: grid; grid-template-columns: 1fr 320px; gap: 40px; align-items: start; }
+  @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+
+  /* chooser rail (shared / global chrome) */
+  .ch-title { font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--gestalt-label); margin-bottom: 10px; }
+  .chooser { display: flex; flex-direction: column; gap: 8px; }
+  .fchip { display: flex; align-items: center; gap: 12px; padding: 11px 13px; width: 100%; text-align: left;
+    border: 1.5px solid var(--gestalt-border-soft); border-radius: 12px; background: var(--gestalt-card-bg); transition: transform 100ms; }
+  .fchip:hover { transform: translateX(2px); }
+  .fchip.sel { border-color: var(--gestalt-pink); box-shadow: 0 4px 12px var(--gestalt-glow); }
+  .fchip .dot { width: 26px; height: 26px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 2px rgba(255,255,255,0.35); }
+  .fchip .nm { display: block; font-size: 12px; font-weight: 700; color: var(--gestalt-ink); }
+  .fchip .ds { display: block; font-size: 9.5px; color: var(--gestalt-label); margin-top: 2px; }
+  .fchip .arrow { margin-left: auto; font-size: 14px; color: var(--gestalt-label); }
+  .fchip.sel .arrow { color: var(--gestalt-pink); }
+  .ch-note { font-size: 10px; line-height: 1.6; color: var(--gestalt-label); margin-top: 12px; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+</head>
+<body>
+<nav class="nav">
+  <span class="wordmark">World Zero</span>
+  <div class="nav-links">
+    <a href="#">Home</a><a href="#">Tasks</a><a href="#">Praxis</a><a href="#">Players</a>
+    <a class="active" href="Warriors of Whimsy Faction Page.dc.html">Factions</a><a href="#">Updates</a>
+  </div>
+  <button class="nav-toggle" id="theme-toggle">Dark</button>
+</nav>
+
+<div class="page"><div id="root"></div></div>
+
+<script type="text/babel">
+const { WOWSigil } = window.WorldZeroDesignSystem_019e22;
+
+/* ── what the join API returns for Warriors of Whimsy (join-contract.json) ── */
+const JOIN = {
+  slug: "wow", name: "Warriors of Whimsy",
+  recruit: {
+    kicker: "the circle is recruiting",
+    headline: "Come be a little magic",
+    pitch: "Warriors of Whimsy is World Zero's coven for the soft and the strange. No spectators here — only witches mid-spell. Take a quest, do the tiny brave thing, and let the circle cheer you on.",
+    terms: [
+      { label: "membership fee", value: "one act of everyday magic" },
+      { label: "required skills", value: "none — only nerve" },
+      { label: "expected output", value: "small, brave, strange things" },
+      { label: "season rank", value: "#3 and rising ✦" },
+    ],
+    perks: [
+      "A coven that cheers every tiny victory",
+      "Quests that make a Tuesday enchanted",
+      "Your praxis, sealed and hearted by the circle",
+    ],
+    cta: { join: "Join the coven ✦", joined: "✦ welcome home, witch" },
+  },
+  viewer: {
+    state: "prospective", eligible: true,
+    requirement: {
+      summary: "Two quests away from an invitation",
+      detail: "Complete 2 more whimsy quests and the circle opens. Keep going — the magic is in the doing ✦",
+      have: 6, needed: 8, unit: "quests done",
+    },
+  },
+  social: {
+    memberCount: 2418,
+    recentJoiners: [{ name: "Willow", initial: "W" }, { name: "Cricket", initial: "C" }, { name: "B4ndit", initial: "B" }],
+  },
+};
+
+const FACTIONS = [
+  { slug: "ua",          name: "UA",                 color: "#c2541f", tagline: "the gilt salon" },
+  { slug: "wow",         name: "Warriors of Whimsy", color: "#be185d", tagline: "a little magic" },
+  { slug: "snide",       name: "S.N.I.D.E.",         color: "#16a34a", tagline: "gleeful disorder" },
+  { slug: "ephemerists", name: "The Ephemerists",    color: "#1d6e72", tagline: "the long road" },
+  { slug: "singularity", name: "Singularity",        color: "#2563eb", tagline: "the signal" },
+  { slug: "everymen",    name: "The Everymen",       color: "#c1272d", tagline: "the common good" },
+  { slug: "albescent",   name: "Albescent",          color: "#1c1c1a", tagline: "quiet witness" },
+];
+
+function Sparkle({ size = 14, color = "#f6c75e", style }) {
+  return <svg width={size} height={size} viewBox="0 0 24 24" style={{ display: "block", ...style }}><path d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z" fill={color} /></svg>;
+}
+function Heart({ size = 16, color = "#ec5f99" }) {
+  return <svg width={size} height={size} viewBox="0 0 36 36" style={{ display: "block" }}><path d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z" fill={color} stroke="#fff" strokeWidth="2.2" strokeLinejoin="round" /></svg>;
+}
+
+/* the whimsy recruitment flyer — pinned to the cork board */
+function WhimsyRecruitFlyer({ data }) {
+  const [joined, setJoined] = React.useState(false);
+  const { recruit, viewer, social } = data;
+  const eligible = viewer.eligible && viewer.state === "prospective";
+  const isMember = viewer.state === "member";
+  const req = viewer.requirement;
+  const pct = req.needed ? Math.min(100, Math.round((req.have / req.needed) * 100)) : 0;
+
+  return (
+    <div style={{ position: "relative", maxWidth: 620, padding: "22px", borderRadius: 16,
+      background: "#eeb4ce", backgroundImage: "radial-gradient(rgba(200,90,150,0.24) 1px,transparent 1.4px),radial-gradient(rgba(224,150,190,0.18) 1px,transparent 1.3px)", backgroundSize: "7px 7px,11px 11px",
+      border: "9px solid", borderImage: "linear-gradient(135deg,#f7d9e6,#e79ec2,#f7d9e6) 1", boxShadow: "inset 0 0 0 2px rgba(170,90,130,0.35), 0 22px 50px rgba(150,60,110,0.24)" }}>
+
+      {/* pinned flyer */}
+      <div style={{ position: "relative", transform: "rotate(-0.8deg)", borderRadius: 14, overflow: "hidden", border: "2px solid #e487b5", boxShadow: "0 14px 30px rgba(80,50,30,0.32)" }}>
+        {/* push-pins */}
+        <span style={{ position: "absolute", top: 8, left: 26, zIndex: 6, width: 18, height: 18, borderRadius: "50%", background: "radial-gradient(circle at 35% 30%,#fff,#ec5f99 62%,rgba(0,0,0,0.25))", boxShadow: "0 4px 6px rgba(80,50,30,0.4)" }} />
+        <span style={{ position: "absolute", top: 8, right: 26, zIndex: 6, width: 18, height: 18, borderRadius: "50%", background: "radial-gradient(circle at 35% 30%,#fff,#86cfa6 62%,rgba(0,0,0,0.25))", boxShadow: "0 4px 6px rgba(80,50,30,0.4)" }} />
+
+        {/* title bar */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "9px 14px", background: "linear-gradient(180deg,#fbcfe2,#f3a6cb)", borderBottom: "2px solid #e487b5" }}>
+          <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#fb7aa8", border: "1.4px solid rgba(255,255,255,0.7)" }} />
+          <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#f6c75e", border: "1.4px solid rgba(255,255,255,0.7)" }} />
+          <span style={{ width: 11, height: 11, borderRadius: "50%", background: "#86cfa6", border: "1.4px solid rgba(255,255,255,0.7)" }} />
+          <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "center", gap: 5, fontSize: 11, color: "#8e2f5c" }}><Sparkle size={10} color="#8e2f5c" /> join.exe</span>
+        </div>
+
+        {/* body */}
+        <div style={{ position: "relative", padding: "26px 30px 30px", background: "#fffdfa", backgroundImage: "radial-gradient(rgba(214,90,150,0.14) 1.3px,transparent 1.3px)", backgroundSize: "14px 14px" }}>
+          <div style={{ position: "absolute", top: 18, right: 22 }}><WOWSigil size={30} color="#f6c75e" /></div>
+
+          <div style={{ fontSize: 10, letterSpacing: "0.2em", textTransform: "uppercase", color: "#c2698f", marginBottom: 6 }}>{recruit.kicker}</div>
+          <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 52, fontWeight: 700, lineHeight: 0.92, color: "#a83a6e" }}>{recruit.headline}</div>
+          <p style={{ fontSize: 12.5, lineHeight: 1.7, color: "#8a5a72", marginTop: 12, maxWidth: 460 }}>{recruit.pitch}</p>
+
+          {/* perks */}
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 16 }}>
+            {recruit.perks.map((p, i) => (
+              <span key={i} style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 10.5, color: "#8e2f5c", background: "#fde7f1", border: "1px solid #f3b6d2", borderRadius: 20, padding: "6px 12px" }}>
+                <Heart size={11} /> {p}
+              </span>
+            ))}
+          </div>
+
+          {/* terms slip (taped) */}
+          <div style={{ position: "relative", marginTop: 22, background: "#fffdf8", backgroundImage: "repeating-linear-gradient(#fffdf8,#fffdf8 25px,#f2d0dd 25px,#f2d0dd 26px)", border: "1px solid #ecccd9", borderRadius: 5, boxShadow: "0 8px 18px rgba(80,50,30,0.2)", padding: "16px 20px 18px", transform: "rotate(0.6deg)" }}>
+            <span style={{ position: "absolute", top: -10, left: "50%", marginLeft: -34, width: 68, height: 22, background: "repeating-linear-gradient(45deg,#f6c75e 0 6px,#f9d886 6px 12px)", opacity: 0.82, transform: "rotate(-3deg)", boxShadow: "0 2px 4px rgba(80,50,30,0.25)" }} />
+            <div style={{ fontSize: 9, letterSpacing: "0.16em", textTransform: "uppercase", color: "#c2698f", marginBottom: 10 }}>the fine print (the honest kind)</div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px 20px" }}>
+              {recruit.terms.map((t) => (
+                <div key={t.label} style={{ borderBottom: "1px dashed rgba(190,60,120,0.28)", paddingBottom: 7 }}>
+                  <div style={{ fontSize: 8, letterSpacing: "0.12em", textTransform: "uppercase", color: "#b06a8c" }}>{t.label}</div>
+                  <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 20, color: "#a83a6e", lineHeight: 1.1, marginTop: 2 }}>{t.value}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* enlist — resolves from viewer state */}
+          <div style={{ marginTop: 24, display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+            {isMember ? (
+              <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 26, color: "#2f8f5f" }}>You're already in the circle ✦</div>
+            ) : eligible ? (
+              <React.Fragment>
+                {!joined ? (
+                  <button onClick={() => setJoined(true)} style={{ border: "none", borderRadius: 26, background: "#ec5f99", color: "#fff", fontFamily: "var(--font-body)", fontWeight: 800, fontSize: 15, letterSpacing: "0.02em", padding: "15px 28px", boxShadow: "0 8px 20px rgba(236,95,153,0.4)" }}>{recruit.cta.join}</button>
+                ) : (
+                  <div style={{ borderRadius: 26, background: "#86cfa6", color: "#fff", fontFamily: "var(--font-body)", fontWeight: 800, fontSize: 15, padding: "15px 28px", boxShadow: "0 8px 20px rgba(134,207,166,0.45)" }}>{recruit.cta.joined}</div>
+                )}
+                <div style={{ display: "inline-flex", alignItems: "center", gap: 8, color: "#8a6a7c" }}>
+                  <div style={{ display: "flex" }}>
+                    {social.recentJoiners.map((m, i) => (
+                      <span key={m.name} style={{ width: 26, height: 26, borderRadius: "50%", marginLeft: i ? -8 : 0, background: "linear-gradient(150deg,#fbcfe2,#ec5f99)", border: "2px solid #fffdfa", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 11 }}>{m.initial}</span>
+                    ))}
+                  </div>
+                  <span style={{ fontSize: 11 }}>{joined ? "the circle just got brighter" : social.memberCount.toLocaleString() + " witches, and counting"}</span>
+                </div>
+              </React.Fragment>
+            ) : (
+              /* soft gate — never a dead end */
+              <div style={{ width: "100%" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 8 }}>
+                  <Sparkle size={18} color="#ec5f99" />
+                  <span style={{ fontFamily: "var(--font-faction-script)", fontSize: 24, color: "#a83a6e" }}>{req.summary}</span>
+                </div>
+                <p style={{ fontSize: 11.5, lineHeight: 1.6, color: "#8a6a7c", margin: "0 0 12px" }}>{req.detail}</p>
+                <div style={{ height: 9, borderRadius: 6, background: "#fde7f1", overflow: "hidden" }}>
+                  <div style={{ width: pct + "%", height: "100%", borderRadius: 6, background: "linear-gradient(90deg,#f6c75e,#ec5f99)" }} />
+                </div>
+                <div style={{ fontSize: 9.5, color: "#b06a8c", marginTop: 6, letterSpacing: "0.04em" }}>{req.have} / {req.needed} {req.unit}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* charms peeking off the flyer */}
+      <div style={{ position: "absolute", bottom: -14, left: 40, transform: "rotate(-9deg)", filter: "drop-shadow(0 2px 3px rgba(120,40,80,0.28))" }}><Heart size={38} /></div>
+      <div style={{ position: "absolute", top: 60, right: -12, transform: "rotate(12deg)", filter: "drop-shadow(0 2px 3px rgba(120,40,80,0.28))" }}><Sparkle size={30} color="#f6c75e" /></div>
+    </div>
+  );
+}
+
+function WrongPoster({ name }) {
+  return (
+    <div style={{ maxWidth: 620, background: "var(--gestalt-card-bg)", border: "2px dashed var(--gestalt-border)", borderRadius: 14, padding: "40px 32px", color: "var(--gestalt-label)" }}>
+      <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 34, color: "var(--gestalt-ink)", marginBottom: 10 }}>{name}'s recruiter lives here</div>
+      <p style={{ fontSize: 12.5, lineHeight: 1.7, margin: "0 0 16px" }}>Every faction owns its own enlistment treatment — this is where {name}'s poster would render from the same join contract. But you wandered into the whimsy circle.</p>
+      <div style={{ fontFamily: "var(--font-faction-script)", fontSize: 20, color: "var(--gestalt-pink)" }}>pick us instead? no pressure ✦</div>
+    </div>
+  );
+}
+
+function JoinPage() {
+  const [sel, setSel] = React.useState("wow");
+  return (
+    <div>
+      <div className="kicker">World Zero · Enlistment · Choose Your Faction</div>
+      <div className="layout">
+        <div>{sel === "wow" ? <WhimsyRecruitFlyer data={JOIN} /> : <WrongPoster name={FACTIONS.find((f) => f.slug === sel).name} />}</div>
+        <div>
+          <div className="ch-title">All factions</div>
+          <div className="chooser">
+            {FACTIONS.map((f) => (
+              <button key={f.slug} className={"fchip" + (sel === f.slug ? " sel" : "")} onClick={() => setSel(f.slug)}>
+                <span className="dot" style={{ background: f.color }} />
+                <span><span className="nm">{f.name}</span><span className="ds">{f.tagline}</span></span>
+                <span className="arrow">{sel === f.slug ? "✦" : "→"}</span>
+              </button>
+            ))}
+          </div>
+          <p className="ch-note">Selecting a faction shows its recruiter. Each one renders from the shared <code>join-contract.json</code> — same shape, seven skins.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<JoinPage />);
+const tog = document.getElementById("theme-toggle");
+tog.addEventListener("click", () => {
+  const dark = document.documentElement.getAttribute("data-theme") === "dark";
+  document.documentElement.setAttribute("data-theme", dark ? "light" : "dark");
+  tog.textContent = dark ? "Dark" : "Light";
+});
+</script>
+</body>
+</html>

--- a/docs/design/join/join-contract.json
+++ b/docs/design/join/join-contract.json
@@ -1,0 +1,63 @@
+{
+  "_doc": "World Zero — canonical JOIN / recruitment data contract. The full-surface enlistment screen ('Choose Your Faction') renders from ONE object of this shape per faction. Faction-agnostic: every faction returns the same keys; all per-faction decoration (ransom cut-letters, whimsy stickers, gilt frames, terminal glyphs) is derived CLIENT-SIDE from `slug`, never stored here. This is the FULL recruitment surface — distinct from the in-page join block on the faction page (that uses faction-contract.json's `viewer`, and shares the SAME `viewer` sub-shape as below so one resolver serves both). Example values are the Warriors of Whimsy instance.",
+
+  "slug": "wow",
+  "name": "Warriors of Whimsy",
+  "archetype": "whimsy.exe",
+
+  "recruit": {
+    "_doc": "The recruitment pitch — all copy is faction-authored, in-voice (like faction-contract.json's `requirement`/`membership`), NOT generic backend strings. `kicker` = small overline. `headline` = the big call to enlist. `pitch` = 1–2 sentences of why. `terms` = the abbreviated 'what you're signing up for' facts (label/value pairs, shown as a slip/ledger). `perks` = short bullets of what a member gets. `cta` labels the enlist button in both states.",
+    "kicker": "the circle is recruiting",
+    "headline": "Come be a little magic",
+    "pitch": "Warriors of Whimsy is World Zero's coven for the soft and the strange. No spectators here — only witches mid-spell. Take a quest, do the tiny brave thing, and let the circle cheer you on.",
+    "terms": [
+      { "label": "membership fee", "value": "one act of everyday magic" },
+      { "label": "required skills", "value": "none — only nerve" },
+      { "label": "expected output", "value": "small, brave, strange things" },
+      { "label": "season rank", "value": "#3 and rising ✦" }
+    ],
+    "perks": [
+      "A coven that cheers every tiny victory",
+      "Quests that make a Tuesday enchanted",
+      "Your praxis, sealed and hearted by the circle"
+    ],
+    "cta": { "join": "Join the coven ✦", "joined": "✦ welcome home, witch" }
+  },
+
+  "viewer": {
+    "_doc": "Who is looking — the SAME sub-shape as faction-contract.json's `viewer`, so one client resolver drives both the in-page join block and this full screen. `state` = 'prospective' | 'member'. When prospective + eligible → the enlist CTA is live. When prospective + !eligible → the `requirement` gate shows a soft, encouraging path (never a dead-end). When member → a 'you're already in' confirmation + a keep-tasking nudge replace the CTA.",
+    "state": "prospective",
+    "eligible": true,
+    "requirement": {
+      "_doc": "Only meaningful when state=prospective && eligible=false. `have`/`needed` render a progress bar; `summary` is the headline, `detail` the encouragement.",
+      "summary": "Two quests away from an invitation",
+      "detail": "Complete 2 more whimsy quests and the circle opens. Keep going — the magic is in the doing.",
+      "have": 6,
+      "needed": 8,
+      "unit": "quests done"
+    }
+  },
+
+  "social": {
+    "_doc": "Optional social proof for the recruitment surface. `memberCount` is the headline number; `recentJoiners` are the last few names/initials to enlist (avatar chips). Purely presentational — safe to omit.",
+    "memberCount": 2418,
+    "recentJoiners": [
+      { "name": "Willow", "initial": "W" },
+      { "name": "Cricket", "initial": "C" },
+      { "name": "B4ndit", "initial": "B" }
+    ]
+  },
+
+  "factions": {
+    "_doc": "SHARED / GLOBAL list, NOT per-faction data — the roster the enlistment chooser rail renders so a prospect can switch which faction's poster they're viewing. Same list for every faction's join screen. `current` marks the one whose recruitment surface is showing.",
+    "_items": [
+      { "slug": "ua",          "name": "UA",                 "color": "#c2541f", "tagline": "the gilt salon" },
+      { "slug": "wow",         "name": "Warriors of Whimsy", "color": "#be185d", "tagline": "a little magic", "current": true },
+      { "slug": "snide",       "name": "S.N.I.D.E.",         "color": "#16a34a", "tagline": "gleeful disorder" },
+      { "slug": "ephemerists", "name": "The Ephemerists",    "color": "#1d6e72", "tagline": "the long road" },
+      { "slug": "singularity", "name": "Singularity",        "color": "#2563eb", "tagline": "the signal" },
+      { "slug": "everymen",    "name": "The Everymen",       "color": "#c1272d", "tagline": "the common good" },
+      { "slug": "albescent",   "name": "Albescent",          "color": "#1c1c1a", "tagline": "quiet witness" }
+    ]
+  }
+}


### PR DESCRIPTION
Design-vendoring PR (same pattern as #269/#281/#286). No source changes.

- `docs/design/join/`: the canonical **join-contract.json** (fetched fresh today) + the Albescent / Warriors of Whimsy / S.N.I.D.E. join screens from the cloud design system. These feed #347 (membership moves to the faction detail page), #395 (Albescent invitation entry flow), and design issue #243.
- `docs/design/albescent-kit/`: the Albescent vellum-correspondence kit (06-26 template tier) as local fallback, with a README pointing at the fresh `components/factions/albescent/` React kit in the cloud project. Feeds #232.
- Flags two design-system findings: the SNIDE join screen carries a pre-rename faction roster, and **UA has no join screen design at all** (noted for #200/#243).

🤖 Generated with [Claude Code](https://claude.com/claude-code)