### PR TITLE
fix: add missing is_top_for_task to isViewerMember test fixture

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/isViewerMember.test.ts
+++ b/frontend/src/pages/praxisDetail/__tests__/isViewerMember.test.ts
@@ -47,6 +47,7 @@ function praxis(members: PraxisMemberOut[]): PraxisOut {
     invites: [],
     media_items: [],
     score: 0,
+    is_top_for_task: false,
     duel_id: null,
     can_flag: true,
     applied_metatasks: [],


### PR DESCRIPTION
The `praxis()` fixture in `isViewerMember.test.ts` was missing the `is_top_for_task` field added to `PraxisOut` by ADR-0028 (Task Crown, #405), so `tsc --noEmit` reported one error on main. Vitest wasn't affected (esbuild strips types), so CI stayed green — but every agent working in the tree trips over it. One-field fixup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)