### PR TITLE
feat: NA "not part of a faction" default spectrum skin (#418)

### DIFF
--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -4,6 +4,7 @@ import { factionCssVar } from "../utils/factions";
 import { pickVariant } from "../utils/factionDispatch";
 import SnideMasthead from "./cards/SnideMasthead";
 import AlbescentMark from "./cards/AlbescentMark";
+import DefaultSigil from "./cards/DefaultSigil";
 import { EphMark, Foxing } from "./cards/ephemeristsAtoms";
 import {
   AdminOverlay,
@@ -613,31 +614,61 @@ function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
   );
 }
 
-/** Fallback card for `na` / unknown task factions — a plain accent-bordered slab. */
+/**
+ * Fallback praxis card for `na` / unaffiliated + any task faction without a
+ * bespoke archetype — the spectrum default skin (#418). A clean sheet wrapped in
+ * the spectrum band and marked with the seven-segment ring; the shared
+ * PraxisBody inside. No longer borrows the task faction's costume. All colours
+ * via --faction-default-* tokens; flips light/dark.
+ */
 export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const slug = praxis.task_faction_slug ?? "ua";
   return (
+    // Spectrum band → clean inner sheet.
     <div
       style={{
         width: "100%",
         flex: "1 1 280px",
         minWidth: 280,
-        background: factionCssVar(slug, "card-bg"),
-        borderLeft: `4px solid ${factionCssVar(slug, "card-accent")}`,
-        color: factionCssVar(slug, "card-text"),
-        padding: "14px 16px",
-        position: "relative",
+        borderRadius: 10,
+        padding: 5,
+        background: "var(--faction-default-rainbow)",
+        boxShadow: "0 12px 26px -14px rgba(0,0,0,0.4)",
         boxSizing: "border-box",
       }}
     >
-      <AdminOverlay {...adminProps} />
-      <PraxisBody
-        praxis={praxis}
-        tint={factionCssVar(slug, "card-accent")}
-        muted={factionCssVar(slug, "card-muted")}
-        paper={factionCssVar(slug, "card-bg")}
-        showCrown={showCrown}
-      />
+      <div
+        style={{
+          position: "relative",
+          background: "var(--faction-default-card-bg)",
+          color: "var(--faction-default-card-text)",
+          borderRadius: 5,
+          padding: "14px 16px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            marginBottom: 10,
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 8.5,
+            letterSpacing: "0.22em",
+            textTransform: "uppercase",
+            color: "var(--faction-default-card-muted)",
+          }}
+        >
+          <DefaultSigil size={22} /> Praxis · unaffiliated
+        </div>
+        <AdminOverlay {...adminProps} />
+        <PraxisBody
+          praxis={praxis}
+          tint="var(--faction-default-card-accent)"
+          muted="var(--faction-default-card-muted)"
+          paper="var(--faction-default-card-bg)"
+          showCrown={showCrown}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -9,6 +9,7 @@ import EphemeristsTaskCard from './cards/EphemeristsTaskCard'
 import SingularityTaskCard from './cards/SingularityTaskCard'
 import EverymenTaskCard from './cards/EverymenTaskCard'
 import AlbescentTaskCard from './cards/AlbescentTaskCard'
+import DefaultTaskCard from './cards/DefaultTaskCard'
 import { factionCssVar, factionName } from '../utils/factions'
 import { pickVariant } from '../utils/factionDispatch'
 import type { ComponentType } from 'react'
@@ -32,7 +33,9 @@ export const CARD_COMPONENTS: Record<string, ComponentType<CardProps>> = {
   albescent: AlbescentTaskCard,
 }
 
-export const DEFAULT_CARD = UATaskCard
+// `na` / unaffiliated + any faction without a bespoke card → the spectrum
+// default skin (#418). No longer borrows UA's costume.
+export const DEFAULT_CARD = DefaultTaskCard
 
 export default function TaskCard({ task, displayPoints, onSignup }: CardProps) {
   const { user } = useAuth()

--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -9,13 +9,14 @@ import EphemeristsAvatar from './EphemeristsAvatar'
 import SingularityAvatar from './SingularityAvatar'
 import UAAvatar from './UAAvatar'
 import AlbescentAvatar from './AlbescentAvatar'
+import DefaultSigil from '../cards/DefaultSigil'
 
 /**
  * Per-faction avatar + membership-badge dispatcher (Tier-3 surface). Keyed by
- * the character's MEMBER faction (character.faction_slug). Faction variants
- * (cog sigil, moon glyph, …) register in Sessions 3-4. The default below is the
- * plain avatar circle previously inlined in CharacterBadge — no membership
- * badge — so behavior is unchanged until a variant opts in.
+ * the character's MEMBER faction (character.faction_slug). The default below is
+ * the UNAFFILIATED / no-faction (`na`) skin (#418): the portrait/monogram inside
+ * a thin spectrum ring, tagged with the seven-segment sigil — every path still
+ * open. All colours via --faction-default-* tokens; flips light/dark.
  */
 export interface FactionAvatarProps {
   character: CharacterOut
@@ -23,20 +24,64 @@ export interface FactionAvatarProps {
 }
 
 function DefaultAvatar({ character, size = 'md' }: FactionAvatarProps) {
-  const isSmall = size === 'sm'
-  return character.avatar_url ? (
-    <img
-      src={mediaUrl(character.avatar_url)}
-      alt={character.username}
-      className={`rounded-full border-2 border-border object-cover ${isSmall ? 'w-6 h-6' : 'w-8 h-8'}`}
-    />
-  ) : (
-    <span
-      className={`rounded-full border-2 border-border bg-paper flex items-center justify-center font-display font-bold text-ink ${
-        isSmall ? 'w-6 h-6 text-xs' : 'w-8 h-8 text-sm'
-      }`}
-    >
-      {character.username[0]?.toUpperCase()}
+  const dim = size === 'sm' ? 24 : 32
+  const badge = Math.max(12, Math.round(dim * 0.44))
+  return (
+    <span style={{ position: 'relative', display: 'inline-block', width: dim, height: dim }}>
+      {/* spectrum ring around the portrait / monogram */}
+      <span
+        style={{
+          display: 'block',
+          width: dim,
+          height: dim,
+          borderRadius: '50%',
+          padding: 2,
+          boxSizing: 'border-box',
+          background: 'var(--faction-default-rainbow)',
+        }}
+      >
+        {character.avatar_url ? (
+          <img
+            src={mediaUrl(character.avatar_url)}
+            alt={character.username}
+            className="rounded-full object-cover"
+            style={{ width: '100%', height: '100%', display: 'block' }}
+          />
+        ) : (
+          <span
+            className="rounded-full flex items-center justify-center italic"
+            style={{
+              width: '100%',
+              height: '100%',
+              background: 'var(--faction-default-card-bg)',
+              color: 'var(--faction-default-card-text)',
+              fontFamily: 'var(--faction-default-card-font)',
+              fontSize: Math.round(dim * 0.44),
+              lineHeight: 1,
+            }}
+          >
+            {character.username[0]?.toUpperCase()}
+          </span>
+        )}
+      </span>
+      {/* seven-segment sigil corner mark */}
+      <span
+        style={{
+          position: 'absolute',
+          right: -3,
+          bottom: -3,
+          width: badge,
+          height: badge,
+          borderRadius: '50%',
+          background: 'var(--faction-default-card-bg)',
+          boxShadow: '0 0 0 1.5px var(--faction-default-card-bg)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <DefaultSigil size={badge - 3} />
+      </span>
     </span>
   )
 }

--- a/frontend/src/components/cards/DefaultSigil.tsx
+++ b/frontend/src/components/cards/DefaultSigil.tsx
@@ -1,0 +1,36 @@
+/**
+ * DefaultSigil — the mark for the unaffiliated / no-faction (`na`) state: a
+ * seven-segment spectrum ring (one arc per faction = every path still open).
+ * Pure presentation, no data. Built on the `--faction-default-ring` conic token
+ * so it flips to the brightened spectrum in dark automatically (#418). Parity
+ * with the seven faction sigils; consumed by the default task/praxis cards,
+ * DefaultAvatar, and the Edit Character retheme (#434).
+ */
+interface DefaultSigilProps {
+  /** px diameter */
+  size?: number;
+  /** inner cut-out as a fraction of the radius (0–1) */
+  hole?: number;
+}
+
+export default function DefaultSigil({ size = 48, hole = 0.4 }: DefaultSigilProps) {
+  const inner = Math.round(hole * 100);
+  // The mask color is an alpha stencil (not a themed value): opaque keeps the
+  // ring, transparent punches the centre hole.
+  const mask = `radial-gradient(circle, transparent ${inner - 2}%, #000 ${inner}%)`;
+  return (
+    <div
+      role="img"
+      aria-label="Unaffiliated — all paths open"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        flex: "none",
+        background: "var(--faction-default-ring)",
+        WebkitMask: mask,
+        mask,
+      }}
+    />
+  );
+}

--- a/frontend/src/components/cards/DefaultTaskCard.tsx
+++ b/frontend/src/components/cards/DefaultTaskCard.tsx
@@ -1,0 +1,146 @@
+import { Link } from "react-router-dom";
+import type { TaskOut } from "../../api/tasks";
+import DefaultSigil from "./DefaultSigil";
+
+/**
+ * DefaultTaskCard — the task-card archetype for the UNAFFILIATED / no-faction
+ * (`na`) state, and the fallback for any task whose faction has no bespoke card.
+ * Where each faction commits to one loud archetype, the default stays
+ * deliberately un-committed: a clean sheet wrapped in a thick spectrum band
+ * (every faction colour at once = all paths open), marked with the seven-segment
+ * ring. Replaces the old borrowed-UA `DEFAULT_CARD = UATaskCard` (#418). All
+ * colours via --faction-default-* tokens (no hardcoded hex — CLAUDE.md); flips
+ * light/dark through the cascade.
+ */
+const MONO = "'Courier Prime', monospace";
+
+interface Props {
+  task: TaskOut;
+  displayPoints: number;
+  onSignup?: (id: number) => void;
+}
+
+export default function DefaultTaskCard({ task, displayPoints, onSignup }: Props) {
+  return (
+    // Spectrum band → clean inner sheet.
+    <div
+      style={{
+        minWidth: 240,
+        maxWidth: 292,
+        flex: "0 1 282px",
+        borderRadius: 10,
+        padding: 6,
+        background: "var(--faction-default-rainbow)",
+        boxShadow: "0 12px 32px -14px rgba(0,0,0,0.4)",
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          background: "var(--faction-default-card-bg)",
+          borderRadius: 5,
+          padding: "24px 22px 22px",
+          color: "var(--faction-default-card-text)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 16,
+            fontFamily: MONO,
+            fontSize: 10,
+            letterSpacing: "0.22em",
+            textTransform: "uppercase",
+            color: "var(--faction-default-card-muted)",
+          }}
+        >
+          <DefaultSigil size={28} /> Unaffiliated · all paths
+        </div>
+
+        <Link to={`/tasks/${task.id}`} style={{ textDecoration: "none", color: "inherit" }}>
+          <h3
+            style={{
+              fontFamily: "var(--faction-default-card-font)",
+              fontStyle: "italic",
+              fontSize: 26,
+              lineHeight: 1.08,
+              margin: "0 0 10px",
+              color: "var(--faction-default-card-text)",
+              overflowWrap: "anywhere",
+            }}
+          >
+            {task.title}
+          </h3>
+        </Link>
+
+        {task.description && (
+          <p
+            className="card-description"
+            style={{
+              fontSize: 11.5,
+              lineHeight: 1.55,
+              color: "var(--faction-default-card-muted)",
+              margin: "0 0 20px",
+            }}
+          >
+            {task.description}
+          </p>
+        )}
+
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span
+            style={{
+              fontFamily: MONO,
+              fontSize: 10,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "var(--faction-default-card-muted)",
+              border: "1px solid var(--faction-default-border)",
+              borderRadius: 99,
+              padding: "4px 10px",
+            }}
+          >
+            lvl {task.level_required}
+          </span>
+          <span
+            style={{
+              fontFamily: "var(--faction-default-card-font)",
+              fontStyle: "italic",
+              fontWeight: 700,
+              fontSize: 26,
+              lineHeight: 1,
+              color: "var(--faction-default-card-text)",
+            }}
+          >
+            {displayPoints}
+            <span style={{ fontSize: 11, marginLeft: 2, color: "var(--faction-default-card-muted)" }}>
+              pts
+            </span>
+          </span>
+          {onSignup && (
+            <button
+              onClick={() => onSignup(task.id)}
+              style={{
+                marginLeft: "auto",
+                cursor: "pointer",
+                fontFamily: "var(--faction-default-card-font)",
+                fontStyle: "italic",
+                fontSize: 14,
+                letterSpacing: "0.03em",
+                padding: "8px 14px",
+                borderRadius: 3,
+                color: "var(--faction-default-card-text)",
+                background: "transparent",
+                border: "1.5px solid var(--faction-default-card-accent)",
+              }}
+            >
+              Sign up ↗
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,6 +96,22 @@
   --faction-ephemerists-card-font: var(--eph-display);
   --faction-singularity-card-font: var(--font-faction-terminal);
 
+  /* ── DEFAULT · unaffiliated (no faction; rainbow = every path still open) ──
+     Not a rainbow-spine faction — the blank-slate / first-life state (na). Its
+     signature is the full spectrum at once. card-* tokens follow the faction
+     naming so shared components can skin it; the two gradient tokens flip
+     brighter in dark. Neutral --faction-default hex is canvas/SVG only. (#418) */
+  --faction-default: #6b6a7a;
+  --faction-default-light: rgba(107, 106, 122, 0.1);
+  --faction-default-border: rgba(0, 0, 0, 0.12);
+  --faction-default-rainbow: linear-gradient(90deg, #c1272d 0%, #c2541f 17%, #ca8a04 33%, #16a34a 50%, #1d6e72 67%, #2563eb 83%, #be185d 100%);
+  --faction-default-ring: conic-gradient(#c1272d 0 51deg, #c2541f 0 103deg, #ca8a04 0 154deg, #16a34a 0 206deg, #1d6e72 0 257deg, #2563eb 0 309deg, #be185d 0 360deg);
+  --faction-default-card-bg: #fffdf9;
+  --faction-default-card-text: #1a1209;
+  --faction-default-card-accent: #1a1209;
+  --faction-default-card-muted: #6b6050;
+  --faction-default-card-font: var(--font-display);
+
   /* ── S.N.I.D.E. punk extension — ransom/xerox/spray pigments + font set ──
      Extra named pigments beyond the standard suffix set, namespaced to the
      faction (sanctioned exception, see SPEC-faction-ui-profile.md §3). Card
@@ -377,6 +393,17 @@
   --faction-snide-wall-deep: #0b0a08;
   --faction-snide-wall-text: #e9e6da;
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
+
+  /* ── DEFAULT · unaffiliated (dark — brightened spectrum) ── */
+  --faction-default: #8b8aa0;
+  --faction-default-light: rgba(255, 255, 255, 0.06);
+  --faction-default-border: rgba(255, 255, 255, 0.12);
+  --faction-default-rainbow: linear-gradient(90deg, #e2433f 0%, #e07a3a 17%, #e6b94f 33%, #4ade80 50%, #3aa0a4 67%, #60a5fa 83%, #f472b6 100%);
+  --faction-default-ring: conic-gradient(#e2433f 0 51deg, #e07a3a 0 103deg, #e6b94f 0 154deg, #4ade80 0 206deg, #3aa0a4 0 257deg, #60a5fa 0 309deg, #f472b6 0 360deg);
+  --faction-default-card-bg: #1c1b24;
+  --faction-default-card-text: #f0e6d0;
+  --faction-default-card-accent: #f0e6d0;
+  --faction-default-card-muted: #9b9080;
 
   /* Albescent — always-light: identical to the :root values so the vellum
      register never dims, regardless of the global theme (#231/#232). */

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -3,7 +3,6 @@ import ReactMarkdown from 'react-markdown'
 import MediaGallery from '../../../components/MediaGallery'
 import { formatTimestamp } from '../../../utils/dates'
 import VoteUI from '../../../components/vote/VoteUI'
-import { factionCssVar } from '../../../utils/factions'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
 
@@ -53,7 +52,7 @@ export default function DefaultPraxisDetail({
             style={{
               width: 42,
               height: 42,
-              background: `linear-gradient(135deg, ${factionCssVar(null, 'card-accent')}, ${factionCssVar(null, 'card-bg')})`,
+              background: 'var(--faction-default-rainbow)',
             }}
           />
         </Link>
@@ -61,7 +60,7 @@ export default function DefaultPraxisDetail({
           <MemberByline
             praxis={praxis}
             linkClassName="font-display italic"
-            linkStyle={{ fontSize: 14, color: factionCssVar(null, 'card-accent'), textDecoration: 'none' }}
+            linkStyle={{ fontSize: 14, color: 'var(--faction-default-card-accent)', textDecoration: 'none' }}
           />
           <span className="eyebrow">{formatTimestamp(praxis.created_at)}</span>
         </div>
@@ -96,7 +95,7 @@ export default function DefaultPraxisDetail({
       <div
         className="sidebar-card mb-5"
         style={{
-          borderLeft: `4px solid ${factionCssVar(null, 'card-accent')}`,
+          borderLeft: '4px solid var(--faction-default-card-accent)',
           borderRadius: '0 8px 8px 0',
           padding: '8px 14px',
           display: 'flex',

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import PraxisCard from "../../../components/PraxisCard";
 import LevelPill from "../../../components/ui/LevelPill";
 import FeedBadge from "../../../components/feed/FeedBadge";
+import DefaultSigil from "../../../components/cards/DefaultSigil";
 import { factionCssVar, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { TaskDetailState } from "../useTaskDetail";
@@ -45,7 +46,10 @@ export default function DefaultTaskDetail({
   // Guarded non-null by the dispatcher.
   if (!task) return null;
 
-  const color = factionCssVar(task.primary_faction_slug);
+  // Unaffiliated / no-faction fallback — the spectrum default skin (#418), not
+  // the borrowed UA tint. The neutral --faction-default carries buttons/borders;
+  // the rainbow band + sigil carry the "all paths open" signature.
+  const color = "var(--faction-default)";
   const fname = factionName(task.primary_faction_slug);
   const showMultiplierTile = factionMultiplier !== 1.0;
 
@@ -88,11 +92,12 @@ export default function DefaultTaskDetail({
                 marginBottom: 10,
               }}
             >
+              <DefaultSigil size={20} />
               <span
                 className="pennant-shape"
                 style={{
                   display: "inline-block",
-                  background: color,
+                  background: "var(--faction-default-rainbow)",
                   color: "var(--color-text-on-accent)",
                   fontFamily: "'Courier Prime', monospace",
                   fontSize: 9,
@@ -311,8 +316,8 @@ export default function DefaultTaskDetail({
             >
               <div
                 style={{
-                  background: factionCssVar(task.primary_faction_slug, "light"),
-                  border: `1.5px solid ${factionCssVar(task.primary_faction_slug, "border")}`,
+                  background: "var(--faction-default-light)",
+                  border: "1.5px solid var(--faction-default-border)",
                   borderRadius: 8,
                   padding: "8px 16px",
                   display: "flex",
@@ -353,8 +358,8 @@ export default function DefaultTaskDetail({
             >
               <div
                 style={{
-                  background: factionCssVar(task.primary_faction_slug, "light"),
-                  border: `1.5px solid ${factionCssVar(task.primary_faction_slug, "border")}`,
+                  background: "var(--faction-default-light)",
+                  border: "1.5px solid var(--faction-default-border)",
                   borderRadius: 8,
                   padding: "8px 16px",
                   display: "flex",


### PR DESCRIPTION
Closes #418

Dresses unaffiliated (`na`) characters — and any faction without a bespoke archetype — in a first-class **spectrum default skin**, replacing the borrowed-UA fallbacks. Signature: the full spectrum at once ("every path still open"). All decisions map to existing ADRs (0016, 0019, 0030) — no new ADR.

## What changed
| Surface | Change |
|---|---|
| `index.css` | Added the `--faction-default-*` block (`rainbow`, `ring`, `card-*`, `border`, `light`) for `:root` + `[data-theme="dark"]`, synced from the design's `tokens/colors.css`. |
| `DefaultSigil` *(new)* | Seven-segment spectrum ring mark on the `--faction-default-ring` conic token — parity with the faction sigils. |
| `DefaultTaskCard` *(new)* | Spectrum-band task card; `DEFAULT_CARD` now points here — **kills the `DEFAULT_CARD = UATaskCard` borrowed-UA bug.** |
| `DefaultPraxisCard` | Re-skinned from the `slug ?? "ua"` slab to the spectrum band (keeps the shared `PraxisBody` slots + Task Crown). |
| `FactionAvatar` default | Spectrum ring around the portrait/monogram + sigil corner mark (was a plain bordered circle). |
| Default task/praxis detail | Swapped the `na`→UA-tinted `factionCssVar` accents to `--faction-default-*`; task-detail hero gains the rainbow pennant + sigil. |

## Out of scope (deliberate)
- **`DefaultEditPraxis`** — already a distinct casual "proof board" with `RainbowTitle`/`RainbowUnderline` (not borrowed-UA); the issue makes edit-praxis conditional/secondary. Left as-is.
- **praxis-row** — no repo fallback exists on that surface (issue's "if a repo fallback exists").
- **DefaultFeedFrame / DefaultComment / faction page** — per the issue.

## Validation
- `tsc --noEmit` clean; **frontend 196 passed**; production `vite build` green.
- Acceptance tests green: `factionCardSlots.test.tsx` (DEFAULT_CARD + DefaultPraxisCard slots), `factionAvatar.test.tsx` (default has no UA tokens, keeps the monogram). No hardcoded hex in components — all via `--faction-default-*`.