### PR TITLE
feat: UA gilt-salon faction avatar (#200)

### DIFF
--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -7,6 +7,7 @@ import WowAvatar from './WowAvatar'
 import SnideAvatar from './SnideAvatar'
 import EphemeristsAvatar from './EphemeristsAvatar'
 import SingularityAvatar from './SingularityAvatar'
+import UAAvatar from './UAAvatar'
 
 /**
  * Per-faction avatar + membership-badge dispatcher (Tier-3 surface). Keyed by
@@ -147,6 +148,7 @@ const FACTION_AVATARS: Record<string, ComponentType<FactionAvatarProps>> = {
   snide: SnideAvatar,
   ephemerists: EphemeristsAvatar,
   singularity: SingularityAvatar,
+  ua: UAAvatar,
 }
 
 export default function FactionAvatar({ character, size }: FactionAvatarProps) {

--- a/frontend/src/components/avatar/UAAvatar.tsx
+++ b/frontend/src/components/avatar/UAAvatar.tsx
@@ -1,0 +1,35 @@
+import { BadgedAvatar, type FactionAvatarProps } from "./FactionAvatar";
+import { UACrest } from "../cards/UACrest";
+
+/**
+ * UA (University of Asthmatics) avatar — the Salon "Artist in Residence"
+ * portrait: a parchment disc ringed in gilt with a regal italic monogram (or
+ * the character's uploaded portrait), plus the heraldic UA crest clipped to the
+ * lower-right as the membership badge.
+ *
+ * Reuses the shared BadgedAvatar shell (image/initial circle + corner badge)
+ * and the repo's own {@link UACrest} for the badge glyph rather than porting a
+ * separate sigil. UA is ALWAYS LIGHT: its --ua-* / --faction-ua-* tokens are
+ * identical in both themes, so the salon styles itself with them and never
+ * mutates data-theme. All colors via tokens (never hardcode hex — CLAUDE.md).
+ */
+export default function UAAvatar({ character, size }: FactionAvatarProps) {
+  return (
+    <BadgedAvatar
+      character={character}
+      size={size}
+      circle={{
+        borderColor: "var(--ua-orange)",
+        bg: "var(--faction-ua-card-bg)",
+        textColor: "var(--ua-ink)",
+        fontFamily: "var(--faction-ua-card-font)",
+      }}
+      badgeBg="var(--ua-paper-warm)"
+      badgeRing="var(--ua-gold)"
+      // The crest is a shield (100×120 viewBox); render it square at badge
+      // scale — BadgedAvatar hands us the inner glyph size and the ring color
+      // (unused here; the crest carries its own --ua-* palette).
+      glyph={(s) => <UACrest width={s} height={s} />}
+    />
+  );
+}

--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Faction avatar dispatch guard (Tier-3 surface). Focuses on the UA variant
+ * (#200): a `ua` character must render the gilt-salon avatar (gilt ring +
+ * heraldic crest badge), while an unknown/neutral slug falls back to the plain
+ * DefaultAvatar circle with no membership badge.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import type { CharacterOut } from "../../../api/auth";
+import FactionAvatar from "../FactionAvatar";
+
+function character(overrides: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    id: 1,
+    username: "Isolde",
+    display_name: "Isolde",
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 3,
+    score: 0,
+    all_time_score: 0,
+    faction_slug: null,
+    status: "active",
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("FactionAvatar — UA variant (#200)", () => {
+  it("renders the UA gilt-salon avatar for a ua character", () => {
+    const html = renderToStaticMarkup(
+      <FactionAvatar character={character({ faction_slug: "ua" })} />,
+    );
+    // Monogram fallback (no avatar_url) — the initial letter, uppercased.
+    expect(html).toContain("I");
+    // Parchment disc ringed in UA gilt tokens (never hardcoded hex).
+    expect(html).toContain("var(--ua-orange)");
+    expect(html).toContain("var(--faction-ua-card-font)");
+    // The heraldic crest badge is present (UACrest draws --ua-* shield fills).
+    expect(html).toContain("var(--ua-gold)");
+    expect(html).toContain("var(--ua-paper-warm)");
+    // UACrest markup marker — the shield uses an SVG viewBox unique to the crest.
+    expect(html).toContain('viewBox="0 0 100 120"');
+  });
+
+  it("renders the character portrait when avatar_url is present", () => {
+    const html = renderToStaticMarkup(
+      <FactionAvatar
+        character={character({ faction_slug: "ua", avatar_url: "/media/isolde.png" })}
+      />,
+    );
+    expect(html).toContain("isolde.png");
+    // Still badged with the crest.
+    expect(html).toContain('viewBox="0 0 100 120"');
+  });
+
+  it("falls back to the plain default avatar for an unknown slug", () => {
+    const html = renderToStaticMarkup(
+      <FactionAvatar character={character({ faction_slug: "totally-unknown" })} />,
+    );
+    // No UA gilt tokens and no crest badge on the fallback circle.
+    expect(html).not.toContain("var(--ua-orange)");
+    expect(html).not.toContain('viewBox="0 0 100 120"');
+    // Default renders the plain initial circle.
+    expect(html).toContain("I");
+  });
+});


### PR DESCRIPTION
## What

UA's only missing per-faction Tier-3 surface was the **avatar** — `FactionAvatar` dispatched `ua` to the plain `DefaultAvatar` while vote/backdrop/hero had already shipped.

Adds `frontend/src/components/avatar/UAAvatar.tsx` — the Salon "Artist in Residence" portrait — and registers `ua: UAAvatar` in `FACTION_AVATARS`.

## How

- Reuses the shared **`BadgedAvatar`** shell (image/initial circle + lower-right badge) that every other faction avatar builds on, so the img/initial + sizing logic stays in one place.
- Circle: parchment disc (`--faction-ua-card-bg`), gilt `--ua-orange` ring, regal italic monogram in `--faction-ua-card-font` (or the character's `avatar_url` portrait when present).
- Badge: reuses the repo's own **`UACrest`** (`components/cards/UACrest.tsx`) as the corner crest rather than porting a separate sigil from the design kit.

## Tokens

All colors via existing `--ua-*` / `--faction-ua-*` tokens — no hardcoded hex (CLAUDE.md). No new tokens needed. UA is **always-light**, so the tokens read identically in both themes and the component never touches `[data-theme]`.

## Tests

New `frontend/src/components/avatar/__tests__/factionAvatar.test.tsx`:
- `ua` character renders the gilt ring + crest badge (monogram path).
- `ua` character with `avatar_url` renders the portrait, still badged.
- unknown slug falls back to the plain `DefaultAvatar` (no UA tokens, no crest).

Full suite green (168 tests) and `tsc --noEmit` clean.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)