### PR TITLE
feat: Albescent first-class on remaining surfaces + drop the alias (#232, final)

### DIFF
--- a/docs/adr/0017-praxis-read-page.md
+++ b/docs/adr/0017-praxis-read-page.md
@@ -47,7 +47,7 @@ identity on this surface** (no longer a `ua` alias here) — see decision 7 belo
 | snide | ✅ bundle | ❌ → Default | #205 |
 | singularity | ✅ bundle | ❌ → Default | #206 (+ build `SingularityVote`) |
 | ua | ✅ bundle | ❌ → Default | #209 (+ build `UaVote`) |
-| albescent | ✅ bundle (always-light) | ❌ → Default (ua alias) | #231 first-class on this surface; #232 promote everywhere |
+| albescent | ✅ bundle (always-light) | ✅ first-class everywhere | #231 read page; **#232 done** — promoted on all surfaces; `albescent → ua` alias dropped |
 | aged_out | ❌ (inherits `ua`) | ❌ → Default | stays a `ua` alias |
 
 ### 2. A shared slot module owns the behavior slots; archetypes own presentation

--- a/docs/spec/SPEC-faction-ui-profile.md
+++ b/docs/spec/SPEC-faction-ui-profile.md
@@ -134,7 +134,7 @@ Hand this to whoever wires the faction after design is delivered. (Designer only
 
 **What this is.** The *state* companion to §1's *contract*: which factions have a bespoke version of each surface wired **today**, and which fall back to a generic default. Use it to brief design ("commission an `X` for these factions") and to scope a new faction ("here's everything it could own"). Audited from the dispatchers in code on **2026-06-24** — re-audit by grepping `pickVariant(` and the `Record<slug, …>` maps if it looks stale.
 
-**Playable factions (6):** `ua` · `everymen` · `wow` · `snide` · `ephemerists` · `singularity`. (`ua_masters` is dormant → Era 2; `albescent`/`aged_out` are alias slugs that inherit `ua`'s archetype via `FACTION_ALIASES`, so they own nothing of their own by design.)
+**First-class factions (7):** `ua` · `everymen` · `wow` · `snide` · `ephemerists` · `singularity` · `albescent`. As of #232, `albescent` is a fully first-class identity: it owns a bespoke archetype on **every** surface (task/praxis card, edit-praxis, task/praxis detail, feed frame, avatar, backdrop, vote "bear witness", comment, faction body + hero) plus its own `--faction-albescent-*` token set and `CSS_KEY` entry — the `albescent → ua` alias has been **dropped** from `FACTION_ALIASES`. (`ua_masters` is dormant → Era 2; only `aged_out` remains a `ua` alias slug that owns nothing of its own by design.)
 
 ### A. Bespoke-component surfaces — "missing" = falls back to a generic `Default*`
 

--- a/frontend/src/components/__tests__/voteReframes.test.tsx
+++ b/frontend/src/components/__tests__/voteReframes.test.tsx
@@ -76,8 +76,14 @@ describe('reframeLabel', () => {
     expect(reframeLabel('snide', 1)).toBe('meh')
   })
 
-  it('resolves the albescent→ua alias', () => {
-    expect(reframeLabel('albescent', 3)).toBe('accomplished')
+  it('labels albescent in its own first-class "bear witness" vocabulary (#232)', () => {
+    // No longer aliases to ua — albescent has its own witness scale.
+    expect(reframeLabel('albescent', 3)).toBe('Witnessed')
+    expect(reframeLabel('albescent', 5)).toBe('Inscribed')
+  })
+
+  it('still resolves the aged_out→ua alias', () => {
+    expect(reframeLabel('aged_out', 5)).toBe('masterwork')
   })
 
   it('falls back to the arabic number when no reframe exists', () => {

--- a/frontend/src/components/avatar/AlbescentAvatar.tsx
+++ b/frontend/src/components/avatar/AlbescentAvatar.tsx
@@ -1,0 +1,31 @@
+import { BadgedAvatar, type FactionAvatarProps } from "./FactionAvatar";
+import AlbescentMark from "../cards/AlbescentMark";
+
+/**
+ * Albescent avatar (Tier-3 surface, #232). A white cotton-paper disc with a
+ * hairline ink ring and the character's monogram (or uploaded portrait), badged
+ * with the surveyor's-cross-hair {@link AlbescentMark} — the faction's only
+ * sigil. No hue, no crest: the order leaves no trace.
+ *
+ * Reuses the shared BadgedAvatar shell and the existing AlbescentMark atom
+ * (slice 1). Albescent is ALWAYS LIGHT — its --faction-albescent-* tokens are
+ * identical in both themes, so it never mutates data-theme; all colors via
+ * tokens (never hardcode hex — CLAUDE.md).
+ */
+export default function AlbescentAvatar({ character, size }: FactionAvatarProps) {
+  return (
+    <BadgedAvatar
+      character={character}
+      size={size}
+      circle={{
+        borderColor: "var(--faction-albescent-card-accent)",
+        bg: "var(--faction-albescent-card-bg)",
+        textColor: "var(--faction-albescent-card-text)",
+        fontFamily: "var(--faction-albescent-card-font)",
+      }}
+      badgeBg="var(--faction-albescent-surface)"
+      badgeRing="var(--faction-albescent-border)"
+      glyph={(s) => <AlbescentMark size={s} />}
+    />
+  );
+}

--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -8,6 +8,7 @@ import SnideAvatar from './SnideAvatar'
 import EphemeristsAvatar from './EphemeristsAvatar'
 import SingularityAvatar from './SingularityAvatar'
 import UAAvatar from './UAAvatar'
+import AlbescentAvatar from './AlbescentAvatar'
 
 /**
  * Per-faction avatar + membership-badge dispatcher (Tier-3 surface). Keyed by
@@ -149,6 +150,7 @@ const FACTION_AVATARS: Record<string, ComponentType<FactionAvatarProps>> = {
   ephemerists: EphemeristsAvatar,
   singularity: SingularityAvatar,
   ua: UAAvatar,
+  albescent: AlbescentAvatar,
 }
 
 export default function FactionAvatar({ character, size }: FactionAvatarProps) {

--- a/frontend/src/components/backdrop/AlbescentBackdrop.tsx
+++ b/frontend/src/components/backdrop/AlbescentBackdrop.tsx
@@ -1,0 +1,27 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Albescent full-page backdrop (#232) — a cream cotton-paper wall
+ * (`--faction-albescent-page`) lifted by a soft white highlight and ruled with
+ * faint horizontal ledger lines, like a standing record sheet. Albescent is
+ * always-light: its `--faction-albescent-*` tokens are identical in both themes,
+ * so this never flips with data-theme. Fixed behind page content at z-index 0.
+ * Ported from docs/design/albescent-kit/albescent.css `.al-backdrop`.
+ */
+const backdropStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 0,
+  pointerEvents: 'none',
+  backgroundColor: 'var(--faction-albescent-page)',
+  backgroundImage: [
+    // soft white highlight, centred and high
+    'radial-gradient(ellipse 72% 58% at 50% 38%, rgba(255,255,255,0.58) 0%, transparent 100%)',
+    // faint ruled ledger lines (neutral ink, no hue)
+    'repeating-linear-gradient(to bottom, transparent 0 27px, rgba(0,0,0,0.016) 27px 28px)',
+  ].join(', '),
+}
+
+export default function AlbescentBackdrop() {
+  return <div style={backdropStyle} aria-hidden="true" />
+}

--- a/frontend/src/components/backdrop/FactionBackdrop.tsx
+++ b/frontend/src/components/backdrop/FactionBackdrop.tsx
@@ -6,6 +6,7 @@ import SnideBackdrop from './SnideBackdrop'
 import EphemeristsBackdrop from './EphemeristsBackdrop'
 import SingularityBackdrop from './SingularityBackdrop'
 import UABackdrop from './UABackdrop'
+import AlbescentBackdrop from './AlbescentBackdrop'
 import { useBackdropSlug } from './BackdropContext'
 import { pickVariant } from '../../utils/factionDispatch'
 
@@ -22,6 +23,7 @@ const FACTION_BACKDROPS: Record<string, ComponentType> = {
   ephemerists: EphemeristsBackdrop,
   singularity: SingularityBackdrop,
   ua: UABackdrop,
+  albescent: AlbescentBackdrop,
 }
 
 export default function FactionBackdrop() {

--- a/frontend/src/components/cards/AlbescentFactionHero.tsx
+++ b/frontend/src/components/cards/AlbescentFactionHero.tsx
@@ -1,0 +1,154 @@
+import type { FactionHeroProps } from "../../pages/FactionDetail";
+import AlbescentMark from "./AlbescentMark";
+
+/**
+ * Albescent faction-page hero — a still, meditative frontispiece (#232). No
+ * chrome, no color: a white cotton-paper sheet, the faction name set large in
+ * italic, the surveyor's mark watermarked behind and struck once at the side,
+ * and the three counts kept as a quiet ledger. Ported from the Albescent design
+ * kit (`AlHero`); conforms to {@link FactionHeroProps}.
+ *
+ * Always light — every --faction-albescent-* token is identical in both themes,
+ * so it never mutates data-theme. All colors via tokens (no hardcoded hex —
+ * CLAUDE.md). The page passes raw counts; the order names them in its own voice.
+ * Motto is a faction constant, not a backend field.
+ */
+
+const INK = "var(--faction-albescent-card-text)";
+const SURFACE = "var(--faction-albescent-surface)";
+const BORDER = "var(--faction-albescent-border)";
+const FONT = "var(--faction-albescent-card-font)"; // Cormorant Garamond
+const MONO = "var(--faction-albescent-mono)"; // Courier Prime
+
+const ink = (pct: number): string => `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
+
+const MOTTO = "The work is the work";
+
+export default function AlbescentFactionHero({
+  name,
+  description,
+  members,
+  tasks,
+  praxes,
+}: FactionHeroProps) {
+  const stats = [
+    { value: members, label: "Keepers" },
+    { value: tasks, label: "Open Work" },
+    { value: praxes, label: "Returned" },
+  ];
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        background: SURFACE,
+        border: `1px solid ${BORDER}`,
+        marginBottom: 24,
+      }}
+    >
+      {/* Faint watermark mark, high and to the side. */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "68%",
+          transform: "translate(-50%,-50%)",
+          pointerEvents: "none",
+          zIndex: 0,
+          opacity: 0.035,
+        }}
+      >
+        <AlbescentMark size={220} />
+      </div>
+
+      <div
+        style={{
+          position: "relative",
+          zIndex: 1,
+          padding: "36px 40px 40px",
+          display: "grid",
+          gridTemplateColumns: "1fr auto",
+          gap: 40,
+          alignItems: "center",
+        }}
+      >
+        <div>
+          {/* Pre-title eyebrow */}
+          <div
+            style={{
+              fontFamily: MONO,
+              fontSize: 7.5,
+              letterSpacing: "0.28em",
+              textTransform: "uppercase",
+              color: ink(22),
+              marginBottom: 16,
+              lineHeight: 1.9,
+            }}
+          >
+            <div>Faction · {name}</div>
+            <div>Unranked · By design</div>
+          </div>
+
+          {/* Faction name */}
+          <div
+            style={{
+              fontFamily: FONT,
+              fontStyle: "italic",
+              fontWeight: 300,
+              fontSize: 60,
+              lineHeight: 0.94,
+              color: INK,
+              marginBottom: 14,
+              letterSpacing: "-0.015em",
+            }}
+          >
+            {name}
+          </div>
+
+          {/* Motto */}
+          <div
+            style={{
+              fontFamily: MONO,
+              fontSize: 9,
+              letterSpacing: "0.34em",
+              textTransform: "uppercase",
+              color: ink(28),
+              marginBottom: 18,
+            }}
+          >
+            {MOTTO}
+          </div>
+
+          {/* Blurb — the faction's own description */}
+          {description && (
+            <p style={{ fontFamily: MONO, fontSize: 9.5, lineHeight: 1.74, color: ink(46), maxWidth: 490, marginBottom: 26 }}>
+              {description}
+            </p>
+          )}
+
+          {/* Stats ledger */}
+          <div style={{ display: "flex", gap: 26, flexWrap: "wrap" }}>
+            {stats.map((s) => (
+              <div key={s.label} style={{ paddingTop: 12, borderTop: `1px solid ${BORDER}`, minWidth: 80 }}>
+                <div style={{ fontFamily: FONT, fontStyle: "italic", fontWeight: 300, fontSize: 26, lineHeight: 1, color: ink(68), marginBottom: 5 }}>
+                  {s.value}
+                </div>
+                <div style={{ fontFamily: MONO, fontSize: 7, letterSpacing: "0.2em", textTransform: "uppercase", color: ink(26) }}>
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Struck mark at the side. ponytail: static, not the design's slow
+            "breathe" — a decorative keyframe not worth a global @keyframes here. */}
+        <div style={{ flexShrink: 0 }}>
+          <AlbescentMark size={96} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -1,0 +1,129 @@
+import type { VoteUIProps } from './VoteUI'
+import { useVote } from './useVote'
+import { VoteLoginGate, VoteSummary } from './VoteShell'
+import { VOTE_REFRAMES } from './voteReframes'
+
+/**
+ * Albescent vote UI — BEAR WITNESS (#232). The 1-5 approval is recast as an act
+ * of witnessing: how completely was a task attended, from "Unseeing" up to the
+ * final "Inscribed". Five grayscale cross-hair marks in rising ink — no hue, no
+ * numerals; the chosen mark takes a white centre. Albescent refuses the palette.
+ *
+ * Same 1-5 data model as every faction — a visual reskin over the shared
+ * {@link useVote} hook, so cast/refetch logic stays in one place. Always-light:
+ * every --faction-albescent-* token is identical in both themes; the rising
+ * shades derive from the ink token via color-mix (no hardcoded hex — CLAUDE.md).
+ * Design: docs/design/albescent-kit `AlWitnessWidget`.
+ */
+
+const INK = 'var(--faction-albescent-card-text)'
+const FONT = 'var(--faction-albescent-card-font)' // Cormorant Garamond
+const MONO = 'var(--faction-albescent-mono)' // Courier Prime
+
+const TIERS = VOTE_REFRAMES['albescent'].tiers
+
+// Rising ink weight per mark (1 → 5), mixed from the near-black ink token.
+const SHADE_PCT = [16, 30, 48, 66, 84]
+const shade = (value: number): string =>
+  `color-mix(in srgb, ${INK} ${SHADE_PCT[value - 1]}%, transparent)`
+
+export default function AlbescentVote({
+  praxisId,
+  currentValue,
+  points,
+  totalVotes,
+}: VoteUIProps) {
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+
+  if (!user) {
+    return <VoteLoginGate />
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 7,
+          letterSpacing: '0.26em',
+          textTransform: 'uppercase',
+          color: 'var(--faction-albescent-text-faint)',
+          marginBottom: 10,
+        }}
+      >
+        Bear Witness
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'flex-start' }}>
+        {TIERS.map((tier) => {
+          const reached = selected >= tier.value
+          const picked = selected === tier.value
+          const marked = shade(tier.value)
+          return (
+            <div
+              key={tier.value}
+              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 7, minWidth: 44 }}
+            >
+              <button
+                disabled={saving}
+                onClick={() => void vote(tier.value)}
+                aria-label={`Witness ${tier.value} — ${tier.label}`}
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: '50%',
+                  padding: 0,
+                  cursor: saving ? 'default' : 'pointer',
+                  border: `1.5px solid ${marked}`,
+                  background: reached ? marked : 'transparent',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  transition: 'all 200ms ease',
+                }}
+              >
+                {picked && (
+                  <span
+                    style={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      background: 'var(--faction-albescent-surface)',
+                    }}
+                  />
+                )}
+              </button>
+              <span
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 6.5,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  textAlign: 'center',
+                  color: picked ? 'var(--faction-albescent-card-accent)' : 'var(--faction-albescent-card-muted)',
+                }}
+              >
+                {tier.label}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <VoteSummary
+        selected={selected}
+        points={points}
+        totalVotes={totalVotes}
+        error={error}
+        theme={{
+          muted: 'var(--faction-albescent-card-muted)',
+          accent: 'var(--faction-albescent-card-accent)',
+          accentFont: FONT,
+          avgFontSize: 16,
+          errorColor: 'var(--faction-albescent-card-accent)',
+          avgLetterSpacing: '0.04em',
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -7,6 +7,7 @@ import SnideVote from './SnideVote'
 import EphemeristsVote from './EphemeristsVote'
 import SingularityVote from './SingularityVote'
 import UAVote from './UAVote'
+import AlbescentVote from './AlbescentVote'
 
 /**
  * Per-faction vote/rating UI dispatcher (Tier-3 surface). Keyed by the voted
@@ -29,6 +30,7 @@ const FACTION_VOTE: Record<string, ComponentType<VoteUIProps>> = {
   ephemerists: EphemeristsVote,
   singularity: SingularityVote,
   ua: UAVote,
+  albescent: AlbescentVote,
 }
 
 export default function VoteUI({

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -68,6 +68,17 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
       { value: 5, label: 'masterwork' },
     ],
   },
+  // Albescent "bear witness" vocabulary (#232) — how completely a task was
+  // attended, Unseeing → Inscribed. Words from docs/design/albescent-kit.
+  albescent: {
+    tiers: [
+      { value: 1, label: 'Unseeing' },
+      { value: 2, label: 'Glimpsed' },
+      { value: 3, label: 'Witnessed' },
+      { value: 4, label: 'Verified' },
+      { value: 5, label: 'Inscribed' },
+    ],
+  },
 }
 
 /**

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -222,6 +222,7 @@
   --faction-albescent-card-font: "Cormorant Garamond", Georgia, serif;
   /* Full vellum-correspondence set — the whole palette is one near-black hue. */
   --faction-albescent-primary: #1c1c1a; /* near-black ink */
+  --faction-albescent: var(--faction-albescent-primary); /* bare primary — first-class, no longer aliases ua (#232) */
   --faction-albescent-light: #faf9f7; /* warm off-white sheet */
   --faction-albescent-border: rgba(0, 0, 0, 0.1);
   --faction-albescent-surface: #ffffff; /* the sheet */
@@ -385,6 +386,7 @@
   --faction-albescent-card-muted: rgba(28, 28, 26, 0.44);
   --faction-albescent-card-font: "Cormorant Garamond", Georgia, serif;
   --faction-albescent-primary: #1c1c1a;
+  --faction-albescent: var(--faction-albescent-primary); /* bare primary — first-class, no longer aliases ua (#232) */
   --faction-albescent-light: #faf9f7;
   --faction-albescent-border: rgba(0, 0, 0, 0.1);
   --faction-albescent-surface: #ffffff;

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -11,12 +11,14 @@ import SingularityFactionBody from "./factionDetail/archetypes/SingularityFactio
 import SnideFactionBody from "./factionDetail/archetypes/SnideFactionBody";
 import EphemeristsFactionBody from "./factionDetail/archetypes/EphemeristsFactionBody";
 import WowFactionBody from "./factionDetail/archetypes/WowFactionBody";
+import AlbescentFactionBody from "./factionDetail/archetypes/AlbescentFactionBody";
 import EphemeristsFactionHero from "../components/cards/EphemeristsFactionHero";
 import SnideFactionHero from "../components/cards/SnideFactionHero";
 import SingularityFactionHero from "../components/cards/SingularityFactionHero";
 import EverymenFactionHero from "../components/cards/EverymenFactionHero";
 import UAFactionHero from "../components/cards/UAFactionHero";
 import WowFactionHero from "../components/cards/WowFactionHero";
+import AlbescentFactionHero from "../components/cards/AlbescentFactionHero";
 
 /**
  * Faction detail page (`/factions/:slug`). Per-faction surface #13 in
@@ -48,11 +50,12 @@ const FACTION_HEROES: Record<string, ComponentType<FactionHeroProps>> = {
   everymen: EverymenFactionHero,
   ua: UAFactionHero,
   wow: WowFactionHero,
+  albescent: AlbescentFactionHero,
 };
 
-// The standardized six-section body, dispatched per faction. albescent is not
-// registered: it aliases to ua (FACTION_ALIASES) and so inherits the UA body
-// via pickVariant until its own vellum skin lands with the alias removal.
+// The standardized six-section body, dispatched per faction. The explicit
+// albescent row renders "The Record" skin now (#232); it beats the albescent→ua
+// alias in pickVariant, so it no longer inherits the UA body.
 const FACTION_BODIES: Record<string, ComponentType<{ state: FactionDetailState }>> = {
   everymen: EverymenFactionBody,
   ua: UaFactionBody,
@@ -60,6 +63,7 @@ const FACTION_BODIES: Record<string, ComponentType<{ state: FactionDetailState }
   snide: SnideFactionBody,
   ephemerists: EphemeristsFactionBody,
   wow: WowFactionBody,
+  albescent: AlbescentFactionBody,
 };
 
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {

--- a/frontend/src/pages/factionDetail/archetypes/AlbescentFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/AlbescentFactionBody.tsx
@@ -1,0 +1,143 @@
+import { type CSSProperties, type ReactNode } from "react";
+import TaskCard from "../../../components/TaskCard";
+import PraxisCard from "../../../components/PraxisCard";
+import CharacterBadge from "../../../components/CharacterBadge";
+import { computeDisplayPoints } from "../../../utils/points";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * Albescent faction-body — "The Record" skin of the standardized body spine
+ * (Members / Tasks / Recently completed), #232. Section ① (hero) is
+ * AlbescentFactionHero above; this owns the archival chrome: white sheets ruled
+ * with hairlines, quiet mono kickers, and Cormorant-italic headings. Tasks and
+ * Praxis reuse the app-wide cards (already dispatching to the Albescent
+ * archetypes from slice 1); this file only supplies the section chrome and the
+ * keeper tiles.
+ *
+ * Same shape as the other bodies. Always light — every --faction-albescent-*
+ * token is identical in both themes; all colors via tokens (no hardcoded hex,
+ * CLAUDE.md). Design: docs/design/albescent-kit `AlHero` / faction page.
+ */
+
+const INK = "var(--faction-albescent-card-text)";
+const MUTED = "var(--faction-albescent-card-muted)";
+const FAINT = "var(--faction-albescent-text-faint)";
+const BORDER = "var(--faction-albescent-border)";
+const BORDER_FAINT = "var(--faction-albescent-border-faint)";
+const SURFACE = "var(--faction-albescent-surface)";
+const FONT = "var(--faction-albescent-card-font)"; // Cormorant Garamond
+const MONO = "var(--faction-albescent-mono)"; // Courier Prime
+
+const CARD_GRID: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "1rem",
+  alignItems: "flex-start",
+};
+
+/** White archival sheet with an inset architectural hairline. */
+function Sheet({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ background: SURFACE, border: `1px solid ${BORDER}`, marginBottom: 20 }}>
+      <div style={{ margin: 6, border: `1px solid ${BORDER_FAINT}`, padding: "20px 22px" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function SectionHeading({ kicker, title, count }: { kicker: string; title: string; count?: number }) {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 7,
+          letterSpacing: "0.26em",
+          textTransform: "uppercase",
+          color: FAINT,
+          marginBottom: 7,
+        }}
+      >
+        {kicker}
+        {count !== undefined ? ` · ${count}` : ""}
+      </div>
+      <h2 style={{ fontFamily: FONT, fontStyle: "italic", fontWeight: 300, fontSize: 26, lineHeight: 1, color: INK, margin: 0 }}>
+        {title}
+      </h2>
+      <div style={{ height: 1, width: 56, background: BORDER, marginTop: 12 }} />
+    </div>
+  );
+}
+
+function Quiet({ children }: { children: ReactNode }) {
+  return (
+    <p style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 15, color: MUTED, margin: 0 }}>
+      {children}
+    </p>
+  );
+}
+
+export default function AlbescentFactionBody({ state }: { state: FactionDetailState }) {
+  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!faction) return null;
+
+  return (
+    <>
+      {/* ── Keepers (members) ── */}
+      <Sheet>
+        <SectionHeading kicker="The Houses" title="Keepers" count={members.length} />
+        {members.length === 0 ? (
+          <Quiet>No keepers on record.</Quiet>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {members.map((m) => (
+              <div key={m.id} style={{ border: `1px solid ${BORDER_FAINT}`, padding: "6px 10px", background: SURFACE }}>
+                <CharacterBadge character={m} size="sm" />
+              </div>
+            ))}
+          </div>
+        )}
+      </Sheet>
+
+      {/* ── Tasks (the ledger) ── reuses the Albescent TaskCard archetype ── */}
+      <Sheet>
+        <SectionHeading kicker="Open Work" title="The Ledger" count={tasks.length} />
+        {tasks.length === 0 ? (
+          <Quiet>The ledger is clear.</Quiet>
+        ) : (
+          <div style={CARD_GRID}>
+            {tasks.map((task) => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                displayPoints={computeDisplayPoints(
+                  task.point_value,
+                  viewerFactionSlug,
+                  task.primary_faction_slug,
+                  gameFactions,
+                )}
+              />
+            ))}
+          </div>
+        )}
+      </Sheet>
+
+      {/* ── Recently completed (returned) ── reuses the Albescent PraxisCard ── */}
+      <Sheet>
+        <SectionHeading kicker="Attended To" title="Lately Returned" />
+        {recentPraxis.length === 0 ? (
+          <Quiet>Nothing returned yet. The Record waits.</Quiet>
+        ) : (
+          <div style={CARD_GRID}>
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </Sheet>
+    </>
+  );
+}

--- a/frontend/src/utils/__tests__/factionAlbescentFirstClass.test.ts
+++ b/frontend/src/utils/__tests__/factionAlbescentFirstClass.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Guards Albescent's first-class identity (#232): the albescent→ua alias is
+ * dropped, so faction dispatch and CSS both resolve to albescent's own tokens.
+ * aged_out still aliases ua. If someone re-adds the alias, these fail.
+ */
+import { describe, it, expect } from 'vitest'
+import { FACTION_ALIASES, factionCssVar, factionColor } from '../factions'
+
+describe('Albescent is first-class (#232)', () => {
+  it('is no longer an alias; aged_out still is', () => {
+    expect(FACTION_ALIASES['albescent']).toBeUndefined()
+    expect(FACTION_ALIASES['aged_out']).toBe('ua')
+  })
+
+  it('factionCssVar resolves albescent to its own tokens, not ua', () => {
+    expect(factionCssVar('albescent', 'card-bg')).toBe('var(--faction-albescent-card-bg)')
+    expect(factionCssVar('albescent', 'border')).toBe('var(--faction-albescent-border)')
+    // bare (primary) must resolve to the albescent var, not fall back to ua
+    expect(factionCssVar('albescent')).toBe('var(--faction-albescent)')
+  })
+
+  it('aged_out still resolves to ua tokens via the alias', () => {
+    expect(factionCssVar('aged_out', 'card-bg')).toBe('var(--faction-ua-card-bg)')
+  })
+
+  it('albescent raw color is the near-black ink, no hue', () => {
+    expect(factionColor('albescent')).toBe('#1c1c1a')
+  })
+})

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -31,7 +31,8 @@ const FACTION_FALLBACKS: Record<string, FactionConfig> = {
   snide: { slug: "snide", name: "S.N.I.D.E.", color: "#6fae00" },
   ephemerists: { slug: "ephemerists", name: "The Ephemerists", color: "#1d6e72" },
   singularity: { slug: "singularity", name: "Singularity", color: "#2563eb" },
-  albescent: { slug: "albescent", name: "/Albescent", color: "#7c3aed" },
+  // First-class identity (#232): near-black ink, no hue — the order refuses the palette.
+  albescent: { slug: "albescent", name: "/Albescent", color: "#1c1c1a" },
   aged_out: { slug: "aged_out", name: "Aged Out", color: "#7c3aed" },
 };
 
@@ -65,7 +66,10 @@ export function populateFactionRegistry(
  * display names; only the visual identity aliases.)
  */
 export const FACTION_ALIASES: Record<string, string> = {
-  albescent: "ua",
+  // albescent dropped (#232): it is now first-class on every surface, with its
+  // own archetypes (CARD/PRAXIS/edit/detail/feed/avatar/backdrop/vote/comment/
+  // faction body+hero) and its own --faction-albescent-* / CSS_KEY entry. Only
+  // aged_out still borrows UA's identity.
   aged_out: "ua",
 };
 
@@ -80,6 +84,7 @@ const CSS_KEY: Record<string, string> = {
   snide: "snide",
   ephemerists: "ephemerists",
   singularity: "singularity",
+  albescent: "albescent", // first-class (#232) — its own --faction-albescent-* set
 };
 
 /**


### PR DESCRIPTION
> **Re-opened against `main`.** The original PR #430 was auto-closed when its base branch (#427, the feed frame) merged — GitHub closed it instead of retargeting. Same commit, now rebased onto current main (which already contains the #427 feed frame). Re-verified green.

## What
The final slice of #232 — Albescent becomes a fully first-class faction identity and the `albescent → ua` alias is **dropped**.

## New surface variants
Design: `docs/design/albescent-kit/`.
- **Avatar** `AlbescentAvatar` — white cotton-paper disc, hairline ink ring, the surveyor's-cross-hair mark badge.
- **Backdrop** `AlbescentBackdrop` — cream ledger wall, soft highlight + faint ruled lines.
- **Vote** `AlbescentVote` + `VOTE_REFRAMES.albescent` "bear witness" scale (Unseeing → Inscribed): five grayscale marks, rising ink via `color-mix` on the ink token.
- **Faction page** `AlbescentFactionBody` ("The Record") + `AlbescentFactionHero`.

Already first-class from slices 1–2 (task/praxis card, edit-praxis, task/praxis detail, feed frame) and pre-existing (comment, credential). I audited **every** `pickVariant` dispatcher to confirm an albescent key exists before dropping the alias.

## The alias drop
- Remove `albescent` from `FACTION_ALIASES` (only `aged_out` still aliases ua).
- Add `albescent` to `CSS_KEY` **and** a bare `--faction-albescent` token (light + dark), so `factionCssVar('albescent', …)` resolves its own `--faction-albescent-*` set instead of falling back to ua.
- `factionColor('albescent')` → near-black `#1c1c1a` (no hue).

## Docs & tests
- ADR-0017 gap-tracker + SPEC-faction-ui-profile updated (7 first-class factions).
- Guard test `factionAlbescentFirstClass` locks the drop; vote-reframe test updated.

## Verification
`tsc --noEmit` clean · vitest **196/196** · `vite build` green (rebased onto current main).

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)