### PR TITLE
feat(i18n): sweep task pages into tasks.json (#446)

### DIFF
--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -1,1 +1,360 @@
-{}
+{
+  "detail": {
+    "loading": "Loading...",
+    "fetchError": "<0>Try refreshing.</0>",
+    "notFound": "Task not found.",
+    "pageTitle": "Task",
+    "pageEyebrow": "Tasks · Detail"
+  },
+  "propose": {
+    "pageTitle": "Propose a Task",
+    "loginRequired": "You need to be logged in to propose a task.",
+    "levelGate": "You must be level 3 or higher to propose tasks. You are currently level {{level}}."
+  },
+  "default": {
+    "breadcrumb": "Tasks",
+    "metataskFor": "Metatask for {{faction}}",
+    "meta": "META",
+    "stats": {
+      "basePoints": "Base Pts",
+      "yourPoints": "Your Pts (×{{multiplier}})",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "topScore": "Top Score"
+    },
+    "signup": {
+      "cta": "Sign up · earn up to {{points}} pts",
+      "slots": "You have {{open}} of {{max}} task slots open",
+      "levelRequired": "Level {{level}} required",
+      "met": "MET"
+    },
+    "submitted": {
+      "badge": "DONE",
+      "text": "You've submitted praxis for this task",
+      "edit": "edit"
+    },
+    "inProgress": {
+      "badge": "IN PROGRESS",
+      "text": "You're on this task",
+      "continue": "Continue editing",
+      "drop": "drop"
+    },
+    "completedHeading": "{{count}} Completed Praxis",
+    "sort": {
+      "topRated": "Top Rated",
+      "recent": "Recent"
+    },
+    "empty": "No submissions yet. Be the first.",
+    "viewAll": "View all {{count}} praxis →",
+    "playersInProgress": "{{count}} Players in Progress",
+    "moreSignups": "+{{count}} more →",
+    "friend": "Friend",
+    "foe": "Foe"
+  },
+  "snide": {
+    "breadcrumb": "Tasks",
+    "faction": "S.N.I.D.E.",
+    "jobFile": "JOB FILE",
+    "openCase": "OPEN CASE",
+    "caseFile": "S.N.I.D.E. Case File · job no. {{number}}",
+    "metataskFor": "↳ metatask for {{faction}}",
+    "evidence": {
+      "points": "Points",
+      "level": "Level",
+      "levelValue": "LVL {{level}}",
+      "filed": "Filed",
+      "closed": "Closed"
+    },
+    "signup": {
+      "cta": "★ PULL THIS JOB ★",
+      "warning": "↳ no take-backs once it's filed",
+      "meta": "earn up to {{points}} pts · {{open}} of {{max}} slots open · lvl {{level}} met"
+    },
+    "submitted": {
+      "edit": "→ EDIT THE RAP SHEET",
+      "note": "↳ filed. on the record."
+    },
+    "inProgress": {
+      "continue": "→ CONTINUE THE RAP SHEET",
+      "drop": "↳ ditch the job"
+    },
+    "verdict": {
+      "closed": "{{count}} CLOSED · TOP {{top}}",
+      "none": "NO VERDICT YET"
+    },
+    "brief": "the brief",
+    "briefEmpty": "No brief on file. Figure it out.",
+    "accomplices": "accomplices on file",
+    "onTheJob": "on the job",
+    "casesClosed": "cases closed · {{count}}",
+    "sort": {
+      "topMarks": "top marks",
+      "recent": "recent"
+    },
+    "empty": "no files yet. nobody's pulled it off.",
+    "topMarks": "TOP MARKS",
+    "viewAll": "open all {{count}} files →"
+  },
+  "everymen": {
+    "breadcrumb": "Tasks",
+    "faction": "The Everymen",
+    "masthead": "THE EVERYMEN",
+    "statusOpen": "Open · accepting hands",
+    "levelValue": "LVL {{level}}",
+    "pointsValue": "{{points}} PTS",
+    "onView": "{{signups}} on the job · {{completed}} delivered",
+    "signup": {
+      "cta": "Report for duty ▸",
+      "meta": "earn up to {{points}} pts · {{open}} of {{max}} slots open",
+      "levelRequired": "Level {{level}} required · met"
+    },
+    "submitted": {
+      "text": "✓ Your report is filed",
+      "edit": "edit"
+    },
+    "inProgress": {
+      "text": "You're on the job",
+      "continue": "continue",
+      "drop": "drop"
+    },
+    "orderHeading": "The Order",
+    "orderEmpty": "No order posted yet. The work outlasts the worker — figure out what needs doing and report for duty.",
+    "handsHeading": "Hands On The Job",
+    "onTheJob": "on the job",
+    "verdictHeading": "The Hall's Verdict",
+    "verdict": {
+      "topMark": "TOP MARK",
+      "reports_one": "{{count}} report on the books",
+      "reports_other": "{{count}} reports on the books",
+      "none": "No verdict yet. The hall hasn't weighed in — be the first to deliver."
+    },
+    "reportsHeading": "Work Reports Filed",
+    "sort": {
+      "topRated": "Top Rated",
+      "recent": "Recent"
+    },
+    "empty": "No reports filed yet. Be the first hand to deliver.",
+    "bestInHall": "BEST IN HALL",
+    "viewAll": "View all {{count}} reports →"
+  },
+  "wow": {
+    "breadcrumb": "Tasks",
+    "faction": "Warriors of Whimsy",
+    "window": "quest.exe",
+    "statusOpen": "open · the party's still gathering",
+    "level": "level {{level}}",
+    "sparks": "{{points}} sparks",
+    "onView": "{{signups}} tried · {{completed}} pulled it off",
+    "signup": {
+      "cta": "join the party ✦ earn up to {{points}} pts",
+      "note": "no experience with magic required",
+      "slots": "{{open}} of {{max}} slots open",
+      "levelRequired": "level {{level}} required · met"
+    },
+    "submitted": {
+      "text": "✦ your spell is cast",
+      "edit": "edit"
+    },
+    "inProgress": {
+      "text": "✦ your spell is half-woven",
+      "continue": "continue",
+      "drop": "leave the party"
+    },
+    "partyHeading": "the party so far",
+    "inTheParty": "in the party",
+    "askingHeading": "what we're asking",
+    "askingEmpty": "No spell written yet. Trust the pull and conjure something kind.",
+    "loveHeading": "the love so far",
+    "love": {
+      "top": "top love",
+      "adored_one": "{{count}} spell adored",
+      "adored_other": "{{count}} spells adored",
+      "none": "no love yet — be the first to cast a little wonder."
+    },
+    "spellsHeading": "spells cast so far · {{count}}",
+    "sort": {
+      "mostLoved": "most loved",
+      "recent": "recent"
+    },
+    "empty": "no spells cast yet. nobody's pulled it off.",
+    "mostLoved": "most loved",
+    "viewAll": "see all {{count}} spells ✦"
+  },
+  "ephemerists": {
+    "breadcrumb": "Tasks",
+    "faction": "The Ephemerists",
+    "masthead": "THE EPHEMERISTS",
+    "statusOpen": "open commission",
+    "statusLine": "{{status}} · commission {{number}}",
+    "metataskFor": "↳ metatask for {{faction}}",
+    "grade": "▦ GRADE {{level}}",
+    "puncta": "PVNCTA",
+    "onView": "{{signups}} triangulating · {{completed}} sealed",
+    "footnote": "† the road does not return you to where you began — <0>see †</0>",
+    "commissionHeading": "The Commission",
+    "commissionEmpty": "No commission is scribed. Walk the ground and let the contradictions guide you.",
+    "signup": {
+      "cta": "Triangulate the truth ▸ earn up to {{points}} pts",
+      "note": "bring no certainty. only instruments.",
+      "meta": "{{open}} of {{max}} leaves open · grade {{level}} met"
+    },
+    "submitted": {
+      "text": "your leaf is filed against this exhibit.",
+      "edit": "edit"
+    },
+    "inProgress": {
+      "text": "your readings are unsealed — the survey is unfinished.",
+      "continue": "continue",
+      "drop": "drop"
+    },
+    "cartographersHeading": "The Cartographers",
+    "cartographersGloss": "{{count}} on the ground",
+    "triangulating": "triangulating",
+    "credenceHeading": "The Credence",
+    "credence": {
+      "highest": "HIGHEST",
+      "weighed": "weighed across {{count}} sealed leaves",
+      "none": "no credence yet. the concordance awaits its first leaf."
+    },
+    "ephemeridesHeading": "Sealed Ephemerides",
+    "ephemeridesGloss": "{{count}} leaves filed",
+    "sort": {
+      "mostCanonical": "Most Canonical",
+      "recent": "Recent"
+    },
+    "empty": "no leaves sealed yet. be the first to file your contradictions.",
+    "mostCanonical": "MOST CANONICAL",
+    "viewAll": "view all {{count}} ephemerides ↗"
+  },
+  "singularity": {
+    "faction": "SINGULARITY",
+    "statusOpen": "ACCEPTING NODES",
+    "consensusOpen": "OPEN",
+    "protocol": "> OPEN PROTOCOL #{{number}}",
+    "class": "> CLASS: OBSERVATION · LVL {{level}} · {{points}} CR",
+    "statusLine": "> STATUS: {{status}}",
+    "consensusLine": "CONSENSUS:",
+    "stats": {
+      "credits": "credits",
+      "level": "level",
+      "arrays": "arrays",
+      "sealed": "sealed"
+    },
+    "observationHeading": "// the_observation",
+    "observationEmpty": "No protocol logged. Find the signal yourself; the array interprets, you only witness.",
+    "signup": {
+      "cta": "> JOIN ARRAY — earn up to {{points}} pts",
+      "note": "no credentials. only signal. · {{open}} of {{max}} arrays open",
+      "levelRequired": "LVL {{level}} REQUIRED · MET"
+    },
+    "submitted": {
+      "edit": "> EDIT SIGNAL LOG",
+      "note": "◉ your log is sealed against this protocol."
+    },
+    "inProgress": {
+      "continue": "> CONTINUE OBSERVATION",
+      "drop": "> abort array"
+    },
+    "rosterHeading": "// array_roster",
+    "rosterSynced": "{{count}} nodes synced",
+    "nodesOnArray": "nodes on array",
+    "consensusHeading": "// consensus_signal",
+    "consensus": {
+      "peakSignal": "peak signal",
+      "sealed": "{{count}} logs sealed",
+      "none": "> no consensus yet. the array is silent. seal the first signal."
+    },
+    "sealedHeading": "// sealed_praxis",
+    "sealedCount": "{{count}} logs sealed",
+    "sort": {
+      "highestSignal": "highest signal",
+      "recent": "recent"
+    },
+    "empty": "> no logs sealed. no node has witnessed this yet.",
+    "highestSignal": "HIGHEST SIGNAL",
+    "viewAll": "> view all {{count}} logs →"
+  },
+  "ua": {
+    "faction": "UA",
+    "masthead": "University of Asthmatics",
+    "commissionLine": "COMMISSION №{{number}} · EST · MMXX",
+    "statusOpen": "On View · Open Salon",
+    "stats": {
+      "anno": "ANNO",
+      "honoraria": "HONORARIA",
+      "honorariaUnit": "pts",
+      "onView": "ON VIEW",
+      "onViewValue": "{{signups}} sitting · {{completed}} hung"
+    },
+    "signup": {
+      "cta": "Matriculate ▸ earn up to {{points}} pts",
+      "meta": "{{open}} of {{max}} easels reserved · Anno {{level}} standing met"
+    },
+    "submitted": {
+      "text": "✦ Your work hangs on the Salon Wall",
+      "edit": "edit"
+    },
+    "inProgress": {
+      "text": "Your easel is at the salon",
+      "continue": "continue",
+      "drop": "drop"
+    },
+    "commissionHeading": "The Commission",
+    "commissionEmpty": "No commission posted yet. The Salon awaits its brief — render the light before it leaves and pin your work to the wall.",
+    "matriculatedHeading": "Matriculated",
+    "matriculated": "matriculated",
+    "critiqueHeading": "The Critique",
+    "critique": {
+      "finest": "Finest Critique",
+      "appraised_one": "{{count}} work appraised",
+      "appraised_other": "{{count}} works appraised",
+      "none": "The Salon has rendered no verdict yet. Be the first hand to hang a work."
+    },
+    "salonWallHeading": "The Salon Wall",
+    "sort": {
+      "finest": "Finest",
+      "recent": "recent"
+    },
+    "empty": "The wall is bare. Be the first hand to file a work against this commission.",
+    "finestHand": "FINEST HAND",
+    "viewAll": "View all {{count}} works →"
+  },
+  "albescent": {
+    "faction": "Albescent",
+    "correspondence": "Correspondence №{{number}} · in confidence",
+    "stats": {
+      "standing": "Standing",
+      "standingValue": "Lvl {{level}}",
+      "worth": "Worth",
+      "worthValue": "{{points}} pts",
+      "returned": "Returned"
+    },
+    "signup": {
+      "cta": "Acknowledge · earn up to {{points}} pts",
+      "note": "no portfolio. no announcement.",
+      "meta": "{{open}} of {{max}} slots open · Lvl {{level}} standing met"
+    },
+    "submitted": {
+      "text": "⚜ Your account is inscribed in the Register",
+      "edit": "edit"
+    },
+    "inProgress": {
+      "text": "Your account is unfiled, still in hand",
+      "continue": "continue",
+      "drop": "withdraw"
+    },
+    "askHeading": "The Ask",
+    "askGloss": "in the hand of the keeper",
+    "askEmpty": "No correspondence entered yet. The Register waits for the ask to be set down — plainly, in the fewest words that keep it true.",
+    "inConfidenceHeading": "Taken in Confidence",
+    "inHand": "in hand",
+    "registerHeading": "Inscribed in the Register",
+    "sort": {
+      "mostWitnessed": "most witnessed",
+      "recent": "recent"
+    },
+    "empty": "The Register holds no accounts against this correspondence. Be the first to return one, unsigned.",
+    "mostWitnessed": "most witnessed",
+    "viewAll": "all {{count}} accounts →"
+  }
+}

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -8,6 +8,7 @@
  * eligibility gates live here so archetypes only ever render the happy-path
  * form (or its success screen).
  */
+import { useTranslation } from "react-i18next";
 import { useProposeTask } from "./proposeTask/useProposeTask";
 import PageTitle from "../components/ui/PageTitle";
 import DefaultProposeTask from "./proposeTask/archetypes/DefaultProposeTask";
@@ -15,15 +16,14 @@ import DefaultProposeTask from "./proposeTask/archetypes/DefaultProposeTask";
 // ponytail: no faction has a bespoke proposal form yet — everyone renders
 // DefaultProposeTask. Add a pickVariant dispatch here when one does.
 export default function ProposeTask() {
+  const { t } = useTranslation("tasks");
   const state = useProposeTask();
 
   if (!state.isLoggedIn) {
     return (
       <div className="py-8" style={{ maxWidth: 720, margin: "0 auto" }}>
-        <PageTitle title="Propose a Task" />
-        <p className="font-body text-muted">
-          You need to be logged in to propose a task.
-        </p>
+        <PageTitle title={t("propose.pageTitle")} />
+        <p className="font-body text-muted">{t("propose.loginRequired")}</p>
       </div>
     );
   }
@@ -31,13 +31,12 @@ export default function ProposeTask() {
   if (!state.canProposeTask) {
     return (
       <div className="py-8" style={{ maxWidth: 720, margin: "0 auto" }}>
-        <PageTitle title="Propose a Task" />
+        <PageTitle title={t("propose.pageTitle")} />
         <p
           className="font-body"
           style={{ color: "var(--color-text-secondary)" }}
         >
-          You must be level 3 or higher to propose tasks. You are currently
-          level {state.currentLevel}.
+          {t("propose.levelGate", { level: state.currentLevel })}
         </p>
       </div>
     );

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -8,6 +8,7 @@
  * docs/spec/SPEC-faction-ui-profile.md.
  */
 import { useParams } from "react-router-dom";
+import { Trans, useTranslation } from "react-i18next";
 import PageTitle from "../components/ui/PageTitle";
 import { pickVariant } from "../utils/factionDispatch";
 import { useTaskDetail, type TaskDetailState } from "./taskDetail/useTaskDetail";
@@ -38,35 +39,43 @@ export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
 
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation("tasks");
   const state = useTaskDetail(id);
 
   if (state.loading)
-    return <div className="py-8 font-body text-muted">Loading...</div>;
+    return <div className="py-8 font-body text-muted">{t("detail.loading")}</div>;
 
   if (state.fetchError)
     return (
       <div className="py-8">
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
           {state.fetchError}{" "}
-          <button
-            onClick={() => window.location.reload()}
-            className="underline"
-          >
-            Try refreshing.
-          </button>
+          <Trans
+            t={t}
+            i18nKey="detail.fetchError"
+            components={[
+              <button
+                key="0"
+                onClick={() => window.location.reload()}
+                className="underline"
+              />,
+            ]}
+          />
         </p>
       </div>
     );
 
   if (!state.task)
-    return <div className="py-8 font-body text-muted">Task not found.</div>;
+    return (
+      <div className="py-8 font-body text-muted">{t("detail.notFound")}</div>
+    );
 
   const slug = state.task.primary_faction_slug ?? null;
   const Archetype = pickVariant(ARCHETYPE_BY_SLUG, slug, DefaultTaskDetail);
 
   return (
     <>
-      <PageTitle title="Task" eyebrow="Tasks · Detail" />
+      <PageTitle title={t("detail.pageTitle")} eyebrow={t("detail.pageEyebrow")} />
       <Archetype state={state} />
       {/* Comments below every archetype (ADR-0006); tasks are commentable while active. */}
       {state.task.status === "active" && (

--- a/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import AlbescentMark from "../../../components/cards/AlbescentMark";
 import { mediaUrl } from "../../../utils/media";
@@ -55,6 +56,7 @@ function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode 
 }
 
 export default function AlbescentTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     signups,
@@ -109,10 +111,10 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
         }}
       >
         <Link to="/tasks" style={{ color: "inherit", textDecoration: "none" }}>
-          Tasks
+          {t("default.breadcrumb")}
         </Link>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
-        <span>Albescent</span>
+        <span>{t("albescent.faction")}</span>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
         <span style={{ color: INK }}>{task.title}</span>
       </nav>
@@ -142,7 +144,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                 marginBottom: 6,
               }}
             >
-              Albescent
+              {t("albescent.faction")}
             </div>
             <div
               style={{
@@ -154,7 +156,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                 marginBottom: 26,
               }}
             >
-              Correspondence №{correspondenceNo} · in confidence
+              {t("albescent.correspondence", { number: correspondenceNo })}
             </div>
             <div style={{ width: 54, height: 1, background: ink(12), margin: "0 auto 26px" }} />
             <h1
@@ -175,9 +177,22 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
             <div style={{ width: 54, height: 1, background: ink(12), margin: "0 auto 28px" }} />
             <div style={{ display: "flex", justifyContent: "center", gap: 48, flexWrap: "wrap" }}>
               {[
-                { label: "Standing", value: `Lvl ${task.level_required}` },
-                { label: "Worth", value: `${modifiedPoints} pts` },
-                { label: "Returned", value: `${submissions.length}` },
+                {
+                  label: t("albescent.stats.standing"),
+                  value: t("albescent.stats.standingValue", {
+                    level: task.level_required,
+                  }),
+                },
+                {
+                  label: t("albescent.stats.worth"),
+                  value: t("albescent.stats.worthValue", {
+                    points: modifiedPoints,
+                  }),
+                },
+                {
+                  label: t("albescent.stats.returned"),
+                  value: `${submissions.length}`,
+                },
               ].map((stat, index) => (
                 <div key={stat.label} style={{ display: "flex", gap: 48 }}>
                   {index > 0 && <div style={{ borderLeft: `1px solid ${ink(10)}` }} />}
@@ -229,10 +244,10 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                   padding: "13px 26px",
                 }}
               >
-                Acknowledge · earn up to {modifiedPoints} pts
+                {t("albescent.signup.cta", { points: modifiedPoints })}
               </button>
               <div style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 15, color: ink(55) }}>
-                no portfolio. no announcement.
+                {t("albescent.signup.note")}
               </div>
               <div
                 style={{
@@ -244,7 +259,11 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                   color: ink(40),
                 }}
               >
-                {slotsOpen} of {maxTaskSlots} slots open · Lvl {task.level_required} standing met
+                {t("albescent.signup.meta", {
+                  open: slotsOpen,
+                  max: maxTaskSlots,
+                  level: task.level_required,
+                })}
               </div>
               <ErrorBanner
                 message={signupError}
@@ -272,7 +291,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
               }}
             >
               <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 17, color: ink(65) }}>
-                ⚜ Your account is inscribed in the Register
+                {t("albescent.submitted.text")}
               </span>
               <Link
                 to={`/praxes/${mySubmission.id}/edit`}
@@ -288,7 +307,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                   textDecoration: "none",
                 }}
               >
-                edit
+                {t("albescent.submitted.edit")}
               </Link>
             </div>
           )}
@@ -306,7 +325,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
               }}
             >
               <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 17, color: ink(65) }}>
-                Your account is unfiled, still in hand
+                {t("albescent.inProgress.text")}
               </span>
               <Link
                 to={`/praxes/${inProgressPraxisId}/edit`}
@@ -322,7 +341,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                   textDecoration: "none",
                 }}
               >
-                continue
+                {t("albescent.inProgress.continue")}
               </Link>
               <button
                 onClick={handleDrop}
@@ -337,7 +356,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                   color: ink(40),
                 }}
               >
-                withdraw
+                {t("albescent.inProgress.drop")}
               </button>
               <ErrorBanner
                 message={signupError}
@@ -355,10 +374,10 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
           {/* THE ASK — the user-written brief */}
           <section>
             <SectionHead
-              title="The Ask"
+              title={t("albescent.askHeading")}
               trailing={
                 <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 13, color: ink(45), whiteSpace: "nowrap" }}>
-                  in the hand of the keeper
+                  {t("albescent.askGloss")}
                 </span>
               }
             />
@@ -381,8 +400,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                   whiteSpace: "pre-wrap",
                 }}
               >
-                {task.description ||
-                  "No correspondence entered yet. The Register waits for the ask to be set down — plainly, in the fewest words that keep it true."}
+                {task.description || t("albescent.askEmpty")}
               </p>
             </div>
           </section>
@@ -390,7 +408,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
           {/* Hands — signups (quiet avatar row) */}
           {signups.length > 0 && (
             <section>
-              <SectionHead title="Taken in Confidence" />
+              <SectionHead title={t("albescent.inConfidenceHeading")} />
               <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
                 {signups.map((hand) => {
                   const rel = relationOf(hand.character_id, friends, foes);
@@ -440,7 +458,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                     marginLeft: 4,
                   }}
                 >
-                  in hand
+                  {t("albescent.inHand")}
                 </span>
               </div>
             </section>
@@ -449,7 +467,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
           {/* INSCRIBED IN THE REGISTER — returned accounts */}
           <section>
             <SectionHead
-              title="Inscribed in the Register"
+              title={t("albescent.registerHeading")}
               trailing={
                 <div style={{ display: "flex", gap: 0 }}>
                   {(["score", "recent"] as const).map((sort) => {
@@ -470,7 +488,9 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                           cursor: "pointer",
                         }}
                       >
-                        {sort === "score" ? "most witnessed" : "recent"}
+                        {sort === "score"
+                          ? t("albescent.sort.mostWitnessed")
+                          : t("albescent.sort.recent")}
                       </button>
                     );
                   })}
@@ -479,7 +499,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
             />
             {sortedSubmissions.length === 0 ? (
               <p style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 16, color: ink(45) }}>
-                The Register holds no accounts against this correspondence. Be the first to return one, unsigned.
+                {t("albescent.empty")}
               </p>
             ) : (
               <>
@@ -507,7 +527,8 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                             padding: "3px 14px",
                           }}
                         >
-                          <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> most witnessed
+                          <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span>{" "}
+                          {t("albescent.mostWitnessed")}
                         </div>
                       )}
                       <PraxisCard praxis={s} />
@@ -529,7 +550,7 @@ export default function AlbescentTaskDetail({ state }: { state: TaskDetailState 
                         paddingBottom: 2,
                       }}
                     >
-                      all {submissions.length} accounts &rarr;
+                      {t("albescent.viewAll", { count: submissions.length })}
                     </Link>
                   </div>
                 )}

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import LevelPill from "../../../components/ui/LevelPill";
 import FeedBadge from "../../../components/feed/FeedBadge";
@@ -20,6 +21,7 @@ export default function DefaultTaskDetail({
 }: {
   state: TaskDetailState;
 }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     submissions,
@@ -68,7 +70,7 @@ export default function DefaultTaskDetail({
           to="/tasks"
           style={{ color: "var(--faction-ephemerists)", textDecoration: "none" }}
         >
-          Tasks
+          {t("default.breadcrumb")}
         </Link>
         {" › "}
         <span style={{ color: "var(--color-text-primary)" }}>{task.title}</span>
@@ -145,7 +147,7 @@ export default function DefaultTaskDetail({
                     textShadow: "0 1px 2px rgba(0,0,0,0.3)",
                   }}
                 >
-                  META
+                  {t("default.meta")}
                 </span>
               )}
               <LevelPill level={task.level_required} />
@@ -173,7 +175,9 @@ export default function DefaultTaskDetail({
                   color: factionCssVar(task.metatask_faction_slug),
                 }}
               >
-                Metatask for {factionName(task.metatask_faction_slug)}
+                {t("default.metataskFor", {
+                  faction: factionName(task.metatask_faction_slug),
+                })}
               </p>
             )}
 
@@ -187,18 +191,20 @@ export default function DefaultTaskDetail({
               }}
             >
               {[
-                { label: "Base Pts", value: task.point_value },
+                { label: t("default.stats.basePoints"), value: task.point_value },
                 ...(showMultiplierTile
                   ? [
                       {
-                        label: `Your Pts (×${factionMultiplier})`,
+                        label: t("default.stats.yourPoints", {
+                          multiplier: factionMultiplier,
+                        }),
                         value: modifiedPoints,
                       },
                     ]
                   : []),
-                { label: "Completed", value: submissions.length },
-                { label: "In Progress", value: signups.length },
-                { label: "Top Score", value: topScore },
+                { label: t("default.stats.completed"), value: submissions.length },
+                { label: t("default.stats.inProgress"), value: signups.length },
+                { label: t("default.stats.topScore"), value: topScore },
               ].map((stat) => (
                 <div
                   key={stat.label}
@@ -265,7 +271,7 @@ export default function DefaultTaskDetail({
                     pointerEvents: "none",
                   }}
                 />
-                Sign up · earn up to {modifiedPoints} pts
+                {t("default.signup.cta", { points: modifiedPoints })}
               </button>
 
               <div
@@ -277,11 +283,16 @@ export default function DefaultTaskDetail({
                 }}
               >
                 <span>
-                  You have {slotsOpen} of {maxTaskSlots} task slots open
+                  {t("default.signup.slots", {
+                    open: slotsOpen,
+                    max: maxTaskSlots,
+                  })}
                 </span>
                 <span>
-                  Level {task.level_required} required{" "}
-                  <span className="eyebrow">MET</span>
+                  {t("default.signup.levelRequired", {
+                    level: task.level_required,
+                  })}{" "}
+                  <span className="eyebrow">{t("default.signup.met")}</span>
                 </span>
               </div>
 
@@ -327,13 +338,13 @@ export default function DefaultTaskDetail({
                 }}
               >
                 <span className="eyebrow" style={{ color }}>
-                  DONE
+                  {t("default.submitted.badge")}
                 </span>
                 <span
                   className="font-body"
                   style={{ fontSize: 11, color: "var(--color-text-primary)" }}
                 >
-                  You've submitted praxis for this task
+                  {t("default.submitted.text")}
                 </span>
               </div>
               <Link
@@ -341,7 +352,7 @@ export default function DefaultTaskDetail({
                 className="btn-outline"
                 style={{ fontSize: 8, padding: "4px 12px" }}
               >
-                edit
+                {t("default.submitted.edit")}
               </Link>
             </div>
           )}
@@ -369,13 +380,13 @@ export default function DefaultTaskDetail({
                 }}
               >
                 <span className="eyebrow" style={{ color }}>
-                  IN PROGRESS
+                  {t("default.inProgress.badge")}
                 </span>
                 <span
                   className="font-body"
                   style={{ fontSize: 11, color: "var(--color-text-primary)" }}
                 >
-                  You're on this task
+                  {t("default.inProgress.text")}
                 </span>
               </div>
               <Link
@@ -401,7 +412,7 @@ export default function DefaultTaskDetail({
                     pointerEvents: "none",
                   }}
                 />
-                Continue editing
+                {t("default.inProgress.continue")}
               </Link>
               <button
                 onClick={handleDrop}
@@ -413,7 +424,7 @@ export default function DefaultTaskDetail({
                   color: "var(--color-text-tertiary)",
                 }}
               >
-                drop
+                {t("default.inProgress.drop")}
               </button>
             </div>
           )}
@@ -429,7 +440,7 @@ export default function DefaultTaskDetail({
               }}
             >
               <span className="eyebrow">
-                {submissions.length} Completed Praxis
+                {t("default.completedHeading", { count: submissions.length })}
               </span>
               <div style={{ display: "flex", gap: 0 }}>
                 {(["score", "recent"] as const).map((sort) => (
@@ -455,16 +466,16 @@ export default function DefaultTaskDetail({
                       cursor: "pointer",
                     }}
                   >
-                    {sort === "score" ? "Top Rated" : "Recent"}
+                    {sort === "score"
+                      ? t("default.sort.topRated")
+                      : t("default.sort.recent")}
                   </button>
                 ))}
               </div>
             </div>
 
             {sortedSubmissions.length === 0 ? (
-              <p className="font-body text-muted">
-                No submissions yet. Be the first.
-              </p>
+              <p className="font-body text-muted">{t("default.empty")}</p>
             ) : (
               <>
                 <div className="flex flex-wrap gap-4 items-start">
@@ -486,7 +497,7 @@ export default function DefaultTaskDetail({
                         textDecoration: "none",
                       }}
                     >
-                      View all {submissions.length} praxis &rarr;
+                      {t("default.viewAll", { count: submissions.length })}
                     </Link>
                   </div>
                 )}
@@ -499,7 +510,9 @@ export default function DefaultTaskDetail({
         <div style={{ width: 240, flexShrink: 0 }}>
           {/* Players in Progress */}
           <div className="sidebar-card mb-3">
-            <p className="eyebrow mb-2">{signups.length} Players in Progress</p>
+            <p className="eyebrow mb-2">
+              {t("default.playersInProgress", { count: signups.length })}
+            </p>
             <div
               style={{ display: "flex", flexDirection: "column", gap: 6 }}
             >
@@ -552,8 +565,10 @@ export default function DefaultTaskDetail({
                     >
                       {signup.display_name}
                     </Link>
-                    {isFriend && <FeedBadge type="friend" label="Friend" />}
-                    {isFoe && <FeedBadge type="duel" label="Foe" />}
+                    {isFriend && (
+                      <FeedBadge type="friend" label={t("default.friend")} />
+                    )}
+                    {isFoe && <FeedBadge type="duel" label={t("default.foe")} />}
                   </div>
                 );
               })}
@@ -563,7 +578,9 @@ export default function DefaultTaskDetail({
                 className="eyebrow"
                 style={{ marginTop: 6, color: "var(--color-text-tertiary)" }}
               >
-                +{signups.length - VISIBLE_SIGNUPS} more &rarr;
+                {t("default.moreSignups", {
+                  count: signups.length - VISIBLE_SIGNUPS,
+                })}
               </p>
             )}
           </div>

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Trans, useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { factionName } from "../../../utils/factions";
@@ -215,6 +216,7 @@ function SurveyorRow({
   friends: Set<number>;
   foes: Set<number>;
 }) {
+  const { t } = useTranslation("tasks");
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
       {signups.map((m) => {
@@ -291,7 +293,7 @@ function SurveyorRow({
           marginLeft: 4,
         }}
       >
-        triangulating
+        {t("ephemerists.triangulating")}
       </span>
     </div>
   );
@@ -302,6 +304,7 @@ export default function EphemeristsTaskDetail({
 }: {
   state: TaskDetailState;
 }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     signups,
@@ -332,7 +335,8 @@ export default function EphemeristsTaskDetail({
   const commissionNo = `C-${task.id}`;
   const isMeta = task.task_type === "metatask";
   // The faction's voice: an active task is an OPEN commission; else honest status.
-  const statusLabel = task.status === "active" ? "open commission" : task.status;
+  const statusLabel =
+    task.status === "active" ? t("ephemerists.statusOpen") : task.status;
   // Top-rated ephemeris (most canonical) by real score.
   const topId = submissions.length
     ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
@@ -358,10 +362,10 @@ export default function EphemeristsTaskDetail({
           to="/tasks"
           style={{ color: "var(--faction-ephemerists)", textDecoration: "none" }}
         >
-          Tasks
+          {t("ephemerists.breadcrumb")}
         </Link>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
-        <span>The Ephemerists</span>
+        <span>{t("ephemerists.faction")}</span>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ color: "var(--eph-rubric)" }}>{task.title}</span>
       </nav>
@@ -413,7 +417,7 @@ export default function EphemeristsTaskDetail({
                     letterSpacing: "0.24em",
                   }}
                 >
-                  THE EPHEMERISTS
+                  {t("ephemerists.masthead")}
                 </span>
               </div>
               <div
@@ -425,7 +429,10 @@ export default function EphemeristsTaskDetail({
                   marginBottom: 16,
                 }}
               >
-                {statusLabel} · commission {commissionNo}
+                {t("ephemerists.statusLine", {
+                  status: statusLabel,
+                  number: commissionNo,
+                })}
               </div>
               {isMeta && (
                 <div
@@ -438,7 +445,9 @@ export default function EphemeristsTaskDetail({
                     marginBottom: 10,
                   }}
                 >
-                  ↳ metatask for {factionName(task.metatask_faction_slug)}
+                  {t("ephemerists.metataskFor", {
+                    faction: factionName(task.metatask_faction_slug),
+                  })}
                 </div>
               )}
               <h1
@@ -476,7 +485,7 @@ export default function EphemeristsTaskDetail({
                     color: VELLUM_TEXT,
                   }}
                 >
-                  ▦ GRADE {task.level_required}
+                  {t("ephemerists.grade", { level: task.level_required })}
                 </span>
                 <span
                   style={{
@@ -487,7 +496,9 @@ export default function EphemeristsTaskDetail({
                   }}
                 >
                   {modifiedPoints}{" "}
-                  <span style={{ fontSize: 11, letterSpacing: "0.06em" }}>PVNCTA</span>
+                  <span style={{ fontSize: 11, letterSpacing: "0.06em" }}>
+                    {t("ephemerists.puncta")}
+                  </span>
                 </span>
                 <span
                   style={{
@@ -497,7 +508,10 @@ export default function EphemeristsTaskDetail({
                     color: MUTED,
                   }}
                 >
-                  {signups.length} triangulating · {submissions.length} sealed
+                  {t("ephemerists.onView", {
+                    signups: signups.length,
+                    completed: submissions.length,
+                  })}
                 </span>
               </div>
               <div
@@ -509,8 +523,13 @@ export default function EphemeristsTaskDetail({
                   lineHeight: 1.4,
                 }}
               >
-                † the road does not return you to where you began —{" "}
-                <span style={{ color: "var(--eph-lapis)" }}>see †</span>
+                <Trans
+                  t={t}
+                  i18nKey="ephemerists.footnote"
+                  components={[
+                    <span key="0" style={{ color: "var(--eph-lapis)" }} />,
+                  ]}
+                />
               </div>
             </div>
           </div>
@@ -518,7 +537,7 @@ export default function EphemeristsTaskDetail({
 
         {/* ── The Commission (brief) ── */}
         <section>
-          <SectionHead title="The Commission" />
+          <SectionHead title={t("ephemerists.commissionHeading")} />
           <div
             className="font-body"
             style={{
@@ -536,8 +555,7 @@ export default function EphemeristsTaskDetail({
           >
             <Foxing opacity={0.3} />
             <span style={{ position: "relative", zIndex: 2 }}>
-              {task.description ||
-                "No commission is scribed. Walk the ground and let the contradictions guide you."}
+              {task.description || t("ephemerists.commissionEmpty")}
             </span>
           </div>
         </section>
@@ -569,7 +587,7 @@ export default function EphemeristsTaskDetail({
                 padding: "13px 26px",
               }}
             >
-              Triangulate the truth ▸ earn up to {modifiedPoints} pts
+              {t("ephemerists.signup.cta", { points: modifiedPoints })}
             </button>
             <div
               style={{
@@ -579,7 +597,7 @@ export default function EphemeristsTaskDetail({
                 color: MUTED,
               }}
             >
-              bring no certainty. only instruments.
+              {t("ephemerists.signup.note")}
             </div>
             <div
               style={{
@@ -591,7 +609,11 @@ export default function EphemeristsTaskDetail({
                 textTransform: "uppercase",
               }}
             >
-              {slotsOpen} of {maxTaskSlots} leaves open · grade {task.level_required} met
+              {t("ephemerists.signup.meta", {
+                open: slotsOpen,
+                max: maxTaskSlots,
+                level: task.level_required,
+              })}
             </div>
           </section>
         )}
@@ -627,7 +649,7 @@ export default function EphemeristsTaskDetail({
                 color: VELLUM_TEXT,
               }}
             >
-              your leaf is filed against this exhibit.
+              {t("ephemerists.submitted.text")}
             </span>
             <Link
               to={`/praxes/${mySubmission.id}/edit`}
@@ -642,7 +664,7 @@ export default function EphemeristsTaskDetail({
                 textDecoration: "none",
               }}
             >
-              edit
+              {t("ephemerists.submitted.edit")}
             </Link>
           </section>
         )}
@@ -667,7 +689,7 @@ export default function EphemeristsTaskDetail({
                 color: VELLUM_TEXT,
               }}
             >
-              your readings are unsealed — the survey is unfinished.
+              {t("ephemerists.inProgress.text")}
             </span>
             <Link
               to={`/praxes/${inProgressPraxisId}/edit`}
@@ -682,7 +704,7 @@ export default function EphemeristsTaskDetail({
                 textDecoration: "none",
               }}
             >
-              continue
+              {t("ephemerists.inProgress.continue")}
             </Link>
             <button
               onClick={handleDrop}
@@ -696,7 +718,7 @@ export default function EphemeristsTaskDetail({
                 color: "var(--eph-rubric)",
               }}
             >
-              drop
+              {t("ephemerists.inProgress.drop")}
             </button>
           </section>
         )}
@@ -704,14 +726,19 @@ export default function EphemeristsTaskDetail({
         {/* ── Marginalia of cartographers (signups) ── */}
         {signups.length > 0 && (
           <section>
-            <SectionHead title="The Cartographers" gloss={`${signups.length} on the ground`} />
+            <SectionHead
+              title={t("ephemerists.cartographersHeading")}
+              gloss={t("ephemerists.cartographersGloss", {
+                count: signups.length,
+              })}
+            />
             <SurveyorRow signups={signups} friends={friends} foes={foes} />
           </section>
         )}
 
         {/* ── Credence (read-only vote aggregate) ── */}
         <section>
-          <SectionHead title="The Credence" />
+          <SectionHead title={t("ephemerists.credenceHeading")} />
           {voteCount > 0 ? (
             <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
               <span
@@ -734,7 +761,7 @@ export default function EphemeristsTaskDetail({
                     color: VELLUM_TEXT,
                   }}
                 >
-                  HIGHEST
+                  {t("ephemerists.credence.highest")}
                 </div>
                 <div
                   style={{
@@ -744,7 +771,7 @@ export default function EphemeristsTaskDetail({
                     color: MUTED,
                   }}
                 >
-                  weighed across {voteCount} sealed leaves
+                  {t("ephemerists.credence.weighed", { count: voteCount })}
                 </div>
               </div>
             </div>
@@ -758,7 +785,7 @@ export default function EphemeristsTaskDetail({
                 margin: 0,
               }}
             >
-              no credence yet. the concordance awaits its first leaf.
+              {t("ephemerists.credence.none")}
             </p>
           )}
         </section>
@@ -776,8 +803,10 @@ export default function EphemeristsTaskDetail({
             }}
           >
             <SectionHead
-              title="Sealed Ephemerides"
-              gloss={`${submissions.length} leaves filed`}
+              title={t("ephemerists.ephemeridesHeading")}
+              gloss={t("ephemerists.ephemeridesGloss", {
+                count: submissions.length,
+              })}
             />
             <div style={{ display: "flex", gap: 0 }}>
               {(["score", "recent"] as const).map((sort) => {
@@ -798,7 +827,9 @@ export default function EphemeristsTaskDetail({
                       cursor: "pointer",
                     }}
                   >
-                    {sort === "score" ? "Most Canonical" : "Recent"}
+                    {sort === "score"
+                      ? t("ephemerists.sort.mostCanonical")
+                      : t("ephemerists.sort.recent")}
                   </button>
                 );
               })}
@@ -815,7 +846,7 @@ export default function EphemeristsTaskDetail({
                 margin: 0,
               }}
             >
-              no leaves sealed yet. be the first to file your contradictions.
+              {t("ephemerists.empty")}
             </p>
           ) : (
             <>
@@ -844,7 +875,7 @@ export default function EphemeristsTaskDetail({
                         }}
                       >
                         <span style={{ fontSize: 12, lineHeight: 1, color: "var(--eph-gold-light)" }}>⚜</span>{" "}
-                        MOST CANONICAL
+                        {t("ephemerists.mostCanonical")}
                       </div>
                     )}
                     <PraxisCard praxis={s} />
@@ -864,7 +895,7 @@ export default function EphemeristsTaskDetail({
                       borderBottom: "1px solid color-mix(in srgb, var(--eph-rubric) 40%, transparent)",
                     }}
                   >
-                    view all {submissions.length} ephemerides ↗
+                    {t("ephemerists.viewAll", { count: submissions.length })}
                   </Link>
                 </div>
               )}

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { ErrorBanner, relationOf } from "./shared";
@@ -100,6 +101,7 @@ function HandsRow({
   friends: Set<number>;
   foes: Set<number>;
 }) {
+  const { t } = useTranslation("tasks");
   return (
     <div
       style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}
@@ -178,7 +180,7 @@ function HandsRow({
           marginLeft: 4,
         }}
       >
-        on the job
+        {t("everymen.onTheJob")}
       </span>
     </div>
   );
@@ -189,6 +191,7 @@ export default function EverymenTaskDetail({
 }: {
   state: TaskDetailState;
 }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     signups,
@@ -217,7 +220,7 @@ export default function EverymenTaskDetail({
 
   // Status in the union's voice: active reads as an open call for hands.
   const statusVoice =
-    task.status === "active" ? "Open · accepting hands" : task.status;
+    task.status === "active" ? t("everymen.statusOpen") : task.status;
 
   // Top-rated work report wears the fleur-de-lis.
   const topId = submissions.length
@@ -240,10 +243,10 @@ export default function EverymenTaskDetail({
         }}
       >
         <Link to="/tasks" style={{ color: RED, textDecoration: "none" }}>
-          Tasks
+          {t("everymen.breadcrumb")}
         </Link>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
-        <span>The Everymen</span>
+        <span>{t("everymen.faction")}</span>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ color: RED }}>{task.title}</span>
       </nav>
@@ -311,7 +314,7 @@ export default function EverymenTaskDetail({
                     letterSpacing: "0.2em",
                   }}
                 >
-                  THE EVERYMEN
+                  {t("everymen.masthead")}
                 </span>
               </div>
               <span
@@ -378,7 +381,7 @@ export default function EverymenTaskDetail({
                     padding: "6px 16px",
                   }}
                 >
-                  LVL {task.level_required}
+                  {t("everymen.levelValue", { level: task.level_required })}
                 </span>
                 <span
                   style={{
@@ -390,7 +393,7 @@ export default function EverymenTaskDetail({
                     padding: "6px 16px",
                   }}
                 >
-                  {modifiedPoints} PTS
+                  {t("everymen.pointsValue", { points: modifiedPoints })}
                 </span>
                 <span
                   style={{
@@ -400,7 +403,10 @@ export default function EverymenTaskDetail({
                     color: CREAM,
                   }}
                 >
-                  {signups.length} on the job · {submissions.length} delivered
+                  {t("everymen.onView", {
+                    signups: signups.length,
+                    completed: submissions.length,
+                  })}
                 </span>
               </div>
             </div>
@@ -434,11 +440,14 @@ export default function EverymenTaskDetail({
                   color: CREAM,
                 }}
               >
-                Report for duty ▸
+                {t("everymen.signup.cta")}
               </button>
               <div style={{ fontSize: 11, color: MUTED }}>
-                earn up to {modifiedPoints} pts · {slotsOpen} of {maxTaskSlots}{" "}
-                slots open
+                {t("everymen.signup.meta", {
+                  points: modifiedPoints,
+                  open: slotsOpen,
+                  max: maxTaskSlots,
+                })}
               </div>
               <div
                 style={{
@@ -449,7 +458,9 @@ export default function EverymenTaskDetail({
                   color: RED,
                 }}
               >
-                Level {task.level_required} required · met
+                {t("everymen.signup.levelRequired", {
+                  level: task.level_required,
+                })}
               </div>
               <ErrorBanner
                 message={signupError}
@@ -483,7 +494,7 @@ export default function EverymenTaskDetail({
                   color: OLIVE,
                 }}
               >
-                ✓ Your report is filed
+                {t("everymen.submitted.text")}
               </span>
               <Link
                 to={`/praxes/${mySubmission.id}/edit`}
@@ -500,7 +511,7 @@ export default function EverymenTaskDetail({
                   textDecoration: "none",
                 }}
               >
-                edit
+                {t("everymen.submitted.edit")}
               </Link>
             </div>
           )}
@@ -525,7 +536,7 @@ export default function EverymenTaskDetail({
                   color: RED,
                 }}
               >
-                You're on the job
+                {t("everymen.inProgress.text")}
               </span>
               <Link
                 to={`/praxes/${inProgressPraxisId}/edit`}
@@ -542,7 +553,7 @@ export default function EverymenTaskDetail({
                   textDecoration: "none",
                 }}
               >
-                continue
+                {t("everymen.inProgress.continue")}
               </Link>
               <button
                 onClick={handleDrop}
@@ -557,7 +568,7 @@ export default function EverymenTaskDetail({
                   color: MUTED,
                 }}
               >
-                drop
+                {t("everymen.inProgress.drop")}
               </button>
               <ErrorBanner
                 message={signupError}
@@ -573,7 +584,7 @@ export default function EverymenTaskDetail({
 
           {/* ── THE ORDER — the work-order body ── */}
           <section>
-            <SectionHead title="The Order" />
+            <SectionHead title={t("everymen.orderHeading")} />
             <div
               style={{
                 border: `1.5px solid ${INK}`,
@@ -592,8 +603,7 @@ export default function EverymenTaskDetail({
                   whiteSpace: "pre-wrap",
                 }}
               >
-                {task.description ||
-                  "No order posted yet. The work outlasts the worker — figure out what needs doing and report for duty."}
+                {task.description || t("everymen.orderEmpty")}
               </p>
             </div>
           </section>
@@ -601,14 +611,14 @@ export default function EverymenTaskDetail({
           {/* ── Hands signed on ── */}
           {signups.length > 0 && (
             <section>
-              <SectionHead title="Hands On The Job" />
+              <SectionHead title={t("everymen.handsHeading")} />
               <HandsRow signups={signups} friends={friends} foes={foes} />
             </section>
           )}
 
           {/* ── Hall verdict (read-only aggregate) ── */}
           <section>
-            <SectionHead title="The Hall's Verdict" />
+            <SectionHead title={t("everymen.verdictHeading")} />
             {voteCount > 0 ? (
               <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
                 <span
@@ -630,7 +640,7 @@ export default function EverymenTaskDetail({
                       color: INK,
                     }}
                   >
-                    TOP MARK
+                    {t("everymen.verdict.topMark")}
                   </div>
                   <div
                     style={{
@@ -640,7 +650,7 @@ export default function EverymenTaskDetail({
                       color: MUTED,
                     }}
                   >
-                    {voteCount} report{voteCount === 1 ? "" : "s"} on the books
+                    {t("everymen.verdict.reports", { count: voteCount })}
                   </div>
                 </div>
               </div>
@@ -652,7 +662,7 @@ export default function EverymenTaskDetail({
                   color: MUTED,
                 }}
               >
-                No verdict yet. The hall hasn't weighed in — be the first to deliver.
+                {t("everymen.verdict.none")}
               </p>
             )}
           </section>
@@ -660,7 +670,7 @@ export default function EverymenTaskDetail({
           {/* ── Work reports filed (completions) ── */}
           <section>
             <SectionHead
-              title="Work Reports Filed"
+              title={t("everymen.reportsHeading")}
               trailing={
                 <div style={{ display: "flex", gap: 0 }}>
                   {(["score", "recent"] as const).map((sort) => {
@@ -686,7 +696,9 @@ export default function EverymenTaskDetail({
                           cursor: "pointer",
                         }}
                       >
-                        {sort === "score" ? "Top Rated" : "Recent"}
+                        {sort === "score"
+                          ? t("everymen.sort.topRated")
+                          : t("everymen.sort.recent")}
                       </button>
                     );
                   })}
@@ -701,7 +713,7 @@ export default function EverymenTaskDetail({
                   color: MUTED,
                 }}
               >
-                No reports filed yet. Be the first hand to deliver.
+                {t("everymen.empty")}
               </p>
             ) : (
               <>
@@ -739,8 +751,8 @@ export default function EverymenTaskDetail({
                             boxShadow: "0 3px 8px rgba(0,0,0,0.3)",
                           }}
                         >
-                          <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span> BEST IN
-                          HALL
+                          <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span>{" "}
+                          {t("everymen.bestInHall")}
                         </div>
                       )}
                       <PraxisCard praxis={s} />
@@ -759,7 +771,7 @@ export default function EverymenTaskDetail({
                         textDecoration: "none",
                       }}
                     >
-                      View all {submissions.length} reports &rarr;
+                      {t("everymen.viewAll", { count: submissions.length })}
                     </Link>
                   </div>
                 )}

--- a/frontend/src/pages/taskDetail/archetypes/SNIDETaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SNIDETaskDetail.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { factionName } from "../../../utils/factions";
@@ -183,6 +184,7 @@ function AccompliceRow({
   friends: Set<number>;
   foes: Set<number>;
 }) {
+  const { t } = useTranslation("tasks");
   return (
     <div
       style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
@@ -263,7 +265,7 @@ function AccompliceRow({
           marginLeft: 6,
         }}
       >
-        on the job
+        {t("snide.onTheJob")}
       </span>
     </div>
   );
@@ -274,6 +276,7 @@ export default function SNIDETaskDetail({
 }: {
   state: TaskDetailState;
 }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     signups,
@@ -328,11 +331,11 @@ export default function SNIDETaskDetail({
           to="/tasks"
           style={{ color: "var(--faction-snide)", textDecoration: "none" }}
         >
-          Tasks
+          {t("snide.breadcrumb")}
         </Link>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ fontFamily: "var(--faction-snide-font-cond)", letterSpacing: "0.12em" }}>
-          S.N.I.D.E.
+          {t("snide.faction")}
         </span>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ color: wall }}>{task.title}</span>
@@ -395,7 +398,7 @@ export default function SNIDETaskDetail({
                   marginTop: 12,
                 }}
               >
-                JOB FILE
+                {t("snide.jobFile")}
               </div>
               <div
                 style={{
@@ -406,7 +409,7 @@ export default function SNIDETaskDetail({
                   marginTop: 3,
                 }}
               >
-                OPEN CASE
+                {t("snide.openCase")}
               </div>
             </div>
             {/* case details */}
@@ -428,7 +431,7 @@ export default function SNIDETaskDetail({
                   marginBottom: 10,
                 }}
               >
-                S.N.I.D.E. Case File · job no. {caseNo}
+                {t("snide.caseFile", { number: caseNo })}
               </div>
               {/* Ransom-note title cut from the real task.title */}
               <h1
@@ -455,7 +458,9 @@ export default function SNIDETaskDetail({
                     marginBottom: 12,
                   }}
                 >
-                  ↳ metatask for {factionName(task.metatask_faction_slug)}
+                  {t("snide.metataskFor", {
+                    faction: factionName(task.metatask_faction_slug),
+                  })}
                 </div>
               )}
               <div
@@ -465,11 +470,26 @@ export default function SNIDETaskDetail({
                   flexWrap: "wrap",
                 }}
               >
-                <EvidenceTag label="Points" value={modifiedPoints} accent />
-                <EvidenceTag label="Level" value={`LVL ${task.level_required}`} />
+                <EvidenceTag
+                  label={t("snide.evidence.points")}
+                  value={modifiedPoints}
+                  accent
+                />
+                <EvidenceTag
+                  label={t("snide.evidence.level")}
+                  value={t("snide.evidence.levelValue", {
+                    level: task.level_required,
+                  })}
+                />
                 {/* Honest counts (kit's "filed N times" → real in-progress / closed) */}
-                <EvidenceTag label="Filed" value={`${signups.length}`} />
-                <EvidenceTag label="Closed" value={`${submissions.length}`} />
+                <EvidenceTag
+                  label={t("snide.evidence.filed")}
+                  value={`${signups.length}`}
+                />
+                <EvidenceTag
+                  label={t("snide.evidence.closed")}
+                  value={`${submissions.length}`}
+                />
               </div>
               {/* OPEN CASE / real-status stamp */}
               <span
@@ -486,7 +506,9 @@ export default function SNIDETaskDetail({
                   transform: "rotate(-7deg)",
                 }}
               >
-                {task.status === "active" ? "OPEN CASE" : task.status.toUpperCase()}
+                {task.status === "active"
+                  ? t("snide.openCase")
+                  : task.status.toUpperCase()}
               </span>
             </div>
           </div>
@@ -508,7 +530,7 @@ export default function SNIDETaskDetail({
           {canSignUp && (
             <>
               <button onClick={handleSignup} style={rapSheetStyle("var(--faction-snide-acid-deep)", true)}>
-                ★ PULL THIS JOB ★
+                {t("snide.signup.cta")}
               </button>
               <div
                 style={{
@@ -518,7 +540,7 @@ export default function SNIDETaskDetail({
                   transform: "rotate(-1deg)",
                 }}
               >
-                ↳ no take-backs once it's filed
+                {t("snide.signup.warning")}
               </div>
               <div
                 style={{
@@ -529,8 +551,12 @@ export default function SNIDETaskDetail({
                   width: "100%",
                 }}
               >
-                earn up to {modifiedPoints} pts · {slotsOpen} of {maxTaskSlots}{" "}
-                slots open · lvl {task.level_required} met
+                {t("snide.signup.meta", {
+                  points: modifiedPoints,
+                  open: slotsOpen,
+                  max: maxTaskSlots,
+                  level: task.level_required,
+                })}
               </div>
             </>
           )}
@@ -541,7 +567,7 @@ export default function SNIDETaskDetail({
                 to={`/praxes/${mySubmission.id}/edit`}
                 style={rapSheetStyle(PINK)}
               >
-                → EDIT THE RAP SHEET
+                {t("snide.submitted.edit")}
               </Link>
               <div
                 style={{
@@ -551,7 +577,7 @@ export default function SNIDETaskDetail({
                   transform: "rotate(-1deg)",
                 }}
               >
-                ↳ filed. on the record.
+                {t("snide.submitted.note")}
               </div>
             </>
           )}
@@ -562,7 +588,7 @@ export default function SNIDETaskDetail({
                 to={`/praxes/${inProgressPraxisId}/edit`}
                 style={rapSheetStyle("var(--faction-snide-acid-deep)")}
               >
-                → CONTINUE THE RAP SHEET
+                {t("snide.inProgress.continue")}
               </Link>
               <button
                 onClick={handleDrop}
@@ -576,7 +602,7 @@ export default function SNIDETaskDetail({
                   transform: "rotate(-1deg)",
                 }}
               >
-                ↳ ditch the job
+                {t("snide.inProgress.drop")}
               </button>
             </>
           )}
@@ -592,8 +618,11 @@ export default function SNIDETaskDetail({
             }}
           >
             {voteCount > 0
-              ? `${submissions.length} CLOSED · TOP ${topScore}`
-              : "NO VERDICT YET"}
+              ? t("snide.verdict.closed", {
+                  count: submissions.length,
+                  top: topScore,
+                })
+              : t("snide.verdict.none")}
           </div>
         </div>
         <ErrorBanner
@@ -606,7 +635,7 @@ export default function SNIDETaskDetail({
 
         {/* ── The brief (lined paper) ── */}
         <section>
-          <MarkerTab text="the brief" rot={-1.5} />
+          <MarkerTab text={t("snide.brief")} rot={-1.5} />
           <div
             style={{
               position: "relative",
@@ -635,7 +664,7 @@ export default function SNIDETaskDetail({
                 whiteSpace: "pre-wrap",
               }}
             >
-              {task.description || "No brief on file. Figure it out."}
+              {task.description || t("snide.briefEmpty")}
             </p>
           </div>
         </section>
@@ -643,7 +672,7 @@ export default function SNIDETaskDetail({
         {/* ── Accomplices on file ── */}
         {signups.length > 0 && (
           <section>
-            <MarkerTab text="accomplices on file" rot={1} />
+            <MarkerTab text={t("snide.accomplices")} rot={1} />
             <AccompliceRow signups={signups} friends={friends} foes={foes} />
           </section>
         )}
@@ -659,7 +688,10 @@ export default function SNIDETaskDetail({
               gap: 8,
             }}
           >
-            <MarkerTab text={`cases closed · ${submissions.length}`} rot={1} />
+            <MarkerTab
+              text={t("snide.casesClosed", { count: submissions.length })}
+              rot={1}
+            />
             <div style={{ display: "flex", gap: 0, marginBottom: 14 }}>
               {(["score", "recent"] as const).map((sort) => {
                 const on = submissionSort === sort;
@@ -679,7 +711,9 @@ export default function SNIDETaskDetail({
                       cursor: "pointer",
                     }}
                   >
-                    {sort === "score" ? "top marks" : "recent"}
+                    {sort === "score"
+                      ? t("snide.sort.topMarks")
+                      : t("snide.sort.recent")}
                   </button>
                 );
               })}
@@ -694,7 +728,7 @@ export default function SNIDETaskDetail({
                 color: PINK,
               }}
             >
-              no files yet. nobody's pulled it off.
+              {t("snide.empty")}
             </p>
           ) : (
             <>
@@ -722,7 +756,8 @@ export default function SNIDETaskDetail({
                           boxShadow: `2px 3px 0 ${INK}`,
                         }}
                       >
-                        <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span> TOP MARKS
+                        <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span>{" "}
+                        {t("snide.topMarks")}
                       </div>
                     )}
                     <PraxisCard praxis={s} />
@@ -740,7 +775,7 @@ export default function SNIDETaskDetail({
                       textDecoration: "none",
                     }}
                   >
-                    open all {submissions.length} files &rarr;
+                    {t("snide.viewAll", { count: submissions.length })}
                   </Link>
                 </div>
               )}

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { ErrorBanner, relationOf } from "./shared";
@@ -97,6 +98,7 @@ function ArrayRoster({
   friends: Set<number>;
   foes: Set<number>;
 }) {
+  const { t } = useTranslation("tasks");
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
       {signups.map((member) => {
@@ -165,7 +167,7 @@ function ArrayRoster({
           marginLeft: 6,
         }}
       >
-        nodes on array
+        {t("singularity.nodesOnArray")}
       </span>
     </div>
   );
@@ -176,6 +178,7 @@ export default function SingularityTaskDetail({
 }: {
   state: TaskDetailState;
 }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     signups,
@@ -204,8 +207,13 @@ export default function SingularityTaskDetail({
 
   // Terminal-voiced status: an active job is a RUNNING/OPEN protocol; else the real status.
   const statusVoice =
-    task.status === "active" ? "ACCEPTING NODES" : task.status.toUpperCase();
-  const consensusVoice = task.status === "active" ? "OPEN" : task.status.toUpperCase();
+    task.status === "active"
+      ? t("singularity.statusOpen")
+      : task.status.toUpperCase();
+  const consensusVoice =
+    task.status === "active"
+      ? t("singularity.consensusOpen")
+      : task.status.toUpperCase();
   // Highest-signal log wears the fleur-de-lis.
   const topId = submissions.length
     ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
@@ -238,10 +246,10 @@ export default function SingularityTaskDetail({
           }}
         >
           <Link to="/tasks" style={{ color: BLUE, textDecoration: "none" }}>
-            Tasks
+            {t("default.breadcrumb")}
           </Link>
           <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
-          <span>SINGULARITY</span>
+          <span>{t("singularity.faction")}</span>
           <span style={{ opacity: 0.5, margin: "0 8px" }}>/</span>
           <span style={{ color: GREEN }}>{task.title}</span>
         </nav>
@@ -276,12 +284,20 @@ export default function SingularityTaskDetail({
                   marginBottom: 18,
                 }}
               >
-                <div>&gt; OPEN PROTOCOL #{String(task.id).padStart(4, "0")}</div>
                 <div>
-                  &gt; CLASS: OBSERVATION · LVL {task.level_required} · {modifiedPoints} CR
+                  {t("singularity.protocol", {
+                    number: String(task.id).padStart(4, "0"),
+                  })}
                 </div>
                 <div>
-                  &gt; STATUS: {statusVoice} &nbsp;·&nbsp; CONSENSUS:{" "}
+                  {t("singularity.class", {
+                    level: task.level_required,
+                    points: modifiedPoints,
+                  })}
+                </div>
+                <div>
+                  {t("singularity.statusLine", { status: statusVoice })}{" "}
+                  &nbsp;·&nbsp; {t("singularity.consensusLine")}{" "}
                   <span style={{ color: GREEN }}>{consensusVoice}</span>
                 </div>
               </div>
@@ -313,25 +329,25 @@ export default function SingularityTaskDetail({
                   <div style={{ fontSize: 26, lineHeight: 1, color: GREEN }}>
                     {modifiedPoints}
                   </div>
-                  <div style={statLabel}>credits</div>
+                  <div style={statLabel}>{t("singularity.stats.credits")}</div>
                 </div>
                 <div style={statBox}>
                   <div style={{ fontSize: 26, lineHeight: 1, color: GREEN }}>
                     {task.level_required}
                   </div>
-                  <div style={statLabel}>level</div>
+                  <div style={statLabel}>{t("singularity.stats.level")}</div>
                 </div>
                 <div style={statBox}>
                   <div style={{ fontSize: 26, lineHeight: 1, color: BLUE }}>
                     {signups.length}
                   </div>
-                  <div style={statLabel}>arrays</div>
+                  <div style={statLabel}>{t("singularity.stats.arrays")}</div>
                 </div>
                 <div style={statBox}>
                   <div style={{ fontSize: 26, lineHeight: 1, color: GREEN }}>
                     {submissions.length}
                   </div>
-                  <div style={statLabel}>sealed</div>
+                  <div style={statLabel}>{t("singularity.stats.sealed")}</div>
                 </div>
               </div>
             </div>
@@ -350,7 +366,7 @@ export default function SingularityTaskDetail({
           {/* ── The observation (task body) ── */}
           <section>
             <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
-              <h2 style={sectionH2}>// the_observation</h2>
+              <h2 style={sectionH2}>{t("singularity.observationHeading")}</h2>
               <span style={sectionRule} />
             </div>
             <div
@@ -371,8 +387,7 @@ export default function SingularityTaskDetail({
                   whiteSpace: "pre-wrap",
                 }}
               >
-                {task.description ||
-                  "No protocol logged. Find the signal yourself; the array interprets, you only witness."}
+                {task.description || t("singularity.observationEmpty")}
               </p>
             </div>
           </section>
@@ -404,7 +419,7 @@ export default function SingularityTaskDetail({
                   padding: "13px 24px",
                 }}
               >
-                &gt; JOIN ARRAY — earn up to {modifiedPoints} pts
+                {t("singularity.signup.cta", { points: modifiedPoints })}
               </button>
               <div
                 style={{
@@ -414,7 +429,10 @@ export default function SingularityTaskDetail({
                   fontStyle: "italic",
                 }}
               >
-                no credentials. only signal. · {slotsOpen} of {maxTaskSlots} arrays open
+                {t("singularity.signup.note", {
+                  open: slotsOpen,
+                  max: maxTaskSlots,
+                })}
               </div>
               <div
                 style={{
@@ -424,7 +442,9 @@ export default function SingularityTaskDetail({
                   color: BLUE_DIM,
                 }}
               >
-                LVL {task.level_required} REQUIRED · MET
+                {t("singularity.signup.levelRequired", {
+                  level: task.level_required,
+                })}
               </div>
             </div>
           )}
@@ -455,10 +475,10 @@ export default function SingularityTaskDetail({
                   textDecoration: "none",
                 }}
               >
-                &gt; EDIT SIGNAL LOG
+                {t("singularity.submitted.edit")}
               </Link>
               <div style={{ fontSize: 8, letterSpacing: "0.06em", color: GREEN_DIM, fontStyle: "italic" }}>
-                ◉ your log is sealed against this protocol.
+                {t("singularity.submitted.note")}
               </div>
             </div>
           )}
@@ -489,7 +509,7 @@ export default function SingularityTaskDetail({
                   textDecoration: "none",
                 }}
               >
-                &gt; CONTINUE OBSERVATION
+                {t("singularity.inProgress.continue")}
               </Link>
               <button
                 onClick={handleDrop}
@@ -504,7 +524,7 @@ export default function SingularityTaskDetail({
                   color: BLUE_DIM,
                 }}
               >
-                &gt; abort array
+                {t("singularity.inProgress.drop")}
               </button>
             </div>
           )}
@@ -522,10 +542,10 @@ export default function SingularityTaskDetail({
           {signups.length > 0 && (
             <section>
               <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
-                <h2 style={sectionH2}>// array_roster</h2>
+                <h2 style={sectionH2}>{t("singularity.rosterHeading")}</h2>
                 <span style={sectionRule} />
                 <span style={{ fontSize: 7, letterSpacing: "0.12em", color: BLUE_DIM }}>
-                  {signups.length} nodes synced
+                  {t("singularity.rosterSynced", { count: signups.length })}
                 </span>
               </div>
               <ArrayRoster signups={signups} friends={friends} foes={foes} />
@@ -535,7 +555,7 @@ export default function SingularityTaskDetail({
           {/* ── Mob verdict (read-only vote aggregate) ── */}
           <section>
             <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
-              <h2 style={sectionH2}>// consensus_signal</h2>
+              <h2 style={sectionH2}>{t("singularity.consensusHeading")}</h2>
               <span style={sectionRule} />
             </div>
             {voteCount > 0 ? (
@@ -553,16 +573,16 @@ export default function SingularityTaskDetail({
                       textTransform: "uppercase",
                     }}
                   >
-                    peak signal
+                    {t("singularity.consensus.peakSignal")}
                   </div>
                   <div style={{ fontSize: 8, letterSpacing: "0.1em", color: BLUE_DIM }}>
-                    {voteCount} logs sealed
+                    {t("singularity.consensus.sealed", { count: voteCount })}
                   </div>
                 </div>
               </div>
             ) : (
               <p style={{ fontFamily: TERM_FONT, fontSize: 11, color: GREEN_DIM, margin: 0 }}>
-                &gt; no consensus yet. the array is silent. seal the first signal.
+                {t("singularity.consensus.none")}
               </p>
             )}
           </section>
@@ -578,10 +598,10 @@ export default function SingularityTaskDetail({
                 flexWrap: "wrap",
               }}
             >
-              <h2 style={sectionH2}>// sealed_praxis</h2>
+              <h2 style={sectionH2}>{t("singularity.sealedHeading")}</h2>
               <span style={sectionRule} />
               <span style={{ fontSize: 7, letterSpacing: "0.12em", color: BLUE_DIM }}>
-                {submissions.length} logs sealed
+                {t("singularity.sealedCount", { count: submissions.length })}
               </span>
               <div style={{ display: "flex", gap: 0 }}>
                 {(["score", "recent"] as const).map((sort) => {
@@ -602,7 +622,9 @@ export default function SingularityTaskDetail({
                         cursor: "pointer",
                       }}
                     >
-                      {sort === "score" ? "highest signal" : "recent"}
+                      {sort === "score"
+                        ? t("singularity.sort.highestSignal")
+                        : t("singularity.sort.recent")}
                     </button>
                   );
                 })}
@@ -611,7 +633,7 @@ export default function SingularityTaskDetail({
 
             {sortedSubmissions.length === 0 ? (
               <p style={{ fontFamily: TERM_FONT, fontSize: 11, color: GREEN_DIM, margin: 0 }}>
-                &gt; no logs sealed. no node has witnessed this yet.
+                {t("singularity.empty")}
               </p>
             ) : (
               <>
@@ -640,7 +662,8 @@ export default function SingularityTaskDetail({
                             boxShadow: "0 0 12px rgba(74,222,128,0.4)",
                           }}
                         >
-                          <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span> HIGHEST SIGNAL
+                          <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span>{" "}
+                          {t("singularity.highestSignal")}
                         </div>
                       )}
                       <PraxisCard praxis={s} />
@@ -660,7 +683,7 @@ export default function SingularityTaskDetail({
                         textDecoration: "none",
                       }}
                     >
-                      &gt; view all {submissions.length} logs &rarr;
+                      {t("singularity.viewAll", { count: submissions.length })}
                     </Link>
                   </div>
                 )}

--- a/frontend/src/pages/taskDetail/archetypes/UATaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UATaskDetail.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { ErrorBanner, relationOf } from "./shared";
@@ -153,6 +154,7 @@ function HandsRow({
   friends: Set<number>;
   foes: Set<number>;
 }) {
+  const { t } = useTranslation("tasks");
   return (
     <div
       style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}
@@ -232,7 +234,7 @@ function HandsRow({
           marginLeft: 4,
         }}
       >
-        matriculated
+        {t("ua.matriculated")}
       </span>
     </div>
   );
@@ -290,6 +292,7 @@ export default function UATaskDetail({
 }: {
   state: TaskDetailState;
 }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     signups,
@@ -318,7 +321,7 @@ export default function UATaskDetail({
 
   // Status in the salon's voice: active reads as an open salon "on view".
   const statusVoice =
-    task.status === "active" ? "On View · Open Salon" : task.status;
+    task.status === "active" ? t("ua.statusOpen") : task.status;
 
   // Decorative: the salon's "commission №" — derived from the real task id.
   const commissionNo = String(task.id).padStart(4, "0");
@@ -345,10 +348,10 @@ export default function UATaskDetail({
         }}
       >
         <Link to="/tasks" style={{ color: ORANGE, textDecoration: "none" }}>
-          Tasks
+          {t("default.breadcrumb")}
         </Link>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
-        <span style={{ fontFamily: "var(--ua-engraved)" }}>UA</span>
+        <span style={{ fontFamily: "var(--ua-engraved)" }}>{t("ua.faction")}</span>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ color: ORANGE }}>{task.title}</span>
       </nav>
@@ -396,7 +399,7 @@ export default function UATaskDetail({
                       marginBottom: 3,
                     }}
                   >
-                    University of Asthmatics
+                    {t("ua.masthead")}
                   </div>
                   <div
                     style={{
@@ -407,7 +410,7 @@ export default function UATaskDetail({
                       marginBottom: 14,
                     }}
                   >
-                    COMMISSION №{commissionNo} · EST · MMXX
+                    {t("ua.commissionLine", { number: commissionNo })}
                   </div>
                   <h1
                     style={{
@@ -441,8 +444,10 @@ export default function UATaskDetail({
                     <span style={{ color: PAPER_WARM }}>{statusVoice}</span>
                   </div>
                   <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-                    <StatPlate label="ANNO">{romanLevel(task.level_required)}</StatPlate>
-                    <StatPlate label="HONORARIA" accent>
+                    <StatPlate label={t("ua.stats.anno")}>
+                      {romanLevel(task.level_required)}
+                    </StatPlate>
+                    <StatPlate label={t("ua.stats.honoraria")} accent>
                       {modifiedPoints}
                       <span
                         style={{
@@ -453,10 +458,10 @@ export default function UATaskDetail({
                           fontWeight: 400,
                         }}
                       >
-                        pts
+                        {t("ua.stats.honorariaUnit")}
                       </span>
                     </StatPlate>
-                    <StatPlate label="ON VIEW">
+                    <StatPlate label={t("ua.stats.onView")}>
                       <span
                         style={{
                           fontWeight: 600,
@@ -465,7 +470,10 @@ export default function UATaskDetail({
                           color: SUB,
                         }}
                       >
-                        {signups.length} sitting · {submissions.length} hung
+                        {t("ua.stats.onViewValue", {
+                          signups: signups.length,
+                          completed: submissions.length,
+                        })}
                       </span>
                     </StatPlate>
                   </div>
@@ -501,7 +509,7 @@ export default function UATaskDetail({
                   boxShadow: "0 3px 8px rgba(194,84,31,0.3)",
                 }}
               >
-                Matriculate ▸ earn up to {modifiedPoints} pts
+                {t("ua.signup.cta", { points: modifiedPoints })}
               </button>
               <div
                 style={{
@@ -511,8 +519,11 @@ export default function UATaskDetail({
                   color: SUB,
                 }}
               >
-                {slotsOpen} of {maxTaskSlots} easels reserved · Anno{" "}
-                {romanLevel(task.level_required)} standing met
+                {t("ua.signup.meta", {
+                  open: slotsOpen,
+                  max: maxTaskSlots,
+                  level: romanLevel(task.level_required),
+                })}
               </div>
               <ErrorBanner
                 message={signupError}
@@ -547,7 +558,7 @@ export default function UATaskDetail({
                   color: GOLD,
                 }}
               >
-                ✦ Your work hangs on the Salon Wall
+                {t("ua.submitted.text")}
               </span>
               <Link
                 to={`/praxes/${mySubmission.id}/edit`}
@@ -562,7 +573,7 @@ export default function UATaskDetail({
                   textDecoration: "none",
                 }}
               >
-                edit
+                {t("ua.submitted.edit")}
               </Link>
             </div>
           )}
@@ -587,7 +598,7 @@ export default function UATaskDetail({
                   color: ORANGE,
                 }}
               >
-                Your easel is at the salon
+                {t("ua.inProgress.text")}
               </span>
               <Link
                 to={`/praxes/${inProgressPraxisId}/edit`}
@@ -602,7 +613,7 @@ export default function UATaskDetail({
                   textDecoration: "none",
                 }}
               >
-                continue
+                {t("ua.inProgress.continue")}
               </Link>
               <button
                 onClick={handleDrop}
@@ -617,7 +628,7 @@ export default function UATaskDetail({
                   color: MUTED,
                 }}
               >
-                drop
+                {t("ua.inProgress.drop")}
               </button>
               <ErrorBanner
                 message={signupError}
@@ -634,7 +645,7 @@ export default function UATaskDetail({
 
           {/* ── The Commission — the user-written brief ── */}
           <section>
-            <SectionHead title="The Commission" />
+            <SectionHead title={t("ua.commissionHeading")} />
             <div
               style={{
                 border: `1px solid ${LINE}`,
@@ -653,8 +664,7 @@ export default function UATaskDetail({
                   whiteSpace: "pre-wrap",
                 }}
               >
-                {task.description ||
-                  "No commission posted yet. The Salon awaits its brief — render the light before it leaves and pin your work to the wall."}
+                {task.description || t("ua.commissionEmpty")}
               </p>
             </div>
           </section>
@@ -662,14 +672,14 @@ export default function UATaskDetail({
           {/* ── Hands matriculated ── */}
           {signups.length > 0 && (
             <section>
-              <SectionHead title="Matriculated" />
+              <SectionHead title={t("ua.matriculatedHeading")} />
               <HandsRow signups={signups} friends={friends} foes={foes} />
             </section>
           )}
 
           {/* ── The Critique — read-only aggregate verdict ── */}
           <section>
-            <SectionHead title="The Critique" />
+            <SectionHead title={t("ua.critiqueHeading")} />
             {voteCount > 0 ? (
               <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
                 <span
@@ -693,7 +703,7 @@ export default function UATaskDetail({
                       color: INK,
                     }}
                   >
-                    Finest Critique
+                    {t("ua.critique.finest")}
                   </div>
                   <div
                     style={{
@@ -703,7 +713,7 @@ export default function UATaskDetail({
                       color: MUTED,
                     }}
                   >
-                    {voteCount} work{voteCount === 1 ? "" : "s"} appraised
+                    {t("ua.critique.appraised", { count: voteCount })}
                   </div>
                 </div>
               </div>
@@ -716,8 +726,7 @@ export default function UATaskDetail({
                   color: SUB,
                 }}
               >
-                The Salon has rendered no verdict yet. Be the first hand to hang a
-                work.
+                {t("ua.critique.none")}
               </p>
             )}
           </section>
@@ -725,7 +734,7 @@ export default function UATaskDetail({
           {/* ── The Salon Wall — filed praxis (completions) ── */}
           <section>
             <SectionHead
-              title="The Salon Wall"
+              title={t("ua.salonWallHeading")}
               trailing={
                 <div style={{ display: "flex", gap: 0 }}>
                   {(["score", "recent"] as const).map((sort) => {
@@ -750,7 +759,9 @@ export default function UATaskDetail({
                           cursor: "pointer",
                         }}
                       >
-                        {sort === "score" ? "Finest" : "recent"}
+                        {sort === "score"
+                          ? t("ua.sort.finest")
+                          : t("ua.sort.recent")}
                       </button>
                     );
                   })}
@@ -766,8 +777,7 @@ export default function UATaskDetail({
                   color: SUB,
                 }}
               >
-                The wall is bare. Be the first hand to file a work against this
-                commission.
+                {t("ua.empty")}
               </p>
             ) : (
               <>
@@ -806,7 +816,7 @@ export default function UATaskDetail({
                           }}
                         >
                           <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span>{" "}
-                          FINEST HAND
+                          {t("ua.finestHand")}
                         </div>
                       )}
                       <PraxisCard praxis={s} />
@@ -825,7 +835,7 @@ export default function UATaskDetail({
                         textDecoration: "none",
                       }}
                     >
-                      View all {submissions.length} works &rarr;
+                      {t("ua.viewAll", { count: submissions.length })}
                     </Link>
                   </div>
                 )}

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { ErrorBanner, relationOf } from "./shared";
@@ -86,11 +87,6 @@ function SectionHead({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Party-voiced status phrasing — active reads as a playful "open" line. */
-function statusVoice(status: string): string {
-  return status === "active" ? "open · the party's still gathering" : status;
-}
-
 /** Real signup avatars as a little coven row, tilted, with friend/foe charms. */
 function PartyRow({
   signups,
@@ -101,6 +97,7 @@ function PartyRow({
   friends: Set<number>;
   foes: Set<number>;
 }) {
+  const { t } = useTranslation("tasks");
   return (
     <div
       style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
@@ -178,13 +175,14 @@ function PartyRow({
           marginLeft: 6,
         }}
       >
-        in the party
+        {t("wow.inTheParty")}
       </span>
     </div>
   );
 }
 
 export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation("tasks");
   const {
     task,
     signups,
@@ -247,11 +245,11 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
         }}
       >
         <Link to="/tasks" style={{ color: PINK, textDecoration: "none" }}>
-          Tasks
+          {t("wow.breadcrumb")}
         </Link>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ fontFamily: SCRIPT, fontSize: 18 }}>
-          Warriors of Whimsy
+          {t("wow.faction")}
         </span>
         <span style={{ opacity: 0.5, margin: "0 8px" }}>›</span>
         <span style={{ color: PINK }}>{task.title}</span>
@@ -302,7 +300,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 textShadow: `1px 1px 0 ${TITLE_TEXT}`,
               }}
             >
-              quest.exe
+              {t("wow.window")}
             </span>
           </div>
 
@@ -345,7 +343,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 marginBottom: 8,
               }}
             >
-              {statusVoice(task.status)}
+              {task.status === "active" ? t("wow.statusOpen") : task.status}
             </div>
             <div
               style={{
@@ -368,7 +366,8 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
               }}
             >
               <span style={pill}>
-                <Sparkle size={11} color={PINK} /> level {task.level_required}
+                <Sparkle size={11} color={PINK} />{" "}
+                {t("wow.level", { level: task.level_required })}
               </span>
               <span
                 style={{
@@ -389,10 +388,13 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                     strokeLinejoin="round"
                   />
                 </svg>
-                {modifiedPoints} sparks
+                {t("wow.sparks", { points: modifiedPoints })}
               </span>
               <span style={pill}>
-                {signups.length} tried · {submissions.length} pulled it off
+                {t("wow.onView", {
+                  signups: signups.length,
+                  completed: submissions.length,
+                })}
               </span>
             </div>
           </div>
@@ -430,10 +432,10 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                   boxShadow: `0 4px 10px color-mix(in srgb, ${PINK} 35%, transparent)`,
                 }}
               >
-                join the party ✦ earn up to {modifiedPoints} pts
+                {t("wow.signup.cta", { points: modifiedPoints })}
               </button>
               <div style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK }}>
-                no experience with magic required
+                {t("wow.signup.note")}
               </div>
               <div
                 style={{
@@ -445,9 +447,11 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 }}
               >
                 <div>
-                  {slotsOpen} of {maxTaskSlots} slots open
+                  {t("wow.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
                 </div>
-                <div>level {task.level_required} required · met</div>
+                <div>
+                  {t("wow.signup.levelRequired", { level: task.level_required })}
+                </div>
               </div>
             </div>
             <ErrorBanner message={signupError} />
@@ -469,7 +473,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
             }}
           >
             <span style={{ fontFamily: SCRIPT, fontSize: 22, color: TITLE_TEXT }}>
-              ✦ your spell is cast
+              {t("wow.submitted.text")}
             </span>
             <Link
               to={`/praxes/${mySubmission.id}/edit`}
@@ -486,7 +490,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 textDecoration: "none",
               }}
             >
-              edit
+              {t("wow.submitted.edit")}
             </Link>
           </div>
         )}
@@ -506,7 +510,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
             }}
           >
             <span style={{ fontFamily: SCRIPT, fontSize: 22, color: TITLE_TEXT }}>
-              ✦ your spell is half-woven
+              {t("wow.inProgress.text")}
             </span>
             <Link
               to={`/praxes/${inProgressPraxisId}/edit`}
@@ -523,7 +527,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 textDecoration: "none",
               }}
             >
-              continue
+              {t("wow.inProgress.continue")}
             </Link>
             <button
               onClick={handleDrop}
@@ -536,7 +540,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 color: CARD_MUTED,
               }}
             >
-              leave the party
+              {t("wow.inProgress.drop")}
             </button>
           </div>
         )}
@@ -544,14 +548,14 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
         {/* ── The party so far (signups) ── */}
         {signups.length > 0 && (
           <section>
-            <SectionHead>the party so far</SectionHead>
+            <SectionHead>{t("wow.partyHeading")}</SectionHead>
             <PartyRow signups={signups} friends={friends} foes={foes} />
           </section>
         )}
 
         {/* ── What we're asking (description) ── */}
         <section>
-          <SectionHead>what we're asking</SectionHead>
+          <SectionHead>{t("wow.askingHeading")}</SectionHead>
           <div
             style={{
               border: `2px solid ${NOTEPAD_BORDER}`,
@@ -571,15 +575,14 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 whiteSpace: "pre-wrap",
               }}
             >
-              {task.description ||
-                "No spell written yet. Trust the pull and conjure something kind."}
+              {task.description || t("wow.askingEmpty")}
             </p>
           </div>
         </section>
 
         {/* ── The love so far (vote aggregate) ── */}
         <section>
-          <SectionHead>the love so far</SectionHead>
+          <SectionHead>{t("wow.loveHeading")}</SectionHead>
           {voteCount > 0 ? (
             <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
               <span
@@ -600,16 +603,16 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                     color: TITLE_TEXT,
                   }}
                 >
-                  top love
+                  {t("wow.love.top")}
                 </div>
                 <div style={{ fontSize: 10, color: CARD_MUTED }}>
-                  {voteCount} {voteCount === 1 ? "spell" : "spells"} adored
+                  {t("wow.love.adored", { count: voteCount })}
                 </div>
               </div>
             </div>
           ) : (
             <p style={{ fontFamily: SCRIPT, fontSize: 22, color: PINK }}>
-              no love yet — be the first to cast a little wonder.
+              {t("wow.love.none")}
             </p>
           )}
         </section>
@@ -637,7 +640,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                   whiteSpace: "nowrap",
                 }}
               >
-                spells cast so far · {submissions.length}
+                {t("wow.spellsHeading", { count: submissions.length })}
               </h2>
             </div>
             <div style={{ display: "flex", gap: 0 }}>
@@ -660,7 +663,9 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                       cursor: "pointer",
                     }}
                   >
-                    {sort === "score" ? "most loved" : "recent"}
+                    {sort === "score"
+                      ? t("wow.sort.mostLoved")
+                      : t("wow.sort.recent")}
                   </button>
                 );
               })}
@@ -669,7 +674,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
 
           {sortedSubmissions.length === 0 ? (
             <p style={{ fontFamily: SCRIPT, fontSize: 22, color: PINK }}>
-              no spells cast yet. nobody's pulled it off.
+              {t("wow.empty")}
             </p>
           ) : (
             <>
@@ -705,7 +710,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                         }}
                       >
                         <span style={{ fontSize: 13, lineHeight: 1 }}>⚜</span>{" "}
-                        most loved
+                        {t("wow.mostLoved")}
                       </div>
                     )}
                     <PraxisCard praxis={s} />
@@ -723,7 +728,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                       textDecoration: "none",
                     }}
                   >
-                    see all {submissions.length} spells ✦
+                    {t("wow.viewAll", { count: submissions.length })}
                   </Link>
                 </div>
               )}


### PR DESCRIPTION
Extracts task-detail and propose-task non-form chrome into the `tasks` i18n namespace (#446), part of the frontend text-extraction epic (#440).

## Scope
- **Task-detail dispatcher** (`TaskDetail.tsx`): loading/error/not-found states, page title/eyebrow; the fetch-error retry uses `<Trans>`.
- **All eight task-detail archetypes** (`taskDetail/archetypes/*`): breadcrumbs, faction mastheads, hero/stat labels, signup CTAs, submitted/in-progress states, section headings, empty/loading states, sort toggles, verdict/critique aggregates, and per-faction flavor. Copy is nested under the faction slug (`snide`, `everymen`, `wow`, `ephemerists`, `singularity`, `ua`, `albescent`), with shared default chrome under `default`.
- **Propose-task dispatcher** (`ProposeTask.tsx`): login gate + level-eligibility gate + page title only.

## Out of scope (untouched)
- Propose-task **FORM** copy (#442, `forms.json`) — `DefaultProposeTask.tsx` already swept; not touched.
- Backend-authored task titles/descriptions from `era_1.py`.
- Decorative UI ornament (coordinate marginalia, terminal glyphs) left in place.

## Pattern
Components use `useTranslation('tasks')` with bare unprefixed keys; embedded markup uses `<Trans t={t}>`. a11y attributes preserved. The Ephemerists footnote's inline lapis span became a `<Trans>` with a `<0>` tag.

## Gates
- `npx tsc --noEmit`: clean (post-merge with origin/main)
- `npm test -- --run`: 201 passed / 22 files (taskDetail archetypeSlots invariant still green)

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)