### PR TITLE
feat(i18n): sweep admin & moderation into admin.json (#449)

### DIFF
--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -1,1 +1,135 @@
-{}
+{
+  "title": "Admin",
+  "tabs": {
+    "moderation": "Moderation",
+    "tasks": "Tasks",
+    "accounts": "Accounts",
+    "overview": "Overview"
+  },
+  "flagReasons": {
+    "spam": "Spam",
+    "harassment": "Harassment",
+    "nsfw": "NSFW",
+    "slop": "Slop",
+    "other": "Other"
+  },
+  "overview": {
+    "loadError": "Couldn't load overview.",
+    "stats": {
+      "accounts": "Accounts",
+      "characters": "Characters",
+      "activeTasks": "Active Tasks",
+      "praxis": "Praxis",
+      "votes": "Votes",
+      "flagged": "Flagged",
+      "suspended": "Suspended"
+    }
+  },
+  "accounts": {
+    "loadError": "Couldn't load accounts.",
+    "detailError": "Could not load account detail.",
+    "suspendError": "Could not update account.",
+    "banError": "Could not update character.",
+    "searchPlaceholder": "Search by email...",
+    "empty": "No accounts found.",
+    "idLabel": "ID #{{id}}",
+    "suspend": "suspend",
+    "unsuspend": "unsuspend",
+    "charactersHeading": "Characters ({{count}})",
+    "noCharacters": "No characters.",
+    "ban": "ban",
+    "unban": "unban",
+    "status": {
+      "active": "active",
+      "suspended": "suspended",
+      "banned": "banned",
+      "paused": "paused"
+    }
+  },
+  "tasks": {
+    "loadError": "Couldn't load tasks.",
+    "statusError": "Could not update task status.",
+    "saveError": "Could not save task edits.",
+    "filters": {
+      "all": "all",
+      "pending": "pending",
+      "active": "active",
+      "retired": "retired"
+    },
+    "empty": "No {{filter}} tasks.",
+    "titlePlaceholder": "Title",
+    "descriptionPlaceholder": "Description",
+    "pointsLabel": "Points",
+    "levelLabel": "Level req.",
+    "meta": "{{points}} pts · lvl {{level}} · {{faction}}",
+    "crossFaction": "cross-faction",
+    "status": {
+      "active": "active",
+      "pending": "pending",
+      "retired": "retired"
+    },
+    "actions": {
+      "edit": "edit",
+      "activate": "activate",
+      "retire": "retire",
+      "reactivate": "reactivate",
+      "save": "save",
+      "saving": "saving…",
+      "cancel": "cancel"
+    }
+  },
+  "moderation": {
+    "loadError": "Couldn't load moderation data.",
+    "actionError": "Moderation action failed.",
+    "archiveError": "Could not archive message.",
+    "reportedByOne": "reported by {{name}}",
+    "reportedByMany": "reported by {{count}} members",
+    "log": {
+      "keptPraxis": "Kept praxis \"{{title}}\"",
+      "removedPraxis": "Removed praxis \"{{title}}\"",
+      "failedPraxis": "Failed praxis \"{{title}}\"",
+      "keptComment": "Kept comment by {{name}}",
+      "removedComment": "Removed comment by {{name}}"
+    },
+    "typeLabel": {
+      "praxis": "Praxis",
+      "comment": "Comment"
+    },
+    "stats": {
+      "openReports": "Open reports",
+      "activeMembers": "Active members"
+    },
+    "queue": {
+      "heading": "Review queue",
+      "empty": {
+        "title": "Queue clear",
+        "body": "Nothing flagged right now. Check back later."
+      },
+      "byline": "by {{author}}",
+      "flags_one": "{{count}} flag",
+      "flags_other": "{{count}} flags",
+      "viewPraxis": "View praxis →",
+      "viewThread": "View thread →",
+      "failNotePlaceholder": "Reason for failure (visible to player)...",
+      "actions": {
+        "keep": "keep",
+        "remove": "remove",
+        "fail": "fail",
+        "confirmFail": "confirm fail",
+        "cancel": "cancel"
+      }
+    },
+    "actionLog": {
+      "heading": "Your last actions",
+      "note": "This session only — the list clears when you leave the page."
+    },
+    "messages": {
+      "heading": "Messages",
+      "showArchived": "show archived",
+      "emptyArchived": "No archived messages.",
+      "empty": "No messages.",
+      "archive": "archive",
+      "unarchive": "unarchive"
+    }
+  }
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import PageTitle from '../components/ui/PageTitle'
 import ModerationTab from './admin/ModerationTab'
 import TasksTab from './admin/TasksTab'
@@ -7,20 +8,16 @@ import OverviewTab from './admin/OverviewTab'
 
 type Tab = 'moderation' | 'tasks' | 'accounts' | 'overview'
 
-const TABS: { key: Tab; label: string }[] = [
-  { key: 'moderation', label: 'Moderation' },
-  { key: 'tasks', label: 'Tasks' },
-  { key: 'accounts', label: 'Accounts' },
-  { key: 'overview', label: 'Overview' },
-]
+const TABS: Tab[] = ['moderation', 'tasks', 'accounts', 'overview']
 
 function getInitialTab(): Tab {
   const hash = window.location.hash.replace('#', '')
-  if (TABS.some((t) => t.key === hash)) return hash as Tab
+  if (TABS.some((t) => t === hash)) return hash as Tab
   return 'moderation'
 }
 
 export default function Admin() {
+  const { t } = useTranslation('admin')
   const [activeTab, setActiveTab] = useState<Tab>(getInitialTab)
 
   const switchTab = (tab: Tab) => {
@@ -30,14 +27,14 @@ export default function Admin() {
 
   return (
     <div className="py-8">
-      <PageTitle title="Admin" />
+      <PageTitle title={t('title')} />
 
       {/* Tab bar */}
       <div
         className="flex gap-6 mb-6"
         style={{ borderBottom: '2px solid var(--color-border)' }}
       >
-        {TABS.map(({ key, label }) => (
+        {TABS.map((key) => (
           <button
             key={key}
             onClick={() => switchTab(key)}
@@ -55,7 +52,7 @@ export default function Admin() {
               letterSpacing: '0.12em',
             }}
           >
-            {label}
+            {t(`tabs.${key}`)}
           </button>
         ))}
       </div>

--- a/frontend/src/pages/admin/AccountsTab.tsx
+++ b/frontend/src/pages/admin/AccountsTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import {
   getAccounts,
   getAccountDetail,
@@ -9,7 +10,22 @@ import type { AccountSummary, AccountDetail } from "../../api/admin";
 import { extractError } from "../../utils/errors";
 import { formatTimestamp } from "../../utils/dates";
 
+type AccountStatus = "active" | "suspended" | "banned" | "paused";
+const ACCOUNT_STATUSES: AccountStatus[] = [
+  "active",
+  "suspended",
+  "banned",
+  "paused",
+];
+
 export default function AccountsTab() {
+  const { t } = useTranslation(["admin", "common"]);
+  // Backend statuses are open strings; render the known ones through the
+  // catalog and fall back to the raw value for anything unmapped.
+  const statusLabel = (status: string): string => {
+    const known = ACCOUNT_STATUSES.find((s) => s === status);
+    return known ? t(`accounts.status.${known}`) : status;
+  };
   const [accounts, setAccounts] = useState<AccountSummary[]>([]);
   const [searchEmail, setSearchEmail] = useState("");
   const [expandedId, setExpandedId] = useState<number | null>(null);
@@ -23,7 +39,7 @@ export default function AccountsTab() {
     setError(null);
     getAccounts(email || undefined)
       .then(setAccounts)
-      .catch((err) => setError(extractError(err, "Couldn't load accounts.")))
+      .catch((err) => setError(extractError(err, t("accounts.loadError"))))
       .finally(() => setLoading(false));
   };
 
@@ -50,7 +66,7 @@ export default function AccountsTab() {
       const d = await getAccountDetail(accountId);
       setDetail(d);
     } catch (err) {
-      setActionError(extractError(err, "Could not load account detail."));
+      setActionError(extractError(err, t("accounts.detailError")));
     }
   };
 
@@ -64,7 +80,7 @@ export default function AccountsTab() {
         setDetail(d);
       }
     } catch (err) {
-      setActionError(extractError(err, "Could not update account."));
+      setActionError(extractError(err, t("accounts.suspendError")));
     }
   };
 
@@ -77,12 +93,12 @@ export default function AccountsTab() {
         setDetail(d);
       }
     } catch (err) {
-      setActionError(extractError(err, "Could not update character."));
+      setActionError(extractError(err, t("accounts.banError")));
     }
   };
 
   if (loading)
-    return <div className="font-body text-muted text-sm">Loading...</div>;
+    return <div className="font-body text-muted text-sm">{t("common:loading")}</div>;
   if (error) return <p className="font-body text-sm text-red-600">{error}</p>;
 
   return (
@@ -96,7 +112,7 @@ export default function AccountsTab() {
       {/* Search */}
       <input
         type="text"
-        placeholder="Search by email..."
+        placeholder={t("accounts.searchPlaceholder")}
         value={searchEmail}
         onChange={(e) => handleSearch(e.target.value)}
         className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink w-full mb-4"
@@ -104,7 +120,7 @@ export default function AccountsTab() {
 
       {/* Accounts list */}
       {accounts.length === 0 ? (
-        <p className="font-body text-sm text-muted">No accounts found.</p>
+        <p className="font-body text-sm text-muted">{t("accounts.empty")}</p>
       ) : (
         <div className="flex flex-col gap-3">
           {accounts.map((account) => (
@@ -133,9 +149,9 @@ export default function AccountsTab() {
                         fontWeight: 700,
                       }}
                     >
-                      {account.status}
+                      {statusLabel(account.status)}
                     </span>{" "}
-                    &middot; ID #{account.id} &middot;{" "}
+                    &middot; {t("accounts.idLabel", { id: account.id })} &middot;{" "}
                     {formatTimestamp(account.created_at)}
                   </p>
                 </button>
@@ -159,7 +175,9 @@ export default function AccountsTab() {
                         }
                   }
                 >
-                  {account.status === "suspended" ? "unsuspend" : "suspend"}
+                  {account.status === "suspended"
+                    ? t("accounts.unsuspend")
+                    : t("accounts.suspend")}
                 </button>
               </div>
 
@@ -170,11 +188,13 @@ export default function AccountsTab() {
                     className="eyebrow mb-2"
                     style={{ color: "var(--color-text-tertiary)" }}
                   >
-                    Characters ({detail.characters.length})
+                    {t("accounts.charactersHeading", {
+                      count: detail.characters.length,
+                    })}
                   </p>
                   {detail.characters.length === 0 ? (
                     <p className="font-body text-xs text-muted">
-                      No characters.
+                      {t("accounts.noCharacters")}
                     </p>
                   ) : (
                     <div className="flex flex-col gap-2">
@@ -203,7 +223,7 @@ export default function AccountsTab() {
                                 fontWeight: 700,
                               }}
                             >
-                              {character.status}
+                              {statusLabel(character.status)}
                             </span>
                           </div>
                           <button
@@ -230,7 +250,9 @@ export default function AccountsTab() {
                                   }
                             }
                           >
-                            {character.status === "banned" ? "unban" : "ban"}
+                            {character.status === "banned"
+                              ? t("accounts.unban")
+                              : t("accounts.ban")}
                           </button>
                         </div>
                       ))}

--- a/frontend/src/pages/admin/ModerationTab.tsx
+++ b/frontend/src/pages/admin/ModerationTab.tsx
@@ -12,6 +12,7 @@
  */
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import {
   getFlaggedPraxes,
@@ -31,6 +32,7 @@ import type {
 import { formatTimestamp, relativeTime } from '../../utils/dates'
 import { extractError } from '../../utils/errors'
 import { flagReasonLabel } from '../../utils/flagReasons'
+import i18n from '../../i18n'
 
 // ── Queue shaping ─────────────────────────────────────────────────────────────
 
@@ -73,8 +75,10 @@ function topReason(flags: FlagOut[]): string {
 /** "reported by {name}" for one reporter, "reported by N members" for more. */
 function reporterText(flags: FlagOut[]): string {
   const distinct = new Set(flags.map((flag) => flag.flagged_by_id))
-  if (distinct.size === 1 && flags[0]) return `reported by ${flags[0].flagged_by_name}`
-  return `reported by ${distinct.size} members`
+  if (distinct.size === 1 && flags[0]) {
+    return i18n.t('admin:moderation.reportedByOne', { name: flags[0].flagged_by_name })
+  }
+  return i18n.t('admin:moderation.reportedByMany', { count: distinct.size })
 }
 
 interface ActionLogEntry {
@@ -128,6 +132,7 @@ function QueueCardFrame({
 // ── The tab ──────────────────────────────────────────────────────────────────
 
 export default function ModerationTab() {
+  const { t } = useTranslation(['admin', 'common'])
   const [flaggedPraxes, setFlaggedPraxes] = useState<FlaggedPraxisOut[]>([])
   const [flaggedComments, setFlaggedComments] = useState<FlaggedCommentOut[]>([])
   const [activeMembers, setActiveMembers] = useState<number | null>(null)
@@ -159,7 +164,7 @@ export default function ModerationTab() {
         setActiveMembers(characters.length)
         setMessages(messageRows)
       })
-      .catch((err) => setError(extractError(err, "Couldn't load moderation data.")))
+      .catch((err) => setError(extractError(err, t('moderation.loadError'))))
       .finally(() => setLoading(false))
   }
 
@@ -178,15 +183,20 @@ export default function ModerationTab() {
     note?: string,
   ) => {
     setActionError(null)
-    const verb = status === 'visible' ? 'Kept' : status === 'hidden' ? 'Removed' : 'Failed'
+    const logKey =
+      status === 'visible'
+        ? 'moderation.log.keptPraxis'
+        : status === 'hidden'
+          ? 'moderation.log.removedPraxis'
+          : 'moderation.log.failedPraxis'
     try {
       await moderatePraxis(praxis.id, status, note)
       setFailNoteTarget(null)
       setFailNote('')
-      logAction(`${verb} praxis "${praxis.title || praxis.task_title}"`)
+      logAction(t(logKey, { title: praxis.title || praxis.task_title }))
       refresh()
     } catch (err) {
-      setActionError(extractError(err, 'Moderation action failed.'))
+      setActionError(extractError(err, t('moderation.actionError')))
     }
   }
 
@@ -195,13 +205,16 @@ export default function ModerationTab() {
     status: 'visible' | 'deleted',
   ) => {
     setActionError(null)
-    const verb = status === 'visible' ? 'Kept' : 'Removed'
+    const logKey =
+      status === 'visible'
+        ? 'moderation.log.keptComment'
+        : 'moderation.log.removedComment'
     try {
       await moderateComment(comment.id, status)
-      logAction(`${verb} comment by ${comment.author.display_name}`)
+      logAction(t(logKey, { name: comment.author.display_name }))
       refresh()
     } catch (err) {
-      setActionError(extractError(err, 'Moderation action failed.'))
+      setActionError(extractError(err, t('moderation.actionError')))
     }
   }
 
@@ -211,11 +224,11 @@ export default function ModerationTab() {
       await archiveMessage(id)
       refresh()
     } catch (err) {
-      setActionError(extractError(err, 'Could not archive message.'))
+      setActionError(extractError(err, t('moderation.archiveError')))
     }
   }
 
-  if (loading) return <div className="font-body text-muted text-sm">Loading...</div>
+  if (loading) return <div className="font-body text-muted text-sm">{t('common:loading')}</div>
   if (error) return <p className="font-body text-sm text-red-600">{error}</p>
 
   const queue: QueueItem[] = [
@@ -235,24 +248,24 @@ export default function ModerationTab() {
       <div className="flex gap-4">
         <div className="card px-5 py-3" style={{ minWidth: 140 }}>
           <p className="font-display text-2xl font-bold">{queue.length}</p>
-          <p className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Open reports</p>
+          <p className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('moderation.stats.openReports')}</p>
         </div>
         <div className="card px-5 py-3" style={{ minWidth: 140 }}>
           <p className="font-display text-2xl font-bold">{activeMembers ?? '—'}</p>
-          <p className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>Active members</p>
+          <p className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('moderation.stats.activeMembers')}</p>
         </div>
       </div>
 
       {/* Review queue — flagged praxes + comments, one list, newest first. */}
       <section>
         <h3 className="font-display text-xl font-bold mb-3 border-b-2 border-border pb-1">
-          Review queue <span className="text-muted text-base">({queue.length})</span>
+          {t('moderation.queue.heading')} <span className="text-muted text-base">({queue.length})</span>
         </h3>
         {queue.length === 0 ? (
           <div className="card px-4 py-6" style={{ textAlign: 'center' }}>
-            <p className="font-display text-lg font-bold">Queue clear</p>
+            <p className="font-display text-lg font-bold">{t('moderation.queue.empty.title')}</p>
             <p className="font-body text-sm text-muted">
-              Nothing flagged right now. Check back later.
+              {t('moderation.queue.empty.body')}
             </p>
           </div>
         ) : (
@@ -262,7 +275,7 @@ export default function ModerationTab() {
                 <QueueCardFrame
                   key={`praxis-${item.praxis.id}`}
                   badgeReason={topReason(item.praxis.flags)}
-                  typeLabel="Praxis"
+                  typeLabel={t('moderation.typeLabel.praxis')}
                   when={queueTime(item)}
                 >
                   <div className="flex items-start gap-4">
@@ -275,9 +288,13 @@ export default function ModerationTab() {
                         {item.praxis.title || item.praxis.task_title}
                       </Link>
                       <p className="font-body text-xs text-muted">
-                        by {item.praxis.created_by_display_name || `#${item.praxis.created_by_id}`}
+                        {t('moderation.queue.byline', {
+                          author:
+                            item.praxis.created_by_display_name ||
+                            `#${item.praxis.created_by_id}`,
+                        })}
                         {' '}&middot; {reporterText(item.praxis.flags)}
-                        {' '}&middot; {item.praxis.flags.length} flag{item.praxis.flags.length === 1 ? '' : 's'}
+                        {' '}&middot; {t('moderation.queue.flags', { count: item.praxis.flags.length })}
                       </p>
                       {item.praxis.flags[0]?.reason_detail && (
                         <p className="font-body text-xs text-muted" style={{ marginTop: 4, fontStyle: 'italic' }}>
@@ -289,7 +306,7 @@ export default function ModerationTab() {
                         className="eyebrow"
                         style={{ display: 'inline-block', marginTop: 6 }}
                       >
-                        View praxis &rarr;
+                        {t('moderation.queue.viewPraxis')}
                       </Link>
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
@@ -297,21 +314,21 @@ export default function ModerationTab() {
                         onClick={() => void handlePraxisAction(item.praxis, 'visible')}
                         className="btn-primary text-xs"
                       >
-                        keep
+                        {t('moderation.queue.actions.keep')}
                       </button>
                       <button
                         onClick={() => void handlePraxisAction(item.praxis, 'hidden')}
                         className="btn-outline text-xs"
                         style={{ borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }}
                       >
-                        remove
+                        {t('moderation.queue.actions.remove')}
                       </button>
                       <button
                         onClick={() => setFailNoteTarget(failNoteTarget === item.praxis.id ? null : item.praxis.id)}
                         className="btn-outline text-xs"
                         style={{ borderColor: 'rgba(245,158,11,0.5)', color: 'var(--color-warning)' }}
                       >
-                        fail
+                        {t('moderation.queue.actions.fail')}
                       </button>
                     </div>
                   </div>
@@ -320,7 +337,7 @@ export default function ModerationTab() {
                       <textarea
                         className="border-2 border-border bg-card px-3 py-1 font-body text-sm focus:outline-none focus:border-ink flex-1 resize-none"
                         rows={2}
-                        placeholder="Reason for failure (visible to player)..."
+                        placeholder={t('moderation.queue.failNotePlaceholder')}
                         value={failNote}
                         onChange={(e) => setFailNote(e.target.value)}
                       />
@@ -329,13 +346,13 @@ export default function ModerationTab() {
                         className="btn-primary text-xs"
                         style={{ background: 'var(--color-warning)', borderColor: 'var(--color-warning)' }}
                       >
-                        confirm fail
+                        {t('moderation.queue.actions.confirmFail')}
                       </button>
                       <button
                         onClick={() => { setFailNoteTarget(null); setFailNote('') }}
                         className="btn-outline text-xs"
                       >
-                        cancel
+                        {t('moderation.queue.actions.cancel')}
                       </button>
                     </div>
                   )}
@@ -344,7 +361,7 @@ export default function ModerationTab() {
                 <QueueCardFrame
                   key={`comment-${item.comment.id}`}
                   badgeReason={topReason(item.comment.flags)}
-                  typeLabel="Comment"
+                  typeLabel={t('moderation.typeLabel.comment')}
                   when={queueTime(item)}
                 >
                   <div className="flex items-start gap-4">
@@ -353,9 +370,9 @@ export default function ModerationTab() {
                         &ldquo;{item.comment.body_text}&rdquo;
                       </p>
                       <p className="font-body text-xs text-muted" style={{ marginTop: 4 }}>
-                        by {item.comment.author.display_name}
+                        {t('moderation.queue.byline', { author: item.comment.author.display_name })}
                         {' '}&middot; {reporterText(item.comment.flags)}
-                        {' '}&middot; {item.comment.flags.length} flag{item.comment.flags.length === 1 ? '' : 's'}
+                        {' '}&middot; {t('moderation.queue.flags', { count: item.comment.flags.length })}
                       </p>
                       {item.comment.flags[0]?.reason_detail && (
                         <p className="font-body text-xs text-muted" style={{ marginTop: 4, fontStyle: 'italic' }}>
@@ -370,7 +387,7 @@ export default function ModerationTab() {
                         className="eyebrow"
                         style={{ display: 'inline-block', marginTop: 6 }}
                       >
-                        View thread &rarr;
+                        {t('moderation.queue.viewThread')}
                       </Link>
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
@@ -378,14 +395,14 @@ export default function ModerationTab() {
                         onClick={() => void handleCommentAction(item.comment, 'visible')}
                         className="btn-primary text-xs"
                       >
-                        keep
+                        {t('moderation.queue.actions.keep')}
                       </button>
                       <button
                         onClick={() => void handleCommentAction(item.comment, 'deleted')}
                         className="btn-outline text-xs"
                         style={{ borderColor: 'rgba(220,38,38,0.5)', color: 'var(--color-danger)' }}
                       >
-                        remove
+                        {t('moderation.queue.actions.remove')}
                       </button>
                     </div>
                   </div>
@@ -400,10 +417,10 @@ export default function ModerationTab() {
       {actionLog.length > 0 && (
         <section>
           <h3 className="font-display text-xl font-bold mb-3 border-b-2 border-border pb-1">
-            Your last actions
+            {t('moderation.actionLog.heading')}
           </h3>
           <p className="font-body text-xs text-muted mb-2">
-            This session only — the list clears when you leave the page.
+            {t('moderation.actionLog.note')}
           </p>
           <ul className="flex flex-col gap-1">
             {actionLog.map((entry) => (
@@ -420,7 +437,7 @@ export default function ModerationTab() {
       <section>
         <div className="flex items-center gap-4 mb-3 border-b-2 border-border pb-1">
           <h3 className="font-display text-xl font-bold">
-            Messages <span className="text-muted text-base">({messages.length})</span>
+            {t('moderation.messages.heading')} <span className="text-muted text-base">({messages.length})</span>
           </h3>
           <label className="font-body text-xs text-muted flex items-center gap-1 cursor-pointer">
             <input
@@ -428,12 +445,12 @@ export default function ModerationTab() {
               checked={showArchived}
               onChange={(e) => setShowArchived(e.target.checked)}
             />
-            show archived
+            {t('moderation.messages.showArchived')}
           </label>
         </div>
         {messages.length === 0 ? (
           <p className="font-body text-sm text-muted">
-            {showArchived ? 'No archived messages.' : 'No messages.'}
+            {showArchived ? t('moderation.messages.emptyArchived') : t('moderation.messages.empty')}
           </p>
         ) : (
           <div className="flex flex-col gap-3">
@@ -454,7 +471,7 @@ export default function ModerationTab() {
                     onClick={() => void handleArchive(m.id)}
                     className="btn-outline text-xs shrink-0"
                   >
-                    {m.is_archived ? 'unarchive' : 'archive'}
+                    {m.is_archived ? t('moderation.messages.unarchive') : t('moderation.messages.archive')}
                   </button>
                 </div>
                 <p className="font-body text-sm text-ink mt-2 whitespace-pre-wrap">{m.message}</p>

--- a/frontend/src/pages/admin/OverviewTab.tsx
+++ b/frontend/src/pages/admin/OverviewTab.tsx
@@ -1,29 +1,31 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { getOverview } from '../../api/admin'
 import type { OverviewStats } from '../../api/admin'
 import { extractError } from '../../utils/errors'
 
 export default function OverviewTab() {
+  const { t } = useTranslation(['admin', 'common'])
   const [stats, setStats] = useState<OverviewStats | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     getOverview()
       .then(setStats)
-      .catch((err) => setError(extractError(err, "Couldn't load overview.")))
-  }, [])
+      .catch((err) => setError(extractError(err, t('overview.loadError'))))
+  }, [t])
 
   if (error) return <p className="font-body text-sm text-red-600">{error}</p>
-  if (!stats) return <div className="font-body text-muted text-sm">Loading...</div>
+  if (!stats) return <div className="font-body text-muted text-sm">{t('common:loading')}</div>
 
   const items = [
-    { label: 'Accounts', value: stats.accounts },
-    { label: 'Characters', value: stats.characters },
-    { label: 'Active Tasks', value: stats.active_tasks },
-    { label: 'Praxis', value: stats.praxis },
-    { label: 'Votes', value: stats.votes },
-    { label: 'Flagged', value: stats.flagged_praxis, highlight: stats.flagged_praxis > 0 },
-    { label: 'Suspended', value: stats.suspended_accounts, highlight: stats.suspended_accounts > 0 },
+    { label: t('overview.stats.accounts'), value: stats.accounts },
+    { label: t('overview.stats.characters'), value: stats.characters },
+    { label: t('overview.stats.activeTasks'), value: stats.active_tasks },
+    { label: t('overview.stats.praxis'), value: stats.praxis },
+    { label: t('overview.stats.votes'), value: stats.votes },
+    { label: t('overview.stats.flagged'), value: stats.flagged_praxis, highlight: stats.flagged_praxis > 0 },
+    { label: t('overview.stats.suspended'), value: stats.suspended_accounts, highlight: stats.suspended_accounts > 0 },
   ]
 
   return (

--- a/frontend/src/pages/admin/TasksTab.tsx
+++ b/frontend/src/pages/admin/TasksTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getAllTasks, updateTaskStatus, adminPatchTask } from "../../api/admin";
 import type { TaskOut } from "../../api/tasks";
 import { extractError } from "../../utils/errors";
@@ -14,7 +15,19 @@ interface EditState {
   level_required: string;
 }
 
+const TASK_STATUSES = ["active", "pending", "retired"] as const;
+type TaskStatus = (typeof TASK_STATUSES)[number];
+
 export default function TasksTab() {
+  const { t } = useTranslation(["admin", "common"]);
+  // Task status is an open backend string; map the known ones through the
+  // catalog, falling back to the raw value for anything unmapped.
+  const statusLabel = (status: string): string => {
+    const known = TASK_STATUSES.find((s) => s === status) as
+      | TaskStatus
+      | undefined;
+    return known ? t(`tasks.status.${known}`) : status;
+  };
   const [tasks, setTasks] = useState<TaskOut[]>([]);
   const [filter, setFilter] = useState<StatusFilter>("all");
   const [loading, setLoading] = useState(true);
@@ -28,7 +41,7 @@ export default function TasksTab() {
     setError(null);
     getAllTasks()
       .then(setTasks)
-      .catch((err) => setError(extractError(err, "Couldn't load tasks.")))
+      .catch((err) => setError(extractError(err, t("tasks.loadError"))))
       .finally(() => setLoading(false));
   };
 
@@ -42,17 +55,17 @@ export default function TasksTab() {
       await updateTaskStatus(taskId, newStatus);
       refresh();
     } catch (err) {
-      setActionError(extractError(err, "Could not update task status."));
+      setActionError(extractError(err, t("tasks.statusError")));
     }
   };
 
-  const openEdit = (t: TaskOut) => {
-    setEditingId(t.id);
+  const openEdit = (task: TaskOut) => {
+    setEditingId(task.id);
     setEditState({
-      title: t.title,
-      description: t.description ?? "",
-      point_value: String(t.point_value),
-      level_required: String(t.level_required),
+      title: task.title,
+      description: task.description ?? "",
+      point_value: String(task.point_value),
+      level_required: String(task.level_required),
     });
   };
 
@@ -82,17 +95,17 @@ export default function TasksTab() {
       setEditState(null);
       refresh();
     } catch (err) {
-      setActionError(extractError(err, "Could not save task edits."));
+      setActionError(extractError(err, t("tasks.saveError")));
     } finally {
       setSaving(false);
     }
   };
 
   const filtered =
-    filter === "all" ? tasks : tasks.filter((t) => t.status === filter);
+    filter === "all" ? tasks : tasks.filter((task) => task.status === filter);
 
   if (loading)
-    return <div className="font-body text-muted text-sm">Loading...</div>;
+    return <div className="font-body text-muted text-sm">{t("common:loading")}</div>;
   if (error) return <p className="font-body text-sm text-red-600">{error}</p>;
 
   return (
@@ -111,10 +124,10 @@ export default function TasksTab() {
             onClick={() => setFilter(s)}
             className={filter === s ? "chip-active" : "chip"}
           >
-            {s}
+            {t(`tasks.filters.${s}`)}
             {s !== "all" && (
               <span className="ml-1 text-xs">
-                ({tasks.filter((t) => t.status === s).length})
+                ({tasks.filter((task) => task.status === s).length})
               </span>
             )}
           </button>
@@ -123,12 +136,14 @@ export default function TasksTab() {
 
       {/* Tasks list */}
       {filtered.length === 0 ? (
-        <p className="font-body text-sm text-muted">No {filter} tasks.</p>
+        <p className="font-body text-sm text-muted">
+          {t("tasks.empty", { filter: t(`tasks.filters.${filter}`) })}
+        </p>
       ) : (
         <div className="flex flex-col gap-3">
-          {filtered.map((t) => (
-            <div key={t.id} className="card px-4 py-3 flex flex-col gap-3">
-              {editingId === t.id && editState ? (
+          {filtered.map((task) => (
+            <div key={task.id} className="card px-4 py-3 flex flex-col gap-3">
+              {editingId === task.id && editState ? (
                 /* Inline edit form */
                 <div className="flex flex-col gap-2">
                   <input
@@ -137,7 +152,7 @@ export default function TasksTab() {
                     onChange={(e) =>
                       setEditState({ ...editState, title: e.target.value })
                     }
-                    placeholder="Title"
+                    placeholder={t("tasks.titlePlaceholder")}
                   />
                   <textarea
                     className="font-body text-sm border border-border bg-surface px-2 py-1 resize-y"
@@ -149,11 +164,11 @@ export default function TasksTab() {
                         description: e.target.value,
                       })
                     }
-                    placeholder="Description"
+                    placeholder={t("tasks.descriptionPlaceholder")}
                   />
                   <div className="flex gap-3">
                     <label className="font-body text-xs text-muted flex items-center gap-1">
-                      Points
+                      {t("tasks.pointsLabel")}
                       <input
                         type="number"
                         min={1}
@@ -168,7 +183,7 @@ export default function TasksTab() {
                       />
                     </label>
                     <label className="font-body text-xs text-muted flex items-center gap-1">
-                      Level req.
+                      {t("tasks.levelLabel")}
                       <input
                         type="number"
                         min={0}
@@ -186,17 +201,17 @@ export default function TasksTab() {
                   </div>
                   <div className="flex gap-2">
                     <button
-                      onClick={() => void handleSaveEdit(t.id)}
+                      onClick={() => void handleSaveEdit(task.id)}
                       disabled={saving}
                       className="btn-primary text-xs"
                     >
-                      {saving ? "saving…" : "save"}
+                      {saving ? t("tasks.actions.saving") : t("tasks.actions.save")}
                     </button>
                     <button
                       onClick={cancelEdit}
                       className="btn-outline text-xs"
                     >
-                      cancel
+                      {t("tasks.actions.cancel")}
                     </button>
                   </div>
                 </div>
@@ -206,7 +221,7 @@ export default function TasksTab() {
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
                       <p className="font-display text-lg font-bold">
-                        {t.title}
+                        {task.title}
                       </p>
                       <span
                         className="eyebrow"
@@ -215,64 +230,73 @@ export default function TasksTab() {
                           padding: "1px 6px",
                           border: "1px solid var(--color-border)",
                           color:
-                            t.status === "active"
+                            task.status === "active"
                               ? "var(--color-success)"
-                              : t.status === "pending"
+                              : task.status === "pending"
                                 ? "var(--color-warning)"
                                 : "var(--color-text-tertiary)",
                         }}
                       >
-                        {t.status}
+                        {statusLabel(task.status)}
                       </span>
                     </div>
                     <p className="font-body text-xs text-muted">
-                      {t.point_value} pts &middot; lvl {t.level_required}{" "}
-                      &middot; {t.primary_faction_slug ?? "cross-faction"}
+                      {t("tasks.meta", {
+                        points: task.point_value,
+                        level: task.level_required,
+                        faction:
+                          task.primary_faction_slug ?? t("tasks.crossFaction"),
+                      })}
                     </p>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
-                    {(t.status === "pending" || t.status === "retired") && (
+                    {(task.status === "pending" ||
+                      task.status === "retired") && (
                       <button
-                        onClick={() => openEdit(t)}
+                        onClick={() => openEdit(task)}
                         className="btn-outline text-xs"
                       >
-                        edit
+                        {t("tasks.actions.edit")}
                       </button>
                     )}
-                    {t.status === "pending" && (
+                    {task.status === "pending" && (
                       <>
                         <button
                           onClick={() =>
-                            void handleStatusChange(t.id, "active")
+                            void handleStatusChange(task.id, "active")
                           }
                           className="btn-primary text-xs"
                         >
-                          activate
+                          {t("tasks.actions.activate")}
                         </button>
                         <button
                           onClick={() =>
-                            void handleStatusChange(t.id, "retired")
+                            void handleStatusChange(task.id, "retired")
                           }
                           className="btn-outline text-xs"
                         >
-                          retire
+                          {t("tasks.actions.retire")}
                         </button>
                       </>
                     )}
-                    {t.status === "active" && (
+                    {task.status === "active" && (
                       <button
-                        onClick={() => void handleStatusChange(t.id, "retired")}
+                        onClick={() =>
+                          void handleStatusChange(task.id, "retired")
+                        }
                         className="btn-outline text-xs"
                       >
-                        retire
+                        {t("tasks.actions.retire")}
                       </button>
                     )}
-                    {t.status === "retired" && (
+                    {task.status === "retired" && (
                       <button
-                        onClick={() => void handleStatusChange(t.id, "active")}
+                        onClick={() =>
+                          void handleStatusChange(task.id, "active")
+                        }
                         className="btn-primary text-xs"
                       >
-                        reactivate
+                        {t("tasks.actions.reactivate")}
                       </button>
                     )}
                   </div>

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -17,7 +17,7 @@ import { reframeLabel } from '../../components/vote/voteReframes'
 import { TaskCrown } from '../../components/cards/TaskCrown'
 import type { PraxisDetailState } from './usePraxisDetail'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
-import { FLAG_REASONS, FLAG_REASON_OTHER } from '../../utils/flagReasons'
+import { flagReasonOptions, FLAG_REASON_OTHER } from '../../utils/flagReasons'
 
 // ── Egalitarian byline (#387) ────────────────────────────────────────────────
 //
@@ -308,7 +308,7 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
         <div style={{ marginTop: 10 }}>
           {/* Reason picker — the shared vocabulary (ADR-0031), not free text. */}
           <div className="flex items-center gap-2" style={{ flexWrap: 'wrap' }} role="radiogroup" aria-label="Flag reason">
-            {FLAG_REASONS.map(({ value, label }) => (
+            {flagReasonOptions().map(({ value, label }) => (
               <button
                 key={value}
                 role="radio"

--- a/frontend/src/utils/flagReasons.ts
+++ b/frontend/src/utils/flagReasons.ts
@@ -4,22 +4,35 @@
  * One flat list shared by praxis and comment flags. The player flag control
  * picks from these keys; the moderator queue badges on them. `other` carries
  * an optional free-text note.
+ *
+ * The enum keys/values are the shared, backend-mirrored vocabulary and stay
+ * fixed. Only the display labels are copy — they resolve through the `admin`
+ * catalog (i18n) so they can be reworded without touching this module.
  */
+import i18n from '../i18n'
 
 export type FlagReason = 'spam' | 'harassment' | 'nsfw' | 'slop' | 'other'
 
 export const FLAG_REASON_OTHER: FlagReason = 'other'
 
-export const FLAG_REASONS: { value: FlagReason; label: string }[] = [
-  { value: 'spam', label: 'Spam' },
-  { value: 'harassment', label: 'Harassment' },
-  { value: 'nsfw', label: 'NSFW' },
-  { value: 'slop', label: 'Slop' },
-  { value: 'other', label: 'Other' },
+const FLAG_REASON_VALUES: FlagReason[] = [
+  'spam',
+  'harassment',
+  'nsfw',
+  'slop',
+  'other',
 ]
 
 /** Badge label for a stored reason key; unknown keys read as Other (ADR-0031). */
 export function flagReasonLabel(value: string): string {
-  const match = FLAG_REASONS.find((reason) => reason.value === value)
-  return match ? match.label : 'Other'
+  const match = FLAG_REASON_VALUES.find((reason) => reason === value)
+  return i18n.t(`admin:flagReasons.${match ?? FLAG_REASON_OTHER}`)
+}
+
+/** The pickable reasons, paired with their (localized) display labels. */
+export function flagReasonOptions(): { value: FlagReason; label: string }[] {
+  return FLAG_REASON_VALUES.map((value) => ({
+    value,
+    label: i18n.t(`admin:flagReasons.${value}`),
+  }))
 }


### PR DESCRIPTION
Extracts admin/moderation screen copy into the `admin` i18next namespace (epic #440).

## What changed
- `frontend/src/locales/en/admin.json` — populated the previously-empty namespace with all admin/moderation copy: page title, tab labels, per-tab error messages, table/stat labels, action buttons, confirm dialogs, placeholders, empty states, plurals, and the moderation action-log messages.
- `Admin.tsx`, `admin/OverviewTab.tsx`, `admin/AccountsTab.tsx`, `admin/TasksTab.tsx`, `admin/ModerationTab.tsx` — replaced hardcoded strings with `useTranslation('admin')` bare keys (`['admin','common']` where the shared `common:loading` label is reused). Kept all a11y attrs.
- `utils/flagReasons.ts` — flag-reason display labels (ADR-0031) now resolve through `i18n.t('admin:flagReasons.*')`; enum keys/values stay intact. `FLAG_REASONS` (static, hardcoded labels) is replaced by `flagReasonLabel()` (unchanged signature) + `flagReasonOptions()`.
- `pages/praxisDetail/shared.tsx` — call-site update only: the player flag picker now maps over `flagReasonOptions()` instead of the removed `FLAG_REASONS` const (same `{value,label}` shape). No copy swept here; that surface belongs to the praxis sweep (#445).

Open backend statuses (account/character/task) render known values through the catalog and fall back to the raw string for anything unmapped, so no API types were widened.

## Gates
- `npx tsc --noEmit` — clean
- `npm test -- --run` — 200 passed / 22 files
- `npx eslint` on swept files — 0 errors (only `i18next/no-literal-string` warnings, which flag the `t(...)` key args themselves — expected rule noise, warning-only)

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)