### PR TITLE
Mobile foundation: form-factor shell + bottom tab bar + mobile-skin dispatch seam (#494)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Read only what your task needs.
 - Each faction has its own card archetype; don't unify
 - Reuse `.card-footer`, `.card-meta`, `.card-description` for repeated patterns
 - Hide unusable controls; don't show them disabled
+- Form factor (#494): a new dispatched surface provides a `Default*` mobile skin and dispatches through a parallel `MOBILE_ARCHETYPE_BY_SLUG` on `useFormFactor() === 'mobile'`. The mobile path stacks single-column — never fixed-px inline grids for layout structure. See `docs/spec/SPEC-faction-ui-profile.md` §1a.
 
 ## Do NOT
 - Duplicate game rules into this file, services, tests, or docs — read `era.*` or cite the spec

--- a/docs/spec/SPEC-faction-ui-profile.md
+++ b/docs/spec/SPEC-faction-ui-profile.md
@@ -43,6 +43,20 @@
 
 ---
 
+## 1a. The form-factor axis (mobile vs. desktop)
+
+Faction is not the only presentation axis — **form factor** is a second one, orthogonal to it (#494). A phone gets a *mobile-native* experience (bottom-tab nav, single-column, one-handed), not a responsive squeeze of the desktop skin.
+
+- **Detection.** `useFormFactor()` reports `mobile` vs `desktop` from one `matchMedia` breakpoint (`max-width: 767px`) — viewport-based, reactive to resize/rotate, not UA sniffing. One breakpoint; no tablet tier.
+- **Switch location.** Only two places branch on form factor: the **`Layout` shell** (`MobileLayout` with `MobileTabBar` vs. `DesktopLayout` with the top NavBar + sidebar) and **each page dispatcher**. Never a per-leaf-component branch — mobile and desktop are distinct component trees.
+- **Shared boundary.** All `use*` hooks, API clients, and state contracts (`TaskDetailState`, …) are shared verbatim. Mobile adds *presentation only*; zero backend/data change.
+- **Mobile skin registry.** Each surface that has a `ARCHETYPE_BY_SLUG` dispatcher gains a parallel `MOBILE_ARCHETYPE_BY_SLUG` with a `Default*` mobile skin. Partial faction coverage is intended — every faction renders via the Default until a bespoke mobile skin lands (like the desktop archetypes). Task detail is the reference implementation (`pages/taskDetail/mobileArchetypes/`).
+- **No fixed-px grids on the mobile path.** The desktop archetypes lay out with fixed-width inline grids (`width: 240` sidebars, `gridTemplateColumns: 1fr 322px`). A mobile skin must not — it stacks single-column with flow/wrap so it survives a 375px viewport.
+
+Reference issues: mobile foundation #494; design language + prompts #495; core-loop screens #496–#500.
+
+---
+
 ## 2. Whose faction themes each surface? (contextual-faction resolution)
 
 A per-faction surface needs to know *which* faction to render as. Use these rules — they are not all the same.

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,19 +1,19 @@
 import { useEffect, type ReactNode } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
-import NavBar from './NavBar'
+import { useFormFactor } from '../hooks/useFormFactor'
 import { BackdropProvider } from './backdrop/BackdropContext'
 import FactionBackdrop from './backdrop/FactionBackdrop'
 import LevelUpWatcher from './LevelUpWatcher'
 import InvitationWatcher from './InvitationWatcher'
-import Sidebar from './layout/Sidebar'
+import DesktopLayout from './layout/DesktopLayout'
+import MobileLayout from './layout/MobileLayout'
 
 export default function Layout({ children }: { children: ReactNode }) {
-  const { t } = useTranslation('common')
   const { user, loading } = useAuth()
   const navigate = useNavigate()
   const { pathname } = useLocation()
+  const Shell = useFormFactor() === 'mobile' ? MobileLayout : DesktopLayout
 
   useEffect(() => {
     window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
@@ -32,33 +32,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       <LevelUpWatcher />
       <InvitationWatcher />
 
-      <NavBar />
-
-      {/* Page body: main content + sidebar (Style Guide §4.1) */}
-      <div
-        className="flex-1 relative max-w-5xl mx-auto w-full px-4 sm:px-6 py-5"
-        style={{ zIndex: 5 }}
-      >
-        <div className={`gap-4 items-start ${user ? 'lg:grid lg:grid-cols-[1fr_256px]' : ''}`}>
-          <main className="min-w-0">{children}</main>
-          {user && (
-            <div className="hidden lg:block">
-              <Sidebar />
-            </div>
-          )}
-        </div>
-      </div>
-
-      <footer
-        className="relative font-body text-xs flex gap-6 flex-wrap max-w-5xl mx-auto w-full px-4 sm:px-6 py-4 mt-8"
-        style={{ color: 'var(--color-text-tertiary)', zIndex: 5 }}
-      >
-        <Link to="/about" className="hover:underline">{t('footer.about')}</Link>
-        <Link to="/contact" className="hover:underline">{t('footer.contact')}</Link>
-        <Link to="/disclaimer" className="hover:underline">{t('footer.disclaimer')}</Link>
-        <Link to="/attributions" className="hover:underline">{t('footer.attributions')}</Link>
-        <Link to="/donate" className="hover:underline">{t('footer.donate')}</Link>
-      </footer>
+      <Shell>{children}</Shell>
     </div>
     </BackdropProvider>
   )

--- a/frontend/src/components/layout/DesktopLayout.tsx
+++ b/frontend/src/components/layout/DesktopLayout.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../../auth/AuthContext'
+import NavBar from '../NavBar'
+import Sidebar from './Sidebar'
+
+/**
+ * Desktop shell chrome: top NavBar, centered content grid with the sidebar, and
+ * the footer. The shared frame (backdrop, global watchers, scroll/redirect
+ * effects) lives in Layout; this renders only the desktop-native presentation.
+ */
+export default function DesktopLayout({ children }: { children: ReactNode }) {
+  const { t } = useTranslation('common')
+  const { user } = useAuth()
+
+  return (
+    <>
+      <NavBar />
+
+      {/* Page body: main content + sidebar (Style Guide §4.1) */}
+      <div
+        className="flex-1 relative max-w-5xl mx-auto w-full px-4 sm:px-6 py-5"
+        style={{ zIndex: 5 }}
+      >
+        <div className={`gap-4 items-start ${user ? 'lg:grid lg:grid-cols-[1fr_256px]' : ''}`}>
+          <main className="min-w-0">{children}</main>
+          {user && (
+            <div className="hidden lg:block">
+              <Sidebar />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <footer
+        className="relative font-body text-xs flex gap-6 flex-wrap max-w-5xl mx-auto w-full px-4 sm:px-6 py-4 mt-8"
+        style={{ color: 'var(--color-text-tertiary)', zIndex: 5 }}
+      >
+        <Link to="/about" className="hover:underline">{t('footer.about')}</Link>
+        <Link to="/contact" className="hover:underline">{t('footer.contact')}</Link>
+        <Link to="/disclaimer" className="hover:underline">{t('footer.disclaimer')}</Link>
+        <Link to="/attributions" className="hover:underline">{t('footer.attributions')}</Link>
+        <Link to="/donate" className="hover:underline">{t('footer.donate')}</Link>
+      </footer>
+    </>
+  )
+}

--- a/frontend/src/components/layout/MobileLayout.tsx
+++ b/frontend/src/components/layout/MobileLayout.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MobileTabBar from './MobileTabBar'
+
+/**
+ * Mobile shell: a minimal top wordmark bar, full-bleed main (no sidebar, no
+ * desktop grid), and the bottom MobileTabBar. Secondary controls (theme,
+ * logout, admin, profile) move behind a More affordance per the design issue
+ * (#495); the shared frame (backdrop, watchers, effects) lives in Layout.
+ */
+export default function MobileLayout({ children }: { children: ReactNode }) {
+  const { t } = useTranslation('common')
+
+  return (
+    <>
+      <header
+        className="sticky top-0 flex items-center px-4 h-12"
+        style={{
+          zIndex: 10,
+          background: 'var(--color-nav-bg)',
+          backdropFilter: 'blur(var(--nav-blur))',
+          borderBottom: '1px solid var(--color-border)',
+        }}
+      >
+        <Link to="/" className="font-display italic" style={{ fontSize: 18, color: 'var(--color-text-primary)', textDecoration: 'none' }}>
+          {t('brand')}
+        </Link>
+      </header>
+
+      {/* Full-bleed main; bottom padding clears the fixed tab bar + safe area. */}
+      <main
+        className="flex-1 relative px-4 py-4"
+        style={{ zIndex: 5, paddingBottom: 'calc(3.5rem + env(safe-area-inset-bottom))' }}
+      >
+        {children}
+      </main>
+
+      <MobileTabBar />
+    </>
+  )
+}

--- a/frontend/src/components/layout/MobileTabBar.tsx
+++ b/frontend/src/components/layout/MobileTabBar.tsx
@@ -1,0 +1,47 @@
+import { NavLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+// Five thumb-reachable core-loop destinations. Labels reuse the existing nav
+// keys; secondary links (Updates, Admin, profile, logout, theme) live behind a
+// More affordance per the design issue (#495) — not here.
+type TabKey = 'nav.home' | 'nav.tasks' | 'nav.praxis' | 'nav.players' | 'nav.factions'
+const TABS: { to: string; key: TabKey; end?: boolean }[] = [
+  { to: '/', key: 'nav.home', end: true },
+  { to: '/tasks', key: 'nav.tasks' },
+  { to: '/praxes', key: 'nav.praxis' },
+  { to: '/leaderboard', key: 'nav.players' },
+  { to: '/factions', key: 'nav.factions' },
+]
+
+export default function MobileTabBar() {
+  const { t } = useTranslation('common')
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 flex"
+      style={{
+        zIndex: 10,
+        background: 'var(--color-nav-bg)',
+        backdropFilter: 'blur(var(--nav-blur))',
+        borderTop: '1px solid var(--color-border)',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
+      {TABS.map(({ to, key, end }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={end}
+          className="flex-1 text-center font-body py-2"
+          style={({ isActive }) => ({
+            fontSize: 12,
+            textDecoration: 'none',
+            color: isActive ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
+            borderTop: isActive ? '2px solid var(--color-text-primary)' : '2px solid transparent',
+          })}
+        >
+          {t(key)}
+        </NavLink>
+      ))}
+    </nav>
+  )
+}

--- a/frontend/src/components/layout/__tests__/MobileTabBar.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileTabBar.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so nav copy keys resolve to English text.
+import '../../../i18n'
+import MobileTabBar from '../MobileTabBar'
+
+function render(path: string): string {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[path]}>
+      <MobileTabBar />
+    </MemoryRouter>,
+  )
+}
+
+describe('MobileTabBar', () => {
+  it('renders the five core-loop destinations', () => {
+    const html = render('/')
+    for (const label of ['Home', 'Tasks', 'Praxis', 'Players', 'Factions']) {
+      expect(html).toContain(label)
+    }
+    for (const href of ['href="/"', 'href="/tasks"', 'href="/praxes"', 'href="/leaderboard"', 'href="/factions"']) {
+      expect(html).toContain(href)
+    }
+  })
+
+  it('marks the active route with the primary-text underline', () => {
+    // NavLink applies the active style only to the matching tab.
+    const activeStyle = 'border-top:2px solid var(--color-text-primary)'
+    const onTasks = render('/tasks')
+    expect((onTasks.match(/border-top:2px solid var\(--color-text-primary\)/g) || []).length).toBe(1)
+    expect(onTasks).toContain(activeStyle)
+  })
+})

--- a/frontend/src/hooks/__tests__/useFormFactor.test.ts
+++ b/frontend/src/hooks/__tests__/useFormFactor.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { formFactorFor, MOBILE_QUERY } from '../useFormFactor'
+
+describe('useFormFactor', () => {
+  it('maps a matching mobile media query to mobile, else desktop', () => {
+    expect(formFactorFor(true)).toBe('mobile')
+    expect(formFactorFor(false)).toBe('desktop')
+  })
+
+  it('breaks at the phone/desktop boundary (768px), no tablet tier', () => {
+    expect(MOBILE_QUERY).toBe('(max-width: 767px)')
+  })
+})

--- a/frontend/src/hooks/useFormFactor.ts
+++ b/frontend/src/hooks/useFormFactor.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from 'react'
+
+export type FormFactor = 'mobile' | 'desktop'
+
+// Single phone/desktop breakpoint. Below 768px is mobile; no tablet tier (#494).
+export const MOBILE_QUERY = '(max-width: 767px)'
+
+export function formFactorFor(matchesMobile: boolean): FormFactor {
+  return matchesMobile ? 'mobile' : 'desktop'
+}
+
+function subscribe(onChange: () => void): () => void {
+  const mql = window.matchMedia(MOBILE_QUERY)
+  mql.addEventListener('change', onChange)
+  return () => mql.removeEventListener('change', onChange)
+}
+
+/**
+ * Reports 'mobile' vs 'desktop' from one matchMedia breakpoint, reactive to
+ * resize/rotate. Viewport-based, not UA sniffing. Defaults to 'desktop' when
+ * matchMedia is absent (SSR / test node env).
+ */
+export function useFormFactor(): FormFactor {
+  return useSyncExternalStore(
+    subscribe,
+    () => formFactorFor(window.matchMedia(MOBILE_QUERY).matches),
+    () => 'desktop', // ponytail: SSR/no-matchMedia default; desktop is the safe layout
+  )
+}

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -11,8 +11,10 @@ import { useParams } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import PageTitle from "../components/ui/PageTitle";
 import { pickVariant } from "../utils/factionDispatch";
+import { useFormFactor } from "../hooks/useFormFactor";
 import { useTaskDetail, type TaskDetailState } from "./taskDetail/useTaskDetail";
 import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
+import DefaultMobileTaskDetail from "./taskDetail/mobileArchetypes/DefaultTaskDetail";
 import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
@@ -37,10 +39,16 @@ export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   albescent: AlbescentTaskDetail,
 };
 
+// Parallel MOBILE registry. Empty for now — every faction falls through to the
+// Default mobile skin; bespoke faction mobile skins land incrementally (#496–
+// #500) exactly like the desktop archetypes above.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {};
+
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation("tasks");
   const state = useTaskDetail(id);
+  const formFactor = useFormFactor();
 
   if (state.loading)
     return <div className="py-8 font-body text-muted">{t("detail.loading")}</div>;
@@ -71,7 +79,10 @@ export default function TaskDetail() {
     );
 
   const slug = state.task.primary_faction_slug ?? null;
-  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, slug, DefaultTaskDetail);
+  const Archetype =
+    formFactor === "mobile"
+      ? pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)
+      : pickVariant(ARCHETYPE_BY_SLUG, slug, DefaultTaskDetail);
 
   return (
     <>

--- a/frontend/src/pages/taskDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Mobile task-detail slot invariant — the mobile twin of archetypeSlots.test.
+ * Walks the MOBILE_ARCHETYPE_BY_SLUG registry plus the Default mobile skin and
+ * asserts each still emits the invariant content slots (title, description,
+ * all-tasks breadcrumb, sort toggle, signup CTA, edit/continue controls). The
+ * registry is empty today, so this mainly guards the Default fallback and any
+ * bespoke mobile skin added later (#496–#500).
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+// Initialize the i18n catalog so shared copy keys resolve to English text.
+import "../../../i18n";
+import { MOBILE_ARCHETYPE_BY_SLUG } from "../../TaskDetail";
+import DefaultMobileTaskDetail from "../mobileArchetypes/DefaultTaskDetail";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut } from "../../../api/tasks";
+import type { PraxisCardOut } from "../../../api/praxis";
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+const TASK: TaskOut = {
+  id: 7,
+  title: "Reforestation",
+  description: "Mangrove",
+  point_value: 30,
+  level_required: 3,
+  status: "active",
+  task_type: "standard",
+  created_by: 3,
+  primary_faction_slug: "snide",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+const MY_PRAXIS: PraxisCardOut = {
+  id: 55,
+  task_id: 7,
+  task_title: "Reforestation",
+  task_point_value: 30,
+  task_level_required: 3,
+  type: "solo",
+  status: "submitted",
+  title: "Seedlings",
+  moderation_status: "visible",
+  created_by_id: 3,
+  created_by_display_name: "Ada",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  submitted_at: "2026-01-02T00:00:00Z",
+  member_count: 1,
+  score: 4.2,
+  voter_count: 0,
+  is_top_for_task: false,
+  task_faction_slug: "snide",
+};
+
+function baseState(overrides: Partial<TaskDetailState>): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: false,
+    slotsOpen: 13,
+    maxTaskSlots: 17,
+    factionMultiplier: 1.0,
+    modifiedPoints: 4242,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+const archetypes = { ...MOBILE_ARCHETYPE_BY_SLUG, __default__: DefaultMobileTaskDetail };
+
+describe("mobile task-detail content-slot invariant", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders title, description, breadcrumb + sort toggle`, () => {
+      const { html, text } = render(<Archetype state={baseState({ canSignUp: true })} />);
+      expect(text, "title slot").toContain("Reforestation");
+      expect(text, "description slot").toContain("Mangrove");
+      expect(html, "all-tasks breadcrumb slot").toContain('href="/tasks"');
+      expect(html.toLowerCase(), "sort-toggle slot").toContain("recent");
+    });
+
+    it(`${slug} renders the signup CTA when canSignUp`, () => {
+      const { text } = render(<Archetype state={baseState({ canSignUp: true })} />);
+      expect(text.toLowerCase(), "signup-CTA slot").toContain("earn up to");
+    });
+
+    it(`${slug} renders the edit control for a submitted praxis`, () => {
+      const { html } = render(<Archetype state={baseState({ mySubmission: MY_PRAXIS })} />);
+      expect(html, "edit-submission slot").toContain('href="/praxes/55/edit"');
+    });
+
+    it(`${slug} renders the continue control while in progress`, () => {
+      const { html } = render(<Archetype state={baseState({ isInProgress: true, inProgressPraxisId: 99 })} />);
+      expect(html, "continue-in-progress slot").toContain('href="/praxes/99/edit"');
+    });
+  }
+});

--- a/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
@@ -1,0 +1,228 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import PraxisCard from "../../../components/PraxisCard";
+import LevelPill from "../../../components/ui/LevelPill";
+import DefaultSigil from "../../../components/cards/DefaultSigil";
+import { factionName } from "../../../utils/factions";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * Default MOBILE task-detail skin — single-column, thumb-first, no fixed-px
+ * two-column grid (the desktop Default's `width:240` sidebar would crush the
+ * main column on a phone). Renders the same content slots as the desktop
+ * archetypes (title, description, breadcrumb, sort toggle, signup CTA, edit /
+ * continue controls) so the slot-invariant guard holds; reuses the existing
+ * `tasks` copy keys verbatim. Every faction falls through here until it
+ * registers a bespoke mobile skin (#496–#500).
+ */
+export default function DefaultTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation("tasks");
+  const {
+    task,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    topScore,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  if (!task) return null;
+
+  const color = "var(--faction-default)";
+
+  return (
+    <div className="py-4">
+      {/* Breadcrumb */}
+      <nav
+        className="font-body mb-3"
+        style={{ fontSize: 10, letterSpacing: "0.08em", color: "var(--color-text-tertiary)" }}
+      >
+        <Link to="/tasks" style={{ color: "var(--faction-ephemerists)", textDecoration: "none" }}>
+          {t("default.breadcrumb")}
+        </Link>
+        {" › "}
+        <span style={{ color: "var(--color-text-primary)" }}>{task.title}</span>
+      </nav>
+
+      {/* Hero */}
+      <div className="sidebar-card mb-4" style={{ borderLeft: `4px solid ${color}`, padding: "16px 18px" }}>
+        <div className="flex items-center gap-2 mb-2">
+          <DefaultSigil size={18} />
+          <span className="eyebrow" style={{ color }}>{factionName(task.primary_faction_slug)}</span>
+          <LevelPill level={task.level_required} />
+        </div>
+
+        <h1
+          className="font-display italic font-medium mb-2"
+          style={{ fontSize: 24, color: "var(--color-text-primary)", lineHeight: 1.2 }}
+        >
+          {task.title}
+        </h1>
+
+        {/* Stats — wrap, no fixed grid */}
+        <div className="flex flex-wrap gap-2 mb-3">
+          {[
+            { label: t("default.stats.basePoints"), value: task.point_value },
+            { label: t("default.stats.yourPoints", { multiplier: state.factionMultiplier }), value: modifiedPoints },
+            { label: t("default.stats.topScore"), value: topScore },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center py-2 px-3"
+              style={{ border: "1px solid var(--color-border)", background: "var(--color-bg-surface)", flex: "1 0 28%" }}
+            >
+              <div className="font-body font-bold text-lg" style={{ color: "var(--color-text-primary)" }}>{stat.value}</div>
+              <div className="eyebrow" style={{ fontSize: 7 }}>{stat.label}</div>
+            </div>
+          ))}
+        </div>
+
+        {task.description && (
+          <p
+            className="font-body"
+            style={{ fontSize: 14, lineHeight: 1.7, color: "var(--color-text-secondary)", whiteSpace: "pre-wrap" }}
+          >
+            {task.description}
+          </p>
+        )}
+      </div>
+
+      {/* Signup CTA */}
+      {canSignUp && (
+        <div className="sidebar-card mb-4" style={{ padding: "16px 18px" }}>
+          <button
+            onClick={handleSignup}
+            style={{
+              width: "100%",
+              background: color,
+              color: "var(--color-text-on-accent)",
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 14,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.12em",
+              padding: "12px 20px",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            {t("default.signup.cta", { points: modifiedPoints })}
+          </button>
+          <div className="eyebrow flex justify-between" style={{ marginTop: 6 }}>
+            <span>{t("default.signup.slots", { open: slotsOpen, max: maxTaskSlots })}</span>
+            <span>{t("default.signup.levelRequired", { level: task.level_required })} {t("default.signup.met")}</span>
+          </div>
+          {signupError && (
+            <div
+              className="font-body"
+              style={{ fontSize: 12, color: "var(--color-danger)", marginTop: 8, padding: "8px 12px", background: "rgba(220,38,38,0.06)", border: "1px solid rgba(220,38,38,0.2)" }}
+            >
+              {signupError}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Submitted */}
+      {mySubmission && (
+        <div className="sidebar-card mb-4 flex items-center gap-3" style={{ padding: "14px 18px" }}>
+          <span className="eyebrow flex-1" style={{ color }}>{t("default.submitted.badge")}</span>
+          <Link to={`/praxes/${mySubmission.id}/edit`} className="btn-outline" style={{ fontSize: 9, padding: "6px 14px" }}>
+            {t("default.submitted.edit")}
+          </Link>
+        </div>
+      )}
+
+      {/* In progress */}
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <div className="sidebar-card mb-4 flex items-center gap-3" style={{ padding: "14px 18px" }}>
+          <span className="eyebrow flex-1" style={{ color }}>{t("default.inProgress.badge")}</span>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{
+              background: color,
+              color: "var(--color-text-on-accent)",
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 12,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              padding: "8px 16px",
+              textDecoration: "none",
+            }}
+          >
+            {t("default.inProgress.continue")}
+          </Link>
+          <button
+            onClick={handleDrop}
+            className="eyebrow"
+            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--color-text-tertiary)" }}
+          >
+            {t("default.inProgress.drop")}
+          </button>
+        </div>
+      )}
+
+      {/* Completed praxis */}
+      <div className="mt-2">
+        <div className="flex items-center justify-between mb-3">
+          <span className="eyebrow">{t("default.completedHeading", { count: submissions.length })}</span>
+          <div className="flex">
+            {(["score", "recent"] as const).map((sort) => (
+              <button
+                key={sort}
+                onClick={() => setSubmissionSort(sort)}
+                style={{
+                  fontFamily: "'Courier Prime', monospace",
+                  fontSize: 9,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                  padding: "5px 12px",
+                  background: submissionSort === sort ? "var(--color-text-primary)" : "transparent",
+                  color: submissionSort === sort ? "var(--color-bg-page)" : "var(--color-text-tertiary)",
+                  border: `1px solid ${submissionSort === sort ? "transparent" : "var(--color-border)"}`,
+                  cursor: "pointer",
+                }}
+              >
+                {sort === "score" ? t("default.sort.topRated") : t("default.sort.recent")}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {sortedSubmissions.length === 0 ? (
+          <p className="font-body text-muted">{t("default.empty")}</p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4">
+              {sortedSubmissions.slice(0, 4).map((s) => (
+                <PraxisCard key={s.id} praxis={s} />
+              ))}
+            </div>
+            {submissions.length > 4 && (
+              <div style={{ textAlign: "center", marginTop: 16 }}>
+                <Link
+                  to={`/praxes?task_id=${task.id}`}
+                  style={{ fontFamily: "'Courier Prime', monospace", fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", color: "var(--faction-ephemerists)", textDecoration: "none" }}
+                >
+                  {t("default.viewAll", { count: submissions.length })}
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #494.

Adds a **form-factor axis** alongside the existing per-faction dispatch seam: a phone gets a mobile-native shell (bottom tab bar, single-column) while desktop is untouched. Delivered as the 7 commits from the issue.

## What's here
1. `useFormFactor()` — `matchMedia` at one 768px breakpoint, reactive to resize/rotate, desktop default when matchMedia is absent. + test.
2. `MobileTabBar` — fixed bottom bar, 5 core-loop destinations (Home/Tasks/Praxis/Players/Factions), active-route styling from CSS-var tokens, safe-area inset. Reuses existing nav copy keys. + test.
3. `DesktopLayout` — pure extraction of the current desktop chrome from `Layout`; shared frame (backdrop, watchers, effects) stays in `Layout`. No visual change.
4. `MobileLayout` — wordmark bar + full-bleed main + `MobileTabBar`.
5. `Layout` wires `useFormFactor() === 'mobile' ? MobileLayout : DesktopLayout`.
6. **Reference implementation on Task detail**: `taskDetail/mobileArchetypes/DefaultTaskDetail` (single-column, no fixed-px sidebar grid), empty `MOBILE_ARCHETYPE_BY_SLUG` registry, form-factor branch in `TaskDetail.tsx`. Ships Default-only; every faction gets a usable mobile task page. + slot-invariant test mirroring `archetypeSlots`.
7. Docs: form-factor axis §1a in `SPEC-faction-ui-profile.md` + authoring rule in `CLAUDE.md`.

No data-hook, API-client, or backend change. Reuses existing `tasks`/`common` i18n keys (zero new copy).

## Verification
- `vitest run`: **217 passed** (26 files), including the 3 new test files.
- `tsc --noEmit`: no new errors in touched files (12 pre-existing `AlbescentInvitation.tsx` i18n-key errors remain on `main`; CI runs vitest only).
- Browser (dev server): mobile 375px shows the wordmark bar + bottom tab bar (active route tracks), no sidebar; the mobile Task-detail Default renders single-column (breadcrumb, hero, wrapping stats, description, sort toggle, stacked praxis). Desktop 1280px is unchanged (NavBar + sidebar + footer). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)