### PR TITLE
feat: first-class Albescent content archetypes (#232 slice 1)

### DIFF
--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -3,6 +3,7 @@ import type { PraxisCardOut } from "../api/praxis";
 import { factionCssVar } from "../utils/factions";
 import { pickVariant } from "../utils/factionDispatch";
 import SnideMasthead from "./cards/SnideMasthead";
+import AlbescentMark from "./cards/AlbescentMark";
 import { EphMark, Foxing } from "./cards/ephemeristsAtoms";
 import {
   AdminOverlay,
@@ -531,6 +532,87 @@ function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
 }
 
 
+/**
+ * Albescent — a filed account in the Register. Vellum correspondence: pure white
+ * sheet, a hairline architectural inset border, the surveyor's Mark and a quiet
+ * "Account · filed" running head in mono, then the shared body in Cormorant
+ * Garamond italic. Always-light — never dims. First-class identity: the explicit
+ * PRAXIS_CARD_BY_SLUG['albescent'] entry beats the albescent→ua alias in
+ * pickVariant, so it renders immediately. Reads its own --faction-albescent-*
+ * tokens directly (not factionCssVar('albescent', …), which resolves to ua until
+ * the alias drops in slice 2 of #232). Ported from docs/design/albescent-kit.
+ */
+function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+  const ink = (pct: number) =>
+    `color-mix(in srgb, var(--faction-albescent-card-text) ${pct}%, transparent)`;
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        flex: "1 1 280px",
+        minWidth: 280,
+        boxSizing: "border-box",
+        background: "var(--faction-albescent-card-bg)",
+        color: "var(--faction-albescent-card-text)",
+        border: `1px solid ${ink(10)}`,
+        fontFamily: "var(--faction-albescent-card-font)",
+        boxShadow: "0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)",
+      }}
+    >
+      {/* architectural inset hairline — the sheet's quiet frame */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 5,
+          border: `1px solid ${ink(5)}`,
+          pointerEvents: "none",
+        }}
+      />
+      {/* running head — sigil + "Account · filed" */}
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "9px 15px 7px",
+          borderBottom: `1px solid ${ink(7)}`,
+        }}
+      >
+        <AlbescentMark size={13} />
+        <span
+          style={{
+            fontFamily: "var(--faction-albescent-mono)",
+            fontSize: 8,
+            letterSpacing: "0.22em",
+            textTransform: "uppercase",
+            color: ink(30),
+          }}
+        >
+          Account · filed
+        </span>
+      </div>
+      <div style={{ position: "relative", padding: "12px 15px 14px" }}>
+        <AdminOverlay {...adminProps} />
+        <PraxisBody
+          praxis={praxis}
+          tint={ink(60)}
+          muted={ink(42)}
+          paper="var(--faction-albescent-card-bg)"
+          titleStyle={{
+            fontFamily: "var(--faction-albescent-card-font)",
+            fontStyle: "italic",
+            fontWeight: 300,
+            color: "var(--faction-albescent-card-text)",
+          }}
+          showCrown={showCrown}
+        />
+      </div>
+    </div>
+  );
+}
+
 /** Fallback card for `na` / unknown task factions — a plain accent-bordered slab. */
 export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const slug = praxis.task_faction_slug ?? "ua";
@@ -569,6 +651,8 @@ export const PRAXIS_CARD_BY_SLUG: Record<string, ComponentType<ArchetypeProps>> 
   snide: SnidePraxisCard,
   ephemerists: EphemeristsPraxisCard,
   singularity: SingularityPraxisCard,
+  // First-class Albescent identity (#232 slice 1) — beats the albescent→ua alias.
+  albescent: AlbescentPraxisCard,
 };
 
 export default function PraxisCard({ praxis, onModerated, showCrown = true }: Props) {

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -8,6 +8,7 @@ import TaskCardSNIDE from './cards/TaskCardSNIDE'
 import TaskCardEphemerists from './cards/TaskCardEphemerists'
 import TaskCardSingularity from './cards/TaskCardSingularity'
 import TaskCardEverymen from './cards/TaskCardEverymen'
+import AlbescentTaskCard from './cards/AlbescentTaskCard'
 import { factionCssVar, factionName } from '../utils/factions'
 import { pickVariant } from '../utils/factionDispatch'
 import type { ComponentType } from 'react'
@@ -26,6 +27,9 @@ export const CARD_COMPONENTS: Record<string, ComponentType<CardProps>> = {
   snide: TaskCardSNIDE,
   ephemerists: TaskCardEphemerists,
   singularity: TaskCardSingularity,
+  // First-class Albescent identity (#232 slice 1). The explicit entry beats the
+  // albescent→ua alias in pickVariant, so it renders immediately.
+  albescent: AlbescentTaskCard,
 }
 
 export const DEFAULT_CARD = TaskCardUA

--- a/frontend/src/components/cards/AlbescentMark.tsx
+++ b/frontend/src/components/cards/AlbescentMark.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties } from "react";
+
+/**
+ * The Albescent Mark — the surveyor's cross-hair sigil, the faction's only
+ * emblem. Outer ring (18% opacity) · inner ring (50%) · 4 cardinal tick marks ·
+ * a filled centre dot. It asks only: where are you, exactly?
+ *
+ * Shared across every Albescent surface (task card, praxis card, edit-praxis,
+ * task-detail, read page). Ported from docs/design/albescent-kit
+ * (albescent-cards.jsx `AlbescentMark`). Draws in the faction's near-black ink
+ * token by default — no hue, always-light.
+ */
+export default function AlbescentMark({
+  size = 20,
+  color = "var(--faction-albescent-card-text)",
+  opacity = 1,
+  style,
+}: {
+  size?: number;
+  color?: string;
+  opacity?: number;
+  style?: CSSProperties;
+}) {
+  const c = size / 2;
+  const rOuter = size * 0.43;
+  const rInner = size * 0.235;
+  const rDot = size * 0.044;
+  const tickStart = rInner + size * 0.025;
+  const tickEnd = tickStart + size * 0.13;
+
+  const tick = (deg: number) => {
+    const a = (deg * Math.PI) / 180;
+    return {
+      x1: c + tickStart * Math.cos(a),
+      y1: c + tickStart * Math.sin(a),
+      x2: c + tickEnd * Math.cos(a),
+      y2: c + tickEnd * Math.sin(a),
+    };
+  };
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      fill="none"
+      style={{ display: "block", flexShrink: 0, opacity, ...style }}
+      aria-hidden
+    >
+      <circle cx={c} cy={c} r={rOuter} stroke={color} strokeWidth={size * 0.022} opacity={0.18} />
+      <circle cx={c} cy={c} r={rInner} stroke={color} strokeWidth={size * 0.038} opacity={0.5} />
+      {[0, 90, 180, 270].map((deg) => {
+        const { x1, y1, x2, y2 } = tick(deg);
+        return <line key={deg} x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth={size * 0.038} />;
+      })}
+      <circle cx={c} cy={c} r={rDot} fill={color} />
+    </svg>
+  );
+}

--- a/frontend/src/components/cards/AlbescentTaskCard.tsx
+++ b/frontend/src/components/cards/AlbescentTaskCard.tsx
@@ -1,0 +1,171 @@
+import { Link } from "react-router-dom";
+import type { TaskOut } from "../../api/tasks";
+import AlbescentMark from "./AlbescentMark";
+
+/**
+ * Albescent — Vellum correspondence. The quietest card in the grid: pure white
+ * cotton paper, hairline borders, Cormorant Garamond italic title, the
+ * surveyor's Mark as the only sigil. The card whispers. There is no colour, no
+ * shout — a task here is an act of devotion with no audience.
+ *
+ * Albescent is a FIRST-CLASS identity on this surface: the explicit
+ * CARD_COMPONENTS['albescent'] entry beats the albescent→ua alias via
+ * pickVariant (map[slug] is looked up before the alias), so this renders as soon
+ * as it is registered — it is not dead code. It reads its own component-private
+ * --faction-albescent-* tokens (identical light/dark — always-light, never
+ * dims) rather than factionCssVar('albescent', …), which would resolve the alias
+ * to ua until the alias drops in slice 2 of #232.
+ *
+ * Ported from docs/design/albescent-kit (albescent-cards.jsx `AlbescentCard` +
+ * `Albescent Task Card Explorations.html`). Visuals only — same prop contract as
+ * every other faction task card. No hardcoded hex (CLAUDE.md).
+ */
+
+const FONT = "var(--faction-albescent-card-font)";
+const MONO = "var(--faction-albescent-mono)";
+const INK = "var(--faction-albescent-card-text)";
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
+
+interface Props {
+  task: TaskOut;
+  displayPoints: number;
+  onSignup?: (id: number) => void;
+}
+
+export default function AlbescentTaskCard({ task, displayPoints, onSignup }: Props) {
+  return (
+    <div
+      style={{
+        minWidth: 212,
+        maxWidth: 248,
+        flex: "0 1 224px",
+        background: "var(--faction-albescent-card-bg)",
+        border: `1px solid ${ink(9)}`,
+        boxShadow: "0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)",
+        padding: "24px 20px 18px",
+        fontFamily: FONT,
+        color: INK,
+        boxSizing: "border-box",
+      }}
+    >
+      {/* Centred sigil */}
+      <div style={{ display: "flex", justifyContent: "center", marginBottom: 16 }}>
+        <AlbescentMark size={20} />
+      </div>
+
+      {/* Top rule */}
+      <div style={{ height: 1, background: ink(7), marginBottom: 13 }} />
+
+      {/* Eyebrow */}
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 8,
+          letterSpacing: "0.32em",
+          textTransform: "uppercase",
+          color: ink(24),
+          marginBottom: 10,
+        }}
+      >
+        Albescent
+      </div>
+
+      {/* Title */}
+      <Link to={`/tasks/${task.id}`} style={{ textDecoration: "none", color: "inherit" }}>
+        <div
+          style={{
+            fontSize: 18,
+            fontStyle: "italic",
+            fontWeight: 300,
+            lineHeight: 1.28,
+            color: INK,
+            marginBottom: 11,
+            overflowWrap: "anywhere",
+          }}
+        >
+          {task.title}
+        </div>
+      </Link>
+
+      {/* Description — quiet mono, clamped to three lines */}
+      {task.description && (
+        <div
+          style={{
+            fontFamily: MONO,
+            fontSize: 9,
+            color: ink(42),
+            lineHeight: 1.6,
+            marginBottom: 16,
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {task.description}
+        </div>
+      )}
+
+      {/* Acknowledge — the sign-up affordance, a bordered whisper */}
+      {onSignup && (
+        <div style={{ marginBottom: 14 }}>
+          <button
+            onClick={() => onSignup(task.id)}
+            style={{
+              background: "none",
+              border: "none",
+              padding: "0 0 1px",
+              cursor: "pointer",
+              fontFamily: MONO,
+              fontSize: 9,
+              letterSpacing: "0.22em",
+              textTransform: "uppercase",
+              color: ink(40),
+              borderBottom: `1px solid ${ink(20)}`,
+            }}
+          >
+            acknowledge
+          </button>
+        </div>
+      )}
+
+      {/* Footer — level + points, in one hue */}
+      <div
+        style={{
+          borderTop: `1px solid ${ink(7)}`,
+          paddingTop: 11,
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: MONO,
+            fontSize: 8,
+            letterSpacing: "0.2em",
+            textTransform: "uppercase",
+            color: ink(22),
+          }}
+        >
+          Lvl {task.level_required}
+        </span>
+        <span style={{ fontSize: 15, fontWeight: 300, color: ink(52) }}>
+          {displayPoints}
+          <span
+            style={{
+              fontFamily: MONO,
+              fontSize: 8,
+              marginLeft: 3,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+            }}
+          >
+            pts
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -209,13 +209,29 @@
   --faction-everymen-card-font: var(--font-accent); /* Bebas Neue */
 
   /* ── Albescent · vellum register (always-light — identical in both themes,
-     same mechanism Singularity uses to stay always-dark; #231). First-class
-     read-surface identity; the global albescent→ua alias stays until #232. ── */
+     same mechanism Singularity uses to stay always-dark; #231/#232). First-class
+     content identity across four surfaces (task card, praxis card, edit praxis,
+     task detail) + the read page. The global albescent→ua alias stays until the
+     second slice of #232, so these components read these tokens directly rather
+     than via factionCssVar('albescent', …) (which resolves the alias to ua).
+     Values ported from docs/design/albescent-kit/albescent.css. ── */
   --faction-albescent-card-bg: #ffffff;
   --faction-albescent-card-text: #1c1c1a; /* near-black ink, no hue */
   --faction-albescent-card-accent: rgba(28, 28, 26, 0.72);
   --faction-albescent-card-muted: rgba(28, 28, 26, 0.44);
   --faction-albescent-card-font: "Cormorant Garamond", Georgia, serif;
+  /* Full vellum-correspondence set — the whole palette is one near-black hue. */
+  --faction-albescent-primary: #1c1c1a; /* near-black ink */
+  --faction-albescent-light: #faf9f7; /* warm off-white sheet */
+  --faction-albescent-border: rgba(0, 0, 0, 0.1);
+  --faction-albescent-surface: #ffffff; /* the sheet */
+  --faction-albescent-surface-warm: #faf9f7;
+  --faction-albescent-ink: rgba(28, 28, 26, 0.72);
+  --faction-albescent-text-faint: rgba(28, 28, 26, 0.22);
+  --faction-albescent-border-faint: rgba(0, 0, 0, 0.055);
+  --faction-albescent-border-rule: rgba(0, 0, 0, 0.07);
+  --faction-albescent-page: #f7f4ee; /* cream backdrop */
+  --faction-albescent-mono: "Courier Prime", "Courier New", monospace;
 
   /* ── Vote stamp colors (orange → yellow → green → blue → magenta) ── */
   --vote-1: #c2410c;
@@ -362,12 +378,23 @@
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
 
   /* Albescent — always-light: identical to the :root values so the vellum
-     register never dims, regardless of the global theme (#231). */
+     register never dims, regardless of the global theme (#231/#232). */
   --faction-albescent-card-bg: #ffffff;
   --faction-albescent-card-text: #1c1c1a;
   --faction-albescent-card-accent: rgba(28, 28, 26, 0.72);
   --faction-albescent-card-muted: rgba(28, 28, 26, 0.44);
   --faction-albescent-card-font: "Cormorant Garamond", Georgia, serif;
+  --faction-albescent-primary: #1c1c1a;
+  --faction-albescent-light: #faf9f7;
+  --faction-albescent-border: rgba(0, 0, 0, 0.1);
+  --faction-albescent-surface: #ffffff;
+  --faction-albescent-surface-warm: #faf9f7;
+  --faction-albescent-ink: rgba(28, 28, 26, 0.72);
+  --faction-albescent-text-faint: rgba(28, 28, 26, 0.22);
+  --faction-albescent-border-faint: rgba(0, 0, 0, 0.055);
+  --faction-albescent-border-rule: rgba(0, 0, 0, 0.07);
+  --faction-albescent-page: #f7f4ee;
+  --faction-albescent-mono: "Courier Prime", "Courier New", monospace;
 
   /* ══ Ephemerists palette (dark) — pigments stay vivid; vellum darkens
      to aged tobacco and its text flips ink→parchment. The card contract

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -19,11 +19,13 @@ import EditPraxisEphemeris from "./editPraxis/archetypes/EditPraxisEphemeris";
 import EditPraxisStickyNote from "./editPraxis/archetypes/EditPraxisStickyNote";
 import EditPraxisEverymen from "./editPraxis/archetypes/EditPraxisEverymen";
 import EditPraxisUA from "./editPraxis/archetypes/EditPraxisUA";
+import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
-// ua owns the gilt-salon Atelier archetype. albescent / aged_out inherit it via
-// pickVariant's alias rule, so they need no explicit rows. StickyNote remains
+// ua owns the gilt-salon Atelier archetype; aged_out inherits it via pickVariant's
+// alias rule (no explicit row). albescent is now a FIRST-CLASS identity (#232
+// slice 1) — its explicit entry beats the albescent→ua alias. StickyNote remains
 // the fallback for `na` / unknown factions.
 const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   everymen: EditPraxisEverymen,
@@ -32,6 +34,7 @@ const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   wow: EditPraxisPaperCollage,
   ephemerists: EditPraxisEphemeris,
   ua: EditPraxisUA,
+  albescent: AlbescentEditPraxis,
 };
 
 export default function EditPraxis() {

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -18,12 +18,15 @@ import TaskDetailWow from "./taskDetail/archetypes/TaskDetailWow";
 import TaskDetailEphemerists from "./taskDetail/archetypes/TaskDetailEphemerists";
 import TaskDetailSingularity from "./taskDetail/archetypes/TaskDetailSingularity";
 import TaskDetailUA from "./taskDetail/archetypes/TaskDetailUA";
+import AlbescentTaskDetail from "./taskDetail/archetypes/AlbescentTaskDetail";
 import CommentThread from "../components/comments/CommentThread";
 
 type Archetype = (props: { state: TaskDetailState }) => JSX.Element | null;
 
 // Only factions with a bespoke archetype are listed; everything else (incl.
-// albescent / aged_out) falls through to DefaultTaskDetail below.
+// aged_out) falls through to DefaultTaskDetail below. albescent is now a
+// FIRST-CLASS identity (#232 slice 1) — its explicit entry beats the
+// albescent→ua alias in pickVariant.
 export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   snide: TaskDetailSNIDE,
   everymen: TaskDetailEverymen,
@@ -31,6 +34,7 @@ export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   ephemerists: TaskDetailEphemerists,
   singularity: TaskDetailSingularity,
   ua: TaskDetailUA,
+  albescent: AlbescentTaskDetail,
 };
 
 export default function TaskDetail() {

--- a/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
@@ -1,0 +1,578 @@
+/**
+ * Albescent edit-praxis archetype — FILE AN ACCOUNT.
+ *
+ * The vellum-correspondence counterpart to the read page (AlbescentPraxisDetail)
+ * and the register cards: a returned task entered into the Register as a plain
+ * account, "no more than was done". A white sheet with an architectural inset
+ * border, the surveyor's Mark, Cormorant Garamond italic display, a quiet mono
+ * for labels, and the faction's ceremonial voice ("The Manner", "The Account",
+ * "Enter into the Register"). The sheet never dims — Albescent is always-light,
+ * so every --faction-albescent-* token reads identically in both themes and we
+ * style with them directly without touching data-theme.
+ *
+ * Albescent is a FIRST-CLASS identity here (not a ua alias): the explicit
+ * ARCHETYPE_BY_SLUG['albescent'] entry beats the albescent→ua alias via
+ * pickVariant, so this renders immediately. Behaviour (autosave, mode-switch
+ * guards, invite, media, publish) comes from the shared control primitives; this
+ * archetype owns only presentation. Ported from
+ * docs/design/albescent-kit/Albescent Edit Praxis.dc.html. No hardcoded hex
+ * (CLAUDE.md) — every colour is a --faction-albescent-* token or an ink() wash.
+ */
+import { mediaUrl } from "../../../utils/media";
+import { type PraxisType } from "../../../api/praxis";
+import type { CSSProperties, ReactNode } from "react";
+import MediaArt from "../blocks/MediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
+import AlbescentMark from "../../../components/cards/AlbescentMark";
+import {
+  Breadcrumb,
+  ErrorBanner,
+  TitleCounter,
+  formatAutosave,
+} from "./shared";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  ModePicker,
+  PublishButton,
+  TitleField,
+} from "./controls";
+import type { EditPraxisState } from "../useEditPraxis";
+
+interface Props {
+  state: EditPraxisState;
+}
+
+const FONT = "var(--faction-albescent-card-font)";
+const MONO = "var(--faction-albescent-mono)";
+const INK = "var(--faction-albescent-card-text)";
+const SHEET = "var(--faction-albescent-card-bg)";
+const WARM = "var(--faction-albescent-surface-warm)";
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
+
+const MODE_OPTIONS: Array<{ key: PraxisType; label: string; desc: string }> = [
+  { key: "solo", label: "Alone", desc: "no witness present" },
+  { key: "collab", label: "In Concord", desc: "attended together" },
+  { key: "duel", label: "In Contest", desc: "one account against another" },
+];
+
+/** Quiet mono section label with a trailing serif gloss and a hairline rule. */
+function MannerLabel({ label, gloss }: { label: string; gloss?: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 13 }}>
+      <span
+        style={{
+          fontFamily: MONO,
+          fontSize: 8,
+          letterSpacing: "0.26em",
+          textTransform: "uppercase",
+          color: ink(30),
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </span>
+      {gloss && (
+        <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 13, color: ink(40), whiteSpace: "nowrap" }}>
+          {gloss}
+        </span>
+      )}
+      <span style={{ flex: 1, height: 1, background: ink(7) }} />
+    </div>
+  );
+}
+
+export default function AlbescentEditPraxis({ state }: Props) {
+  const praxis = state.praxis!;
+  const task = state.task;
+  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background:
+          "radial-gradient(ellipse 72% 58% at 50% 38%, rgba(255,255,255,0.58) 0%, transparent 100%), var(--faction-albescent-page)",
+        fontFamily: MONO,
+        color: INK,
+        padding: "24px 24px 90px",
+      }}
+    >
+      <div style={{ maxWidth: 780, margin: "0 auto" }}>
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+          inkColor={ink(34)}
+        />
+
+        {/* The sheet */}
+        <div
+          style={{
+            position: "relative",
+            background: SHEET,
+            border: `1px solid ${ink(10)}`,
+            boxShadow: "0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)",
+            padding: "40px 46px 44px",
+          }}
+        >
+          {/* architectural inset hairline */}
+          <div style={{ position: "absolute", inset: 6, border: `1px solid ${ink(5)}`, pointerEvents: "none" }} />
+
+          {/* masthead */}
+          <div
+            style={{
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 14,
+              paddingBottom: 18,
+              borderBottom: `1px solid ${ink(7)}`,
+            }}
+          >
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 9,
+                fontFamily: MONO,
+                fontSize: 8.5,
+                letterSpacing: "0.24em",
+                textTransform: "uppercase",
+                color: ink(30),
+              }}
+            >
+              <AlbescentMark size={13} />
+              Albescent · Account № {praxis.id}
+            </span>
+            <span
+              style={{
+                fontFamily: MONO,
+                fontSize: 7.5,
+                letterSpacing: "0.16em",
+                textTransform: "uppercase",
+                color: ink(26),
+                borderBottom: `1px solid ${ink(18)}`,
+                paddingBottom: 1,
+              }}
+            >
+              {state.autosaveAt ? `noted ${formatAutosave(state.autosaveAt)}` : "unfiled draft"}
+            </span>
+          </div>
+
+          {/* title + preamble */}
+          <h1
+            style={{
+              position: "relative",
+              fontFamily: FONT,
+              fontStyle: "italic",
+              fontWeight: 300,
+              fontSize: 56,
+              lineHeight: 1.0,
+              color: INK,
+              margin: "26px 0 8px",
+            }}
+          >
+            File an Account
+          </h1>
+          <p
+            style={{
+              position: "relative",
+              fontFamily: FONT,
+              fontStyle: "italic",
+              fontWeight: 300,
+              fontSize: 16,
+              lineHeight: 1.5,
+              color: ink(50),
+              maxWidth: 480,
+              marginBottom: 30,
+            }}
+          >
+            A returned task is entered into the Register as a plain account — no more than was done. The keepers will bear
+            witness; you need not persuade them.
+          </p>
+
+          {/* reference slip */}
+          <div
+            style={{
+              position: "relative",
+              display: "flex",
+              gap: 16,
+              alignItems: "center",
+              border: `1px solid ${ink(7)}`,
+              background: WARM,
+              padding: "15px 18px",
+              marginBottom: 34,
+            }}
+          >
+            <AlbescentMark size={38} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 7.5,
+                  letterSpacing: "0.2em",
+                  textTransform: "uppercase",
+                  color: ink(30),
+                  marginBottom: 5,
+                }}
+              >
+                Returning · Ref. {praxis.task_id}
+              </div>
+              <div
+                style={{
+                  fontFamily: FONT,
+                  fontStyle: "italic",
+                  fontSize: 24,
+                  lineHeight: 1.05,
+                  color: INK,
+                  marginBottom: 7,
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {praxis.task_title}
+              </div>
+              {task?.description && (
+                <div style={{ fontFamily: MONO, fontSize: 9, lineHeight: 1.5, color: ink(40), marginBottom: 6, overflowWrap: "anywhere" }}>
+                  {task.description}
+                </div>
+              )}
+              <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.08em", color: ink(40) }}>
+                {praxis.task_point_value} pts on return
+              </div>
+            </div>
+          </div>
+
+          {/* The Manner — mode picker */}
+          {!state.controlsLocked && (
+            <div style={{ position: "relative", marginBottom: 32 }}>
+              <MannerLabel label="The Manner" gloss="how was it attended?" />
+              <ModePicker
+                state={state}
+                skin={{
+                  containerStyle: { display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 },
+                  options: MODE_OPTIONS,
+                  allowedModes,
+                  renderOption: (opt, { active, disabled, onSelect }) => (
+                    <button
+                      key={opt.key}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={onSelect}
+                      disabled={disabled && !active}
+                      style={{
+                        cursor: disabled && !active ? "not-allowed" : "pointer",
+                        textAlign: "left",
+                        padding: "14px 16px",
+                        width: "100%",
+                        background: active ? INK : SHEET,
+                        color: active ? "var(--faction-albescent-page)" : INK,
+                        border: `1px solid ${active ? INK : ink(12)}`,
+                        transition: "all 160ms",
+                      }}
+                    >
+                      <div style={{ fontFamily: FONT, fontStyle: "italic", fontWeight: 400, fontSize: 22, lineHeight: 1 }}>
+                        {opt.label}
+                      </div>
+                      <div style={{ fontFamily: MONO, fontSize: 7.5, letterSpacing: "0.06em", marginTop: 6, opacity: 0.7 }}>
+                        {opt.desc}
+                      </div>
+                    </button>
+                  ),
+                }}
+              />
+            </div>
+          )}
+
+          {/* Invitees / challenger */}
+          {state.showInviteBox && (
+            <div style={{ position: "relative", marginBottom: 32 }}>
+              <MannerLabel label={praxis.type === "duel" ? "The Other Account" : "The Other Hands"} />
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: FONT,
+                  inputBg: WARM,
+                  inputColor: INK,
+                  inputBorder: `1px solid ${ink(12)}`,
+                  dropdownBg: SHEET,
+                  dropdownBorder: `1px solid ${ink(12)}`,
+                  acceptedBg: INK,
+                  acceptedColor: "var(--faction-albescent-page)",
+                  placeholder: "name or @handle",
+                }}
+              />
+            </div>
+          )}
+
+          {/* The Closing Line — the title */}
+          <div style={{ position: "relative", marginBottom: 32 }}>
+            <MannerLabel label="The Closing Line" gloss="the one line the Register keeps" />
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: "what remains, now that it is done",
+                inputStyle: {
+                  width: "100%",
+                  border: "none",
+                  borderBottom: `1px solid ${ink(18)}`,
+                  background: "transparent",
+                  fontFamily: FONT,
+                  fontStyle: "italic",
+                  fontWeight: 400,
+                  fontSize: 26,
+                  color: INK,
+                  padding: "4px 2px 10px",
+                  outline: "none",
+                },
+              }}
+            />
+            <div style={{ marginTop: 8 }}>
+              <TitleCounter length={state.title.length} color={ink(34)} />
+            </div>
+          </div>
+
+          {/* The Account — the body */}
+          <div style={{ position: "relative", marginBottom: 32 }}>
+            <MannerLabel label="The Account" gloss={`${state.wordCount} words · markdown`} />
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 7,
+                placeholder: "Set down what was done, one line at a time. Leave nothing out; add nothing in.",
+                textareaStyle: {
+                  width: "100%",
+                  resize: "vertical",
+                  border: `1px solid ${ink(10)}`,
+                  background: WARM,
+                  fontFamily: FONT,
+                  fontSize: 18,
+                  lineHeight: 1.75,
+                  color: INK,
+                  padding: "16px 18px",
+                  outline: "none",
+                  minHeight: 200,
+                },
+              }}
+            />
+            <BodyPreview
+              state={state}
+              skin={{
+                wrapperStyle: { borderTop: `1px solid ${ink(7)}`, marginTop: 14, paddingTop: 12 },
+                label: (
+                  <div
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: 8,
+                      letterSpacing: "0.2em",
+                      textTransform: "uppercase",
+                      color: ink(30),
+                      marginBottom: 8,
+                    }}
+                  >
+                    As the Register will keep it
+                  </div>
+                ),
+                markdownStyle: { fontFamily: FONT, fontStyle: "italic", fontSize: 15, lineHeight: 1.75, color: ink(62) },
+              }}
+            />
+          </div>
+
+          {/* The Plates — media */}
+          <div style={{ position: "relative", marginBottom: 32 }}>
+            <MannerLabel label="The Plates" gloss="what was seen, if anything" />
+            <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "flex-start" }}>
+              {state.media.map((item) => {
+                const filename = item.file_path.split("/").pop() ?? item.file_path;
+                const src = mediaUrl(item.file_path);
+                return (
+                  <PlateFrame key={item.id} caption={filename} onRemove={() => void state.removeMedia(item)}>
+                    {item.type === "image" ? (
+                      <img src={src} alt="" style={{ width: 140, height: 100, objectFit: "cover", display: "block" }} />
+                    ) : item.type === "video" ? (
+                      <video src={src} style={{ width: 140, height: 100, objectFit: "cover", display: "block" }} />
+                    ) : (
+                      <MediaArt art={pickArtKey(filename, "audio")} />
+                    )}
+                  </PlateFrame>
+                );
+              })}
+              <FilePicker
+                state={state}
+                skin={{
+                  buttonStyle: {
+                    width: 152,
+                    height: 130,
+                    background: WARM,
+                    border: `1px dashed ${ink(16)}`,
+                    cursor: "pointer",
+                    fontFamily: MONO,
+                    fontSize: 9,
+                    letterSpacing: "0.14em",
+                    textTransform: "uppercase",
+                    color: ink(40),
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexDirection: "column",
+                    gap: 4,
+                  },
+                  buttonLabel: "+ affix a plate",
+                  errorColor: "var(--color-danger)",
+                  helperText: "images · video · audio · max 50mb",
+                  helperStyle: { fontFamily: MONO, fontSize: 8, letterSpacing: "0.08em", color: ink(30), marginTop: 8 },
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Further merit — metatasks */}
+          {state.showMetatasks && (
+            <div style={{ position: "relative", marginBottom: 32 }}>
+              <MannerLabel label="Further Merit" />
+              <MetatasksList
+                state={state}
+                skin={{
+                  rowStyle: (selected) => ({
+                    padding: "8px 10px",
+                    background: selected ? WARM : "transparent",
+                    border: selected ? `1px solid ${ink(10)}` : "1px solid transparent",
+                    marginBottom: 4,
+                    fontFamily: FONT,
+                  }),
+                  titleColor: INK,
+                  descColor: ink(45),
+                  pointsActiveColor: INK,
+                  pointsIdleColor: ink(35),
+                }}
+              />
+            </div>
+          )}
+
+          <ErrorBanner message={state.error} />
+
+          {/* File bar */}
+          <div
+            style={{
+              position: "relative",
+              borderTop: `1px solid ${ink(7)}`,
+              paddingTop: 24,
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              flexWrap: "wrap",
+            }}
+          >
+            <PublishButton
+              state={state}
+              skin={{
+                idleLabel: "Enter into the Register",
+                busyLabel: "entering…",
+                style: {
+                  cursor: state.submitting ? "wait" : "pointer",
+                  border: `1px solid ${INK}`,
+                  background: INK,
+                  color: "var(--faction-albescent-page)",
+                  fontFamily: FONT,
+                  fontStyle: "italic",
+                  fontWeight: 500,
+                  fontSize: 20,
+                  letterSpacing: "0.02em",
+                  padding: "12px 30px",
+                  whiteSpace: "nowrap",
+                },
+              }}
+            />
+            <DropButton
+              state={state}
+              skin={{
+                label: "Withdraw",
+                style: {
+                  cursor: "pointer",
+                  border: `1px solid ${ink(12)}`,
+                  background: "transparent",
+                  color: ink(50),
+                  fontFamily: MONO,
+                  fontSize: 9,
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  padding: "14px 18px",
+                },
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** A framed plate for one piece of evidence — the sheet's quiet polaroid. */
+function PlateFrame({
+  children,
+  caption,
+  onRemove,
+}: {
+  children: ReactNode;
+  caption: string;
+  onRemove: () => void;
+}) {
+  const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
+  const frame: CSSProperties = {
+    position: "relative",
+    background: SHEET,
+    border: `1px solid ${ink(10)}`,
+    padding: 5,
+    boxShadow: "0 2px 12px rgba(0,0,0,0.05)",
+  };
+  return (
+    <div style={frame}>
+      <div style={{ width: 140, height: 100, overflow: "hidden" }}>{children}</div>
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 8,
+          letterSpacing: "0.04em",
+          color: ink(40),
+          textAlign: "center",
+          marginTop: 4,
+          maxWidth: 140,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {caption}
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${caption}`}
+        style={{
+          position: "absolute",
+          top: -8,
+          right: -8,
+          width: 22,
+          height: 22,
+          borderRadius: "50%",
+          background: SHEET,
+          border: `1.5px solid ${INK}`,
+          color: INK,
+          fontSize: 12,
+          fontWeight: 700,
+          cursor: "pointer",
+          lineHeight: 1,
+          padding: 0,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
@@ -1,0 +1,543 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import PraxisCard from "../../../components/PraxisCard";
+import AlbescentMark from "../../../components/cards/AlbescentMark";
+import { mediaUrl } from "../../../utils/media";
+import { ErrorBanner, relationOf } from "./shared";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * Albescent task-detail archetype — THE CORRESPONDENCE.
+ *
+ * A task in the Register reads as a letter admitted in confidence: a centred
+ * vellum sheet, the surveyor's Mark, Cormorant Garamond italic display, a quiet
+ * mono for labels. "The Ask" holds the brief; "Inscribed in the Register" is the
+ * wall of returned accounts (the finest is most-witnessed). To take a task is to
+ * "Acknowledge" it — no portfolio, no announcement.
+ *
+ * Albescent is a FIRST-CLASS identity here (not a ua alias): the explicit
+ * ARCHETYPE_BY_SLUG['albescent'] entry beats the albescent→ua alias via
+ * pickVariant, so this renders immediately. The sheet never dims — Albescent is
+ * always-light, so every --faction-albescent-* token reads identically in both
+ * themes and we style with them directly. Ported from
+ * docs/design/albescent-kit/Albescent Task Detail.dc.html; wired to the real
+ * {@link TaskDetailState}. No hardcoded hex (CLAUDE.md).
+ */
+
+const FONT = "var(--faction-albescent-card-font)";
+const MONO = "var(--faction-albescent-mono)";
+const INK = "var(--faction-albescent-card-text)";
+const SHEET = "var(--faction-albescent-card-bg)";
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
+
+/** Section heading — a serif-italic title flanked by a fading hairline rule. */
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 18 }}>
+      <h2
+        style={{
+          fontFamily: FONT,
+          fontStyle: "italic",
+          fontWeight: 500,
+          fontSize: 22,
+          margin: 0,
+          color: INK,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {title}
+      </h2>
+      <span style={{ flex: 1, height: 1, background: ink(8) }} />
+      {trailing}
+    </div>
+  );
+}
+
+export default function AlbescentTaskDetail({ state }: { state: TaskDetailState }) {
+  const {
+    task,
+    signups,
+    submissions,
+    friends,
+    foes,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  // Decorative: the correspondence's reference number, from the real task id.
+  const correspondenceNo = String(task.id).padStart(4, "0");
+
+  // The most-witnessed account on the wall wears the ⚜ mark.
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null;
+
+  return (
+    <div
+      className="py-8"
+      style={{
+        fontFamily: MONO,
+        color: INK,
+        background:
+          "radial-gradient(ellipse 72% 58% at 50% 38%, rgba(255,255,255,0.55) 0%, transparent 100%), var(--faction-albescent-page)",
+      }}
+    >
+      {/* Breadcrumb */}
+      <nav
+        className="mb-4"
+        style={{
+          fontFamily: MONO,
+          fontSize: 10,
+          letterSpacing: "0.16em",
+          textTransform: "uppercase",
+          color: ink(40),
+        }}
+      >
+        <Link to="/tasks" style={{ color: "inherit", textDecoration: "none" }}>
+          Tasks
+        </Link>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
+        <span>Albescent</span>
+        <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
+        <span style={{ color: INK }}>{task.title}</span>
+      </nav>
+
+      <div style={{ maxWidth: 880, margin: "0 auto" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 34 }}>
+          {/* HERO — the letter */}
+          <div
+            style={{
+              background: SHEET,
+              border: `1px solid ${ink(10)}`,
+              boxShadow: "0 2px 24px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)",
+              padding: "54px 60px 48px",
+              textAlign: "center",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "center", marginBottom: 24 }}>
+              <AlbescentMark size={44} />
+            </div>
+            <div
+              style={{
+                fontFamily: MONO,
+                fontSize: 9,
+                letterSpacing: "0.34em",
+                textTransform: "uppercase",
+                color: ink(45),
+                marginBottom: 6,
+              }}
+            >
+              Albescent
+            </div>
+            <div
+              style={{
+                fontFamily: MONO,
+                fontSize: 8,
+                letterSpacing: "0.28em",
+                textTransform: "uppercase",
+                color: ink(30),
+                marginBottom: 26,
+              }}
+            >
+              Correspondence №{correspondenceNo} · in confidence
+            </div>
+            <div style={{ width: 54, height: 1, background: ink(12), margin: "0 auto 26px" }} />
+            <h1
+              style={{
+                fontFamily: FONT,
+                fontStyle: "italic",
+                fontWeight: 500,
+                fontSize: 46,
+                lineHeight: 1.16,
+                color: INK,
+                margin: "0 auto 22px",
+                maxWidth: 560,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {task.title}
+            </h1>
+            <div style={{ width: 54, height: 1, background: ink(12), margin: "0 auto 28px" }} />
+            <div style={{ display: "flex", justifyContent: "center", gap: 48, flexWrap: "wrap" }}>
+              {[
+                { label: "Standing", value: `Lvl ${task.level_required}` },
+                { label: "Worth", value: `${modifiedPoints} pts` },
+                { label: "Returned", value: `${submissions.length}` },
+              ].map((stat, index) => (
+                <div key={stat.label} style={{ display: "flex", gap: 48 }}>
+                  {index > 0 && <div style={{ borderLeft: `1px solid ${ink(10)}` }} />}
+                  <div>
+                    <div
+                      style={{
+                        fontFamily: MONO,
+                        fontSize: 8,
+                        letterSpacing: "0.22em",
+                        textTransform: "uppercase",
+                        color: ink(40),
+                        marginBottom: 6,
+                      }}
+                    >
+                      {stat.label}
+                    </div>
+                    <div style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 22, color: INK }}>{stat.value}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* CTA bar — Acknowledge / signed-on states */}
+          {canSignUp && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 18,
+                flexWrap: "wrap",
+                background: SHEET,
+                border: `1px solid ${ink(10)}`,
+                boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
+                padding: "16px 22px",
+              }}
+            >
+              <button
+                onClick={handleSignup}
+                style={{
+                  cursor: "pointer",
+                  fontFamily: MONO,
+                  fontSize: 9,
+                  letterSpacing: "0.22em",
+                  textTransform: "uppercase",
+                  color: INK,
+                  background: "transparent",
+                  border: `1px solid ${INK}`,
+                  padding: "13px 26px",
+                }}
+              >
+                Acknowledge · earn up to {modifiedPoints} pts
+              </button>
+              <div style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 15, color: ink(55) }}>
+                no portfolio. no announcement.
+              </div>
+              <div
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: MONO,
+                  fontSize: 8,
+                  letterSpacing: "0.18em",
+                  textTransform: "uppercase",
+                  color: ink(40),
+                }}
+              >
+                {slotsOpen} of {maxTaskSlots} slots open · Lvl {task.level_required} standing met
+              </div>
+              <ErrorBanner
+                message={signupError}
+                style={{
+                  flexBasis: "100%",
+                  marginTop: 0,
+                  background: ink(3),
+                  border: `1px solid ${ink(14)}`,
+                  color: "var(--color-danger)",
+                }}
+              />
+            </div>
+          )}
+
+          {mySubmission && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 16,
+                flexWrap: "wrap",
+                background: SHEET,
+                border: `1px solid ${ink(10)}`,
+                padding: "16px 22px",
+              }}
+            >
+              <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 17, color: ink(65) }}>
+                ⚜ Your account is inscribed in the Register
+              </span>
+              <Link
+                to={`/praxes/${mySubmission.id}/edit`}
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: MONO,
+                  fontSize: 9,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  padding: "10px 20px",
+                  background: INK,
+                  color: "var(--faction-albescent-page)",
+                  textDecoration: "none",
+                }}
+              >
+                edit
+              </Link>
+            </div>
+          )}
+
+          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 16,
+                flexWrap: "wrap",
+                background: SHEET,
+                border: `1px solid ${ink(10)}`,
+                padding: "16px 22px",
+              }}
+            >
+              <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 17, color: ink(65) }}>
+                Your account is unfiled, still in hand
+              </span>
+              <Link
+                to={`/praxes/${inProgressPraxisId}/edit`}
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: MONO,
+                  fontSize: 9,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  padding: "10px 20px",
+                  background: INK,
+                  color: "var(--faction-albescent-page)",
+                  textDecoration: "none",
+                }}
+              >
+                continue
+              </Link>
+              <button
+                onClick={handleDrop}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: MONO,
+                  fontSize: 9,
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  color: ink(40),
+                }}
+              >
+                withdraw
+              </button>
+              <ErrorBanner
+                message={signupError}
+                style={{
+                  flexBasis: "100%",
+                  marginTop: 0,
+                  background: ink(3),
+                  border: `1px solid ${ink(14)}`,
+                  color: "var(--color-danger)",
+                }}
+              />
+            </div>
+          )}
+
+          {/* THE ASK — the user-written brief */}
+          <section>
+            <SectionHead
+              title="The Ask"
+              trailing={
+                <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 13, color: ink(45), whiteSpace: "nowrap" }}>
+                  in the hand of the keeper
+                </span>
+              }
+            />
+            <div
+              style={{
+                background: SHEET,
+                border: `1px solid ${ink(10)}`,
+                boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
+                padding: "34px 40px",
+                maxWidth: 640,
+              }}
+            >
+              <p
+                style={{
+                  fontFamily: FONT,
+                  fontSize: 20,
+                  lineHeight: 1.62,
+                  color: ink(72),
+                  margin: 0,
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {task.description ||
+                  "No correspondence entered yet. The Register waits for the ask to be set down — plainly, in the fewest words that keep it true."}
+              </p>
+            </div>
+          </section>
+
+          {/* Hands — signups (quiet avatar row) */}
+          {signups.length > 0 && (
+            <section>
+              <SectionHead title="Taken in Confidence" />
+              <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                {signups.map((hand) => {
+                  const rel = relationOf(hand.character_id, friends, foes);
+                  return (
+                    <Link
+                      key={hand.character_id}
+                      to={`/characters/${hand.character_id}`}
+                      title={`${hand.display_name}${rel ? ` · ${rel}` : ""}`}
+                      style={{ position: "relative", width: 36, height: 36, flexShrink: 0 }}
+                    >
+                      {hand.avatar_url ? (
+                        <img
+                          src={mediaUrl(hand.avatar_url)}
+                          alt={hand.display_name}
+                          style={{ width: 36, height: 36, borderRadius: "50%", objectFit: "cover", border: `1px solid ${ink(14)}` }}
+                        />
+                      ) : (
+                        <span
+                          style={{
+                            display: "flex",
+                            width: 36,
+                            height: 36,
+                            borderRadius: "50%",
+                            background: ink(4),
+                            border: `1px solid ${ink(14)}`,
+                            alignItems: "center",
+                            justifyContent: "center",
+                            color: ink(50),
+                            fontFamily: FONT,
+                            fontStyle: "italic",
+                            fontSize: 16,
+                          }}
+                        >
+                          {hand.display_name[0]?.toUpperCase()}
+                        </span>
+                      )}
+                    </Link>
+                  );
+                })}
+                <span
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: 9,
+                    letterSpacing: "0.12em",
+                    textTransform: "uppercase",
+                    color: ink(40),
+                    marginLeft: 4,
+                  }}
+                >
+                  in hand
+                </span>
+              </div>
+            </section>
+          )}
+
+          {/* INSCRIBED IN THE REGISTER — returned accounts */}
+          <section>
+            <SectionHead
+              title="Inscribed in the Register"
+              trailing={
+                <div style={{ display: "flex", gap: 0 }}>
+                  {(["score", "recent"] as const).map((sort) => {
+                    const on = submissionSort === sort;
+                    return (
+                      <button
+                        key={sort}
+                        onClick={() => setSubmissionSort(sort)}
+                        style={{
+                          fontFamily: MONO,
+                          fontSize: 9,
+                          letterSpacing: "0.12em",
+                          textTransform: "uppercase",
+                          padding: "5px 12px",
+                          background: on ? INK : "transparent",
+                          color: on ? "var(--faction-albescent-page)" : ink(45),
+                          border: `1px solid ${on ? INK : ink(14)}`,
+                          cursor: "pointer",
+                        }}
+                      >
+                        {sort === "score" ? "most witnessed" : "recent"}
+                      </button>
+                    );
+                  })}
+                </div>
+              }
+            />
+            {sortedSubmissions.length === 0 ? (
+              <p style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 16, color: ink(45) }}>
+                The Register holds no accounts against this correspondence. Be the first to return one, unsigned.
+              </p>
+            ) : (
+              <>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "30px 24px", alignItems: "flex-start" }}>
+                  {sortedSubmissions.slice(0, 4).map((s) => (
+                    <div key={s.id} style={{ position: "relative", paddingTop: 22 }}>
+                      {s.id === topId && (
+                        <div
+                          style={{
+                            position: "absolute",
+                            top: 0,
+                            left: "50%",
+                            transform: "translateX(-50%)",
+                            zIndex: 3,
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 6,
+                            whiteSpace: "nowrap",
+                            background: INK,
+                            color: "var(--faction-albescent-page)",
+                            fontFamily: FONT,
+                            fontStyle: "italic",
+                            fontSize: 13,
+                            letterSpacing: "0.04em",
+                            padding: "3px 14px",
+                          }}
+                        >
+                          <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> most witnessed
+                        </div>
+                      )}
+                      <PraxisCard praxis={s} />
+                    </div>
+                  ))}
+                </div>
+                {submissions.length > 4 && (
+                  <div style={{ marginTop: 18 }}>
+                    <Link
+                      to={`/praxes?task_id=${task.id}`}
+                      style={{
+                        fontFamily: MONO,
+                        fontSize: 10,
+                        letterSpacing: "0.12em",
+                        textTransform: "uppercase",
+                        color: ink(55),
+                        textDecoration: "none",
+                        borderBottom: `1px solid ${ink(20)}`,
+                        paddingBottom: 2,
+                      }}
+                    >
+                      all {submissions.length} accounts &rarr;
+                    </Link>
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Slice 1 of #232 (content archetypes); alias drop deferred to slice 2.**

Promotes `albescent` from a `ua` alias to a first-class identity on the four **content** surfaces, plus the complete `--faction-albescent-*` CSS token set. Does **not** touch `CSS_KEY`/`FACTION_ALIASES` — dropping the alias is slice 2's job.

### Surfaces built + registered
Each registers an explicit `albescent` key. Because `pickVariant` looks up the raw slug *before* the `albescent→ua` alias fallback, every entry is **live immediately** (not dead code):

| Surface | Component | Map |
|---|---|---|
| Task card | `AlbescentTaskCard` (new) | `CARD_COMPONENTS` (`TaskCard.tsx`) |
| Praxis card | `AlbescentPraxisCard` (inline) | `PRAXIS_CARD_BY_SLUG` (`PraxisCard.tsx`) |
| Edit praxis | `AlbescentEditPraxis` (new) | `ARCHETYPE_BY_SLUG` (`EditPraxis.tsx`) |
| Task detail | `AlbescentTaskDetail` (new) | `ARCHETYPE_BY_SLUG` (`TaskDetail.tsx`) |

Plus a shared `AlbescentMark` sigil atom (surveyor's cross-hair). The vellum-correspondence idiom is carried faithfully from `docs/design/albescent-kit/`: always-light, near-black ink, Cormorant Garamond italic, quiet mono labels, "bear witness" / "the Register" voice.

### Tokens
`index.css` now owns the **complete** `--faction-albescent-*` set (primary, light, border, surface, ink, page, mono, etc.), identical in light + dark (always-light), values from `albescent.css`. Existing `--faction-albescent-card-*` keys were extended, not duplicated. Slice 2 will not need to touch `index.css`.

### Alias caveat honored
`factionCssVar('albescent', …)` still resolves the alias to `ua` until slice 2, so every albescent component reads its `--faction-albescent-*` tokens **directly** rather than via `factionCssVar`. (This is also why `AlbescentTaskCard` renders its own ink "Lvl N" text instead of `LevelPill factionSlug="albescent"`, which would render UA-orange.)

### Verification
- `tsc --noEmit` — clean (exit 0)
- `vitest run` — 172/172 pass, incl. `taskDetail/__tests__/archetypeSlots.test.tsx` and `praxisDetail/__tests__/archetypeSlots.test.tsx` (the map-walking slot guards)
- `vite build` — green

### Scope
Only the four content surfaces + tokens + the shared Mark atom. Faction hero/body, feed frame, vote, avatar, backdrop, and `factions.ts` are untouched (slice 2). Does not `Closes #232`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)