### PR TITLE
chore(frontend): remove vestigial aged_out references (#457)

### DIFF
--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -26,7 +26,7 @@ export interface CredentialCardProps {
 }
 
 /** Faction slugs with a bespoke `--faction-<key>-card-*` token set in index.css.
- *  Everything else (na, aged_out, factionless, unknown) → neutral field treatment.
+ *  Everything else (na, factionless, unknown) → neutral field treatment.
  *  NB: do not route through factions.ts FACTION_ALIASES — albescent keeps its own
  *  identity here, and na must stay neutral (not aliased to ua). */
 const CARD_KEY: Record<string, string> = {

--- a/frontend/src/components/__tests__/factionFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/factionFeedFrame.test.tsx
@@ -55,8 +55,8 @@ describe("FactionFeedFrame dispatch", () => {
   });
 
   it("tints (does not swallow) a non-null unregistered faction card", () => {
-    // The default frame owns the faction tint lifted off the cards: ua/aged_out
-    // have no bespoke frame, so they get the neutral tinted chrome here — but the
+    // The default frame owns the faction tint lifted off the cards: a faction
+    // with no bespoke frame gets the neutral tinted chrome here — but the
     // card body must still render inside it.
     for (const key of Object.keys(FACTION_FEED_FRAMES)) delete FACTION_FEED_FRAMES[key];
     const html = renderToStaticMarkup(

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -25,9 +25,7 @@ import AlbescentFeedFrame from './AlbescentFeedFrame'
 type FrameProps = { children: ReactNode }
 
 /** Per-faction frames. Each row makes that faction's feed cards bespoke.
- *  The explicit `albescent` row beats the albescent→ua alias in pickVariant, so
- *  Albescent renders its own "Record" frame now (#232 slice 2); aged_out still
- *  inherits ua via the alias. */
+ *  Albescent renders its own "Record" frame (#232 slice 2). */
 const FACTION_FEED_FRAMES: Record<string, ComponentType<FrameProps>> = {
   everymen: EverymenFeedFrame,
   ephemerists: EphemeristsFeedFrame,

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -23,10 +23,9 @@ import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
-// ua owns the gilt-salon Atelier archetype; aged_out inherits it via pickVariant's
-// alias rule (no explicit row). albescent is now a FIRST-CLASS identity (#232
-// slice 1) — its explicit entry beats the albescent→ua alias. StickyNote remains
-// the fallback for `na` / unknown factions.
+// ua owns the gilt-salon Atelier archetype. albescent is a FIRST-CLASS
+// identity (#232 slice 1) with its own entry. StickyNote remains the fallback
+// for `na` / unknown factions.
 const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   everymen: EverymenEditPraxis,
   snide: SNIDEEditPraxis,

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -24,9 +24,8 @@ import CommentThread from "../components/comments/CommentThread";
 type Archetype = (props: { state: TaskDetailState }) => JSX.Element | null;
 
 // Only factions with a bespoke archetype are listed; everything else (incl.
-// aged_out) falls through to DefaultTaskDetail below. albescent is now a
-// FIRST-CLASS identity (#232 slice 1) — its explicit entry beats the
-// albescent→ua alias in pickVariant.
+// na) falls through to DefaultTaskDetail below. albescent is a FIRST-CLASS
+// identity (#232 slice 1) with its own entry.
 export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   snide: SNIDETaskDetail,
   everymen: EverymenTaskDetail,

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -247,8 +247,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                   <div>
                     <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.6, color: TEXT, marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na" &&
-                      membership.currentFactionSlug !== "aged_out"
+                      membership.currentFactionSlug !== "na"
                         ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
                         : `Join ${faction.name}?`}
                     </div>

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -255,8 +255,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                   <div>
                     <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na" &&
-                      membership.currentFactionSlug !== "aged_out"
+                      membership.currentFactionSlug !== "na"
                         ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
                         : `Join ${faction.name}?`}
                     </div>

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -333,8 +333,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                   <div>
                     <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.7, color: phosphor(72), marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na" &&
-                      membership.currentFactionSlug !== "aged_out"
+                      membership.currentFactionSlug !== "na"
                         ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
                         : `Join ${faction.name}?`}
                     </div>

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -343,8 +343,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                   <div>
                     <div style={{ fontFamily: TYPE, fontSize: 11, lineHeight: 1.6, color: "#e7e4d8", marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na" &&
-                      membership.currentFactionSlug !== "aged_out"
+                      membership.currentFactionSlug !== "na"
                         ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
                         : `Join ${faction.name}?`}
                     </div>

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -251,8 +251,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                 <div>
                   <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
                     {membership.currentFactionSlug &&
-                    membership.currentFactionSlug !== "na" &&
-                    membership.currentFactionSlug !== "aged_out"
+                    membership.currentFactionSlug !== "na"
                       ? `Enroll in ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
                       : `Enroll in ${faction.name}?`}
                   </div>

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -346,8 +346,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                   <div>
                     <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na" &&
-                      membership.currentFactionSlug !== "aged_out"
+                      membership.currentFactionSlug !== "na"
                         ? `Join ${faction.name}? You won't be able to rejoin ${factionName(membership.currentFactionSlug)} after leaving.`
                         : `Join ${faction.name}?`}
                     </div>

--- a/frontend/src/utils/factionDispatch.ts
+++ b/frontend/src/utils/factionDispatch.ts
@@ -5,8 +5,9 @@
  * Before this helper, ~10 dispatchers (TaskCard, PraxisCard, EditPraxis,
  * TaskDetail, VoteUI, FactionAvatar, FactionBackdrop,
  * FactionDetail heroes) each spelled "look up slug, else
- * default" three different ways and none of them handled the albescent /
- * aged_out aliases. Routing every dispatcher through `pickVariant` makes
+ * default" three different ways and none of them handled faction-identity
+ * aliases (then albescent→ua and aged_out→ua, both since retired). Routing
+ * every dispatcher through `pickVariant` makes
  * slug-normalization, alias handling, and unknown-slug behaviour live in one
  * place, and means a new page dispatcher is one map + one call.
  */
@@ -18,9 +19,10 @@ import { FACTION_ALIASES } from './factions'
  * Resolve a faction slug to its archetype component.
  *
  * Lookup order: an explicit entry for the slug wins; then its alias's entry
- * (so albescent/aged_out inherit ua's variant without a duplicate map row);
- * then the supplied fallback. A null/undefined/empty slug goes straight to the
- * fallback.
+ * (a derived slug inherits its canonical faction's variant without a duplicate
+ * map row — the seam the retired aged_out→ua alias used; FACTION_ALIASES in
+ * factions.ts is currently empty); then the supplied fallback. A
+ * null/undefined/empty slug goes straight to the fallback.
  *
  * The fallback is optional: with one, you always get a component (the
  * "every faction renders something" page case); without one, you get


### PR DESCRIPTION
## What

The `aged_out` faction was retired in #428 (backend migration `0012`) — no character can ever carry `faction_slug === "aged_out"` again. This removes the frontend leftovers:

- **Dead guard clause dropped** in all six faction-body enroll confirmations (`Ua`/`Wow`/`Snide`/`Everymen`/`Singularity`/`Ephemerists` `FactionBody.tsx`): the check is now just `currentFactionSlug && currentFactionSlug !== "na"`.
- **Stale comments refreshed** in `TaskDetail.tsx`, `EditPraxis.tsx`, `FactionFeedFrame.tsx`, `CredentialCard.tsx`, `factionFeedFrame.test.tsx` — they described the alias (or the albescent→ua alias, dropped in #433) as still live.
- **Design-seam notes reworded, not deleted**, in `factionDispatch.ts`: the pickVariant alias-rule docs now describe the seam generically with the retired `aged_out→ua` alias as the historical example.

Remaining `aged_out` grep hits in `frontend/src` are all intentional design-seam / retirement notes: `factionDispatch.ts` (2), `factions.ts:67` (the FACTION_ALIASES seam's source-of-truth comment, per the issue), and `factionAlbescentFirstClass.test.ts:4` (explains why the alias map is empty).

## Verification

- `npx tsc --noEmit` — clean
- `npm test -- --run` — 21 files, 194 tests passed

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)