### PR TITLE
Re-home self-edit affordance in sidebar character card

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -54,8 +54,17 @@ export default function Sidebar() {
       {/* ── Character Card ── */}
       {character ? (
         <div className="sidebar-card">
-          <div className="eyebrow mb-2" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-            {t('sidebar.characterCard.eyebrow')}
+          <div className="flex items-baseline justify-between mb-2">
+            <span className="eyebrow" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
+              {t('sidebar.characterCard.eyebrow')}
+            </span>
+            <Link
+              to={`/characters/${character.id}/edit`}
+              className="eyebrow hover:underline"
+              style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}
+            >
+              {t('sidebar.characterCard.edit')}
+            </Link>
           </div>
           <div className="flex items-center gap-3 mb-3">
             {character.avatar_url ? (

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -56,6 +56,7 @@
   "sidebar": {
     "characterCard": {
       "eyebrow": "Your Character",
+      "edit": "edit",
       "factionLevel": "{{faction}} · Level {{level}}",
       "noCharacter": "No character yet"
     },


### PR DESCRIPTION
## What

Adds a small **`edit`** link to the always-on Sidebar "Your Character" card, pointing to `/characters/:id/edit`.

## Why

Issue #459 rebuilds `CharacterProfile.tsx` as the public player-profile contract, which by design removes the **"Edit Profile"** and **"+ New Character"** buttons. "Edit Profile" was the *only* UI link to the `/characters/:id/edit` route ([EditCharacter.tsx](frontend/src/pages/EditCharacter.tsx)), so it would be orphaned once #459 lands. This pre-positions its new home.

`/characters/create` needs **no** new home — it's already covered by:
- [FieldDesk](frontend/src/pages/FieldDesk.tsx)'s `NewSelfDossier` (gated on `can_create_additional_character`), and
- [NavBar](frontend/src/components/NavBar.tsx) (create-character link when no character exists).

So only the edit affordance is re-homed here.

## Where

The Sidebar "Your Character" card ([Sidebar.tsx](frontend/src/components/layout/Sidebar.tsx)) already shows the active character and links to its profile — the natural place for self-management. The new link reuses the existing eyebrow-link pattern (matches the praxis-edit link style), so no design input was needed.

## Verification

- `npx tsc --noEmit` — no errors in `Sidebar.tsx` (pre-existing errors in unrelated uncommitted working-tree files only)
- `vitest run` — no new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)