### PR TITLE
refactor: rename faction surfaces to <FACTION><Surface> (DS naming)

### DIFF
--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -2,12 +2,12 @@ import type { TaskOut } from '../api/tasks'
 import { useAuth } from '../auth/AuthContext'
 import { useAdminMode } from '../auth/AdminModeContext'
 import { updateTaskStatus } from '../api/admin'
-import TaskCardUA from './cards/TaskCardUA'
-import TaskCardWow from './cards/TaskCardWow'
-import TaskCardSNIDE from './cards/TaskCardSNIDE'
-import TaskCardEphemerists from './cards/TaskCardEphemerists'
-import TaskCardSingularity from './cards/TaskCardSingularity'
-import TaskCardEverymen from './cards/TaskCardEverymen'
+import UATaskCard from './cards/UATaskCard'
+import WowTaskCard from './cards/WowTaskCard'
+import SNIDETaskCard from './cards/SNIDETaskCard'
+import EphemeristsTaskCard from './cards/EphemeristsTaskCard'
+import SingularityTaskCard from './cards/SingularityTaskCard'
+import EverymenTaskCard from './cards/EverymenTaskCard'
 import AlbescentTaskCard from './cards/AlbescentTaskCard'
 import { factionCssVar, factionName } from '../utils/factions'
 import { pickVariant } from '../utils/factionDispatch'
@@ -21,18 +21,18 @@ export interface CardProps {
 
 /** Style Guide §6 — one card archetype per faction. */
 export const CARD_COMPONENTS: Record<string, ComponentType<CardProps>> = {
-  ua: TaskCardUA,
-  everymen: TaskCardEverymen,
-  wow: TaskCardWow,
-  snide: TaskCardSNIDE,
-  ephemerists: TaskCardEphemerists,
-  singularity: TaskCardSingularity,
+  ua: UATaskCard,
+  everymen: EverymenTaskCard,
+  wow: WowTaskCard,
+  snide: SNIDETaskCard,
+  ephemerists: EphemeristsTaskCard,
+  singularity: SingularityTaskCard,
   // First-class Albescent identity (#232 slice 1). The explicit entry beats the
   // albescent→ua alias in pickVariant, so it renders immediately.
   albescent: AlbescentTaskCard,
 }
 
-export const DEFAULT_CARD = TaskCardUA
+export const DEFAULT_CARD = UATaskCard
 
 export default function TaskCard({ task, displayPoints, onSignup }: CardProps) {
   const { user } = useAuth()

--- a/frontend/src/components/cards/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/cards/EphemeristsTaskCard.tsx
@@ -17,7 +17,7 @@ interface Props {
   onSignup?: (id: number) => void;
 }
 
-export default function TaskCardEphemerists({ task, displayPoints, onSignup }: Props) {
+export default function EphemeristsTaskCard({ task, displayPoints, onSignup }: Props) {
   return (
     <div
       style={{

--- a/frontend/src/components/cards/EverymenTaskCard.tsx
+++ b/frontend/src/components/cards/EverymenTaskCard.tsx
@@ -172,7 +172,7 @@ function PointsSeal({
 
 /* ── card ───────────────────────────────────────────────────────── */
 
-export default function TaskCardEverymen({ task, displayPoints, onSignup }: Props) {
+export default function EverymenTaskCard({ task, displayPoints, onSignup }: Props) {
   return (
     <div
       style={{

--- a/frontend/src/components/cards/SNIDETaskCard.tsx
+++ b/frontend/src/components/cards/SNIDETaskCard.tsx
@@ -97,7 +97,7 @@ function Ransom({ text, size = 22 }: { text: string; size?: number }) {
   );
 }
 
-export default function TaskCardSNIDE({
+export default function SNIDETaskCard({
   task,
   displayPoints,
   onSignup,

--- a/frontend/src/components/cards/SingularityTaskCard.tsx
+++ b/frontend/src/components/cards/SingularityTaskCard.tsx
@@ -45,7 +45,7 @@ function SprocketHoles() {
   );
 }
 
-export default function TaskCardSingularity({
+export default function SingularityTaskCard({
   task,
   displayPoints,
   onSignup,

--- a/frontend/src/components/cards/UATaskCard.tsx
+++ b/frontend/src/components/cards/UATaskCard.tsx
@@ -23,7 +23,7 @@ interface Props {
   onSignup?: (id: number) => void;
 }
 
-export default function TaskCardUA({ task, displayPoints, onSignup }: Props) {
+export default function UATaskCard({ task, displayPoints, onSignup }: Props) {
   return (
     // Gilt frame: gold-leaf gradient border, then the parchment plate, hung with
     // a slight rotation like a plate on the salon wall.

--- a/frontend/src/components/cards/WowFactionHero.tsx
+++ b/frontend/src/components/cards/WowFactionHero.tsx
@@ -11,7 +11,7 @@ import type { FactionHeroProps } from "../../pages/FactionDetail";
  * Theme-aware through the cascade: every colour resolves to a --faction-wow-*
  * token (which already carries light + dark values), so the board never mutates
  * the global theme. The script face is the WoW card-font token (Caveat); body
- * copy uses --font-body, matching TaskCardWow / the WoW PraxisCard branch.
+ * copy uses --font-body, matching WowTaskCard / the WoW PraxisCard branch.
  *
  * The page passes raw counts; the faction labels them in its own whimsy voice.
  * Motto is a faction constant (not a backend field).

--- a/frontend/src/components/cards/WowTaskCard.tsx
+++ b/frontend/src/components/cards/WowTaskCard.tsx
@@ -48,7 +48,7 @@ function WindowDot({ color }: { color: string }) {
   );
 }
 
-export default function TaskCardWow({
+export default function WowTaskCard({
   task,
   displayPoints,
   onSignup,

--- a/frontend/src/components/comments/voices/UAComment.tsx
+++ b/frontend/src/components/comments/voices/UAComment.tsx
@@ -8,7 +8,7 @@ import { type CommentProps, authorToCharacter, ComposerControls, MentionText } f
  * UA — University of Asthmatics. The gilt salon (ADR-0026, superseding
  * ADR-0018's comment-scoped orange letterhead): a gold museum-frame around a
  * parchment plate, Marcellus small-caps house line, Playfair-italic body. Mirrors
- * UaFeedFrame / UAPraxisDetail; all colors via --ua-* tokens (no hex — CLAUDE.md).
+ * UAFeedFrame / UAPraxisDetail; all colors via --ua-* tokens (no hex — CLAUDE.md).
  * UA is always-light, so tokens read identically in both themes.
  */
 const GILT = 'var(--ua-gilt)'

--- a/frontend/src/components/feed/AlbescentFeedFrame.tsx
+++ b/frontend/src/components/feed/AlbescentFeedFrame.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from 'react'
  *
  * Albescent is ALWAYS LIGHT: its --faction-albescent-* tokens are identical in
  * both themes, so the sheet reads as white paper regardless of the global theme
- * and never mutates data-theme (mirror of UaFeedFrame / SingularityFeedFrame).
+ * and never mutates data-theme (mirror of UAFeedFrame / SingularityFeedFrame).
  * It reads --faction-albescent-* directly rather than factionCssVar('albescent',
  * …), which still resolves the albescent→ua alias until the alias is dropped
  * (the final #232 step). An explicit `albescent` row in FACTION_FEED_FRAMES beats

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -19,7 +19,7 @@ import EphemeristsFeedFrame from './EphemeristsFeedFrame'
 import WowFeedFrame from './WowFeedFrame'
 import SnideFeedFrame from './SnideFeedFrame'
 import SingularityFeedFrame from './SingularityFeedFrame'
-import UaFeedFrame from './UaFeedFrame'
+import UAFeedFrame from './UAFeedFrame'
 import AlbescentFeedFrame from './AlbescentFeedFrame'
 
 type FrameProps = { children: ReactNode }
@@ -34,7 +34,7 @@ const FACTION_FEED_FRAMES: Record<string, ComponentType<FrameProps>> = {
   wow: WowFeedFrame,
   snide: SnideFeedFrame,
   singularity: SingularityFeedFrame,
-  ua: UaFeedFrame,
+  ua: UAFeedFrame,
   albescent: AlbescentFeedFrame,
 }
 

--- a/frontend/src/components/feed/UAFeedFrame.tsx
+++ b/frontend/src/components/feed/UAFeedFrame.tsx
@@ -29,7 +29,7 @@ const FONT_ENGRAVED = 'var(--font-faction-engraved)' // Cinzel
 const ink = (pct: number): string =>
   `color-mix(in srgb, ${INK} ${pct}%, transparent)`
 
-export default function UaFeedFrame({ children }: { children: ReactNode }) {
+export default function UAFeedFrame({ children }: { children: ReactNode }) {
   return (
     // Outer gilt border + soft brown drop-shadow & inset white hairline.
     <div

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -12,13 +12,13 @@ import {
   useEditPraxis,
   type EditPraxisState,
 } from "./editPraxis/useEditPraxis";
-import EditPraxisPunkZine from "./editPraxis/archetypes/EditPraxisPunkZine";
-import EditPraxisTerminal from "./editPraxis/archetypes/EditPraxisTerminal";
-import EditPraxisPaperCollage from "./editPraxis/archetypes/EditPraxisPaperCollage";
-import EditPraxisEphemeris from "./editPraxis/archetypes/EditPraxisEphemeris";
-import EditPraxisStickyNote from "./editPraxis/archetypes/EditPraxisStickyNote";
-import EditPraxisEverymen from "./editPraxis/archetypes/EditPraxisEverymen";
-import EditPraxisUA from "./editPraxis/archetypes/EditPraxisUA";
+import SNIDEEditPraxis from "./editPraxis/archetypes/SNIDEEditPraxis";
+import SingularityEditPraxis from "./editPraxis/archetypes/SingularityEditPraxis";
+import WowEditPraxis from "./editPraxis/archetypes/WowEditPraxis";
+import EphemeristsEditPraxis from "./editPraxis/archetypes/EphemeristsEditPraxis";
+import DefaultEditPraxis from "./editPraxis/archetypes/DefaultEditPraxis";
+import EverymenEditPraxis from "./editPraxis/archetypes/EverymenEditPraxis";
+import UAEditPraxis from "./editPraxis/archetypes/UAEditPraxis";
 import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
@@ -28,12 +28,12 @@ type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 // slice 1) — its explicit entry beats the albescent→ua alias. StickyNote remains
 // the fallback for `na` / unknown factions.
 const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
-  everymen: EditPraxisEverymen,
-  snide: EditPraxisPunkZine,
-  singularity: EditPraxisTerminal,
-  wow: EditPraxisPaperCollage,
-  ephemerists: EditPraxisEphemeris,
-  ua: EditPraxisUA,
+  everymen: EverymenEditPraxis,
+  snide: SNIDEEditPraxis,
+  singularity: SingularityEditPraxis,
+  wow: WowEditPraxis,
+  ephemerists: EphemeristsEditPraxis,
+  ua: UAEditPraxis,
   albescent: AlbescentEditPraxis,
 };
 
@@ -63,7 +63,7 @@ export default function EditPraxis() {
   }
 
   const slug = state.task?.primary_faction_slug ?? null;
-  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, slug, EditPraxisStickyNote);
+  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, slug, DefaultEditPraxis);
 
   return (
     <>

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -12,12 +12,12 @@ import PageTitle from "../components/ui/PageTitle";
 import { pickVariant } from "../utils/factionDispatch";
 import { useTaskDetail, type TaskDetailState } from "./taskDetail/useTaskDetail";
 import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
-import TaskDetailSNIDE from "./taskDetail/archetypes/TaskDetailSNIDE";
-import TaskDetailEverymen from "./taskDetail/archetypes/TaskDetailEverymen";
-import TaskDetailWow from "./taskDetail/archetypes/TaskDetailWow";
-import TaskDetailEphemerists from "./taskDetail/archetypes/TaskDetailEphemerists";
-import TaskDetailSingularity from "./taskDetail/archetypes/TaskDetailSingularity";
-import TaskDetailUA from "./taskDetail/archetypes/TaskDetailUA";
+import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
+import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
+import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
+import EphemeristsTaskDetail from "./taskDetail/archetypes/EphemeristsTaskDetail";
+import SingularityTaskDetail from "./taskDetail/archetypes/SingularityTaskDetail";
+import UATaskDetail from "./taskDetail/archetypes/UATaskDetail";
 import AlbescentTaskDetail from "./taskDetail/archetypes/AlbescentTaskDetail";
 import CommentThread from "../components/comments/CommentThread";
 
@@ -28,12 +28,12 @@ type Archetype = (props: { state: TaskDetailState }) => JSX.Element | null;
 // FIRST-CLASS identity (#232 slice 1) — its explicit entry beats the
 // albescent→ua alias in pickVariant.
 export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
-  snide: TaskDetailSNIDE,
-  everymen: TaskDetailEverymen,
-  wow: TaskDetailWow,
-  ephemerists: TaskDetailEphemerists,
-  singularity: TaskDetailSingularity,
-  ua: TaskDetailUA,
+  snide: SNIDETaskDetail,
+  everymen: EverymenTaskDetail,
+  wow: WowTaskDetail,
+  ephemerists: EphemeristsTaskDetail,
+  singularity: SingularityTaskDetail,
+  ua: UATaskDetail,
   albescent: AlbescentTaskDetail,
 };
 

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -50,7 +50,7 @@ const CORK_DEEP = "#a17c4f";
 const SLATE = "#475569";
 const SLATE_DEEP = "#1e293b";
 
-export default function EditPraxisStickyNote({ state }: Props) {
+export default function DefaultEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -76,7 +76,7 @@ const MODE_OPTIONS: Array<{ key: PraxisType; label: string; sub: string }> = [
   { key: "duel", label: "IN DISPUTE", sub: "accounts differ" },
 ];
 
-export default function EditPraxisEphemeris({ state }: Props) {
+export default function EphemeristsEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
   const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -145,7 +145,7 @@ function FieldLabel({
   );
 }
 
-export default function EditPraxisEverymen({ state }: Props) {
+export default function EverymenEditPraxis({ state }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
   const praxis = state.praxis!;
   const task = state.task;

--- a/frontend/src/pages/editPraxis/archetypes/SNIDEEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SNIDEEditPraxis.tsx
@@ -106,7 +106,7 @@ function RansomChar({ ch, index }: { ch: string; index: number }) {
   );
 }
 
-export default function EditPraxisPunkZine({ state }: Props) {
+export default function SNIDEEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -34,7 +34,7 @@ const MODE_OPTIONS: Array<{ key: PraxisType; flag: string; desc: string }> = [
   { key: "duel", flag: "--adversarial", desc: "pvp. winner-take-all on vote median." },
 ];
 
-export default function EditPraxisTerminal({ state }: Props) {
+export default function SingularityEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 

--- a/frontend/src/pages/editPraxis/archetypes/UAEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UAEditPraxis.tsx
@@ -83,7 +83,7 @@ function RegaliaLabel({ children }: { children: ReactNode }) {
   );
 }
 
-export default function EditPraxisUA({ state }: Props) {
+export default function UAEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
   const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -190,7 +190,7 @@ function Ivy({
   );
 }
 
-export default function EditPraxisPaperCollage({ state }: Props) {
+export default function WowEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -22,7 +22,7 @@ import type { FactionDetailState } from "../useFactionDetail";
  *
  * Every colour resolves to a --faction-wow-* token (dark-mode-aware via the
  * cascade). The script face is the WoW card-font token (Caveat); body copy uses
- * --font-body, matching TaskCardWow and the WoW PraxisCard branch.
+ * --font-body, matching WowTaskCard and the WoW PraxisCard branch.
  */
 
 const PINK = "var(--faction-wow)";

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -22,7 +22,7 @@ import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
-// ── whimsy.exe token vocabulary (same as TaskDetailWow) ──────────────────────
+// ── whimsy.exe token vocabulary (same as WowTaskDetail) ──────────────────────
 const PINK = 'var(--faction-wow)'
 const TITLE_TEXT = 'var(--faction-wow-title-text)'
 const CARD_TEXT = 'var(--faction-wow-card-text)'

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -297,7 +297,7 @@ function SurveyorRow({
   );
 }
 
-export default function TaskDetailEphemerists({
+export default function EphemeristsTaskDetail({
   state,
 }: {
   state: TaskDetailState;

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -184,7 +184,7 @@ function HandsRow({
   );
 }
 
-export default function TaskDetailEverymen({
+export default function EverymenTaskDetail({
   state,
 }: {
   state: TaskDetailState;

--- a/frontend/src/pages/taskDetail/archetypes/SNIDETaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SNIDETaskDetail.tsx
@@ -269,7 +269,7 @@ function AccompliceRow({
   );
 }
 
-export default function TaskDetailSNIDE({
+export default function SNIDETaskDetail({
   state,
 }: {
   state: TaskDetailState;

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -171,7 +171,7 @@ function ArrayRoster({
   );
 }
 
-export default function TaskDetailSingularity({
+export default function SingularityTaskDetail({
   state,
 }: {
   state: TaskDetailState;

--- a/frontend/src/pages/taskDetail/archetypes/UATaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UATaskDetail.tsx
@@ -285,7 +285,7 @@ function StatPlate({
   );
 }
 
-export default function TaskDetailUA({
+export default function UATaskDetail({
   state,
 }: {
   state: TaskDetailState;

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -184,7 +184,7 @@ function PartyRow({
   );
 }
 
-export default function TaskDetailWow({ state }: { state: TaskDetailState }) {
+export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
   const {
     task,
     signups,


### PR DESCRIPTION
Mechanical rename adopting the Design System's `<FACTION><Surface>` naming on the three surface-first component families. Brings them in line with the already-faction-first siblings (`*PraxisDetail`, `*FactionHero`, `*Vote`, `*Comment`, `*Backdrop`, `*Avatar`).

Scope: **core-only** (per request) — surface-first → faction-first, no broader `Snide`→`SNIDE` casing sweep on files that are already faction-first.

| Family | Rename |
|---|---|
| Task card (6) | `TaskCard<F>` → `<F>TaskCard` |
| Task detail (6) | `TaskDetail<F>` → `<F>TaskDetail` |
| Edit praxis (7) | `EditPraxis<style>` → `<F>EditPraxis` (faction decoded via the `EditPraxis.tsx` dispatcher) |
| Feed (1) | `UaFeedFrame` → `UAFeedFrame` (casing) |

`EditPraxisStickyNote` is the generic fallback (no faction in the dispatcher map) → `DefaultEditPraxis`, matching the existing `DefaultTaskDetail` / `DefaultPraxisDetail` / `DefaultFactionBody`.

Done via `git mv` + word-boundary identifier/import-path replace — no behaviour change, no CSS/className changes.

## Verification
- `tsc --noEmit` clean
- `vitest run` — 21 files / 196 tests pass
- grep confirms zero old identifiers remain

Follows #433 (Albescent first-class); intentionally sequenced after it so the new `Albescent*` surfaces (already faction-first) needed no renaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)