### PR TITLE
refactor: name the task-level gate — meets_task_level (#292)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -405,6 +405,19 @@ async def list_praxes(
     return praxes
 
 
+def meets_task_level(character_level: int, task: Task) -> bool:
+    """Whether ``character_level`` clears the task's own level bar (#292).
+
+    The single home for the **task-level** gate — the "level half" that used to
+    be ANDed inline into :func:`is_task_eligible_for_character` and the sign-up
+    predicate. A distinct axis from :func:`~services.faction_service.faction_permits`
+    (the faction half, #171) and from the era-config thresholds
+    (collab/flag/comment/metatask-apply), which each already sit in their own
+    purpose-named predicate and share a single ``era.*`` source for their value.
+    """
+    return character_level >= task.level_required
+
+
 class SignupDenialReason(str, Enum):
     """Why the type-agnostic sign-up gates reject a claim (ADR-0008)."""
 
@@ -442,7 +455,7 @@ async def evaluate_signup(
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, character.id, era_row.id)
 
-    if stats.level < task.level_required:
+    if not meets_task_level(stats.level, task):
         return SignupEligibility(False, SignupDenialReason.below_level)
 
     if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
@@ -932,9 +945,9 @@ def is_task_eligible_for_character(
     """
     if character is None:
         return False
-    if character_level < task.level_required:
+    # Two named single-purpose gates, no bundled inline checks (#171, #292).
+    if not meets_task_level(character_level, task):
         return False
-    # Faction gating routes through the single seam (ADR-0029, #171).
     if not faction_permits(character, task):
         return False
     return True

--- a/backend/tests/unit/test_meets_task_level.py
+++ b/backend/tests/unit/test_meets_task_level.py
@@ -1,0 +1,27 @@
+"""Unit tests for the task-level gate (#292).
+
+``meets_task_level`` is the named home for the task-level half that used to be
+inlined into the eligibility/sign-up predicates. Pure predicate — no DB.
+"""
+from models.task import Task
+from services.praxis import meets_task_level
+
+
+def _task(level_required: int) -> Task:
+    return Task(level_required=level_required)
+
+
+def test_below_required_level_is_denied() -> None:
+    assert meets_task_level(2, _task(3)) is False
+
+
+def test_exact_level_meets_the_bar() -> None:
+    assert meets_task_level(3, _task(3)) is True
+
+
+def test_above_required_level_is_permitted() -> None:
+    assert meets_task_level(8, _task(3)) is True
+
+
+def test_level_zero_task_is_open_to_everyone() -> None:
+    assert meets_task_level(0, _task(0)) is True


### PR DESCRIPTION
> **Stacked on #425 (#171).** Base is the #171 branch so this diff is only #292's change; it retargets to `main` automatically when #171 merges.

## What
Spun out of #171. While extracting `faction_permits`, the same smell recurred: a meaningful gating sub-rule buried inside a broader predicate that ANDs unrelated axes together. This gives the reused one its own named home.

## Audit → decision
Checked every gating predicate (`is_task_eligible_for_character`, the sign-up guard `evaluate_signup`, vote, flag, comment, metatask-apply). The **only** sub-rule that is both *reused* and *inlined into an unrelated predicate* is the **task-level gate** (`character_level >= task.level_required`), ANDed into both `is_task_eligible_for_character` and the sign-up predicate.

- **Extracted:** `meets_task_level(character_level, task)` — the named home, mirroring `faction_permits`. Both sites now consult it. No behaviour change.
- **Left bundled by design:** flag / collab / comment / metatask-apply level gates are each single-site, already sit in their own purpose-named predicate, and share a single `era.*` source for their threshold value. Wrapping each one-liner would add indirection without reuse — the issue explicitly asks us to decide which axes deserve a home vs. which are fine as-is.

Pure hygiene, no gameplay-rule change (kept off the gameplay-design surface per the issue). Unit test for `meets_task_level`. Full suite: **530 passed**.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)