### PR TITLE
feat(i18n): sweep vote UI chrome into votes.json (#443)

### DIFF
--- a/frontend/src/components/__tests__/voteReframes.test.tsx
+++ b/frontend/src/components/__tests__/voteReframes.test.tsx
@@ -21,7 +21,15 @@ vi.mock('../../auth/AuthContext', () => ({
 
 // ── Registry structure ────────────────────────────────────────────────────────
 
-const REGISTERED_SLUGS = ['ephemerists', 'everymen', 'wow', 'snide', 'singularity', 'ua'] as const
+const REGISTERED_SLUGS = [
+  'ephemerists',
+  'everymen',
+  'wow',
+  'snide',
+  'singularity',
+  'ua',
+  'albescent',
+] as const
 
 describe('VOTE_REFRAMES registry', () => {
   for (const slug of REGISTERED_SLUGS) {

--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteSummary } from './VoteShell'
@@ -33,6 +34,7 @@ export default function AlbescentVote({
   points,
   totalVotes,
 }: VoteUIProps) {
+  const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -51,7 +53,7 @@ export default function AlbescentVote({
           marginBottom: 10,
         }}
       >
-        Bear Witness
+        {t('chrome.albescent.prompt')}
       </div>
 
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'flex-start' }}>
@@ -67,7 +69,7 @@ export default function AlbescentVote({
               <button
                 disabled={saving}
                 onClick={() => void vote(tier.value)}
-                aria-label={`Witness ${tier.value} — ${tier.label}`}
+                aria-label={t('chrome.albescent.rateAria', { value: tier.value, label: tier.label })}
                 style={{
                   width: 32,
                   height: 32,

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import type { VoteUIProps } from "./VoteUI";
 import { useVote } from "./useVote";
 import { VoteLoginGate, VoteSummary } from "./VoteShell";
@@ -25,6 +26,7 @@ export default function EphemeristsVote({
   points,
   totalVotes,
 }: VoteUIProps) {
+  const { t } = useTranslation("votes");
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue);
 
   if (!user) {
@@ -43,7 +45,7 @@ export default function EphemeristsVote({
               <button
                 disabled={saving}
                 onClick={() => void vote(tier.value)}
-                aria-label={`Mark ${tier.value} — ${tier.label}`}
+                aria-label={t("chrome.ephemerists.rateAria", { value: tier.value, label: tier.label })}
                 style={{
                   position: "relative",
                   width: SEAL_SIZE,

--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteSummary } from './VoteShell'
@@ -27,6 +28,7 @@ const STAMP_SIZE = 40
 const TIERS = VOTE_REFRAMES['everymen'].tiers
 
 export default function EverymenVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
+  const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -48,7 +50,7 @@ export default function EverymenVote({ praxisId, currentValue, points, totalVote
               <button
                 disabled={saving}
                 onClick={() => void vote(tier.value)}
-                aria-label={`Rate ${tier.value} — ${tier.label}`}
+                aria-label={t('chrome.everymen.rateAria', { value: tier.value, label: tier.label })}
                 style={{
                   position: 'relative',
                   width: STAMP_SIZE,

--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteSummary } from './VoteShell'
@@ -33,6 +34,7 @@ const KEY_SIZE = 42
 const TIERS = VOTE_REFRAMES['singularity'].tiers
 
 export default function SingularityVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
+  const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -50,7 +52,7 @@ export default function SingularityVote({ praxisId, currentValue, points, totalV
           marginBottom: 3,
         }}
       >
-        Cast Signal
+        {t('chrome.singularity.prompt')}
       </div>
       <div
         style={{
@@ -60,7 +62,7 @@ export default function SingularityVote({ praxisId, currentValue, points, totalV
           marginBottom: 12,
         }}
       >
-        how confidently does this output hold?
+        {t('chrome.singularity.promptHint')}
       </div>
 
       <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
@@ -73,7 +75,7 @@ export default function SingularityVote({ praxisId, currentValue, points, totalV
               <button
                 disabled={saving}
                 onClick={() => void vote(tier.value)}
-                aria-label={`Cast ${tier.value} — ${tier.label}`}
+                aria-label={t('chrome.singularity.rateAria', { value: tier.value, label: tier.label })}
                 style={{
                   position: 'relative',
                   width: KEY_SIZE,

--- a/frontend/src/components/vote/SnideVote.tsx
+++ b/frontend/src/components/vote/SnideVote.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteSummary } from './VoteShell'
@@ -36,6 +37,7 @@ const SNIDE_VISUALS: Record<number, StampVisual> = {
 const TIERS = VOTE_REFRAMES['snide'].tiers
 
 export default function SnideVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
+  const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -54,7 +56,7 @@ export default function SnideVote({ praxisId, currentValue, points, totalVotes }
               key={tier.value}
               disabled={saving}
               onClick={() => void vote(tier.value)}
-              aria-label={`Rate ${tier.value} — ${tier.label}`}
+              aria-label={t('chrome.snide.rateAria', { value: tier.value, label: tier.label })}
               style={{
                 minWidth: 46,
                 height: 40,

--- a/frontend/src/components/vote/UAVote.tsx
+++ b/frontend/src/components/vote/UAVote.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteSummary } from './VoteShell'
@@ -25,6 +26,7 @@ export default function UAVote({
   points,
   totalVotes,
 }: VoteUIProps) {
+  const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -46,7 +48,7 @@ export default function UAVote({
               <button
                 disabled={saving}
                 onClick={() => void vote(tier.value)}
-                aria-label={`Appraise ${tier.value} — ${tier.label}`}
+                aria-label={t('chrome.ua.rateAria', { value: tier.value, label: tier.label })}
                 style={{
                   minWidth: 60,
                   height: 40,
@@ -87,7 +89,9 @@ export default function UAVote({
                   textTransform: 'uppercase',
                 }}
               >
-                {tier.value === 5 ? '✦' : `№${tier.value}`}
+                {tier.value === 5
+                  ? t('chrome.ua.plateTopMark')
+                  : t('chrome.ua.plateNumber', { value: tier.value })}
               </span>
             </div>
           )

--- a/frontend/src/components/vote/VoteShell.tsx
+++ b/frontend/src/components/vote/VoteShell.tsx
@@ -1,13 +1,17 @@
+import { Trans, useTranslation } from 'react-i18next'
+
 /**
  * Shared chrome for per-faction vote UIs. The 1-5 control itself is faction-
  * specific (ink stamps, hearts, …), but the logged-out gate and the
  * points/"voted"/error summary are identical in structure — only their theme
- * colors differ. These two helpers keep that chrome in one place.
+ * colors differ. These two helpers keep that chrome in one place. Copy lives
+ * in the votes:chrome catalog branch (ADR-0032).
  */
 
 /** Logged-out gate shown in place of the vote control. */
 export function VoteLoginGate() {
-  return <p className="eyebrow">Log in to vote</p>
+  const { t } = useTranslation('votes')
+  return <p className="eyebrow">{t('chrome.loginGate')}</p>
 }
 
 export interface VoteSummaryTheme {
@@ -33,11 +37,13 @@ export function VoteSummary({
   error: string
   theme: VoteSummaryTheme
 }) {
+  const { t } = useTranslation('votes')
+
   return (
     <>
       {selected > 0 && (
         <p className="font-body" style={{ fontSize: 8, color: theme.muted, margin: '8px 0 0' }}>
-          Voted {selected} pts
+          {t('chrome.voted', { stars: selected })}
         </p>
       )}
 
@@ -51,11 +57,23 @@ export function VoteSummary({
             letterSpacing: theme.avgLetterSpacing,
           }}
         >
-          {totalVotes ?? 0} votes ·{' '}
-          <b style={{ color: theme.accent, fontFamily: theme.accentFont, fontSize: theme.avgFontSize }}>
-            {points}
-          </b>{' '}
-          pts
+          <Trans
+            t={t}
+            i18nKey="chrome.tally"
+            count={totalVotes ?? 0}
+            values={{ points }}
+            components={{
+              1: (
+                <b
+                  style={{
+                    color: theme.accent,
+                    fontFamily: theme.accentFont,
+                    fontSize: theme.avgFontSize,
+                  }}
+                />
+              ),
+            }}
+          />
         </p>
       )}
 

--- a/frontend/src/components/vote/WowVote.tsx
+++ b/frontend/src/components/vote/WowVote.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteSummary } from './VoteShell'
@@ -42,6 +43,7 @@ function HeartGlyph({ filled, color, size = 30 }: { filled: boolean; color: stri
 }
 
 export default function WowVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
+  const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   if (!user) {
@@ -63,7 +65,7 @@ export default function WowVote({ praxisId, currentValue, points, totalVotes }: 
               <button
                 disabled={saving}
                 onClick={() => void vote(tier.value)}
-                aria-label={`Rate ${tier.value} — ${tier.label}`}
+                aria-label={t('chrome.wow.rateAria', { value: tier.value, label: tier.label })}
                 style={{
                   width: HEART_TILE,
                   height: HEART_TILE,

--- a/frontend/src/components/vote/useVote.ts
+++ b/frontend/src/components/vote/useVote.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { castVote } from '../../api/votes'
 import { useAuth } from '../../auth/AuthContext'
 import { extractError } from '../../utils/errors'
@@ -9,6 +10,7 @@ import { extractError } from '../../utils/errors'
  * hook so the cast/refetch logic lives in exactly one place.
  */
 export function useVote(praxisId: number, currentValue?: number) {
+  const { t } = useTranslation('votes')
   const { user, refetch } = useAuth()
   const [selected, setSelected] = useState(currentValue ?? 0)
   const [saving, setSaving] = useState(false)
@@ -23,7 +25,7 @@ export function useVote(praxisId: number, currentValue?: number) {
       // Refresh sidebar character stats (score/level may have changed)
       void refetch()
     } catch (err) {
-      setError(extractError(err, 'Could not save your vote. Please try again.'))
+      setError(extractError(err, t('chrome.saveError')))
     } finally {
       setSaving(false)
     }

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -1,3 +1,4 @@
+import i18n from '../../i18n'
 import { FACTION_ALIASES } from '../../utils/factions'
 
 export interface ReframeTier {
@@ -11,72 +12,77 @@ export interface VoteReframe {
   tiers: ReframeTier[]
 }
 
-/** Per-faction tier vocabulary (structure + words only; visual tokens stay in each archetype). */
+/**
+ * Per-faction tier vocabulary (structure only; the words live in the copy
+ * catalog at locales/en/votes.json and visual tokens stay in each archetype).
+ * Labels are resolved through i18n at module load — the catalog is bundled and
+ * initialized synchronously, and the app is single-locale (ADR-0032).
+ */
 export const VOTE_REFRAMES: Record<string, VoteReframe> = {
   ephemerists: {
     numeral: 'roman',
     tiers: [
-      { value: 1, label: 'apocryphal' },
-      { value: 2, label: 'disputed' },
-      { value: 3, label: 'plausible' },
-      { value: 4, label: 'corroborated' },
-      { value: 5, label: 'canonical' },
+      { value: 1, label: i18n.t('votes:ephemerists.apocryphal') },
+      { value: 2, label: i18n.t('votes:ephemerists.disputed') },
+      { value: 3, label: i18n.t('votes:ephemerists.plausible') },
+      { value: 4, label: i18n.t('votes:ephemerists.corroborated') },
+      { value: 5, label: i18n.t('votes:ephemerists.canonical') },
     ],
   },
   everymen: {
     tiers: [
-      { value: 1, label: 'a start' },
-      { value: 2, label: 'solid' },
-      { value: 3, label: 'good' },
-      { value: 4, label: 'excellent' },
-      { value: 5, label: 'legendary' },
+      { value: 1, label: i18n.t('votes:everymen.a-start') },
+      { value: 2, label: i18n.t('votes:everymen.solid') },
+      { value: 3, label: i18n.t('votes:everymen.good') },
+      { value: 4, label: i18n.t('votes:everymen.excellent') },
+      { value: 5, label: i18n.t('votes:everymen.legendary') },
     ],
   },
   wow: {
     tiers: [
-      { value: 1, label: 'a start' },
-      { value: 2, label: 'solid' },
-      { value: 3, label: 'good' },
-      { value: 4, label: 'excellent' },
-      { value: 5, label: 'legendary' },
+      { value: 1, label: i18n.t('votes:wow.a-start') },
+      { value: 2, label: i18n.t('votes:wow.solid') },
+      { value: 3, label: i18n.t('votes:wow.good') },
+      { value: 4, label: i18n.t('votes:wow.excellent') },
+      { value: 5, label: i18n.t('votes:wow.legendary') },
     ],
   },
   snide: {
     tiers: [
-      { value: 1, label: 'meh' },
-      { value: 2, label: 'not bad' },
-      { value: 3, label: 'rad' },
-      { value: 4, label: 'sick' },
-      { value: 5, label: 'ANARCHY' },
+      { value: 1, label: i18n.t('votes:snide.meh') },
+      { value: 2, label: i18n.t('votes:snide.not-bad') },
+      { value: 3, label: i18n.t('votes:snide.rad') },
+      { value: 4, label: i18n.t('votes:snide.sick') },
+      { value: 5, label: i18n.t('votes:snide.anarchy') },
     ],
   },
   singularity: {
     tiers: [
-      { value: 1, label: 'NOISE' },
-      { value: 2, label: 'WEAK' },
-      { value: 3, label: 'SIGNAL' },
-      { value: 4, label: 'CLEAR' },
-      { value: 5, label: 'VERIFIED' },
+      { value: 1, label: i18n.t('votes:singularity.noise') },
+      { value: 2, label: i18n.t('votes:singularity.weak') },
+      { value: 3, label: i18n.t('votes:singularity.signal') },
+      { value: 4, label: i18n.t('votes:singularity.clear') },
+      { value: 5, label: i18n.t('votes:singularity.verified') },
     ],
   },
   ua: {
     tiers: [
-      { value: 1, label: 'rough sketch' },
-      { value: 2, label: 'study' },
-      { value: 3, label: 'accomplished' },
-      { value: 4, label: 'distinguished' },
-      { value: 5, label: 'masterwork' },
+      { value: 1, label: i18n.t('votes:ua.rough-sketch') },
+      { value: 2, label: i18n.t('votes:ua.study') },
+      { value: 3, label: i18n.t('votes:ua.accomplished') },
+      { value: 4, label: i18n.t('votes:ua.distinguished') },
+      { value: 5, label: i18n.t('votes:ua.masterwork') },
     ],
   },
   // Albescent "bear witness" vocabulary (#232) — how completely a task was
   // attended, Unseeing → Inscribed. Words from docs/design/albescent-kit.
   albescent: {
     tiers: [
-      { value: 1, label: 'Unseeing' },
-      { value: 2, label: 'Glimpsed' },
-      { value: 3, label: 'Witnessed' },
-      { value: 4, label: 'Verified' },
-      { value: 5, label: 'Inscribed' },
+      { value: 1, label: i18n.t('votes:albescent.unseeing') },
+      { value: 2, label: i18n.t('votes:albescent.glimpsed') },
+      { value: 3, label: i18n.t('votes:albescent.witnessed') },
+      { value: 4, label: i18n.t('votes:albescent.verified') },
+      { value: 5, label: i18n.t('votes:albescent.inscribed') },
     ],
   },
 }

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -5,8 +5,17 @@ import praxis from '../en/praxis.json'
 import votes from '../en/votes.json'
 
 // Factions with a vote voice (per-faction tier labels). Kept as an explicit
-// list, mirroring the seed catalog this test was ported from.
-const FACTION_SLUGS = ['ephemerists', 'everymen', 'wow', 'snide', 'singularity', 'ua'] as const
+// list, mirroring the seed catalog this test was ported from. Albescent joined
+// with its first-class "bear witness" vocabulary in the #443 sweep.
+const FACTION_SLUGS = [
+  'ephemerists',
+  'everymen',
+  'wow',
+  'snide',
+  'singularity',
+  'ua',
+  'albescent',
+] as const
 const EXPECTED_TIER_COUNT = 5
 
 describe('en copy catalog shape', () => {

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -40,5 +40,45 @@
     "accomplished": "accomplished",
     "distinguished": "distinguished",
     "masterwork": "masterwork"
+  },
+  "albescent": {
+    "unseeing": "Unseeing",
+    "glimpsed": "Glimpsed",
+    "witnessed": "Witnessed",
+    "verified": "Verified",
+    "inscribed": "Inscribed"
+  },
+  "chrome": {
+    "loginGate": "Log in to vote",
+    "voted": "Voted {{stars}} pts",
+    "tally_one": "{{count}} vote · <1>{{points}}</1> pts",
+    "tally_other": "{{count}} votes · <1>{{points}}</1> pts",
+    "saveError": "Could not save your vote. Please try again.",
+    "ephemerists": {
+      "rateAria": "Mark {{value}} — {{label}}"
+    },
+    "everymen": {
+      "rateAria": "Rate {{value}} — {{label}}"
+    },
+    "wow": {
+      "rateAria": "Rate {{value}} — {{label}}"
+    },
+    "snide": {
+      "rateAria": "Rate {{value}} — {{label}}"
+    },
+    "singularity": {
+      "rateAria": "Cast {{value}} — {{label}}",
+      "prompt": "Cast Signal",
+      "promptHint": "how confidently does this output hold?"
+    },
+    "ua": {
+      "rateAria": "Appraise {{value}} — {{label}}",
+      "plateNumber": "№{{value}}",
+      "plateTopMark": "✦"
+    },
+    "albescent": {
+      "rateAria": "Witness {{value}} — {{label}}",
+      "prompt": "Bear Witness"
+    }
   }
 }


### PR DESCRIPTION
Closes #443

## What

Sweeps every remaining user-facing string in `frontend/src/components/vote/` into the `votes` copy catalog (ADR-0032). The per-faction tier labels keep their existing flat `votes.<slug>.<tier>` structure; all new chrome lives under a `votes.chrome` branch with explicit faction-slug nesting.

### Extracted

- **Shared chrome** — login gate ("Log in to vote"), "Voted {{stars}} pts", the votes/points tally (`<Trans>` with native `_one`/`_other` plurals and a numbered tag for the bold points), and the cast-vote error fallback in `useVote`.
- **Per-faction aria templates** — `chrome.<slug>.rateAria` for all seven vote archetypes ("Rate/Mark/Cast/Appraise/Witness {{value}} — {{label}}").
- **Faction prompts** — Singularity "Cast Signal" + hint, Albescent "Bear Witness", UA plate marks (`№{{value}}` / `✦`).
- **Albescent tier labels** join the catalog first-class (`Unseeing` → `Inscribed`) — they previously existed only hardcoded in `voteReframes.ts`.

### Mechanics

- `voteReframes.ts` now resolves every tier label through `i18n.t` instead of carrying a duplicate hardcoded vocabulary; `VOTE_REFRAMES` / `reframeLabel` API unchanged, so `praxisDetail/shared.tsx` consumers are untouched.
- Components bind `useTranslation('votes')` with unprefixed keys — the typed `t` from the default-NS hook rejects `votes:`-prefixed keys in react-i18next v17, while the namespace-bound hook typechecks (same pattern the #448 Home sweep used).
- The "5 tiers per faction" assertions are kept and extended to `albescent` in both guards (`locales/__tests__/catalog.test.ts` and `components/__tests__/voteReframes.test.tsx`).

22 new catalog keys; 30 previously-duplicated tier labels now flow from the catalog.

## Gates

- `npx tsc --noEmit` — clean
- `npm test -- --run` — 21 files / 194 tests passed
- `npx eslint src/components/vote/` — 0 errors (remaining warnings are the warning-only `no-literal-string` rule firing on CSS-var strings and on the `t()` calls themselves; #450 owns tuning that rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
