### PR TITLE
feat(i18n): sweep common chrome into common.json (#441)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import Layout from './components/Layout'
 import ProtectedRoute from './auth/ProtectedRoute'
 import { useAuth } from './auth/AuthContext'
@@ -27,8 +28,9 @@ import Donate from './pages/Donate'
 
 /** `/` is the FieldDesk for an authenticated account, the marketing Home otherwise. */
 function RootLanding() {
+  const { t } = useTranslation('common')
   const { user, loading } = useAuth()
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="page font-body text-muted">{t('loading')}</div>
   return user ? <FieldDesk /> : <Home />
 }
 
@@ -40,8 +42,9 @@ function RootLanding() {
  * visually until #232; here we only route to the existing FactionDetail.
  */
 function AlbescentGate() {
+  const { t } = useTranslation('common')
   const { user, loading } = useAuth()
-  if (loading) return <div className="page font-body text-muted">Loading...</div>
+  if (loading) return <div className="page font-body text-muted">{t('loading')}</div>
   return user?.albescent_revealed ? <FactionDetail slug="albescent" /> : <AlbescentSecretPlaceholder />
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactNode } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
 import NavBar from './NavBar'
 import { BackdropProvider } from './backdrop/BackdropContext'
@@ -8,6 +9,7 @@ import LevelUpWatcher from './LevelUpWatcher'
 import Sidebar from './layout/Sidebar'
 
 export default function Layout({ children }: { children: ReactNode }) {
+  const { t } = useTranslation('common')
   const { user, loading } = useAuth()
   const navigate = useNavigate()
   const { pathname } = useLocation()
@@ -49,11 +51,11 @@ export default function Layout({ children }: { children: ReactNode }) {
         className="relative font-body text-xs flex gap-6 flex-wrap max-w-5xl mx-auto w-full px-4 sm:px-6 py-4 mt-8"
         style={{ color: 'var(--color-text-tertiary)', zIndex: 5 }}
       >
-        <Link to="/about" className="hover:underline">About</Link>
-        <Link to="/contact" className="hover:underline">Contact</Link>
-        <Link to="/disclaimer" className="hover:underline">Disclaimer</Link>
-        <Link to="/attributions" className="hover:underline">Attributions</Link>
-        <Link to="/donate" className="hover:underline">Donate</Link>
+        <Link to="/about" className="hover:underline">{t('footer.about')}</Link>
+        <Link to="/contact" className="hover:underline">{t('footer.contact')}</Link>
+        <Link to="/disclaimer" className="hover:underline">{t('footer.disclaimer')}</Link>
+        <Link to="/attributions" className="hover:underline">{t('footer.attributions')}</Link>
+        <Link to="/donate" className="hover:underline">{t('footer.donate')}</Link>
       </footer>
     </div>
     </BackdropProvider>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,23 +1,25 @@
 import { NavLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
 import { useAdminMode } from '../auth/AdminModeContext'
 import { loginWithGoogle, logout } from '../api/auth'
 import { useTheme } from '../hooks/useTheme'
 
-const links = [
-  { to: '/', label: 'Home', end: true },
-  { to: '/tasks', label: 'Tasks' },
-  { to: '/praxes', label: 'Praxis' },
-  { to: '/leaderboard', label: 'Players' },
-  { to: '/factions', label: 'Factions' },
-  { to: '/updates', label: 'Updates' },
-]
-
 export default function NavBar() {
+  const { t } = useTranslation('common')
   const { user, refetch } = useAuth()
   const { theme, toggle } = useTheme()
   const { adminMode, toggleAdminMode } = useAdminMode()
   const dark = theme === 'dark'
+
+  const links = [
+    { to: '/', label: t('nav.home'), end: true },
+    { to: '/tasks', label: t('nav.tasks') },
+    { to: '/praxes', label: t('nav.praxis') },
+    { to: '/leaderboard', label: t('nav.players') },
+    { to: '/factions', label: t('nav.factions') },
+    { to: '/updates', label: t('nav.updates') },
+  ]
 
   const handleLogout = async () => {
     await logout()
@@ -52,7 +54,7 @@ export default function NavBar() {
               paddingBottom: 2,
             }}
           >
-            World Zero
+            {t('brand')}
           </span>
         </NavLink>
 
@@ -83,7 +85,7 @@ export default function NavBar() {
                   borderBottom: isActive ? '1.5px solid var(--color-text-primary)' : '1.5px solid transparent',
                 })}
               >
-                Admin
+                {t('nav.admin')}
               </NavLink>
             </li>
           )}
@@ -93,7 +95,7 @@ export default function NavBar() {
         {user?.is_admin && (
           <button
             onClick={toggleAdminMode}
-            title={adminMode ? 'Admin mode ON — click to disable' : 'Enable admin mode'}
+            title={adminMode ? t('nav.adminMode.disableTitle') : t('nav.adminMode.enableTitle')}
             className="eyebrow"
             style={{
               background: 'none',
@@ -105,7 +107,7 @@ export default function NavBar() {
               borderRadius: 2,
             }}
           >
-            MOD
+            {t('nav.adminMode.badge')}
           </button>
         )}
 
@@ -122,7 +124,7 @@ export default function NavBar() {
             transition: 'color 150ms',
           }}
         >
-          {dark ? 'light' : 'dark'}
+          {dark ? t('nav.themeToggle.toLight') : t('nav.themeToggle.toDark')}
         </button>
 
         {/* User area */}
@@ -133,7 +135,7 @@ export default function NavBar() {
                 <NavLink
                   to="/"
                   end
-                  title="Your FieldDesk — switch lives or begin a new one"
+                  title={t('nav.fieldDeskTitle')}
                   className="nav-link transition-colors"
                   style={{ color: 'var(--color-text-secondary)' }}
                 >
@@ -145,16 +147,16 @@ export default function NavBar() {
                   className="nav-link transition-colors"
                   style={{ color: 'var(--color-text-secondary)' }}
                 >
-                  create character
+                  {t('nav.createCharacter')}
                 </NavLink>
               )}
               <button onClick={handleLogout} className="btn-outline" style={{ padding: '0.25rem 0.75rem' }}>
-                logout
+                {t('nav.logout')}
               </button>
             </>
           ) : (
             <button onClick={loginWithGoogle} className="btn-primary">
-              Login
+              {t('nav.login')}
             </button>
           )}
         </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
+import { Trans, useTranslation } from 'react-i18next'
 import { useAuth } from '../../auth/AuthContext'
 import { getActivityFeed, type ActivityFeedItem } from '../../api/activityFeed'
 import { relativeTime } from '../../utils/dates'
@@ -15,17 +16,12 @@ import { useGameConfig } from '../../hooks/useGameConfig'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
 
-const PRAXIS_TYPE_LABEL: Record<PraxisType, string> = {
-  solo: 'Solo',
-  collab: 'Collab',
-  duel: 'Duel',
-}
-
 /**
  * Always-on right sidebar (Style Guide §4.2).
  * Character card + pending requests + active tasks + recent global activity + propose button.
  */
 export default function Sidebar() {
+  const { t } = useTranslation('common')
   const { user } = useAuth()
   const character = user?.character
 
@@ -34,6 +30,12 @@ export default function Sidebar() {
   const { pendingRequests, refetch: refetchPendingRequests } = usePendingRequests()
   const gameConfig = useGameConfig()
   const [globalActivity, setGlobalActivity] = useState<ActivityFeedItem[]>([])
+
+  const praxisTypeLabel: Record<PraxisType, string> = {
+    solo: t('praxisType.solo'),
+    collab: t('praxisType.collab'),
+    duel: t('praxisType.duel'),
+  }
 
   useEffect(() => {
     if (!user) return
@@ -53,7 +55,7 @@ export default function Sidebar() {
       {character ? (
         <div className="sidebar-card">
           <div className="eyebrow mb-2" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-            Your Character
+            {t('sidebar.characterCard.eyebrow')}
           </div>
           <div className="flex items-center gap-3 mb-3">
             {character.avatar_url ? (
@@ -89,16 +91,19 @@ export default function Sidebar() {
                   color: factionCssVar(character.faction_slug),
                 }}
               >
-                {factionName(character.faction_slug)} · Level {character.level}
+                {t('sidebar.characterCard.factionLevel', {
+                  faction: factionName(character.faction_slug),
+                  level: character.level,
+                })}
               </span>
             </div>
           </div>
 
           <div className="grid grid-cols-3 gap-1">
             {[
-              { label: 'Score', value: character.score?.toLocaleString() ?? '0' },
-              { label: 'Votes', value: votesReceived.toLocaleString() },
-              { label: 'Current', value: `Era 3`, sublabel: true },
+              { label: t('sidebar.stats.score'), value: character.score?.toLocaleString() ?? '0' },
+              { label: t('sidebar.stats.votes'), value: votesReceived.toLocaleString() },
+              { label: t('sidebar.stats.current'), value: t('sidebar.stats.currentValue') },
             ].map((stat) => (
               <div
                 key={stat.label}
@@ -117,7 +122,7 @@ export default function Sidebar() {
         </div>
       ) : (
         <div className="sidebar-card">
-          <p className="eyebrow text-center">No character yet</p>
+          <p className="eyebrow text-center">{t('sidebar.characterCard.noCharacter')}</p>
         </div>
       )}
 
@@ -125,7 +130,7 @@ export default function Sidebar() {
       {pendingRequests.length > 0 && (
         <div className="sidebar-card">
           <p className="eyebrow mb-2">
-            Pending Requests · {pendingRequests.length}
+            {t('sidebar.pendingRequests.heading', { count: pendingRequests.length })}
           </p>
           <div className="flex flex-col gap-1.5">
             {pendingRequests.map((item, index) => (
@@ -147,11 +152,11 @@ export default function Sidebar() {
 
       {/* ── Active Tasks Panel ── */}
       <div className="sidebar-card">
-        <p className="eyebrow mb-2">In progress tasks</p>
+        <p className="eyebrow mb-2">{t('sidebar.activeTasks.heading')}</p>
 
         {activeTasks.length === 0 ? (
           <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-            No in progress tasks
+            {t('sidebar.activeTasks.empty')}
           </p>
         ) : (
           <div className="flex flex-col gap-1.5">
@@ -175,7 +180,7 @@ export default function Sidebar() {
                 </div>
                 <FeedBadge
                   type={praxis.type === 'solo' ? 'global' : praxis.type}
-                  label={PRAXIS_TYPE_LABEL[praxis.type]}
+                  label={praxisTypeLabel[praxis.type]}
                 />
               </div>
             ))}
@@ -203,18 +208,18 @@ export default function Sidebar() {
             />
           </div>
           <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)', marginTop: 3 }}>
-            {slotCount} / {maxTaskSlots} slots
+            {t('sidebar.activeTasks.slots', { count: slotCount, max: maxTaskSlots })}
           </p>
         </div>
       </div>
 
       {/* ── Recent Global Activity Panel ── */}
       <div className="sidebar-card">
-        <p className="eyebrow mb-2">Recent global activity</p>
+        <p className="eyebrow mb-2">{t('sidebar.globalActivity.heading')}</p>
 
         {globalActivity.length === 0 ? (
           <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-            No activity yet
+            {t('sidebar.globalActivity.empty')}
           </p>
         ) : (
           <div className="flex flex-col">
@@ -232,28 +237,35 @@ export default function Sidebar() {
                   <div className="font-body" style={{ fontSize: 9, lineHeight: 1.4 }}>
                     {isEra ? (
                       <span style={{ fontWeight: 700, color: 'var(--faction-ephemerists)' }}>
-                        {item.payload.era_name} has begun
+                        {t('sidebar.globalActivity.eraBegun', { eraName: item.payload.era_name })}
                       </span>
                     ) : isTask ? (
-                      <>
-                        <span style={{ fontWeight: 700, color: 'var(--color-text-primary)' }}>New task: </span>
-                        <Link
-                          to={`/tasks/${item.payload.task_id}`}
-                          style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}
-                        >
-                          {item.payload.task_title}
-                        </Link>
-                      </>
+                      <Trans
+                        i18nKey="sidebar.globalActivity.newTask"
+                        values={{ title: item.payload.task_title }}
+                        components={[
+                          <span style={{ fontWeight: 700, color: 'var(--color-text-primary)' }} />,
+                          <Link
+                            to={`/tasks/${item.payload.task_id}`}
+                            style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}
+                          />,
+                        ]}
+                      />
                     ) : (
-                      <>
-                        <span style={{ fontWeight: 700, color: 'var(--color-text-primary)' }}>
-                          {item.actor_display_name}
-                        </span>
-                        {' completed '}
-                        <span style={{ color: 'var(--color-text-secondary)' }}>
-                          {item.payload.task_title || item.payload.praxis_title || 'a task'}
-                        </span>
-                      </>
+                      <Trans
+                        i18nKey="sidebar.globalActivity.completedTask"
+                        values={{
+                          actor: item.actor_display_name,
+                          title:
+                            item.payload.task_title ||
+                            item.payload.praxis_title ||
+                            t('sidebar.globalActivity.fallbackTaskTitle'),
+                        }}
+                        components={[
+                          <span style={{ fontWeight: 700, color: 'var(--color-text-primary)' }} />,
+                          <span style={{ color: 'var(--color-text-secondary)' }} />,
+                        ]}
+                      />
                     )}
                   </div>
                   <span className="font-body" style={{ fontSize: 7, color: 'var(--color-text-tertiary)' }}>
@@ -271,7 +283,7 @@ export default function Sidebar() {
         to="/propose-task"
         className="btn-primary text-center w-full block"
       >
-        Propose a Task
+        {t('actions.proposeTask')}
       </Link>
     </aside>
   )
@@ -299,6 +311,7 @@ function PendingRequestRow({
   isFirst: boolean
   onResolved: () => void
 }) {
+  const { t } = useTranslation('common')
   const isCollab = item.type === 'collab_invite'
   const actorId = isCollab
     ? item.payload.inviter_character_id
@@ -340,7 +353,7 @@ function PendingRequestRow({
             className="eyebrow block"
             style={{ color: 'var(--color-text-tertiary)', textDecoration: 'none' }}
           >
-            {isCollab ? 'Collab Invite' : 'Duel Challenge'}
+            {isCollab ? t('requests.collabInvite') : t('requests.duelChallenge')}
           </Link>
         </div>
       </div>
@@ -356,7 +369,7 @@ function PendingRequestRow({
             cursor: loading ? 'not-allowed' : 'pointer',
           }}
         >
-          Accept
+          {t('actions.accept')}
         </button>
         <button
           onClick={() => respond(decline)}
@@ -369,7 +382,7 @@ function PendingRequestRow({
             cursor: loading ? 'not-allowed' : 'pointer',
           }}
         >
-          Decline
+          {t('actions.decline')}
         </button>
       </div>
       {error && (

--- a/frontend/src/components/ui/FilterFactionTabs.tsx
+++ b/frontend/src/components/ui/FilterFactionTabs.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import type { FactionOut } from "../../api/factions";
 import {
   factionCssVar,
@@ -20,9 +21,10 @@ export default function FilterFactionTabs({
   value,
   onChange,
 }: Props) {
+  const { t } = useTranslation('common');
   return (
     <div className="flex gap-1 items-center">
-      <span className="eyebrow">faction:</span>
+      <span className="eyebrow">{t("filters.faction")}</span>
       {sortFactionsByRainbowOrder(factions).map((faction) => {
         const active = value === faction.slug;
         return (

--- a/frontend/src/components/ui/FilterLevelNodes.tsx
+++ b/frontend/src/components/ui/FilterLevelNodes.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 /**
  * Level filter — Connected Nodes (Style Guide §5.3).
  * Row of circles connected by horizontal bars. Active: dark fill, scale(1.15).
@@ -11,9 +13,10 @@ interface Props {
 }
 
 export default function FilterLevelNodes({ levels, value, onChange }: Props) {
+  const { t } = useTranslation('common')
   return (
     <div className="flex items-center">
-      <span className="eyebrow mr-2">level:</span>
+      <span className="eyebrow mr-2">{t('filters.level')}</span>
       {levels.map((level, index) => {
         const active = value === level
         return (
@@ -43,7 +46,7 @@ export default function FilterLevelNodes({ levels, value, onChange }: Props) {
                 padding: 0,
               }}
             >
-              {level}+
+              {t('filters.levelAtLeast', { level })}
             </button>
           </div>
         )

--- a/frontend/src/components/ui/FilterStamps.tsx
+++ b/frontend/src/components/ui/FilterStamps.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 /**
  * Status filter — Rubber Stamps (Style Guide §5.3).
  * Rectangular, no border-radius, inner dashed border, bold uppercase.
@@ -11,9 +13,10 @@ interface Props {
 }
 
 export default function FilterStamps({ options, value, onChange }: Props) {
+  const { t } = useTranslation('common')
   return (
     <div className="flex gap-1.5 items-center">
-      <span className="eyebrow">status:</span>
+      <span className="eyebrow">{t('filters.status')}</span>
       {options.map((option) => {
         const active = value === option
         return (

--- a/frontend/src/components/ui/LevelPill.tsx
+++ b/frontend/src/components/ui/LevelPill.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { factionCssVar } from "../../utils/factions";
 
 /**
@@ -14,6 +15,7 @@ export default function LevelPill({
   level: number;
   factionSlug?: string | null;
 }) {
+  const { t } = useTranslation('common');
   const bg = factionSlug
     ? factionCssVar(factionSlug, "card-accent")
     : "var(--color-text-primary)";
@@ -34,7 +36,7 @@ export default function LevelPill({
         letterSpacing: "0.08em",
       }}
     >
-      lvl {level}
+      {t("level.short", { level })}
     </span>
   );
 }

--- a/frontend/src/components/ui/VoteStamps.tsx
+++ b/frontend/src/components/ui/VoteStamps.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { castVote } from '../../api/votes'
 import { useAuth } from '../../auth/AuthContext'
 import { extractError } from '../../utils/errors'
@@ -14,14 +15,6 @@ interface StampConfig {
   color: string
 }
 
-const STAMPS: StampConfig[] = [
-  { value: 1, label: 'a start', color: 'var(--vote-1)' },
-  { value: 2, label: 'solid',   color: 'var(--vote-2)' },
-  { value: 3, label: 'good',    color: 'var(--vote-3)' },
-  { value: 4, label: 'excellent', color: 'var(--vote-4)' },
-  { value: 5, label: 'legendary', color: 'var(--vote-5)' },
-]
-
 interface Props {
   praxisId: number
   currentValue?: number
@@ -31,10 +24,19 @@ interface Props {
 }
 
 export default function VoteStamps({ praxisId, currentValue, points, totalVotes }: Props) {
+  const { t } = useTranslation('common')
   const { user, refetch } = useAuth()
   const [selected, setSelected] = useState(currentValue ?? 0)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+
+  const stamps: StampConfig[] = [
+    { value: 1, label: t('voteStamps.a-start'), color: 'var(--vote-1)' },
+    { value: 2, label: t('voteStamps.solid'), color: 'var(--vote-2)' },
+    { value: 3, label: t('voteStamps.good'), color: 'var(--vote-3)' },
+    { value: 4, label: t('voteStamps.excellent'), color: 'var(--vote-4)' },
+    { value: 5, label: t('voteStamps.legendary'), color: 'var(--vote-5)' },
+  ]
 
   const handleVote = async (stars: number) => {
     setSaving(true)
@@ -45,7 +47,7 @@ export default function VoteStamps({ praxisId, currentValue, points, totalVotes 
       // Refresh sidebar character stats (score/level may have changed)
       void refetch()
     } catch (err) {
-      setError(extractError(err, 'Could not save your vote. Please try again.'))
+      setError(extractError(err, t('voteStamps.saveError')))
     } finally {
       setSaving(false)
     }
@@ -55,10 +57,10 @@ export default function VoteStamps({ praxisId, currentValue, points, totalVotes 
     <div>
       {/* Stamp buttons — hidden for logged-out users */}
       {!user ? (
-        <p className="eyebrow">Log in to vote</p>
+        <p className="eyebrow">{t('voteStamps.loginPrompt')}</p>
       ) : (
         <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
-          {STAMPS.map((stamp) => {
+          {stamps.map((stamp) => {
             const active = selected === stamp.value
             return (
               <div key={stamp.value} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
@@ -67,7 +69,7 @@ export default function VoteStamps({ praxisId, currentValue, points, totalVotes 
                   onClick={() => void handleVote(stamp.value)}
                   className={active ? 'vote-stamp vote-stamp-active' : 'vote-stamp'}
                   style={{ '--stamp-color': stamp.color } as React.CSSProperties}
-                  aria-label={`Rate ${stamp.value} — ${stamp.label}`}
+                  aria-label={t('voteStamps.rateAria', { value: stamp.value, label: stamp.label })}
                 >
                   {/* Inner dashed border on selected */}
                   {active && (
@@ -105,14 +107,14 @@ export default function VoteStamps({ praxisId, currentValue, points, totalVotes 
       {/* Vote economy info */}
       {selected > 0 && (
         <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)', marginBottom: 8 }}>
-          Voted {selected} pts
+          {t('voteStamps.voted', { count: selected })}
         </p>
       )}
 
       {/* Summary */}
       {points != null && (
         <p className="font-body" style={{ fontSize: 9, color: 'var(--color-text-secondary)' }}>
-          {totalVotes ?? 0} votes · {points} pts
+          {t('voteStamps.summary', { count: totalVotes ?? 0, points })}
         </p>
       )}
 

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -1,1 +1,101 @@
-{}
+{
+  "brand": "World Zero",
+  "loading": "Loading...",
+  "nav": {
+    "home": "Home",
+    "tasks": "Tasks",
+    "praxis": "Praxis",
+    "players": "Players",
+    "factions": "Factions",
+    "updates": "Updates",
+    "admin": "Admin",
+    "adminMode": {
+      "badge": "MOD",
+      "enableTitle": "Enable admin mode",
+      "disableTitle": "Admin mode ON — click to disable"
+    },
+    "themeToggle": {
+      "toLight": "light",
+      "toDark": "dark"
+    },
+    "fieldDeskTitle": "Your FieldDesk — switch lives or begin a new one",
+    "createCharacter": "create character",
+    "logout": "logout",
+    "login": "Login"
+  },
+  "footer": {
+    "about": "About",
+    "contact": "Contact",
+    "disclaimer": "Disclaimer",
+    "attributions": "Attributions",
+    "donate": "Donate"
+  },
+  "actions": {
+    "accept": "Accept",
+    "decline": "Decline",
+    "proposeTask": "Propose a Task"
+  },
+  "filters": {
+    "faction": "faction:",
+    "level": "level:",
+    "status": "status:",
+    "levelAtLeast": "{{level}}+"
+  },
+  "level": {
+    "short": "lvl {{level}}"
+  },
+  "praxisType": {
+    "solo": "Solo",
+    "collab": "Collab",
+    "duel": "Duel"
+  },
+  "requests": {
+    "collabInvite": "Collab Invite",
+    "duelChallenge": "Duel Challenge"
+  },
+  "sidebar": {
+    "characterCard": {
+      "eyebrow": "Your Character",
+      "factionLevel": "{{faction}} · Level {{level}}",
+      "noCharacter": "No character yet"
+    },
+    "stats": {
+      "score": "Score",
+      "votes": "Votes",
+      "current": "Current",
+      "currentValue": "Era 3"
+    },
+    "pendingRequests": {
+      "heading_one": "Pending Requests · {{count}}",
+      "heading_other": "Pending Requests · {{count}}"
+    },
+    "activeTasks": {
+      "heading": "In progress tasks",
+      "empty": "No in progress tasks",
+      "slots_one": "{{count}} / {{max}} slots",
+      "slots_other": "{{count}} / {{max}} slots"
+    },
+    "globalActivity": {
+      "heading": "Recent global activity",
+      "empty": "No activity yet",
+      "eraBegun": "{{eraName}} has begun",
+      "newTask": "<0>New task:</0> <1>{{title}}</1>",
+      "completedTask": "<0>{{actor}}</0> completed <1>{{title}}</1>",
+      "fallbackTaskTitle": "a task"
+    }
+  },
+  "voteStamps": {
+    "a-start": "a start",
+    "solid": "solid",
+    "good": "good",
+    "excellent": "excellent",
+    "legendary": "legendary",
+    "rateAria": "Rate {{value}} — {{label}}",
+    "loginPrompt": "Log in to vote",
+    "voted_one": "Voted {{count}} pt",
+    "voted_other": "Voted {{count}} pts",
+    "summary_one": "{{count}} vote · {{points}} pts",
+    "summary_other": "{{count}} votes · {{points}} pts",
+    "saveError": "Could not save your vote. Please try again."
+  }
+}


### PR DESCRIPTION
## Summary
Extracts every user-facing string in the app-wide chrome into the `common` i18n namespace, per the #440 foundation and `locales/README.md` conventions.

**Swept files:** `App.tsx` (loading states), `components/Layout.tsx` (footer links), `components/NavBar.tsx` (wordmark, nav links, admin-mode toggle + titles, theme toggle, login/logout, FieldDesk title), `components/layout/Sidebar.tsx` (character card, stats, pending requests, active tasks, global activity, propose button), `components/ui/` (VoteStamps incl. aria-labels + error copy, FilterFactionTabs, FilterLevelNodes, FilterStamps, LevelPill). `components/layout/WatercolorBackground.tsx` and `components/ui/PageTitle.tsx` contain no user-facing literals.

**Catalog:** 67 keys added to `locales/en/common.json` (~63 distinct strings; 4 plural pairs).

## Notes
- **Key style:** `useTranslation('common')` + unprefixed keys. The i18next v26 typed `t` bound via `useTranslation` rejects inline `ns:`-prefixed keys (only the raw `i18n.t` accepts them), so `t('common:...')` fails `tsc`. This matches the pattern the merged #469 home sweep used (`useTranslation('home')`).
- **`<Trans>` with numbered tags** for the two sidebar activity rows with embedded markup (new-task link, completed-task bold/secondary spans).
- **Native plurals** (`_one`/`_other`) wherever a count renders: vote summary ("1 vote" vs "n votes"), voted points, task slots, pending-request heading. Grammar fix as a side effect: "1 votes" → "1 vote", "Voted 1 pts" → "Voted 1 pt".
- Vote-tier stamp labels (`a-start`…`legendary`) live in `common` because `ui/VoteStamps` is the generic (non-faction) caster; the per-faction voices stay in `votes.json`.
- Non-user-facing strings (routes, classNames, CSS vars, identifiers) untouched.

## Gates
- `tsc --noEmit`: clean
- `vitest run`: 21 files / 193 tests passed
- `vite build`: green

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)