### PR TITLE
feat: faction grid cards are pure preview links; membership moves to detail page (#347)

### DIFF
--- a/frontend/src/components/cards/EverymenFactionCard.tsx
+++ b/frontend/src/components/cards/EverymenFactionCard.tsx
@@ -1,11 +1,12 @@
 import type { FactionCardProps } from "./FactionCard";
 
 /**
- * EverymenFactionCard — the Everymen faction-SELECTION card.
+ * EverymenFactionCard — the Everymen faction PREVIEW card.
  *
- * A union "ENLIST" recruitment poster: a masthead with the faction name in a
- * big Bebas headline, the motto/blurb pulled from faction.description, and an
- * enlist CTA wired to the real join/leave/accept/decline handlers.
+ * A union recruitment poster: a masthead with the faction name in a big Bebas
+ * headline and the motto/blurb pulled from faction.description. Pure preview —
+ * the whole card is a link to the faction detail page, where the enlist / leave
+ * membership block lives (issue #347). No interactive controls here.
  *
  * Self-contained: the SVG poster atoms (CogMark sigil, Halftone, Sunburst) are
  * declared locally so this file has no external dependencies beyond the
@@ -81,162 +82,11 @@ function Sunburst({
   );
 }
 
-// ─── Enlist action footer ──────────────────────────────────────────────────────
-
-const ENLIST_STATES = new Set(["eligible", "can_return", "welcome_back", "invited", "not_invited"]);
-
-function EnlistAction({
-  faction,
-  status,
-  onJoin,
-  onLeave,
-  onConfirm,
-  onDecline,
-  confirmPending,
-  leavePending,
-}: Pick<
-  FactionCardProps,
-  | "faction"
-  | "status"
-  | "onJoin"
-  | "onLeave"
-  | "onConfirm"
-  | "onDecline"
-  | "confirmPending"
-  | "leavePending"
->) {
-  const enlistButton = (label: string, onClick: () => void, pending?: boolean) => (
-    <button
-      onClick={onClick}
-      disabled={pending}
-      style={
-        {
-          marginTop: 26,
-          width: "100%",
-          maxWidth: 380,
-          border: "2px solid var(--everymen-ink)",
-          cursor: pending ? "not-allowed" : "pointer",
-          fontFamily: "var(--faction-everymen-card-font)",
-          fontSize: 26,
-          letterSpacing: "0.12em",
-          padding: "12px",
-          background: "var(--everymen-gold)",
-          color: "var(--everymen-ink)",
-          transition: "background 150ms",
-        } as React.CSSProperties
-      }
-    >
-      {label}
-    </button>
-  );
-
-  // Already enlisted — show member state + a quiet "stand down" (leave).
-  if (status === "member") {
-    return (
-      <div style={{ marginTop: 26, display: "flex", flexDirection: "column", alignItems: "center", gap: 11 }}>
-        <div
-          style={
-            {
-              display: "inline-block",
-              background: "var(--everymen-olive)",
-              border: "2px solid var(--everymen-ink)",
-              color: "var(--everymen-ink)",
-              fontFamily: "var(--faction-everymen-card-font)",
-              fontSize: 22,
-              letterSpacing: "0.12em",
-              padding: "10px 22px",
-            } as React.CSSProperties
-          }
-        >
-          ✓ ON THE LINE
-        </div>
-        {onLeave && (
-          <button
-            onClick={onLeave}
-            disabled={leavePending}
-            style={{
-              background: "transparent",
-              border: "none",
-              fontFamily: "var(--font-body)",
-              fontSize: 9.5,
-              letterSpacing: "0.14em",
-              textTransform: "uppercase",
-              color: "var(--everymen-cream)",
-              opacity: 0.8,
-              cursor: leavePending ? "not-allowed" : "pointer",
-              padding: 0,
-            }}
-          >
-            {leavePending ? "Standing down…" : "Stand down"}
-          </button>
-        )}
-      </div>
-    );
-  }
-
-  // Explicit invitation: accept/decline wired to onConfirm/onDecline.
-  if (status === "invited" && (onConfirm || onDecline)) {
-    return (
-      <div style={{ marginTop: 26, display: "flex", flexDirection: "column", alignItems: "center", gap: 11 }}>
-        {onConfirm && enlistButton(confirmPending ? "ENLISTING…" : "ENLIST NOW ▸", onConfirm, confirmPending)}
-        {onDecline && (
-          <button
-            onClick={onDecline}
-            style={{
-              background: "transparent",
-              border: "none",
-              fontFamily: "var(--font-body)",
-              fontSize: 9.5,
-              letterSpacing: "0.14em",
-              textTransform: "uppercase",
-              color: "var(--everymen-cream)",
-              opacity: 0.8,
-              cursor: "pointer",
-              padding: 0,
-            }}
-          >
-            Not this time
-          </button>
-        )}
-      </div>
-    );
-  }
-
-  // Eligible / returning / open enlistment — single ENLIST button → onJoin.
-  if (ENLIST_STATES.has(status) && onJoin) {
-    const rejoining = status === "can_return" || status === "welcome_back";
-    return enlistButton(rejoining ? "RE-ENLIST ▸" : "ENLIST NOW ▸", onJoin);
-  }
-
-  // Defected/burned — the line is closed to them.
-  if (status === "burned" || status === "defected") {
-    return (
-      <p
-        style={{
-          fontFamily: "var(--font-body)",
-          fontSize: 11,
-          fontStyle: "italic",
-          lineHeight: 1.5,
-          color: "var(--everymen-muted)",
-          margin: "22px auto 0",
-          maxWidth: 380,
-        }}
-      >
-        You walked off the {faction.name} line. They won't sign you back on.
-      </p>
-    );
-  }
-
-  return null;
-}
-
 // ─── Card ──────────────────────────────────────────────────────────────────────
 
 export default function EverymenCard({
   faction,
-  status,
   invitationNote,
-  ...actions
 }: FactionCardProps) {
   const blurb =
     faction.description ??
@@ -406,9 +256,6 @@ export default function EverymenCard({
             </div>
           ))}
         </div>
-
-        {/* enlist CTA — wired to the real handlers */}
-        <EnlistAction faction={faction} status={status} {...actions} />
       </div>
     </div>
   );

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -7,19 +7,16 @@ import { EphSeal, LapisLastWord } from "./ephemeristsAtoms";
 /**
  * FactionCard — faction-archetype switcher.
  *
- * Renders a visually distinct card per faction slug, mirroring the task card
- * archetypes but showing faction info (name, description, status, actions).
+ * Renders a visually distinct PREVIEW card per faction slug, mirroring the task
+ * card archetypes but showing faction info (name, description, status). It is a
+ * pure preview: the whole grid card is a link to the faction's detail page, and
+ * ALL membership actions (Join / Leave / Accept / Decline) live on that page's
+ * membership block (issue #347). The card carries no interactive controls.
  */
 
 export interface FactionCardProps {
   faction: FactionOut;
   status: string;
-  onJoin?: () => void;
-  onLeave?: () => void;
-  onConfirm?: () => void;
-  onDecline?: () => void;
-  confirmPending?: boolean;
-  leavePending?: boolean;
   /** When set, renders a "NEW INVITATION" eyebrow above the card content. */
   invitationNote?: string | null;
 }
@@ -89,148 +86,6 @@ function StatusBadge({ status, slug }: { status: string; slug: string }) {
   return null;
 }
 
-// ─── Action footer ────────────────────────────────────────────────────────────
-
-function ActionRow({
-  faction,
-  status,
-  onJoin,
-  onLeave,
-  onConfirm,
-  onDecline,
-  confirmPending,
-  leavePending,
-}: Pick<
-  FactionCardProps,
-  | "faction"
-  | "status"
-  | "onJoin"
-  | "onLeave"
-  | "onConfirm"
-  | "onDecline"
-  | "confirmPending"
-  | "leavePending"
->) {
-  if (status === "member") {
-    if (!onLeave) return null;
-    return (
-      <button
-        onClick={onLeave}
-        disabled={leavePending}
-        style={{
-          background: "transparent",
-          border: "none",
-          fontSize: 9,
-          color: "var(--color-text-tertiary)",
-          cursor: leavePending ? "not-allowed" : "pointer",
-          padding: 0,
-          fontFamily: "var(--font-body)",
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-        }}
-      >
-        {leavePending ? "Leaving..." : "Leave"}
-      </button>
-    );
-  }
-  if (status === "invited") {
-    // Explicit Accept/Decline mode (when Factions.tsx wires onConfirm/onDecline)
-    if (onConfirm || onDecline) {
-      return (
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          {onConfirm && (
-            <button
-              onClick={onConfirm}
-              disabled={confirmPending}
-              className="btn-primary"
-              style={{ fontSize: 9, padding: "3px 10px" }}
-            >
-              {confirmPending ? "Joining..." : "Accept"}
-            </button>
-          )}
-          {onDecline && (
-            <button
-              onClick={onDecline}
-              style={{
-                background: "transparent",
-                border: "none",
-                fontSize: 9,
-                color: "var(--color-text-tertiary)",
-                cursor: "pointer",
-                padding: 0,
-                fontFamily: "var(--font-body)",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-              }}
-            >
-              Decline
-            </button>
-          )}
-        </div>
-      );
-    }
-    // Simple single-button mode (confirmation dialog lives outside the card)
-    if (onJoin) {
-      return (
-        <button
-          onClick={onJoin}
-          className="btn-primary"
-          style={{ fontSize: 9, padding: "3px 10px" }}
-        >
-          Join {faction.name}
-        </button>
-      );
-    }
-    return null;
-  }
-  if (
-    status === "eligible" ||
-    status === "can_return" ||
-    status === "welcome_back"
-  ) {
-    if (!onJoin) return null;
-    return (
-      <button
-        onClick={onJoin}
-        className="btn-primary"
-        style={{ fontSize: 9, padding: "3px 10px" }}
-      >
-        {status === "can_return" || status === "welcome_back"
-          ? `Rejoin ${faction.name}`
-          : `Join ${faction.name}`}
-      </button>
-    );
-  }
-  if (status === "burned" || status === "defected") {
-    return (
-      <div
-        className="font-body"
-        style={{
-          fontSize: 10,
-          lineHeight: 1.45,
-          color: factionCssVar(faction.slug, "card-muted"),
-          fontStyle: "italic",
-        }}
-      >
-        You defected from {faction.name}. They won't take you back.
-      </div>
-    );
-  }
-  // For not_invited with onJoin provided (e.g. needsFactionChoice)
-  if (onJoin) {
-    return (
-      <button
-        onClick={onJoin}
-        className="btn-primary"
-        style={{ fontSize: 9, padding: "3px 10px" }}
-      >
-        Join {faction.name}
-      </button>
-    );
-  }
-  return null;
-}
-
 // ─── Invitation note ──────────────────────────────────────────────────────────
 
 function InvitationNote({ slug, note }: { slug: string; note: string }) {
@@ -264,7 +119,6 @@ function UACard({
   faction,
   status,
   invitationNote,
-  ...actions
 }: FactionCardProps) {
   const rotation = ROTATIONS[faction.slug.length % ROTATIONS.length];
   const desc = faction.description
@@ -327,7 +181,6 @@ function UACard({
           {desc}
         </div>
       )}
-      <ActionRow faction={faction} status={status} {...actions} />
     </div>
   );
 }
@@ -379,7 +232,6 @@ function WowCard({
   faction,
   status,
   invitationNote,
-  ...actions
 }: FactionCardProps) {
   const desc = faction.description
     ? faction.description.slice(0, 100) +
@@ -556,10 +408,6 @@ function WowCard({
               </div>
             )}
           </div>
-          {/* action footer */}
-          <div style={{ position: "relative", zIndex: 2 }}>
-            <ActionRow faction={faction} status={status} {...actions} />
-          </div>
         </div>
       </div>
     </div>
@@ -573,7 +421,6 @@ function SnideCard({
   faction,
   status,
   invitationNote,
-  ...actions
 }: FactionCardProps) {
   const desc = faction.description
     ? faction.description.slice(0, 100) +
@@ -666,7 +513,6 @@ function SnideCard({
           </div>
         </div>
       )}
-      <ActionRow faction={faction} status={status} {...actions} />
     </div>
   );
 }
@@ -680,7 +526,6 @@ function EphemeristsCard({
   faction,
   status,
   invitationNote,
-  ...actions
 }: FactionCardProps) {
   const desc = faction.description
     ? faction.description.slice(0, 110) +
@@ -766,7 +611,6 @@ function EphemeristsCard({
             {desc}
           </div>
         )}
-        <ActionRow faction={faction} status={status} {...actions} />
       </div>
     </div>
   );
@@ -803,7 +647,6 @@ function SingularityCard({
   faction,
   status,
   invitationNote,
-  ...actions
 }: FactionCardProps) {
   const desc = faction.description
     ? faction.description.slice(0, 100) +
@@ -933,14 +776,6 @@ function SingularityCard({
             {desc}
           </div>
         )}
-        <div
-          style={{
-            borderTop: "1px solid var(--faction-singularity-border-hard)",
-            paddingTop: 8,
-          }}
-        >
-          <ActionRow faction={faction} status={status} {...actions} />
-        </div>
       </div>
       <SingularityHoles />
       <style>{`@keyframes blink { 50% { opacity: 0; } }`}</style>
@@ -1009,16 +844,6 @@ export default function FactionCard(props: FactionCardProps) {
               {props.faction.description.slice(0, 100)}
             </div>
           )}
-          <ActionRow
-            faction={props.faction}
-            status={props.status}
-            onJoin={props.onJoin}
-            onLeave={props.onLeave}
-            onConfirm={props.onConfirm}
-            onDecline={props.onDecline}
-            confirmPending={props.confirmPending}
-            leavePending={props.leavePending}
-          />
         </div>
       );
   }

--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { getFactions, getFactionStatus, getInvitations, chooseFaction } from '../api/factions'
+import { getFactions, getFactionStatus, getInvitations } from '../api/factions'
 import type { FactionOut, FactionPageOut, InvitationLetterOut } from '../api/factions'
 import PageTitle from '../components/ui/PageTitle'
 import FactionCard from '../components/cards/FactionCard'
 import { extractError } from '../utils/errors'
-import { factionCssVar, factionName } from '../utils/factions'
+import { factionCssVar } from '../utils/factions'
 import { relativeTime } from '../utils/dates'
 import { useAuth } from '../auth/AuthContext'
 
@@ -21,8 +21,15 @@ const STATUS_CAN_RETURN = 'can_return'
 /** Factions that should be hidden from the player-facing grid */
 const HIDDEN_SLUGS = new Set([NA_SLUG, AGED_OUT_SLUG, 'ua'])
 
+/**
+ * Factions grid — a directory of pure PREVIEW cards. Each whole card is a link
+ * to the faction's detail page (`/factions/:slug`), where ALL membership actions
+ * (Join / Leave / Accept / Decline) now live (issue #347). The grid itself
+ * carries no interactive controls; it only previews name, description, and the
+ * viewer's status, and orders the cards by that status.
+ */
 export default function Factions() {
-  const { user, refetch } = useAuth()
+  const { user } = useAuth()
   const character = user?.character ?? null
 
   const [factions, setFactions] = useState<FactionOut[]>([])
@@ -31,12 +38,7 @@ export default function Factions() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  // Join flow state
-  const [confirmSlug, setConfirmSlug] = useState<string | null>(null)
-  const [joining, setJoining] = useState(false)
-  const [joinError, setJoinError] = useState<string | null>(null)
-
-  // Invitations panel (collapsed by default once each card surfaces its own prompt)
+  // Invitations panel (collapsed by default once each card surfaces its own status)
   const [invitationsExpanded, setInvitationsExpanded] = useState(false)
 
   const fetchAll = async () => {
@@ -67,26 +69,6 @@ export default function Factions() {
     if (!factionPage) return STATUS_NOT_INVITED
     const entry = factionPage.all_factions.find((f) => f.slug === slug)
     return entry?.status ?? STATUS_NOT_INVITED
-  }
-
-  // Unaffiliated = no faction to lose, so no "can't rejoin" warning on join.
-  const isUnaffiliated =
-    character?.faction_slug === NA_SLUG ||
-    character?.faction_slug === AGED_OUT_SLUG
-
-  const handleJoin = async (slug: string) => {
-    setJoining(true)
-    setJoinError(null)
-    try {
-      await chooseFaction(slug)
-      await refetch()
-      setConfirmSlug(null)
-      await fetchAll()
-    } catch (err) {
-      setJoinError(extractError(err, 'Could not join faction.'))
-    } finally {
-      setJoining(false)
-    }
   }
 
   if (loading) return <div className="py-8 font-body text-muted">Loading...</div>
@@ -122,7 +104,7 @@ export default function Factions() {
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2 mb-4">{error}</p>
       )}
 
-      {/* Invitation letters — collapsible; each card also surfaces its own prompt below */}
+      {/* Invitation letters — collapsible; each card also surfaces its own status below */}
       {character && invitations.length > 0 && (
         <div className="mb-6">
           <button
@@ -185,28 +167,15 @@ export default function Factions() {
         </p>
       )}
 
-      {/* Faction grid */}
+      {/* Faction grid — each whole card links to the faction's detail page,
+          where the membership actions live (issue #347). */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 20, alignItems: 'flex-start' }}>
         {sortedFactions.map((f) => {
           const status = statusFor(f.slug)
           const isDefected = status === STATUS_DEFECTED
-          const canReturn = status === STATUS_CAN_RETURN
-          const hasInvitationLetter = Boolean(invitationBySlug[f.slug])
-          // Any signal that the player is welcome here: explicit status or an
-          // open invitation letter (invite-gated per ADR-0019).
-          const canJoin =
-            status === STATUS_INVITED ||
-            canReturn ||
-            hasInvitationLetter
-          const isConfirming = confirmSlug === f.slug
 
-          // Derive card-level props from page state
-          // "eligible" is passed when the character can join (via invitation or return)
-          const cardStatus = isConfirming
-            ? status
-            : status === STATUS_CAN_RETURN
-            ? 'welcome_back'
-            : status
+          // "welcome_back" reads better than the raw "can_return" status badge.
+          const cardStatus = status === STATUS_CAN_RETURN ? 'welcome_back' : status
 
           // Compact per-card invitation marker (when an open letter exists).
           // Skip for current-member / defected states where it would be noise.
@@ -226,96 +195,20 @@ export default function Factions() {
                 opacity: isDefected ? 0.5 : 1,
               }}
             >
-              {isConfirming ? (
-                // Confirmation overlay wrapping the card
-                <div>
-                  <FactionCard
-                    faction={f}
-                    status={cardStatus}
-                    invitationNote={invitationNote}
-                  />
-                  <div
-                    style={{
-                      marginTop: 8,
-                      padding: '12px 14px',
-                      background: 'var(--color-bg-card)',
-                      border: '1px solid var(--color-border)',
-                    }}
-                  >
-                    <p className="font-body" style={{ fontSize: 11, color: 'var(--color-text-primary)', marginBottom: 8 }}>
-                      {isUnaffiliated
-                        ? `Join ${f.name}?`
-                        : `Join ${f.name}? You won't be able to rejoin ${factionName(character?.faction_slug)} after leaving.`
-                      }
-                    </p>
-                    {joinError && (
-                      <p className="font-body" style={{ fontSize: 10, color: 'var(--color-danger)', marginBottom: 6 }}>
-                        {joinError}
-                      </p>
-                    )}
-                    <div style={{ display: 'flex', gap: 8 }}>
-                      <button
-                        onClick={() => void handleJoin(f.slug)}
-                        disabled={joining}
-                        style={{
-                          fontFamily: "'Courier Prime', monospace",
-                          fontSize: 9,
-                          fontWeight: 700,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.1em',
-                          background: 'var(--color-success)',
-                          color: 'var(--color-text-on-accent)',
-                          border: 'none',
-                          padding: '5px 14px',
-                          cursor: joining ? 'not-allowed' : 'pointer',
-                        }}
-                      >
-                        {joining ? 'Joining...' : 'Confirm'}
-                      </button>
-                      <button
-                        onClick={() => { setConfirmSlug(null); setJoinError(null) }}
-                        disabled={joining}
-                        style={{
-                          fontFamily: "'Courier Prime', monospace",
-                          fontSize: 9,
-                          fontWeight: 700,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.1em',
-                          background: 'transparent',
-                          color: 'var(--color-text-secondary)',
-                          border: '1px solid var(--color-border)',
-                          padding: '5px 14px',
-                          cursor: joining ? 'not-allowed' : 'pointer',
-                        }}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ) : (
+              <Link
+                to={`/factions/${f.slug}`}
+                aria-label={`View ${f.name}`}
+                style={{
+                  display: 'block',
+                  textDecoration: 'none',
+                  color: 'inherit',
+                }}
+              >
                 <FactionCard
                   faction={f}
                   status={cardStatus}
                   invitationNote={invitationNote}
-                  onJoin={character && canJoin ? () => setConfirmSlug(f.slug) : undefined}
                 />
-              )}
-
-              {/* Visit the faction's detail page. PLACEHOLDER affordance —
-                  design may fold this into the card archetype later. */}
-              <Link
-                to={`/factions/${f.slug}`}
-                className="font-body no-underline"
-                style={{
-                  display: 'inline-block',
-                  marginTop: 6,
-                  fontSize: 10,
-                  letterSpacing: '0.05em',
-                  color: factionCssVar(f.slug, 'border'),
-                }}
-              >
-                Visit faction →
               </Link>
 
               {/* Not-invited hint */}

--- a/frontend/src/pages/__tests__/factionMembershipRelocation.test.tsx
+++ b/frontend/src/pages/__tests__/factionMembershipRelocation.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Membership relocation guard (issue #347).
+ *
+ * The Factions GRID is a directory of pure preview cards: the whole card links
+ * to the faction detail page and carries NO membership controls. All Join /
+ * Leave / Accept / Decline actions live on the detail page's membership block.
+ *
+ * This test pins that split:
+ *   1. A grid FactionCard renders no interactive controls (no <button>).
+ *   2. The detail-page membership block renders the Join CTA for an eligible
+ *      viewer, and hides it for a viewer with no join affordance ("none") —
+ *      which is exactly the state the hook resolves for UA (graduation-gated,
+ *      no chosen-join flow).
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter, Link } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import FactionCard from "../../components/cards/FactionCard";
+import EverymenFactionBody from "../factionDetail/archetypes/EverymenFactionBody";
+import type { FactionDetailState, Membership } from "../factionDetail/useFactionDetail";
+import type { FactionOut } from "../../api/factions";
+
+const FACTION: FactionOut = {
+  slug: "everymen",
+  name: "The Everymen",
+  description: "Honest work, honestly done.",
+};
+
+function html(node: React.ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>);
+}
+
+/** Tag-stripped text — some archetypes split the name across spans (the
+ *  Ephemerists' lapis last word), so the name only reads contiguously here. */
+function text(node: React.ReactElement): string {
+  return html(node).replace(/<[^>]*>/g, "");
+}
+
+// ─── 1. Grid card is a pure preview (no interactive controls) ─────────────────
+
+describe("faction grid card is a pure preview", () => {
+  for (const slug of ["everymen", "wow", "snide", "ephemerists", "singularity", "ua"]) {
+    it(`${slug} card renders the name but no membership buttons`, () => {
+      const card = (
+        <FactionCard
+          faction={{ ...FACTION, slug, name: `Faction ${slug}` }}
+          status="eligible"
+        />
+      );
+      expect(text(card), "faction name renders").toContain(`Faction ${slug}`);
+      expect(html(card), "no interactive controls on the grid card").not.toContain(
+        "<button",
+      );
+    });
+  }
+
+  it("is wrapped in a link to the faction detail page (grid usage)", () => {
+    // Mirrors how Factions.tsx wraps each card; the whole card is the link.
+    const markup = html(
+      <Link to="/factions/everymen">
+        <FactionCard faction={FACTION} status="eligible" />
+      </Link>,
+    );
+    expect(markup).toContain('href="/factions/everymen"');
+  });
+});
+
+// ─── 2. Detail-page membership block ──────────────────────────────────────────
+
+function stateWith(membership: Partial<Membership>): FactionDetailState {
+  return {
+    slug: FACTION.slug,
+    loading: false,
+    faction: FACTION,
+    fetchError: null,
+    members: [],
+    tasks: [],
+    recentPraxis: [],
+    viewerFactionSlug: null,
+    gameFactions: [],
+    membership: {
+      state: "eligible",
+      currentFactionSlug: null,
+      join: async () => {},
+      joining: false,
+      joinError: null,
+      ...membership,
+    },
+  };
+}
+
+describe("faction detail page membership CTA", () => {
+  it("renders the Join CTA for an eligible viewer", () => {
+    const markup = html(
+      <EverymenFactionBody state={stateWith({ state: "eligible" })} />,
+    );
+    // The Everymen enlist CTA in its faction voice.
+    expect(markup.toUpperCase()).toContain("ENLIST");
+  });
+
+  it("hides the join block when the viewer has no join affordance", () => {
+    // membership.state === "none" is what the hook resolves for logged-out
+    // viewers AND for UA (graduation-gated, no chosen join). The block is gone.
+    const markup = html(
+      <EverymenFactionBody state={stateWith({ state: "none" })} />,
+    );
+    expect(markup.toUpperCase()).not.toContain("ENLIST");
+    expect(markup).not.toContain("<button");
+  });
+});

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -160,13 +160,21 @@ export function useFactionDetail(
     };
   }, [slug, characterId]);
 
+  // UA has no chosen-join flow — membership is graduation-gated, not earned by
+  // tasking, and has no join design (#200/#243). So UA never surfaces an
+  // "eligible" Join CTA nor the "keep tasking" gate: a non-member viewer sees no
+  // join block at all ("none"), per the "hide unusable controls" convention.
+  const isGraduationGated = slug === "ua"
+
   const membershipState: MembershipState = !characterId
     ? "none"
     : rawStatus === "member"
       ? "member"
-      : rawStatus === "invited" || rawStatus === "can_return" || hasInvite
-        ? "eligible"
-        : "gate";
+      : isGraduationGated
+        ? "none"
+        : rawStatus === "invited" || rawStatus === "can_return" || hasInvite
+          ? "eligible"
+          : "gate";
 
   const join = useCallback(async () => {
     if (!slug) return;


### PR DESCRIPTION
Closes #347

## What changed

The **Factions grid** (`/factions`) is now a directory of **pure preview cards**. Each whole grid card is a link to the faction's detail page (`/factions/:slug`); the card carries no interactive controls. All membership actions relocate to the detail page.

### Grid (scope 1 & 2)
- `Factions.tsx`: each `FactionCard` is wrapped in a `<Link to="/factions/:slug">`. Removed the separate "Visit faction →" placeholder link, the in-grid join flow (confirmation overlay + `chooseFaction` + "you won't be able to rejoin…" copy), and the join-flow state. The status-based sort/priority ordering stays.
- `FactionCard.tsx` + `EverymenFactionCard.tsx`: stripped `ActionRow` / `EnlistAction` and the `onJoin` / `onLeave` / `onConfirm` / `onDecline` / `confirmPending` / `leavePending` props. The cards are now pure previews (name, description, status badge, optional invitation note). `FactionCard` is the only consumer, so the props were removed outright (no dead back-compat surface).

### Detail-page membership (scope 3 & 4 — already present, plus UA fix)
The detail-page membership flow **already landed** in PR #359 (the faction-page standardization): `useFactionDetail` loads the viewer's per-faction status + open invitation (via `getFactionStatus()` / `getInvitations()`) and exposes a `membership` object with `join` (→ `chooseFaction`), which refetches auth. Each of the six faction bodies renders a per-faction, **in-voice join CTA + soft gate + "won't be able to rejoin {current}" confirm** — i.e. the Design-System join treatment ported faithfully per faction. This PR leaves that intact and only relocates the grid controls onto it.

## Which factions got a join popup vs. the UA fallback

| Faction | Detail-page join CTA |
|---|---|
| Everymen, WoW, S.N.I.D.E., Ephemerists, Singularity | ✅ per-faction in-voice join/gate/confirm block (from #359) |
| **UA** | ⛔ **hidden** — UA is graduation-gated with no chosen-join flow and no join design (tracked separately by #200/#243). `useFactionDetail` now resolves a non-member UA viewer to membership state `"none"`, so the join/gate block hides rather than showing a broken CTA (per the "hide unusable controls" convention). |
| **Albescent** | Not in the grid (secret society, gated out by #390). No grid card to make clickable; its page is reached only via its own gated route. Untouched here. |

No new join popup was hand-rolled. Note: the six in-voice join blocks are the repo archetypes composed with the contract fields (the README's fallback path), not literal ports of the vendored `docs/design/join/*.html` — those blocks predate this issue.

## Backend note
There is no `leave` / `accept` / `decline` faction endpoint — the only membership write is `POST /factions/choose` (join/defect). The old grid never actually wired `onLeave`/`onConfirm`/`onDecline` (only `onJoin`), so those were dead props; removing them changes no behavior.

## Tests
Added `frontend/src/pages/__tests__/factionMembershipRelocation.test.tsx` (static-markup, lightweight):
- every grid `FactionCard` archetype renders its name and **no `<button>`**;
- the grid card is a link to `/factions/:slug`;
- the detail-page body renders the Join CTA for an `eligible` viewer and **hides** it for a `"none"` viewer (the UA / logged-out case).

## Verification
- `npx tsc --noEmit` clean.
- `npx vite build` green.
- `npx vitest run` — **174 passed (18 files)**, including the new test.
- Did **not** run a live browser preview: the grid needs the FastAPI backend + Postgres, which aren't provisioned in this worktree. The static-render tests assert the exact markup (link href, absence of buttons, CTA presence) a visual check would confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)