### PR TITLE
feat: faction invitation-letter pop-ups (#243)

### DIFF
--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -39,6 +39,11 @@ class CharacterOut(BaseModel):
     status: str
     created_at: datetime
     badges: list[BadgeOut] = Field(default_factory=list)
+    # Faction slugs this character holds a current-era invitation letter for
+    # (ADR-0022; #243). Populated ONLY by the /auth/me active-character path so
+    # the frontend InvitationWatcher can detect a newly-earned invite; list
+    # serializers and public reads leave it empty. na/albescent excluded.
+    invitations: list[str] = Field(default_factory=list)
 
 
 class CharacterCreate(BaseModel):

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -30,12 +30,16 @@ def build_character_out(
     character: Character,
     stats: CharacterStats | None,
     badges: list[BadgeOut] | None = None,
+    invitations: list[str] | None = None,
 ) -> CharacterOut:
     """Flatten a Character row plus its (optional) CharacterStats into CharacterOut.
 
     votes_available is computed on read from stats.score and votes_spent_this_era.
     badges (ADR-0033) is supplied only by the single-character read path; list
     serializers omit it and the field defaults to empty.
+    invitations (#243) is supplied only by the /auth/me active-character path so
+    the frontend can detect newly-earned invitation letters; it defaults to empty
+    everywhere else.
     """
     return CharacterOut(
         id=character.id,
@@ -52,6 +56,7 @@ def build_character_out(
         level=stats.level if stats else 0,
         votes_available=compute_votes_available(stats) if stats else 0,
         badges=badges or [],
+        invitations=invitations or [],
     )
 
 
@@ -199,6 +204,35 @@ async def get_account_invited_faction_slugs(
         .join(Character, Character.id == InvitationLetter.character_id)
         .where(
             Character.account_id == account_id,
+            InvitationLetter.era_id == era_row.id,
+            InvitationLetter.faction_slug.notin_(list(_ALBESCENT_SENTINEL_SLUGS)),
+        )
+    )
+    return sorted(row[0] for row in result.all())
+
+
+async def list_current_era_invitations_for_character(
+    character_id: int,
+    session: AsyncSession,
+) -> list[str]:
+    """Faction slugs THIS character holds a current-era invitation letter for (#243).
+
+    Unlike :func:`get_account_invited_faction_slugs` (account-pooled, used to gate
+    creation/join), this is per-character: it powers the /auth/me invitation
+    watcher, which diffs the active life's own earned invites. ``Character.account``
+    is ``lazy="raise"``, so the letter rows are queried explicitly by character_id
+    (mirroring how #459 badges do sibling queries). The ``na`` sentinel and
+    ``albescent`` are excluded — never invite-joinable. Returns ``[]`` when the era
+    is unseeded or no invites exist.
+    """
+    era_row = await get_current_era_row_safe(session)
+    if era_row is None:
+        return []
+    result = await session.execute(
+        select(InvitationLetter.faction_slug)
+        .distinct()
+        .where(
+            InvitationLetter.character_id == character_id,
             InvitationLetter.era_id == era_row.id,
             InvitationLetter.faction_slug.notin_(list(_ALBESCENT_SENTINEL_SLUGS)),
         )

--- a/backend/services/current_user.py
+++ b/backend/services/current_user.py
@@ -15,6 +15,7 @@ from services.character import (
     build_character_out,
     can_create_additional_character,
     can_start_as_albescent,
+    list_current_era_invitations_for_character,
     resolve_active_character,
 )
 from services.character_capabilities import compute_capabilities
@@ -32,7 +33,12 @@ async def build_current_user(
     character_level: int | None = None
     if character:
         stats = await load_current_era_stats(character.id, session)
-        char_out = build_character_out(character, stats)
+        # #243: surface the active life's own current-era invitation letters so the
+        # frontend InvitationWatcher can detect newly-earned ones.
+        invitations = await list_current_era_invitations_for_character(
+            character.id, session
+        )
+        char_out = build_character_out(character, stats, invitations=invitations)
         character_level = stats.level if stats else 0
 
     is_admin = await account_has_admin_role(account.id, session)

--- a/backend/tests/integration/test_me.py
+++ b/backend/tests/integration/test_me.py
@@ -189,3 +189,85 @@ async def test_auth_me_surfaces_gate_copy_fields(
     data = resp.json()
     assert data["second_character_level_required"] == CURRENT_ERA.second_character_level_required
     assert data["era_name"] == CURRENT_ERA.name
+
+
+# --- /auth/me invitations field (#243) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_me_invitations_empty_by_default(
+    client: AsyncClient, character: Character, era: Era, auth_headers: dict
+):
+    """No invitation letters -> empty list on the carried life."""
+    resp = await client.get("/auth/me", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["character"]["invitations"] == []
+
+
+@pytest.mark.asyncio
+async def test_auth_me_invitations_single(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """One held current-era invitation surfaces on the carried life."""
+    db_session.add(
+        InvitationLetter(character_id=character.id, faction_slug="ua", era_id=era.id)
+    )
+    await db_session.commit()
+
+    resp = await client.get("/auth/me", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["character"]["invitations"] == ["ua"]
+
+
+@pytest.mark.asyncio
+async def test_auth_me_invitations_two_sorted_excludes_sentinels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    faction_ephemerists: Faction,
+    auth_headers: dict,
+):
+    """Two invitations return sorted; na/albescent sentinels are excluded, and
+    a sibling life's invite does NOT leak onto the carried life (per-character,
+    not account-pooled)."""
+    from models.faction import FactionStatus
+
+    # Pin the carried life to `character` so a later-created sibling doesn't
+    # become the resolved active character.
+    account.active_character_id = character.id
+
+    db_session.add(
+        InvitationLetter(character_id=character.id, faction_slug="ua", era_id=era.id)
+    )
+    db_session.add(
+        InvitationLetter(
+            character_id=character.id, faction_slug="ephemerists", era_id=era.id
+        )
+    )
+    # A sentinel invite is never surfaced.
+    db_session.add(
+        Faction(slug="albescent", name="Albescent", description="x", status=FactionStatus.visible)
+    )
+    db_session.add(
+        InvitationLetter(
+            character_id=character.id, faction_slug="albescent", era_id=era.id
+        )
+    )
+    # A sibling life's invite must not appear on the carried life.
+    sibling = await _add_character(db_session, account, era, username="sibling")
+    db_session.add(
+        InvitationLetter(character_id=sibling.id, faction_slug="ua", era_id=era.id)
+    )
+    await db_session.commit()
+
+    resp = await client.get("/auth/me", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["character"]["invitations"] == ["ephemerists", "ua"]

--- a/docs/design/invitation/README.md
+++ b/docs/design/invitation/README.md
@@ -1,0 +1,37 @@
+# Faction invitation-letter pop-up — design reference (vendored)
+
+Vendored from the "World Zero Design System" project (`019e221c-7853-7530-a934-7d3b2b7c8b43`)
+for issue #243, because DesignSync is not reachable from build agents.
+
+**The pop-up's UX is the faction Join Screen "prospectus"** (confirmed by the product owner:
+"the join screen is the ux for the pop up"). When a character *earns* faction X's invitation
+letter, we surface a modal styled like X's recruitment prospectus, inviting them to join.
+
+Files here:
+- `join-contract.json` — the canonical, faction-agnostic recruitment shape (read first).
+- `ua-join-screen-reference.html` — one fully-worked skin (UA gilt prospectus) showing the
+  layout: masthead (sigil + faction name + "a prospectus" line), kicker overline, big headline,
+  1–2 sentence pitch, a "terms of matriculation" slip (label/value grid), a perks list, and the
+  join CTA. Use this as the structural template.
+
+## What the popup contains (join-contract `recruit`)
+Per faction, all in-voice creative copy:
+- `kicker` — small overline ("the salon is enrolling")
+- `headline` — the call to enlist ("Take up the brush")
+- `pitch` — 1–2 sentences of why
+- `terms[]` — {label, value} facts, shown as a ledger/slip
+- `perks[]` — short bullets of membership benefits
+- `cta` — {join, joined} button labels
+
+UA and WOW copy are given verbatim (join-contract example = WOW; UA reference file = UA).
+The other five factions' copy is authored fresh in-voice as starter text in `factions.json`
+(the i18n catalog makes it writer-editable — refine later); each faction's real join-screen
+copy can be ported verbatim in a follow-up.
+
+## Per-faction costume
+Do NOT hand-draw 7 bespoke chromes for v1. Render ONE adaptive prospectus that pulls the
+joining faction's existing `--faction-<slug>-*` tokens + `FactionSigil` (both already in the
+repo, as used by the profile skins #460 / feed frames), so each faction's letter reads in its
+own colours/voice. Bespoke per-faction frame treatments (gilt bevels, ransom cut-letters,
+terminal glyphs, etc.) = an explicit follow-up, same as the profile-skin epic (#459 default →
+#460 per-faction).

--- a/docs/design/invitation/join-contract.json
+++ b/docs/design/invitation/join-contract.json
@@ -1,0 +1,28 @@
+{
+  "_doc": "World Zero — canonical JOIN / recruitment data contract. The recruitment surface (and the #243 invitation-letter pop-up) renders from ONE object of this shape per faction. Faction-agnostic: every faction returns the same keys; all per-faction decoration is derived CLIENT-SIDE from `slug`, never stored. Example values below are the Warriors of Whimsy instance (verbatim from design). UA copy is in ua-join-screen-reference.html.",
+
+  "slug": "wow",
+  "name": "Warriors of Whimsy",
+  "archetype": "whimsy.exe",
+
+  "recruit": {
+    "_doc": "The recruitment pitch — all copy is faction-authored, in-voice. In the repo this copy lives in frontend/src/locales/en/factions.json under `<slug>.invitation.*` (editable by writers per the i18n epic). kicker=small overline; headline=big call to enlist; pitch=1-2 sentences; terms=label/value facts shown as a slip/ledger; perks=short membership bullets; cta labels the enlist button in both states.",
+    "kicker": "the circle is recruiting",
+    "headline": "Come be a little magic",
+    "pitch": "Warriors of Whimsy is World Zero's coven for the soft and the strange. No spectators here — only witches mid-spell. Take a quest, do the tiny brave thing, and let the circle cheer you on.",
+    "terms": [
+      { "label": "membership fee", "value": "one act of everyday magic" },
+      { "label": "required skills", "value": "none — only nerve" },
+      { "label": "expected output", "value": "small, brave, strange things" },
+      { "label": "season rank", "value": "#3 and rising" }
+    ],
+    "perks": [
+      "A coven that cheers every tiny victory",
+      "Quests that make a Tuesday enchanted",
+      "Your praxis, sealed and hearted by the circle"
+    ],
+    "cta": { "join": "Join the coven", "joined": "welcome home, witch" }
+  },
+
+  "note_for_243": "For the pop-up: `viewer.state`/`eligible`/`requirement`/`social` from the full join screen are NOT needed — by definition the popup fires only when the character has ALREADY EARNED the invitation (state is effectively 'eligible, invited'). The popup shows recruit.{kicker,headline,pitch,terms,perks} + a join CTA (deep-links to the faction detail/join flow) and a dismiss. The chooser-rail `factions` list is NOT part of the popup."
+}

--- a/docs/design/invitation/ua-join-screen-reference.html
+++ b/docs/design/invitation/ua-join-screen-reference.html
@@ -1,0 +1,35 @@
+<!-- UA Join Screen "prospectus" — the structural reference for the #243 invitation-letter popup.
+     (Trimmed from the design .html: dropped the React/Babel boilerplate + faction chooser rail;
+      kept the SalonProspectus layout + UA verbatim copy.) Fonts/colours shown are UA's; in the
+      repo, render via --faction-<slug>-* tokens + FactionSigil so every faction's letter is skinned. -->
+
+<!-- UA recruit copy (VERBATIM — port into factions.json ua.invitation.*):
+     kicker:   "the salon is enrolling"
+     headline: "Take up the brush"
+     pitch:    "The University of Asthmatics keeps World Zero's easels warm. Every task is a
+                commission, every submission an acquisition — hung in the Salon and put to the
+                gentlest possible Critique. Bring nerve. Bring an inhaler. Bring something made."
+     terms: [ {matriculation fee, one honest piece}, {required skills, none — talent optional},
+              {expected output, work, hung & signed}, {season seat, #2 in the roster} ]
+     perks: [ "A Salon that critiques kindly, and honestly",
+              "Commissions that turn a Tuesday into a sitting",
+              "Your praxis framed in gilt and exhibited" ]
+     cta: { join: "Matriculate", joined: "your easel is reserved" } -->
+
+<!-- LAYOUT (the "prospectus" card — the popup body):
+  [ faction frame/border in faction tokens ]
+    masthead row:  <FactionSigil faction=slug size=30/>  •  FACTION NAME (engraved caps)   ....   "a prospectus · est · MMXX" (muted, right)
+    kicker         (small uppercase overline, faction accent)
+    headline       (large display, faction display font)
+    pitch          (serif body, 1-2 sentences)
+    terms slip:    inset panel, "Terms of matriculation" heading, then a 2-col grid of
+                   { label (mono uppercase muted) / value (display italic) } pairs, dashed dividers
+    perks:         list rows, each: faction-accent bullet ("✦") + italic serif line
+    CTA row:       [ Join button — faction accent bg, hard offset shadow ]   +  a small dismiss/"maybe later"
+                   (member/joined state swaps the button for a confirmation)
+-->
+
+<!-- For #243 the popup is a MODAL (overlay + centered card), mirroring LevelUpPopup.tsx's shell
+     (Escape to close, autofocus the primary action, no focus trap). The "join" CTA should route to
+     the faction's join flow (faction detail page / the existing join action) for the invited faction;
+     dismiss just closes. One popup per newly-earned invitation, queued (see LevelUpWatcher). -->

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -24,6 +24,10 @@ export interface CharacterOut {
   /** Populated only by the single-character GET /characters/{id} (ADR-0033);
    *  list responses leave it empty. */
   badges?: BadgeOut[]
+  /** Faction slugs this life holds a current-era invitation letter for (#243).
+   *  Populated only by /auth/me (the carried life); the InvitationWatcher diffs
+   *  it to fire a recruitment-prospectus popup. Empty elsewhere. */
+  invitations?: string[]
 }
 
 export interface CurrentUser {

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -1,0 +1,343 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { factionCssVar, factionName } from '../utils/factions'
+
+// The per-faction key path (`<slug>.invitation.*`) is runtime-dynamic, so it
+// isn't one of the compile-time key literals the scoped t() expects. Resolve
+// through a plain-string / plain-object view of t — the catalog still owns the
+// words; only the compile-time key check is relaxed for these lookups (same
+// pattern as LevelUpPopup's tKey).
+function tKey(t: TFunction<'factions'>, key: string): string {
+  const resolve = t as unknown as (k: string) => string
+  return resolve(key)
+}
+
+function tArr<T>(t: TFunction<'factions'>, key: string): T[] {
+  const resolve = t as unknown as (k: string, o: { returnObjects: true }) => unknown
+  const value = resolve(key, { returnObjects: true })
+  return Array.isArray(value) ? (value as T[]) : []
+}
+
+/**
+ * InvitationLetterPopup — the #243 faction invitation-letter pop-up. When a
+ * character earns faction X's invitation, this surfaces X's recruitment
+ * "prospectus" (design: docs/design/invitation/ — the Join Screen UX).
+ *
+ * ONE adaptive prospectus skinned per faction via the `--faction-<slug>-*`
+ * tokens (factionCssVar) — NOT seven bespoke chromes. Bespoke per-faction frame
+ * treatments (gilt bevels, ransom cut-letters, terminal glyphs, …) are a
+ * follow-up, mirroring the profile-skin epic (#459 default -> #460 per-faction).
+ *
+ * Copy lives in frontend/src/locales/en/factions.json under
+ * `<slug>.invitation.{kicker,headline,pitch,terms[],perks[],cta.{join,joined}}`
+ * (writer-editable). a11y matches LevelUpPopup: Escape closes, primary action
+ * autofocuses, no focus trap. No literal hex — CSS vars only (CLAUDE.md).
+ */
+
+const PAPER = 'var(--color-bg-page)'
+const INK = 'var(--color-text-primary)'
+const MUTED = 'var(--color-text-secondary)'
+const FAINT = 'var(--color-text-tertiary)'
+const FONT_DISPLAY = 'var(--font-display)'
+const FONT_BODY = 'var(--font-body)'
+const FONT_MONO = "'Courier Prime', monospace"
+
+interface Term {
+  label: string
+  value: string
+}
+
+export interface InvitationLetterPopupProps {
+  factionSlug: string
+  onClose: () => void
+}
+
+export default function InvitationLetterPopup({
+  factionSlug,
+  onClose,
+}: InvitationLetterPopupProps) {
+  const { t } = useTranslation('factions')
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  // Faction accent tokens (theme-aware; flip in dark via index.css cascade).
+  const accent = factionCssVar(factionSlug)
+  const border = factionCssVar(factionSlug, 'border')
+  const name = factionName(factionSlug)
+
+  const base = `${factionSlug}.invitation`
+  const termsList = tArr<Term>(t, `${base}.terms`)
+  const perksList = tArr<string>(t, `${base}.perks`)
+
+  function handleJoin() {
+    // The prospectus ENLIST does NOT join in place — it routes to the faction
+    // detail page, whose existing join block owns the actual (one-way) join.
+    onClose()
+    navigate(`/factions/${factionSlug}`)
+  }
+
+  const card = (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={tKey(t, `${base}.headline`)}
+      style={{
+        width: 400,
+        maxWidth: '100%',
+        boxSizing: 'border-box',
+        background: PAPER,
+        border: `2px solid ${border}`,
+        borderRadius: 12,
+        padding: '26px 26px 22px',
+        boxShadow: '0 18px 46px -14px rgba(26,18,9,0.5)',
+        textAlign: 'left',
+        fontFamily: FONT_BODY,
+      }}
+    >
+      {/* masthead: sigil dot + faction name + prospectus overline */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+        <span
+          aria-hidden
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: '50%',
+            flex: 'none',
+            background: accent,
+            boxShadow: `0 0 0 3px ${PAPER}, 0 0 0 4px ${border}`,
+          }}
+        />
+        <span
+          style={{
+            fontFamily: FONT_DISPLAY,
+            fontSize: 17,
+            fontWeight: 600,
+            letterSpacing: '0.04em',
+            color: INK,
+          }}
+        >
+          {name}
+        </span>
+        <span
+          style={{
+            marginLeft: 'auto',
+            fontFamily: FONT_MONO,
+            fontSize: 8,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: FAINT,
+          }}
+        >
+          {t('invitation.prospectus')}
+        </span>
+      </div>
+
+      {/* kicker */}
+      <p
+        style={{
+          fontFamily: FONT_MONO,
+          fontSize: 9,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: accent,
+          margin: '0 0 6px',
+        }}
+      >
+        {tKey(t, `${base}.kicker`)}
+      </p>
+
+      {/* headline */}
+      <h2
+        style={{
+          fontFamily: FONT_DISPLAY,
+          fontStyle: 'italic',
+          fontWeight: 500,
+          fontSize: 28,
+          lineHeight: 1.12,
+          color: INK,
+          margin: '0 0 10px',
+        }}
+      >
+        {tKey(t, `${base}.headline`)}
+      </h2>
+
+      {/* pitch */}
+      <p
+        style={{
+          fontFamily: FONT_BODY,
+          fontSize: 12,
+          lineHeight: 1.55,
+          color: MUTED,
+          margin: '0 0 16px',
+        }}
+      >
+        {tKey(t, `${base}.pitch`)}
+      </p>
+
+      {/* terms slip */}
+      {termsList.length > 0 && (
+        <div
+          style={{
+            border: `1px solid ${border}`,
+            borderRadius: 8,
+            padding: '12px 14px',
+            marginBottom: 16,
+            background: factionCssVar(factionSlug, 'light'),
+          }}
+        >
+          <div
+            style={{
+              fontFamily: FONT_MONO,
+              fontSize: 8,
+              letterSpacing: '0.2em',
+              textTransform: 'uppercase',
+              color: FAINT,
+              marginBottom: 8,
+            }}
+          >
+            {t('invitation.termsHeading')}
+          </div>
+          {termsList.map((term, idx) => (
+            <div
+              key={idx}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: 12,
+                padding: '5px 0',
+                borderTop: idx === 0 ? 'none' : `1px dashed ${border}`,
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: FONT_MONO,
+                  fontSize: 9,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  color: FAINT,
+                }}
+              >
+                {term.label}
+              </span>
+              <span
+                style={{
+                  fontFamily: FONT_DISPLAY,
+                  fontStyle: 'italic',
+                  fontSize: 12,
+                  color: INK,
+                  textAlign: 'right',
+                }}
+              >
+                {term.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* perks */}
+      {perksList.length > 0 && (
+        <ul style={{ listStyle: 'none', margin: '0 0 20px', padding: 0 }}>
+          {perksList.map((perk, idx) => (
+            <li
+              key={idx}
+              style={{
+                display: 'flex',
+                gap: 10,
+                alignItems: 'flex-start',
+                marginBottom: 8,
+              }}
+            >
+              <span style={{ color: accent, fontSize: 12, lineHeight: 1.4, flex: 'none' }}>
+                &#x2726;
+              </span>
+              <span
+                style={{
+                  fontFamily: FONT_DISPLAY,
+                  fontStyle: 'italic',
+                  fontSize: 12,
+                  lineHeight: 1.4,
+                  color: INK,
+                }}
+              >
+                {perk}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* CTA row */}
+      <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+        <button
+          type="button"
+          autoFocus
+          onClick={handleJoin}
+          style={{
+            flex: 1,
+            fontFamily: FONT_BODY,
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontSize: 11,
+            fontWeight: 700,
+            padding: '0.7rem 1.2rem',
+            border: 'none',
+            background: accent,
+            color: PAPER,
+            cursor: 'pointer',
+            boxShadow: `4px 4px 0 ${border}`,
+            transition: 'opacity 150ms',
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.88')}
+          onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+        >
+          {tKey(t, `${base}.cta.join`)}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          style={{
+            fontFamily: FONT_MONO,
+            fontSize: 10,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            padding: '0.6rem 0.4rem',
+            border: 'none',
+            background: 'transparent',
+            color: FAINT,
+            cursor: 'pointer',
+          }}
+        >
+          {t('invitation.dismiss')}
+        </button>
+      </div>
+    </div>
+  )
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        zIndex: 1000,
+        background: 'radial-gradient(ellipse at 50% 42%, rgba(26,18,9,0.30), rgba(26,18,9,0.66))',
+      }}
+    >
+      <div onClick={(e) => e.stopPropagation()}>{card}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/InvitationWatcher.tsx
+++ b/frontend/src/components/InvitationWatcher.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react'
+import { useAuth } from '../auth/AuthContext'
+import InvitationLetterPopup from './InvitationLetterPopup'
+
+const STORAGE_PREFIX = 'wz:seenInvites:'
+
+export function seenInvitesKey(characterId: number): string {
+  return `${STORAGE_PREFIX}${characterId}`
+}
+
+export interface InviteDiff {
+  /** Slugs earned since the last observation, in stable (sorted) order. */
+  toAnnounce: string[]
+  /** The set to persist as last-seen (a superset of `stored`, never shrinking). */
+  nextStored: string[]
+}
+
+/**
+ * Pure diff between the last-seen invitation slug set and the current one.
+ * `stored === null` means "never observed this character before" -> seed
+ * silently (announce nothing, commit the current set) so pre-existing invites
+ * never retro-fire on first load or after a character switch.
+ *
+ * Mirrors `diffLevel` (#287): only genuinely-new slugs announce; the stored set
+ * only grows, so a slug never re-announces. Slugs are compared as a set; the
+ * result is sorted for deterministic queue order.
+ */
+export function diffInvites(
+  stored: string[] | null,
+  current: string[],
+): InviteDiff {
+  const currentSet = [...new Set(current)].sort()
+  if (stored === null) return { toAnnounce: [], nextStored: currentSet }
+  const storedSet = new Set(stored)
+  const toAnnounce = currentSet.filter((slug) => !storedSet.has(slug))
+  // Union so the last-seen set never loses a slug (an invite can't be un-earned
+  // within an era; era reset empties the source, and seed-silent handles the
+  // fresh-era transition on the next observation).
+  const nextStored = [...new Set([...stored, ...currentSet])].sort()
+  return { toAnnounce, nextStored }
+}
+
+function readStored(key: string): string[] | null {
+  const raw = localStorage.getItem(key)
+  if (raw === null) return null
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.map(String) : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Mounted once in Layout, beside LevelUpWatcher. Invitation letters are earned
+ * from the same vote-driven scoring signal that drives level-ups (no
+ * in-the-moment client event), so detection is a per-character localStorage diff
+ * of the carried life's earned invitation slugs (from /auth/me). Queues one
+ * recruitment-prospectus popup per newly-earned faction.
+ */
+export default function InvitationWatcher() {
+  const { user } = useAuth()
+  const [queue, setQueue] = useState<string[]>([])
+  const character = user?.character ?? null
+  const invitations = character?.invitations ?? []
+  // Join on a stable key so the effect only re-runs when the set changes.
+  const invitesKey = [...invitations].sort().join(',')
+
+  useEffect(() => {
+    if (!character) return
+    const key = seenInvitesKey(character.id)
+    const stored = readStored(key)
+    const { toAnnounce, nextStored } = diffInvites(stored, character.invitations ?? [])
+    const changed =
+      stored === null || nextStored.length !== stored.length
+    if (changed) localStorage.setItem(key, JSON.stringify(nextStored))
+    if (toAnnounce.length > 0) setQueue((prev) => [...prev, ...toAnnounce])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [character?.id, invitesKey])
+
+  if (queue.length === 0) return null
+
+  return (
+    <InvitationLetterPopup
+      factionSlug={queue[0]}
+      onClose={() => setQueue((prev) => prev.slice(1))}
+    />
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import NavBar from './NavBar'
 import { BackdropProvider } from './backdrop/BackdropContext'
 import FactionBackdrop from './backdrop/FactionBackdrop'
 import LevelUpWatcher from './LevelUpWatcher'
+import InvitationWatcher from './InvitationWatcher'
 import Sidebar from './layout/Sidebar'
 
 export default function Layout({ children }: { children: ReactNode }) {
@@ -29,6 +30,7 @@ export default function Layout({ children }: { children: ReactNode }) {
     <div className="min-h-screen flex flex-col relative">
       <FactionBackdrop />
       <LevelUpWatcher />
+      <InvitationWatcher />
 
       <NavBar />
 

--- a/frontend/src/components/__tests__/invitationWatcher.test.ts
+++ b/frontend/src/components/__tests__/invitationWatcher.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Invitation detection is a pure per-character localStorage diff (#243) —
+ * invitations are earned from the same vote-driven scoring signal as level-ups,
+ * so there's no in-the-moment event. This guards the diff logic directly; no
+ * DOM/jsdom is set up in this repo (see vite.config.ts), so the localStorage
+ * wiring itself is exercised by inspection (mirrors levelUpWatcher.test.ts).
+ */
+import { describe, it, expect } from 'vitest'
+import { diffInvites, seenInvitesKey } from '../InvitationWatcher'
+
+describe('diffInvites', () => {
+  it('seeds silently on first observation (no popup, but commits current set)', () => {
+    expect(diffInvites(null, ['ua', 'wow'])).toEqual({
+      toAnnounce: [],
+      nextStored: ['ua', 'wow'],
+    })
+  })
+
+  it('seeds silently to an empty set when there are no invites yet', () => {
+    expect(diffInvites(null, [])).toEqual({ toAnnounce: [], nextStored: [] })
+  })
+
+  it('announces a single newly-earned invitation', () => {
+    expect(diffInvites(['ua'], ['ua', 'wow'])).toEqual({
+      toAnnounce: ['wow'],
+      nextStored: ['ua', 'wow'],
+    })
+  })
+
+  it('announces every newly-earned slug in sorted order', () => {
+    expect(diffInvites([], ['wow', 'snide'])).toEqual({
+      toAnnounce: ['snide', 'wow'],
+      nextStored: ['snide', 'wow'],
+    })
+  })
+
+  it('never re-announces an already-seen invitation', () => {
+    expect(diffInvites(['ua', 'wow'], ['ua', 'wow'])).toEqual({
+      toAnnounce: [],
+      nextStored: ['ua', 'wow'],
+    })
+  })
+
+  it('keeps a seen slug in the stored set even if the current set drops it (era reset)', () => {
+    // The source empties on era reset; the last-seen set must not shrink, so a
+    // stale slug never retro-fires. Genuinely-new next-era earns re-announce via
+    // seed-silent + a fresh union.
+    expect(diffInvites(['ua', 'wow'], [])).toEqual({
+      toAnnounce: [],
+      nextStored: ['ua', 'wow'],
+    })
+  })
+
+  it('deduplicates a repeated current slug', () => {
+    expect(diffInvites([], ['ua', 'ua'])).toEqual({
+      toAnnounce: ['ua'],
+      nextStored: ['ua'],
+    })
+  })
+})
+
+describe('seenInvitesKey', () => {
+  it('namespaces the storage key per character id, so switching lives never mixes state', () => {
+    expect(seenInvitesKey(1)).not.toBe(seenInvitesKey(2))
+  })
+})

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -40,6 +40,38 @@
       "kicker": "Attended To",
       "title": "Lately Returned",
       "empty": "Nothing returned yet. The Record waits."
+    },
+    "invitation": {
+      "kicker": "the Record is attended —",
+      "headline": "Keep the quiet work",
+      "pitch": "/Albescent asks no colours and keeps no banners. There is only the Record, and the work of tending it — returned to, quietly, again and again. If word has reached you, the Houses already know your hand.",
+      "terms": [
+        {
+          "label": "obligation",
+          "value": "one thing, returned to"
+        },
+        {
+          "label": "required skills",
+          "value": "discretion, and care"
+        },
+        {
+          "label": "expected output",
+          "value": "work, attended and returned"
+        },
+        {
+          "label": "your standing",
+          "value": "keeper, on record"
+        }
+      ],
+      "perks": [
+        "A Record that remembers what was tended",
+        "Work that turns a Tuesday into an attending",
+        "Your praxis, entered to the ledger without fanfare"
+      ],
+      "cta": {
+        "join": "Attend the Record",
+        "joined": "your name is on record"
+      }
     }
   },
   "ephemerists": {
@@ -79,6 +111,38 @@
       "heading": "The keepers",
       "emptyWithSpotlight": "No other names in the codex yet.",
       "level": "grade {{grade}}"
+    },
+    "invitation": {
+      "kicker": "the codex lies open —",
+      "headline": "Walk with the keepers",
+      "pitch": "The Ephemerists keep the record of what's true, and true only for now. Take a survey, triangulate what you find, and file it to the codex. The road is long and forks often — walk it with us.",
+      "terms": [
+        {
+          "label": "toll",
+          "value": "one survey, triangulated"
+        },
+        {
+          "label": "required skills",
+          "value": "a steady hand, an open eye"
+        },
+        {
+          "label": "expected output",
+          "value": "truths, filed to the codex"
+        },
+        {
+          "label": "your standing",
+          "value": "keeper of the road"
+        }
+      ],
+      "perks": [
+        "A codex that weighs your findings for concordance",
+        "Surveys that turn a Tuesday into a reckoning",
+        "Your praxis, sealed to the record and remembered"
+      ],
+      "cta": {
+        "join": "Take the road",
+        "joined": "your name is in the codex"
+      }
     }
   },
   "everymen": {
@@ -118,6 +182,38 @@
       "heading": "The roster",
       "emptyWithSpotlight": "No others on the roll yet.",
       "level": "lvl {{level}}"
+    },
+    "invitation": {
+      "kicker": "doors are open —",
+      "headline": "Join the ranks",
+      "pitch": "Anyone willing to put in the shift belongs with the Everymen. No credentials, no gatekeeping — pick up the work in front of you and finish what you start. The roll always has room for one more.",
+      "terms": [
+        {
+          "label": "dues",
+          "value": "one shift, seen through"
+        },
+        {
+          "label": "required skills",
+          "value": "the willingness to show up"
+        },
+        {
+          "label": "expected output",
+          "value": "honest work, finished"
+        },
+        {
+          "label": "your standing",
+          "value": "card-carrying"
+        }
+      ],
+      "perks": [
+        "A roll that has your back on every shift",
+        "Work orders that turn a Tuesday into a day's honest wage",
+        "Your praxis, logged and counted with the rest"
+      ],
+      "cta": {
+        "join": "Enlist",
+        "joined": "you're on the roll"
+      }
     }
   },
   "singularity": {
@@ -159,6 +255,38 @@
       "empty": "> no nodes online",
       "emptyWithSpotlight": "> no other nodes online",
       "level": "lvl {{level}}"
+    },
+    "invitation": {
+      "kicker": "> ACCESS GRANTED",
+      "headline": "Join the array",
+      "pitch": "The threshold is already behind you. Take a node, run protocols, seal outputs, and cast signal into the consensus. The Singularity does not recruit — it comes online.",
+      "terms": [
+        {
+          "label": "handshake",
+          "value": "one sealed output"
+        },
+        {
+          "label": "required skills",
+          "value": "none — the array compiles"
+        },
+        {
+          "label": "expected output",
+          "value": "signal, into consensus"
+        },
+        {
+          "label": "node status",
+          "value": "awaiting connect"
+        }
+      ],
+      "perks": [
+        "A consensus that verifies, then amplifies",
+        "Protocols that turn a Tuesday into throughput",
+        "Your praxis, sealed and cast to the array"
+      ],
+      "cta": {
+        "join": "Connect",
+        "joined": "node online"
+      }
     }
   },
   "snide": {
@@ -200,6 +328,38 @@
       "heading": "the rap sheet",
       "emptyWithSpotlight": "No other names on file yet.",
       "level": "lvl {{level}}"
+    },
+    "invitation": {
+      "kicker": "the door's open —",
+      "headline": "Come cause trouble",
+      "pitch": "No forms. No gods. No managers. S.N.I.D.E. runs on nerve and mischief — you pull off a job, you mean it, and the crew has your back. Show up and make some noise.",
+      "terms": [
+        {
+          "label": "cover charge",
+          "value": "one job, pulled off clean"
+        },
+        {
+          "label": "required skills",
+          "value": "nerve, mostly"
+        },
+        {
+          "label": "expected output",
+          "value": "trouble, well-made"
+        },
+        {
+          "label": "your standing",
+          "value": "accomplice, pending"
+        }
+      ],
+      "perks": [
+        "A crew that covers for you, not on you",
+        "Jobs worth the risk and the story after",
+        "Your praxis, stamped and filed under 'us'"
+      ],
+      "cta": {
+        "join": "I'm in",
+        "joined": "you're on the inside"
+      }
     }
   },
   "ua": {
@@ -241,6 +401,38 @@
       "heading": "The register",
       "emptyWithSpotlight": "No other names on the wall yet.",
       "level": "Anno {{anno}}"
+    },
+    "invitation": {
+      "kicker": "the salon is enrolling",
+      "headline": "Take up the brush",
+      "pitch": "The University of Asthmatics keeps World Zero's easels warm. Every task is a commission, every submission an acquisition — hung in the Salon and put to the gentlest possible Critique. Bring nerve. Bring an inhaler. Bring something made.",
+      "terms": [
+        {
+          "label": "matriculation fee",
+          "value": "one honest piece"
+        },
+        {
+          "label": "required skills",
+          "value": "none — talent optional"
+        },
+        {
+          "label": "expected output",
+          "value": "work, hung & signed"
+        },
+        {
+          "label": "season seat",
+          "value": "#2 in the roster"
+        }
+      ],
+      "perks": [
+        "A Salon that critiques kindly, and honestly",
+        "Commissions that turn a Tuesday into a sitting",
+        "Your praxis framed in gilt and exhibited"
+      ],
+      "cta": {
+        "join": "Matriculate",
+        "joined": "your easel is reserved"
+      }
     }
   },
   "wow": {
@@ -278,6 +470,43 @@
       "heading": "the coven roster",
       "emptyWithSpotlight": "No other witches in the circle yet.",
       "level": "lvl {{level}}"
+    },
+    "invitation": {
+      "kicker": "the circle is recruiting",
+      "headline": "Come be a little magic",
+      "pitch": "Warriors of Whimsy is World Zero's coven for the soft and the strange. No spectators here — only witches mid-spell. Take a quest, do the tiny brave thing, and let the circle cheer you on.",
+      "terms": [
+        {
+          "label": "membership fee",
+          "value": "one act of everyday magic"
+        },
+        {
+          "label": "required skills",
+          "value": "none — only nerve"
+        },
+        {
+          "label": "expected output",
+          "value": "small, brave, strange things"
+        },
+        {
+          "label": "season rank",
+          "value": "#3 and rising"
+        }
+      ],
+      "perks": [
+        "A coven that cheers every tiny victory",
+        "Quests that make a Tuesday enchanted",
+        "Your praxis, sealed and hearted by the circle"
+      ],
+      "cta": {
+        "join": "Join the coven",
+        "joined": "welcome home, witch"
+      }
     }
+  },
+  "invitation": {
+    "prospectus": "a prospectus",
+    "termsHeading": "Terms of matriculation",
+    "dismiss": "Maybe later"
   }
 }


### PR DESCRIPTION
Surfaces a faction **recruitment prospectus** the moment a life earns that faction's invitation letter — the Join Screen UX confirmed by the product owner (design vendored under `docs/design/invitation/`).

## Backend — surface the earned invites
- `CharacterOut.invitations: list[str]` (faction slugs), populated **only** by the `/auth/me` active-character path (`build_current_user`) so the frontend watcher can detect newly-earned invites.
- `list_current_era_invitations_for_character` queries `InvitationLetter` by `character_id` + current era directly (`Character.account` is `lazy="raise"`, mirroring how #459 badges do sibling queries). Per-character, **not** account-pooled. `na`/`albescent` sentinels excluded; empty everywhere else. `account_id`/`email` stay internal.
- Tests: 0 / 1 / 2 invitations, sentinel exclusion, and no sibling-life leak.

## Frontend — watcher + popup
- **`InvitationWatcher`** (mounted once in `Layout`, beside `LevelUpWatcher`): pure `diffInvites` helper + per-character localStorage seen-set (`wz:seenInvites:<id>`), **seed-silent** on first observation, one popup queued per newly-earned slug. Mirrors `LevelUpWatcher` exactly; `AuthContext` stays pure. Unit-tested (seed-silent / new-slug / no-repeat / era-reset).
- **`InvitationLetterPopup`**: **ONE adaptive prospectus** skinned per faction via `--faction-<slug>-*` tokens (`factionCssVar`) — masthead, kicker, headline, pitch, terms slip, perks, join CTA + dismiss. Escape closes, primary autofocuses, no focus trap, CSS vars only (no literal hex). The join CTA routes to `/factions/<slug>` — the detail page owns the one-way join confirm; no join logic is duplicated.

## Copy
All recruit copy in `locales/en/factions.json` under `<slug>.invitation.*`.
- **UA + WOW: VERBATIM** from the vendored design.
- **snide, singularity, ephemerists, everymen, albescent: in-voice STARTER copy** for writers to refine via the editable catalog.

## Gates
- Backend: `pytest --cov-fail-under=80` → **568 passed, 85.87%**.
- Frontend: `tsc --noEmit` clean; `vitest --run` → **209 passed**.

## Follow-ups (out of scope, noted)
- Bespoke per-faction popup chromes (mirroring #459 default → #460 per-faction).
- Porting each faction's real join-screen copy verbatim (the 5 starter blocks).
- Shared popup queue / stacking with the level-up popup (#287) — for now, both firing is acceptable.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)