### PR TITLE
feat: player-profile contract + default skin + badges foundation (#459)

### DIFF
--- a/backend/badges.py
+++ b/backend/badges.py
@@ -1,0 +1,50 @@
+"""Badge registry — code-defined badges evaluated on read (ADR-0033, #459).
+
+A badge is a frozen dataclass with a ``condition`` predicate over a
+:class:`BadgeContext`. There is no badge table, no ``earned_at``, no award
+events, and no admin grant — a badge either holds *right now* for a character
+or it doesn't. Adding a badge = adding one entry to :data:`ALL_BADGES`.
+
+The badge image is NOT part of the payload: the frontend maps ``key`` to a
+bundled asset (like faction sigils).
+"""
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class BadgeContext:
+    """Per-character facts a badge condition may consult.
+
+    Built by ``services.badge.build_badge_context`` from explicit queries —
+    never from lazy-loaded relationships (``Character.account`` is
+    ``lazy="raise"``).
+    """
+
+    # Total characters owned by this character's account (this one included).
+    account_character_count: int
+    # True when this character is the account's earliest by (created_at, id).
+    is_earliest_on_account: bool
+
+
+@dataclass(frozen=True)
+class Badge:
+    key: str  # stable identifier, e.g. "sock_puppeteer"
+    name: str  # display name, e.g. "Sock Puppeteer"
+    condition: Callable[[BadgeContext], bool]
+
+
+def _is_sock_puppeteer(context: BadgeContext) -> bool:
+    """Earliest character on an account that owns more than one."""
+    return context.account_character_count > 1 and context.is_earliest_on_account
+
+
+def _is_sock_puppet(context: BadgeContext) -> bool:
+    """A later character on an account that owns more than one."""
+    return context.account_character_count > 1 and not context.is_earliest_on_account
+
+
+ALL_BADGES: tuple[Badge, ...] = (
+    Badge(key="sock_puppeteer", name="Sock Puppeteer", condition=_is_sock_puppeteer),
+    Badge(key="sock_puppet", name="Sock Puppet", condition=_is_sock_puppet),
+)

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -19,6 +19,7 @@ from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
 from schemas.relationship import RelationshipOut
 from schemas.praxis import PraxisOut
 from services.auth import get_current_account
+from services.badge import list_badges_for_character
 from services.character import (
     CharacterCreationResult,
     build_character_out,
@@ -76,7 +77,9 @@ async def get_character(
         raise HTTPException(status_code=404, detail="Character not found.")
 
     stats = await load_current_era_stats(character_id, session)
-    return build_character_out(character, stats)
+    # Badges are evaluated on read, single-character path only (ADR-0033).
+    badges = await list_badges_for_character(character, session)
+    return build_character_out(character, stats, badges=badges)
 
 
 @router.post("", response_model=CharacterOut, status_code=201)

--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -3,12 +3,24 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class BadgeOut(BaseModel):
+    """A badge a character currently holds (ADR-0033). The image is a frontend
+    asset keyed by ``key`` — never part of the payload."""
+
+    key: str
+    name: str
+
+
 class CharacterOut(BaseModel):
     """Public character response. Stats (score, level, all_time_score) come from CharacterStats.
 
     votes_available is the on-read computed vote budget for the current era
     (see services.scoring.compute_votes_available); it reflects score growth
     and spent votes without a stored counter.
+
+    badges is evaluated on read (ADR-0033) and populated ONLY by the
+    single-character GET /characters/{id} — list serializers leave it empty
+    to avoid N+1 sibling queries. account_id / email never leave the backend.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -26,6 +38,7 @@ class CharacterOut(BaseModel):
     faction_slug: str
     status: str
     created_at: datetime
+    badges: list[BadgeOut] = Field(default_factory=list)
 
 
 class CharacterCreate(BaseModel):

--- a/backend/services/badge.py
+++ b/backend/services/badge.py
@@ -1,0 +1,53 @@
+"""Badge evaluation service (ADR-0033, #459).
+
+Evaluates the code-defined :data:`badges.ALL_BADGES` registry against a
+per-character :class:`badges.BadgeContext` built from explicit queries.
+Only the single-character read path calls this — list serializers skip
+badges entirely to avoid N+1 sibling queries.
+"""
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from badges import ALL_BADGES, BadgeContext
+from models.character import Character
+from schemas.character import BadgeOut
+
+
+async def build_badge_context(
+    character: Character,
+    session: AsyncSession,
+) -> BadgeContext:
+    """Assemble the facts badge conditions consult for one character.
+
+    ``Character.account`` is ``lazy="raise"`` — sibling characters are queried
+    explicitly by ``account_id``. The account's "earliest" character is the
+    first by ``(created_at, id)`` (id breaks same-instant creation ties).
+    """
+    result = await session.execute(
+        select(Character.id)
+        .where(Character.account_id == character.account_id)
+        .order_by(Character.created_at.asc(), Character.id.asc())
+    )
+    sibling_ids = [row[0] for row in result.all()]
+    earliest_id = sibling_ids[0] if sibling_ids else character.id
+    return BadgeContext(
+        account_character_count=len(sibling_ids),
+        is_earliest_on_account=character.id == earliest_id,
+    )
+
+
+def evaluate_badges(context: BadgeContext) -> list[BadgeOut]:
+    """Every registry badge whose condition holds, in registry order."""
+    return [
+        BadgeOut(key=badge.key, name=badge.name)
+        for badge in ALL_BADGES
+        if badge.condition(context)
+    ]
+
+
+async def list_badges_for_character(
+    character: Character,
+    session: AsyncSession,
+) -> list[BadgeOut]:
+    context = await build_badge_context(character, session)
+    return evaluate_badges(context)

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -14,7 +14,7 @@ from models.character_stats import CharacterStats
 from models.invitation_letter import InvitationLetter
 from models.praxis import ModerationStatus, Praxis, PraxisMember, PraxisStatus
 from models.task import Task
-from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
+from schemas.character import BadgeOut, CharacterCreate, CharacterOut, CharacterUpdate
 from services.era import get_current_era_row, get_current_era_row_safe, get_or_create_stats
 from services.scoring import compute_level, compute_vote_budget, compute_votes_available
 
@@ -29,10 +29,13 @@ _HANDLE_MAX_LEN = 14
 def build_character_out(
     character: Character,
     stats: CharacterStats | None,
+    badges: list[BadgeOut] | None = None,
 ) -> CharacterOut:
     """Flatten a Character row plus its (optional) CharacterStats into CharacterOut.
 
     votes_available is computed on read from stats.score and votes_spent_this_era.
+    badges (ADR-0033) is supplied only by the single-character read path; list
+    serializers omit it and the field defaults to empty.
     """
     return CharacterOut(
         id=character.id,
@@ -48,6 +51,7 @@ def build_character_out(
         all_time_score=stats.all_time_score if stats else 0,
         level=stats.level if stats else 0,
         votes_available=compute_votes_available(stats) if stats else 0,
+        badges=badges or [],
     )
 
 

--- a/backend/tests/integration/test_badges.py
+++ b/backend/tests/integration/test_badges.py
@@ -1,0 +1,145 @@
+"""Integration tests for on-read badges on GET /characters/{id} (ADR-0033, #459).
+
+The seed pair keys off one account owning multiple characters, ordered by
+created_at (earliest = sock_puppeteer, later = sock_puppet). Badges are
+populated only by the single-character read — the list endpoint leaves the
+field empty.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction
+
+
+async def _add_second_character(
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    created_at: datetime,
+) -> Character:
+    """Insert a second life for ``account`` directly (bypasses the level gate)."""
+    second = Character(
+        account_id=account.id,
+        username="secondlife",
+        display_name="Second Life",
+        faction_slug="na",
+        created_at=created_at,
+    )
+    db_session.add(second)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=second.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=0,
+            votes_spent_this_era=0,
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(second)
+    return second
+
+
+@pytest.mark.asyncio
+async def test_solo_character_has_no_badges(
+    client: AsyncClient, character: Character
+):
+    resp = await client.get(f"/characters/{character.id}")
+    assert resp.status_code == 200
+    assert resp.json()["badges"] == []
+
+
+@pytest.mark.asyncio
+async def test_two_lives_earn_sock_puppeteer_and_sock_puppet(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    second = await _add_second_character(
+        db_session,
+        account,
+        era,
+        created_at=character.created_at + timedelta(seconds=1),
+    )
+
+    first_resp = await client.get(f"/characters/{character.id}")
+    assert first_resp.status_code == 200
+    assert first_resp.json()["badges"] == [
+        {"key": "sock_puppeteer", "name": "Sock Puppeteer"}
+    ]
+
+    second_resp = await client.get(f"/characters/{second.id}")
+    assert second_resp.status_code == 200
+    assert second_resp.json()["badges"] == [
+        {"key": "sock_puppet", "name": "Sock Puppet"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_other_accounts_do_not_cross_pollinate(
+    client: AsyncClient, character: Character, character2: Character
+):
+    """Two solo characters on different accounts earn nothing from each other."""
+    for character_id in (character.id, character2.id):
+        resp = await client.get(f"/characters/{character_id}")
+        assert resp.status_code == 200
+        assert resp.json()["badges"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_endpoint_does_not_evaluate_badges(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    """Badges appear empty in the list serializer even when they'd be earned."""
+    await _add_second_character(
+        db_session,
+        account,
+        era,
+        created_at=character.created_at + timedelta(seconds=1),
+    )
+    resp = await client.get("/characters")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert rows, "expected at least the fixture characters"
+    assert all(row["badges"] == [] for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_profile_response_never_exposes_account_or_email(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    await _add_second_character(
+        db_session,
+        account,
+        era,
+        created_at=character.created_at + timedelta(seconds=1),
+    )
+    resp = await client.get(f"/characters/{character.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "account_id" not in data
+    assert "email" not in data
+    for badge in data["badges"]:
+        assert set(badge.keys()) == {"key", "name"}

--- a/backend/tests/unit/test_badges.py
+++ b/backend/tests/unit/test_badges.py
@@ -1,0 +1,41 @@
+"""Unit tests for the badge registry conditions (ADR-0033, #459).
+
+Covers the seed pair — sock_puppeteer / sock_puppet — across 1-character and
+2-character accounts, plus registry invariants. (A 0-character context cannot
+exist: the context is always built *for* a character, so the count includes it.)
+"""
+from badges import ALL_BADGES, BadgeContext
+from services.badge import evaluate_badges
+
+
+def _badge_keys(context: BadgeContext) -> list[str]:
+    return [badge.key for badge in evaluate_badges(context)]
+
+
+def test_solo_character_earns_nothing() -> None:
+    context = BadgeContext(account_character_count=1, is_earliest_on_account=True)
+    assert _badge_keys(context) == []
+
+
+def test_earliest_of_two_is_sock_puppeteer() -> None:
+    context = BadgeContext(account_character_count=2, is_earliest_on_account=True)
+    assert _badge_keys(context) == ["sock_puppeteer"]
+
+
+def test_later_of_two_is_sock_puppet() -> None:
+    context = BadgeContext(account_character_count=2, is_earliest_on_account=False)
+    assert _badge_keys(context) == ["sock_puppet"]
+
+
+def test_later_of_three_is_sock_puppet() -> None:
+    context = BadgeContext(account_character_count=3, is_earliest_on_account=False)
+    assert _badge_keys(context) == ["sock_puppet"]
+
+
+def test_registry_keys_are_unique() -> None:
+    keys = [badge.key for badge in ALL_BADGES]
+    assert len(keys) == len(set(keys))
+
+
+def test_registry_badges_have_display_names() -> None:
+    assert all(badge.name for badge in ALL_BADGES)

--- a/docs/adr/0033-player-profile-contract-and-badge-registry.md
+++ b/docs/adr/0033-player-profile-contract-and-badge-registry.md
@@ -1,0 +1,63 @@
+# Player profile: one faction-agnostic contract; badges are a code registry evaluated on read
+
+Issue #459 (foundation of the player-profile epic; the seven faction skins are #460).
+Design source: `player-profile-contract.json` + `guidelines/player-profile-contract.html`
+in the "World Zero Design System" cloud project.
+
+## Decision 1 — one profile contract, skin derived client-side from faction, never stored
+
+A player profile is a **public** view of one character. Every profile renders
+the **same locked sections in the same order** — ① identity + progression
+(the shared `CredentialCard` pinned as the header), ③ badges (hidden when
+empty), ⑤ praxis (the faction `PraxisCard`, FDL laurel on the top entry by
+base+vote points) — plus the two kept features the design predates: proposed
+tasks (faction `TaskCard`) and friend/foe (faction-skinned). ② About is
+skipped until a long-form field exists. There is no self-edit affordance on
+the profile.
+
+Only the **skin** changes per faction, and the skin is **derived client-side
+from `faction_slug`** by `FactionProfileBody`
+(`frontend/src/pages/characterProfile/`), following the existing
+`pickVariant` / `FACTION_*_BY_SLUG` dispatch pattern. Nothing
+archetype-specific is stored, and the payload carries no skin fields.
+
+Consequence: adding a faction's profile needs only its kit tokens + one
+registry row + one skin component — zero new profile fields, zero backend
+change. Until a row is registered, every slug falls back to the fully-built
+default (spectrum-band / unaffiliated) skin, so every player gets a correct
+profile from day one.
+
+## Decision 2 — badges are a code registry evaluated on read
+
+Badges (deliberately not "achievements") are **code-defined** in
+`backend/badges.py`: a module-level registry of frozen `Badge` dataclasses,
+each `(key, name, condition)` where `condition: Callable[[BadgeContext],
+bool]`. They are **evaluated on read** in `services/badge.py` — no table, no
+`earned_at`, no award events, no admin grants (all future work, if ever).
+A badge either holds right now or it doesn't; a new badge is one registry
+entry.
+
+- The payload is `{ key, name }[]` on `CharacterOut.badges`, populated
+  **only** by the single-character `GET /characters/{id}` — list serializers
+  leave it empty (no N+1 sibling queries).
+- The **image is not in the payload**: the frontend maps `key` to a bundled
+  SVG (`frontend/src/components/badges/badgeArt.tsx`), exactly like faction
+  sigils.
+- `BadgeContext` is built from **explicit queries** (`Character.account` is
+  `lazy="raise"` and must stay un-loaded); `account_id` / `email` never leave
+  the backend — only the resolved badge list does.
+
+Seed pair (both key off one account owning multiple characters, ordered by
+`(created_at, id)`): `sock_puppeteer` on the account's earliest character,
+`sock_puppet` on every later one. A solo-account character has neither.
+
+## Rejected
+
+- **Stored/awarded badge subsystem** (table + `earnedAt` + admin grant): the
+  design's model, deferred — on-read conditions cover the seed pair and keep
+  the blast radius to one module.
+- **Badge icon or skin hints in the payload**: presentation is
+  faction/frontend-owned, per the component-constants rule every other
+  surface follows.
+- **`role` / standing field**: the game has no membership-rank system; the
+  header shows faction + level. Design copy assuming ranks was dropped.

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,12 @@
 import api from './axios'
 
+/** A badge the character currently holds (ADR-0033). Evaluated on read by the
+ *  backend; the image is a bundled frontend asset mapped by `key`. */
+export interface BadgeOut {
+  key: string
+  name: string
+}
+
 export interface CharacterOut {
   id: number
   username: string
@@ -14,6 +21,9 @@ export interface CharacterOut {
   /** "active" | "paused" | "banned" — the roster includes paused lives (#270). */
   status: string
   created_at: string
+  /** Populated only by the single-character GET /characters/{id} (ADR-0033);
+   *  list responses leave it empty. */
+  badges?: BadgeOut[]
 }
 
 export interface CurrentUser {

--- a/frontend/src/components/badges/badgeArt.tsx
+++ b/frontend/src/components/badges/badgeArt.tsx
@@ -1,0 +1,92 @@
+/**
+ * Badge artwork registry (ADR-0033, #459). The backend sends only
+ * `{ key, name }` — the image is a bundled frontend asset mapped by key,
+ * exactly like faction sigils. Placeholder line art for now; every glyph
+ * draws in `currentColor` so it inherits the surrounding skin's ink and
+ * flips light/dark through the cascade (no hardcoded hex — CLAUDE.md).
+ */
+import type { ComponentType } from 'react'
+
+export interface BadgeArtProps {
+  /** px box (square). */
+  size?: number
+}
+
+/** sock_puppeteer — the marionette control bar: crossed rods + three strings. */
+function SockPuppeteerArt({ size = 18 }: BadgeArtProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      role="img"
+      aria-label="Sock Puppeteer badge"
+    >
+      <path d="M3 6h18" />
+      <path d="M12 2v8" />
+      <path d="M6 6v10" />
+      <path d="M18 6v10" />
+      <circle cx="6" cy="18.5" r="2" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12.5" r="2" fill="currentColor" stroke="none" />
+      <circle cx="18" cy="18.5" r="2" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+/** sock_puppet — the sock itself, one button eye and a stitched mouth. */
+function SockPuppetArt({ size = 18 }: BadgeArtProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Sock Puppet badge"
+    >
+      <path d="M8 2v9.5c0 1.5-.8 2.4-2.2 3.3C4.3 15.8 3.5 17 3.8 18.6 4.2 20.6 6 22 8.2 22c1.6 0 2.9-.6 4-1.7L16 16.5V2Z" />
+      <path d="M8 5.5h8" />
+      <circle cx="12.5" cy="9.5" r="1.1" fill="currentColor" stroke="none" />
+      <path d="M9.5 12.5c1 .8 2.4.8 3.4 0" />
+    </svg>
+  )
+}
+
+/** Unknown key → a plain medallion ring, so a new backend badge never renders
+ *  blank while its art is pending. */
+function UnknownBadgeArt({ size = 18 }: BadgeArtProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      role="img"
+      aria-label="Badge"
+    >
+      <circle cx="12" cy="12" r="8" strokeDasharray="3.2 2.4" />
+    </svg>
+  )
+}
+
+/** key → glyph. One row per registry badge (backend/badges.py). */
+const BADGE_ART: Record<string, ComponentType<BadgeArtProps>> = {
+  sock_puppeteer: SockPuppeteerArt,
+  sock_puppet: SockPuppetArt,
+}
+
+export function badgeArtFor(key: string): ComponentType<BadgeArtProps> {
+  return BADGE_ART[key] ?? UnknownBadgeArt
+}
+
+export { BADGE_ART, UnknownBadgeArt }

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -1,5 +1,16 @@
+/**
+ * CharacterProfile — the public player profile (#459, ADR-0033).
+ *
+ * One faction-agnostic contract; the skin is picked client-side from
+ * `faction_slug` by FactionProfileBody (default spectrum-band skin until a
+ * faction's bespoke body lands, #460). This page owns data fetching and the
+ * friend/foe relationship state; all rendering lives in the profile bodies.
+ *
+ * Public view: no self-edit affordance here (the credential card is the
+ * identity header; editing moves to the account's own surfaces).
+ */
 import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { getCharacter, type CharacterOut } from "../api/characters";
 import { listPraxes, type PraxisCardOut } from "../api/praxis";
 import { listTasks, type TaskOut } from "../api/tasks";
@@ -10,15 +21,14 @@ import {
   unblockRelationship,
   type RelationshipListItem,
 } from "../api/relationships";
-import PraxisCard from "../components/PraxisCard";
-import TaskCard from "../components/TaskCard";
-import PageTitle from "../components/ui/PageTitle";
 import { useAuth } from "../auth/AuthContext";
 import { useGameConfig } from "../hooks/useGameConfig";
 import { extractError } from "../utils/errors";
-import { factionCssVar, factionName } from "../utils/factions";
-import { mediaUrl } from "../utils/media";
+import { factionCssVar } from "../utils/factions";
 import { useFactionBackdrop } from "../components/backdrop/BackdropContext";
+import FactionProfileBody, {
+  type ProfileProgression,
+} from "./characterProfile/FactionProfileBody";
 
 export default function CharacterProfile() {
   const { id } = useParams<{ id: string }>();
@@ -161,488 +171,169 @@ export default function CharacterProfile() {
       <div className="py-8 font-body text-muted">Character not found.</div>
     );
 
-  const charFactionName = factionName(character.faction_slug);
   const isOwn = user?.character?.id === character.id;
+
+  // ① progression toward level+1 — same thresholds the old level track used.
   const levelThresholds = gameConfig?.level_thresholds ?? [];
   const maxLevel = Math.max(levelThresholds.length - 1, 0);
   const nextLevel = Math.min(character.level + 1, maxLevel);
   const nextThreshold = levelThresholds[nextLevel] ?? 999;
   const currentThreshold = levelThresholds[character.level] ?? 0;
-  const progressPercent =
-    nextThreshold > currentThreshold
-      ? Math.min(
-          ((character.score - currentThreshold) /
-            (nextThreshold - currentThreshold)) *
-            100,
-          100,
-        )
-      : 100;
+  const progression: ProfileProgression | null = gameConfig
+    ? {
+        nextLevel,
+        currentThreshold,
+        nextThreshold,
+        progressPercent:
+          nextThreshold > currentThreshold
+            ? Math.min(
+                ((character.score - currentThreshold) /
+                  (nextThreshold - currentThreshold)) *
+                  100,
+                100,
+              )
+            : 100,
+      }
+    : null;
 
-  return (
-    <div className="py-8">
-      {/* ── Profile Header — Faction-Framed (§14.2) ── */}
+  // Friend/foe controls (kept feature) — faction-skinned via the character's
+  // tokens, folded into the identity header. Hidden (not disabled) for own
+  // profile and logged-out viewers.
+  const identityActions =
+    !isOwn && user?.character ? (
       <div
-        className="sidebar-card mb-5"
         style={{
-          borderLeft: `4px solid ${factionCssVar(character.faction_slug, "border")}`,
-          padding: "16px 20px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+          width: "100%",
         }}
       >
-        <div className="flex gap-5 items-start">
-          {/* Avatar orb */}
-          <div className="flex flex-col items-center gap-2 shrink-0">
-            {character.avatar_url ? (
-              <img
-                src={mediaUrl(character.avatar_url)}
-                alt={character.username}
-                style={{
-                  width: 80,
-                  height: 80,
-                  borderRadius: "50%",
-                  objectFit: "cover",
-                  border: `3px solid white`,
-                  boxShadow: `0 0 0 3px ${factionCssVar(character.faction_slug)}`,
-                }}
-              />
-            ) : (
-              <div
-                style={{
-                  width: 80,
-                  height: 80,
-                  borderRadius: "50%",
-                  background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, "light")}, ${factionCssVar(character.faction_slug)})`,
-                  border: "3px solid white",
-                  boxShadow: `0 0 0 3px ${factionCssVar(character.faction_slug)}`,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontFamily: "'Lora', serif",
-                  fontStyle: "italic",
-                  fontSize: 28,
-                  color: "var(--color-text-on-accent)",
-                }}
-              >
-                {character.username[0]?.toUpperCase()}
-              </div>
-            )}
-            {/* Level badge */}
-            <span
+        {relationship ? (
+          <>
+            {/* Show relationship status */}
+            <div
               style={{
-                background: factionCssVar(character.faction_slug),
+                background:
+                  relationship.display_status === "Blocked"
+                    ? "var(--color-text-tertiary)"
+                    : relationship.type === "friend"
+                      ? "var(--badge-friend)"
+                      : "var(--color-danger)",
                 color: "var(--color-text-on-accent)",
+                fontFamily: "'Courier Prime', monospace",
                 fontSize: 8,
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
-                padding: "2px 10px",
-                borderRadius: 10,
-                fontFamily: "'Courier Prime', monospace",
+                padding: "4px 0",
+                textAlign: "center",
+                borderRadius: 2,
               }}
             >
-              Level {character.level}
-            </span>
-            {/* Action buttons */}
-            {isOwn ? (
-              <>
-                <Link
-                  to={`/characters/${character.id}/edit`}
-                  className="btn-outline"
-                  style={{
-                    fontSize: 8,
-                    padding: "3px 12px",
-                    width: "100%",
-                    textAlign: "center",
-                  }}
-                >
-                  Edit Profile
-                </Link>
-                {user?.can_create_additional_character && (
-                  <Link
-                    to="/characters/create"
-                    className="btn-outline"
-                    style={{
-                      fontSize: 8,
-                      padding: "3px 12px",
-                      width: "100%",
-                      textAlign: "center",
-                    }}
-                  >
-                    + New Character
-                  </Link>
-                )}
-              </>
-            ) : user?.character ? (
-              <div
+              {relationship.display_status === "Blocked"
+                ? "Blocked"
+                : relationship.type === "friend"
+                  ? "Friends"
+                  : "Foe"}
+            </div>
+            {relationship.display_status !== "Blocked" ? (
+              <button
+                onClick={handleRemoveRelationship}
+                disabled={relationshipLoading}
+                className="eyebrow"
                 style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 4,
-                  width: "100%",
-                }}
-              >
-                {relationship ? (
-                  <>
-                    {/* Show relationship status */}
-                    <div
-                      style={{
-                        background:
-                          relationship.display_status === "Blocked"
-                            ? "var(--color-text-tertiary)"
-                            : relationship.type === "friend"
-                              ? "var(--badge-friend)"
-                              : "var(--color-danger)",
-                        color: "var(--color-text-on-accent)",
-                        fontFamily: "'Courier Prime', monospace",
-                        fontSize: 8,
-                        textTransform: "uppercase",
-                        letterSpacing: "0.1em",
-                        padding: "4px 0",
-                        textAlign: "center",
-                        borderRadius: 2,
-                      }}
-                    >
-                      {relationship.display_status === "Blocked"
-                        ? "Blocked"
-                        : relationship.type === "friend"
-                          ? "Friends"
-                          : "Foe"}
-                    </div>
-                    {relationship.display_status !== "Blocked" ? (
-                      <button
-                        onClick={handleRemoveRelationship}
-                        disabled={relationshipLoading}
-                        className="eyebrow"
-                        style={{
-                          background: "none",
-                          border: "none",
-                          cursor: "pointer",
-                          color: "var(--color-text-tertiary)",
-                          textAlign: "center",
-                        }}
-                      >
-                        remove
-                      </button>
-                    ) : (
-                      // ADR-0009 — a block is reversible; either party can unblock.
-                      <button
-                        onClick={handleUnblockRelationship}
-                        disabled={relationshipLoading}
-                        className="eyebrow"
-                        style={{
-                          background: "none",
-                          border: "none",
-                          cursor: "pointer",
-                          color: "var(--color-text-tertiary)",
-                          textAlign: "center",
-                        }}
-                      >
-                        unblock
-                      </button>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <button
-                      onClick={() => handleAddRelationship("friend")}
-                      disabled={relationshipLoading}
-                      style={{
-                        background: factionCssVar(character.faction_slug),
-                        color: "var(--color-text-on-accent)",
-                        fontFamily: "'Courier Prime', monospace",
-                        fontSize: 8,
-                        textTransform: "uppercase",
-                        letterSpacing: "0.1em",
-                        padding: "4px 0",
-                        border: "none",
-                        cursor: "pointer",
-                        borderRadius: 2,
-                        opacity: relationshipLoading ? 0.5 : 1,
-                      }}
-                    >
-                      Friend
-                    </button>
-                    <button
-                      onClick={() => handleAddRelationship("foe")}
-                      disabled={relationshipLoading}
-                      style={{
-                        background: "none",
-                        color: "var(--color-danger)",
-                        fontFamily: "'Courier Prime', monospace",
-                        fontSize: 8,
-                        textTransform: "uppercase",
-                        letterSpacing: "0.1em",
-                        padding: "3px 0",
-                        border: "1.5px solid var(--color-danger)",
-                        cursor: "pointer",
-                        borderRadius: 2,
-                        opacity: relationshipLoading ? 0.5 : 1,
-                      }}
-                    >
-                      Foe
-                    </button>
-                  </>
-                )}
-              </div>
-            ) : null}
-            {relationshipError && (
-              <p
-                className="font-body"
-                style={{
-                  fontSize: 8,
-                  color: "var(--color-danger)",
-                  marginTop: 4,
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "var(--color-text-tertiary)",
                   textAlign: "center",
                 }}
               >
-                {relationshipError}
-              </p>
+                remove
+              </button>
+            ) : (
+              // ADR-0009 — a block is reversible; either party can unblock.
+              <button
+                onClick={handleUnblockRelationship}
+                disabled={relationshipLoading}
+                className="eyebrow"
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "var(--color-text-tertiary)",
+                  textAlign: "center",
+                }}
+              >
+                unblock
+              </button>
             )}
-          </div>
-
-          {/* Info */}
-          <div className="flex-1 min-w-0">
-            <h1
-              className="font-display italic"
+          </>
+        ) : (
+          <>
+            <button
+              onClick={() => handleAddRelationship("friend")}
+              disabled={relationshipLoading}
               style={{
-                fontSize: 26,
-                color: factionCssVar(character.faction_slug),
-                marginBottom: 2,
-              }}
-            >
-              {character.display_name}
-            </h1>
-            <p className="eyebrow" style={{ marginBottom: 8 }}>
-              @{character.username} · Joined{" "}
-              {new Date(character.created_at).toLocaleDateString(undefined, {
-                month: "short",
-                year: "numeric",
-              })}
-            </p>
-
-            {/* Faction pennant */}
-            <span
-              className="pennant-shape"
-              style={{
-                display: "inline-block",
                 background: factionCssVar(character.faction_slug),
                 color: "var(--color-text-on-accent)",
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 9,
-                fontWeight: 700,
+                fontSize: 8,
                 textTransform: "uppercase",
-                letterSpacing: "0.07em",
-                padding: "3px 14px",
-                textShadow: "0 1px 2px rgba(0,0,0,0.3)",
-                marginBottom: 8,
+                letterSpacing: "0.1em",
+                padding: "4px 0",
+                border: "none",
+                cursor: "pointer",
+                borderRadius: 2,
+                opacity: relationshipLoading ? 0.5 : 1,
               }}
             >
-              {charFactionName}
-            </span>
-
-            {/* Bio */}
-            {character.bio && (
-              <p
-                className="font-body"
-                style={{
-                  fontSize: 11,
-                  lineHeight: 1.6,
-                  borderLeft: `3px solid ${factionCssVar(character.faction_slug, "border")}`,
-                  paddingLeft: 10,
-                  marginTop: 6,
-                  marginBottom: 8,
-                  color: "var(--color-text-secondary)",
-                  fontFamily: "'Special Elite', serif",
-                }}
-              >
-                {character.bio}
-              </p>
-            )}
-
-            {/* Stat strip */}
-            <div
+              Friend
+            </button>
+            <button
+              onClick={() => handleAddRelationship("foe")}
+              disabled={relationshipLoading}
               style={{
-                display: "flex",
-                gap: 8,
-                flexWrap: "wrap",
-                marginTop: 8,
+                background: "none",
+                color: "var(--color-danger)",
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 8,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                padding: "3px 0",
+                border: "1.5px solid var(--color-danger)",
+                cursor: "pointer",
+                borderRadius: 2,
+                opacity: relationshipLoading ? 0.5 : 1,
               }}
             >
-              {[
-                { label: "Era score", value: character.score },
-                { label: "All-time", value: character.all_time_score },
-                { label: "Praxis", value: submissions.length },
-              ].map((stat) => (
-                <div
-                  key={stat.label}
-                  className="sidebar-card"
-                  style={{
-                    padding: "6px 12px",
-                    borderRadius: 8,
-                    textAlign: "center",
-                    minWidth: 70,
-                  }}
-                >
-                  <div
-                    className="font-body font-bold"
-                    style={{ fontSize: 14, color: "var(--color-text-primary)" }}
-                  >
-                    {stat.value}
-                  </div>
-                  <div className="eyebrow" style={{ fontSize: 7 }}>
-                    {stat.label}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* ── Level Track (§14.3) ── */}
-      {gameConfig && (
-        <div className="sidebar-card mb-5" style={{ padding: "14px 18px" }}>
-          {/* Node track */}
-          <div
-            style={{ display: "flex", alignItems: "center", marginBottom: 10 }}
+              Foe
+            </button>
+          </>
+        )}
+        {relationshipError && (
+          <p
+            className="font-body"
+            style={{
+              fontSize: 8,
+              color: "var(--color-danger)",
+              marginTop: 4,
+              textAlign: "center",
+            }}
           >
-            {levelThresholds.map((_threshold, level) => {
-              const completed = character.level > level;
-              const current = character.level === level;
-              return (
-                <div
-                  key={level}
-                  style={{ display: "flex", alignItems: "center" }}
-                >
-                  {level > 0 && (
-                    <div
-                      style={{
-                        width: 16,
-                        height: 3,
-                        background: completed
-                          ? factionCssVar(character.faction_slug)
-                          : "rgba(0,0,0,0.1)",
-                        transition: "background 200ms",
-                      }}
-                    />
-                  )}
-                  <div
-                    style={{
-                      width: current ? 32 : 26,
-                      height: current ? 32 : 26,
-                      borderRadius: "50%",
-                      background: completed
-                        ? factionCssVar(character.faction_slug)
-                        : current
-                          ? `${factionCssVar(character.faction_slug)}20`
-                          : "var(--level-node-incomplete)",
-                      border: current
-                        ? `3px solid ${factionCssVar(character.faction_slug)}`
-                        : `2px solid ${completed ? factionCssVar(character.faction_slug) : "rgba(0,0,0,0.12)"}`,
-                      boxShadow: current
-                        ? `0 0 0 3px ${factionCssVar(character.faction_slug)}33`
-                        : "none",
-                      color: completed
-                        ? "var(--color-text-on-accent)"
-                        : current
-                          ? factionCssVar(character.faction_slug)
-                          : "var(--color-level-inactive)",
-                      fontFamily: "'Courier Prime', monospace",
-                      fontSize: current ? 10 : 8,
-                      fontWeight: 700,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      transition: "all 200ms",
-                    }}
-                  >
-                    {level}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Progress bar */}
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span
-              className="eyebrow"
-              style={{ fontSize: 8, whiteSpace: "nowrap" }}
-            >
-              Lvl {character.level} → {nextLevel}
-            </span>
-            <div
-              style={{
-                flex: 1,
-                height: 5,
-                borderRadius: 3,
-                background: "var(--color-bg-surface-alt)",
-                overflow: "hidden",
-              }}
-            >
-              <div
-                style={{
-                  height: "100%",
-                  width: `${progressPercent}%`,
-                  background: factionCssVar(character.faction_slug),
-                  borderRadius: 3,
-                  transition: "width 300ms",
-                }}
-              />
-            </div>
-            <span
-              className="font-body"
-              style={{
-                fontSize: 9,
-                fontWeight: 700,
-                color: factionCssVar(character.faction_slug),
-                whiteSpace: "nowrap",
-              }}
-            >
-              {character.score} / {nextThreshold} pts
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* ── Praxis Grid (§14.4) ── */}
-      <div className="mb-5">
-        <div className="flex items-baseline justify-between mb-3">
-          <PageTitle title="Praxis" eyebrow={`${submissions.length} total`} />
-        </div>
-
-        {submissions.length === 0 ? (
-          <p className="font-body text-muted">No submissions yet.</p>
-        ) : (
-          <div className="flex flex-wrap gap-4 items-start">
-            {submissions.map((s) => (
-              <PraxisCard key={s.id} praxis={s} />
-            ))}
-          </div>
+            {relationshipError}
+          </p>
         )}
       </div>
+    ) : null;
 
-      {/* ── Proposed Tasks (#419) — approved tasks this character created ── */}
-      <div className="mb-5">
-        <div className="flex items-baseline justify-between mb-3">
-          <PageTitle
-            title="Proposed tasks"
-            eyebrow={`${proposedTasks.length} total`}
-          />
-        </div>
-
-        {proposedTasks.length === 0 ? (
-          <p className="font-body text-muted">No proposed tasks yet.</p>
-        ) : (
-          <div className="flex flex-wrap gap-4 items-start">
-            {proposedTasks.map((task) => (
-              <TaskCard
-                key={task.id}
-                task={task}
-                displayPoints={task.point_value}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
+  return (
+    <FactionProfileBody
+      character={character}
+      submissions={submissions}
+      proposedTasks={proposedTasks}
+      progression={progression}
+      identityActions={identityActions}
+    />
   );
 }

--- a/frontend/src/pages/characterProfile/FactionProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/FactionProfileBody.tsx
@@ -1,0 +1,71 @@
+/**
+ * Per-faction player-profile body dispatch (#459, ADR-0033).
+ *
+ * The player profile renders ONE faction-agnostic contract; the skin is
+ * derived client-side from `character.faction_slug`, never stored. This is
+ * the single seam where a faction's bespoke profile skin plugs in — mirrors
+ * FACTION_FEED_FRAMES / CARD_COMPONENTS / PRAXIS_CARD_BY_SLUG.
+ *
+ * Every profile lays out the same locked section spine (§player-profile
+ * contract): ① identity + progression (shared CredentialCard as header),
+ * ③ badges (hidden when empty), ⑤ praxis (faction PraxisCard, FDL laurel on
+ * the top entry) — plus the two kept features: proposed tasks (faction
+ * TaskCard) and friend/foe (faction-skinned, folded into the identity area).
+ *
+ * The default / unaffiliated skin is fully built; register a faction's row
+ * below and its players adopt the bespoke skin with no other change (#460):
+ *
+ *   ua:          UaProfileBody,
+ *   wow:         WowProfileBody,
+ *   snide:       SnideProfileBody,
+ *   ephemerists: EphemeristsProfileBody,
+ *   singularity: SingularityProfileBody,
+ *   everymen:    EverymenProfileBody,
+ *   albescent:   AlbescentProfileBody,
+ */
+import type { ComponentType, ReactNode } from 'react'
+
+import type { CharacterOut } from '../../api/auth'
+import type { PraxisCardOut } from '../../api/praxis'
+import type { TaskOut } from '../../api/tasks'
+import { pickVariant } from '../../utils/factionDispatch'
+import DefaultProfileBody from './archetypes/DefaultProfileBody'
+
+export interface ProfileProgression {
+  /** The level the current score is climbing toward (capped at max level). */
+  nextLevel: number
+  /** Absolute score where the current level began. */
+  currentThreshold: number
+  /** Absolute score where nextLevel begins. */
+  nextThreshold: number
+  /** 0–100 fill of the points-into-level bar. */
+  progressPercent: number
+}
+
+export interface ProfileBodyProps {
+  character: CharacterOut
+  /** The character's own praxis, newest first (⑤). */
+  submissions: PraxisCardOut[]
+  /** Approved tasks this character authored (kept feature, #419). */
+  proposedTasks: TaskOut[]
+  /** Null until game config loads — skins then hide the progression bar. */
+  progression: ProfileProgression | null
+  /** Friend/foe controls (faction-skinned), folded into the identity header.
+   *  Null for own profile / logged-out viewers — hide, don't disable. */
+  identityActions: ReactNode
+}
+
+/** Per-faction profile skins land in #460 — until a row is registered here,
+ *  every slug falls back to the default spectrum-band skin below. */
+const FACTION_PROFILE_BODIES: Record<string, ComponentType<ProfileBodyProps>> = {}
+
+export default function FactionProfileBody(props: ProfileBodyProps) {
+  const Body = pickVariant(
+    FACTION_PROFILE_BODIES,
+    props.character.faction_slug,
+    DefaultProfileBody,
+  )
+  return <Body {...props} />
+}
+
+export { FACTION_PROFILE_BODIES }

--- a/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Player-profile body dispatch + badge-board guards (#459, ADR-0033).
+ *
+ * The profile is one faction-agnostic contract; the skin is derived
+ * client-side from faction_slug. Until the per-faction skins land (#460),
+ * EVERY slug — including null/na — must fall back to the default
+ * spectrum-band body, and ③ Badges must render only when badges exist.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+
+import type { CharacterOut } from "../../../api/auth";
+import FactionProfileBody, {
+  FACTION_PROFILE_BODIES,
+  type ProfileBodyProps,
+} from "../FactionProfileBody";
+
+function makeCharacter(overrides: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    id: 7,
+    username: "wren",
+    display_name: "Wren Aldercross",
+    bio: "Keeps a field notebook.",
+    avatar_url: null,
+    location: null,
+    level: 3,
+    score: 320,
+    all_time_score: 320,
+    faction_slug: null,
+    status: "active",
+    created_at: "2026-06-01T00:00:00Z",
+    badges: [],
+    ...overrides,
+  };
+}
+
+function renderBody(overrides: Partial<CharacterOut> = {}) {
+  const props: ProfileBodyProps = {
+    character: makeCharacter(overrides),
+    submissions: [],
+    proposedTasks: [],
+    progression: {
+      nextLevel: 4,
+      currentThreshold: 200,
+      nextThreshold: 500,
+      progressPercent: 40,
+    },
+    identityActions: null,
+  };
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FactionProfileBody {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("FactionProfileBody dispatch", () => {
+  it("starts with no bespoke skins registered — #460 fills the map", () => {
+    expect(Object.keys(FACTION_PROFILE_BODIES)).toHaveLength(0);
+  });
+
+  it("renders the default skin for an unaffiliated (null) character", () => {
+    const html = renderBody({ faction_slug: null });
+    expect(html).toContain("Unaffiliated · faction pending");
+    expect(html).toContain("Wren Aldercross");
+    expect(html).toContain("No praxis sealed yet");
+  });
+
+  it("falls back to the default skin for every faction slug until #460", () => {
+    for (const slug of [
+      "ua",
+      "wow",
+      "snide",
+      "ephemerists",
+      "singularity",
+      "everymen",
+      "albescent",
+      "na",
+    ]) {
+      const html = renderBody({ faction_slug: slug });
+      expect(html, `${slug} renders a profile`).toContain("Wren Aldercross");
+      // The faction-pending line is unaffiliated-only copy.
+      if (slug !== "na") {
+        expect(html, `${slug} is not labelled faction-pending`).not.toContain(
+          "faction pending",
+        );
+      }
+    }
+  });
+
+  it("hides ③ Badges when the character has none", () => {
+    const html = renderBody({ badges: [] });
+    expect(html).not.toContain(">Badges<");
+  });
+
+  it("shows ③ Badges with names when present", () => {
+    const html = renderBody({
+      badges: [
+        { key: "sock_puppeteer", name: "Sock Puppeteer" },
+        { key: "sock_puppet", name: "Sock Puppet" },
+      ],
+    });
+    expect(html).toContain("Badges");
+    expect(html).toContain("2 earned");
+    expect(html).toContain("Sock Puppeteer");
+    expect(html).toContain("Sock Puppet");
+    expect(html).toContain("Sock Puppeteer badge"); // aria-label of the mapped art
+  });
+
+  it("shows the progression bar toward level+1", () => {
+    const html = renderBody();
+    expect(html).toContain("next · lvl 4");
+    expect(html).toContain("120 / 300 pts this level");
+  });
+});

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -1,0 +1,527 @@
+/**
+ * DefaultProfileBody — the unaffiliated / no-faction player-profile skin
+ * (#459), ported from the design system's `templates/default/Default
+ * Profile.dc.html`: a clean sheet inside the thick spectrum band (all paths
+ * open), and the fallback for every faction until its bespoke skin lands
+ * (#460). All colours via `--faction-default-*` / global tokens (#418) — no
+ * hardcoded hex; light/dark flips through the cascade.
+ *
+ * Locked section spine: ① identity + progression (shared CredentialCard as
+ * the header), ② about — skipped in v1 (no field), ③ badges (hidden when
+ * empty), ⑤ praxis (faction PraxisCard, FDL laurel on the top entry), plus
+ * the kept proposed-tasks and friend/foe features.
+ */
+import type { CSSProperties } from 'react'
+
+import type { BadgeOut } from '../../../api/auth'
+import { badgeArtFor } from '../../../components/badges/badgeArt'
+import CredentialCard from '../../../components/CredentialCard'
+import PraxisCard from '../../../components/PraxisCard'
+import TaskCard from '../../../components/TaskCard'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import type { ProfileBodyProps } from '../FactionProfileBody'
+
+const EYEBROW: CSSProperties = {
+  fontFamily: 'var(--font-body)',
+  fontSize: 10,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: 'var(--color-text-tertiary)',
+}
+
+/** Section heading: display-italic title + optional eyebrow + a soft rainbow rule. */
+function SectionHeading({ title, eyebrow }: { title: string; eyebrow?: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+      <h2
+        className="font-display italic"
+        style={{ fontSize: 24, margin: 0, color: 'var(--color-text-primary)' }}
+      >
+        {title}
+      </h2>
+      {eyebrow && <span style={{ ...EYEBROW, letterSpacing: '0.08em' }}>{eyebrow}</span>}
+      <span
+        aria-hidden
+        style={{
+          flex: 1,
+          height: 3,
+          borderRadius: 3,
+          background: 'var(--faction-default-rainbow)',
+          opacity: 0.5,
+        }}
+      />
+    </div>
+  )
+}
+
+/** The FDL laurel stamped on the character's top praxis (highest base+vote
+ *  points — `praxis.score` is exactly that sum). Spectrum ring, ink glyph. */
+function FdlLaurel() {
+  return (
+    <span
+      title="Top praxis"
+      style={{
+        position: 'absolute',
+        top: -11,
+        right: 14,
+        zIndex: 20,
+        width: 44,
+        height: 44,
+        filter: 'drop-shadow(0 4px 8px rgba(0,0,0,0.25))',
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: '50%',
+          background: 'var(--faction-default-ring)',
+        }}
+      />
+      <span
+        style={{
+          position: 'absolute',
+          inset: 4,
+          borderRadius: '50%',
+          background: 'var(--color-bg-surface-alt)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--color-text-primary)',
+        }}
+      >
+        <svg width={18} height={22} viewBox="0 0 40 48" fill="currentColor" aria-hidden>
+          <path d="M20 1 C16 10 16 17 20 24 C24 17 24 10 20 1 Z" />
+          <path d="M20 22 C14 15 8 15 6 21 C4.6 25 8 29 13.5 27.6 C10.5 25 12.5 21 20 22 Z" />
+          <path d="M20 22 C26 15 32 15 34 21 C35.4 25 32 29 26.5 27.6 C29.5 25 27.5 21 20 22 Z" />
+          <rect x="11" y="26" width="18" height="4.5" rx="2.2" />
+          <path d="M20 30 C17.5 37 16 41 20 47 C24 41 22.5 37 20 30 Z" />
+        </svg>
+      </span>
+    </span>
+  )
+}
+
+/** ③ One badge row: spectrum-ring medallion + name. */
+function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
+  const Art = badgeArtFor(badge.key)
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 11,
+        padding: '10px 0',
+        borderBottom: last ? 'none' : '1px solid var(--color-border)',
+      }}
+    >
+      <span
+        style={{
+          flexShrink: 0,
+          width: 34,
+          height: 34,
+          borderRadius: '50%',
+          padding: 2.5,
+          background: 'var(--faction-default-ring)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          boxSizing: 'border-box',
+        }}
+      >
+        <span
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: '50%',
+            background: 'var(--color-bg-surface-alt)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          <Art size={16} />
+        </span>
+      </span>
+      <div
+        className="font-display italic"
+        style={{ fontSize: 15, color: 'var(--color-text-primary)', lineHeight: 1.15 }}
+      >
+        {badge.name}
+      </div>
+    </div>
+  )
+}
+
+export default function DefaultProfileBody({
+  character,
+  submissions,
+  proposedTasks,
+  progression,
+  identityActions,
+}: ProfileBodyProps) {
+  const isUnaffiliated = !character.faction_slug || character.faction_slug === 'na'
+  const badges = character.badges ?? []
+  const joined = new Date(character.created_at).toLocaleDateString(undefined, {
+    month: 'short',
+    year: 'numeric',
+  })
+
+  // ⑤ FDL laurel target: highest earned points (task base + points from votes
+  // — PraxisCardOut.score is that sum); first entry wins a tie.
+  const topScore = submissions.reduce(
+    (max, praxis) => Math.max(max, praxis.score ?? 0),
+    0,
+  )
+  const laurelId =
+    submissions.find((praxis) => (praxis.score ?? 0) === topScore)?.id ?? null
+
+  // ① progression numbers (hidden until game config supplies thresholds).
+  const pointsIntoLevel = progression
+    ? Math.max(character.score - progression.currentThreshold, 0)
+    : 0
+  const levelSpan = progression
+    ? Math.max(progression.nextThreshold - progression.currentThreshold, 0)
+    : 0
+  const ringDegrees = progression
+    ? Math.round(Math.min(Math.max(progression.progressPercent, 0), 100) * 3.6)
+    : 0
+
+  const mainColumn = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 34, minWidth: 0 }}>
+      {/* ── ⑤ Praxis ── */}
+      <section>
+        <SectionHeading
+          title="Praxis"
+          eyebrow={`sealed by ${character.display_name}`}
+        />
+        {submissions.length === 0 ? (
+          <div
+            style={{
+              border: '1.5px dashed var(--color-border-strong)',
+              borderRadius: 12,
+              padding: 30,
+              textAlign: 'center',
+              background: 'var(--color-bg-surface-alt)',
+            }}
+          >
+            <div
+              className="font-display italic"
+              style={{ fontSize: 19, color: 'var(--color-text-primary)' }}
+            >
+              No praxis sealed yet
+            </div>
+            <div
+              className="font-body"
+              style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginTop: 5 }}
+            >
+              Every path is still open — the first finding is the hardest.
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-4 items-start">
+            {submissions.map((praxis) => (
+              <div key={praxis.id} style={{ position: 'relative' }}>
+                {praxis.id === laurelId && <FdlLaurel />}
+                <PraxisCard praxis={praxis} />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Proposed tasks (kept feature, #419) ── */}
+      <section>
+        <SectionHeading
+          title="Proposed tasks"
+          eyebrow={`${proposedTasks.length} total`}
+        />
+        {proposedTasks.length === 0 ? (
+          <p className="font-body text-muted">No proposed tasks yet.</p>
+        ) : (
+          <div className="flex flex-wrap gap-4 items-start">
+            {proposedTasks.map((task) => (
+              <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+
+  return (
+    <div className="py-8">
+      {/* ── ① Identity + progression — spectrum band, credential pinned ── */}
+      <div
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          borderRadius: 16,
+          padding: 5,
+          background: 'var(--faction-default-rainbow)',
+          boxShadow: '0 20px 50px -26px rgba(0,0,0,0.4)',
+          marginBottom: 30,
+        }}
+      >
+        <div
+          style={{
+            borderRadius: 12,
+            background: 'var(--faction-default-card-bg)',
+            padding: '26px 28px',
+            display: 'flex',
+            gap: 30,
+            alignItems: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <div style={{ flexShrink: 0 }}>
+            <CredentialCard
+              displayName={character.display_name}
+              handle={character.username}
+              bio={character.bio}
+              factionSlug={character.faction_slug}
+              level={character.level}
+              score={character.score}
+              avatarUrl={character.avatar_url ? mediaUrl(character.avatar_url) : null}
+            />
+          </div>
+
+          <div style={{ flex: 1, minWidth: 280 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+              <span
+                aria-hidden
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: '50%',
+                  flex: 'none',
+                  background: 'var(--faction-default-ring)',
+                  WebkitMask: 'radial-gradient(circle, transparent 38%, #000 40%)',
+                  mask: 'radial-gradient(circle, transparent 38%, #000 40%)',
+                }}
+              />
+              <span style={{ ...EYEBROW, color: 'var(--faction-default-card-muted)' }}>
+                Player · {isUnaffiliated ? 'Unaffiliated' : factionName(character.faction_slug)}
+              </span>
+            </div>
+
+            <h1
+              className="font-display italic"
+              style={{
+                fontSize: 44,
+                lineHeight: 0.98,
+                margin: 0,
+                color: 'var(--faction-default-card-text)',
+                overflowWrap: 'anywhere',
+              }}
+            >
+              {character.display_name}
+            </h1>
+
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                flexWrap: 'wrap',
+                marginTop: 10,
+              }}
+            >
+              {isUnaffiliated && (
+                <>
+                  <span
+                    className="font-display italic"
+                    style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}
+                  >
+                    Unaffiliated · faction pending
+                  </span>
+                  <span
+                    aria-hidden
+                    style={{
+                      width: 4,
+                      height: 4,
+                      borderRadius: '50%',
+                      background: 'var(--color-text-tertiary)',
+                    }}
+                  />
+                </>
+              )}
+              <span
+                className="font-body"
+                style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}
+              >
+                @{character.username} · joined {joined}
+              </span>
+            </div>
+
+            {/* progression panel */}
+            {progression && (
+              <div
+                style={{
+                  marginTop: 20,
+                  border: '1px solid var(--color-border-strong)',
+                  borderRadius: 12,
+                  padding: '14px 16px',
+                  background: 'var(--color-bg-surface-alt)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 16,
+                  maxWidth: 440,
+                }}
+              >
+                {/* level ring */}
+                <div
+                  style={{
+                    flexShrink: 0,
+                    width: 60,
+                    height: 60,
+                    borderRadius: '50%',
+                    background: `conic-gradient(var(--color-text-primary) ${ringDegrees}deg, var(--color-border) 0)`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 46,
+                      height: 46,
+                      borderRadius: '50%',
+                      background: 'var(--color-bg-surface-alt)',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      lineHeight: 1,
+                    }}
+                  >
+                    <span style={{ ...EYEBROW, fontSize: 7, letterSpacing: '0.1em' }}>lvl</span>
+                    <span
+                      className="font-display italic"
+                      style={{ fontSize: 22, color: 'var(--color-text-primary)' }}
+                    >
+                      {character.level}
+                    </span>
+                  </span>
+                </div>
+
+                {/* points-into-level bar toward level+1 */}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'baseline',
+                      marginBottom: 6,
+                    }}
+                  >
+                    <span
+                      className="font-body"
+                      style={{ fontSize: 10, color: 'var(--color-text-secondary)' }}
+                    >
+                      {pointsIntoLevel} / {levelSpan} pts this level
+                    </span>
+                    <span style={{ ...EYEBROW, fontSize: 9, letterSpacing: '0.08em' }}>
+                      next · lvl {progression.nextLevel}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      height: 10,
+                      borderRadius: 20,
+                      background: 'var(--color-border)',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        height: '100%',
+                        borderRadius: 20,
+                        width: `${progression.progressPercent}%`,
+                        background: 'var(--faction-default-rainbow)',
+                        transition: 'width 300ms',
+                      }}
+                    />
+                  </div>
+                  <div
+                    className="font-body"
+                    style={{ fontSize: 9, color: 'var(--color-text-tertiary)', marginTop: 5 }}
+                  >
+                    {character.score} / {progression.nextThreshold} pts
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* friend/foe — kept feature, faction-skinned, folded into the header */}
+            {identityActions && (
+              <div style={{ marginTop: 16, maxWidth: 220 }}>{identityActions}</div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ── ② About: skipped in v1 (no long-form field; contract hides empty) ── */}
+
+      {badges.length > 0 ? (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'minmax(0, 1fr) 300px',
+            gap: 30,
+            alignItems: 'start',
+          }}
+        >
+          {mainColumn}
+
+          {/* ── ③ Badges — hidden entirely when the character has none ── */}
+          <aside>
+            <div
+              style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}
+            >
+              <h2
+                className="font-display italic"
+                style={{ fontSize: 22, margin: 0, color: 'var(--color-text-primary)' }}
+              >
+                Badges
+              </h2>
+              <span
+                style={{
+                  ...EYEBROW,
+                  fontSize: 9,
+                  letterSpacing: '0.1em',
+                  marginLeft: 'auto',
+                  border: '1px solid var(--color-border-strong)',
+                  borderRadius: 20,
+                  padding: '3px 9px',
+                }}
+              >
+                {badges.length} earned
+              </span>
+            </div>
+            <div
+              style={{
+                border: '1px solid var(--color-border)',
+                borderRadius: 12,
+                background: 'var(--color-bg-surface-alt)',
+                padding: '4px 14px',
+              }}
+            >
+              {badges.map((badge, index) => (
+                <BadgeRow
+                  key={badge.key}
+                  badge={badge}
+                  last={index === badges.length - 1}
+                />
+              ))}
+            </div>
+          </aside>
+        </div>
+      ) : (
+        mainColumn
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Retheme the character profile into the faction-agnostic **player-profile contract** — one payload, faction-selected skins — plus the lightweight **badge** system. Foundation of the profile epic; the 7 faction skins are #460.

## Frontend
- `pages/characterProfile/FactionProfileBody.tsx` — profile-body dispatcher on the `pickVariant` / `FACTION_*_BY_SLUG` pattern. The map starts empty (documented slots for all seven slugs); every slug falls back to the default skin until #460 registers rows.
- `pages/characterProfile/archetypes/DefaultProfileBody.tsx` — the unaffiliated / default skin, ported from the design system's `templates/default/Default Profile.dc.html`: spectrum-band identity frame with the shared `CredentialCard` pinned as header, level ring + points-into-level bar toward `level+1`, joined date; ⑤ praxis via the existing faction `PraxisCard` with the FDL laurel on the top entry (highest base+vote points); ③ badges rail hidden when empty; kept features: proposed tasks (faction `TaskCard`) and friend/foe (faction-skinned, folded into the identity header). ② About skipped (no field yet). All colours via `--faction-default-*` / global tokens (#418) — no hardcoded hex.
- `components/badges/badgeArt.tsx` — bundled placeholder SVGs mapped by badge `key` (`sock_puppeteer`, `sock_puppet`, unknown-key fallback), drawn in `currentColor`.
- `CharacterProfile.tsx` now owns only data fetching + relationship state; **no self-edit affordance** (public view per the contract).

## Backend
- `backend/badges.py` — module-level registry of frozen `Badge(key, name, condition)` dataclasses; seed pair `sock_puppeteer` (earliest character on an account owning >1) / `sock_puppet` (the later ones), ordered by `(created_at, id)`.
- `services/badge.py` — evaluates the registry on read; siblings queried explicitly by `account_id` (`Character.account` stays `lazy="raise"`).
- `CharacterOut.badges: list[BadgeOut]` (`{key, name}`), populated **only** by the single-character `GET /characters/{id}` — list serializers leave it empty (no N+1). `account_id` / `email` never leave the backend.
- ADR-0033 records both decisions (skin derived client-side, never stored; badges are a code registry evaluated on read).

## Tests
- Unit: badge conditions across 1/2/3-character contexts + registry invariants.
- Integration: solo -> `[]`; two lives -> puppeteer on char #1, puppet on char #2; other accounts don't cross-pollinate; list endpoint doesn't evaluate; response never exposes `account_id`/`email`.
- Frontend: dispatch fallback for every slug, badges hidden-when-empty / shown-with-art, progression bar copy.

## Gates
- `pytest --cov=. --cov-fail-under=80`: **553 passed, 85.73%**
- `npx tsc --noEmit`: clean
- `vitest --run`: **200 passed (22 files)**

## Notes
- Removing the profile's Edit button leaves `/characters/:id/edit` (EditCharacter, #434) with no inbound UI link — flagged as a follow-up to re-home it (likely FieldDesk).
- New copy is plain strings; the profile surface picks up `t()` in its i18n sweep (#441-449 series).

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)