### PR TITLE
feat: Albescent secrecy/reveal gate — hide the faction until joined (#390, ADR-0027)

### DIFF
--- a/backend/alembic/versions/0011_account_albescent_revealed.py
+++ b/backend/alembic/versions/0011_account_albescent_revealed.py
@@ -1,0 +1,37 @@
+"""Sticky Albescent reveal flag — add ``account.albescent_revealed`` (ADR-0027, #390).
+
+Non-null boolean, server default false. Flips True the first time any character
+on the account joins Albescent (the secret society) and is never unset; gates
+whether the faction listing/page surfaces Albescent at all.
+
+Idempotent (like 0006/0010): the squashed baseline ``create_all`` reflects the
+current ORM, so on a fresh DB the column already exists and ``ADD COLUMN IF NOT
+EXISTS`` is a no-op. On an existing DB it adds the column, backfilling every
+existing row to false via the server default.
+
+Revision ID: 0011_account_albescent_revealed
+Revises: 0010_duel_forfeited_by
+Create Date: 2026-07-03
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011_account_albescent_revealed"
+down_revision: Union[str, None] = "0010_duel_forfeited_by"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text(
+        "ALTER TABLE account ADD COLUMN IF NOT EXISTS albescent_revealed"
+        " BOOLEAN NOT NULL DEFAULT false"
+    ))
+
+
+def downgrade() -> None:
+    op.execute(sa.text(
+        "ALTER TABLE account DROP COLUMN IF EXISTS albescent_revealed"
+    ))

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -35,6 +35,40 @@ async def get_current_character(
     return character
 
 
+async def get_current_account_optional(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_OPTIONAL_BEARER),
+    access_token: Optional[str] = Cookie(default=None),
+    session: AsyncSession = Depends(get_db),
+) -> Optional[Account]:
+    """Resolve the current account when a token is present, else ``None``.
+
+    Mirror of :func:`services.auth.get_current_account` that never raises — used
+    by public endpoints (e.g. the faction listing) that stay anonymous-friendly
+    but tailor their response for a logged-in caller when a token is supplied.
+    """
+    token = None
+    if credentials:
+        token = credentials.credentials
+    elif access_token:
+        token = access_token
+    if not token:
+        return None
+
+    try:
+        payload = decode_jwt(token)
+        account_id = int(payload["sub"])
+    except Exception:
+        return None
+
+    account_result = await session.execute(
+        select(Account).where(Account.id == account_id)
+    )
+    account = account_result.scalar_one_or_none()
+    if account is None or account.status != AccountStatus.active:
+        return None
+    return account
+
+
 async def get_current_character_optional(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(_OPTIONAL_BEARER),
     access_token: Optional[str] = Cookie(default=None),

--- a/backend/models/account.py
+++ b/backend/models/account.py
@@ -1,7 +1,7 @@
 import enum
 from typing import TYPE_CHECKING, List
 
-from sqlalchemy import Enum, ForeignKey, String
+from sqlalchemy import Boolean, Enum, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
@@ -31,6 +31,13 @@ class Account(TimestampMixin, Base):
     active_character_id: Mapped[int | None] = mapped_column(
         ForeignKey("character.id", use_alter=True, name="fk_account_active_character"),
         nullable=True,
+    )
+    # Sticky reveal flag for the Albescent secret society (ADR-0027, #390): flips
+    # True the first time any character on this account joins Albescent, and is
+    # never unset. Gates whether the faction listing/page surfaces Albescent at
+    # all. Do NOT derive from live membership — it survives age-out and switches.
+    albescent_revealed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
     )
 
     # foreign_keys pins this to character.account_id — active_character_id adds a

--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -3,7 +3,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import get_current_character, require_admin
+from dependencies import (
+    get_current_account_optional,
+    get_current_character,
+    require_admin,
+)
 from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character
@@ -17,6 +21,8 @@ from schemas.faction import (
     FactionUpdate,
     InvitationLetterOut,
 )
+from services.auth import get_current_account
+from services.character import ALBESCENT_FACTION_SLUG
 from services.era import get_current_era_row
 from services.faction_service import (
     defect_to_faction,
@@ -30,12 +36,26 @@ router = APIRouter()
 
 
 @router.get("", response_model=list[FactionOut])
-async def list_factions(session: AsyncSession = Depends(get_db)):
-    """Return all non-hidden factions."""
+async def list_factions(
+    account: Account | None = Depends(get_current_account_optional),
+    session: AsyncSession = Depends(get_db),
+):
+    """Return all non-hidden factions.
+
+    Albescent is a secret society (ADR-0027, #390): it is omitted unless the
+    current account has been revealed to it. Optional auth — anonymous callers
+    stay anonymous and never see Albescent.
+    """
     result = await session.execute(
         select(Faction).where(Faction.status == FactionStatus.visible).order_by(Faction.slug)
     )
-    return [FactionOut.model_validate(faction) for faction in result.scalars().all()]
+    factions = result.scalars().all()
+    reveal_albescent = account is not None and account.albescent_revealed
+    return [
+        FactionOut.model_validate(faction)
+        for faction in factions
+        if faction.slug != ALBESCENT_FACTION_SLUG or reveal_albescent
+    ]
 
 
 @router.put("/{slug}", response_model=FactionOut)
@@ -73,10 +93,15 @@ async def choose_faction(
 
 @router.get("/status", response_model=FactionPageOut)
 async def get_faction_status(
+    account: Account = Depends(get_current_account),
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    """Return faction page data: current faction and status of all factions."""
+    """Return faction page data: current faction and status of all factions.
+
+    Albescent (ADR-0027, #390) is omitted from ``all_factions`` unless this
+    account has been revealed to the secret society.
+    """
     era_row = await get_current_era_row(session)
     status_map = await get_invitation_status(
         character.id, era_row.id, session
@@ -88,6 +113,7 @@ async def get_faction_status(
             status=status,
         )
         for slug, status in status_map.items()
+        if slug != ALBESCENT_FACTION_SLUG or account.albescent_revealed
     ]
     return FactionPageOut(
         current_faction_slug=character.faction_slug,

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -22,6 +22,10 @@ class CurrentUser(BaseModel):
     # the propose/see flags to True; the eligibility flags have their own rules.
     can_create_additional_character: bool = False
     can_start_as_albescent: bool = False
+    # Sticky Albescent secret-society reveal (ADR-0027, #390). True once any
+    # character on this account has ever joined Albescent; gates whether the
+    # frontend shows the real faction page vs. the sealed placeholder.
+    albescent_revealed: bool = False
     # FieldDesk "locked dossier" gate copy reads these (#270/#274): the level an
     # existing life must reach to unlock a second life, and the live era's name.
     second_character_level_required: int = 0

--- a/backend/services/current_user.py
+++ b/backend/services/current_user.py
@@ -54,6 +54,7 @@ async def build_current_user(
         is_admin=is_admin,
         can_create_additional_character=can_create_more,
         can_start_as_albescent=can_albescent,
+        albescent_revealed=account.albescent_revealed,
         second_character_level_required=era.second_character_level_required,
         era_name=era.name,
         **asdict(capabilities),

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
+from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.faction import Faction
@@ -112,6 +113,15 @@ async def defect_to_faction(
         session.add(defection)
 
     character.faction_slug = target_slug
+
+    # ADR-0027 / #390: joining Albescent permanently reveals the secret society to
+    # this account. Sticky/monotonic — set once, never unset. Do NOT derive from
+    # live membership; it must survive age-out, death, and active-character switch.
+    if target_slug == ALBESCENT_FACTION_SLUG:
+        account = await session.get(Account, character.account_id)
+        if account is not None:
+            account.albescent_revealed = True
+
     await session.flush()
     await session.refresh(character)
     return character

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -262,6 +262,125 @@ async def test_choose_nonexistent_faction(
 
 
 # ---------------------------------------------------------------------------
+# Albescent secret-society reveal gate (ADR-0027, #390)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_factions_hides_albescent_when_unrevealed(
+    client: AsyncClient,
+    account: Account,
+    auth_headers: dict,
+    faction_ua: Faction,
+    db_session: AsyncSession,
+):
+    """Albescent is a secret society: an account with no albescent history never
+    sees it in GET /factions, even though the row is a visible faction."""
+    await _seed_faction(db_session, "albescent")
+    await db_session.commit()
+
+    resp = await client.get("/factions", headers=auth_headers)
+    assert resp.status_code == 200
+    slugs = [f["slug"] for f in resp.json()]
+    assert "albescent" not in slugs
+    # Non-secret visible factions still show.
+    assert "ua" in slugs
+
+
+@pytest.mark.asyncio
+async def test_list_factions_hides_albescent_when_anonymous(
+    client: AsyncClient,
+    faction_ua: Faction,
+    db_session: AsyncSession,
+):
+    """Anonymous callers stay anonymous and never see the secret society."""
+    await _seed_faction(db_session, "albescent")
+    await db_session.commit()
+
+    resp = await client.get("/factions")
+    assert resp.status_code == 200
+    slugs = [f["slug"] for f in resp.json()]
+    assert "albescent" not in slugs
+
+
+@pytest.mark.asyncio
+async def test_albescent_join_reveals_and_lists(
+    client: AsyncClient,
+    character: Character,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """A successful Albescent defect flips albescent_revealed and unlocks the
+    faction in GET /factions for that account."""
+    await _seed_faction(db_session, "albescent")
+    await _make_account_albescent_eligible(db_session, character, era)
+
+    # Pre-join: hidden.
+    before = await client.get("/factions", headers=auth_headers)
+    assert "albescent" not in [f["slug"] for f in before.json()]
+
+    resp = await client.post(
+        "/factions/choose",
+        json={"faction_slug": "albescent"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+
+    # The sticky flag is now set on the account.
+    await db_session.refresh(account)
+    assert account.albescent_revealed is True
+
+    # And the faction now surfaces for this account.
+    after = await client.get("/factions", headers=auth_headers)
+    assert "albescent" in [f["slug"] for f in after.json()]
+
+
+@pytest.mark.asyncio
+async def test_albescent_reveal_is_sticky_not_derived_from_membership(
+    client: AsyncClient,
+    character: Character,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """Reveal survives leaving Albescent — it is not derived from live membership.
+
+    After joining (which reveals), the character defects back to a real faction;
+    the flag stays True and the faction stays listed."""
+    await _seed_faction(db_session, "albescent")
+    await _make_account_albescent_eligible(db_session, character, era)
+
+    join = await client.post(
+        "/factions/choose",
+        json={"faction_slug": "albescent"},
+        headers=auth_headers,
+    )
+    assert join.status_code == 200
+
+    # Leave Albescent for a real faction (albescent can_always_rejoin, and the
+    # target is one covered by the eligibility seeding).
+    leave = await client.post(
+        "/factions/choose",
+        json={"faction_slug": "wow"},
+        headers=auth_headers,
+    )
+    assert leave.status_code == 200
+
+    await db_session.refresh(character)
+    assert character.faction_slug != "albescent"
+
+    # Flag persists even with no live Albescent membership.
+    await db_session.refresh(account)
+    assert account.albescent_revealed is True
+
+    listed = await client.get("/factions", headers=auth_headers)
+    assert "albescent" in [f["slug"] for f in listed.json()]
+
+
+# ---------------------------------------------------------------------------
 # Update faction (admin-only)
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,7 +42,7 @@ function RootLanding() {
 function AlbescentGate() {
   const { user, loading } = useAuth()
   if (loading) return <div className="page font-body text-muted">Loading...</div>
-  return user?.albescent_revealed ? <FactionDetail /> : <AlbescentSecretPlaceholder />
+  return user?.albescent_revealed ? <FactionDetail slug="albescent" /> : <AlbescentSecretPlaceholder />
 }
 
 export default function App() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,19 @@ function RootLanding() {
   return user ? <FieldDesk /> : <Home />
 }
 
+/**
+ * Albescent secrecy gate (#390, ADR-0027). Albescent is a secret society: an
+ * account only sees the real faction page once it has ever had a character join
+ * Albescent (sticky `albescent_revealed`). Everyone else — including anonymous
+ * visitors — gets the in-world sealed placeholder. Albescent stays ua-aliased
+ * visually until #232; here we only route to the existing FactionDetail.
+ */
+function AlbescentGate() {
+  const { user, loading } = useAuth()
+  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  return user?.albescent_revealed ? <FactionDetail /> : <AlbescentSecretPlaceholder />
+}
+
 export default function App() {
   return (
     <Layout>
@@ -60,11 +73,11 @@ export default function App() {
         />
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/factions" element={<Factions />} />
-        {/* Albescent is sealed: outsiders get an in-world dead end, not the
-            faction page. Static segment outranks `:slug`, so this intercepts.
-            TODO(#390): gate on account.albescent_revealed — show real faction
-            page once revealed. */}
-        <Route path="/factions/albescent" element={<AlbescentSecretPlaceholder />} />
+        {/* Albescent is sealed until revealed (#390, ADR-0027). Static segment
+            outranks `:slug`, so this intercepts. AlbescentGate shows the real
+            faction page to revealed accounts, the in-world dead end to everyone
+            else. */}
+        <Route path="/factions/albescent" element={<AlbescentGate />} />
         <Route path="/factions/:slug" element={<FactionDetail />} />
         <Route
           path="/updates"

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -24,6 +24,10 @@ export interface CurrentUser {
   // flags to true. Drive UI off these instead of comparing character.level.
   can_create_additional_character: boolean
   can_start_as_albescent: boolean
+  // Sticky Albescent secret-society reveal (ADR-0027, #390). True once any
+  // character on this account has ever joined Albescent; gates the real faction
+  // page vs. the sealed placeholder at /factions/albescent.
+  albescent_revealed: boolean
   can_propose_task: boolean
   can_propose_metatask: boolean
   can_see_retired_tasks: boolean

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -62,8 +62,9 @@ const FACTION_BODIES: Record<string, ComponentType<{ state: FactionDetailState }
   wow: WowFactionBody,
 };
 
-export default function FactionDetail() {
-  const { slug } = useParams<{ slug: string }>();
+export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {
+  const { slug: slugParam } = useParams<{ slug: string }>();
+  const slug = slugProp ?? slugParam;
   const state = useFactionDetail(slug);
   const { loading, faction, fetchError, members, tasks, recentPraxis } = state;
 


### PR DESCRIPTION
## What

Implements the Albescent **secrecy/reveal gate** (#390, ADR-0027). Albescent is a secret society: its existence *as a faction* (the listing surfaces + faction page) is hidden from an account until that account has **ever** had a character join Albescent. The reveal is sticky/monotonic — once revealed, always revealed (survives age-out, death, active-character switch). Albescent characters/tasks/praxis cards still render normally; only the faction *listing/page* is the secret (the visual de-alias is #232, separate).

Prereq #395 (PR #411, the eligibility 403 guard + entry-flow card) is merged; this branch was rebased onto it.

## Backend
- **`Account.albescent_revealed`** — non-null bool, `server_default="false"`.
- **Migration `0011_account_albescent_revealed`** — `down_revision = 0010_duel_forfeited_by`; idempotent `ADD COLUMN IF NOT EXISTS`, backfills existing rows to false.
- **`defect_to_faction`** flips the flag `True` on a successful Albescent join, right alongside the #395 eligibility guard. Never unset; **not** derived from live membership.
- **`GET /factions`** is now account-aware via **optional auth** (new `get_current_account_optional` dependency) and omits albescent unless the account is revealed; anonymous callers stay anonymous and never see it. **`GET /factions/status`** gated the same way.
- There is **no** `GET /factions/{slug}` route — per-faction detail is derived frontend-side from the now-gated `/factions` list, so it's gated transitively.
- **`GET /auth/me`** exposes `albescent_revealed` for the frontend gate.

## Frontend
- **`App.tsx`**: `/factions/albescent` routes through a new `AlbescentGate` — revealed accounts get the real `FactionDetail`, everyone else (incl. anonymous) the existing sealed placeholder.
- **Grid + filter strip** already render whatever `/factions` returns, so they drop albescent automatically once the API omits it — no change needed beyond confirming.
- `CurrentUser` type gains `albescent_revealed`.

## Tests
Added to `backend/tests/integration/test_factions.py`:
- Unrevealed account + anonymous caller don't see albescent in `GET /factions`.
- A successful albescent defect flips `albescent_revealed` to true and lists it.
- The flag survives leaving Albescent (asserts it's not derived from live membership).

## Verification
- `pytest tests/integration/test_factions.py` → **16 passed** (incl. 4 new gate tests).
- `pytest tests/integration/test_auth.py test_factions.py` → **37 passed** (no regression from the endpoint signature changes / `/auth/me` payload).
- `alembic heads` → single head `0011`. The integration harness (Postgres-backed) round-trips the new column, proving the schema + flag persistence.
- Frontend build/tsc not run — no `node_modules` in this worktree; changes are minimal and type-safe by inspection. Browser verification of the revealed path requires a live OAuth login + a level-8/full-coverage account that has actually joined Albescent, not reproducible in a dev preview; the gate's data source is covered by the backend tests.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)