### PR TITLE
feat(era1): flatten cross-faction point modifiers to 1.0 (#452)

### DIFF
--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -18,6 +18,9 @@ from game_config import (
 # FACTIONS
 # =============================================================================
 
+# Cross-faction modifiers (other_task_modifier / collab_other_modifier) are
+# deliberately flattened to 1.0 for Era 1 — no faction is penalized for working
+# a task outside its own faction (issue #452). Re-tune in a future era if desired.
 ERA_1_FACTIONS = {
     "ua": FactionConfig(
         slug="ua",
@@ -40,9 +43,9 @@ ERA_1_FACTIONS = {
         description="Specialists in one-on-one competition. Bonus points for winning duels.",
         can_always_rejoin=False,
         own_task_modifier=1.0,
-        other_task_modifier=0.7,
+        other_task_modifier=1.0,
         collab_own_modifier=1.0,
-        collab_other_modifier=0.7,
+        collab_other_modifier=1.0,
         duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
         duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
     ),
@@ -52,9 +55,9 @@ ERA_1_FACTIONS = {
         description="Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
         can_always_rejoin=False,
         own_task_modifier=1.1,        # +10% on solo own-faction
-        other_task_modifier=0.7,      # -30% on solo other-faction
+        other_task_modifier=1.0,
         collab_own_modifier=1.1,      # +10% on collab own-faction
-        collab_other_modifier=0.9,    # -10% on collab other-faction (less penalty)
+        collab_other_modifier=1.0,
         duel_win_modifier=1.5,
         duel_loss_modifier=0.5,
     ),
@@ -64,9 +67,9 @@ ERA_1_FACTIONS = {
         description="Wanderers who set down fleeting truths before the road moves on. Task Vision — access to select retired tasks.",
         can_always_rejoin=False,
         own_task_modifier=1.0,
-        other_task_modifier=0.7,
+        other_task_modifier=1.0,
         collab_own_modifier=1.0,
-        collab_other_modifier=0.7,
+        collab_other_modifier=1.0,
         duel_win_modifier=1.5,
         duel_loss_modifier=0.5,
     ),
@@ -77,9 +80,9 @@ ERA_1_FACTIONS = {
         "do the work in front of them and finish what they start.",
         can_always_rejoin=False,
         own_task_modifier=1.0,
-        other_task_modifier=0.7,
+        other_task_modifier=1.0,
         collab_own_modifier=1.0,
-        collab_other_modifier=0.7,
+        collab_other_modifier=1.0,
         duel_win_modifier=1.5,
         duel_loss_modifier=0.5,
     ),

--- a/backend/tests/unit/test_faction_config.py
+++ b/backend/tests/unit/test_faction_config.py
@@ -6,13 +6,13 @@ from game_config import ERA_1
 def test_wow_solo_modifiers():
     config = ERA_1.factions["wow"]
     assert config.own_task_modifier == 1.1
-    assert config.other_task_modifier == 0.7
+    assert config.other_task_modifier == 1.0
 
 
 def test_wow_collab_modifiers():
     config = ERA_1.factions["wow"]
     assert config.collab_own_modifier == 1.1
-    assert config.collab_other_modifier == 0.9
+    assert config.collab_other_modifier == 1.0
 
 
 def test_snide_duel_modifiers():
@@ -21,9 +21,10 @@ def test_snide_duel_modifiers():
     assert config.duel_loss_modifier == 0.0  # Snide high-risk penalty
 
 
-def test_snide_other_faction_penalty():
+def test_snide_no_cross_faction_penalty():
+    # Flattened to 1.0 for Era 1 (issue #452).
     config = ERA_1.factions["snide"]
-    assert config.other_task_modifier == 0.7
+    assert config.other_task_modifier == 1.0
 
 
 def test_ua_masters_cut_from_era_1():
@@ -46,18 +47,25 @@ def test_ua_baseline():
     assert config.other_task_modifier == 1.0
 
 
-def test_ephemerists_penalties():
+def test_ephemerists_modifiers():
     config = ERA_1.factions["ephemerists"]
     assert config.own_task_modifier == 1.0
-    assert config.other_task_modifier == 0.7
-    assert config.collab_other_modifier == 0.7
+    assert config.other_task_modifier == 1.0
+    assert config.collab_other_modifier == 1.0
 
 
-def test_everymen_penalties():
+def test_everymen_modifiers():
     config = ERA_1.factions["everymen"]
     assert config.own_task_modifier == 1.0
-    assert config.other_task_modifier == 0.7
-    assert config.collab_other_modifier == 0.7
+    assert config.other_task_modifier == 1.0
+    assert config.collab_other_modifier == 1.0
+
+
+def test_all_factions_flat_cross_faction_modifiers():
+    # Era-1 decision (issue #452): no cross-faction penalty for any faction.
+    for slug, config in ERA_1.factions.items():
+        assert config.other_task_modifier == 1.0, slug
+        assert config.collab_other_modifier == 1.0, slug
 
 
 def test_singularity_defaults():

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -207,7 +207,7 @@ def test_faction_multiplier_own_faction():
 def test_faction_multiplier_other_faction():
     result = compute_faction_multiplier("wow", "ua", ERA_1)
     assert result == ERA_1.factions["wow"].other_task_modifier
-    assert result == 0.7
+    assert result == 1.0  # flattened for Era 1 (issue #452)
 
 
 def test_faction_multiplier_unknown_faction():
@@ -239,7 +239,7 @@ def test_collab_other_faction():
         collaboration_mode=COLLABORATION_MODE_COLLAB,
     )
     assert result == ERA_1.factions["wow"].collab_other_modifier
-    assert result == 0.9
+    assert result == 1.0  # flattened for Era 1 (issue #452)
 
 
 def test_collab_unaffiliated_task():
@@ -322,8 +322,8 @@ def test_cross_faction_collab_example():
         "ephemerists", "snide", ERA_1,
         collaboration_mode=COLLABORATION_MODE_COLLAB,
     )
-    assert wow_mult == 0.9   # collab_other_modifier for wow
-    assert ephemerists_mult == 0.7  # collab_other_modifier for ephemerists
+    assert wow_mult == 1.0   # collab_other_modifier for wow (flattened, #452)
+    assert ephemerists_mult == 1.0  # collab_other_modifier for ephemerists (flattened, #452)
 
 
 def test_ua_full_points():
@@ -344,17 +344,17 @@ def test_albescent_no_penalties():
     assert config.collab_other_modifier == 1.0
 
 
-def test_ephemerists_other_faction_penalty():
-    """Ephemerists get 0.7 on other-faction tasks."""
+def test_ephemerists_no_other_faction_penalty():
+    """Ephemerists get full points on other-faction tasks (flattened, #452)."""
     config = ERA_1.factions["ephemerists"]
     assert config.own_task_modifier == 1.0
-    assert config.other_task_modifier == 0.7
+    assert config.other_task_modifier == 1.0
     assert config.collab_own_modifier == 1.0
-    assert config.collab_other_modifier == 0.7
+    assert config.collab_other_modifier == 1.0
 
 
-def test_everymen_other_faction_penalty():
-    """Everymen get 0.7 on other-faction tasks."""
+def test_everymen_no_other_faction_penalty():
+    """Everymen get full points on other-faction tasks (flattened, #452)."""
     config = ERA_1.factions["everymen"]
     assert config.own_task_modifier == 1.0
-    assert config.other_task_modifier == 0.7
+    assert config.other_task_modifier == 1.0

--- a/docs/spec/SPEC-game-rules.md
+++ b/docs/spec/SPEC-game-rules.md
@@ -150,18 +150,20 @@ Level is recalculated synchronously every time score changes (via `recalculate_c
 
 Multipliers are applied based on the character's faction and the task's `primary_faction_slug`. A task with `primary_faction_slug = "na"` is treated as own-faction for all characters (no penalty).
 
+**Era 1 balance decision (issue #452):** all cross-faction (other-faction) modifiers are flattened to 1.0× — no faction is penalized for working a task outside its own faction. These values are era-configurable and may be re-tuned in a later era.
+
 ### Solo and duel (use `own_task_modifier` / `other_task_modifier`)
 
 | Faction | Own-faction task | Other-faction task |
 |---|---|---|
 | UA | 1.0× | 1.0× |
-| UA Masters | 0.8× | 0.8× |
-| S.N.I.D.E. | 1.0× | 0.7× |
-| Gestalt | 1.1× | 0.7× |
-| Ephemerists | 1.0× | 0.7× |
-| Analog | 1.0× | 0.7× |
-| Singularity | 1.0× | 0.7× |
+| S.N.I.D.E. | 1.0× | 1.0× |
+| Warriors of Whimsy | 1.1× | 1.0× |
+| Ephemerists | 1.0× | 1.0× |
+| Everymen | 1.0× | 1.0× |
+| Singularity | 1.0× | 1.0× |
 | /Albescent | 1.0× | 1.0× |
+| None (`na`) | 1.0× | 1.0× |
 
 For duels, `faction_multiplier` uses the solo own/other modifiers, and `duel_multiplier` is applied on top.
 
@@ -172,13 +174,13 @@ Each member's score is computed independently using their own faction's collab m
 | Faction | Own-faction collab | Other-faction collab |
 |---|---|---|
 | UA | 1.0× | 1.0× |
-| UA Masters | 0.8× | 0.8× |
-| S.N.I.D.E. | 1.0× | 0.7× |
-| Gestalt | 1.1× | 0.9× (less penalty than solo) |
-| Ephemerists | 1.0× | 0.7× |
-| Analog | 1.0× | 0.7× |
-| Singularity | 1.0× | 0.7× |
+| S.N.I.D.E. | 1.0× | 1.0× |
+| Warriors of Whimsy | 1.1× | 1.0× |
+| Ephemerists | 1.0× | 1.0× |
+| Everymen | 1.0× | 1.0× |
+| Singularity | 1.0× | 1.0× |
 | /Albescent | 1.0× | 1.0× |
+| None (`na`) | 1.0× | 1.0× |
 
 ---
 
@@ -267,10 +269,10 @@ Point thresholds come from `era.level_thresholds` and vary per era.
 |---|---|---|
 | `ua_masters` | UA Masters | Veterans aged out of UA. Flat 0.8× on everything. |
 | `snide` | S.N.I.D.E. | High-risk duel specialists. 2.0× wins, 0.0× losses. |
-| `gestalt` | Gestalt | Collective-minded. Bonus on own tasks, penalty on other. |
+| `gestalt` | Gestalt | Collective-minded. Bonus on own tasks; no cross-faction penalty in Era 1 (#452). |
 | `journeymen` | The Ephemerists | Wanderers recording fleeting truths. Task Vision (access to select retired tasks — deferred v2). |
 | `analog` | Analog | Depth over breadth. Double Dipper (repeat one task per level — deferred v2). |
-| `singularity` | Singularity | Hidden/lurker faction. Currently 1.0× own / 0.7× other. Lurker ability (vote bank +100 on trigger) — deferred. |
+| `singularity` | Singularity | Hidden/lurker faction. Currently 1.0× own / 1.0× other. Lurker ability (vote bank +100 on trigger) — deferred. |
 
 ### Special / non-selectable factions
 


### PR DESCRIPTION
## What

Sets `other_task_modifier = 1.0` and `collab_other_modifier = 1.0` for every faction in `ERA_1_FACTIONS`. Previously mixed: snide 0.7/0.7, wow 0.7/0.9, ephemerists 0.7/0.7, everymen 0.7/0.7; ua/singularity/albescent/na were already 1.0/1.0.

Deliberate Era 1 balance setting: no faction is penalized for working a task outside its own faction. Values stay era-configurable for later re-tuning (comment added above `ERA_1_FACTIONS`).

**Untouched (explicitly out of scope per the issue):** `own_task_modifier` (wow keeps 1.1), `duel_win_modifier` / `duel_loss_modifier` (snide keeps 2.0/0.0).

## Tests

- `backend/tests/unit/test_faction_config.py` — updated pinned 0.7/0.9 assertions; renamed the now-misnamed `*_penalty` tests; added `test_all_factions_flat_cross_faction_modifiers` asserting flatness across the whole roster.
- `backend/tests/unit/test_scoring.py` — updated pinned values in the multiplier and cross-faction-collab example tests.

## Spec

- `docs/spec/SPEC-game-rules.md` — faction-multiplier tables (solo/duel + collab) now show 1.0 in the other-faction columns, with a note citing the balance decision. While reconciling, the table rows were aligned with the live Era 1 roster (current faction names Warriors of Whimsy/Everymen, dropped the UA Masters row cut per ADR-0004, added `na`). Also fixed the stale singularity `0.7× other` note in the roster section. Duel-outcome table left untouched.
- Note: the "Era 1 selectable factions" roster section remains stale in unrelated ways (old slugs `gestalt`/`journeymen`/`analog`, `ua_masters`, UA-as-starting-faction contradicting ADR-0030) — left for a separate reconciliation.

## Verification

`pytest --cov=. --cov-fail-under=80` from `backend/`: **537 passed**, coverage 85.58%.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)