### PR TITLE
fix: dedupe change_praxis_type — keep takeover semantics (#321), clear ADR-0012 window on takeover

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -249,28 +249,6 @@ async def submit_praxis_route(
     return await build_praxis_out(praxis, session, viewer=character)
 
 
-class PraxisTypeChange(BaseModel):
-    type: PraxisType
-
-
-@router.post("/{praxis_id}/change-type", response_model=PraxisOut)
-async def change_praxis_type_route(
-    praxis_id: int,
-    data: PraxisTypeChange,
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    """Flip a praxis between solo and collab in place (#321) — content/id/media kept."""
-    praxis = await change_praxis_type(
-        praxis_id=praxis_id,
-        new_type=data.type,
-        character_id=character.id,
-        session=session,
-        era=CURRENT_ERA,
-    )
-    return await build_praxis_out(praxis, session, viewer=character)
-
-
 # ---------------------------------------------------------------------------
 # Media
 # ---------------------------------------------------------------------------

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -597,86 +597,6 @@ async def update_praxis(
     return await get_praxis(praxis_id, session)
 
 
-async def change_praxis_type(
-    praxis_id: int,
-    new_type: PraxisType,
-    character_id: int,
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-) -> Praxis:
-    """Flip a praxis between solo and collab in place, preserving id/content/media (#321).
-
-    A collab is just a ``type=solo`` praxis + members; recreation is unnecessary
-    and destructive (the old flow ``delete_praxis`` + ``create_praxis`` discarded
-    the draft). This flips ``Praxis.type`` instead.
-
-    Guards:
-    - Only the author may change mode.
-    - Praxis must be ``in_progress``.
-    - Target must be solo or collab — duels are issued via the challenge endpoint
-      (ADR-0011), never a direct type change.
-    - solo → collab requires ``era.collaboration_level_required``.
-    - A duel side (a solo praxis linked by a live Duel row) cannot change type.
-
-    solo → collab flips the type; collab → solo drops every non-author member and
-    any pending invites (the caller confirms this loss first).
-    """
-    if new_type not in (PraxisType.solo, PraxisType.collab):
-        raise HTTPException(
-            status_code=400,
-            detail="Only solo and collab modes can be switched in place; duels use the challenge endpoint (ADR-0011).",
-        )
-
-    praxis = await get_praxis(praxis_id, session)
-    if praxis.created_by_id != character_id:
-        raise HTTPException(status_code=403, detail="Only the author can change the praxis mode.")
-    if praxis.status != PraxisStatus.in_progress:
-        raise HTTPException(status_code=422, detail="Only an in-progress praxis can change mode.")
-
-    # A duel side is a solo praxis linked by a Duel row; never let it morph.
-    duel_result = await session.execute(
-        select(Duel.id).where(
-            or_(
-                Duel.challenger_praxis_id == praxis_id,
-                Duel.opponent_praxis_id == praxis_id,
-            ),
-            Duel.status.in_([DuelStatus.pending, DuelStatus.active, DuelStatus.settled]),
-        )
-    )
-    if duel_result.scalar_one_or_none() is not None:
-        raise HTTPException(
-            status_code=409,
-            detail="This praxis is part of a duel and cannot change mode.",
-        )
-
-    if praxis.type == new_type:
-        return praxis
-
-    if new_type == PraxisType.collab:
-        era_row = await get_current_era_row(session)
-        stats = await get_or_create_stats(session, character_id, era_row.id)
-        if stats.level < era.collaboration_level_required:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Collaborations require level {era.collaboration_level_required}.",
-            )
-    else:
-        # collab → solo: drop everyone but the author + any pending invites.
-        # delete-orphan cascades the row DELETEs (see models/praxis.py).
-        for member in list(praxis.members):
-            if member.character_id != character_id:
-                praxis.members.remove(member)
-        for invite in list(praxis.invites):
-            if invite.status == PraxisInviteStatus.pending:
-                praxis.invites.remove(invite)
-
-    praxis.type = new_type
-    await session.flush()
-    # A type change is a structural edit — reset any collab pending-publish window.
-    await cancel_pending_publish_on_edit(praxis, session, era)
-    return await get_praxis(praxis_id, session)
-
-
 async def withdraw_praxis(
     praxis_id: int,
     character_id: int,
@@ -794,6 +714,10 @@ async def change_praxis_type(
         praxis.type = PraxisType.collab
     else:
         # collab → solo: the actor takes it over as their own solo praxis.
+        # A type change is a structural edit — clear any pending-publish window
+        # (ADR-0012) while this is still a collab, so a later flip back to collab
+        # can't inherit a stale, already-lapsed window and instantly auto-seal.
+        await cancel_pending_publish_on_edit(praxis, session, era)
         # Mutate the loaded collections so the delete-orphan cascade fires *and*
         # the returned/serialized praxis reflects the drop (session.delete alone
         # would leave the selectin-cached collections stale).

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1115,67 +1115,6 @@ async def test_solo_submit_opens_no_window(
 
 
 @pytest.mark.asyncio
-async def test_change_type_solo_to_collab_preserves_content(
-    client: AsyncClient,
-    character2: Character,
-    active_task: Task,
-    auth_headers2: dict,
-):
-    """solo → collab keeps the same id, title, and body (no delete+recreate).
-
-    Actor is character2 (level 5) to clear the collaboration level gate.
-    """
-    create_resp = await client.post(
-        "/praxes",
-        json={
-            "task_id": active_task.id,
-            "type": "solo",
-            "title": "Keep me",
-            "body_text": "draft body",
-        },
-        headers=auth_headers2,
-    )
-    praxis_id = create_resp.json()["id"]
-
-    resp = await client.post(
-        f"/praxes/{praxis_id}/change-type",
-        json={"type": "collab"},
-        headers=auth_headers2,
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["id"] == praxis_id
-    assert data["type"] == "collab"
-    assert data["title"] == "Keep me"
-    assert data["body_text"] == "draft body"
-
-
-@pytest.mark.asyncio
-async def test_change_type_collab_to_solo_drops_members_keeps_content(
-    client: AsyncClient,
-    character: Character,
-    character2: Character,
-    active_task: Task,
-    auth_headers: dict,
-    auth_headers2: dict,
-):
-    """collab → solo drops the co-author but preserves id/title (author = level-5 character2)."""
-    praxis_id = await _two_member_collab(
-        client, active_task, auth_headers2, character.id, auth_headers
-    )
-    resp = await client.post(
-        f"/praxes/{praxis_id}/change-type",
-        json={"type": "solo"},
-        headers=auth_headers2,
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["id"] == praxis_id
-    assert data["type"] == "solo"
-    assert {m["character_id"] for m in data["members"]} == {character2.id}
-
-
-@pytest.mark.asyncio
 async def test_change_type_to_duel_rejected(
     client: AsyncClient,
     character2: Character,
@@ -2196,3 +2135,39 @@ async def test_change_type_rejects_duel_side(
         f"/praxes/{pid}/change-type", json={"type": "collab"}, headers=auth_headers2
     )
     assert resp.status_code == 409
+@pytest.mark.asyncio
+async def test_change_type_takeover_clears_pending_publish_window(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """A takeover resets the ADR-0012 pending-publish window, so a later flip
+    back to collab can't inherit a stale, already-lapsed window and auto-seal."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Shared work"},
+        headers=auth_headers2,
+    )
+    assert create.status_code == 201, create.text
+    pid = create.json()["id"]
+    db_session.add(PraxisMember(praxis_id=pid, character_id=character.id, has_submitted=False))
+    await db_session.commit()
+
+    # The creator proposes submit → the pending-publish window opens.
+    submit = await client.post(f"/praxes/{pid}/submit", headers=auth_headers2)
+    assert submit.status_code == 200, submit.text
+    assert submit.json()["submit_proposed_at"] is not None
+
+    # The co-author takes it over → solo; the window must be gone.
+    resp = await client.post(
+        f"/praxes/{pid}/change-type", json={"type": "solo"}, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "in_progress"
+    assert body["submit_proposed_at"] is None
+    assert all(not m["has_submitted"] for m in body["members"])


### PR DESCRIPTION
## What

`backend/services/praxis.py` defined `change_praxis_type` **twice** — #355 and #356 both implemented #321 concurrently on 2026-07-01. The router duplicated the `POST /praxes/{id}/change-type` route (plus a local `PraxisTypeChange` class shadowing the schemas import), and `test_praxes.py` had two near-identical test sections.

## Which version survives

The **takeover** version (#355): any member may flip collab→solo and becomes sole owner (`created_by_id` reassigned, other members + pending invites dropped). That's the grill 2026-07-01 decision quoted in #355's commit message, and — since the *second* definition wins at import time — it was already the live behavior. #356's author-only version (added later the same day, but placed first in the file) was dead code from the moment it merged. **No runtime semantics change from the dedupe.**

Deleted: the dead author-only service def, the duplicate route + shadowing local request class, and the two duplicate tests (the unique 400-on-`type=duel` test is kept).

## One real fix

The surviving takeover branch never cleared `submit_proposed_at`. Latent bug: open a collab pending-publish window, take the praxis over to solo (window field lingers, inert since `settle_if_window_lapsed` skips solo), then flip back to collab later — the stale, already-lapsed window would instantly auto-seal the praxis to Live on the next read. Now the takeover calls `cancel_pending_publish_on_edit` while the praxis is still a collab (mirroring what edits do), clearing the window and `has_submitted` flags.

## Tests

- New: `test_change_type_takeover_clears_pending_publish_window` — verified red without the fix, green with it.
- Full backend suite: **521 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)