### PR TITLE
docs: handoff — remaining ready-for-agent + DS audit (2026-07-03)

### DIFF
--- a/docs/agents/HANDOFF-2026-07-03.md
+++ b/docs/agents/HANDOFF-2026-07-03.md
@@ -1,0 +1,159 @@
+# Handoff — ready-for-agent build run + design-system audit (2026-07-03)
+
+Session ran out of usage mid-batch. This is the pickup prompt for the next agent.
+Everything below is verified against `origin/main` and `gh` at handoff time.
+
+## How this run works (context for the next agent)
+- Molly's `/ponytail` request had three parts: (1) build every `ready-for-agent`
+  issue in sensible order, PR + auto-merge each, close on merge; (2) audit the
+  World Zero Design System (ledger at
+  `.claude/worktrees/interesting-gates-022368/.design-sync/AUDIT.md`), slim the
+  faction components to all-React, adopt the DS's unified `<FACTION><Surface>`
+  naming; (3) resolve `ready-for-human` issues whose designs now exist (leave the
+  DB one, #227, alone).
+- **Build method that worked:** one `general-purpose` subagent per issue, launched
+  with `isolation: worktree` + `run_in_background: true`. Each was given the full
+  grilled spec inline (the issue *bodies* are thin — the real spec lives in the
+  issue **comments**; always `gh issue view N --json body,comments`).
+- **Repo gotchas to pass to every subagent:** (a) OneDrive silently drops
+  Edit-tool writes in worktrees — grep every edit on disk after writing, rewrite
+  with Write if it vanished; (b) branch protection requires up-to-date branches
+  and **auto-merge is disabled** on the repo, so merges are serial:
+  `gh pr update-branch N` → wait CI green → `gh pr merge N --squash --delete-branch`.
+  There's a reusable serial merge-queue script at
+  `<scratchpad>/merge-queue.sh` (takes PR numbers as args).
+- **DesignSync IS available in the main session** (tool loads via ToolSearch
+  `select:DesignSync`), project `019e221c-7853-7530-a934-7d3b2b7c8b43`. It is
+  **NOT available inside subagents** (confirmed — subagents must read vendored
+  copies from `docs/design/` instead). A full local export also lives at
+  `~/Downloads/World Zero Design System/` (dated 2026-06-26 — slightly stale;
+  cloud is fresher).
+
+## DONE — merged to main this session (issues auto-closed)
+| Issue(s) | What | PR |
+|---|---|---|
+| #360 | dirty-check `persistEdits` so collab submit can seal consensus | #399 |
+| #394 | Albescent "You know not what you seek" wall page | #400 |
+| #352 | faction filter strip rainbow order | #398 |
+| #348 | collab member (not just creator) sees edit/submit on praxis read page | #401 |
+| #344 + #349 | in-progress sidebar rename + `member_id` filter + per-row type badge | #402 |
+| #346 + #393 | shared `useRespondToRequest` hook; sidebar accept/decline; duel-feed wiring fix | #403 |
+| #354 | Task Crown replaces FdlLaurel (ADR-0028); backend `is_top_for_task` | #405 |
+| — | ADR-0027 + ADR-0028 landed on main (were stranded on grill branches) | #397 |
+| — | vendored join designs + albescent kit into `docs/design/` | #404 |
+
+Also merged from before this run (on main already): #375/#376/#384/#385/#391 etc.
+
+## NOT DONE — remaining `ready-for-agent` issues (START HERE, in this order)
+
+Dependency order matters. Suggested sequence:
+
+1. **#395 — Albescent join eligibility + invitation entry flow.**
+   ⚠️ **Partial work exists, uncommitted, in a dead worktree** — recover or
+   restart. Files were being edited at:
+   `.claude/worktrees/agent-ab4339e04d67cc40a/` (dirty, ahead=0, nothing
+   committed/pushed). Touched: `backend/services/faction_service.py`,
+   `backend/services/character.py`, `backend/eras/era_1.py`,
+   `backend/tests/integration/test_factions.py`, `frontend/src/api/auth.ts`,
+   `frontend/src/pages/FieldDesk.tsx`, and NEW
+   `frontend/src/components/AlbescentInvitation.tsx` (+ its test). **Verify this
+   work against the spec before trusting it — it was never tested or reviewed.**
+   Spec: 403 in `defect_to_faction` when target==albescent and
+   `not can_start_as_albescent`; reconcile stale "starting faction" copy at
+   `era_1.py:562` + the `can_start_as_albescent` docstring; invitation card from
+   `docs/design/join/Albescent Join Screen.html` (the `AlRecruit` component),
+   char-chooser → switch-active-character → `POST /factions/choose`. **#390 is
+   blocked_by this.**
+
+2. **#390 — Albescent secrecy gate (sticky per-account reveal).** After #395.
+   `Account.albescent_revealed` sticky bool (needs a migration), flip it in
+   `defect_to_faction` right after the successful defect (same block #395 adds the
+   403 to); gate `GET /factions`, `/factions/status`, `/factions/{slug}` to omit
+   albescent unless revealed; the `/factions/albescent` route already renders the
+   #394 wall — swap its unconditional render for the real gate (there's a
+   `TODO(#390)` at the wiring site in `App.tsx`). ADR-0027 is on main.
+
+3. **#232 — Albescent first-class identity across all surfaces.** Build each
+   albescent variant (task card, praxis card, edit praxis, task detail, faction
+   body/hero, vote "bear witness", avatar, backdrop, feed frame) from the DS
+   albescent kit, THEN drop `albescent` from `FACTION_ALIASES` in
+   `frontend/src/utils/factions.ts` **last** (dropping it early regresses every
+   un-built surface to the generic fallback). Design source: the fresh cloud
+   `components/factions/albescent/` kit (read via DesignSync), fallback vendored at
+   `docs/design/albescent-kit/`. This is large — consider splitting into 2-3 PRs
+   (cards / pages / vote+avatar+backdrop+alias-drop).
+
+4. **#347 — faction cards clickable; membership moves to faction detail page.**
+   Whole grid card → `Link` to `/factions/:slug`; strip `ActionRow` from the grid;
+   port Join/Leave/Accept/Decline to `FactionDetail.tsx` (`useFactionDetail` must
+   also load per-faction status + invitation). Join uses the per-faction join
+   popup from the DS — vendored at `docs/design/join/` (all 7 screens; **UA has
+   NO join design** — flag/pause on UA's join, see #200/#243). Spec in #347's
+   comment is detailed.
+
+5. **#388 — e2e infra (isolated DB + nightly CI).** ⚠️ **Partial work exists,
+   uncommitted** at `.claude/worktrees/agent-a5d043ddd8b2668da/` (dirty, ahead=0).
+   New files: `.github/workflows/e2e.yml`, `backend/scripts/reset_e2e_db.py`,
+   `frontend/e2e/run-e2e.sh`; modified `docs/spec/SPEC-testing.md`,
+   `frontend/playwright.config.ts`, `frontend/e2e/{auth.setup,collaboration.spec}.ts`.
+   **Recover and verify, or restart.** Never claim an untested green e2e run.
+
+6. **#322 — collab drop-a-task-to-accept** and **#314 — duel drop-a-task-to-accept.**
+   Both worktrees were lost with **nothing salvageable** (#322 worktree clean,
+   #314 worktree gone). Restart both from origin/main. They wire the *existing
+   dormant* drop-modal skeleton in `FeedCardCollabInvite.tsx` (#322) /
+   `FeedCardDuelChallenge.tsx` (#314). Both now build on the merged #403 shared
+   `useRespondToRequest` hook — detect bank-full on the error-detail **substring**
+   `"Task bank is full"` (collab=409, duel=400 — do NOT key on status code), fetch
+   `useMyActiveTasks()`, drop via `deletePraxis`/`leavePraxis` (NEVER
+   `withdrawPraxis`), retry, use real `max_task_signups` cap. These two touch
+   sibling files — safe to run concurrently, but keep any `useRespondToRequest`
+   change additive.
+
+## Step 2 (design-system audit + naming refactor) — IN PROGRESS, mostly analysis done
+- The **audit ledger is refreshed and pushed** (branch
+  `claude/interesting-gates-022368`, `.design-sync/AUDIT.md`, Session-4 block at
+  top + updated matrix). Key finding: **every drift the audit ever filed is now
+  built and merged**; the DS `templates/` tier is deprecated; for the three PAGE
+  surfaces the **repo is now ahead of the DS** (not the other way round).
+- **DS slim-down + join extraction: NOT yet pushed to the cloud project.** The
+  plan was to extract the six faction Join Screens into React
+  `components/factions/<slug>/<FACTION>Join.jsx` + a `FactionJoin` switcher, then
+  delete the stale `templates/` tier from the cloud DS. The subagent that was
+  going to generate that React bundle got cut off (empty output dir). **Redo
+  that extraction** (spec was: poster component only, props `{data, onJoin}` from
+  `join-contract.json`, import sibling `<FACTION>Sigil`, `@dsCard` preview card
+  per faction, `ua` returns null — no design). Vendored source HTML for all of it
+  is already in the repo at `docs/design/join/`. Push to the DS with the
+  DesignSync write flow (finalize_plan → write_files); only touch the cloud
+  project, never delete templates/ until the React equivalents are uploaded.
+- **The repo-side naming refactor (`TaskCardUA`→`UATaskCard`, `UaFeedFrame`→
+  `UAFeedFrame`, `EditPraxisPunkZine`→`SNIDEEditPraxis`, etc.) has NOT been
+  started.** This is a mechanical but wide rename to match the DS's
+  `<FACTION><Surface>` convention (the DS `readme.md` documents the target names).
+  Do it as its own PR AFTER the albescent/#232 work lands (they add albescent
+  variants — renaming first would create churn/conflicts). Grep for the current
+  names first (see the current-vs-target list the DS readme gives) and rename
+  file + export + all imports together per component; run `tsc --noEmit` + vitest.
+
+## Step 3 (ready-for-human reconciliation) — NOT started
+Open `ready-for-human` issues: **#243** (faction invitation-letter pop-ups —
+design now exists: `docs/design/join/*` join letters + the invitation card #395
+builds; likely closeable-into-#395 or a thin new build issue), **#202**
+(everymen+wow faction-detail heroes — check they're satisfied by the shipped
+`FACTION_HEROES` in `FactionDetail.tsx`), **#200** (UA kit: vote/backdrop/avatar/
+hero — **UA avatar is the real remaining gap**, and UA has no join design).
+**Leave #227 (Alembic squash) alone** per Molly. For each: check whether step-2's
+designs resolve it, then either close with a pointer to the merged work or convert
+to a small `ready-for-agent` build issue. Molly wants these *checked against the
+design system*, not necessarily all built.
+
+## Cleanup notes
+- Dead agent worktrees to prune once their work is recovered/abandoned:
+  `agent-ab4339e04d67cc40a` (#395 wip), `agent-a5d043ddd8b2668da` (#388 wip), and
+  the already-merged ones (`agent-a3cd819e…` #344, `agent-a35e63…` #354, etc.).
+  `git worktree remove` each after confirming nothing unmerged is lost.
+- Background task `task_caf3ef86` ("Remove duplicate `change_praxis_type` in
+  `praxis.py`") is running in a **separate session** the user started — a real bug
+  #354's build surfaced (function defined twice ~lines 561 & 704, second shadows
+  first). Don't duplicate it.


### PR DESCRIPTION
Pickup prompt for the next session. Documents what merged this run (#360/#394/#352/#348/#344+#349/#346+#393/#354 + ADRs + vendored designs), the remaining ready-for-agent issues in dependency order (#395→#390→#232, #347, #388, #322/#314) with the two partially-built-then-orphaned worktrees flagged, and the state of the design-system audit/rename (step 2) + ready-for-human reconciliation (step 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)