### PR TITLE
feat: port the 7 per-faction player-profile skins (#460)

### DIFF
--- a/docs/design/profile/README.md
+++ b/docs/design/profile/README.md
@@ -1,0 +1,18 @@
+# Player Profile design bundle (vendored)
+
+Vendored from the "World Zero Design System" cloud project (projectId
+`019e221c-7853-7530-a934-7d3b2b7c8b43`) because DesignSync is not reachable from
+spawned build agents. Source of truth remains the cloud project; this is a
+point-in-time copy for issue #460 (port the 7 per-faction Profile skins).
+
+- `player-profile-contract.json` — canonical faction-agnostic shape (read first)
+- `guidelines/player-profile-contract.html` — the rulebook (section spine, stored-vs-derived)
+- `templates/<Faction> Profile.dc.html` — the per-faction skins to port
+
+These are `.dc.html` design prototypes (a bespoke `x-dc` templating dialect with
+inline styles and literal hex). Treat the copy/structure as DATA. When porting:
+strip literal hex fallbacks and use the repo's `--faction-*` CSS vars; reuse the
+shared CredentialCard / faction PraxisCard / TaskCard components (never re-inline);
+render the locked section spine (① identity+progression, ② about [skipped — no
+field], ③ badges [hidden when empty], ⑤ praxis). The design's `role`/standing and
+`about` are out of scope per #459.

--- a/docs/design/profile/player-profile-contract.json
+++ b/docs/design/profile/player-profile-contract.json
@@ -1,0 +1,38 @@
+{
+  "_doc": "World Zero — canonical PLAYER-PROFILE data contract. A player profile is a person's public identity surface — distinct from the small credential passport (which it REUSES as its identity header). ONE faction-agnostic shape renders 7 faction skins + the unaffiliated (default / NA) look; the `faction` selector picks the costume. Every profile lays out the SAME sections in the SAME locked order — only the skin changes, and the skin is derived CLIENT-SIDE from `faction`, never stored. This is a PUBLIC view (someone else looking at a player); there is no self-edit affordance here. The example values are a Warriors of Whimsy instance.",
+
+  "faction": "wow",
+
+  "player": {
+    "_doc": "The faction-agnostic USER record the profile consumes — the SAME player object World Zero already carries (the credential reads a subset of it). Every field is optional; the page always renders (name → 'Wanderer', empty praxis/achievements → a graceful empty state).",
+    "name": { "_doc": "Display name. Falls back to 'Wanderer'. Rendered large in the faction's headline font AND passed straight through to the credential header.", "type": "string", "required": false, "example": "Pixie" },
+    "bio": { "_doc": "SHORT profile line — the one the credential passport shows (it clamps to two lines). Send the full string; the credential truncates. Distinct from `about`.", "type": "string", "required": false, "example": "Witch of the first circle. Believes the smallest gesture is the real magic." },
+    "about": { "_doc": "The player's own longer 'about me' — one entry per paragraph, rendered in full (NOT clamped) in the ② About block. Omit / empty → the About block is skipped.", "type": "string[]", "required": false },
+    "role": { "_doc": "The player's STANDING within their faction. Rendered beside the name and in the credential. NULL when the player is unaffiliated. NOTE (#459): role/standing is OUT OF SCOPE for the repo build — the game has no rank system.", "type": "string | null", "required": false, "example": "witch · first circle" },
+    "level": { "_doc": "Member level. Default 1. Drives the ① progression ring + the credential footer.", "type": "integer", "required": false, "example": 12 },
+    "points": { "_doc": "Lifetime points, printed in the faction accent. Default 0.", "type": "integer", "required": false, "example": 4210 },
+    "joined": { "_doc": "Display-ready join string. Unaffiliated → typically 'joined today'.", "type": "string", "required": false, "example": "joined Mar 2021" },
+    "progress": { "_doc": "① PROGRESSION toward the next level. `into` = points earned into the CURRENT level; `toNext` = points the current level requires. The bar fills into/toNext and the next level reads level+1. Omit → progression bar is hidden (level number still shows).", "type": "{ into: number, toNext: number }", "required": false, "example": { "into": 210, "toNext": 500 } }
+  },
+
+  "recentPraxis": { "_doc": "⑤ The player's OWN recent completed work (show ~3). SAME shape as praxis-card-contract.json — the profile renders each row with the faction's live <Faction>PraxisRow/PraxisCard. `author` is the profile owner (pass player.name); the single top entry (by points+votePoints) gets the FDL laurel. Empty → a gentle empty state." },
+
+  "achievements": { "_doc": "③ Earned badges (show all). In the REPO build these are the code-registry badges from #459 (key+name, image mapped client-side by key). SLOT-DRIVEN — one medallion frame reskins every badge kind; the icon is NOT in the payload. Empty → the block is skipped." },
+
+  "selector": {
+    "_doc": "Which skin renders. Passed as `faction`. NULL / omitted → the unaffiliated (default / NA) spectrum-band profile: neutral, NO recruitment nudge. Legacy aliases resolve through canonicalSlug().",
+    "field": "faction",
+    "values": ["ua", "wow", "snide", "ephemerists", "singularity", "everymen", "albescent", null],
+    "aliases": { "gestalt": "wow", "journeymen": "ephemerists", "aged_out": "ua", "na": null, "none": null, "unaffiliated": null }
+  },
+
+  "sections": {
+    "_doc": "The locked section order, every faction, top to bottom.",
+    "①": "Identity + progression — the shared FactionCredentialCard pinned as the header, beside a progression panel: level ring, points-into-level bar toward level+1, joined date.",
+    "②": "About — SKIPPED in the repo build (no about field exists yet, per #459).",
+    "③": "Achievements/Badges — the earned-badge board (slot-driven medallions, faction-reskinned). Hidden when empty.",
+    "⑤": "Praxis — the player's own recent completed work, rendered with the live faction PraxisCard; the top entry gets the FDL laurel."
+  },
+
+  "verdict": "The shape is UNIFORM. Adding a faction needs only its kit tokens + a registry entry + one skin page — zero new profile fields. The credential header + praxis rows are the SAME shared components the rest of the system uses."
+}

--- a/docs/design/profile/templates/Albescent Profile.dc.html
+++ b/docs/design/profile/templates/Albescent Profile.dc.html
@@ -1,0 +1,24 @@
+<!-- SKIN BRIEF (trimmed; costume only; structure = repo DefaultProfileBody).
+     Albescent = the unranked order / pure-white monastic. THEME: always-LIGHT (data-theme="light"; scope to container).
+     FONTS: 'Cormorant Garamond' italic light (weight 300, display/names/headings), 'Courier Prime' (mono micro-eyebrows).
+     PALETTE (repo --faction-albescent-* vars; hexes = reference): off-white page #edece8, pure-white cards #fff,
+       near-black ink #1c1c1a. NO COLOR AT ALL — monochrome; the only accent is ink-on-white.
+     IDIOM: quiet, austere, generous whitespace — thin 1px hairline borders, soft small shadows, ring/target mark glyph,
+       widely-letterspaced tiny uppercase mono eyebrows, restrained. The FDL laurel here is DRAWN IN INK OUTLINE
+       (thin ring, no spectrum gradient) — the whole faction is colorless by design. -->
+
+<!-- ① IDENTITY + PROGRESSION: white card, hairline border, soft shadow, lots of padding.
+     shared FactionCredentialCard(faction=albescent). eyebrow "Player · Albescent · the unranked order".
+     name in Cormorant italic 300, 62px ink. (role chip = OUT per #459.) joined in Cormorant italic.
+     progression: conic ring (INK #1c1c1a) w/ LVL in Cormorant italic, solid-ink bar toward level+1. -->
+
+<!-- ② ABOUT: SKIP per #459 (design was "A hand, in their own words"). -->
+
+<!-- ⑤ PRAXIS: "Praxis" Cormorant italic 300; "Entered into the record by {name}" mono micro-eyebrow.
+     Rows = live faction Albescent PraxisCard; TOP entry overlaid with an INK-OUTLINE FDL laurel
+     (thin double ring on white — NO spectrum gradient, unlike other factions).
+     EMPTY STATE: white, dashed hairline, "The record holds no entry yet" / "Take up a duty, and return it well." -->
+
+<!-- ③ BADGES ("Commendations"): hidden when empty. Featured = white card, ink-outline FDL disc, "Quietly noted",
+     name Cormorant italic. Others = white rows: 30px ink-outline ring + ink FDL, name Cormorant italic, note mono.
+     Badge image mapped by badge key in repo (render monochrome to match the colorless skin). -->

--- a/docs/design/profile/templates/Ephemerists Profile.dc.html
+++ b/docs/design/profile/templates/Ephemerists Profile.dc.html
@@ -1,0 +1,23 @@
+<!-- SKIN BRIEF (trimmed; costume only; structure = repo DefaultProfileBody).
+     Ephemerists = antiquarian cartographer / codex archive. THEME: supports light/dark toggle (scope to container).
+     FONTS: 'Cinzel' (display/headings, letterspaced), 'EB Garamond' (body), 'Cormorant Garamond' italic (captions).
+     PALETTE (repo --faction-ephemerists-* vars; hexes = reference): parchment #e4d8ba / card #efe4c8, lapis
+       radial #1d4f6e→#143b54→#05131c, gold #b0863a / #d4ab55, rust accent #9c3622, ink #2a1d12.
+     IDIOM: lapis-and-gold codex — deep blue gradient header framed by gold+cream+ink nested rules
+       (box-shadow ring stack), faint grid/graticule overlay, ROMAN NUMERAL levels ("GRADE"), foxed-parchment
+       texture on light cards, eye/fleur SVG glyphs, latinate flavor ("pvncta"). -->
+
+<!-- ① IDENTITY + PROGRESSION: lapis-gradient header, 2px gold border + cream/ink outer rings, gold top strip, grid overlay.
+     shared FactionCredentialCard(faction=ephemerists). name in Cinzel 48px cream w/ blue shadow.
+     (role chip = OUT per #459.) joined in Cormorant italic.
+     progression: conic ring (gold #d4ab55) showing level as ROMAN ("GRADE"), gold bar toward level+1 ("grade {nextRoman}"). -->
+
+<!-- ② ABOUT: SKIP per #459 (design was a foxed-parchment "keeper's note" card). -->
+
+<!-- ⑤ PRAXIS: "Praxis" in Cinzel; "Filed to the codex by {name}" Cormorant italic caption.
+     Rows = live faction Ephemerists PraxisCard; TOP entry overlaid with spectrum conic-ring FDL laurel.
+     EMPTY STATE: parchment, dashed gold border, "The codex holds no entry yet" / "Walk a road, and set the first record down." -->
+
+<!-- ③ BADGES ("Concordances"): hidden when empty. Featured = lapis card w/ gold+cream ring, cream FDL disc,
+     "Highest concordance", name in Cinzel cream. Others = parchment rows: 32px lapis disc + gold FDL,
+     name Cinzel ink, note Garamond. Badge image mapped by badge key in repo. -->

--- a/docs/design/profile/templates/Everymen Profile.dc.html
+++ b/docs/design/profile/templates/Everymen Profile.dc.html
@@ -1,0 +1,23 @@
+<!-- SKIN BRIEF (trimmed; costume only; structure = repo DefaultProfileBody).
+     Everymen = WPA / labor-poster. THEME: supports light/dark toggle (scope to container).
+     FONTS: 'Bebas Neue' (condensed Impact-style display), 'Oswald', 'Courier Prime' (mono body), 'Lora' italic (wordmark only).
+     PALETTE (repo --faction-everymen-* vars; hexes = reference): oat #ece1c6 / card #f4ecd6, brick-red #c1272d / #8d1c20,
+       gold #d99a2b, ink #221a12.
+     IDIOM: silkscreen labor poster — 3px ink borders + hard offset shadow (8px 10px 0), gold top strip,
+       faint sunburst repeating-conic-gradient behind the header, dot-grid paper texture, cog seal glyph,
+       red/gold striped rules. Condensed Bebas headings with ink drop-shadow. -->
+
+<!-- ① IDENTITY + PROGRESSION: brick-red header, 3px ink border, gold top strip, sunburst overlay, hard offset shadow.
+     shared FactionCredentialCard(faction=everymen). name in Bebas Neue 72px cream w/ ink shadow.
+     (role chip = OUT per #459.) joined line.
+     progression: ink panel, gold left-border; conic ring (gold) w/ LVL, gold→red bar toward level+1 ("NEXT · LVL {n}"). -->
+
+<!-- ② ABOUT: SKIP per #459 (design was an "In their own words" cog-sealed card). -->
+
+<!-- ⑤ PRAXIS: "Praxis" in Bebas + red/gold striped rule; "Work {name} finished" eyebrow.
+     Rows = live faction Everymen PraxisCard; TOP entry overlaid with spectrum conic-ring FDL laurel (rotate -8deg).
+     EMPTY STATE: cream, dashed ink border, "No work on the board yet" / "Answer a call. Put in the first shift." -->
+
+<!-- ③ BADGES ("Citations"): hidden when empty. Featured = ink card w/ gold ring, sunburst, red FDL disc,
+     "Highest citation", name in Bebas cream. Others = cream rows: 32px red disc + cream FDL,
+     name Bebas ink, note mono. Badge image mapped by badge key in repo. -->

--- a/docs/design/profile/templates/SNIDE Profile.dc.html
+++ b/docs/design/profile/templates/SNIDE Profile.dc.html
@@ -1,0 +1,24 @@
+<!-- SKIN BRIEF (trimmed; costume only; structure = repo DefaultProfileBody).
+     SNIDE = ransom-note / punk-crime aesthetic. THEME: always-DARK (data-theme="dark"; scope to container).
+     FONTS: 'Anton'/'Archivo Black'/'Bebas Neue' (Impact-style display, skewX(-5deg)), 'Special Elite'/'Courier Prime' (typewriter body),
+       'Permanent Marker' (marker script for badge names/about heading).
+     PALETTE (use repo --faction-snide-* vars; hexes = reference): near-black #14110b, acid-green #b6ff2e accent,
+       hot-pink #ff2d8b (name text-shadow + role chip), ransom-tape yellow rgba(228,214,120,.62), green #16a34a.
+     IDIOM: crime-board / ransom note — hard offset box-shadows (8px 10px 0 black), torn/jagged clip-path top strip,
+       skewed Impact headlines with pink drop-shadow, tape strips, halftone dot texture, dashed borders. -->
+
+<!-- ① IDENTITY + PROGRESSION: black header, acid-green hairline border, jagged green clip-path strip on top,
+     hard black offset shadow. shared FactionCredentialCard(faction=snide) tilted rotate(-1.5deg).
+     - "Player · S.N.I.D.E." tape label (rotate -1.5deg). name in Anton 74px acid-green with 4px pink text-shadow, skewX(-5deg).
+     - (role chip = OUT per #459.) joined line in typewriter.
+     - progression: black panel w/ 2px green border; conic ring (accent #b6ff2e) w/ LVL, striped green bar toward level+1. -->
+
+<!-- ② ABOUT: SKIP per #459 (design was a taped "rap sheet" card). -->
+
+<!-- ⑤ PRAXIS: heading "praxis" Anton acid-green skewed, "cases closed by {name}" typewriter eyebrow, dashed pink/green rule.
+     Rows = live faction SNIDE PraxisCard; TOP entry overlaid with spectrum conic-ring FDL laurel (rotate -8deg).
+     EMPTY STATE: black box, dashed green border, "No priors. Yet." / "Clean record's a bad look around here. Go pull a job." -->
+
+<!-- ③ BADGES ("the record"): hidden when empty. Featured = black card, 2px green border, tape strip, "★ TOP PRIOR ★" pink label,
+     cream FDL disc, name in Anton acid-green. Others = rap-sheet rows on cream paper: black skewed disc + FDL mark,
+     name in Permanent Marker, note in Special Elite, dashed dividers. Badge image mapped by badge key in repo. -->

--- a/docs/design/profile/templates/Singularity Profile.dc.html
+++ b/docs/design/profile/templates/Singularity Profile.dc.html
@@ -1,0 +1,23 @@
+<!-- SKIN BRIEF (trimmed; costume only; structure = repo DefaultProfileBody).
+     Singularity = terminal / phosphor-on-void CRT. THEME: always-DARK (data-theme="dark"; scope to container).
+     FONTS: 'Share Tech Mono' (everything — mono, uppercase), 'Lora' italic (only the shared wordmark).
+     PALETTE (repo --faction-singularity-* vars; hexes = reference): void #07090c / panel #050f08, phosphor-green #4ade80
+       (accent, primary text), blue #2563eb / #60a5fa (grid + secondary), amber #fbbf24 (counts).
+     IDIOM: CRT terminal — faint blue graticule grid bg + green scanline overlay, `> ` command-prompt eyebrows
+       (e.g. "> PLAYER: SINGULARITY", "> NODE STATUS: ONLINE"), boxy hairline-blue borders, node-target sigil,
+       green glow on the progress bar. UPPERCASE headings. -->
+
+<!-- ① IDENTITY + PROGRESSION: void panel, blue border + inset hairline, scanline overlay.
+     shared FactionCredentialCard(faction=singularity). Terminal eyebrow ("> PLAYER…/> NODE STATUS: ONLINE").
+     name in Share Tech Mono 48px uppercase phosphor-green. (role chip = OUT per #459.) joined line.
+     progression: conic ring (green) w/ LVL, blue→green glowing bar toward level+1 ("next // lvl {n}"), "> {pointsLabel}". -->
+
+<!-- ② ABOUT: SKIP per #459 (design was a "> cat /node/readme.txt" terminal card). -->
+
+<!-- ⑤ PRAXIS: "Praxis" uppercase mono + hairline rule; "Sealed outputs // by {name}" micro-eyebrow.
+     Rows = live faction Singularity PraxisCard; TOP entry overlaid with spectrum conic-ring FDL laurel (small, green glow).
+     EMPTY STATE: void box, dashed blue border, "> NO OUTPUT SEALED" / "Run a protocol. Cast the first signal." -->
+
+<!-- ③ BADGES ("Verified"): hidden when empty. Featured = void card, blue border + green glow, node-target sigil behind FDL,
+     "> PRIMARY OUTPUT", name uppercase mono #86efac. Others = rows: 32px square hairline-green cell + FDL,
+     name uppercase green, note blue. Badge image mapped by badge key in repo. -->

--- a/docs/design/profile/templates/UA Profile.dc.html
+++ b/docs/design/profile/templates/UA Profile.dc.html
@@ -1,0 +1,78 @@
+<!-- TRIMMED for repo port: the visual skin only. The original .dc.html trailing
+     <script type="text/x-dc" data-dc-script> block (sample DATA + DCLogic renderVals)
+     was dropped — the repo wires real data via DefaultProfileBody / the #459 foundation.
+     Keep: section-spine structure, faction chrome, which tokens/fonts/frames the skin uses.
+     Port with repo --faction-ua-* CSS vars (strip these literal hexes). -->
+<!-- UA (University of Asthmatics) — gilt-salon skin. Fonts: Playfair Display (display, italic),
+     Marcellus/Marcellus SC (labels), EB Garamond (body), Courier Prime (mono eyebrows).
+     Frame idiom: gilt double-border (linear-gradient gold bevel + inset cream/gold rules),
+     radial paper-grain dot texture, orange (#c2541f) accent, ANNO/roman-numeral motif.
+     data-theme="light". -->
+<div data-theme="light" style="min-height:100vh;font-family:'Courier Prime',monospace;color:#3d2410;background:#ece4d2;background-image:radial-gradient(70% 50% at 8% 0%,rgba(221,147,34,.07),transparent 70%),radial-gradient(60% 50% at 100% 8%,rgba(194,84,31,.06),transparent 70%),radial-gradient(rgba(140,106,30,.045) 1px,transparent 1px);background-size:auto,auto,6px 6px;">
+
+  <!-- breadcrumb -->
+  <div style="font-family:'Courier Prime',monospace;font-size:9px;letter-spacing:.14em;text-transform:uppercase;color:#a8895a;margin-bottom:18px;">Players · Profile</div>
+
+  <!-- ① IDENTITY + PROGRESSION — gilt frame around the shared CredentialCard + progression panel -->
+  <header style="position:relative;overflow:hidden;background:#fdf6ea;border:1px solid #cdab63;box-shadow:0 16px 40px rgba(60,40,10,.16),inset 0 0 0 4px #fdf6ea,inset 0 0 0 5px #e7c889;margin-bottom:40px;">
+    <div style="position:absolute;inset:0;pointer-events:none;background-image:radial-gradient(rgba(60,40,10,.03) 1px,transparent 1px);background-size:6px 6px;"></div>
+    <div style="position:relative;z-index:2;display:flex;gap:40px;align-items:center;flex-wrap:wrap;padding:34px 40px;">
+      <!-- gilt bevel wrapper around FactionCredentialCard(faction=ua) -->
+      <div style="flex-shrink:0;padding:12px;background:linear-gradient(135deg,#eec06a 0%,#9c6a1a 24%,#f0c878 50%,#9c6a1a 76%,#dd9322 100%);box-shadow:0 14px 30px rgba(60,40,10,.26),inset 0 0 0 1px rgba(255,255,255,.45);">
+        <div style="padding:4px;background:linear-gradient(135deg,#9c6a1a,#eec06a);">
+          [ shared FactionCredentialCard, faction=ua, name/bio/level/points ]
+        </div>
+      </div>
+      <div style="flex:1;min-width:300px;">
+        <div style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.26em;text-transform:uppercase;color:#a8895a;line-height:2;margin-bottom:8px;">Player · University of Asthmatics</div>
+        <h1 style="font-family:'Playfair Display',serif;font-style:italic;font-weight:800;font-size:56px;line-height:.96;letter-spacing:-.01em;color:#3d2410;margin:0;">{{ name }}</h1>
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-top:12px;">
+          <!-- role chip: OUT OF SCOPE per #459 (no rank system). keep joined only. -->
+          <span style="font-family:'EB Garamond',serif;font-style:italic;font-size:14px;color:#8f6a3a;">{{ joined }}</span>
+        </div>
+        <!-- progression: conic-gradient ring (accent #c2541f) with ANNO/level, points-into-level bar toward level+1 -->
+        <div style="margin-top:22px;background:#fef9f0;border:1px solid #dd9322;box-shadow:inset 0 0 0 3px #fef9f0,inset 0 0 0 4px #ecd6a4;padding:16px 18px;display:flex;align-items:center;gap:16px;max-width:440px;">
+          <div style="flex-shrink:0;width:62px;height:62px;border-radius:50%;background:conic-gradient(#c2541f var(--deg),#e7d3ab 0);display:flex;align-items:center;justify-content:center;">
+            <span style="width:48px;height:48px;border-radius:50%;background:#fef9f0;display:flex;flex-direction:column;align-items:center;justify-content:center;line-height:1;">
+              <span style="font-family:'Marcellus SC',serif;font-size:7px;letter-spacing:.1em;color:#a8895a;">ANNO</span>
+              <span style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:22px;color:#c2541f;">{{ level }}</span>
+            </span>
+          </div>
+          <div style="flex:1;min-width:0;">
+            <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:6px;">
+              <span style="font-family:'EB Garamond',serif;font-size:13px;color:#6a4f2c;">{{ into }} / {{ toNext }} pts this anno</span>
+              <span style="font-family:'Marcellus SC',serif;font-size:8.5px;letter-spacing:.12em;text-transform:uppercase;color:#a8895a;">next · anno {{ level+1 }}</span>
+            </div>
+            <div style="height:10px;background:#e7d3ab;overflow:hidden;box-shadow:inset 0 1px 2px rgba(60,40,10,.2);">
+              <div style="height:100%;background:linear-gradient(90deg,#dd9322,#c2541f);width:{{ pct }};"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- two columns: main (② about [SKIP per #459], ⑤ praxis) + right rail (③ badges) -->
+  <div style="display:grid;grid-template-columns:1fr 322px;gap:34px;align-items:start;">
+    <div style="display:flex;flex-direction:column;gap:46px;">
+      <!-- ⑤ PRAXIS — eyebrow + Playfair heading, then live UA PraxisCard rows; top row gets FDL laurel -->
+      <div>
+        <div style="margin-bottom:18px;">
+          <div style="font-family:'Courier Prime',monospace;font-size:8px;letter-spacing:.26em;text-transform:uppercase;color:#a8895a;margin-bottom:7px;">Exhibited by {{ name }}</div>
+          <h2 style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:30px;line-height:1;color:#3d2410;margin:0;">Praxis</h2>
+        </div>
+        <!-- each row: [ live faction PraxisCard ]; top entry overlaid with the spectrum-ring FDL laurel medallion.
+             empty state: dashed gilt border, "Nothing hung in the Salon yet". -->
+      </div>
+    </div>
+    <!-- RIGHT RAIL — ③ BADGES ("Distinctions") — hidden when empty per #459.
+         featured badge = gilt medallion hero (FDL mark); others = numbered (roman) gilt-disc list rows. -->
+    <div style="display:flex;flex-direction:column;gap:20px;">
+      <div style="display:flex;align-items:center;gap:10px;">
+        <h2 style="font-family:'Playfair Display',serif;font-style:italic;font-weight:700;font-size:24px;margin:0;color:#3d2410;">Distinctions</h2>
+      </div>
+      <!-- badge rows: 32px gilt disc + name (Playfair italic) + note (EB Garamond). image mapped client-side by badge key. -->
+    </div>
+  </div>
+</div>
+<!-- FDL laurel SVG symbol (spectrum conic ring + cream center + fleur mark) accompanies the top praxis + featured badge. -->

--- a/docs/design/profile/templates/Warriors of Whimsy Profile.dc.html
+++ b/docs/design/profile/templates/Warriors of Whimsy Profile.dc.html
@@ -1,0 +1,26 @@
+<!-- SKIN BRIEF (trimmed from the cloud .dc.html — costume only; structure = repo DefaultProfileBody).
+     WOW = Warriors of Whimsy. THEME: supports light/dark toggle (scope to container, don't touch global [data-theme]).
+     FONTS: var(--font-faction-script) for names/headings (big, 56px name), var(--font-body) for meta/notes.
+     PALETTE (use repo --faction-wow-* / --faction-wow-card-* vars; these hexes are the design reference only):
+       accent magenta #a83a6e / #ec5f99, cork-board mat #eeb4ce (radial dot texture), card #fffdfa→#fde7f1,
+       border #e487b5, gradient bars gold #f6c75e → magenta #ec5f99 → lilac #b79ad8.
+     IDIOM: scrapbook/cork-board — push-pin dots at card corners, slight rotate(-.4deg..2deg) tilts,
+       washi-tape strips on the about/badge cards, ".exe window" chrome on the progression panel
+       (title bar with 3 colored dots + "progress.exe" label). Charm stickers: sparkle/heart/star/mushroom SVGs. -->
+
+<!-- ① IDENTITY + PROGRESSION: pinned banner, rotate(-.4deg), push-pin dots top-left/right.
+     Card gradient #fffdfa→#fde7f1, border #e487b5, radius 16px.
+     - shared FactionCredentialCard(faction=wow), tilted rotate(-1.4deg) with drop-shadow.
+     - name in --font-faction-script 56px #a83a6e; joined line. (role/standing = OUT per #459 — drop the star chip.)
+     - progression = ".exe window": title bar (3 dots + "progress.exe") over a conic ring (accent #ec5f99) showing level,
+       + points-into-level bar (gold→magenta→lilac) toward level+1. -->
+
+<!-- ② ABOUT: SKIP per #459 (no about field). (design was a taped lined index card.) -->
+
+<!-- ⑤ PRAXIS: heading "Praxis" in script font on a tilted tan tag; "sealed by {name}" eyebrow.
+     Rows = live faction WOW PraxisCard; TOP entry overlaid with the spectrum conic-ring FDL laurel (magenta fleur center), rotate(-8deg).
+     EMPTY STATE: dashed magenta border, sparkle icon, "No spells sealed yet" / "The first bit of mischief is always the hardest ✦". -->
+
+<!-- ③ BADGES ("charms earned"): hidden when empty. Featured badge = polaroid card (rotate(-2deg), push-pin, magenta gradient
+     photo area + icon), "Proudest charm". Others = sticker rows on lined/washi-taped paper: 34px radial-pink disc + icon,
+     name in script font, note in body. Icons cycle star/heart/sparkle/mushroom; in the repo, map badge image by badge key. -->

--- a/frontend/src/pages/characterProfile/FactionProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/FactionProfileBody.tsx
@@ -29,7 +29,14 @@ import type { CharacterOut } from '../../api/auth'
 import type { PraxisCardOut } from '../../api/praxis'
 import type { TaskOut } from '../../api/tasks'
 import { pickVariant } from '../../utils/factionDispatch'
+import AlbescentProfileBody from './archetypes/AlbescentProfileBody'
 import DefaultProfileBody from './archetypes/DefaultProfileBody'
+import EphemeristsProfileBody from './archetypes/EphemeristsProfileBody'
+import EverymenProfileBody from './archetypes/EverymenProfileBody'
+import SingularityProfileBody from './archetypes/SingularityProfileBody'
+import SnideProfileBody from './archetypes/SnideProfileBody'
+import UaProfileBody from './archetypes/UaProfileBody'
+import WowProfileBody from './archetypes/WowProfileBody'
 
 export interface ProfileProgression {
   /** The level the current score is climbing toward (capped at max level). */
@@ -55,9 +62,20 @@ export interface ProfileBodyProps {
   identityActions: ReactNode
 }
 
-/** Per-faction profile skins land in #460 — until a row is registered here,
- *  every slug falls back to the default spectrum-band skin below. */
-const FACTION_PROFILE_BODIES: Record<string, ComponentType<ProfileBodyProps>> = {}
+/** Per-faction profile skins (#460). Each renders the SAME locked section spine
+ *  as DefaultProfileBody (via ProfileSkin) in the faction's costume; the default
+ *  spectrum-band skin remains the fallback for na / unaffiliated / unknown.
+ *  The explicit `albescent` entry beats the albescent→ua alias in pickVariant,
+ *  so it renders its own colorless skin immediately. */
+const FACTION_PROFILE_BODIES: Record<string, ComponentType<ProfileBodyProps>> = {
+  ua: UaProfileBody,
+  wow: WowProfileBody,
+  snide: SnideProfileBody,
+  ephemerists: EphemeristsProfileBody,
+  singularity: SingularityProfileBody,
+  everymen: EverymenProfileBody,
+  albescent: AlbescentProfileBody,
+}
 
 export default function FactionProfileBody(props: ProfileBodyProps) {
   const Body = pickVariant(

--- a/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
@@ -2,9 +2,9 @@
  * Player-profile body dispatch + badge-board guards (#459, ADR-0033).
  *
  * The profile is one faction-agnostic contract; the skin is derived
- * client-side from faction_slug. Until the per-faction skins land (#460),
- * EVERY slug — including null/na — must fall back to the default
- * spectrum-band body, and ③ Badges must render only when badges exist.
+ * client-side from faction_slug. The seven faction skins landed in #460; the
+ * default spectrum-band body remains the fallback for null / na / unknown, and
+ * ③ Badges must render only when badges exist regardless of skin.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
@@ -56,8 +56,18 @@ function renderBody(overrides: Partial<CharacterOut> = {}) {
 }
 
 describe("FactionProfileBody dispatch", () => {
-  it("starts with no bespoke skins registered — #460 fills the map", () => {
-    expect(Object.keys(FACTION_PROFILE_BODIES)).toHaveLength(0);
+  it("registers the seven bespoke faction skins (#460)", () => {
+    expect(Object.keys(FACTION_PROFILE_BODIES).sort()).toEqual(
+      [
+        "albescent",
+        "ephemerists",
+        "everymen",
+        "singularity",
+        "snide",
+        "ua",
+        "wow",
+      ].sort(),
+    );
   });
 
   it("renders the default skin for an unaffiliated (null) character", () => {
@@ -67,7 +77,7 @@ describe("FactionProfileBody dispatch", () => {
     expect(html).toContain("No praxis sealed yet");
   });
 
-  it("falls back to the default skin for every faction slug until #460", () => {
+  it("renders a profile for every faction slug (bespoke skin or default)", () => {
     for (const slug of [
       "ua",
       "wow",

--- a/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
@@ -1,0 +1,174 @@
+/**
+ * AlbescentProfileBody — the unranked order / pure-white monastic player-profile
+ * skin (#460). Ported from docs/design/profile/templates/Albescent Profile.dc.
+ * html: quiet, austere, generous whitespace, thin hairline borders, soft small
+ * shadows, widely-letterspaced tiny mono eyebrows. The whole faction is COLORLESS
+ * by design — the only accent is ink-on-white, so the FDL laurel here is drawn in
+ * an INK OUTLINE (thin double ring, NO spectrum gradient). Albescent is ALWAYS
+ * LIGHT — its --faction-albescent-* tokens are identical in both themes, so the
+ * container scopes data-theme="light" to itself and never mutates the global
+ * theme.
+ *
+ * Structure is DefaultProfileBody's locked spine via ProfileSkin. No hardcoded
+ * hex — colours via --faction-albescent-* vars.
+ */
+import type { ReactNode } from 'react'
+
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import { BadgeRow, LaurelGlyph, ProfileSkin, type ProfileKit } from './profileSkin'
+
+const INK = 'var(--faction-albescent-card-text)' // near-black
+const MUTED = 'var(--faction-albescent-card-muted)'
+const ACCENT = 'var(--faction-albescent-card-accent)'
+const SURFACE = 'var(--faction-albescent-surface)' // pure white
+const PAGE = 'var(--faction-albescent-page)' // cream backdrop
+const BORDER = 'var(--faction-albescent-border)'
+const RULE = 'var(--faction-albescent-border-rule)'
+const SERIF = 'var(--faction-albescent-card-font)' // Cormorant Garamond
+const MONO = 'var(--faction-albescent-mono)' // Courier Prime
+
+/** The colorless ink-outline laurel: a thin double ring, no spectrum gradient. */
+function InkLaurel() {
+  return (
+    <span
+      title="Top praxis"
+      style={{
+        position: 'absolute',
+        top: -11,
+        right: 14,
+        zIndex: 20,
+        width: 44,
+        height: 44,
+        borderRadius: '50%',
+        background: SURFACE,
+        border: `1px solid ${INK}`,
+        boxShadow: `0 0 0 3px ${SURFACE}, 0 0 0 4px ${INK}, 0 4px 10px rgba(0,0,0,0.12)`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: INK,
+      }}
+    >
+      <LaurelGlyph size={17} />
+    </span>
+  )
+}
+
+function heading(title: string, eyebrow: string): ReactNode {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 9,
+          letterSpacing: '0.24em',
+          textTransform: 'uppercase',
+          color: MUTED,
+          marginBottom: 8,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <h2 style={{ fontFamily: SERIF, fontStyle: 'italic', fontWeight: 300, fontSize: 32, color: INK, margin: 0 }}>
+        {title}
+      </h2>
+    </div>
+  )
+}
+
+const kit: ProfileKit = {
+  slug: 'albescent',
+  dataTheme: 'light',
+  pageBackground: PAGE,
+  ink: INK,
+  muted: MUTED,
+  accent: INK,
+  surface: SURFACE,
+  border: BORDER,
+  displayFont: SERIF,
+  eyebrowFont: MONO,
+  bodyFont: SERIF,
+  headerStyle: {
+    background: SURFACE,
+    border: `1px solid ${BORDER}`,
+    boxShadow: '0 4px 20px -12px rgba(0,0,0,0.18)',
+    padding: '40px 44px',
+    marginBottom: 44,
+  },
+  nameSize: 62,
+  nameExtra: { fontStyle: 'italic', fontWeight: 300 },
+  playerEyebrow: 'Player · Albescent · the unranked order',
+  progressionStyle: {
+    marginTop: 24,
+    background: SURFACE,
+    border: `1px solid ${RULE}`,
+    padding: '18px 20px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 18,
+    maxWidth: 440,
+  },
+  ringLabel: 'lvl',
+  barFill: INK,
+  barTrack: 'var(--faction-albescent-text-faint)',
+  nextLevelLabel: (next) => `next · lvl ${next}`,
+  sectionHeading: heading,
+  praxisEyebrow: (name) => `Entered into the record by ${name}`,
+  praxisEmpty: {
+    title: 'The record holds no entry yet',
+    body: 'Take up a duty, and return it well.',
+  },
+  emptyStateStyle: {
+    border: `1px dashed ${ACCENT}`,
+    padding: 34,
+    textAlign: 'center',
+    background: SURFACE,
+  },
+  laurel: <InkLaurel />,
+  badgeTitle: 'Commendations',
+  badgeBoardStyle: {
+    border: `1px solid ${BORDER}`,
+    background: SURFACE,
+    padding: '4px 16px',
+  },
+  badgeChipStyle: {
+    fontFamily: MONO,
+    fontSize: 9,
+    letterSpacing: '0.14em',
+    textTransform: 'uppercase',
+    color: MUTED,
+    marginLeft: 'auto',
+    border: `1px solid ${BORDER}`,
+    padding: '3px 9px',
+  },
+  badgeRow: (badge, last) => (
+    <BadgeRow
+      badge={badge}
+      last={last}
+      dividerColor={RULE}
+      nameStyle={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 17, color: INK, lineHeight: 1.2 }}
+      medallion={(glyph) => (
+        <span
+          style={{
+            flexShrink: 0,
+            width: 30,
+            height: 30,
+            borderRadius: '50%',
+            background: SURFACE,
+            border: `1px solid ${INK}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: INK,
+          }}
+        >
+          {glyph}
+        </span>
+      )}
+    />
+  ),
+}
+
+export default function AlbescentProfileBody(props: ProfileBodyProps) {
+  return <ProfileSkin props={props} kit={kit} />
+}

--- a/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
@@ -1,0 +1,195 @@
+/**
+ * EphemeristsProfileBody — antiquarian cartographer / lapis-and-gold codex
+ * player-profile skin (#460). Ported from docs/design/profile/templates/
+ * Ephemerists Profile.dc.html: a deep-blue lapis header framed by nested gold /
+ * cream / ink rules, a faint graticule overlay, roman-numeral "GRADE" levels,
+ * and foxed-parchment cards. Follows the global light/dark cascade via the
+ * --eph-* / --faction-ephemerists-* tokens (the vellum surface flips in dark).
+ *
+ * Structure is DefaultProfileBody's locked spine via ProfileSkin. No hardcoded
+ * hex — colours via --eph-* / --faction-ephemerists-* vars.
+ */
+import type { ReactNode } from 'react'
+
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
+
+const INK = 'var(--eph-ink)'
+const MUTED = 'var(--eph-muted)'
+const GOLD = 'var(--eph-gold-light)'
+const GOLD_DEEP = 'var(--eph-gold)'
+const LAPIS = 'var(--eph-lapis)'
+const VELLUM = 'var(--eph-vellum)'
+const CREAM = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)' // Cinzel
+const BODY = 'var(--eph-serif)' // EB Garamond
+const SCRIPT = 'var(--eph-script)' // Cormorant Garamond
+
+const ROMAN: readonly [number, string][] = [
+  [1000, 'M'],
+  [900, 'CM'],
+  [500, 'D'],
+  [400, 'CD'],
+  [100, 'C'],
+  [90, 'XC'],
+  [50, 'L'],
+  [40, 'XL'],
+  [10, 'X'],
+  [9, 'IX'],
+  [5, 'V'],
+  [4, 'IV'],
+  [1, 'I'],
+]
+
+function toRoman(value: number): string {
+  if (value <= 0) return '·'
+  let remaining = value
+  let out = ''
+  for (const [amount, symbol] of ROMAN) {
+    while (remaining >= amount) {
+      out += symbol
+      remaining -= amount
+    }
+  }
+  return out
+}
+
+function heading(title: string, eyebrow: string): ReactNode {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <div style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 13, color: MUTED, marginBottom: 4 }}>
+        {eyebrow}
+      </div>
+      <h2
+        style={{
+          fontFamily: DISPLAY,
+          fontSize: 26,
+          letterSpacing: '0.06em',
+          color: INK,
+          margin: 0,
+        }}
+      >
+        {title}
+      </h2>
+    </div>
+  )
+}
+
+const kit: ProfileKit = {
+  slug: 'ephemerists',
+  pageBackground: 'var(--eph-vellum-deep)',
+  pageOverlay: 'radial-gradient(rgba(42,29,18,0.05) 1px, transparent 1px)',
+  ink: INK,
+  muted: MUTED,
+  accent: GOLD,
+  surface: VELLUM,
+  border: GOLD_DEEP,
+  displayFont: DISPLAY,
+  eyebrowFont: BODY,
+  bodyFont: BODY,
+  headerStyle: {
+    background: `linear-gradient(160deg, ${LAPIS}, var(--eph-lapis-deep))`,
+    border: `2px solid ${GOLD}`,
+    boxShadow: `0 0 0 4px ${CREAM}, 0 0 0 6px var(--eph-ink), 0 18px 40px -20px rgba(0,0,0,0.6)`,
+    padding: '34px 40px',
+    marginBottom: 44,
+    marginTop: 6,
+  },
+  headerDecoration: (
+    <>
+      <div
+        aria-hidden
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 4, background: GOLD, zIndex: 3 }}
+      />
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background:
+            'repeating-linear-gradient(0deg, transparent, transparent 22px, rgba(212,171,85,0.08) 22px, rgba(212,171,85,0.08) 23px), repeating-linear-gradient(90deg, transparent, transparent 22px, rgba(212,171,85,0.08) 22px, rgba(212,171,85,0.08) 23px)',
+        }}
+      />
+    </>
+  ),
+  nameSize: 48,
+  nameExtra: { color: CREAM, textShadow: '0 2px 6px rgba(5,19,28,0.6)', letterSpacing: '0.02em' },
+  playerEyebrow: 'Player · The Ephemerists',
+  progressionStyle: {
+    marginTop: 22,
+    background: 'rgba(5,19,28,0.35)',
+    border: `1px solid ${GOLD}`,
+    boxShadow: `inset 0 0 0 3px rgba(5,19,28,0.25)`,
+    padding: '16px 18px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    maxWidth: 440,
+  },
+  ringLabel: 'grade',
+  barFill: `linear-gradient(90deg, ${GOLD_DEEP}, ${GOLD})`,
+  barTrack: 'rgba(212,171,85,0.22)',
+  formatLevel: toRoman,
+  levelUnitLabel: 'pvncta this grade',
+  nextLevelLabel: (next) => `next · grade ${toRoman(next)}`,
+  sectionHeading: heading,
+  praxisEyebrow: (name) => `Filed to the codex by ${name}`,
+  praxisEmpty: {
+    title: 'The codex holds no entry yet',
+    body: 'Walk a road, and set the first record down.',
+  },
+  emptyStateStyle: {
+    border: `1.5px dashed ${GOLD_DEEP}`,
+    padding: 30,
+    textAlign: 'center',
+    background: VELLUM,
+  },
+  laurel: <SpectrumLaurel centerBg={CREAM} glyphColor={LAPIS} />,
+  badgeTitle: 'Concordances',
+  badgeBoardStyle: {
+    border: `1px solid ${GOLD_DEEP}`,
+    background: VELLUM,
+    padding: '4px 14px',
+  },
+  badgeChipStyle: {
+    fontFamily: DISPLAY,
+    fontSize: 9,
+    letterSpacing: '0.14em',
+    textTransform: 'uppercase',
+    color: MUTED,
+    marginLeft: 'auto',
+    border: `1px solid ${GOLD_DEEP}`,
+    padding: '3px 9px',
+  },
+  badgeRow: (badge, last) => (
+    <BadgeRow
+      badge={badge}
+      last={last}
+      dividerColor="rgba(176,134,58,0.28)"
+      nameStyle={{ fontFamily: DISPLAY, fontSize: 14, color: INK, lineHeight: 1.2, letterSpacing: '0.03em' }}
+      medallion={(glyph) => (
+        <span
+          style={{
+            flexShrink: 0,
+            width: 32,
+            height: 32,
+            borderRadius: '50%',
+            background: LAPIS,
+            border: `1px solid ${GOLD}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: GOLD,
+          }}
+        >
+          {glyph}
+        </span>
+      )}
+    />
+  ),
+}
+
+export default function EphemeristsProfileBody(props: ProfileBodyProps) {
+  return <ProfileSkin props={props} kit={kit} />
+}

--- a/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
@@ -1,0 +1,175 @@
+/**
+ * EverymenProfileBody — WPA / labor-poster player-profile skin (#460). Ported
+ * from docs/design/profile/templates/Everymen Profile.dc.html: 3px ink borders
+ * with a hard offset shadow, a gold top strip, a faint sunburst behind the
+ * header, dot-grid paper texture, and condensed Bebas headings with an ink drop-
+ * shadow. Follows the global light/dark cascade via --everymen-* /
+ * --faction-everymen-* tokens (the paper surface flips in dark).
+ *
+ * Structure is DefaultProfileBody's locked spine via ProfileSkin. No hardcoded
+ * hex — colours via --everymen-* / --faction-everymen-* vars.
+ */
+import type { ReactNode } from 'react'
+
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
+
+const INK = 'var(--everymen-ink)'
+const MUTED = 'var(--everymen-muted)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const CREAM = 'var(--everymen-cream)'
+const PAPER = 'var(--everymen-paper)'
+const BEBAS = 'var(--font-accent)' // Bebas Neue
+const MONO = 'var(--font-body)' // Courier Prime
+
+const SUNBURST =
+  'repeating-conic-gradient(from 0deg at 50% 40%, rgba(255,255,255,0.05) 0deg 6deg, transparent 6deg 12deg)'
+
+function heading(title: string, eyebrow: string): ReactNode {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 10,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: MUTED,
+          marginBottom: 5,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <h2
+        style={{
+          fontFamily: BEBAS,
+          fontSize: 34,
+          letterSpacing: '0.03em',
+          color: INK,
+          margin: 0,
+          textShadow: '2px 2px 0 rgba(0,0,0,0.12)',
+        }}
+      >
+        {title}
+      </h2>
+      <div
+        style={{
+          height: 4,
+          marginTop: 8,
+          background: `repeating-linear-gradient(90deg, ${RED} 0 14px, ${GOLD} 14px 28px)`,
+        }}
+      />
+    </div>
+  )
+}
+
+const kit: ProfileKit = {
+  slug: 'everymen',
+  pageBackground: PAPER,
+  pageOverlay: 'radial-gradient(rgba(34,26,18,0.05) 1px, transparent 1px)',
+  ink: INK,
+  muted: MUTED,
+  accent: GOLD,
+  surface: CREAM,
+  border: INK,
+  displayFont: BEBAS,
+  eyebrowFont: MONO,
+  bodyFont: MONO,
+  headerStyle: {
+    background: `linear-gradient(150deg, ${RED}, var(--everymen-red-deep))`,
+    border: `3px solid ${INK}`,
+    boxShadow: '8px 10px 0 rgba(0,0,0,0.4)',
+    padding: '34px 40px',
+    marginBottom: 44,
+    marginTop: 6,
+  },
+  headerDecoration: (
+    <>
+      <div
+        aria-hidden
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 6, background: GOLD, zIndex: 3 }}
+      />
+      <div
+        aria-hidden
+        style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: SUNBURST }}
+      />
+    </>
+  ),
+  nameSize: 72,
+  nameExtra: { color: CREAM, textShadow: '3px 3px 0 rgba(0,0,0,0.3)', letterSpacing: '0.02em' },
+  playerEyebrow: 'Player · The Everymen',
+  progressionStyle: {
+    marginTop: 22,
+    background: INK,
+    borderLeft: `5px solid ${GOLD}`,
+    padding: '16px 18px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    maxWidth: 440,
+  },
+  ringLabel: 'lvl',
+  barFill: `linear-gradient(90deg, ${GOLD}, ${RED})`,
+  barTrack: 'rgba(255,255,255,0.16)',
+  nextLevelLabel: (next) => `NEXT · LVL ${next}`,
+  sectionHeading: heading,
+  praxisEyebrow: (name) => `Work ${name} finished`,
+  praxisEmpty: {
+    title: 'No work on the board yet',
+    body: 'Answer a call. Put in the first shift.',
+  },
+  emptyStateStyle: {
+    border: `2px dashed ${INK}`,
+    padding: 30,
+    textAlign: 'center',
+    background: CREAM,
+  },
+  laurel: <SpectrumLaurel centerBg={CREAM} glyphColor={RED} rotate={-8} />,
+  badgeTitle: 'Citations',
+  badgeBoardStyle: {
+    border: `3px solid ${INK}`,
+    background: CREAM,
+    padding: '4px 14px',
+  },
+  badgeChipStyle: {
+    fontFamily: MONO,
+    fontSize: 9,
+    letterSpacing: '0.1em',
+    textTransform: 'uppercase',
+    color: MUTED,
+    marginLeft: 'auto',
+    border: `1px solid ${INK}`,
+    padding: '3px 9px',
+  },
+  badgeRow: (badge, last) => (
+    <BadgeRow
+      badge={badge}
+      last={last}
+      dividerColor="rgba(34,26,18,0.18)"
+      nameStyle={{ fontFamily: BEBAS, fontSize: 18, letterSpacing: '0.02em', color: INK, lineHeight: 1.15 }}
+      medallion={(glyph) => (
+        <span
+          style={{
+            flexShrink: 0,
+            width: 34,
+            height: 34,
+            borderRadius: '50%',
+            background: RED,
+            border: `2px solid ${INK}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: CREAM,
+          }}
+        >
+          {glyph}
+        </span>
+      )}
+    />
+  ),
+}
+
+export default function EverymenProfileBody(props: ProfileBodyProps) {
+  return <ProfileSkin props={props} kit={kit} />
+}

--- a/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
@@ -1,0 +1,177 @@
+/**
+ * SingularityProfileBody — terminal / phosphor-on-void CRT player-profile skin
+ * (#460). Ported from docs/design/profile/templates/Singularity Profile.dc.html:
+ * a void panel with a faint blue graticule grid, green scanline overlay, `> `
+ * command-prompt eyebrows, boxy hairline-blue borders, and a green-glow progress
+ * bar. Singularity is ALWAYS DARK — its --faction-singularity-* tokens are
+ * identical in both themes, so the container scopes data-theme="dark" to itself
+ * and never mutates the global theme.
+ *
+ * Structure is DefaultProfileBody's locked spine via ProfileSkin. No hardcoded
+ * hex — colours via --faction-singularity-* vars.
+ */
+import type { ReactNode } from 'react'
+
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
+
+const VOID = 'var(--faction-singularity-card-bg)' // terminal black
+const PHOSPHOR = 'var(--faction-singularity-card-accent)' // green
+const SIGNAL = 'var(--faction-singularity-card-muted)' // blue chrome
+const BORDER = 'var(--faction-singularity-border-hard)'
+const FONT = 'var(--font-faction-terminal)' // Share Tech Mono
+
+const signal = (pct: number) => `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+const GRID =
+  'repeating-linear-gradient(0deg, transparent, transparent 21px, rgba(37,99,235,0.10) 21px, rgba(37,99,235,0.10) 22px), repeating-linear-gradient(90deg, transparent, transparent 21px, rgba(37,99,235,0.10) 21px, rgba(37,99,235,0.10) 22px)'
+const SCANLINES =
+  'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.03) 2px, rgba(74,222,128,0.03) 4px)'
+
+function heading(title: string, eyebrow: string): ReactNode {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          fontFamily: FONT,
+          fontSize: 9,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: signal(65),
+          marginBottom: 6,
+        }}
+      >
+        {'>'} {eyebrow}
+      </div>
+      <h2
+        style={{
+          fontFamily: FONT,
+          fontSize: 24,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: PHOSPHOR,
+          margin: 0,
+          textShadow: '0 0 8px rgba(74,222,128,0.4)',
+        }}
+      >
+        {title}
+      </h2>
+      <div style={{ height: 1, marginTop: 8, background: signal(30) }} />
+    </div>
+  )
+}
+
+const kit: ProfileKit = {
+  slug: 'singularity',
+  dataTheme: 'dark',
+  pageBackground: 'var(--faction-singularity-card-bg)',
+  pageOverlay: GRID,
+  ink: PHOSPHOR,
+  muted: signal(70),
+  accent: PHOSPHOR,
+  surface: VOID,
+  border: BORDER,
+  displayFont: FONT,
+  eyebrowFont: FONT,
+  bodyFont: FONT,
+  headerStyle: {
+    background: VOID,
+    border: `1px solid ${BORDER}`,
+    boxShadow: `inset 0 0 0 1px ${signal(18)}`,
+    padding: '32px 34px',
+    marginBottom: 40,
+  },
+  headerDecoration: (
+    <div
+      aria-hidden
+      style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: SCANLINES, zIndex: 3 }}
+    />
+  ),
+  nameSize: 48,
+  nameExtra: {
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    textShadow: '0 0 12px rgba(74,222,128,0.35)',
+  },
+  playerEyebrow: '> PLAYER: SINGULARITY // NODE STATUS: ONLINE',
+  progressionStyle: {
+    marginTop: 22,
+    background: VOID,
+    border: `1px solid ${signal(40)}`,
+    padding: '16px 18px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    maxWidth: 440,
+  },
+  ringLabel: 'lvl',
+  barFill: 'linear-gradient(90deg, var(--faction-singularity-border-hard), var(--faction-singularity-card-accent))',
+  barTrack: signal(25),
+  nextLevelLabel: (next) => `next // lvl ${next}`,
+  scoreFootnote: (score) => `> ${score} PTS LOGGED`,
+  sectionHeading: heading,
+  praxisEyebrow: (name) => `Sealed outputs // by ${name}`,
+  praxisEmpty: {
+    title: '> NO OUTPUT SEALED',
+    body: 'Run a protocol. Cast the first signal.',
+  },
+  emptyStateStyle: {
+    border: `1px dashed ${signal(50)}`,
+    padding: 30,
+    textAlign: 'center',
+    background: VOID,
+  },
+  laurel: <SpectrumLaurel centerBg={VOID} glyphColor={PHOSPHOR} />,
+  badgeTitle: 'Verified',
+  badgeBoardStyle: {
+    border: `1px solid ${signal(40)}`,
+    background: VOID,
+    padding: '4px 14px',
+  },
+  badgeChipStyle: {
+    fontFamily: FONT,
+    fontSize: 9,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    color: signal(70),
+    marginLeft: 'auto',
+    border: `1px solid ${signal(40)}`,
+    padding: '3px 9px',
+  },
+  badgeRow: (badge, last) => (
+    <BadgeRow
+      badge={badge}
+      last={last}
+      dividerColor={signal(22)}
+      nameStyle={{
+        fontFamily: FONT,
+        fontSize: 13,
+        textTransform: 'uppercase',
+        letterSpacing: '0.04em',
+        color: PHOSPHOR,
+        lineHeight: 1.2,
+      }}
+      medallion={(glyph) => (
+        <span
+          style={{
+            flexShrink: 0,
+            width: 32,
+            height: 32,
+            border: `1px solid ${PHOSPHOR}`,
+            background: VOID,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: PHOSPHOR,
+          }}
+        >
+          {glyph}
+        </span>
+      )}
+    />
+  ),
+}
+
+export default function SingularityProfileBody(props: ProfileBodyProps) {
+  return <ProfileSkin props={props} kit={kit} />
+}

--- a/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
@@ -1,0 +1,178 @@
+/**
+ * SnideProfileBody — S.N.I.D.E. ransom-note / crime-board player-profile skin
+ * (#460). Ported from docs/design/profile/templates/SNIDE Profile.dc.html: hard
+ * offset shadows, a jagged clip-path strip, skewed Impact headlines with a pink
+ * drop-shadow, tape strips, halftone dot texture. SNIDE is ALWAYS DARK — its
+ * --faction-snide-* tokens are identical in both themes, so the container scopes
+ * data-theme="dark" to itself and never mutates the global theme.
+ *
+ * Structure is DefaultProfileBody's locked spine via ProfileSkin. No hardcoded
+ * hex — colours via --faction-snide-* vars.
+ */
+import type { ReactNode } from 'react'
+
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
+
+const INK = 'var(--faction-snide-ink)' // near-black
+const PAPER = 'var(--faction-snide-paper)' // warm xerox
+const ACID = 'var(--faction-snide-acid)' // acid green accent
+const PINK = 'var(--faction-snide-pink)' // hot zine pink
+const IMPACT = 'var(--faction-snide-font-impact)' // Anton
+const TYPE = 'var(--faction-snide-font-type)' // Special Elite
+const MARKER = 'var(--faction-snide-font-marker)' // Permanent Marker
+
+const JAGGED =
+  'polygon(0 0,4% 40%,8% 0,12% 40%,16% 0,20% 40%,24% 0,28% 40%,32% 0,36% 40%,40% 0,44% 40%,48% 0,52% 40%,56% 0,60% 40%,64% 0,68% 40%,72% 0,76% 40%,80% 0,84% 40%,88% 0,92% 40%,96% 0,100% 40%,100% 100%,0 100%)'
+
+function heading(title: string, eyebrow: string): ReactNode {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          fontFamily: TYPE,
+          fontSize: 10,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: PAPER,
+          marginBottom: 5,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <h2
+        style={{
+          fontFamily: IMPACT,
+          fontSize: 34,
+          letterSpacing: '0.02em',
+          textTransform: 'uppercase',
+          color: ACID,
+          transform: 'skewX(-5deg)',
+          margin: 0,
+          textShadow: `2px 2px 0 ${PINK}`,
+        }}
+      >
+        {title}
+      </h2>
+      <div style={{ height: 2, marginTop: 8, borderTop: `2px dashed ${PINK}` }} />
+    </div>
+  )
+}
+
+const kit: ProfileKit = {
+  slug: 'snide',
+  dataTheme: 'dark',
+  pageBackground: INK,
+  pageOverlay: 'radial-gradient(rgba(182,255,46,0.05) 1px, transparent 1px)',
+  ink: PAPER,
+  muted: 'var(--faction-snide-card-muted)',
+  accent: ACID,
+  surface: INK,
+  border: ACID,
+  displayFont: IMPACT,
+  eyebrowFont: TYPE,
+  bodyFont: TYPE,
+  headerStyle: {
+    background: INK,
+    border: `1px solid ${ACID}`,
+    boxShadow: '8px 10px 0 rgba(0,0,0,0.55)',
+    padding: '38px 34px 30px',
+    marginBottom: 40,
+  },
+  headerDecoration: (
+    <div
+      aria-hidden
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 14,
+        background: ACID,
+        clipPath: JAGGED,
+        zIndex: 3,
+      }}
+    />
+  ),
+  credentialFrame: (card) => (
+    <div style={{ transform: 'rotate(-1.5deg)', filter: 'drop-shadow(6px 8px 0 rgba(0,0,0,0.5))' }}>
+      {card}
+    </div>
+  ),
+  nameSize: 60,
+  nameExtra: { transform: 'skewX(-5deg)', textShadow: `3px 3px 0 ${PINK}`, textTransform: 'uppercase' },
+  playerEyebrow: 'Player · S.N.I.D.E.',
+  progressionStyle: {
+    marginTop: 22,
+    background: INK,
+    border: `2px solid ${ACID}`,
+    padding: '16px 18px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    maxWidth: 440,
+  },
+  ringLabel: 'lvl',
+  barFill:
+    'repeating-linear-gradient(45deg, var(--faction-snide-acid) 0 6px, var(--faction-snide-acid-deep) 6px 12px)',
+  barTrack: 'rgba(255,255,255,0.12)',
+  nextLevelLabel: (next) => `next · lvl ${next}`,
+  sectionHeading: heading,
+  praxisEyebrow: (name) => `cases closed by ${name}`,
+  praxisEmpty: {
+    title: 'No priors. Yet.',
+    body: "Clean record's a bad look around here. Go pull a job.",
+  },
+  emptyStateStyle: {
+    border: `2px dashed ${ACID}`,
+    padding: 30,
+    textAlign: 'center',
+    background: INK,
+  },
+  laurel: <SpectrumLaurel centerBg={PAPER} glyphColor={INK} rotate={-8} />,
+  badgeTitle: 'The record',
+  badgeBoardStyle: {
+    border: `2px solid ${ACID}`,
+    background: PAPER,
+    padding: '4px 14px',
+  },
+  badgeChipStyle: {
+    fontFamily: TYPE,
+    fontSize: 9,
+    letterSpacing: '0.1em',
+    textTransform: 'uppercase',
+    color: PINK,
+    marginLeft: 'auto',
+    border: `1px solid ${PINK}`,
+    padding: '3px 9px',
+  },
+  badgeRow: (badge, last) => (
+    <BadgeRow
+      badge={badge}
+      last={last}
+      dividerColor="rgba(20,17,11,0.25)"
+      nameStyle={{ fontFamily: MARKER, fontSize: 16, color: INK, lineHeight: 1.15 }}
+      medallion={(glyph) => (
+        <span
+          style={{
+            flexShrink: 0,
+            width: 34,
+            height: 34,
+            background: INK,
+            transform: 'skewX(-5deg)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: ACID,
+          }}
+        >
+          {glyph}
+        </span>
+      )}
+    />
+  ),
+}
+
+export default function SnideProfileBody(props: ProfileBodyProps) {
+  return <ProfileSkin props={props} kit={kit} />
+}

--- a/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
@@ -1,0 +1,180 @@
+/**
+ * UaProfileBody — University of Asthmatics gilt-salon player-profile skin (#460).
+ * Ported from docs/design/profile/templates/UA Profile.dc.html: a gilt double-
+ * border frame around the shared CredentialCard, paper-grain dot texture, burnt-
+ * amber accent, ANNO/roman-numeral motif. UA is ALWAYS LIGHT — its --faction-ua-*
+ * / --ua-* tokens are identical in both themes, so the container scopes
+ * data-theme="light" to itself and never mutates the global theme.
+ *
+ * Structure is DefaultProfileBody's locked spine via ProfileSkin; only the
+ * costume differs. No hardcoded hex — all colours via --ua-* / --faction-ua-*.
+ */
+import type { ReactNode } from 'react'
+
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
+
+const INK = 'var(--ua-ink)'
+const MUTED = 'var(--ua-muted)'
+const ACCENT = 'var(--ua-orange)'
+const GILT = 'var(--ua-gilt)'
+const PAPER = 'var(--ua-paper)'
+const LINE = 'var(--ua-line)'
+const DISPLAY = 'var(--font-faction-old)' // IM Fell English — salon display serif
+const EYEBROW = 'var(--font-body)' // Courier Prime mono labels
+const BODY = "'EB Garamond', Georgia, serif"
+
+function heading(title: string, eyebrow: string): ReactNode {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <div
+        style={{
+          fontFamily: EYEBROW,
+          fontSize: 8,
+          letterSpacing: '0.26em',
+          textTransform: 'uppercase',
+          color: MUTED,
+          marginBottom: 7,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <h2 style={{ fontFamily: DISPLAY, fontSize: 30, lineHeight: 1, color: INK, margin: 0 }}>
+        {title}
+      </h2>
+    </div>
+  )
+}
+
+const kit: ProfileKit = {
+  slug: 'ua',
+  dataTheme: 'light',
+  pageBackground: 'var(--ua-wall)',
+  pageOverlay:
+    'radial-gradient(70% 50% at 8% 0%, rgba(221,147,34,.07), transparent 70%), radial-gradient(rgba(140,106,30,.045) 1px, transparent 1px)',
+  ink: INK,
+  muted: MUTED,
+  accent: ACCENT,
+  surface: PAPER,
+  border: LINE,
+  displayFont: DISPLAY,
+  eyebrowFont: EYEBROW,
+  bodyFont: BODY,
+  headerStyle: {
+    background: PAPER,
+    border: `1px solid ${LINE}`,
+    boxShadow: 'inset 0 0 0 4px var(--ua-paper), inset 0 0 0 5px var(--ua-line-soft)',
+    padding: '34px 40px',
+    marginBottom: 40,
+  },
+  headerDecoration: (
+    <div
+      aria-hidden
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+        backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
+        backgroundSize: '6px 6px',
+      }}
+    />
+  ),
+  credentialFrame: (card) => (
+    <div style={{ padding: 12, background: GILT }}>
+      <div style={{ padding: 4, background: 'linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))' }}>
+        {card}
+      </div>
+    </div>
+  ),
+  nameSize: 56,
+  playerEyebrow: 'Player · University of Asthmatics',
+  progressionStyle: {
+    marginTop: 22,
+    background: 'var(--ua-paper-warm)',
+    border: `1px solid ${ACCENT}`,
+    boxShadow: 'inset 0 0 0 3px var(--ua-paper-warm), inset 0 0 0 4px var(--ua-line-soft)',
+    padding: '16px 18px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    maxWidth: 440,
+  },
+  ringLabel: 'anno',
+  barFill: 'linear-gradient(90deg, var(--ua-gold-lt), var(--ua-orange))',
+  barTrack: 'var(--ua-line-soft)',
+  levelUnitLabel: 'pts this anno',
+  nextLevelLabel: (next) => `next · anno ${next}`,
+  sectionHeading: heading,
+  praxisEyebrow: (name) => `Exhibited by ${name}`,
+  praxisEmpty: {
+    title: 'Nothing hung in the Salon yet',
+    body: 'The first piece exhibited is always the boldest.',
+  },
+  emptyStateStyle: {
+    border: `1.5px dashed ${ACCENT}`,
+    padding: 30,
+    textAlign: 'center',
+    background: PAPER,
+  },
+  laurel: <SpectrumLaurel centerBg={PAPER} glyphColor={ACCENT} />,
+  badgeTitle: 'Distinctions',
+  badgeBoardStyle: {
+    border: `1px solid ${LINE}`,
+    background: PAPER,
+    padding: '4px 14px',
+  },
+  badgeChipStyle: {
+    fontFamily: EYEBROW,
+    fontSize: 9,
+    letterSpacing: '0.1em',
+    textTransform: 'uppercase',
+    color: MUTED,
+    marginLeft: 'auto',
+    border: `1px solid ${LINE}`,
+    borderRadius: 20,
+    padding: '3px 9px',
+  },
+  badgeRow: (badge, last) => (
+    <BadgeRow
+      badge={badge}
+      last={last}
+      dividerColor={LINE}
+      nameStyle={{ fontFamily: DISPLAY, fontSize: 15, color: INK, lineHeight: 1.15 }}
+      medallion={(glyph) => (
+        <span
+          style={{
+            flexShrink: 0,
+            width: 34,
+            height: 34,
+            borderRadius: '50%',
+            padding: 2.5,
+            background: GILT,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxSizing: 'border-box',
+          }}
+        >
+          <span
+            style={{
+              width: '100%',
+              height: '100%',
+              borderRadius: '50%',
+              background: PAPER,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: ACCENT,
+            }}
+          >
+            {glyph}
+          </span>
+        </span>
+      )}
+    />
+  ),
+}
+
+export default function UaProfileBody(props: ProfileBodyProps) {
+  return <ProfileSkin props={props} kit={kit} />
+}

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -1,0 +1,178 @@
+/**
+ * WowProfileBody — Warriors of Whimsy scrapbook player-profile skin (#460).
+ * Ported from docs/design/profile/templates/Warriors of Whimsy Profile.dc.html:
+ * a cork-board mat with push-pin dots, slight tilts, washi-tape strips, and an
+ * ".exe window" progression panel. WOW follows the global light/dark cascade —
+ * it reads --faction-wow-* / --faction-wow-card-* tokens (which flip with the
+ * theme) and never pins a fixed data-theme.
+ *
+ * Structure is DefaultProfileBody's locked spine via ProfileSkin. No hardcoded
+ * hex — colours via --faction-wow-* vars.
+ */
+import type { ReactNode } from 'react'
+
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
+
+const INK = 'var(--faction-wow-card-text)'
+const MUTED = 'var(--faction-wow-card-muted)'
+const ACCENT = 'var(--faction-wow-card-accent)'
+const SURFACE = 'var(--faction-wow-notepad-bg)'
+const BORDER = 'var(--faction-wow-win-border)'
+const MAT = 'var(--faction-wow-light)'
+const DISPLAY = 'var(--font-faction-script)' // Caveat
+const EYEBROW = 'var(--font-body)'
+const BAR = 'linear-gradient(90deg, var(--faction-wow-title-from), var(--faction-wow-card-accent))'
+
+function Pin({ left, right }: { left?: number; right?: number }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        position: 'absolute',
+        top: 10,
+        left,
+        right,
+        width: 9,
+        height: 9,
+        borderRadius: '50%',
+        background: ACCENT,
+        boxShadow: '0 1px 2px rgba(0,0,0,0.3)',
+        zIndex: 4,
+      }}
+    />
+  )
+}
+
+function heading(title: string, eyebrow: string): ReactNode {
+  return (
+    <div style={{ marginBottom: 16, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+      <span
+        style={{
+          fontFamily: DISPLAY,
+          fontSize: 28,
+          color: ACCENT,
+          background: 'var(--faction-wow-tape)',
+          padding: '2px 12px',
+          transform: 'rotate(-1.5deg)',
+          display: 'inline-block',
+        }}
+      >
+        {title}
+      </span>
+      <span style={{ fontFamily: EYEBROW, fontSize: 10, color: MUTED }}>{eyebrow}</span>
+    </div>
+  )
+}
+
+const kit: ProfileKit = {
+  slug: 'wow',
+  pageBackground: MAT,
+  pageOverlay: 'radial-gradient(var(--faction-wow-dot) 1px, transparent 1px)',
+  ink: INK,
+  muted: MUTED,
+  accent: ACCENT,
+  surface: SURFACE,
+  border: BORDER,
+  displayFont: DISPLAY,
+  eyebrowFont: EYEBROW,
+  headerStyle: {
+    background: 'var(--faction-wow-notepad-bg)',
+    border: `1px solid ${BORDER}`,
+    borderRadius: 16,
+    padding: '30px 34px',
+    marginBottom: 34,
+    transform: 'rotate(-0.4deg)',
+    boxShadow: '0 12px 30px -18px rgba(0,0,0,0.4)',
+  },
+  headerDecoration: (
+    <>
+      <Pin left={12} />
+      <Pin right={12} />
+    </>
+  ),
+  credentialFrame: (card) => (
+    <div style={{ transform: 'rotate(-1.4deg)', filter: 'drop-shadow(0 8px 14px rgba(0,0,0,0.2))' }}>
+      {card}
+    </div>
+  ),
+  nameSize: 56,
+  playerEyebrow: 'Player · Warriors of Whimsy',
+  progressionStyle: {
+    marginTop: 22,
+    background: SURFACE,
+    border: `1px solid ${BORDER}`,
+    borderRadius: 10,
+    padding: '16px 18px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    maxWidth: 440,
+  },
+  ringLabel: 'lvl',
+  barFill: BAR,
+  barTrack: 'var(--faction-wow-notepad-border)',
+  nextLevelLabel: (next) => `next · lvl ${next}`,
+  sectionHeading: heading,
+  praxisEyebrow: (name) => `sealed by ${name}`,
+  praxisEmpty: {
+    title: 'No spells sealed yet',
+    body: 'The first bit of mischief is always the hardest ✦',
+  },
+  emptyStateStyle: {
+    border: `1.5px dashed ${ACCENT}`,
+    borderRadius: 14,
+    padding: 30,
+    textAlign: 'center',
+    background: SURFACE,
+  },
+  laurel: <SpectrumLaurel centerBg={SURFACE} glyphColor={ACCENT} rotate={-8} />,
+  badgeTitle: 'Charms earned',
+  badgeBoardStyle: {
+    border: `1px solid ${BORDER}`,
+    borderRadius: 12,
+    background: SURFACE,
+    padding: '4px 14px',
+  },
+  badgeChipStyle: {
+    fontFamily: EYEBROW,
+    fontSize: 9,
+    letterSpacing: '0.1em',
+    textTransform: 'uppercase',
+    color: MUTED,
+    marginLeft: 'auto',
+    border: `1px solid ${BORDER}`,
+    borderRadius: 20,
+    padding: '3px 9px',
+  },
+  badgeRow: (badge, last) => (
+    <BadgeRow
+      badge={badge}
+      last={last}
+      dividerColor="var(--faction-wow-notepad-border)"
+      nameStyle={{ fontFamily: DISPLAY, fontSize: 18, color: INK, lineHeight: 1.15 }}
+      medallion={(glyph) => (
+        <span
+          style={{
+            flexShrink: 0,
+            width: 34,
+            height: 34,
+            borderRadius: '50%',
+            background: 'radial-gradient(circle at 30% 30%, var(--faction-wow-scrap-mid), var(--faction-wow-scrap-deep))',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: ACCENT,
+            border: `1px solid ${BORDER}`,
+          }}
+        >
+          {glyph}
+        </span>
+      )}
+    />
+  ),
+}
+
+export default function WowProfileBody(props: ProfileBodyProps) {
+  return <ProfileSkin props={props} kit={kit} />
+}

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -1,0 +1,571 @@
+/**
+ * Shared profile-skin scaffold (#460).
+ *
+ * Every faction player-profile renders the SAME locked section spine as
+ * DefaultProfileBody — ① identity + progression, ③ badges (hidden when empty),
+ * ⑤ praxis (faction PraxisCard, FDL laurel on the top entry), plus the kept
+ * proposed-tasks and friend/foe features. Only the COSTUME differs. This module
+ * factors the invariant structure into one skinnable renderer driven by a
+ * per-faction `ProfileKit`; each `<Faction>ProfileBody.tsx` supplies only its
+ * kit (tokens, fonts, copy, chrome slots) and delegates here.
+ *
+ * No hardcoded hex: kits reference the repo's `--faction-<slug>-*` CSS vars.
+ * Always-dark (snide, singularity) / always-light (albescent, ua) factions scope
+ * their tokens to the skin container and NEVER mutate the global [data-theme].
+ */
+import type { CSSProperties, ReactNode } from 'react'
+
+import type { BadgeOut } from '../../../api/auth'
+import { badgeArtFor } from '../../../components/badges/badgeArt'
+import CredentialCard from '../../../components/CredentialCard'
+import PraxisCard from '../../../components/PraxisCard'
+import TaskCard from '../../../components/TaskCard'
+import { mediaUrl } from '../../../utils/media'
+import type { ProfileBodyProps } from '../FactionProfileBody'
+
+/** The costume knobs a faction fills in. Everything is a CSS var reference or
+ *  faction-appropriate copy — no literal hex, no per-theme branching. */
+export interface ProfileKit {
+  /** faction_slug this kit skins (drives the shared CredentialCard skin). */
+  slug: string
+  /** Fixed theme for always-dark/always-light factions; scoped to the
+   *  container only, never applied to the global tree. */
+  dataTheme?: 'light' | 'dark'
+
+  /* ── surfaces / ink ── */
+  /** Page-level wrapper background (the "wall" behind the profile). */
+  pageBackground: string
+  /** Optional decorative overlay layered over the page (texture/grid/etc.). */
+  pageOverlay?: string
+  /** Ink color for headings + the display name. */
+  ink: string
+  /** Secondary / meta ink. */
+  muted: string
+  /** Accent color (progression ring, accents). */
+  accent: string
+  /** Card / panel surface. */
+  surface: string
+  /** Hairline border color. */
+  border: string
+
+  /* ── fonts ── */
+  /** Display font for the big name + section headings. */
+  displayFont: string
+  /** Small mono/label eyebrow font. */
+  eyebrowFont: string
+  /** Body font for meta lines. */
+  bodyFont?: string
+
+  /* ── identity header chrome ── */
+  /** Style for the outer identity banner (frame idiom lives here). */
+  headerStyle: CSSProperties
+  /** Optional absolutely-positioned decoration inside the header (grain, strip). */
+  headerDecoration?: ReactNode
+  /** Optional wrapper chrome placed AROUND the shared CredentialCard. */
+  credentialFrame?: (card: ReactNode) => ReactNode
+  /** px font-size for the big display name (default 48). */
+  nameSize?: number
+  /** Optional CSS text-shadow / transform on the name. */
+  nameExtra?: CSSProperties
+  /** Eyebrow above the name, e.g. "Player · University of Asthmatics". */
+  playerEyebrow: string
+
+  /* ── progression panel ── */
+  /** Style for the progression panel container. */
+  progressionStyle: CSSProperties
+  /** Small label above the level number inside the ring (e.g. "lvl", "ANNO"). */
+  ringLabel: string
+  /** Fill for the points-into-level bar. */
+  barFill: string
+  /** Track behind the progression bar. */
+  barTrack: string
+  /** Render the level number (default: the integer; e.g. roman for ephemerists). */
+  formatLevel?: (level: number) => string
+  /** Copy for "pts this level" (defaults to "pts this level"). */
+  levelUnitLabel?: string
+  /** Copy for "next · lvl {n}". */
+  nextLevelLabel: (nextLevel: number) => string
+  /** Copy for the absolute-score footer line ("{score} / {next} pts"). */
+  scoreFootnote?: (score: number, nextThreshold: number) => string
+
+  /* ── section headings ── */
+  /** Renders a section heading (⑤ praxis, proposed tasks). */
+  sectionHeading: (title: string, eyebrow: string) => ReactNode
+
+  /* ── praxis ── */
+  /** Eyebrow for the praxis section, e.g. "sealed by {name}". */
+  praxisEyebrow: (name: string) => string
+  /** Empty-state title + body copy for the praxis section. */
+  praxisEmpty: { title: string; body: string }
+  /** Empty-state container style. */
+  emptyStateStyle: CSSProperties
+  /** The FDL laurel stamped on the top praxis (spectrum ring by default; some
+   *  factions draw an ink-outline variant). */
+  laurel: ReactNode
+
+  /* ── badges (③) ── */
+  /** Section title, e.g. "Distinctions", "Citations", "Commendations". */
+  badgeTitle: string
+  /** Board container style. */
+  badgeBoardStyle: CSSProperties
+  /** Renders one badge row (medallion + name). */
+  badgeRow: (badge: BadgeOut, last: boolean) => ReactNode
+  /** "{n} earned" chip style. */
+  badgeChipStyle: CSSProperties
+}
+
+/** A reusable spectrum-ring FDL laurel (used by all colored factions; the
+ *  colorless ones supply their own ink-outline variant). `ringBg` defaults to
+ *  the spectrum default ring; `centerBg`/`glyphColor` skin the medallion. */
+export function SpectrumLaurel({
+  ringBg = 'var(--faction-default-ring)',
+  centerBg = 'var(--color-bg-surface-alt)',
+  glyphColor = 'var(--color-text-primary)',
+  rotate = 0,
+}: {
+  ringBg?: string
+  centerBg?: string
+  glyphColor?: string
+  rotate?: number
+}) {
+  return (
+    <span
+      title="Top praxis"
+      style={{
+        position: 'absolute',
+        top: -11,
+        right: 14,
+        zIndex: 20,
+        width: 44,
+        height: 44,
+        transform: rotate ? `rotate(${rotate}deg)` : undefined,
+        filter: 'drop-shadow(0 4px 8px rgba(0,0,0,0.25))',
+      }}
+    >
+      <span
+        style={{ position: 'absolute', inset: 0, borderRadius: '50%', background: ringBg }}
+      />
+      <span
+        style={{
+          position: 'absolute',
+          inset: 4,
+          borderRadius: '50%',
+          background: centerBg,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: glyphColor,
+        }}
+      >
+        <LaurelGlyph />
+      </span>
+    </span>
+  )
+}
+
+/** The fleur/laurel glyph, in currentColor. */
+export function LaurelGlyph({ size = 18 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size * (22 / 18)}
+      viewBox="0 0 40 48"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M20 1 C16 10 16 17 20 24 C24 17 24 10 20 1 Z" />
+      <path d="M20 22 C14 15 8 15 6 21 C4.6 25 8 29 13.5 27.6 C10.5 25 12.5 21 20 22 Z" />
+      <path d="M20 22 C26 15 32 15 34 21 C35.4 25 32 29 26.5 27.6 C29.5 25 27.5 21 20 22 Z" />
+      <rect x="11" y="26" width="18" height="4.5" rx="2.2" />
+      <path d="M20 30 C17.5 37 16 41 20 47 C24 41 22.5 37 20 30 Z" />
+    </svg>
+  )
+}
+
+/** Shared badge-row primitive: a skinnable medallion + the badge name. Kits
+ *  pass their medallion chrome; the glyph is mapped client-side by badge key. */
+export function BadgeRow({
+  badge,
+  last,
+  medallion,
+  nameStyle,
+  dividerColor,
+}: {
+  badge: BadgeOut
+  last: boolean
+  medallion: (glyph: ReactNode) => ReactNode
+  nameStyle: CSSProperties
+  dividerColor: string
+}) {
+  const Art = badgeArtFor(badge.key)
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 11,
+        padding: '10px 0',
+        borderBottom: last ? 'none' : `1px solid ${dividerColor}`,
+      }}
+    >
+      {medallion(<Art size={16} />)}
+      <div style={nameStyle}>{badge.name}</div>
+    </div>
+  )
+}
+
+/**
+ * The invariant profile renderer. Given the live props + a faction kit, lays
+ * out the locked spine in the faction's costume. Structurally identical to
+ * DefaultProfileBody — only the styling knobs move.
+ */
+export function ProfileSkin({
+  props,
+  kit,
+}: {
+  props: ProfileBodyProps
+  kit: ProfileKit
+}) {
+  const { character, submissions, proposedTasks, progression, identityActions } = props
+  const badges = character.badges ?? []
+  const joined = new Date(character.created_at).toLocaleDateString(undefined, {
+    month: 'short',
+    year: 'numeric',
+  })
+
+  // ⑤ FDL laurel target: highest earned points (PraxisCardOut.score is base+vote).
+  const topScore = submissions.reduce((max, p) => Math.max(max, p.score ?? 0), 0)
+  const laurelId = submissions.find((p) => (p.score ?? 0) === topScore)?.id ?? null
+
+  // ① progression numbers (hidden until game config supplies thresholds).
+  const pointsIntoLevel = progression
+    ? Math.max(character.score - progression.currentThreshold, 0)
+    : 0
+  const levelSpan = progression
+    ? Math.max(progression.nextThreshold - progression.currentThreshold, 0)
+    : 0
+  const ringDegrees = progression
+    ? Math.round(Math.min(Math.max(progression.progressPercent, 0), 100) * 3.6)
+    : 0
+
+  const levelText = kit.formatLevel
+    ? kit.formatLevel(character.level)
+    : String(character.level)
+  const levelUnit = kit.levelUnitLabel ?? 'pts this level'
+
+  const credential = (
+    <CredentialCard
+      displayName={character.display_name}
+      handle={character.username}
+      bio={character.bio}
+      factionSlug={character.faction_slug}
+      level={character.level}
+      score={character.score}
+      avatarUrl={character.avatar_url ? mediaUrl(character.avatar_url) : null}
+    />
+  )
+
+  const mainColumn = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 34, minWidth: 0 }}>
+      {/* ── ⑤ Praxis ── */}
+      <section>
+        {kit.sectionHeading('Praxis', kit.praxisEyebrow(character.display_name))}
+        {submissions.length === 0 ? (
+          <div style={kit.emptyStateStyle}>
+            <div
+              style={{
+                fontFamily: kit.displayFont,
+                fontSize: 19,
+                color: kit.ink,
+              }}
+            >
+              {kit.praxisEmpty.title}
+            </div>
+            <div
+              style={{
+                fontFamily: kit.bodyFont ?? kit.eyebrowFont,
+                fontSize: 11,
+                color: kit.muted,
+                marginTop: 5,
+              }}
+            >
+              {kit.praxisEmpty.body}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-4 items-start">
+            {submissions.map((praxis) => (
+              <div key={praxis.id} style={{ position: 'relative' }}>
+                {praxis.id === laurelId && kit.laurel}
+                <PraxisCard praxis={praxis} />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Proposed tasks (kept feature, #419) ── */}
+      <section>
+        {kit.sectionHeading('Proposed tasks', `${proposedTasks.length} total`)}
+        {proposedTasks.length === 0 ? (
+          <p style={{ fontFamily: kit.bodyFont ?? kit.eyebrowFont, color: kit.muted }}>
+            No proposed tasks yet.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-4 items-start">
+            {proposedTasks.map((task) => (
+              <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+
+  return (
+    <div
+      data-theme={kit.dataTheme}
+      style={{
+        position: 'relative',
+        background: kit.pageBackground,
+        padding: '32px 28px',
+        borderRadius: 16,
+        overflow: 'hidden',
+      }}
+    >
+      {kit.pageOverlay && (
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            pointerEvents: 'none',
+            background: kit.pageOverlay,
+          }}
+        />
+      )}
+      <div style={{ position: 'relative', zIndex: 1 }}>
+        {/* ── ① Identity + progression ── */}
+        <header style={{ ...kit.headerStyle, position: 'relative', overflow: 'hidden' }}>
+          {kit.headerDecoration}
+          <div
+            style={{
+              position: 'relative',
+              zIndex: 2,
+              display: 'flex',
+              gap: 34,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <div style={{ flexShrink: 0 }}>
+              {kit.credentialFrame ? kit.credentialFrame(credential) : credential}
+            </div>
+
+            <div style={{ flex: 1, minWidth: 300 }}>
+              <div
+                style={{
+                  fontFamily: kit.eyebrowFont,
+                  fontSize: 9,
+                  letterSpacing: '0.22em',
+                  textTransform: 'uppercase',
+                  color: kit.muted,
+                  marginBottom: 8,
+                }}
+              >
+                {kit.playerEyebrow}
+              </div>
+
+              <h1
+                style={{
+                  fontFamily: kit.displayFont,
+                  fontSize: kit.nameSize ?? 48,
+                  lineHeight: 0.98,
+                  margin: 0,
+                  color: kit.ink,
+                  overflowWrap: 'anywhere',
+                  ...kit.nameExtra,
+                }}
+              >
+                {character.display_name}
+              </h1>
+
+              <div
+                style={{
+                  fontFamily: kit.bodyFont ?? kit.eyebrowFont,
+                  fontSize: 12,
+                  color: kit.muted,
+                  marginTop: 10,
+                }}
+              >
+                @{character.username} · joined {joined}
+              </div>
+
+              {progression && (
+                <div style={kit.progressionStyle}>
+                  {/* level ring */}
+                  <div
+                    style={{
+                      flexShrink: 0,
+                      width: 60,
+                      height: 60,
+                      borderRadius: '50%',
+                      background: `conic-gradient(${kit.accent} ${ringDegrees}deg, ${kit.barTrack} 0)`,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 46,
+                        height: 46,
+                        borderRadius: '50%',
+                        background: kit.surface,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        lineHeight: 1,
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: kit.eyebrowFont,
+                          fontSize: 7,
+                          letterSpacing: '0.12em',
+                          textTransform: 'uppercase',
+                          color: kit.muted,
+                        }}
+                      >
+                        {kit.ringLabel}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: kit.displayFont,
+                          fontSize: 22,
+                          color: kit.accent,
+                        }}
+                      >
+                        {levelText}
+                      </span>
+                    </span>
+                  </div>
+
+                  {/* points-into-level bar toward level+1 */}
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'baseline',
+                        marginBottom: 6,
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: kit.bodyFont ?? kit.eyebrowFont,
+                          fontSize: 10,
+                          color: kit.muted,
+                        }}
+                      >
+                        {pointsIntoLevel} / {levelSpan} {levelUnit}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: kit.eyebrowFont,
+                          fontSize: 9,
+                          letterSpacing: '0.1em',
+                          textTransform: 'uppercase',
+                          color: kit.muted,
+                        }}
+                      >
+                        {kit.nextLevelLabel(progression.nextLevel)}
+                      </span>
+                    </div>
+                    <div
+                      style={{
+                        height: 10,
+                        borderRadius: 20,
+                        background: kit.barTrack,
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <div
+                        style={{
+                          height: '100%',
+                          borderRadius: 20,
+                          width: `${progression.progressPercent}%`,
+                          background: kit.barFill,
+                          transition: 'width 300ms',
+                        }}
+                      />
+                    </div>
+                    {kit.scoreFootnote && (
+                      <div
+                        style={{
+                          fontFamily: kit.bodyFont ?? kit.eyebrowFont,
+                          fontSize: 9,
+                          color: kit.muted,
+                          marginTop: 5,
+                        }}
+                      >
+                        {kit.scoreFootnote(character.score, progression.nextThreshold)}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* friend/foe — kept feature, faction-skinned, folded into header */}
+              {identityActions && (
+                <div style={{ marginTop: 16, maxWidth: 220 }}>{identityActions}</div>
+              )}
+            </div>
+          </div>
+        </header>
+
+        {/* ── ② About: skipped in v1 (no long-form field) ── */}
+
+        {badges.length > 0 ? (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 1fr) 300px',
+              gap: 30,
+              alignItems: 'start',
+            }}
+          >
+            {mainColumn}
+
+            {/* ── ③ Badges — hidden entirely when empty ── */}
+            <aside>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  marginBottom: 14,
+                }}
+              >
+                <h2 style={{ fontFamily: kit.displayFont, fontSize: 22, margin: 0, color: kit.ink }}>
+                  {kit.badgeTitle}
+                </h2>
+                <span style={kit.badgeChipStyle}>{badges.length} earned</span>
+              </div>
+              <div style={kit.badgeBoardStyle}>
+                {badges.map((badge, index) => (
+                  <span key={badge.key}>
+                    {kit.badgeRow(badge, index === badges.length - 1)}
+                  </span>
+                ))}
+              </div>
+            </aside>
+          </div>
+        ) : (
+          mainColumn
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Fills the #459 `FACTION_PROFILE_BODIES` dispatcher with all seven bespoke faction player-profile skins, ported from the design bundle vendored under `docs/design/profile/`.

## What landed
Seven skins, each registered in `FactionProfileBody.tsx`:

- **UA** — gilt-salon: gilt double-border frame, paper-grain dot texture, ANNO motif (always-light).
- **Warriors of Whimsy** — scrapbook cork-board: push-pin dots, tilts, washi-tape headings, `.exe`-style progression (theme-following).
- **SNIDE** — ransom-note crime-board: hard offset shadows, jagged clip-path strip, skewed Impact headlines with pink drop-shadow (always-dark).
- **Ephemerists** — lapis-and-gold codex: nested gold/cream/ink rules, graticule overlay, roman-numeral GRADE levels (theme-following).
- **Singularity** — terminal CRT: blue graticule grid, green scanlines, `> ` prompt eyebrows, green-glow bar (always-dark).
- **Everymen** — WPA labor poster: 3px ink borders + hard offset shadow, gold strip, sunburst, condensed Bebas headings (theme-following).
- **Albescent** — colorless monastic: hairline borders, generous whitespace, ink-outline FDL laurel (no spectrum gradient) (always-light).

## Design decisions
- Each skin renders the **same locked section spine** as `DefaultProfileBody` — ① identity + progression, ③ badges (hidden when empty), ⑤ praxis (faction `PraxisCard`, FDL laurel on the top entry), plus proposed tasks (faction `TaskCard`) and the skinned friend/foe actions. Only the costume differs.
- The invariant structure is factored into one `ProfileSkin` renderer driven by a per-faction `ProfileKit`, so each skin file supplies only tokens, fonts, copy, and chrome slots (no structural drift).
- ② About stays skipped, role/standing stays out (per #459). No new profile data fields — skin derives from faction only.
- No hardcoded hex: colours resolve through the repo's `--faction-<slug>-*` CSS vars. Always-dark/always-light factions scope `data-theme` to their own container and never mutate the global theme.
- The `docs/design/profile/` bundle is included so the design is durable in-repo.

## Gates
- `npx tsc --noEmit` — clean
- `npm test -- --run` — 200 passed (22 files); updated the two #459 tests that asserted the map was empty / all slugs fell back to default
- `npm run build` — clean

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)