### PR TITLE
feat(i18n): sweep home/landing into home.json (#448)

### DIFF
--- a/frontend/src/components/home/ActivityTicker.tsx
+++ b/frontend/src/components/home/ActivityTicker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { getActivityFeed, type ActivityFeedItem } from '../../api/activityFeed'
 import { factionCssVar } from '../../utils/factions'
 
@@ -12,40 +13,44 @@ import { factionCssVar } from '../../utils/factions'
  */
 
 // Feed types we know how to phrase. Anything not listed is skipped so the
-// ticker never renders a half-built entry. Values mirror FEED_ITEM_TYPE_* in
-// backend/services/activity_feed.py.
-const VERBS: Record<string, string> = {
-  friend_completion: 'completed',
-  foe_completion: 'completed',
-  friend_signup: 'signed up for',
-  global_task: 'new task',
-  vote_on_mine: 'voted on',
-  collab_invite: 'started a collab on',
-  duel_challenge: 'challenged a duel on',
-  era_announcement: 'new era',
-}
+// ticker never renders a half-built entry. Map keys mirror FEED_ITEM_TYPE_*
+// in backend/services/activity_feed.py; values are home.json copy keys.
+const VERB_KEYS = {
+  friend_completion: 'ticker.verbs.friend_completion',
+  foe_completion: 'ticker.verbs.foe_completion',
+  friend_signup: 'ticker.verbs.friend_signup',
+  global_task: 'ticker.verbs.global_task',
+  vote_on_mine: 'ticker.verbs.vote_on_mine',
+  collab_invite: 'ticker.verbs.collab_invite',
+  duel_challenge: 'ticker.verbs.duel_challenge',
+  era_announcement: 'ticker.verbs.era_announcement',
+} as const
+
+type VerbKey = (typeof VERB_KEYS)[keyof typeof VERB_KEYS]
 
 interface TickerEntry {
-  player: string
-  verb: string
+  /** null → the system actor ("World Zero") — translated at render time. */
+  player: string | null
+  verbKey: VerbKey
   subject: string
   faction: string | null
 }
 
 function toEntry(item: ActivityFeedItem): TickerEntry | null {
-  const verb = VERBS[item.type]
-  if (!verb) return null
-  const player = item.actor_display_name ?? 'World Zero'
+  const verbKey =
+    item.type in VERB_KEYS ? VERB_KEYS[item.type as keyof typeof VERB_KEYS] : null
+  if (!verbKey) return null
   const subject =
     item.payload?.task_title ??
     item.payload?.title ??
     item.payload?.praxis_title ??
     item.payload?.era_name ??
     ''
-  return { player, verb, subject, faction: item.actor_faction_slug }
+  return { player: item.actor_display_name ?? null, verbKey, subject, faction: item.actor_faction_slug }
 }
 
 function TickerCard({ entry }: { entry: TickerEntry }) {
+  const { t } = useTranslation('home')
   const accent = factionCssVar(entry.faction)
   return (
     <div
@@ -71,13 +76,13 @@ function TickerCard({ entry }: { entry: TickerEntry }) {
           textOverflow: 'ellipsis',
         }}
       >
-        {entry.player}
+        {entry.player ?? t('ticker.defaultActor')}
       </div>
       <div
         className="font-body"
         style={{ fontSize: 9, color: 'var(--color-text-tertiary)', lineHeight: 1 }}
       >
-        {entry.verb}
+        {t(entry.verbKey)}
       </div>
       {entry.subject && (
         <div
@@ -100,6 +105,7 @@ function TickerCard({ entry }: { entry: TickerEntry }) {
 }
 
 export default function ActivityTicker() {
+  const { t } = useTranslation('home')
   const [entries, setEntries] = useState<TickerEntry[]>([])
 
   useEffect(() => {
@@ -158,7 +164,7 @@ export default function ActivityTicker() {
               animation: 'wz-blink 1.4s ease-in-out infinite',
             }}
           />
-          Live
+          {t('ticker.live')}
         </div>
       </div>
 
@@ -186,7 +192,7 @@ export default function ActivityTicker() {
         }}
       >
         {doubled.map((entry, i) => (
-          <TickerCard key={`${i}-${entry.player}`} entry={entry} />
+          <TickerCard key={`${i}-${entry.player ?? 'wz'}`} entry={entry} />
         ))}
       </div>
     </div>

--- a/frontend/src/locales/en/home.json
+++ b/frontend/src/locales/en/home.json
@@ -1,1 +1,46 @@
-{}
+{
+  "loginRequired": "You need to log in to access that page.",
+  "signup": {
+    "error": "Could not sign up — make sure you are logged in."
+  },
+  "hero": {
+    "eyebrow": "players · tasks · praxis · score · city · factions · chaos",
+    "wordmark": "World Zero",
+    "tagline": "a collaborative production game played in the real world",
+    "cta": {
+      "loggedIn": "Find a Task",
+      "loggedOut": "Sign Up Here"
+    },
+    "devLogin": "dev login (no OAuth)"
+  },
+  "sections": {
+    "featuredPraxis": {
+      "title": "Featured Praxis",
+      "link": "see all",
+      "empty": "No praxis yet. Be the first!"
+    },
+    "newestTask": {
+      "title": "Newest Task",
+      "link": "more tasks",
+      "empty": "No tasks yet."
+    }
+  },
+  "closing": {
+    "prompt": "not sure where to start?",
+    "randomTask": "→ grab a random task ←"
+  },
+  "ticker": {
+    "live": "Live",
+    "defaultActor": "World Zero",
+    "verbs": {
+      "friend_completion": "completed",
+      "foe_completion": "completed",
+      "friend_signup": "signed up for",
+      "global_task": "new task",
+      "vote_on_mine": "voted on",
+      "collab_invite": "started a collab on",
+      "duel_challenge": "challenged a duel on",
+      "era_announcement": "new era"
+    }
+  }
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
 import { listPraxes, createPraxis, type PraxisCardOut } from '../api/praxis'
 import { listTasks, type TaskOut } from '../api/tasks'
@@ -47,6 +48,7 @@ const markerButton: CSSProperties = {
 }
 
 export default function Home() {
+  const { t } = useTranslation('home')
   const { user, refetch } = useAuth()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
@@ -71,7 +73,7 @@ export default function Home() {
       const praxis = await createPraxis({ task_id: id, type: 'solo' })
       navigate(`/praxes/${praxis.id}/edit`)
     } catch (err) {
-      setSignupMsg(extractError(err, 'Could not sign up — make sure you are logged in.'))
+      setSignupMsg(extractError(err, t('signup.error')))
     }
   }
 
@@ -98,7 +100,7 @@ export default function Home() {
     <div className="pb-12">
       {loginRequired && (
         <p className="font-body text-sm text-muted mt-6 border-2 border-border px-4 py-2 inline-block">
-          You need to log in to access that page.
+          {t('loginRequired')}
         </p>
       )}
 
@@ -119,7 +121,7 @@ export default function Home() {
           className="relative"
           style={{ fontFamily: 'var(--font-faction-script)', fontSize: 20, color: 'var(--color-text-secondary)', marginBottom: 16, letterSpacing: '0.06em' }}
         >
-          players · tasks · praxis · score · city · factions · chaos
+          {t('hero.eyebrow')}
         </div>
         <div className="relative" style={{ marginBottom: 18 }}>
           <span
@@ -137,21 +139,21 @@ export default function Home() {
               backgroundRepeat: 'no-repeat',
             }}
           >
-            World Zero
+            {t('hero.wordmark')}
           </span>
         </div>
         <div
           className="relative mx-auto"
           style={{ fontFamily: 'var(--font-faction-script)', fontSize: 28, lineHeight: 1.4, color: 'var(--color-text-secondary)', marginBottom: 40, maxWidth: 560 }}
         >
-          a collaborative production game played in the real world
+          {t('hero.tagline')}
         </div>
         <button
           onClick={handlePrimaryCta}
           className="btn-primary relative"
           style={{ ...markerButton, padding: '14px 48px' }}
         >
-          {user ? 'Find a Task' : 'Sign Up Here'}
+          {user ? t('hero.cta.loggedIn') : t('hero.cta.loggedOut')}
         </button>
         {!user && import.meta.env.DEV && (
           <div className="relative" style={{ marginTop: 14 }}>
@@ -160,7 +162,7 @@ export default function Home() {
               className="btn-outline"
               style={{ padding: '0.25rem 0.75rem' }}
             >
-              dev login (no OAuth)
+              {t('hero.devLogin')}
             </button>
           </div>
         )}
@@ -181,9 +183,9 @@ export default function Home() {
 
       {/* ── FEATURED PRAXIS ── */}
       <section style={{ paddingTop: 48 }}>
-        <SectionHeader title="Featured Praxis" href="/praxes" linkLabel="see all" />
+        <SectionHeader title={t('sections.featuredPraxis.title')} href="/praxes" linkLabel={t('sections.featuredPraxis.link')} />
         {feed.length === 0 ? (
-          <p className="font-body text-muted">No praxis yet. Be the first!</p>
+          <p className="font-body text-muted">{t('sections.featuredPraxis.empty')}</p>
         ) : (
           <div className="flex flex-wrap gap-5 items-start">
             {feed.map((p) => <PraxisCard key={p.id} praxis={p} />)}
@@ -193,7 +195,7 @@ export default function Home() {
 
       {/* ── NEWEST TASK ── */}
       <section style={{ paddingTop: 48 }}>
-        <SectionHeader title="Newest Task" href="/tasks" linkLabel="more tasks" />
+        <SectionHeader title={t('sections.newestTask.title')} href="/tasks" linkLabel={t('sections.newestTask.link')} />
         {newestTask ? (
           <TaskCard
             task={newestTask}
@@ -206,7 +208,7 @@ export default function Home() {
             onSignup={user && newestTask.can_submit_praxis ? handleSignup : undefined}
           />
         ) : (
-          <p className="font-body text-muted">No tasks yet.</p>
+          <p className="font-body text-muted">{t('sections.newestTask.empty')}</p>
         )}
       </section>
 
@@ -215,14 +217,14 @@ export default function Home() {
         <div
           style={{ fontFamily: 'var(--font-faction-marker)', fontSize: 36, lineHeight: 1.1, color: 'var(--color-text-primary)', marginBottom: 24, transform: 'rotate(-1.2deg)' }}
         >
-          not sure where to start?
+          {t('closing.prompt')}
         </div>
         <button
           onClick={handleRandomTask}
           className="btn-outline"
           style={{ ...markerButton, padding: '14px 52px' }}
         >
-          → grab a random task ←
+          {t('closing.randomTask')}
         </button>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Extracts all user-facing copy from the home/landing surface into `frontend/src/locales/en/home.json` (23 strings), per the #440 foundation conventions (semantic nested keys, no key named after its English text).
- `pages/Home.tsx`: hero eyebrow/wordmark/tagline, logged-in vs logged-out primary CTA, dev-login button, login-required notice, signup-error fallback, Featured Praxis / Newest Task section headers + links + empty states, closing CTA — all via `useTranslation('home')`. No embedded markup, so no `<Trans>` needed.
- `components/home/ActivityTicker.tsx`: "Live" badge, "World Zero" default-actor fallback, and the per-feed-type verb map. The `VERBS` string map became `VERB_KEYS` (feed type → typed copy key), so unknown feed types are still skipped and a bad key fails `tsc`.

## Out of scope (per sibling sweeps)
- `components/layout/`, `App.tsx` (#441), other locale namespaces — untouched.

## Gates
- `npx tsc --noEmit` — clean
- `npm test -- --run` — 21 files, 193 tests passed

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)