### PR TITLE
feat: drop-to-accept when task bank is full on duel accept (#314)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -174,6 +174,15 @@ export async function submitPraxis(id: number): Promise<PraxisOut> {
   return data
 }
 
+/**
+ * Leave a collab praxis you joined (not authored). Frees a task-bank slot —
+ * unlike withdraw, which keeps the membership. Backend: POST /praxes/{id}/leave.
+ */
+export async function leavePraxis(id: number): Promise<PraxisOut> {
+  const { data } = await api.post<PraxisOut>(`/praxes/${id}/leave`)
+  return data
+}
+
 // ---------------------------------------------------------------------------
 // Media
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -2,19 +2,33 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
 import { useRespondToRequest } from "../../hooks/useRespondToRequest";
+import { useMyActiveTasks } from "../../hooks/useMyActiveTasks";
+import { useGameConfig } from "../../hooks/useGameConfig";
+import { useAuth } from "../../auth/AuthContext";
+import { deletePraxis, leavePraxis } from "../../api/praxis";
+import { respondToChallenge } from "../../api/duel";
 import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
+import { extractError } from "../../utils/errors";
 import FeedBadge from "./FeedBadge";
 
 interface Props {
   item: ActivityFeedItem;
 }
 
+// Duel accept returns 400 "Task bank is full (N in-progress praxes)." when the
+// accepter has no free slot — NOT 409 (the collab twin #322 returns 409). Detect
+// on the detail substring, not the status code.
+const BANK_FULL_MARKER = "Task bank is full";
+
+const DEFAULT_MAX_TASK_SLOTS = 20;
+
 export default function FeedCardDuelChallenge({ item }: Props) {
   // Duel payload carries duel_id / challenger_praxis_id / duel_status — NOT
   // the collab invite_id / praxis_id / invite_status fields. The shared hook
   // owns the endpoint switch (#346).
   const {
+    duel_id,
     challenger_praxis_id,
     task_title,
     task_point_value,
@@ -25,33 +39,74 @@ export default function FeedCardDuelChallenge({ item }: Props) {
   const actorColor = factionColor(item.actor_faction_slug);
   const navigate = useNavigate();
 
-  const { accept, decline, loading, status, error } = useRespondToRequest(item);
-  // Task-list-full modal state — dormant skeleton, wired by #322/#314.
-  const [showDropModal, setShowDropModal] = useState(false);
-  const [myTasks] = useState<
-    { id: number; task: { id: number; title: string } }[]
-  >([]);
+  const { user } = useAuth();
+  const gameConfig = useGameConfig();
+  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS;
 
-  const doAccept = async (drop_task_id?: number) => {
+  const { accept, decline, loading, status, error } = useRespondToRequest(item);
+  // In-progress praxes the viewer can drop to free a bank slot (#314).
+  const { activeTasks, refetch: refetchActiveTasks } = useMyActiveTasks();
+  const [showDropModal, setShowDropModal] = useState(false);
+  // Local error surface: the bank-full path swallows the hook error and opens
+  // the modal instead, so we need our own channel for drop/retry failures.
+  const [dropError, setDropError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const landOnPraxis = (praxisId: number | null) => {
+    // Accepting creates the opponent's fresh praxis server-side — land the
+    // responder on its editor so they can start working (mirrors collab).
+    navigate(
+      praxisId ? `/praxes/${praxisId}/edit` : `/praxes/${challenger_praxis_id}`,
+    );
+  };
+
+  const handleAccept = async () => {
+    setDropError("");
     const result = await accept();
     if (result.ok) {
-      if (drop_task_id) {
-        // Drop task was selected from modal — handled server-side via the task list
-      }
-      setShowDropModal(false);
-      // Accepting creates the opponent's fresh praxis server-side — land the
-      // responder on its editor so they can start working (mirrors collab).
-      navigate(
-        result.praxisId
-          ? `/praxes/${result.praxisId}/edit`
-          : `/praxes/${challenger_praxis_id}`,
-      );
+      landOnPraxis(result.praxisId);
+      return;
+    }
+    // The hook already set `error` from the backend detail. If the accept
+    // failed because the viewer's task bank is full, surface the drop modal
+    // instead of the generic message; any other error falls through to the
+    // inline `error` the hook exposes.
+    if (result.detail?.includes(BANK_FULL_MARKER)) {
+      refetchActiveTasks();
+      setShowDropModal(true);
     }
   };
 
-  const handleAccept = () => doAccept();
-
   const handleDecline = () => decline();
+
+  // Drop the chosen in-progress praxis to free a slot, then retry the accept.
+  //   authored solo  → deletePraxis  (removes the praxis)
+  //   joined collab  → leavePraxis   (drops your membership)
+  // NEVER withdrawPraxis — it keeps the membership and does not free a slot.
+  const dropAndRetry = async (praxis: {
+    id: number;
+    created_by_id: number;
+  }) => {
+    if (busy) return;
+    setBusy(true);
+    setDropError("");
+    try {
+      const mine = user?.character?.id;
+      if (mine !== undefined && praxis.created_by_id === mine) {
+        await deletePraxis(praxis.id);
+      } else {
+        await leavePraxis(praxis.id);
+      }
+      // Slot freed — retry the accept directly (the hook has no drop path).
+      const duel = await respondToChallenge(duel_id, { accept: true });
+      setShowDropModal(false);
+      landOnPraxis(duel.opponent_praxis_id);
+    } catch (err) {
+      setDropError(extractError(err, "Could not drop that task. Try another."));
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const isPending = status === "pending";
 
@@ -166,7 +221,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
           >
             <button
               onClick={handleAccept}
-              disabled={loading}
+              disabled={loading || busy}
               style={{
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 9,
@@ -177,14 +232,14 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 color: "var(--color-text-on-accent)",
                 border: "none",
                 padding: "5px 14px",
-                cursor: loading ? "not-allowed" : "pointer",
+                cursor: loading || busy ? "not-allowed" : "pointer",
               }}
             >
               Accept Duel
             </button>
             <button
               onClick={handleDecline}
-              disabled={loading}
+              disabled={loading || busy}
               style={{
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 9,
@@ -195,12 +250,12 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 color: "var(--color-text-secondary)",
                 border: "1px solid var(--color-border)",
                 padding: "5px 14px",
-                cursor: loading ? "not-allowed" : "pointer",
+                cursor: loading || busy ? "not-allowed" : "pointer",
               }}
             >
               Decline
             </button>
-            {error && (
+            {error && !showDropModal && (
               <span
                 className="eyebrow"
                 style={{ color: "var(--color-danger)" }}
@@ -270,7 +325,8 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 color: "var(--color-text-secondary)",
               }}
             >
-              You have 20 in-progress tasks. Drop one to accept this duel:
+              You have {maxTaskSlots} in-progress tasks. Drop one to accept this
+              duel:
             </p>
             <div
               style={{
@@ -281,26 +337,34 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 overflowY: "auto",
               }}
             >
-              {myTasks.map((ct) => (
+              {activeTasks.map((praxis) => (
                 <button
-                  key={ct.id}
-                  onClick={() => doAccept(ct.task.id)}
-                  disabled={loading}
+                  key={praxis.id}
+                  onClick={() => dropAndRetry(praxis)}
+                  disabled={busy}
                   style={{
                     background: "var(--color-bg-surface-alt)",
                     border: "1px solid var(--color-border)",
                     padding: "8px 12px",
-                    cursor: "pointer",
+                    cursor: busy ? "not-allowed" : "pointer",
                     textAlign: "left",
                     fontFamily: "'Courier Prime', monospace",
                     fontSize: 10,
                     color: "var(--color-text-primary)",
                   }}
                 >
-                  Drop: {ct.task.title}
+                  Drop: {praxis.title || praxis.task_title}
                 </button>
               ))}
             </div>
+            {dropError && (
+              <p
+                className="eyebrow"
+                style={{ color: "var(--color-danger)", marginTop: 10 }}
+              >
+                {dropError}
+              </p>
+            )}
             <button
               onClick={() => setShowDropModal(false)}
               style={{

--- a/frontend/src/hooks/useRespondToRequest.ts
+++ b/frontend/src/hooks/useRespondToRequest.ts
@@ -68,6 +68,12 @@ export interface RespondResult {
   ok: boolean
   /** Praxis to navigate to after a successful accept (null on decline/failure). */
   praxisId: number | null
+  /**
+   * Raw backend `detail` string on failure (undefined on success). Lets callers
+   * branch on a specific reason — e.g. the duel/collab cards detect the
+   * task-bank-full message to open their drop modal (#314/#322).
+   */
+  detail?: string
 }
 
 export function useRespondToRequest(item: ActivityFeedItem) {
@@ -90,8 +96,14 @@ export function useRespondToRequest(item: ActivityFeedItem) {
       // of a generic swallow. (#318)
       const noun = item.type === 'duel_challenge' ? 'duel' : 'invite'
       const verb = acceptRequest ? 'accept' : 'decline'
-      setError(extractError(err, `Could not ${verb} ${noun}. Please try again.`))
-      return { ok: false, praxisId: null }
+      const message = extractError(
+        err,
+        `Could not ${verb} ${noun}. Please try again.`,
+      )
+      setError(message)
+      // extractError returns the backend `detail` verbatim when present, so
+      // callers can substring-match a specific reason (e.g. bank-full).
+      return { ok: false, praxisId: null, detail: message }
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## What

Wires the dormant drop-modal skeleton in `FeedCardDuelChallenge.tsx` so a player at their task-bank cap can still accept a duel by dropping one in-progress task.

Accepting a duel creates the opponent's solo praxis, which the backend rejects with **400** `"Task bank is full (N in-progress praxes)."` when the accepter is at `era.max_task_signups` (`respond_to_duel_challenge`, `backend/services/duel.py`).

## Changes (scope: one card + additive support)

`frontend/src/components/feed/FeedCardDuelChallenge.tsx`
- **Detect bank-full** on the backend `detail` substring (`"Task bank is full"`) — NOT the status code (duel accept is 400; the collab twin #322 returns 409). Opens the drop modal; any other error falls through to the hook's inline error.
- **Populate the list** from the shared `useMyActiveTasks()` hook (`activeTasks: PraxisCardOut[]`), refetched when the modal opens.
- **Drop frees a real slot, then retries:** `deletePraxis(id)` for an authored-solo praxis (`created_by_id === user.character.id`), else `leavePraxis(id)` for a joined collab. Never `withdrawPraxis` (keeps the membership, frees nothing). Then retries `respondToChallenge(duel_id, { accept: true })` and navigates to the fresh opponent praxis editor.
- **Real cap copy:** replaced the hardcoded `"20 in-progress tasks"` with the live `max_task_signups` from `useGameConfig()`.

Additive support (kept the shared-hook contract intact for #322):
- `frontend/src/hooks/useRespondToRequest.ts`: `RespondResult` now carries the backend `detail` string on failure so cards can branch on a specific reason. Existing `{ ok, praxisId }` shape unchanged.
- `frontend/src/api/praxis.ts`: added `leavePraxis(id)` client for the existing `POST /praxes/{id}/leave` route.

## Testing
- `npx vitest run` — 161 passed.
- `npx tsc --noEmit` clean for the touched files (one pre-existing error in `isViewerMember.test.ts` from the ADR-0028 Task Crown commit is unrelated and present on `main`).

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)