### PR TITLE
fix: egalitarian collab byline credits every co-author on praxis detail (#387)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/memberByline.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/memberByline.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * #387 — a published collab praxis credits every co-author, not just the
+ * creator. `orderedMembers` puts the creator first, then the rest by join
+ * order; `MemberByline` renders the ordered names Oxford-style
+ * (Ada / Ada & Beth / Ada, Beth & Cy), each name linked to its character.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { orderedMembers, MemberByline } from "../shared";
+import type { PraxisOut, PraxisMemberOut } from "../../../api/praxis";
+
+function member(
+  characterId: number,
+  name: string,
+  joinedAt: string,
+): PraxisMemberOut {
+  return {
+    id: characterId * 10,
+    praxis_id: 1,
+    character_id: characterId,
+    character_display_name: name,
+    has_submitted: false,
+    joined_at: joinedAt,
+  };
+}
+
+function praxis(members: PraxisMemberOut[], createdById: number): PraxisOut {
+  return {
+    id: 1,
+    task_id: 7,
+    task_title: "Mangrove",
+    task_point_value: 30,
+    task_level_required: 3,
+    task_faction_slug: "ua",
+    type: "collab",
+    status: "submitted",
+    title: "Reforestation",
+    body_text: "Seedlings planted along the estuary.",
+    moderation_status: "visible",
+    admin_note: null,
+    flagged_at: null,
+    submitted_at: null,
+    submit_proposed_at: null,
+    created_by_id: createdById,
+    created_by_display_name: "Ada",
+    created_by_faction_slug: "ua",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    members,
+    invites: [],
+    media_items: [],
+    score: 0,
+    is_top_for_task: false,
+    duel_id: null,
+    can_flag: true,
+    applied_metatasks: [],
+  };
+}
+
+// Creator (id 1 = "Ada") joined last on purpose, to prove creator-first
+// overrides join order for the creator specifically.
+const ADA = member(1, "Ada", "2026-01-03T00:00:00Z");
+const BETH = member(2, "Beth", "2026-01-01T00:00:00Z");
+const CY = member(3, "Cy", "2026-01-02T00:00:00Z");
+
+function bylineText(members: PraxisMemberOut[]): string {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <MemberByline praxis={praxis(members, 1)} />
+    </MemoryRouter>,
+  );
+  return html.replace(/<[^>]+>/g, "").replace(/&amp;/g, "&");
+}
+
+describe("orderedMembers (#387)", () => {
+  it("puts the creator first, then the rest by joined_at ascending", () => {
+    const names = orderedMembers(praxis([ADA, BETH, CY], 1)).map(
+      (m) => m.character_display_name,
+    );
+    expect(names).toEqual(["Ada", "Beth", "Cy"]);
+  });
+
+  it("keeps a single (solo/duel) member as-is", () => {
+    const names = orderedMembers(praxis([ADA], 1)).map(
+      (m) => m.character_display_name,
+    );
+    expect(names).toEqual(["Ada"]);
+  });
+});
+
+describe("MemberByline join format (#387)", () => {
+  it("renders one name plainly", () => {
+    expect(bylineText([ADA])).toBe("Ada");
+  });
+
+  it("joins two names with an ampersand", () => {
+    expect(bylineText([ADA, BETH])).toBe("Ada & Beth");
+  });
+
+  it("joins three+ names Oxford-style (& before the last)", () => {
+    expect(bylineText([ADA, BETH, CY])).toBe("Ada, Beth & Cy");
+  });
+
+  it("links each name to its character profile", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <MemberByline praxis={praxis([ADA, BETH], 1)} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain('href="/characters/1"');
+    expect(html).toContain('href="/characters/2"');
+  });
+});

--- a/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
@@ -19,7 +19,7 @@ import MediaGallery from '../../../components/MediaGallery'
 import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 const INK = 'var(--faction-albescent-card-text)'
@@ -167,12 +167,10 @@ export default function AlbescentPraxisDetail({ state }: { state: PraxisDetailSt
             />
           </Link>
           <div style={{ minWidth: 0 }}>
-            <Link
-              to={`/characters/${praxis.created_by_id}`}
-              style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 15, color: ink(72), textDecoration: 'none', display: 'block' }}
-            >
-              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-            </Link>
+            <MemberByline
+              praxis={praxis}
+              linkStyle={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 15, color: ink(72), textDecoration: 'none' }}
+            />
             <span style={{ fontSize: 7.5, letterSpacing: '0.06em', color: ink(34) }}>{mode}</span>
           </div>
           <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -5,7 +5,7 @@ import { formatTimestamp } from '../../../utils/dates'
 import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 
 /** Style Guide §12.3 */
 const RAINBOW_COLORS = ['var(--underline-1)', 'var(--underline-2)', 'var(--underline-3)', 'var(--underline-4)', 'var(--underline-5)', 'var(--underline-6)', 'var(--underline-1)', 'var(--underline-2)']
@@ -58,13 +58,11 @@ export default function DefaultPraxisDetail({
           />
         </Link>
         <div className="flex-1 min-w-0">
-          <Link
-            to={`/characters/${praxis.created_by_id}`}
-            className="font-display italic block truncate"
-            style={{ fontSize: 14, color: factionCssVar(null, 'card-accent'), textDecoration: 'none' }}
-          >
-            {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-          </Link>
+          <MemberByline
+            praxis={praxis}
+            linkClassName="font-display italic"
+            linkStyle={{ fontSize: 14, color: factionCssVar(null, 'card-accent'), textDecoration: 'none' }}
+          />
           <span className="eyebrow">{formatTimestamp(praxis.created_at)}</span>
         </div>
         {/* Vote score */}

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -16,7 +16,7 @@ import EphemeristsVote from '../../../components/vote/EphemeristsVote'
 import { EphMark, EphEyebrow, Foxing, LapisLastWord, toRoman } from '../../../components/cards/ephemeristsAtoms'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetailState }) {
@@ -166,22 +166,16 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
             />
           </Link>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <Link
-              to={`/characters/${praxis.created_by_id}`}
-              style={{
+            <MemberByline
+              praxis={praxis}
+              linkStyle={{
                 fontFamily: 'var(--eph-serif)',
                 fontStyle: 'italic',
                 fontSize: 13,
                 color: 'var(--eph-lapis)',
                 textDecoration: 'none',
-                display: 'block',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
               }}
-            >
-              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-            </Link>
+            />
             <span
               style={{
                 fontFamily: 'var(--eph-display)',

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -21,7 +21,7 @@ import MediaGallery from '../../../components/MediaGallery'
 import EverymenVote from '../../../components/vote/EverymenVote'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 const POSTER = 'var(--font-accent)' // Bebas Neue
@@ -168,22 +168,16 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
             />
           </Link>
           <div style={{ lineHeight: 1.35, minWidth: 0, flex: 1 }}>
-            <Link
-              to={`/characters/${praxis.created_by_id}`}
-              style={{
+            <MemberByline
+              praxis={praxis}
+              linkStyle={{
                 fontFamily: POSTER,
                 fontSize: 22,
                 color: 'var(--everymen-paper-text)',
                 lineHeight: 1,
                 textDecoration: 'none',
-                display: 'block',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
               }}
-            >
-              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-            </Link>
+            />
             <div style={{ fontSize: 9, letterSpacing: '0.06em', color: 'var(--everymen-muted)', marginTop: 3 }}>
               {praxis.type === 'collab' ? 'all hands' : 'one pair of hands'}
             </div>

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -21,7 +21,7 @@ import MediaGallery from '../../../components/MediaGallery'
 import SingularityVote from '../../../components/vote/SingularityVote'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 // ── Terminal atoms (presentation only — no shared behavior) ──────────────────
@@ -323,20 +323,15 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
               </div>
             </Link>
             <div style={{ flex: 1, minWidth: 0, lineHeight: 1.4 }}>
-              <Link
-                to={`/characters/${praxis.created_by_id}`}
-                style={{
+              <MemberByline
+                praxis={praxis}
+                linkStyle={{
                   fontSize: 13,
                   textDecoration: 'none',
                   color: 'var(--faction-singularity-card-accent)',
-                  display: 'block',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
                 }}
-              >
-                NODE_{praxis.created_by_display_name || `#${praxis.created_by_id}`}
-              </Link>
+                renderName={(name) => `NODE_${name}`}
+              />
               <span
                 style={{
                   fontSize: 8,

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -18,7 +18,7 @@ import MediaGallery from '../../../components/MediaGallery'
 import SnideVote from '../../../components/vote/SnideVote'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 // Always-dark dossier tokens (scoped to this archetype's container).
@@ -231,21 +231,15 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
             />
           </Link>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <Link
-              to={`/characters/${praxis.created_by_id}`}
-              style={{
+            <MemberByline
+              praxis={praxis}
+              linkStyle={{
                 fontFamily: F_MARKER,
                 fontSize: 22,
                 color: PINK,
                 textDecoration: 'none',
-                display: 'block',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
               }}
-            >
-              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-            </Link>
+            />
             <span
               style={{
                 fontFamily: F_BODY,

--- a/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
@@ -22,7 +22,7 @@ import MediaGallery from '../../../components/MediaGallery'
 import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut } from '../../../api/praxis'
 import type { VoteSummary, VoterDetail } from '../../../api/votes'
@@ -302,23 +302,17 @@ export default function UAPraxisDetail({ state }: { state: PraxisDetailState }) 
             />
           </Link>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <Link
-              to={`/characters/${praxis.created_by_id}`}
-              style={{
+            <MemberByline
+              praxis={praxis}
+              linkStyle={{
                 fontFamily: SERIF,
                 fontStyle: 'italic',
                 fontWeight: 500,
                 fontSize: 15,
                 color: 'var(--ua-ink)',
                 textDecoration: 'none',
-                display: 'block',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
               }}
-            >
-              {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-            </Link>
+            />
             <span
               style={{
                 fontFamily: MONO,

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -19,7 +19,7 @@ import MediaGallery from '../../../components/MediaGallery'
 import WowVote from '../../../components/vote/WowVote'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown } from '../shared'
+import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 // ── whimsy.exe token vocabulary (same as TaskDetailWow) ──────────────────────
@@ -287,22 +287,16 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
                 </span>
               </Link>
               <div style={{ lineHeight: 1.4, minWidth: 0 }}>
-                <Link
-                  to={`/characters/${praxis.created_by_id}`}
-                  style={{
+                <MemberByline
+                  praxis={praxis}
+                  linkStyle={{
                     fontFamily: SCRIPT,
                     fontSize: 22,
                     color: TITLE_TEXT,
                     lineHeight: 1,
                     textDecoration: 'none',
-                    display: 'block',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
                   }}
-                >
-                  {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-                </Link>
+                />
                 <div
                   style={{ fontSize: 9, color: CARD_MUTED, letterSpacing: '0.06em', marginTop: 2 }}
                 >

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -11,10 +11,88 @@
  *   - Owner actions (edit / withdraw / resubmit)
  *   - Flag block
  */
+import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { reframeLabel } from '../../components/vote/voteReframes'
 import { TaskCrown } from '../../components/cards/TaskCrown'
 import type { PraxisDetailState } from './usePraxisDetail'
+import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
+
+// ── Egalitarian byline (#387) ────────────────────────────────────────────────
+//
+// A published collab praxis credits every co-author, not just the creator.
+// `orderedMembers` returns the praxis members with the creator first, then the
+// rest by join order; `MemberByline` renders each name as a link to that
+// character, joined Oxford-style (Ada / Ada & Beth / Ada, Beth & Cy). Every
+// archetype keeps its own byline styling by passing its own `linkStyle` — the
+// list logic lives here once. Solo/duel praxes have a single member (the
+// creator is always seeded), so they render exactly one name as before.
+
+/**
+ * Members ordered for display: the creator (member whose `character_id`
+ * matches `created_by_id`) first, then remaining members by `joined_at`
+ * ascending. Members without a matching creator still render in join order.
+ */
+export function orderedMembers(praxis: PraxisOut): PraxisMemberOut[] {
+  const rest = praxis.members
+    .filter((member) => member.character_id !== praxis.created_by_id)
+    .sort((a, b) => a.joined_at.localeCompare(b.joined_at))
+  const creator = praxis.members.find(
+    (member) => member.character_id === praxis.created_by_id,
+  )
+  return creator ? [creator, ...rest] : rest
+}
+
+export function MemberByline({
+  praxis,
+  linkStyle,
+  linkClassName,
+  separatorStyle,
+  renderName,
+}: {
+  praxis: PraxisOut
+  /** Per-archetype link styling so each faction voice stays distinct. */
+  linkStyle?: CSSProperties
+  linkClassName?: string
+  /** Falls back to `linkStyle` so `, ` / ` & ` inherit the byline's look. */
+  separatorStyle?: CSSProperties
+  /** Optional wrapper for each display name (e.g. Singularity's `NODE_` prefix). */
+  renderName?: (name: string) => ReactNode
+}) {
+  const members = orderedMembers(praxis)
+  const sepStyle = separatorStyle ?? linkStyle
+
+  return (
+    <span
+      style={{
+        display: 'block',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+    >
+      {members.map((member, index) => {
+        const name = member.character_display_name || `#${member.character_id}`
+        return (
+          <span key={member.character_id}>
+            {index > 0 && (
+              <span style={sepStyle}>
+                {index === members.length - 1 ? ' & ' : ', '}
+              </span>
+            )}
+            <Link
+              to={`/characters/${member.character_id}`}
+              className={linkClassName}
+              style={linkStyle}
+            >
+              {renderName ? renderName(name) : name}
+            </Link>
+          </span>
+        )
+      })}
+    </span>
+  )
+}
 
 // ── Admin moderation bar ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
A published collaboration praxis credited only its creator on the detail page: every praxis-detail archetype rendered the single `praxis.created_by_display_name` and nothing iterated `praxis.members`, so co-authors were invisible.

## Fix (frontend-only — no backend change)
- New shared helper **`orderedMembers(praxis)`** in `frontend/src/pages/praxisDetail/shared.tsx` — creator first (member whose `character_id === created_by_id`), then the rest by `joined_at` ascending.
- New shared **`MemberByline`** component — renders the ordered members Oxford-style (`Ada` / `Ada & Beth` / `Ada, Beth & Cy`), each name linked to `/characters/:id`. Takes a per-archetype `linkStyle` (plus optional `renderName` for Singularity's `NODE_` prefix) so each faction's byline voice stays distinct.
- Wired into all **eight** archetypes (Default, Wow, UA, Snide, Singularity, Everymen, Ephemerists, Albescent), each replacing its single-name `<Link>` byline.
- Solo/duel praxes seed exactly one creator member, so they render identically to before — **no `praxis.type` conditional**.
- Faction-tinted avatar chip left untouched. `DefaultPraxisDetail`'s `isMember` check left intact.

## Test
`frontend/src/pages/praxisDetail/__tests__/memberByline.test.tsx` covers ordering (creator-first even when the creator joined last) and the 1 / 2 / 3-name join formats, plus per-name profile links.

## Verification
- `npx vitest run` → 171 passed (18 files)
- `npx tsc --noEmit` → clean

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)