### PR TITLE
test: deterministic, isolated e2e infrastructure (#388)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,77 @@
+# Playwright e2e lifecycle suites against an isolated database.
+# Deliberately NOT on the PR-blocking path — nightly + manual only.
+# The whole pipeline (reset DB -> migrate -> seed -> backend -> playwright)
+# lives in frontend/e2e/run-e2e.sh so CI and local runs share one code path.
+name: E2E
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # nightly
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: worldzero
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: worldzero
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # run-e2e.sh uses this directly (no backend/.env in CI); the reset script
+      # only ever drops databases ending in _e2e.
+      E2E_DATABASE_URL: postgresql+asyncpg://worldzero:test@localhost/worldzero_e2e
+      # Settings() fields normally supplied by backend/.env
+      DATABASE_URL: postgresql+asyncpg://worldzero:test@localhost/worldzero_e2e
+      SECRET_KEY: ci-e2e-secret-key-not-for-production
+      GOOGLE_CLIENT_ID: dummy-client-id
+      GOOGLE_CLIENT_SECRET: dummy-client-secret
+      GOOGLE_REDIRECT_URI: http://localhost:8001/auth/google/callback
+      MEDIA_BASE_URL: http://localhost:8001/media
+      MEDIA_ROOT: /tmp/media
+      ENVIRONMENT: development # dev-login must be enabled
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install backend dependencies
+        run: pip install -r backend/requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Run e2e suite (reset db, migrate, seed, backend, playwright)
+        run: bash frontend/e2e/run-e2e.sh
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 14

--- a/backend/scripts/reset_e2e_db.py
+++ b/backend/scripts/reset_e2e_db.py
@@ -1,0 +1,59 @@
+"""
+Drop and recreate the isolated e2e database named in DATABASE_URL.
+
+Used by frontend/e2e/run-e2e.sh (and the e2e CI workflow) to guarantee every
+Playwright run starts from an empty, freshly-migrated database. Refuses to
+touch anything whose name doesn't end in `_e2e`, so it can never nuke the
+dev or prod database by accident.
+
+Usage (DATABASE_URL must point at the e2e database, e.g. .../worldzero_e2e):
+    python scripts/reset_e2e_db.py
+"""
+
+import asyncio
+import os
+import sys
+from urllib.parse import urlsplit
+
+import asyncpg
+
+E2E_DATABASE_SUFFIX = "_e2e"
+MAINTENANCE_DATABASE = "postgres"
+
+
+async def reset_e2e_database() -> None:
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        sys.exit("DATABASE_URL is not set — export it before running (alembic reads it too).")
+
+    # asyncpg.connect wants a plain postgresql:// scheme
+    plain_url = database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    plain_url = plain_url.replace("postgres://", "postgresql://", 1)
+    parts = urlsplit(plain_url)
+    database_name = parts.path.lstrip("/").split("?")[0]
+
+    if not database_name.endswith(E2E_DATABASE_SUFFIX):
+        sys.exit(
+            f"Refusing to reset '{database_name}' — this script only drops databases "
+            f"ending in '{E2E_DATABASE_SUFFIX}'. Check DATABASE_URL."
+        )
+
+    connection = await asyncpg.connect(
+        host=parts.hostname or "localhost",
+        port=parts.port or 5432,
+        user=parts.username,
+        password=parts.password,
+        database=MAINTENANCE_DATABASE,
+    )
+    try:
+        # FORCE (PG13+) kicks any lingering connections from a previous run
+        await connection.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
+        await connection.execute(f'CREATE DATABASE "{database_name}"')
+    finally:
+        await connection.close()
+
+    print(f"Reset e2e database '{database_name}' on {parts.hostname}:{parts.port or 5432}")
+
+
+if __name__ == "__main__":
+    asyncio.run(reset_e2e_database())

--- a/docs/spec/SPEC-testing.md
+++ b/docs/spec/SPEC-testing.md
@@ -80,6 +80,47 @@ def test_current_era_is_defined():
     assert CURRENT_ERA.config_key != ""
 ```
 
+### Running e2e (Playwright lifecycle suites)
+
+Browser end-to-end tests live in `frontend/e2e/` (`playwright.config.ts` next to
+them). They log in via the dev-only `POST /auth/dev-login` bypass and drive real
+pages, so they need a live backend + frontend + Postgres.
+
+**One command, isolated database (recommended):**
+
+```bash
+bash frontend/e2e/run-e2e.sh                        # full suite
+bash frontend/e2e/run-e2e.sh collaboration.spec.ts  # one spec
+```
+
+The script resets a dedicated `worldzero_e2e` database on the compose Postgres
+(never the dev `worldzero` database — the reset script refuses any name not
+ending in `_e2e`), runs `alembic upgrade head` (fails loudly on drift), seeds
+via `seed.py`, starts the *branch* backend on **:8001** (so the docker-compose
+backend image on :8000 can't shadow the code under test), then runs Playwright,
+which starts the frontend dev server on **:5174** with `VITE_API_URL` pointed at
+:8001. Specs run serially (`workers: 1`) because lifecycle tests share DB-level
+gates. Prereqs: Postgres up (`docker-compose up -d db`), `backend/.env` present
+(fresh worktrees: copy it from the main checkout), `npm ci` +
+`npx playwright install chromium` done once in `frontend/`.
+
+**The DATABASE_URL / alembic gotcha:** `backend/alembic/env.py` reads
+`DATABASE_URL` from `os.environ`, **not** from `backend/.env`. Running
+`alembic upgrade head` by hand without it exported dies with
+`Can't load plugin: sqlalchemy.dialects:driver`. The runner script exports it
+for you; export it yourself for manual alembic runs. Because pydantic-settings
+gives real env vars precedence over `.env`, that same exported `DATABASE_URL`
+also repoints the backend and `seed.py` at the e2e database — isolation is
+env-var-only, no code changes.
+
+**Ad-hoc mode** (`npm run e2e` from `frontend/`) still works: it assumes a
+backend already up on :8000 and runs against whatever database that backend
+uses — fine for quick iteration, but it leaves bot accounts behind in the dev DB.
+
+**CI:** `.github/workflows/e2e.yml` runs the same `run-e2e.sh` nightly and on
+manual `workflow_dispatch`, and uploads the Playwright HTML report as an
+artifact. It is deliberately not on the PR-blocking path.
+
 ### GitHub Actions CI
 
 ```yaml

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -7,8 +7,10 @@ const authFile = 'playwright/.auth/user.json'
  * account and returns the httpOnly session cookie (dev/local only — 404s in prod).
  * We save that cookie so every authed spec starts logged in without repeating this.
  */
+const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
+
 setup('authenticate via dev-login', async ({ request }) => {
-  const res = await request.post('http://localhost:8000/auth/dev-login')
-  expect(res.ok(), 'dev-login failed — is the backend up on :8000?').toBeTruthy()
+  const res = await request.post(`${API}/auth/dev-login`)
+  expect(res.ok(), `dev-login failed — is the backend up on ${API}?`).toBeTruthy()
   await request.storageState({ path: authFile })
 })

--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -16,7 +16,7 @@ import { test, expect, type Browser, type BrowserContext } from '@playwright/tes
  * Prereqs: backend on :8000 (seeded dev DB at head), frontend on :5173.
  */
 
-const API = 'http://localhost:8000'
+const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
 // Unique per run so every test gets fresh accounts — no cross-run state bleed
 // (a character that already holds a praxis on the task can't create/join another).
 const RUN = Date.now().toString(36)
@@ -33,7 +33,7 @@ async function login(browser: Browser, key: string, name: string, level: number)
   const res = await ctx.request.post(
     `${API}/auth/dev-login?key=${encodeURIComponent(key)}&name=${encodeURIComponent(name)}&level=${level}`,
   )
-  expect(res.ok(), `dev-login failed for ${key} — is the backend up on :8000?`).toBeTruthy()
+  expect(res.ok(), `dev-login failed for ${key} — is the backend up on ${API}?`).toBeTruthy()
   const body = await res.json()
   return { ctx, characterId: body.character_id, name }
 }

--- a/frontend/e2e/run-e2e.sh
+++ b/frontend/e2e/run-e2e.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# One-command Playwright e2e runner against an ISOLATED database.
+#
+#   bash frontend/e2e/run-e2e.sh              # full suite
+#   bash frontend/e2e/run-e2e.sh collaboration.spec.ts   # extra args pass through
+#
+# What it does, in order:
+#   1. Derives an e2e DATABASE_URL (dev URL with the db name swapped to
+#      worldzero_e2e) unless E2E_DATABASE_URL is already exported (CI does this).
+#   2. Drops + recreates the e2e database (scripts/reset_e2e_db.py — refuses
+#      to touch anything not ending in _e2e).
+#   3. Runs `alembic upgrade head` — DATABASE_URL is exported because
+#      alembic/env.py reads os.environ, NOT backend/.env. Fails loudly on drift.
+#   4. Seeds via seed.py (env vars override .env, so it seeds the e2e db).
+#   5. Starts the branch backend on a dedicated port (default 8001) so the
+#      docker-compose backend on :8000 can't shadow the code under test.
+#   6. Runs `npx playwright test` — the playwright config starts the frontend
+#      dev server on a dedicated port (default 5174) with VITE_API_URL pointed
+#      at the e2e backend, serially (workers=1).
+#   7. Tears the backend down. The dev database is never touched.
+#
+# Prereqs: Postgres up (docker-compose up -d db), backend/.env present
+# (copy from your main checkout if this is a fresh worktree), npm ci done,
+# and `npx playwright install chromium` once.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+
+E2E_DB_NAME="${E2E_DB_NAME:-worldzero_e2e}"
+E2E_BACKEND_PORT="${E2E_BACKEND_PORT:-8001}"
+E2E_WEB_PORT="${E2E_WEB_PORT:-5174}"
+
+# Prefer the backend venv if present (Windows and POSIX layouts), else PATH python.
+if [ -x "$BACKEND_DIR/.venv/Scripts/python.exe" ]; then
+  PYTHON_BIN="$BACKEND_DIR/.venv/Scripts/python.exe"
+elif [ -x "$BACKEND_DIR/.venv/bin/python" ]; then
+  PYTHON_BIN="$BACKEND_DIR/.venv/bin/python"
+else
+  PYTHON_BIN="${PYTHON:-python}"
+fi
+
+cd "$BACKEND_DIR"
+
+if [ -z "${E2E_DATABASE_URL:-}" ]; then
+  if [ ! -f .env ]; then
+    echo "ERROR: backend/.env not found and E2E_DATABASE_URL not set." >&2
+    echo "Fresh worktree? Copy backend/.env from your main checkout." >&2
+    exit 1
+  fi
+  E2E_DATABASE_URL="$(E2E_DB_NAME="$E2E_DB_NAME" "$PYTHON_BIN" - <<'PYEOF'
+import os
+import re
+from script_utils import get_settings
+
+dev_url = get_settings("dev").DATABASE_URL
+e2e_url = re.sub(r"/[^/?]+(\?.*)?$", "/" + os.environ["E2E_DB_NAME"] + r"\1", dev_url)
+print(e2e_url)
+PYEOF
+)"
+fi
+
+export DATABASE_URL="$E2E_DATABASE_URL"
+export CORS_ORIGINS="http://localhost:$E2E_WEB_PORT"
+
+echo "==> e2e database: ${DATABASE_URL##*@}"
+
+echo "==> reset e2e database"
+"$PYTHON_BIN" scripts/reset_e2e_db.py
+
+echo "==> alembic upgrade head"
+"$PYTHON_BIN" -m alembic upgrade head
+
+echo "==> seed"
+"$PYTHON_BIN" seed.py
+
+echo "==> start backend on :$E2E_BACKEND_PORT"
+"$PYTHON_BIN" -m uvicorn main:app --port "$E2E_BACKEND_PORT" &
+BACKEND_PID=$!
+trap 'kill "$BACKEND_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 60); do
+  if curl -sf "http://localhost:$E2E_BACKEND_PORT/health" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+    echo "ERROR: backend exited during startup." >&2
+    exit 1
+  fi
+  sleep 1
+done
+curl -sf "http://localhost:$E2E_BACKEND_PORT/health" >/dev/null || {
+  echo "ERROR: backend never became healthy on :$E2E_BACKEND_PORT." >&2
+  exit 1
+}
+
+echo "==> playwright"
+cd "$FRONTEND_DIR"
+export E2E_API_URL="http://localhost:$E2E_BACKEND_PORT"
+export E2E_WEB_PORT
+npx playwright test "$@"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,31 +1,53 @@
 import { defineConfig, devices } from '@playwright/test'
 
 /**
- * End-to-end tests. Prereqs before `npm run e2e`:
- *   1. Backend up on :8000  (docker-compose up -d && uvicorn main:app --reload)
- *      — needs Postgres + .env, so we do NOT auto-start it here.
- *   2. Frontend on :5173    — auto-started below (reuseExistingServer if already up).
+ * End-to-end tests.
+ *
+ * Two ways to run:
+ *   1. Isolated (recommended): `bash frontend/e2e/run-e2e.sh` — resets a
+ *      dedicated worldzero_e2e database, migrates + seeds it, starts the
+ *      branch backend on :8001 and the frontend on :5174 via the env vars
+ *      below. See that script and docs/spec/SPEC-testing.md.
+ *   2. Ad-hoc (`npm run e2e`): backend must already be up on :8000
+ *      (docker-compose up -d && uvicorn main:app --reload) — it runs against
+ *      whatever database that backend points at. Frontend auto-starts on :5173.
+ *
+ * Env knobs (set by run-e2e.sh / CI, defaults preserve the ad-hoc flow):
+ *   E2E_WEB_PORT — frontend dev-server port (default 5173)
+ *   E2E_API_URL  — backend base URL (default http://localhost:8000); also
+ *                  injected into the dev server as VITE_API_URL so the app
+ *                  itself talks to the same backend the specs do.
  *
  * Auth: the `setup` project hits POST /auth/dev-login (the bot-login bypass,
  * dev-only) once and saves the session cookie to playwright/.auth/user.json.
  * The `chromium` project loads it, so specs start already logged in.
  * Guest specs opt out with test.use({ storageState: { cookies: [], origins: [] } }).
  */
+const WEB_PORT = process.env.E2E_WEB_PORT ?? '5173'
+const BASE_URL = `http://localhost:${WEB_PORT}`
+const API_URL = process.env.E2E_API_URL ?? 'http://localhost:8000'
+
 export default defineConfig({
   testDir: './e2e',
-  fullyParallel: true,
+  // Serial on purpose: lifecycle specs share DB-level gates (bank cap,
+  // one-membership-per-task, invite uniqueness) and race under parallel workers.
+  fullyParallel: false,
+  workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
+    command: `npm run dev -- --port ${WEB_PORT} --strictPort`,
+    url: BASE_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
+    // Playwright replaces the child env entirely when `env` is set — spread
+    // process.env so PATH etc. survive, then pin the API base for Vite.
+    env: { ...process.env, VITE_API_URL: API_URL } as Record<string, string>,
   },
   projects: [
     { name: 'setup', testMatch: /auth\.setup\.ts/ },


### PR DESCRIPTION
Closes #388.

Makes the Playwright lifecycle suites runnable **on demand and on a schedule** from a clean checkout, deterministically, against a **disposable isolated database** that never pollutes the dev DB.

## One command
```bash
bash frontend/e2e/run-e2e.sh                        # full suite
bash frontend/e2e/run-e2e.sh collaboration.spec.ts  # one spec
```
It derives an e2e `DATABASE_URL` (dev URL with the db name swapped to `worldzero_e2e`), drops+recreates that DB, `alembic upgrade head` (fails loudly on drift), seeds via `seed.py`, starts the **branch** backend on **:8001** (so the docker-compose backend on :8000 can't shadow the code under test), then runs Playwright, which starts the frontend on **:5174** with `VITE_API_URL` pointed at :8001. Serial (`workers: 1`) for the shared-DB gates.

## What's here
- **`backend/scripts/reset_e2e_db.py`** — drop + recreate the isolated DB; **refuses any name not ending in `_e2e`** (can't nuke dev/prod).
- **`frontend/e2e/run-e2e.sh`** — the one-command pipeline above.
- **`frontend/playwright.config.ts`** — serial; `E2E_WEB_PORT`/`E2E_API_URL` knobs (defaults preserve ad-hoc `npm run e2e`); injects `VITE_API_URL` so the app talks to the same backend the specs do.
- **`auth.setup.ts` / `collaboration.spec.ts`** — honor `E2E_API_URL`.
- **`.github/workflows/e2e.yml`** — **nightly** (`cron`) + `workflow_dispatch`; spins up Postgres, runs `run-e2e.sh`, uploads the Playwright HTML report artifact. **Not** on the PR-blocking path.
- **`docs/spec/SPEC-testing.md`** — "Running e2e" section documenting the env/alembic/compose/serial gotchas.

## Isolation mechanism
Env-var-only: an exported `DATABASE_URL` overrides `backend/.env` for alembic, `seed.py`, and the backend alike. Verified empirically against `get_settings()` in the main checkout venv — an exported URL wins over the dotenv value, so pointing everything at `worldzero_e2e` needs no code changes.

The dev-login enabler (`POST /auth/dev-login?key/name/level`) from #389 is already on `main`; this builds on it.

## What I could and couldn't verify locally
- ✅ Tracked patch applies cleanly to `main`; `reset_e2e_db.py` compiles and its `_e2e` guard correctly refuses the dev `worldzero` name; the dev→e2e URL swap resolves to `worldzero_e2e` preserving host/creds; `run-e2e.sh` passes `bash -n`; both workflow YAMLs parse; `DATABASE_URL` env-override precedence confirmed via `get_settings`.
- ❌ **Did not execute the Playwright suite** — `frontend/node_modules` isn't installed in this worktree and there's no `backend/.env`/venv here, so I could not run `npm run e2e` or `run-e2e.sh` end-to-end. The nightly CI job (or a local `npm ci && npx playwright install chromium` + `bash frontend/e2e/run-e2e.sh`) is the first real green-run check. No green run is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)