### PR TITLE
refactor: name the task-level gate — meets_task_level (#292)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -405,6 +405,19 @@ async def list_praxes(
     return praxes
 
 
+def meets_task_level(character_level: int, task: Task) -> bool:
+    """Whether ``character_level`` clears the task's own level bar (#292).
+
+    The single home for the **task-level** gate — the "level half" that used to
+    be ANDed inline into :func:`is_task_eligible_for_character` and the sign-up
+    predicate. A distinct axis from :func:`~services.faction_service.faction_permits`
+    (the faction half, #171) and from the era-config thresholds
+    (collab/flag/comment/metatask-apply), which each already sit in their own
+    purpose-named predicate and share a single ``era.*`` source for their value.
+    """
+    return character_level >= task.level_required
+
+
 class SignupDenialReason(str, Enum):
     """Why the type-agnostic sign-up gates reject a claim (ADR-0008)."""
 
@@ -442,7 +455,7 @@ async def evaluate_signup(
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, character.id, era_row.id)
 
-    if stats.level < task.level_required:
+    if not meets_task_level(stats.level, task):
         return SignupEligibility(False, SignupDenialReason.below_level)
 
     if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
@@ -932,9 +945,9 @@ def is_task_eligible_for_character(
     """
     if character is None:
         return False
-    if character_level < task.level_required:
+    # Two named single-purpose gates, no bundled inline checks (#171, #292).
+    if not meets_task_level(character_level, task):
         return False
-    # Faction gating routes through the single seam (ADR-0029, #171).
     if not faction_permits(character, task):
         return False
     return True

--- a/backend/tests/unit/test_meets_task_level.py
+++ b/backend/tests/unit/test_meets_task_level.py
@@ -1,0 +1,27 @@
+"""Unit tests for the task-level gate (#292).
+
+``meets_task_level`` is the named home for the task-level half that used to be
+inlined into the eligibility/sign-up predicates. Pure predicate — no DB.
+"""
+from models.task import Task
+from services.praxis import meets_task_level
+
+
+def _task(level_required: int) -> Task:
+    return Task(level_required=level_required)
+
+
+def test_below_required_level_is_denied() -> None:
+    assert meets_task_level(2, _task(3)) is False
+
+
+def test_exact_level_meets_the_bar() -> None:
+    assert meets_task_level(3, _task(3)) is True
+
+
+def test_above_required_level_is_permitted() -> None:
+    assert meets_task_level(8, _task(3)) is True
+
+
+def test_level_zero_task_is_open_to_everyone() -> None:
+    assert meets_task_level(0, _task(0)) is True


### PR DESCRIPTION
Replaces #426, which auto-closed when its base branch (`claude/171-faction-permits-seam`, PR #425) was deleted on merge. Rebased onto `main` — this is the #292 delta on top of the now-merged #425 (faction_permits seam).

Names the task-level gate `meets_task_level` and routes `praxis.py` through it, with a unit test. Closes #292.