### PR TITLE
Rainbow-spectrum character sidebar makeover + dev seed data

### DIFF
--- a/backend/scripts/seed_demo_praxes.py
+++ b/backend/scripts/seed_demo_praxes.py
@@ -146,7 +146,7 @@ async def seed(session) -> None:
                 praxis_id=praxis.id,
                 voter_character_id=voter.id,
                 voter_account_id=voter.account_id,
-                stars=star,
+                value=star,
             ))
         created += 1
         print(f"  + {faction}: '{title}' by {author.display_name} ({len(voters)} votes)")

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -28,6 +28,7 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction, FactionStatus
+from models.praxis import ModerationStatus, Praxis, PraxisMember, PraxisStatus, PraxisType
 from models.roles import AccountRole, Role
 from models.task import Task, TaskStatus, TaskType
 
@@ -36,7 +37,87 @@ from models.task import Task, TaskStatus, TaskType
 # Faction status mapping
 # ---------------------------------------------------------------------------
 # System factions that should be hidden in the UI.
-HIDDEN_FACTION_SLUGS = frozenset({"na"})
+HIDDEN_FACTION_SLUGS = frozenset({"aged_out", "na"})
+
+
+# ---------------------------------------------------------------------------
+# Dev-only demo content
+# ---------------------------------------------------------------------------
+
+async def seed_dev_demo(session) -> None:
+    """Dev-only: guarantee the app is never empty on a fresh DB.
+
+    Creates the `dev login (no OAuth)` character ("Molly", unaffiliated) with a
+    live in-progress task so the redesigned sidebar renders fully the moment you
+    dev-login — then delegates to scripts/seed_demo_praxes for cross-faction
+    demo players and community-voted praxes. Idempotent. NEVER runs against prod.
+    """
+    dev_oauth = (await session.execute(
+        select(OAuthProvider).where(
+            OAuthProvider.provider == "dev",
+            OAuthProvider.provider_user_id == "dev-user-1",
+        )
+    )).scalar_one_or_none()
+
+    if dev_oauth is None:
+        era_row = (await session.execute(select(Era).limit(1))).scalar_one()
+        dev_acc = Account(email="dev@localhost")
+        session.add(dev_acc)
+        await session.flush()
+        session.add(OAuthProvider(
+            account_id=dev_acc.id,
+            provider="dev",
+            provider_user_id="dev-user-1",
+            access_token="",
+        ))
+        molly = Character(
+            account_id=dev_acc.id,
+            username="dev",
+            display_name="Molly",
+            faction_slug="na",  # unaffiliated — everyone starts here (ADR-0030)
+        )
+        session.add(molly)
+        await session.flush()
+        session.add(CharacterStats(
+            character_id=molly.id,
+            era_id=era_row.id,
+            score=0,
+            all_time_score=0,
+            level=0,
+            votes_spent_this_era=0,
+        ))
+        dev_acc.active_character_id = molly.id
+
+        # One in-progress signup so the sidebar "In Progress" panel isn't empty.
+        task = (await session.execute(
+            select(Task)
+            .where(Task.task_type == TaskType.standard, Task.level_required == 0)
+            .limit(1)
+        )).scalar_one_or_none()
+        if task is not None:
+            praxis = Praxis(
+                task_id=task.id,
+                type=PraxisType.solo,
+                status=PraxisStatus.in_progress,
+                body_text="",
+                created_by_id=molly.id,
+                moderation_status=ModerationStatus.visible,
+            )
+            session.add(praxis)
+            await session.flush()
+            session.add(PraxisMember(
+                praxis_id=praxis.id,
+                character_id=molly.id,
+                has_submitted=False,
+            ))
+        await session.flush()
+        print("  >Dev-login character (@dev 'Molly', unaffiliated) + 1 in-progress task")
+    else:
+        print("  >Dev-login character already exists — skipping")
+
+    # Cross-faction demo players + community-voted praxes (reused, idempotent).
+    from scripts.seed_demo_praxes import seed as seed_demo_praxes
+    await seed_demo_praxes(session)
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +155,9 @@ async def seed(env: str, yes: bool) -> None:
         task_count = (await session.execute(select(func.count()).select_from(Task))).scalar()
 
         if pixie_acc and task_count > 0:
-            print("Database already fully seeded (pixie account + tasks exist). Nothing to do.")
+            print("Database already fully seeded (pixie account + tasks exist).")
+            if env == "dev":
+                await seed_dev_demo(session)  # idempotent — tops up demo content
             await engine.dispose()
             return
 
@@ -224,6 +307,11 @@ async def seed(env: str, yes: bool) -> None:
             print(f"  >Metatasks already exist ({metatask_count}) — skipping")
 
         await session.commit()
+
+        # Phase 5: Dev-only demo content (characters + praxes). Never in prod.
+        if env == "dev":
+            await seed_dev_demo(session)
+
         print("\nSeed complete!\n")
         print(f"  era            : {era.name} ({era.config_key})")
         print(f"  factions       : {len(era.factions)}")

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -39,7 +39,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         className="flex-1 relative max-w-5xl mx-auto w-full px-4 sm:px-6 py-5"
         style={{ zIndex: 5 }}
       >
-        <div className={`gap-4 items-start ${user ? 'lg:grid lg:grid-cols-[1fr_256px]' : ''}`}>
+        <div className={`gap-4 items-start ${user ? 'lg:grid lg:grid-cols-[1fr_340px]' : ''}`}>
           <main className="min-w-0">{children}</main>
           {user && (
             <div className="hidden lg:block">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '../../auth/AuthContext'
 import { getActivityFeed, type ActivityFeedItem } from '../../api/activityFeed'
 import { relativeTime } from '../../utils/dates'
 import { factionCssVar, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
-import FeedBadge from '../feed/FeedBadge'
 import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
 import type { PraxisType } from '../../api/praxis'
 import { useMyCharacterStats } from '../../hooks/useMyCharacterStats'
@@ -16,9 +15,44 @@ import { useGameConfig } from '../../hooks/useGameConfig'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
 
+/** Shared panel shell for the redesigned sidebar (unaffiliated rainbow style). */
+const panelStyle: CSSProperties = {
+  position: 'relative',
+  overflow: 'hidden',
+  background: 'var(--color-bg-surface)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius-xl)',
+  padding: 18,
+}
+
+const sectionLabel: CSSProperties = {
+  fontFamily: 'var(--font-body)',
+  fontSize: 10,
+  letterSpacing: '0.22em',
+  textTransform: 'uppercase',
+  color: 'var(--color-text-secondary)',
+}
+
+/** "LABEL ——————" header: eyebrow + a rule that fades out to the right. */
+function SectionHeader({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2.5 mb-3.5">
+      <span style={sectionLabel}>{label}</span>
+      <span
+        style={{
+          flex: 1,
+          height: 1,
+          background: 'linear-gradient(90deg, var(--color-border-strong), transparent)',
+        }}
+      />
+    </div>
+  )
+}
+
 /**
- * Always-on right sidebar (Style Guide §4.2).
- * Character card + pending requests + active tasks + recent global activity + propose button.
+ * Always-on right sidebar (Style Guide §4.2), redesigned into the unaffiliated
+ * "all paths" rainbow-spectrum identity: character card + pending requests +
+ * in-progress tasks + recent global activity + propose CTA.
  */
 export default function Sidebar() {
   const { t } = useTranslation('common')
@@ -50,65 +84,92 @@ export default function Sidebar() {
   const slotPercent = Math.min((slotCount / maxTaskSlots) * 100, 100)
 
   return (
-    <aside className="flex flex-col gap-3 w-64">
+    <aside className="flex flex-col gap-4 w-full">
       {/* ── Character Card ── */}
       {character ? (
-        <div className="sidebar-card">
-          <div className="flex items-baseline justify-between mb-2">
-            <span className="eyebrow" style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}>
-              {t('sidebar.characterCard.eyebrow')}
-            </span>
+        <section style={panelStyle}>
+          {/* signature rainbow rule (this panel only) */}
+          <span
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 2,
+              opacity: 0.85,
+              background: 'var(--faction-default-rainbow)',
+            }}
+          />
+          <div className="flex items-center justify-between mb-4">
+            <span style={sectionLabel}>{t('sidebar.characterCard.eyebrow')}</span>
             <Link
               to={`/characters/${character.id}/edit`}
-              className="eyebrow hover:underline"
-              style={{ fontSize: 8, color: 'var(--color-text-tertiary)' }}
+              className="hover:opacity-80"
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 10,
+                letterSpacing: '0.16em',
+                textTransform: 'uppercase',
+                color: 'var(--faction-default-card-muted)',
+                textDecoration: 'none',
+                borderBottom: '1px solid var(--color-border-strong)',
+                paddingBottom: 1,
+              }}
             >
               {t('sidebar.characterCard.edit')}
             </Link>
           </div>
-          <div className="flex items-center gap-3 mb-3">
-            {character.avatar_url ? (
-              <img
-                src={mediaUrl(character.avatar_url)}
-                alt={character.display_name}
-                className="shrink-0 rounded-full"
-                style={{ width: 40, height: 40, objectFit: 'cover' }}
-              />
-            ) : (
-              <div
-                className="shrink-0 rounded-full"
-                style={{
-                  width: 40,
-                  height: 40,
-                  background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${factionCssVar(character.faction_slug)})`,
-                }}
-              />
-            )}
+
+          <div className="flex items-center gap-3.5 mb-4">
+            {/* avatar in a rainbow ring (unaffiliated / all-paths mark) */}
+            <div
+              className="shrink-0 rounded-full"
+              style={{ width: 58, height: 58, padding: 3, background: 'var(--faction-default-ring)' }}
+            >
+              {character.avatar_url ? (
+                <img
+                  src={mediaUrl(character.avatar_url)}
+                  alt={character.display_name}
+                  className="w-full h-full rounded-full"
+                  style={{ objectFit: 'cover' }}
+                />
+              ) : (
+                <div
+                  className="w-full h-full rounded-full"
+                  style={{
+                    background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${factionCssVar(character.faction_slug)})`,
+                  }}
+                />
+              )}
+            </div>
             <div className="min-w-0">
               <Link
                 to={`/characters/${character.id}`}
-                className="font-display italic text-sm block truncate"
-                style={{ color: 'var(--color-text-primary)' }}
+                className="font-display italic block truncate"
+                style={{ fontSize: 24, lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
               >
                 {character.display_name}
               </Link>
-              <span
-                className="font-body uppercase block truncate"
+              <div
+                className="truncate"
                 style={{
-                  fontSize: 9,
-                  letterSpacing: '0.12em',
-                  color: factionCssVar(character.faction_slug),
+                  marginTop: 5,
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 10,
+                  letterSpacing: '0.16em',
+                  textTransform: 'uppercase',
+                  color: 'var(--color-text-secondary)',
                 }}
               >
                 {t('sidebar.characterCard.factionLevel', {
                   faction: factionName(character.faction_slug),
                   level: character.level,
                 })}
-              </span>
+              </div>
             </div>
           </div>
 
-          <div className="grid grid-cols-3 gap-1">
+          <div className="grid grid-cols-3 gap-2">
             {[
               { label: t('sidebar.stats.score'), value: character.score?.toLocaleString() ?? '0' },
               { label: t('sidebar.stats.votes'), value: votesReceived.toLocaleString() },
@@ -116,31 +177,43 @@ export default function Sidebar() {
             ].map((stat) => (
               <div
                 key={stat.label}
-                className="text-center rounded-md py-1.5"
-                style={{ background: 'var(--color-bg-surface-alt)' }}
+                className="text-center"
+                style={{
+                  background: 'var(--color-bg-surface)',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 9,
+                  padding: '11px 8px',
+                }}
               >
-                <div className="font-body font-bold text-sm" style={{ color: 'var(--color-text-primary)' }}>
+                <div className="font-display" style={{ fontSize: 22, lineHeight: 1, color: 'var(--color-text-primary)' }}>
                   {stat.value}
                 </div>
-                <div className="eyebrow" style={{ fontSize: 7 }}>
+                <div
+                  style={{
+                    marginTop: 6,
+                    fontFamily: 'var(--font-body)',
+                    fontSize: 8,
+                    letterSpacing: '0.2em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-text-secondary)',
+                  }}
+                >
                   {stat.label}
                 </div>
               </div>
             ))}
           </div>
-        </div>
+        </section>
       ) : (
-        <div className="sidebar-card">
+        <section style={panelStyle}>
           <p className="eyebrow text-center">{t('sidebar.characterCard.noCharacter')}</p>
-        </div>
+        </section>
       )}
 
       {/* ── Pending Requests Panel ── */}
       {pendingRequests.length > 0 && (
-        <div className="sidebar-card">
-          <p className="eyebrow mb-2">
-            {t('sidebar.pendingRequests.heading', { count: pendingRequests.length })}
-          </p>
+        <section style={panelStyle}>
+          <SectionHeader label={t('sidebar.pendingRequests.heading', { count: pendingRequests.length })} />
           <div className="flex flex-col gap-1.5">
             {pendingRequests.map((item, index) => (
               <PendingRequestRow
@@ -156,75 +229,75 @@ export default function Sidebar() {
               />
             ))}
           </div>
-        </div>
+        </section>
       )}
 
-      {/* ── Active Tasks Panel ── */}
-      <div className="sidebar-card">
-        <p className="eyebrow mb-2">{t('sidebar.activeTasks.heading')}</p>
+      {/* ── In Progress Panel ── */}
+      <section style={panelStyle}>
+        <SectionHeader label={t('sidebar.activeTasks.heading')} />
 
         {activeTasks.length === 0 ? (
           <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
             {t('sidebar.activeTasks.empty')}
           </p>
         ) : (
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-3">
             {activeTasks.map((praxis) => (
-              <div
-                key={praxis.id}
-                className="flex items-start justify-between"
-                style={{
-                  borderLeft: `3px solid var(--color-border)`,
-                  paddingLeft: 8,
-                }}
-              >
-                <div className="min-w-0">
-                  <Link
-                    to={`/praxes/${praxis.id}/edit`}
-                    className="font-body block"
-                    style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', lineHeight: 1.3 }}
-                  >
-                    {praxis.task_title}
-                  </Link>
-                </div>
-                <FeedBadge
-                  type={praxis.type === 'solo' ? 'global' : praxis.type}
-                  label={praxisTypeLabel[praxis.type]}
-                />
+              <div key={praxis.id} className="flex items-start justify-between gap-3">
+                <Link
+                  to={`/praxes/${praxis.id}/edit`}
+                  className="font-display min-w-0"
+                  style={{ fontSize: 17, lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                >
+                  {praxis.task_title}
+                </Link>
+                <span
+                  className="shrink-0"
+                  style={{
+                    fontFamily: 'var(--font-body)',
+                    fontSize: 9,
+                    letterSpacing: '0.16em',
+                    textTransform: 'uppercase',
+                    color: 'var(--faction-default-card-muted)',
+                    padding: '4px 9px',
+                    border: '1px solid var(--color-border-strong)',
+                    borderRadius: 999,
+                  }}
+                >
+                  {praxisTypeLabel[praxis.type]}
+                </span>
               </div>
             ))}
           </div>
         )}
 
-        {/* Progress bar */}
-        <div className="mt-2">
-          <div
-            className="overflow-hidden"
-            style={{
-              height: 4,
-              borderRadius: 2,
-              background: 'var(--color-bg-surface-alt)',
-            }}
-          >
+        {/* Slot-usage progress bar — rainbow fill, drifts unless reduced-motion */}
+        <div className="mt-4">
+          <div className="overflow-hidden" style={{ height: 6, borderRadius: 999, background: 'var(--color-bg-surface-alt)' }}>
             <div
+              className="cs-shimmer"
               style={{
                 height: '100%',
                 width: `${slotPercent}%`,
-                background: 'var(--faction-singularity)',
-                borderRadius: 2,
+                borderRadius: 999,
+                background: 'var(--faction-default-rainbow)',
+                backgroundSize: '200% 100%',
                 transition: 'width 300ms',
               }}
             />
           </div>
-          <p className="font-body" style={{ fontSize: 8, color: 'var(--color-text-tertiary)', marginTop: 3 }}>
+          <p
+            className="font-body text-right"
+            style={{ fontSize: 10, letterSpacing: '0.08em', color: 'var(--color-text-secondary)', marginTop: 8 }}
+          >
             {t('sidebar.activeTasks.slots', { count: slotCount, max: maxTaskSlots })}
           </p>
         </div>
-      </div>
+      </section>
 
       {/* ── Recent Global Activity Panel ── */}
-      <div className="sidebar-card">
-        <p className="eyebrow mb-2">{t('sidebar.globalActivity.heading')}</p>
+      <section style={panelStyle}>
+        <SectionHeader label={t('sidebar.globalActivity.heading')} />
 
         {globalActivity.length === 0 ? (
           <p className="font-body text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
@@ -235,64 +308,98 @@ export default function Sidebar() {
             {globalActivity.map((item, index) => {
               const isTask = item.type === 'global_task'
               const isEra = item.type === 'era_announcement'
+              const isLast = index === globalActivity.length - 1
+              const taskId = item.payload.task_id
+              const title = isEra
+                ? item.payload.era_name
+                : item.payload.task_title ||
+                  item.payload.praxis_title ||
+                  t('sidebar.globalActivity.fallbackTaskTitle')
+              const kicker = isEra
+                ? t('sidebar.globalActivity.kickerEra')
+                : isTask
+                  ? t('sidebar.globalActivity.kickerNewTask')
+                  : item.actor_display_name
+              const titleStyle: CSSProperties = {
+                fontSize: 14,
+                lineHeight: 1.3,
+                color: 'var(--color-text-primary)',
+                textDecoration: 'none',
+              }
               return (
                 <div
                   key={`${item.type}-${index}`}
-                  className="py-1"
+                  className="flex gap-3"
                   style={{
-                    borderTop: index > 0 ? '1px dashed var(--color-border)' : undefined,
+                    padding: '13px 0',
+                    borderBottom: isLast ? undefined : '1px solid var(--color-border)',
                   }}
                 >
-                  <div className="font-body" style={{ fontSize: 9, lineHeight: 1.4 }}>
-                    {isEra ? (
-                      <span style={{ fontWeight: 700, color: 'var(--faction-ephemerists)' }}>
-                        {t('sidebar.globalActivity.eraBegun', { eraName: item.payload.era_name })}
-                      </span>
-                    ) : isTask ? (
-                      <Trans
-                        i18nKey="sidebar.globalActivity.newTask"
-                        values={{ title: item.payload.task_title }}
-                        components={[
-                          <span style={{ fontWeight: 700, color: 'var(--color-text-primary)' }} />,
-                          <Link
-                            to={`/tasks/${item.payload.task_id}`}
-                            style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}
-                          />,
-                        ]}
-                      />
+                  {/* rainbow bullet — sampled from the default spectrum by position */}
+                  <span
+                    className="shrink-0"
+                    style={{
+                      width: 6,
+                      height: 6,
+                      marginTop: 5,
+                      borderRadius: 2,
+                      background: 'var(--faction-default-rainbow)',
+                      backgroundSize: '600% 100%',
+                      backgroundPosition: `${index * 20}% 0`,
+                    }}
+                  />
+                  <div className="min-w-0">
+                    <div
+                      style={{
+                        fontFamily: 'var(--font-body)',
+                        fontSize: 9,
+                        letterSpacing: '0.18em',
+                        textTransform: 'uppercase',
+                        color: 'var(--color-text-secondary)',
+                        marginBottom: 3,
+                      }}
+                    >
+                      {kicker}
+                    </div>
+                    {isTask && taskId ? (
+                      <Link to={`/tasks/${taskId}`} className="font-display block truncate" style={titleStyle}>
+                        {title}
+                      </Link>
                     ) : (
-                      <Trans
-                        i18nKey="sidebar.globalActivity.completedTask"
-                        values={{
-                          actor: item.actor_display_name,
-                          title:
-                            item.payload.task_title ||
-                            item.payload.praxis_title ||
-                            t('sidebar.globalActivity.fallbackTaskTitle'),
-                        }}
-                        components={[
-                          <span style={{ fontWeight: 700, color: 'var(--color-text-primary)' }} />,
-                          <span style={{ color: 'var(--color-text-secondary)' }} />,
-                        ]}
-                      />
+                      <div className="font-display truncate" style={titleStyle}>
+                        {title}
+                      </div>
                     )}
+                    <div className="font-body" style={{ marginTop: 3, fontSize: 10, color: 'var(--color-text-tertiary)' }}>
+                      {relativeTime(item.timestamp)}
+                    </div>
                   </div>
-                  <span className="font-body" style={{ fontSize: 7, color: 'var(--color-text-tertiary)' }}>
-                    {relativeTime(item.timestamp)}
-                  </span>
                 </div>
               )
             })}
           </div>
         )}
-      </div>
+      </section>
 
-      {/* ── Propose a Task Button ── */}
+      {/* ── Propose a Task CTA ── */}
       <Link
         to="/propose-task"
-        className="btn-primary text-center w-full block"
+        className="font-display w-full flex items-center justify-center gap-2.5 hover:opacity-90"
+        style={{
+          boxSizing: 'border-box',
+          padding: 14,
+          borderRadius: 11,
+          fontSize: 14,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: 'var(--color-bg-page)',
+          background: 'var(--color-text-primary)',
+          border: '1px solid var(--color-text-primary)',
+          textDecoration: 'none',
+        }}
       >
-        {t('actions.proposeTask')}
+        <span style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+        <span>{t('actions.proposeTask')}</span>
       </Link>
     </aside>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -986,6 +986,12 @@
   .sg-rotate { animation: sg-rotate 120s linear infinite; }
 }
 
+/* Character-sidebar progress bar — rainbow fill drifts left→right. Stilled for reduced-motion. */
+@keyframes cs-shimmer { to { background-position: 200% 0; } }
+@media (prefers-reduced-motion: no-preference) {
+  .cs-shimmer { animation: cs-shimmer 4s linear infinite; }
+}
+
 /* FieldDesk life-card hover-lift (#274). The CredentialCard owns its own rotation;
    this lifts the clickable wrapper without touching the card's tilt. */
 .fielddesk-life { transition: transform 160ms ease; }

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -194,6 +194,8 @@
     "globalActivity": {
       "heading": "Recent global activity",
       "empty": "No activity yet",
+      "kickerNewTask": "New task",
+      "kickerEra": "New era",
       "eraBegun": "{{eraName}} has begun",
       "newTask": "<0>New task:</0> <1>{{title}}</1>",
       "completedTask": "<0>{{actor}}</0> completed <1>{{title}}</1>",


### PR DESCRIPTION
## What & why

Recreates the **character sidebar** redesign from the *World Zero Frontend Kit* handoff in the real React app — the "unaffiliated / all-paths" rainbow-spectrum treatment on the dark cream-on-charcoal palette. Along the way, hardens `seed.py` so a fresh dev DB is never empty (an empty DB is what surfaced the seed gaps while verifying this).

## Frontend

- **`Sidebar.tsx`** — all four panels rebuilt into the rainbow identity:
  - **Character card**: rainbow top-rule, conic-ring avatar, 3 stat tiles (Score / Votes / Era).
  - **In Progress**: Lora task title + neutral pill badge + shimmering rainbow progress bar.
  - **Recent Global Activity**: spectrum bullets, kickers, Lora titles, relative timestamps.
  - **CTA**: cream Lora "＋ Propose a Task".
  - Every color reads an existing token (`--color-*`, `--faction-default-*`) — no hardcoded hex. Faction-neutral by design (the sidebar is the unaffiliated chrome, per the handoff).
- **`Layout.tsx`** — sidebar column `256px → 340px` to match the handoff.
- **`index.css`** — `cs-shimmer` keyframe, gated behind `prefers-reduced-motion: no-preference`.
- **`locales/en/common.json`** — two feed kicker strings.

## Backend

- **`seed.py`** — new dev-only Phase 5 (`seed_dev_demo`): creates the `dev login (no OAuth)` character ("Molly", unaffiliated) with stats + `active_character_id` + one in-progress task, then reuses `seed_demo_praxes` for cross-faction demo players and community-voted praxes. Guarded to `env == "dev"` (never prod), idempotent, runs on both the fresh and already-seeded paths.
- **`scripts/seed_demo_praxes.py`** — fixes the crash that made it unusable: `Vote(stars=…)` → `Vote(value=…)` (the model field is `value`).

## Reviewer notes

- **Design choice**: the sidebar applies the rainbow *default* identity universally, not per-faction — matching the handoff, which is explicitly the unaffiliated/all-paths treatment and references only `--faction-default-*` tokens.
- **Deliberate simplifications** (each one-line to extend): dropped the subtle amber column-glow (hardcoded hex + light-theme risk); bullets sampled from the single rainbow token by `background-position` rather than 5 hardcoded gradients; reused the existing `slots` string for the progress meta.
- The redesign ships the **cream CTA + rainbow ring** defaults; the handoff also offers `rainbow`/`ghost` CTAs and a `solid` ring if we want a different variant later.

## Verification

- Renders correctly live in dark theme — computed styles match the spec (panel `14px`/token bg+border, `2px` rainbow rule, `58×58` conic ring, Lora `24px` name, rainbow progress fill w/ `cs-shimmer`, cream CTA); sidebar column measures exactly `340px`.
- `python seed.py` on a truncated DB builds factions, tasks, admin, Molly + in-progress task, and 6 voted praxes; re-run is a no-op (idempotent); **dev-login now lands on a fully populated sidebar with no manual setup**.
- Frontend typechecks clean (the pre-existing `AlbescentInvitation.tsx` duplicate-key errors flagged in #507 are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)