### PR TITLE
feat: gate Albescent join eligibility at the defection site + field-desk invitation (#395, ADR-0021)

### DIFF
--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -559,8 +559,9 @@ ERA_1_LEVEL_PROFILES = (
     LevelProfile(
         rank="Paragon",
         unlocks=(
-            LevelUnlock(LevelUnlockKind.ability, "Start an Albescent character",
-                        "Unlock /Albescent as a starting faction for a future character."),
+            LevelUnlock(LevelUnlockKind.ability, "Join /Albescent",
+                        "Defect a life you carry to /Albescent — the order is "
+                        "joined in the field, never picked at creation."),
             LevelUnlock(LevelUnlockKind.sense, "See the underline before it's drawn",
                         "You've read enough field stamps to know how this sentence ends."),
         ),

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -117,7 +117,10 @@ async def can_start_as_albescent(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> bool:
-    """True when this account may create a new character in the Albescent faction.
+    """True when this account may move a character into the Albescent faction.
+
+    Albescent is joined in the field via defection (``defect_to_faction``) —
+    it is never a starting faction and never a character-creation option.
 
     Both conditions must hold on the *same* character:
     (a) active and at level ``era.albescent_level_required`` or above, and

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -12,6 +12,7 @@ from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
 from models.task import Task
 from schemas.faction import FactionUpdate
+from services.character import ALBESCENT_FACTION_SLUG, can_start_as_albescent
 from services.era import clear_defection_history_for_era, get_current_era_row, get_or_create_stats
 
 UA_FACTION_SLUG: str = "ua"
@@ -61,7 +62,8 @@ async def defect_to_faction(
     Works for both initial faction choice (from aged_out) and later defections.
     Raises 422 if the target is the current faction, 404 if the target doesn't
     exist or isn't selectable, and 403 if the player previously left this faction
-    and it doesn't allow rejoining.
+    and it doesn't allow rejoining, or if the target is Albescent and the account
+    has not met the ADR-0021 eligibility bar (level + full faction coverage).
     """
     if character.faction_slug == target_slug:
         raise HTTPException(
@@ -86,6 +88,17 @@ async def defect_to_faction(
         raise HTTPException(
             status_code=403,
             detail="Cannot rejoin a faction you have left.",
+        )
+
+    # ADR-0021: Albescent is joined in the field via defection, but only once the
+    # *account* (not this character) has met the eligibility bar. Albescent's
+    # can_always_rejoin=True slips the selectability guard above, so enforce here.
+    if target_slug == ALBESCENT_FACTION_SLUG and not await can_start_as_albescent(
+        character.account_id, session, era
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="The order has not extended its hand to you.",
         )
 
     # Record defection from current faction (if it's a real faction, not na)

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -130,6 +130,121 @@ async def test_choose_faction_from_ua(
     assert resp.json()["slug"] == "wow"
 
 
+# ---------------------------------------------------------------------------
+# Albescent join gate (ADR-0021, #395)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_faction(session: AsyncSession, slug: str) -> None:
+    """Seed a Faction row (FK target) if it doesn't already exist."""
+    from sqlalchemy import select
+
+    existing = await session.execute(select(Faction).where(Faction.slug == slug))
+    if existing.scalar_one_or_none() is None:
+        session.add(Faction(
+            slug=slug,
+            name=slug,
+            description=f"{slug} test faction",
+            status=FactionStatus.visible,
+        ))
+        await session.flush()
+
+
+async def _make_account_albescent_eligible(
+    session: AsyncSession,
+    character: Character,
+    era: Era,
+) -> None:
+    """Meet the ADR-0021 bar: level 8 + a submitted praxis in every non-sentinel faction."""
+    from sqlalchemy import select
+
+    from game_config import CURRENT_ERA
+    from models.character_stats import CharacterStats
+    from models.praxis import Praxis, PraxisStatus, PraxisType
+    from models.task import Task, TaskStatus
+
+    result = await session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.level = CURRENT_ERA.albescent_level_required
+
+    sentinel_slugs = frozenset({"na", "aged_out", "albescent"})
+    for faction_slug in CURRENT_ERA.factions:
+        if faction_slug in sentinel_slugs:
+            continue
+        await _seed_faction(session, faction_slug)
+        task = Task(
+            title=f"Albescent gate task: {faction_slug}",
+            description="test",
+            point_value=5,
+            level_required=0,
+            status=TaskStatus.active,
+            created_by=character.id,
+            primary_faction_slug=faction_slug,
+        )
+        session.add(task)
+        await session.flush()
+        session.add(Praxis(
+            task_id=task.id,
+            created_by_id=character.id,
+            type=PraxisType.solo,
+            title=f"Albescent gate praxis: {faction_slug}",
+            body_text="proof",
+            status=PraxisStatus.submitted,
+        ))
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_choose_albescent_ineligible_forbidden(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """An account that hasn't met the ADR-0021 bar gets 403 defecting to Albescent.
+
+    Albescent is is_selectable=False + can_always_rejoin=True, which slips the
+    selectability guard — the eligibility guard must still refuse the join.
+    """
+    await _seed_faction(db_session, "albescent")
+    await db_session.commit()
+
+    resp = await client.post(
+        "/factions/choose",
+        json={"faction_slug": "albescent"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403
+    assert character.faction_slug == "ua"
+
+
+@pytest.mark.asyncio
+async def test_choose_albescent_eligible_succeeds(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """An eligible account (level 8 + full faction coverage) may defect to Albescent."""
+    await _seed_faction(db_session, "albescent")
+    await _make_account_albescent_eligible(db_session, character, era)
+
+    resp = await client.post(
+        "/factions/choose",
+        json={"faction_slug": "albescent"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "albescent"
+
+
 @pytest.mark.asyncio
 async def test_choose_nonexistent_faction(
     client: AsyncClient,

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -11,6 +11,8 @@ export interface CharacterOut {
   score: number
   all_time_score: number
   faction_slug: string | null
+  /** "active" | "paused" | "banned" — the roster includes paused lives (#270). */
+  status: string
   created_at: string
 }
 

--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -1,0 +1,278 @@
+import { useState, type CSSProperties } from 'react'
+import type { CharacterOut } from '../api/auth'
+import { setActiveCharacter } from '../api/me'
+import { chooseFaction } from '../api/factions'
+import { extractError } from '../utils/errors'
+import { factionName } from '../utils/factions'
+
+/**
+ * AlbescentInvitation — the order's standing correspondence (#395).
+ *
+ * Ported from the World Zero Design System "Albescent Join Screen" (AlRecruit):
+ * a vellum letter — white cotton paper, hairline rules, Cormorant italic, the
+ * surveyor's-mark sigil, a "terms, plainly" slip and the "Accept the order" CTA.
+ *
+ * Shown only when the account's server-computed `can_start_as_albescent` flag is
+ * true (ADR-0021 — account-collective eligibility). The player picks WHICH life
+ * takes up the work; Accept switches the account to that life (existing
+ * character-switch flow) and then defects it via POST /factions/choose.
+ *
+ * SECRECY (ADR-0027 / #390): the letter may name Albescent but never links to
+ * /factions or /factions/albescent — the faction is not to be looked up.
+ */
+
+const ALBESCENT_SLUG = 'albescent'
+
+/** Active, non-Albescent lives — the only ones the order will take. */
+export function eligibleLives(lives: CharacterOut[]): CharacterOut[] {
+  return lives.filter(
+    (life) => life.status === 'active' && life.faction_slug !== ALBESCENT_SLUG,
+  )
+}
+
+// Albescent vellum tokens (index.css). Albescent is always-light by design —
+// these vars are identical in both themes, so the letter never flips dark.
+const BG = 'var(--faction-albescent-card-bg)'
+const INK = 'var(--faction-albescent-card-text)'
+const ACCENT = 'var(--faction-albescent-card-accent)'
+const MUTED = 'var(--faction-albescent-card-muted)'
+const SERIF = 'var(--faction-albescent-card-font)'
+const MONO = "'Courier Prime', monospace"
+// Structural hairlines — no token exists; mirrors AlbescentComment's practice.
+const HAIRLINE = 'rgba(0,0,0,0.10)'
+const HAIRLINE_FAINT = 'rgba(0,0,0,0.055)'
+const RULE = 'rgba(0,0,0,0.07)'
+
+const TERMS: ReadonlyArray<{ label: string; value: string }> = [
+  { label: 'toll of entry', value: 'one duty, quietly kept' },
+  { label: 'required skills', value: 'none — only care' },
+  { label: 'expected output', value: 'accounts, entered plainly' },
+  { label: 'standing', value: 'unranked, by design' },
+]
+
+const PERKS: ReadonlyArray<string> = [
+  'A record that survives the keeper',
+  'Duties that ask nothing back',
+  'Your account, witnessed and inscribed',
+]
+
+/** The surveyor's cross-hair mark — Albescent's only sigil. */
+function AlbescentMark({ size = 44 }: { size?: number }) {
+  const center = size / 2
+  const outerRadius = size * 0.43
+  const innerRadius = size * 0.235
+  const dotRadius = size * 0.044
+  const tickStart = innerRadius + size * 0.025
+  const tickEnd = tickStart + size * 0.13
+  const tick = (degrees: number) => {
+    const angle = (degrees * Math.PI) / 180
+    return {
+      x1: center + tickStart * Math.cos(angle),
+      y1: center + tickStart * Math.sin(angle),
+      x2: center + tickEnd * Math.cos(angle),
+      y2: center + tickEnd * Math.sin(angle),
+    }
+  }
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none" style={{ display: 'block', flexShrink: 0 }} aria-hidden>
+      <circle cx={center} cy={center} r={outerRadius} stroke={INK} strokeWidth={size * 0.022} opacity={0.18} />
+      <circle cx={center} cy={center} r={innerRadius} stroke={INK} strokeWidth={size * 0.038} opacity={0.5} />
+      {[0, 90, 180, 270].map((degrees) => {
+        const { x1, y1, x2, y2 } = tick(degrees)
+        return <line key={degrees} x1={x1} y1={y1} x2={x2} y2={y2} stroke={INK} strokeWidth={size * 0.038} />
+      })}
+      <circle cx={center} cy={center} r={dotRadius} fill={INK} />
+    </svg>
+  )
+}
+
+export interface AlbescentInvitationProps {
+  /** The account's roster (active + paused lives). */
+  lives: CharacterOut[]
+  /** Called after a successful join — refetch auth + roster so the UI reflects it. */
+  onJoined: () => Promise<void> | void
+}
+
+export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvitationProps) {
+  const choices = eligibleLives(lives)
+  const [selectedId, setSelectedId] = useState<number | null>(choices[0]?.id ?? null)
+  const [joined, setJoined] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const hasAlbescentLife = lives.some((life) => life.faction_slug === ALBESCENT_SLUG)
+  // Invitation already answered before this visit, or nobody fit to answer it.
+  if (!joined && (hasAlbescentLife || choices.length === 0)) return null
+
+  const handleAccept = async () => {
+    const picked = choices.find((life) => life.id === selectedId) ?? null
+    if (!picked || submitting) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      // Existing character-switch flow, then the plain defection endpoint —
+      // /factions/choose acts on the account's active character.
+      await setActiveCharacter(picked.id)
+      await chooseFaction(ALBESCENT_SLUG)
+      setJoined(true)
+      await onJoined()
+    } catch (err) {
+      setError(extractError(err, 'The order declined, and gave no reason.'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section style={letter} aria-label="A correspondence">
+      <div style={innerFrame} />
+
+      {/* letterhead */}
+      <div style={{ position: 'relative', padding: '36px 42px 30px', textAlign: 'center' }}>
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 18 }}>
+          <AlbescentMark size={44} />
+        </div>
+        <div style={{ ...monoCaps, fontSize: 9, letterSpacing: '0.34em', color: ACCENT, marginBottom: 6 }}>Albescent</div>
+        <div style={{ ...monoCaps, fontSize: 8, letterSpacing: '0.28em', marginBottom: 22 }}>Faction no. 7 · enlistment · in confidence</div>
+        <div style={{ width: 54, height: 1, background: HAIRLINE, margin: '0 auto 22px' }} />
+        <div style={{ ...monoCaps, fontSize: 8, letterSpacing: '0.2em', marginBottom: 10 }}>A hand is extended —</div>
+        <h2 style={headline}>Take up the work</h2>
+        <p style={pitch}>
+          Albescent is an unranked order that keeps what others let slip. Attend the
+          quiet duties, return them well, and leave no trace of yourself in the work.
+          There is no leaderboard here worth minding.
+        </p>
+      </div>
+
+      {/* terms slip */}
+      <div style={{ position: 'relative', margin: '0 42px', borderTop: `1px solid ${RULE}`, padding: '20px 0 4px', textAlign: 'left' }}>
+        <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.22em', marginBottom: 12 }}>The terms, plainly</div>
+        <div style={termsGrid}>
+          {TERMS.map((term) => (
+            <div key={term.label} style={{ borderBottom: `1px solid ${HAIRLINE_FAINT}`, padding: '8px 0' }}>
+              <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.14em' }}>{term.label}</div>
+              <div style={{ ...serifItalic, fontSize: 18, color: INK, marginTop: 2 }}>{term.value}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: '4px 16px' }}>
+          {PERKS.map((perk) => (
+            <div key={perk} style={{ ...serifItalic, fontSize: 14, color: ACCENT }}>— {perk}</div>
+          ))}
+        </div>
+      </div>
+
+      {/* answer */}
+      <div style={{ position: 'relative', padding: '24px 42px 36px' }}>
+        {joined ? (
+          <div style={{ ...serifItalic, fontSize: 22, color: INK, textAlign: 'center' }}>You are of the Order</div>
+        ) : (
+          <>
+            <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.22em', marginBottom: 10 }}>Who takes up the work</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 20 }}>
+              {choices.map((life) => {
+                const selected = life.id === selectedId
+                return (
+                  <button
+                    key={life.id}
+                    type="button"
+                    onClick={() => setSelectedId(life.id)}
+                    style={{ ...lifeChip, borderColor: selected ? INK : HAIRLINE_FAINT }}
+                    aria-pressed={selected}
+                  >
+                    <span style={{ ...serifItalic, fontSize: 16, color: INK, lineHeight: 1.1 }}>{life.display_name}</span>
+                    <span style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.08em', marginTop: 3 }}>
+                      @{life.username} · {factionName(life.faction_slug)}
+                    </span>
+                    <span style={{ marginLeft: 'auto', fontSize: 12, color: MUTED, position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)' }}>
+                      {selected ? '•' : '→'}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap', justifyContent: 'center' }}>
+              <button type="button" onClick={() => void handleAccept()} disabled={submitting} style={acceptButton}>
+                {submitting ? 'Entering the record…' : 'Accept the order'}
+              </button>
+              <span style={{ ...serifItalic, fontSize: 15, color: ACCENT }}>you need not persuade us.</span>
+            </div>
+            {error && (
+              <p style={{ ...serifItalic, fontSize: 14, color: INK, textAlign: 'center', marginTop: 14, marginBottom: 0 }}>{error}</p>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  )
+}
+
+// --- letter styles (Albescent vellum tokens; always-light by design) ---------
+
+const letter: CSSProperties = {
+  position: 'relative',
+  maxWidth: 620,
+  background: BG,
+  color: INK,
+  border: `1px solid ${HAIRLINE}`,
+  boxShadow: '0 2px 24px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)',
+  overflow: 'hidden',
+  marginTop: 40,
+}
+const innerFrame: CSSProperties = {
+  position: 'absolute',
+  inset: 6,
+  border: `1px solid ${HAIRLINE_FAINT}`,
+  pointerEvents: 'none',
+}
+const monoCaps: CSSProperties = {
+  fontFamily: MONO,
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+const serifItalic: CSSProperties = {
+  fontFamily: SERIF,
+  fontStyle: 'italic',
+  fontWeight: 500,
+}
+const headline: CSSProperties = {
+  ...serifItalic,
+  fontSize: 44,
+  lineHeight: 1.05,
+  color: INK,
+  margin: '0 0 14px',
+}
+const pitch: CSSProperties = {
+  ...serifItalic,
+  fontSize: 17,
+  lineHeight: 1.6,
+  color: ACCENT,
+  maxWidth: 440,
+  margin: '0 auto',
+}
+const termsGrid: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '2px 26px',
+}
+const lifeChip: CSSProperties = {
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  textAlign: 'left',
+  width: '100%',
+  padding: '10px 34px 10px 14px',
+  background: BG,
+  border: `1px solid ${HAIRLINE_FAINT}`,
+  cursor: 'pointer',
+}
+const acceptButton: CSSProperties = {
+  ...serifItalic,
+  cursor: 'pointer',
+  border: `1px solid ${INK}`,
+  background: INK,
+  color: BG,
+  fontSize: 20,
+  padding: '12px 30px',
+}

--- a/frontend/src/components/__tests__/albescentInvitation.test.ts
+++ b/frontend/src/components/__tests__/albescentInvitation.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The Albescent invitation's life chooser (#395) only offers active,
+ * non-Albescent lives — paused/banned lives can't be carried, and a life
+ * already of the Order has nothing left to accept. Pure filter, tested
+ * directly (no jsdom in this repo — see vite.config.ts).
+ */
+import { describe, it, expect } from 'vitest'
+import { eligibleLives } from '../AlbescentInvitation'
+import type { CharacterOut } from '../../api/auth'
+
+function life(overrides: Partial<CharacterOut>): CharacterOut {
+  return {
+    id: 1,
+    username: 'wanderer',
+    display_name: 'Wanderer',
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 8,
+    score: 0,
+    all_time_score: 0,
+    faction_slug: 'ua',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('eligibleLives', () => {
+  it('keeps active, non-Albescent lives', () => {
+    const lives = [life({ id: 1, faction_slug: 'ua' }), life({ id: 2, faction_slug: 'wow' })]
+    expect(eligibleLives(lives).map((l) => l.id)).toEqual([1, 2])
+  })
+
+  it('drops paused lives — the roster includes them, the order will not', () => {
+    const lives = [life({ id: 1, status: 'paused' }), life({ id: 2 })]
+    expect(eligibleLives(lives).map((l) => l.id)).toEqual([2])
+  })
+
+  it('drops lives already of the Order', () => {
+    const lives = [life({ id: 1, faction_slug: 'albescent' }), life({ id: 2, faction_slug: 'na' })]
+    expect(eligibleLives(lives).map((l) => l.id)).toEqual([2])
+  })
+
+  it('returns empty when nobody is fit to answer', () => {
+    expect(eligibleLives([life({ status: 'banned' })])).toEqual([])
+  })
+})

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -48,6 +48,7 @@ export function authorToCharacter(
     level: 0,
     score: 0,
     all_time_score: 0,
+    status: 'active',
     created_at: '',
   }
 }

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth/AuthContext'
 import { getMyCharacters, setActiveCharacter } from '../api/me'
 import type { CharacterOut } from '../api/auth'
 import CredentialCard from '../components/CredentialCard'
+import AlbescentInvitation from '../components/AlbescentInvitation'
 import { mediaUrl } from '../utils/media'
 
 /**
@@ -107,6 +108,19 @@ export default function FieldDesk() {
             onBegin={() => navigate('/characters/create')}
           />
         </div>
+      )}
+
+      {/* The order's correspondence (#395) — account-collective invitation
+          (ADR-0021), shown only while the server flag holds. Deliberately no
+          link to any faction surface (ADR-0027 secrecy). */}
+      {!loading && (user?.can_start_as_albescent ?? false) && (
+        <AlbescentInvitation
+          lives={lives}
+          onJoined={async () => {
+            await refetch()
+            setLives(await getMyCharacters())
+          }}
+        />
       )}
 
       <p style={footerHint}>


### PR DESCRIPTION
Closes #395

## What & why
The Albescent join was **ungated**: `defect_to_faction` (via `POST /factions/choose`) let *any* character defect to Albescent, because Albescent is `is_selectable=False` + `can_always_rejoin=True` — that combination slips the selectability guard (`not is_selectable and not can_always_rejoin` is `False`). The ADR-0021 eligibility bar was computed by `can_start_as_albescent()` and surfaced on `/auth/me`, but **enforced nowhere and consumed by no component**. This PR closes both gaps.

## Part 1 — Backend guardrail
- `defect_to_faction` now, when `target_slug == "albescent"`, calls `can_start_as_albescent(character.account_id, session, era)` (account-collective per ADR-0021 — passes `account_id`, not the picked character's level) and raises `403` if the account hasn't met the bar. Placed **after** the existing current-faction / not-found / rejoin guards.
- Copy reconciliation (join is a defection, not a starting choice):
  - `era_1.py` level-8 `LevelUnlock`: "Start an Albescent character / …starting faction…" → "Join /Albescent / Defect a life you carry…, joined in the field, never picked at creation."
  - `can_start_as_albescent` docstring: "create a new character in the Albescent faction" → "move a character into the Albescent faction … joined in the field via defection."

## Part 2 — Entry-flow affordance (there was no join path)
- New `AlbescentInvitation` card, **ported faithfully from the vendored Design System `docs/design/join/Albescent Join Screen.html` (AlRecruit)** — the vellum "Take up the work" correspondence (Cormorant italic, hairline rules, surveyor's-mark sigil, "terms, plainly" slip). Uses the `--faction-albescent-card-*` tokens (always-light by design); no hardcoded hex.
- **Derived purely from the live `/auth/me` flag** — no new model/table/migration. Shown in `FieldDesk` only when `can_start_as_albescent` is true and the account has ≥1 active, non-Albescent life.
- **Secrecy-compliant (ADR-0027 / composes with #390):** the card names Albescent but links to **no** faction surface. The design's faction-chooser rail (which linked to the faction page) was intentionally replaced with a **life chooser**.
- **Player picks which life joins:** the chooser lists active, non-Albescent lives; Accept switches the active character to the picked one (existing `setActiveCharacter` flow) and then `POST /factions/choose` — no endpoint change.
- `CharacterOut` (frontend) gains the `status` field the backend already returns; `authorToCharacter` stub padded accordingly.

## Tests
- Backend integration (`test_factions.py`): `test_choose_albescent_ineligible_forbidden` (→ 403), `test_choose_albescent_eligible_succeeds` (level 8 + praxis coverage for every non-sentinel faction → 200).
- Frontend unit (`albescentInvitation.test.ts`): `eligibleLives` filter — keeps active non-Albescent, drops paused/banned and already-of-the-Order.

## Verification observed
- Backend: `pytest tests/integration/test_factions.py` → **12 passed** (incl. both new); `pytest -k "character or game_config or level or era"` → **213 passed**. (Ran with the main checkout's venv against the running Postgres; copied `.env` into the worktree, which is gitignored.)
- Frontend: full `vitest run` → **165 passed / 17 files**; `vite build` → clean (438 modules incl. the new component); the new component + FieldDesk transform cleanly through the dev server (HTTP 200, valid JS).
- `tsc --noEmit`: only remaining error is **pre-existing on `main`** (`is_top_for_task` missing in an untouched praxis test mock) — not in this changeset.

## Not verified
Did **not** drive the eligible card in a live browser — rendering it requires a running backend plus a seeded account meeting the full ADR-0021 bar (level 8 + coverage in every faction), which the default dev-login account does not satisfy. Covered instead by the unit test, the green build, and the clean dev-server transform.

## Out of scope
The secrecy/reveal gate + wall page (#390). No ADR needed — implements ADR-0021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)