### PR TITLE
feat: Task Crown — per-task top-praxis mark, FDL retired (#354, ADR-0028)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -36,6 +36,7 @@ from schemas.task import TaskCreate, TaskOut
 from schemas.praxis import PraxisOut
 from schemas.comment import CommentModerationIn, CommentOut
 from services.praxis import build_praxis_out, moderate_praxis
+from services.vote_tally import crowned_praxis_ids
 from services.comment import build_comment_out, list_flagged_comments, moderate_comment
 from services.task import build_task_out
 from services.admin_service import (
@@ -315,7 +316,14 @@ async def admin_list_flagged_praxes(
         .order_by(Praxis.created_at.desc())
     )
     praxis_list = result.scalars().all()
-    return [await build_praxis_out(praxis, session) for praxis in praxis_list]
+    # Task Crown (ADR-0028): one windowed query for the whole list — not per card.
+    crowned = await crowned_praxis_ids(
+        {praxis.task_id for praxis in praxis_list}, session
+    )
+    return [
+        await build_praxis_out(praxis, session, crowned_ids=crowned)
+        for praxis in praxis_list
+    ]
 
 
 @router.patch("/praxes/{praxis_id}/moderate", response_model=PraxisOut)

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -30,6 +30,7 @@ from services.character import (
 from services.era import load_current_era_stats
 from services.media import process_and_save_avatar
 from services.praxis import build_praxis_out, praxis_visibility_condition
+from services.vote_tally import crowned_praxis_ids
 
 router = APIRouter()
 
@@ -135,7 +136,14 @@ async def get_character_praxes(
         .offset(offset)
     )
     praxis_list = result.scalars().all()
-    return [await build_praxis_out(praxis, session) for praxis in praxis_list]
+    # Task Crown (ADR-0028): one windowed query for the whole grid — not per card.
+    crowned = await crowned_praxis_ids(
+        {praxis.task_id for praxis in praxis_list}, session
+    )
+    return [
+        await build_praxis_out(praxis, session, crowned_ids=crowned)
+        for praxis in praxis_list
+    ]
 
 
 @router.post("/{character_id}/avatar", response_model=CharacterOut)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -64,6 +64,7 @@ from services.praxis import (
 )
 from services.media import process_and_save_media
 from services.vote import cast_vote_on_praxis
+from services.vote_tally import crowned_praxis_ids
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +116,12 @@ async def list_praxes_route(
         limit=limit,
         offset=offset,
     )
-    return [await build_praxis_card_out(praxis, session) for praxis in praxes]
+    # Task Crown (ADR-0028): one windowed query for the whole page — not per card.
+    crowned = await crowned_praxis_ids({praxis.task_id for praxis in praxes}, session)
+    return [
+        await build_praxis_card_out(praxis, session, crowned_ids=crowned)
+        for praxis in praxes
+    ]
 
 
 @router.get("/{praxis_id}", response_model=PraxisOut)

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -66,6 +66,7 @@ class PraxisOut(BaseModel):
     media_items: List[MediaItemOut]
     score: float                # populated by build_praxis_out; = Merit (ADR-0014)
     voter_count: int = 0        # populated by build_praxis_out via vote_tally
+    is_top_for_task: bool = False  # Task Crown: top submitted praxis for its task (ADR-0028)
     # duel_id is set when this praxis is a side of a duel (ADR-0011).
     duel_id: Optional[int] = None
     applied_metatasks: List[TaskOut] = []
@@ -93,6 +94,7 @@ class PraxisCardOut(BaseModel):
     member_count: int
     score: float
     voter_count: int = 0
+    is_top_for_task: bool = False  # Task Crown: top submitted praxis for its task (ADR-0028)
     task_faction_slug: Optional[str] = None
 
     model_config = {"from_attributes": True}

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -42,7 +42,7 @@ from services import collab_consensus
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
 from models.duel import Duel, DuelStatus
-from services.vote_tally import get_tally, tally_votes
+from services.vote_tally import crowned_praxis_ids, get_tally, tally_votes
 
 
 EVERYMEN_FACTION_SLUG = "everymen"
@@ -123,11 +123,17 @@ async def build_praxis_out(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
     viewer: Optional[Character] = None,
+    *,
+    crowned_ids: Optional[set[int]] = None,
 ) -> PraxisOut:
     """Build a PraxisOut for any praxis type.
 
     ``viewer`` is the authenticated viewer's character, used to compute
     viewer-relative flags such as ``can_flag`` and invite visibility.
+
+    ``crowned_ids`` are the Task Crown holders (ADR-0028); list routes
+    precompute them once via :func:`~services.vote_tally.crowned_praxis_ids`
+    to avoid an N+1, single-praxis routes leave the default.
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -159,6 +165,10 @@ async def build_praxis_out(
     duel_id: Optional[int] = duel_row.id if duel_row is not None else None
 
     can_flag = await can_flag_praxis(viewer, praxis, session, era)
+
+    # Task Crown (ADR-0028): top submitted praxis for this task, computed live.
+    if crowned_ids is None:
+        crowned_ids = await crowned_praxis_ids([praxis.task_id], session)
 
     created_by_display_name = praxis.created_by.display_name if praxis.created_by else ""
     created_by_faction_slug = praxis.created_by.faction_slug if praxis.created_by else None
@@ -200,6 +210,7 @@ async def build_praxis_out(
         media_items=media_items,
         score=score,
         voter_count=tally.voter_count,
+        is_top_for_task=praxis.id in crowned_ids,
         duel_id=duel_id,
         can_flag=can_flag,
         applied_metatasks=applied_metatasks,
@@ -210,10 +221,16 @@ async def build_praxis_card_out(
     praxis: Praxis,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
+    *,
+    crowned_ids: Optional[set[int]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
 
     score = Merit = task base + points_from_votes (viewer-independent; ADR-0014).
+
+    ``crowned_ids`` are the Task Crown holders (ADR-0028); list routes
+    precompute them once via :func:`~services.vote_tally.crowned_praxis_ids`
+    so the crown never becomes a per-card query.
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -223,6 +240,10 @@ async def build_praxis_card_out(
     tally_map = await tally_votes([praxis.id], session)
     tally = get_tally(tally_map, praxis.id)
     score = float(task_point_value + tally.points_from_votes)
+
+    # Task Crown (ADR-0028): top submitted praxis for this task, computed live.
+    if crowned_ids is None:
+        crowned_ids = await crowned_praxis_ids([praxis.task_id], session)
 
     return PraxisCardOut(
         id=praxis.id,
@@ -242,6 +263,7 @@ async def build_praxis_card_out(
         member_count=len(praxis.members),
         score=score,
         voter_count=tally.voter_count,
+        is_top_for_task=praxis.id in crowned_ids,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
     )
 

--- a/backend/services/vote_tally.py
+++ b/backend/services/vote_tally.py
@@ -3,12 +3,18 @@
 ``tally_votes`` is the one place in the codebase that runs
 ``func.sum(Vote.value)`` / ``func.count``. All scoring code and display code
 consume it; scattered per-query vote sums are deleted.
+
+``crowned_praxis_ids`` (ADR-0028) lives here too: the Task Crown ranking is a
+vote aggregation (a per-task max over ``SUM(Vote.value)``), so it stays beside
+the tally rather than growing a second sum elsewhere.
 """
 from dataclasses import dataclass
+from typing import Collection
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.praxis import Praxis, PraxisStatus
 from models.vote import Vote
 
 
@@ -52,3 +58,43 @@ async def tally_votes(
 def get_tally(tallies: dict[int, VoteTally], praxis_id: int) -> VoteTally:
     """Return the tally for ``praxis_id``, falling back to an empty tally."""
     return tallies.get(praxis_id, _EMPTY_TALLY)
+
+
+async def crowned_praxis_ids(
+    task_ids: Collection[int],
+    session: AsyncSession,
+) -> set[int]:
+    """Ids of every praxis holding its task's Task Crown (ADR-0028).
+
+    The crown marks the top-scoring **submitted** praxis for its task. A task's
+    base points are equal across its praxes, so "top score" reduces to the most
+    vote-points (``SUM(Vote.value)``). Fully permissive by design: ties are all
+    crowned (co-champions, including the all-zero-votes case) and a sole entrant
+    is crowned by default — no minimum-submissions, no vote threshold.
+
+    Computed live in one windowed query over the requested tasks (RANK over the
+    per-praxis vote sum, partitioned by task) — never per-card in a build loop.
+    """
+    if not task_ids:
+        return set()
+
+    vote_points = func.coalesce(func.sum(Vote.value), 0)
+    ranked = (
+        select(
+            Praxis.id.label("praxis_id"),
+            func.rank()
+            .over(partition_by=Praxis.task_id, order_by=vote_points.desc())
+            .label("crown_rank"),
+        )
+        .join(Vote, Vote.praxis_id == Praxis.id, isouter=True)
+        .where(
+            Praxis.status == PraxisStatus.submitted,
+            Praxis.task_id.in_(task_ids),
+        )
+        .group_by(Praxis.id, Praxis.task_id)
+        .subquery()
+    )
+    result = await session.execute(
+        select(ranked.c.praxis_id).where(ranked.c.crown_rank == 1)
+    )
+    return set(result.scalars().all())

--- a/backend/tests/integration/test_task_crown.py
+++ b/backend/tests/integration/test_task_crown.py
@@ -1,0 +1,145 @@
+"""Integration tests for the Task Crown (ADR-0028, #354).
+
+The crown (``is_top_for_task``) marks the top-scoring **submitted** praxis for
+its task, computed live from vote-points. Fully permissive: ties are all
+crowned (including the all-zero-votes case), a sole entrant is crowned by
+default, and ``in_progress`` praxes never compete.
+"""
+import pytest
+from httpx import AsyncClient
+
+from models.character import Character
+from models.task import Task
+
+
+async def _create_and_submit_praxis(
+    client: AsyncClient, task_id: int, title: str, headers: dict
+) -> int:
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": task_id, "type": "solo", "title": title},
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+    submit_resp = await client.post(f"/praxes/{praxis_id}/submit", headers=headers)
+    assert submit_resp.status_code == 200
+    return praxis_id
+
+
+async def _crown_by_id(client: AsyncClient, task_id: int, headers: dict | None = None) -> dict[int, bool]:
+    list_resp = await client.get(
+        "/praxes", params={"task_id": task_id}, headers=headers or {}
+    )
+    assert list_resp.status_code == 200
+    return {card["id"]: card["is_top_for_task"] for card in list_resp.json()}
+
+
+@pytest.mark.asyncio
+async def test_sole_entrant_is_crowned(
+    client: AsyncClient,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """A task's only submitted praxis holds the crown, zero votes required."""
+    praxis_id = await _create_and_submit_praxis(
+        client, active_task.id, "Sole entrant", auth_headers2
+    )
+
+    crowns = await _crown_by_id(client, active_task.id)
+    assert crowns == {praxis_id: True}
+
+    # The detail read (PraxisOut) carries the same flag.
+    detail_resp = await client.get(f"/praxes/{praxis_id}")
+    assert detail_resp.status_code == 200
+    assert detail_resp.json()["is_top_for_task"] is True
+
+
+@pytest.mark.asyncio
+async def test_higher_vote_praxis_takes_the_crown(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Votes decide the crown; the out-voted praxis loses it."""
+    praxis1_id = await _create_and_submit_praxis(
+        client, active_task.id, "Challenger", auth_headers
+    )
+    praxis2_id = await _create_and_submit_praxis(
+        client, active_task.id, "Champion", auth_headers2
+    )
+
+    # Fresh field: zero votes each is a tie — both crowned (ADR-0028).
+    crowns = await _crown_by_id(client, active_task.id)
+    assert crowns == {praxis1_id: True, praxis2_id: True}
+
+    # character votes on character2's praxis (cross-account, so allowed).
+    vote_resp = await client.post(
+        f"/praxes/{praxis2_id}/vote", json={"value": 4}, headers=auth_headers
+    )
+    assert vote_resp.status_code == 200
+
+    crowns = await _crown_by_id(client, active_task.id)
+    assert crowns == {praxis1_id: False, praxis2_id: True}
+
+
+@pytest.mark.asyncio
+async def test_tied_vote_points_crown_all(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Equal non-zero vote-points → co-champions, all crowned."""
+    praxis1_id = await _create_and_submit_praxis(
+        client, active_task.id, "Co-champion A", auth_headers
+    )
+    praxis2_id = await _create_and_submit_praxis(
+        client, active_task.id, "Co-champion B", auth_headers2
+    )
+
+    resp = await client.post(
+        f"/praxes/{praxis2_id}/vote", json={"value": 3}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    resp = await client.post(
+        f"/praxes/{praxis1_id}/vote", json={"value": 3}, headers=auth_headers2
+    )
+    assert resp.status_code == 200
+
+    crowns = await _crown_by_id(client, active_task.id)
+    assert crowns == {praxis1_id: True, praxis2_id: True}
+
+
+@pytest.mark.asyncio
+async def test_in_progress_praxis_neither_competes_nor_wears_the_crown(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Only submitted praxes compete; a draft is never crowned."""
+    # character's praxis stays in_progress (visible only to its member).
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Still drafting"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    draft_id = create_resp.json()["id"]
+
+    submitted_id = await _create_and_submit_praxis(
+        client, active_task.id, "Published", auth_headers2
+    )
+
+    # Viewer = draft member, so the list shows both cards (ADR-0024).
+    crowns = await _crown_by_id(client, active_task.id, headers=auth_headers)
+    assert crowns == {draft_id: False, submitted_id: True}

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -66,6 +66,8 @@ export interface PraxisOut {
   invites: PraxisInviteOut[]
   media_items: MediaItemOut[]
   score: number
+  /** Task Crown — top-scoring submitted praxis for its task (ADR-0028). */
+  is_top_for_task: boolean
   /** Set when this praxis is one side of a duel (ADR-0011). */
   duel_id: number | null
   can_flag: boolean
@@ -90,6 +92,8 @@ export interface PraxisCardOut {
   member_count: number
   score: number
   voter_count: number
+  /** Task Crown — top-scoring submitted praxis for its task (ADR-0028). */
+  is_top_for_task: boolean
   task_faction_slug: string | null
 }
 

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -18,6 +18,12 @@ import { usePraxisCard } from "./praxisCard/usePraxisCard";
 interface Props {
   praxis: PraxisCardOut;
   onModerated?: () => void;
+  /**
+   * Task Crown display (ADR-0028) — on by default. The six faction-page bodies
+   * pass false because they stamp their own larger corner medallion over the
+   * card; every other surface keeps the built-in stamp.
+   */
+  showCrown?: boolean;
 }
 
 /**
@@ -27,7 +33,11 @@ interface Props {
  * moderation + the optimistic local praxis come from usePraxisCard; the frame is
  * selected by task faction via pickVariant.
  */
-export type ArchetypeProps = { praxis: PraxisCardOut; adminProps: AdminProps };
+export type ArchetypeProps = {
+  praxis: PraxisCardOut;
+  adminProps: AdminProps;
+  showCrown?: boolean;
+};
 
 // ─── Per-faction archetypes ───────────────────────────────────────────────────
 
@@ -43,12 +53,17 @@ function PraxisBody({
   praxis,
   tint,
   muted,
+  paper,
   titleStyle,
+  showCrown,
 }: {
   praxis: PraxisCardOut;
   tint: string;
   muted: string;
+  /** The frame's paper colour — inner disc of the Task Crown (ADR-0028). */
+  paper?: string;
   titleStyle?: CSSProperties;
+  showCrown?: boolean;
 }) {
   return (
     <>
@@ -64,7 +79,13 @@ function PraxisBody({
           <PraxisTitle praxis={praxis} style={titleStyle} />
           <PraxisTaskLink praxis={praxis} style={{ color: muted }} />
         </div>
-        <PraxisScoreHero praxis={praxis} color={tint} border={tint} />
+        <PraxisScoreHero
+          praxis={praxis}
+          color={tint}
+          border={tint}
+          paper={paper}
+          showCrown={showCrown}
+        />
       </div>
       <PraxisStats praxis={praxis} style={{ color: muted, marginTop: 8 }} />
       <PraxisByline praxis={praxis} style={{ color: muted }} />
@@ -78,7 +99,7 @@ function PraxisBody({
  * "Acquisition · filed" regalia line. Matches the UA praxis-read sheet, UAVote,
  * and the DS FactionPraxisCard reference. All colors via --ua-* tokens.
  */
-function UAPraxisCard({ praxis, adminProps }: ArchetypeProps) {
+function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     // Gilt frame: gold-leaf gradient border, then the parchment plate.
     <div
@@ -123,14 +144,16 @@ function UAPraxisCard({ praxis, adminProps }: ArchetypeProps) {
           praxis={praxis}
           tint={factionCssVar("ua", "card-accent")}
           muted={factionCssVar("ua", "card-muted")}
+          paper={factionCssVar("ua", "card-bg")}
           titleStyle={{ fontFamily: "'Playfair Display', serif", fontStyle: "italic" }}
+          showCrown={showCrown}
         />
       </div>
     </div>
   );
 }
 
-function EverymenPraxisCard({ praxis, adminProps }: ArchetypeProps) {
+function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
       style={{
@@ -166,12 +189,14 @@ function EverymenPraxisCard({ praxis, adminProps }: ArchetypeProps) {
         praxis={praxis}
         tint={factionCssVar("everymen", "card-accent")}
         muted={factionCssVar("everymen", "card-muted")}
+        paper={factionCssVar("everymen", "card-bg")}
+        showCrown={showCrown}
       />
     </div>
   );
 }
 
-function WowPraxisCard({ praxis, adminProps }: ArchetypeProps) {
+function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
       style={{
@@ -240,6 +265,8 @@ function WowPraxisCard({ praxis, adminProps }: ArchetypeProps) {
           praxis={praxis}
           tint={factionCssVar("wow", "card-accent")}
           muted={factionCssVar("wow", "card-muted")}
+          paper={factionCssVar("wow", "card-bg")}
+          showCrown={showCrown}
         />
       </div>
     </div>
@@ -249,7 +276,7 @@ function WowPraxisCard({ praxis, adminProps }: ArchetypeProps) {
 const SNIDE_TORN_CLIP =
   "polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)";
 
-function SnidePraxisCard({ praxis, adminProps }: ArchetypeProps) {
+function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
       style={{
@@ -294,6 +321,8 @@ function SnidePraxisCard({ praxis, adminProps }: ArchetypeProps) {
         praxis={praxis}
         tint={factionCssVar("snide", "card-accent")}
         muted={factionCssVar("snide", "card-muted")}
+        paper={factionCssVar("snide", "card-bg")}
+        showCrown={showCrown}
       />
     </div>
   );
@@ -303,7 +332,7 @@ function SnidePraxisCard({ praxis, adminProps }: ArchetypeProps) {
  * The Ephemerists (ephemerists slug) — a sealed ephemeris entry. A foxed vellum
  * leaf with a lapis-ruled running head, the sigil, and rubric-accented text.
  */
-function EphemeristsPraxisCard({ praxis, adminProps }: ArchetypeProps) {
+function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
       style={{
@@ -354,7 +383,9 @@ function EphemeristsPraxisCard({ praxis, adminProps }: ArchetypeProps) {
           praxis={praxis}
           tint="var(--eph-rubric)"
           muted="var(--eph-muted)"
+          paper="var(--eph-vellum)"
           titleStyle={{ fontFamily: "var(--eph-display)", color: "var(--eph-vellum-text)" }}
+          showCrown={showCrown}
         />
       </div>
     </div>
@@ -388,7 +419,7 @@ function SingularityHoles() {
   );
 }
 
-function SingularityPraxisCard({ praxis, adminProps }: ArchetypeProps) {
+function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
       style={{
@@ -489,6 +520,8 @@ function SingularityPraxisCard({ praxis, adminProps }: ArchetypeProps) {
           praxis={praxis}
           tint="var(--faction-singularity-card-text)"
           muted="var(--faction-singularity-card-muted)"
+          paper="var(--faction-singularity-card-bg)"
+          showCrown={showCrown}
         />
       </div>
       <SingularityHoles />
@@ -499,7 +532,7 @@ function SingularityPraxisCard({ praxis, adminProps }: ArchetypeProps) {
 
 
 /** Fallback card for `na` / unknown task factions — a plain accent-bordered slab. */
-export function DefaultPraxisCard({ praxis, adminProps }: ArchetypeProps) {
+export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const slug = praxis.task_faction_slug ?? "ua";
   return (
     <div
@@ -520,6 +553,8 @@ export function DefaultPraxisCard({ praxis, adminProps }: ArchetypeProps) {
         praxis={praxis}
         tint={factionCssVar(slug, "card-accent")}
         muted={factionCssVar(slug, "card-muted")}
+        paper={factionCssVar(slug, "card-bg")}
+        showCrown={showCrown}
       />
     </div>
   );
@@ -536,12 +571,12 @@ export const PRAXIS_CARD_BY_SLUG: Record<string, ComponentType<ArchetypeProps>> 
   singularity: SingularityPraxisCard,
 };
 
-export default function PraxisCard({ praxis, onModerated }: Props) {
+export default function PraxisCard({ praxis, onModerated, showCrown = true }: Props) {
   const { localPraxis, adminProps } = usePraxisCard(praxis, onModerated);
   const Card = pickVariant(
     PRAXIS_CARD_BY_SLUG,
     localPraxis.task_faction_slug,
     DefaultPraxisCard,
   );
-  return <Card praxis={localPraxis} adminProps={adminProps} />;
+  return <Card praxis={localPraxis} adminProps={adminProps} showCrown={showCrown} />;
 }

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -51,6 +51,7 @@ const PRAXIS: PraxisCardOut = {
   member_count: 1,
   score: 4.2,
   voter_count: 0,
+  is_top_for_task: false,
   task_faction_slug: "ua",
 };
 
@@ -77,6 +78,39 @@ describe("praxis-card content-slot invariant", () => {
       expect(text, "title slot").toContain("Photosynthesis"); // PraxisTitle
       expect(html, "task-link slot").toContain('href="/tasks/7"'); // PraxisTaskLink
       expect(html, "score slot").toContain("4.2"); // PraxisByline score
+    });
+  }
+});
+
+// ─── Task Crown stamp (ADR-0028) ─────────────────────────────────────────────
+// Every archetype must stamp the crown on a crowned praxis, must not stamp an
+// uncrowned one, and must yield when the surface (a faction page) renders its
+// own corner medallion via showCrown={false}.
+
+const CROWN_TITLE = "Task Crown — top praxis for this task";
+const CROWNED = { ...PRAXIS, is_top_for_task: true };
+
+describe("praxis-card Task Crown stamp", () => {
+  for (const [slug, Card] of Object.entries(praxisArchetypes)) {
+    it(`${slug} stamps the crown iff is_top_for_task`, () => {
+      const crowned = markup(
+        <Card praxis={CROWNED} adminProps={{ ...PRAXIS_ADMIN, praxis: CROWNED }} />,
+      );
+      expect(crowned.html, "crowned card").toContain(CROWN_TITLE);
+
+      const plain = markup(<Card praxis={PRAXIS} adminProps={PRAXIS_ADMIN} />);
+      expect(plain.html, "uncrowned card").not.toContain(CROWN_TITLE);
+
+      const suppressed = markup(
+        <Card
+          praxis={CROWNED}
+          adminProps={{ ...PRAXIS_ADMIN, praxis: CROWNED }}
+          showCrown={false}
+        />,
+      );
+      expect(suppressed.html, "surface renders its own crown").not.toContain(
+        CROWN_TITLE,
+      );
     });
   }
 });

--- a/frontend/src/components/cards/TaskCrown.tsx
+++ b/frontend/src/components/cards/TaskCrown.tsx
@@ -1,23 +1,23 @@
 import type { CSSProperties } from "react";
 
 /**
- * FdlLaurel — the Faction Distinction Laurel.
+ * TaskCrown — the one praxis mark (ADR-0028).
  *
- * The one cross-faction mark: a rainbow medallion with a laurel glyph, awarded
- * to the single highest-scoring praxis on every faction page. The rainbow ring
- * is a fixed brand constant (--fdl-rainbow); each skin only recolours the inner
- * disc (`innerBg`, the card's paper) and the glyph (`glyphColor`, the card's
- * ink) so the laurel sits on its own paper. Albescent passes a monochrome pair.
- *
- * Ported from the faction-page design bundle (lib/FdlLaurel.tsx); hex swapped
- * for the --fdl-rainbow token per repo convention.
+ * A rainbow medallion with a fleur-de-lis glyph, worn by the top-scoring
+ * SUBMITTED praxis for its task (`is_top_for_task`, computed live server-side;
+ * ties are co-champions, a sole entrant is crowned by default). It replaces the
+ * retired cross-task "Faction Distinction Laurel" — same medallion chrome, new
+ * glyph, new meaning. The rainbow ring is a fixed brand constant
+ * (--fdl-rainbow); each skin only recolours the inner disc (`innerBg`, the
+ * card's paper) and the glyph (`glyphColor`, the card's ink) so the crown sits
+ * on its own paper. Albescent passes a monochrome pair.
  */
-export interface FdlLaurelProps {
+export interface TaskCrownProps {
   /** Overall medallion diameter, px. */
   size?: number;
   /** Fill of the inner disc — pass the card's paper colour (a CSS var). */
   innerBg?: string;
-  /** Laurel glyph colour — pass the card's ink colour (a CSS var). */
+  /** Fleur-de-lis glyph colour — pass the card's ink colour (a CSS var). */
   glyphColor?: string;
   /** Ring inset from the edge, px (the coloured rainbow band width). */
   ringInset?: number;
@@ -28,7 +28,7 @@ export interface FdlLaurelProps {
   style?: CSSProperties;
 }
 
-export function FdlLaurel({
+export function TaskCrown({
   size = 44,
   innerBg = "var(--color-bg-card)",
   glyphColor = "var(--color-text-primary)",
@@ -36,11 +36,11 @@ export function FdlLaurel({
   rotate,
   shadow,
   style,
-}: FdlLaurelProps) {
-  const glyph = Math.round(size * 0.42);
+}: TaskCrownProps) {
+  const glyph = Math.round(size * 0.46);
   return (
     <span
-      title="Faction Distinction Laurel — top praxis"
+      title="Task Crown — top praxis for this task"
       style={{
         position: "relative",
         display: "inline-block",
@@ -72,6 +72,7 @@ export function FdlLaurel({
           boxShadow: "inset 0 0 0 1px rgba(0,0,0,.12)",
         }}
       >
+        {/* Fleur-de-lis: central lance, two out-curling arms, band, foot + side feet. */}
         <svg
           viewBox="0 0 40 48"
           width={glyph * (40 / 48)}
@@ -80,21 +81,16 @@ export function FdlLaurel({
           aria-hidden="true"
         >
           <g fill="currentColor">
-            <path d="M20 1 C16 10 16 17 20 24 C24 17 24 10 20 1 Z" />
-            <path d="M20 22 C14 15 8 15 6 21 C4.6 25 8 29 13.5 27.6 C10.5 25 12.5 21 20 22 Z" />
-            <path d="M20 22 C26 15 32 15 34 21 C35.4 25 32 29 26.5 27.6 C29.5 25 27.5 21 20 22 Z" />
-            <rect x="11" y="26" width="18" height="4.5" rx="2.2" />
-            <path d="M20 30 C17.5 37 16 41 20 47 C24 41 22.5 37 20 30 Z" />
+            <path d="M20 1 C15.5 9 15.5 18 20 27 C24.5 18 24.5 9 20 1 Z" />
+            <path d="M17.5 25 C11 15 1.5 17 2.5 25.5 C3.3 31.8 10.8 33.4 15.4 29.4 C10 29 9.5 23.5 17.5 25 Z" />
+            <path d="M22.5 25 C29 15 38.5 17 37.5 25.5 C36.7 31.8 29.2 33.4 24.6 29.4 C30 29 30.5 23.5 22.5 25 Z" />
+            <rect x="12.5" y="29" width="15" height="4.5" rx="2.2" />
+            <path d="M20 33.5 C16.5 39.5 16 43.5 20 47.5 C24 43.5 23.5 39.5 20 33.5 Z" />
+            <path d="M16 33.5 C12 36 9.5 40 12.5 43.5 C13.6 39.5 15.3 37.2 17.6 35.6 Z" />
+            <path d="M24 33.5 C28 36 30.5 40 27.5 43.5 C26.4 39.5 24.7 37.2 22.4 35.6 Z" />
           </g>
         </svg>
       </span>
     </span>
   );
-}
-
-/** Index of the single top-scoring praxis (first max), or -1 when empty. */
-export function topPraxisIndex(scores: number[]): number {
-  if (!scores.length) return -1;
-  const max = Math.max(...scores);
-  return scores.indexOf(max);
 }

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, MouseEvent } from "react";
 import { Link } from "react-router-dom";
 import type { PraxisCardOut } from "../../api/praxis";
+import { TaskCrown } from "../cards/TaskCrown";
 
 /**
  * Praxis-card shared building blocks.
@@ -102,17 +103,25 @@ export function PraxisScoreHero({
   praxis,
   color,
   border,
+  paper,
+  showCrown,
 }: {
   praxis: PraxisCardOut;
   color?: string;
   border?: string;
+  /** The card's paper colour — the crown medallion's inner disc (ADR-0028). */
+  paper?: string;
+  /** Set false when the surface renders its own TaskCrown (the faction pages). */
+  showCrown?: boolean;
 }) {
   if (praxis.score === null || praxis.score === undefined) return null;
   const base = praxis.task_point_value;
   const votePoints = Math.max(0, Math.round(praxis.score - base));
+  const crowned = praxis.is_top_for_task && showCrown !== false;
   return (
     <div
       style={{
+        position: "relative",
         display: "inline-flex",
         flexDirection: "column",
         alignItems: "center",
@@ -127,6 +136,17 @@ export function PraxisScoreHero({
         lineHeight: 1,
       }}
     >
+      {/* Task Crown (ADR-0028) — stamped over the score stamp's corner. */}
+      {crowned && (
+        <TaskCrown
+          size={26}
+          ringInset={3}
+          innerBg={paper}
+          glyphColor={color ?? "currentColor"}
+          rotate="8deg"
+          style={{ position: "absolute", top: -13, right: -12, zIndex: 3 }}
+        />
+      )}
       <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)", whiteSpace: "nowrap" }}>
         {base}
         <span style={{ opacity: 0.55, margin: "0 2px" }}>+</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -550,9 +550,10 @@
   /* Shared faction-page body grid — main column + right rail; collapses to one
      column on narrow viewports (rule below). Every faction skin reuses this. */
 
-  /* ── Faction Distinction Laurel ── the single cross-faction high-score mark.
-     Fixed brand rainbow; the medallion's inner disc + glyph are recoloured
-     per-faction by the caller (see components/cards/FdlLaurel.tsx). */
+  /* ── Task Crown ── the per-task top-praxis mark (ADR-0028; the retired
+     Faction Distinction Laurel's medallion, re-glyphed). Fixed brand rainbow;
+     the medallion's inner disc + glyph are recoloured per-faction by the
+     caller (see components/cards/TaskCrown.tsx). */
   --fdl-rainbow: conic-gradient(from 90deg, #fbbf24, #f97316, #be185d, #4f46e5, #0e7490, #16a34a, #fbbf24);
 }
 

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -2,7 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
-import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { EphMark, Foxing, toRoman } from "../../../components/cards/ephemeristsAtoms";
 import { computeDisplayPoints } from "../../../utils/points";
 import { factionName } from "../../../utils/factions";
@@ -113,9 +113,6 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
   // ② apparatus paragraphs — split the single description on blank lines.
   const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
-  // ⑤ FDL goes to the single highest-scoring praxis.
-  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
-
   // ⑥ spotlight = highest all-time score; roster = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
@@ -182,10 +179,12 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
             <p style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 14, color: MUTED }}>Nothing sealed to the codex yet.</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
-              {recentPraxis.map((praxis, i) => (
+              {recentPraxis.map((praxis) => (
                 <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
-                  {i === topIdx && (
-                    <FdlLaurel
+                  {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
+                      so the card's built-in stamp is suppressed. */}
+                  {praxis.is_top_for_task && (
+                    <TaskCrown
                       size={44}
                       innerBg={VELLUM}
                       glyphColor={INK}
@@ -194,7 +193,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                       style={{ position: "absolute", top: -14, right: -10, zIndex: 5 }}
                     />
                   )}
-                  <PraxisCard praxis={praxis} />
+                  <PraxisCard praxis={praxis} showCrown={false} />
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -2,7 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
-import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
 import { factionName } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
@@ -126,9 +126,6 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
   // ② manifesto paragraphs — split the single description on blank lines.
   const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
-  // ⑤ FDL goes to the single highest-scoring praxis.
-  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
-
   // ⑥ spotlight = highest all-time score; roster = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
@@ -194,10 +191,12 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
             <p style={{ fontFamily: MONO, fontSize: 11, color: MUTED }}>No reports filed yet.</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
-              {recentPraxis.map((praxis, i) => (
+              {recentPraxis.map((praxis) => (
                 <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
-                  {i === topIdx && (
-                    <FdlLaurel
+                  {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
+                      so the card's built-in stamp is suppressed. */}
+                  {praxis.is_top_for_task && (
+                    <TaskCrown
                       size={44}
                       innerBg={CREAM}
                       glyphColor={INK}
@@ -206,7 +205,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                       style={{ position: "absolute", top: -14, right: -10, zIndex: 5 }}
                     />
                   )}
-                  <PraxisCard praxis={praxis} />
+                  <PraxisCard praxis={praxis} showCrown={false} />
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -2,7 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
-import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
 import { factionName } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
@@ -147,9 +147,6 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
     .map((p) => p.trim())
     .filter(Boolean);
 
-  // ⑤ FDL goes to the single highest-scoring praxis.
-  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
-
   // ⑥ spotlight = highest all-time score; array = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
@@ -234,10 +231,12 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
             </p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
-              {recentPraxis.map((praxis, i) => (
+              {recentPraxis.map((praxis) => (
                 <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
-                  {i === topIdx && (
-                    <FdlLaurel
+                  {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
+                      so the card's built-in stamp is suppressed. */}
+                  {praxis.is_top_for_task && (
+                    <TaskCrown
                       size={38}
                       innerBg={VOID}
                       glyphColor={PHOSPHOR}
@@ -246,7 +245,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                       style={{ position: "absolute", top: -12, right: -8, zIndex: 5 }}
                     />
                   )}
-                  <PraxisCard praxis={praxis} />
+                  <PraxisCard praxis={praxis} showCrown={false} />
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -2,7 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
-import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
 import { factionName } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
@@ -175,9 +175,6 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
   // ② about paragraphs — split the single description on blank lines.
   const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
-  // ⑤ FDL goes to the single highest-scoring praxis.
-  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
-
   // ⑥ spotlight = highest all-time score; rap sheet = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
@@ -253,10 +250,12 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
             <p style={{ fontFamily: TYPE, fontSize: 12, color: MUTED }}>No jobs pulled off yet.</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
-              {recentPraxis.map((praxis, i) => (
+              {recentPraxis.map((praxis) => (
                 <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
-                  {i === topIdx && (
-                    <FdlLaurel
+                  {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
+                      so the card's built-in stamp is suppressed. */}
+                  {praxis.is_top_for_task && (
+                    <TaskCrown
                       size={48}
                       innerBg={PAPER}
                       glyphColor={INK}
@@ -265,7 +264,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                       style={{ position: "absolute", top: -12, right: -8, zIndex: 5 }}
                     />
                   )}
-                  <PraxisCard praxis={praxis} />
+                  <PraxisCard praxis={praxis} showCrown={false} />
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -2,7 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
-import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { toRoman } from "../../../components/cards/ephemeristsAtoms";
 import { computeDisplayPoints } from "../../../utils/points";
 import { factionName } from "../../../utils/factions";
@@ -121,7 +121,6 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
   if (!faction) return null;
 
   const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
-  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
   const register = ranked.slice(1);
@@ -184,10 +183,12 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
             <p style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 14, color: SUB }}>Nothing exhibited yet.</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
-              {recentPraxis.map((praxis, i) => (
+              {recentPraxis.map((praxis) => (
                 <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
-                  {i === topIdx && (
-                    <FdlLaurel
+                  {/* Task Crown (ADR-0028) — the skin's own corner medallion,
+                      so the card's built-in stamp is suppressed. */}
+                  {praxis.is_top_for_task && (
+                    <TaskCrown
                       size={42}
                       innerBg={PAPER_WARM}
                       glyphColor={INK}
@@ -196,7 +197,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                       style={{ position: "absolute", top: -12, right: -8, zIndex: 5 }}
                     />
                   )}
-                  <PraxisCard praxis={praxis} />
+                  <PraxisCard praxis={praxis} showCrown={false} />
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -2,7 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
-import { FdlLaurel, topPraxisIndex } from "../../../components/cards/FdlLaurel";
+import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
 import { factionName } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
@@ -171,9 +171,6 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
   // ② manifesto paragraphs — split the single description on blank lines.
   const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
-  // ⑤ FDL goes to the single highest-scoring praxis.
-  const topIdx = topPraxisIndex(recentPraxis.map((p) => p.score));
-
   // ⑥ spotlight = highest all-time score; roster = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
@@ -251,10 +248,12 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
             <p style={{ fontFamily: BODY, fontSize: 11, color: MUTED, marginTop: 12 }}>Nothing cast yet.</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 22, alignItems: "flex-start", marginTop: 16 }}>
-              {recentPraxis.map((praxis, i) => (
+              {recentPraxis.map((praxis) => (
                 <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
-                  {i === topIdx && (
-                    <FdlLaurel
+                  {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
+                      so the card's built-in stamp is suppressed. */}
+                  {praxis.is_top_for_task && (
+                    <TaskCrown
                       size={44}
                       innerBg={NOTEPAD}
                       glyphColor={ACCENT}
@@ -263,7 +262,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                       style={{ position: "absolute", top: -14, right: -10, zIndex: 5 }}
                     />
                   )}
-                  <PraxisCard praxis={praxis} />
+                  <PraxisCard praxis={praxis} showCrown={false} />
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -56,6 +56,7 @@ const PRAXIS: PraxisOut = {
   invites: [],
   media_items: [],
   score: 42,
+  is_top_for_task: false,
   duel_id: null,
   can_flag: true,
   applied_metatasks: [],
@@ -123,6 +124,21 @@ describe("praxis-read content-slot invariant", () => {
       expect(text, "account-body slot").toContain("Seedlings");
       expect(html, "re-task-link slot").toContain('href="/tasks/7"');
       expect(html, "author-byline slot").toContain('href="/characters/3"');
+    });
+  }
+});
+
+// ─── Task Crown hero (ADR-0028) ──────────────────────────────────────────────
+// The crown banner lives in the shared PraxisStatusBanners chrome, so every
+// archetype shows it on a crowned praxis and hides it otherwise.
+
+describe("praxis-read Task Crown hero", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} shows the crown hero iff is_top_for_task`, () => {
+      const crowned = state();
+      crowned.praxis = { ...PRAXIS, is_top_for_task: true };
+      expect(render(<Archetype state={crowned} />).text).toContain("TASK CROWN");
+      expect(render(<Archetype state={state()} />).text).not.toContain("TASK CROWN");
     });
   }
 });

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -13,6 +13,7 @@
  */
 import { Link } from 'react-router-dom'
 import { reframeLabel } from '../../components/vote/voteReframes'
+import { TaskCrown } from '../../components/cards/TaskCrown'
 import type { PraxisDetailState } from './usePraxisDetail'
 
 // ── Admin moderation bar ─────────────────────────────────────────────────────
@@ -94,6 +95,30 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
 
   return (
     <>
+      {/* Task Crown hero (ADR-0028) — this praxis is the task's top submitted
+          entry, computed live. Invariant chrome, so every archetype shows it. */}
+      {praxis.is_top_for_task && (
+        <div
+          style={{
+            border: '2px solid var(--color-border)',
+            borderRadius: 8,
+            padding: '8px 14px',
+            marginBottom: 12,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            background: 'var(--color-bg-card)',
+          }}
+        >
+          <TaskCrown size={34} ringInset={3} />
+          <div>
+            <span className="eyebrow" style={{ display: 'block' }}>TASK CROWN</span>
+            <span className="font-body" style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+              The top-scoring praxis for this task — held until another entry out-votes it.
+            </span>
+          </div>
+        </div>
+      )}
       {praxis.status === 'in_progress' && (
         <div style={{ background: 'rgba(245,158,11,0.1)', border: '2px solid rgba(245,158,11,0.3)', borderRadius: 8, padding: '8px 14px', marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
           <span className="eyebrow">IN EDITING</span>

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -71,6 +71,7 @@ const MY_PRAXIS: PraxisCardOut = {
   member_count: 1,
   score: 4.2,
   voter_count: 0,
+  is_top_for_task: false,
   task_faction_slug: "snide",
 };
 


### PR DESCRIPTION
Implements **ADR-0028** (landing via #397): one mark, one meaning — the **Task Crown** marks the top-scoring **submitted** praxis for its task. The cross-task "Faction Distinction Laurel" is retired, not coexisted with.

Closes #354

## Backend
- `is_top_for_task: bool` on **both** `PraxisCardOut` and `PraxisOut` (`backend/schemas/praxis.py`).
- Computed **live** by `crowned_praxis_ids()` in `services/vote_tally.py` (beside `tally_votes`, keeping vote aggregation single-sourced per ADR-0014): one `RANK() OVER (PARTITION BY task_id ORDER BY SUM(vote.value) DESC)` window query per read — list routes (`/praxes`, `/characters/{id}/praxes`, admin flagged) precompute the set once and pass it into the builders, so the crown never becomes a per-card query.
- Rule (fully permissive): only `submitted` praxes compete; **ties → all crowned** (incl. the all-zero-votes case, via `RANK`); a sole entrant is crowned by default; no minimums, no thresholds.
- Tests: `tests/integration/test_task_crown.py` — sole entrant crowned; higher-vote wins; zero-vote tie and non-zero-vote tie both co-crowned; `in_progress` neither competes nor wears it.

## Frontend
- **`TaskCrown`** (`components/cards/TaskCrown.tsx`) — the FdlLaurel medallion (same `--fdl-rainbow` ring + per-skin `innerBg`/`glyphColor` recolor) with the laurel glyph swapped for an **SVG fleur-de-lis** (crisp at medallion size; the unicode ⚜ renders as an uncolorable emoji on some platforms).
- **`FdlLaurel` + `topPraxisIndex` deleted**; zero references remain.
- Shared card stamp: `PraxisScoreHero` (`components/praxisCard/shared.tsx`) stamps a small crown over the score stamp's corner whenever `is_top_for_task` — so it travels with the praxis card on **every** surface (praxes list, Home, task detail, profile).
- Praxis-detail hero: a crown banner in the shared `PraxisStatusBanners` chrome (`pages/praxisDetail/shared.tsx`), so all eight read archetypes show it.
- Six faction-page bodies: switched from `topPraxisIndex(recentPraxis)` to `praxis.is_top_for_task` per card, keeping their bespoke large corner medallion + per-skin recolor; they pass `showCrown={false}` to `PraxisCard` so the crown renders exactly once there.
- No hardcoded hex; existing token approach kept.

## Decisions / notes
- **Double-crown avoidance:** `PraxisCard` grew an opt-out `showCrown` prop (default on) because the six faction skins render their own, larger corner medallion. Everywhere else the built-in stamp is authoritative.
- **Moderation-hidden praxes still compete** — ADR-0028 defines the competitor set purely as `submitted`. If a crowned praxis gets moderation-hidden, the visible runner-up is not promoted; flag if that should change.
- Pre-existing find (out of scope, flagged separately): `services/praxis.py` defines `change_praxis_type` twice; the second silently shadows the first.

## Verification
- Backend: full suite **521 passed** (incl. 4 new crown tests) against local Postgres.
- Frontend: `vitest` **143 passed** (13 files, incl. new crown stamp/hero invariants across every archetype); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)