### PR TITLE
ci(i18n): run frontend lint in CI to block raw strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
         run: npm ci
         working-directory: frontend
 
+      - name: Lint (blocks raw user-facing strings — ADR-0032)
+        run: npm run lint
+        working-directory: frontend
+
       - name: Run tests
         run: npm test
         working-directory: frontend

--- a/frontend/src/components/InvitationWatcher.tsx
+++ b/frontend/src/components/InvitationWatcher.tsx
@@ -75,7 +75,7 @@ export default function InvitationWatcher() {
       stored === null || nextStored.length !== stored.length
     if (changed) localStorage.setItem(key, JSON.stringify(nextStored))
     if (toAnnounce.length > 0) setQueue((prev) => [...prev, ...toAnnounce])
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Deps intentionally narrow: re-run only on character switch or invite-set change.
   }, [character?.id, invitesKey])
 
   if (queue.length === 0) return null


### PR DESCRIPTION
## What

Adds a `npm run lint` step to the frontend CI job in `.github/workflows/test.yml`.

## Why

#450 armed `i18next/no-literal-string` as `'error'`, but nothing ran ESLint in CI — the frontend job only did `npm ci` + `npm test` (vitest). So a new feature with a raw user-facing JSX string would pass CI green; the rule only bit if a dev happened to run `npm run lint` locally.

This closes the loop: after merge, any raw user-facing string fails CI (ADR-0032).

## Test

Rule is already `'error'` on `main` and the tree is clean, so this step passes today and gates future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)