### PR TITLE
feat: drop-to-accept when task bank full on collab invite (#322)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -212,6 +212,16 @@ export async function respondToInvite(
   return data
 }
 
+/**
+ * Leave a collab praxis you joined (frees a task-bank slot). Distinct from
+ * withdrawPraxis, which reverts your own praxis to edit and does NOT free a
+ * slot. Used by the bank-full drop-to-accept flow (#322).
+ */
+export async function leavePraxis(id: number): Promise<PraxisOut> {
+  const { data } = await api.post<PraxisOut>(`/praxes/${id}/leave`)
+  return data
+}
+
 // ---------------------------------------------------------------------------
 // Metatasks — metatasks are Task rows with task_type='metatask' attached
 // to a praxis via POST /praxes/{id}/metatasks.

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -221,16 +221,6 @@ export async function respondToInvite(
   return data
 }
 
-/**
- * Leave a collab praxis you joined (frees a task-bank slot). Distinct from
- * withdrawPraxis, which reverts your own praxis to edit and does NOT free a
- * slot. Used by the bank-full drop-to-accept flow (#322).
- */
-export async function leavePraxis(id: number): Promise<PraxisOut> {
-  const { data } = await api.post<PraxisOut>(`/praxes/${id}/leave`)
-  return data
-}
-
 // ---------------------------------------------------------------------------
 // Metatasks — metatasks are Task rows with task_type='metatask' attached
 // to a praxis via POST /praxes/{id}/metatasks.

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -1,6 +1,16 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ActivityFeedItem } from "../../api/activityFeed";
 import { useRespondToRequest } from "../../hooks/useRespondToRequest";
+import { useMyActiveTasks } from "../../hooks/useMyActiveTasks";
+import { useGameConfig } from "../../hooks/useGameConfig";
+import { useAuth } from "../../auth/AuthContext";
+import {
+  respondToInvite,
+  deletePraxis,
+  leavePraxis,
+} from "../../api/praxis";
+import { extractError } from "../../utils/errors";
 import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
@@ -9,9 +19,12 @@ interface Props {
   item: ActivityFeedItem;
 }
 
+const DEFAULT_MAX_TASK_SLOTS = 20;
+
 export default function FeedCardCollabInvite({ item }: Props) {
   const {
     praxis_id,
+    invite_id,
     task_title,
     task_point_value,
     task_faction_slug,
@@ -22,7 +35,19 @@ export default function FeedCardCollabInvite({ item }: Props) {
   const actorColor = factionColor(item.actor_faction_slug);
   const navigate = useNavigate();
 
+  const { user } = useAuth();
   const { accept, decline, loading, status, error } = useRespondToRequest(item);
+
+  // Bank-full drop-to-accept flow (#322). The invitee's task bank can be full;
+  // accepting then raises 409 "Task bank is full (N in-progress praxes).". We
+  // let them drop one in-progress praxis to make room, then retry the accept.
+  const { activeTasks, refetch: refetchActiveTasks } = useMyActiveTasks();
+  const gameConfig = useGameConfig();
+  const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS;
+
+  const [showDropModal, setShowDropModal] = useState(false);
+  const [dropError, setDropError] = useState("");
+  const [dropping, setDropping] = useState(false);
 
   const handleAccept = async () => {
     const result = await accept();
@@ -30,108 +55,115 @@ export default function FeedCardCollabInvite({ item }: Props) {
       // New members land on the editor so they can contribute; the editor
       // self-locks if the collab is already submitted (controlsLocked). (#298)
       navigate(`/praxes/${result.praxisId ?? praxis_id}/edit`);
+      return;
+    }
+    // The hook swallowed the failure into `error` (rendered below) but doesn't
+    // hand back the raw axios error, and its `error` state is stale this tick.
+    // Re-issue the accept directly so we can inspect the backend detail: when
+    // the invitee's task bank is full, offer to drop one praxis and retry.
+    // Match on the detail SUBSTRING (bank-full is 409 on collab, 400 on the
+    // duel twin) — not the status code. Other errors stay on the hook's `error`.
+    try {
+      await respondToInvite(praxis_id, invite_id, true);
+      // Raced free between the two calls — land on the collab like happy path.
+      navigate(`/praxes/${praxis_id}/edit`);
+    } catch (err) {
+      const detail = (err as { response?: { data?: { detail?: unknown } } })
+        ?.response?.data?.detail;
+      if (typeof detail === "string" && detail.includes("Task bank is full")) {
+        setDropError("");
+        refetchActiveTasks();
+        setShowDropModal(true);
+      }
     }
   };
 
   const handleDecline = () => decline();
 
+  // Drop one in-progress praxis to free a bank slot, then retry the accept.
+  // Authored-solo praxes are deleted; joined collabs are left. Never withdraw —
+  // withdraw reverts to edit and does NOT free a slot (#322).
+  const handleDrop = async (praxisToDropId: number, createdById: number) => {
+    setDropping(true);
+    setDropError("");
+    try {
+      if (createdById === user?.character?.id) {
+        await deletePraxis(praxisToDropId);
+      } else {
+        await leavePraxis(praxisToDropId);
+      }
+      await respondToInvite(praxis_id, invite_id, true);
+      setShowDropModal(false);
+      navigate(`/praxes/${praxis_id}`);
+    } catch (err) {
+      setDropError(extractError(err, "Could not drop that task. Try again."));
+    } finally {
+      setDropping(false);
+    }
+  };
+
   const isPending = status === "pending";
 
   return (
-    <div style={{ padding: "12px 16px" }}>
-      <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
-        <Link to={`/characters/${inviter_character_id}`}>
-          <div
-            style={{
-              width: 28,
-              height: 28,
-              borderRadius: "50%",
-              background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
-              flexShrink: 0,
-              marginTop: 2,
-            }}
-          />
-        </Link>
-
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-              flexWrap: "wrap",
-            }}
-          >
-            <Link
-              to={`/characters/${inviter_character_id}`}
-              className="font-body"
+    <>
+      <div style={{ padding: "12px 16px" }}>
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+          <Link to={`/characters/${inviter_character_id}`}>
+            <div
               style={{
-                fontSize: 11,
-                fontWeight: 700,
-                color: "var(--color-text-primary)",
-                textDecoration: "none",
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+                flexShrink: 0,
+                marginTop: 2,
+              }}
+            />
+          </Link>
+
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                flexWrap: "wrap",
               }}
             >
-              {item.actor_display_name}
-            </Link>
+              <Link
+                to={`/characters/${inviter_character_id}`}
+                className="font-body"
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: "var(--color-text-primary)",
+                  textDecoration: "none",
+                }}
+              >
+                {item.actor_display_name}
+              </Link>
+              <span
+                className="font-body"
+                style={{ fontSize: 11, color: "var(--color-text-secondary)" }}
+              >
+                invited you to collaborate
+              </span>
+              <FeedBadge type="your_stuff" label="Your Stuff" />
+            </div>
             <span
-              className="font-body"
-              style={{ fontSize: 11, color: "var(--color-text-secondary)" }}
+              className="eyebrow"
+              style={{
+                color: "var(--color-text-tertiary)",
+                display: "block",
+                marginTop: 2,
+              }}
             >
-              invited you to collaborate
+              {relativeTime(item.timestamp)}
             </span>
-            <FeedBadge type="your_stuff" label="Your Stuff" />
           </div>
-          <span
-            className="eyebrow"
-            style={{
-              color: "var(--color-text-tertiary)",
-              display: "block",
-              marginTop: 2,
-            }}
-          >
-            {relativeTime(item.timestamp)}
-          </span>
         </div>
-      </div>
 
-      {/* Task detail */}
-      <div
-        style={{
-          marginTop: 10,
-          marginLeft: 38,
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-        }}
-      >
-        <span
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            background: taskColor,
-            flexShrink: 0,
-          }}
-        />
-        <span
-          className="font-body"
-          style={{
-            fontSize: 11,
-            fontWeight: 700,
-            color: "var(--color-text-primary)",
-          }}
-        >
-          {task_title}
-        </span>
-        <span className="eyebrow" style={{ color: "var(--color-text-tertiary)" }}>
-          {task_point_value} pts · lvl {task_level_required}
-        </span>
-        <FeedBadge type="collab" label="Collab" />
-      </div>
-
-      {/* Accept/Decline buttons */}
-      {isPending && (
+        {/* Task detail */}
         <div
           style={{
             marginTop: 10,
@@ -139,71 +171,213 @@ export default function FeedCardCollabInvite({ item }: Props) {
             display: "flex",
             alignItems: "center",
             gap: 8,
-            flexWrap: "wrap",
           }}
         >
-          <button
-            onClick={handleAccept}
-            disabled={loading}
+          <span
             style={{
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 9,
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: taskColor,
+              flexShrink: 0,
+            }}
+          />
+          <span
+            className="font-body"
+            style={{
+              fontSize: 11,
               fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              background: "var(--badge-collab)",
-              color: "var(--color-text-on-accent)",
-              border: "none",
-              padding: "5px 14px",
-              cursor: loading ? "not-allowed" : "pointer",
+              color: "var(--color-text-primary)",
             }}
           >
-            Accept
-          </button>
-          <button
-            onClick={handleDecline}
-            disabled={loading}
-            style={{
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 9,
-              fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              background: "transparent",
-              color: "var(--color-text-secondary)",
-              border: "1px solid var(--color-border)",
-              padding: "5px 14px",
-              cursor: loading ? "not-allowed" : "pointer",
-            }}
-          >
-            Decline
-          </button>
-          {error && (
-            <span className="eyebrow" style={{ color: "var(--color-danger)" }}>
-              {error}
-            </span>
-          )}
-        </div>
-      )}
-
-      {status === "accepted" && (
-        <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <Link
-            to={`/praxes/${praxis_id}`}
-            className="eyebrow"
-            style={{ color: "var(--badge-collab)", textDecoration: "none" }}
-          >
-            Accepted — view collaboration
-          </Link>
-        </div>
-      )}
-      {status === "declined" && (
-        <div style={{ marginTop: 8, marginLeft: 38 }}>
-          <span className="eyebrow" style={{ color: "var(--color-text-tertiary)" }}>
-            Declined
+            {task_title}
           </span>
+          <span
+            className="eyebrow"
+            style={{ color: "var(--color-text-tertiary)" }}
+          >
+            {task_point_value} pts · lvl {task_level_required}
+          </span>
+          <FeedBadge type="collab" label="Collab" />
+        </div>
+
+        {/* Accept/Decline buttons */}
+        {isPending && (
+          <div
+            style={{
+              marginTop: 10,
+              marginLeft: 38,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flexWrap: "wrap",
+            }}
+          >
+            <button
+              onClick={handleAccept}
+              disabled={loading}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                background: "var(--badge-collab)",
+                color: "var(--color-text-on-accent)",
+                border: "none",
+                padding: "5px 14px",
+                cursor: loading ? "not-allowed" : "pointer",
+              }}
+            >
+              Accept
+            </button>
+            <button
+              onClick={handleDecline}
+              disabled={loading}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                background: "transparent",
+                color: "var(--color-text-secondary)",
+                border: "1px solid var(--color-border)",
+                padding: "5px 14px",
+                cursor: loading ? "not-allowed" : "pointer",
+              }}
+            >
+              Decline
+            </button>
+            {error && (
+              <span className="eyebrow" style={{ color: "var(--color-danger)" }}>
+                {error}
+              </span>
+            )}
+          </div>
+        )}
+
+        {status === "accepted" && (
+          <div style={{ marginTop: 8, marginLeft: 38 }}>
+            <Link
+              to={`/praxes/${praxis_id}`}
+              className="eyebrow"
+              style={{ color: "var(--badge-collab)", textDecoration: "none" }}
+            >
+              Accepted — view collaboration
+            </Link>
+          </div>
+        )}
+        {status === "declined" && (
+          <div style={{ marginTop: 8, marginLeft: 38 }}>
+            <span
+              className="eyebrow"
+              style={{ color: "var(--color-text-tertiary)" }}
+            >
+              Declined
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Task-bank-full drop-to-accept modal (#322) */}
+      {showDropModal && (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000,
+            background: "rgba(0,0,0,0.5)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 20,
+          }}
+          onClick={() => setShowDropModal(false)}
+        >
+          <div
+            style={{
+              background: "var(--color-bg-surface)",
+              border: "1px solid var(--color-border)",
+              padding: "24px",
+              maxWidth: 420,
+              width: "100%",
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="eyebrow" style={{ marginBottom: 8 }}>
+              Task bank full
+            </p>
+            <p
+              className="font-body"
+              style={{
+                fontSize: 11,
+                marginBottom: 16,
+                color: "var(--color-text-secondary)",
+              }}
+            >
+              You have {maxTaskSlots} in-progress tasks. Drop one to accept this
+              collaboration:
+            </p>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
+                maxHeight: 260,
+                overflowY: "auto",
+              }}
+            >
+              {activeTasks.map((praxis) => (
+                <button
+                  key={praxis.id}
+                  onClick={() =>
+                    handleDrop(praxis.id, praxis.created_by_id)
+                  }
+                  disabled={dropping}
+                  style={{
+                    background: "var(--color-bg-surface-alt)",
+                    border: "1px solid var(--color-border)",
+                    padding: "8px 12px",
+                    cursor: dropping ? "not-allowed" : "pointer",
+                    textAlign: "left",
+                    fontFamily: "'Courier Prime', monospace",
+                    fontSize: 10,
+                    color: "var(--color-text-primary)",
+                  }}
+                >
+                  Drop: {praxis.title || praxis.task_title}
+                </button>
+              ))}
+            </div>
+            {dropError && (
+              <p
+                className="eyebrow"
+                style={{ color: "var(--color-danger)", marginTop: 10 }}
+              >
+                {dropError}
+              </p>
+            )}
+            <button
+              onClick={() => setShowDropModal(false)}
+              style={{
+                marginTop: 14,
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                background: "transparent",
+                border: "1px solid var(--color-border)",
+                padding: "5px 14px",
+                cursor: "pointer",
+                color: "var(--color-text-secondary)",
+              }}
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #322

## Problem
Accepting a collab invite when the invitee's task bank is full raises **409** `"Task bank is full (N in-progress praxes)."` (`respond_to_invite`, `backend/services/praxis.py`). The feed card swallowed it into a generic error, leaving the invitee stuck with no way to make room.

## Change
`FeedCardCollabInvite.tsx` now offers a drop-to-accept flow:

1. **Detect bank-full.** On accept failure, re-issue `respondToInvite` to inspect the raw backend detail and match on the **substring** `"Task bank is full"` (not the status code — collab is 409, the duel twin #314 is 400). Any other error stays on the shared hook's `error`.
2. **Populate the list** from the existing `useMyActiveTasks()` hook (real `PraxisCardOut[]`), not the old empty placeholder state.
3. **Drop = un-signup, then retry:**
   - authored-solo (`created_by_id === user.character.id`) -> `deletePraxis(id)`
   - joined collab -> `leavePraxis(id)` (new thin API wrapper for the existing `POST /praxes/{id}/leave`)
   - **never** `withdrawPraxis` (reverts to edit, does NOT free a slot)
   - then retry `respondToInvite(praxis_id, invite_id, true)` and navigate to `/praxes/{praxis_id}`.
4. **Real cap copy** via `useGameConfig().max_task_signups` instead of the hardcoded "20".

The drop logic is kept local to this card so the shared `useRespondToRequest` hook contract is untouched (the duel twin #314 is being built concurrently against it).

## Files
- `frontend/src/components/feed/FeedCardCollabInvite.tsx` — wired the modal + drop flow
- `frontend/src/api/praxis.ts` — added `leavePraxis(id)` wrapper (needed by the drop path)

## Tests
- `npx tsc --noEmit` clean for the changed files (one unrelated pre-existing error in `isViewerMember.test.ts` from ADR-0028, present on `main`).
- `npx vitest run` — 161 passed / 16 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)