### PR TITLE
Surface collaboration submit state in UI (#521)

### DIFF
--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -91,6 +91,7 @@ class PraxisCardOut(BaseModel):
     created_at: datetime
     updated_at: datetime
     submitted_at: Optional[datetime] = None
+    submit_proposed_at: Optional[datetime] = None  # collab pending-publish chip (#521, ADR-0012)
     member_count: int
     score: float
     voter_count: int = 0

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -261,6 +261,7 @@ async def build_praxis_card_out(
         created_at=praxis.created_at,
         updated_at=praxis.updated_at,
         submitted_at=praxis.submitted_at,
+        submit_proposed_at=praxis.submit_proposed_at,
         member_count=len(praxis.members),
         score=score,
         voter_count=tally.voter_count,

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -90,6 +90,12 @@ export interface PraxisCardOut {
   created_at: string
   updated_at: string
   submitted_at: string | null
+  /**
+   * When a collab's pending-publish window opened; null/absent if not pending
+   * (ADR-0012). Optional because the list schema may omit it — the pending chip
+   * simply doesn't render until it's present.
+   */
+  submit_proposed_at?: string | null
   member_count: number
   score: number
   voter_count: number

--- a/frontend/src/components/CollaborationCard.tsx
+++ b/frontend/src/components/CollaborationCard.tsx
@@ -10,6 +10,9 @@ interface Props {
 export default function CollaborationCard({ collab }: Props) {
   const { t } = useTranslation('common')
   const isDuel = collab.type === 'duel'
+  // Pending-publish window is open on this collab (ADR-0012): one member has
+  // proposed submit, waiting on co-authors. Praxis-level, no member array needed.
+  const isPending = collab.submit_proposed_at != null
 
   return (
     <div
@@ -20,22 +23,37 @@ export default function CollaborationCard({ collab }: Props) {
         color: factionCssVar(collab.task_faction_slug, 'card-text'),
       }}
     >
-      {/* Mode label */}
-      <span
-        className="eyebrow self-start"
-        style={{
-          fontSize: 7, padding: '1px 6px',
-          background: isDuel
-            ? 'color-mix(in srgb, var(--color-danger) 12%, transparent)'
-            : 'color-mix(in srgb, var(--color-success) 12%, transparent)',
-          color: isDuel ? 'var(--color-danger)' : 'var(--color-success)',
-          border: `1px solid ${isDuel
-            ? 'color-mix(in srgb, var(--color-danger) 30%, transparent)'
-            : 'color-mix(in srgb, var(--color-success) 30%, transparent)'}`,
-        }}
-      >
-        {isDuel ? t('collaborationCard.duel') : t('collaborationCard.collaboration')}
-      </span>
+      <div className="flex items-center gap-2 self-start">
+        {/* Mode label */}
+        <span
+          className="eyebrow"
+          style={{
+            fontSize: 7, padding: '1px 6px',
+            background: isDuel
+              ? 'color-mix(in srgb, var(--color-danger) 12%, transparent)'
+              : 'color-mix(in srgb, var(--color-success) 12%, transparent)',
+            color: isDuel ? 'var(--color-danger)' : 'var(--color-success)',
+            border: `1px solid ${isDuel
+              ? 'color-mix(in srgb, var(--color-danger) 30%, transparent)'
+              : 'color-mix(in srgb, var(--color-success) 30%, transparent)'}`,
+          }}
+        >
+          {isDuel ? t('collaborationCard.duel') : t('collaborationCard.collaboration')}
+        </span>
+        {isPending && (
+          <span
+            className="eyebrow"
+            style={{
+              fontSize: 7, padding: '1px 6px',
+              background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
+              color: 'var(--color-warning)',
+              border: '1px solid color-mix(in srgb, var(--color-warning) 30%, transparent)',
+            }}
+          >
+            {t('collaborationCard.pending')}
+          </span>
+        )}
+      </div>
 
       {/* Task link */}
       <Link to={`/tasks/${collab.task_id}`} className="font-body text-xs text-muted hover:underline">

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -45,7 +45,8 @@
     "collaboration": "Collaboration",
     "titleFallback": "{{label}} · {{count}} players",
     "viewDuel": "View duel",
-    "viewCollaboration": "View collaboration"
+    "viewCollaboration": "View collaboration",
+    "pending": "pending"
   },
   "credential": {
     "fallbackName": "Wanderer",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -105,6 +105,7 @@
       "statusAccepted": "accepted",
       "statusChallenged": "challenged",
       "statusPending": "pending",
+      "statusSubmitted": "submitted",
       "cancelChallengeAria": "cancel challenge",
       "rescindInviteAria": "rescind invite to {{name}}"
     },

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -57,6 +57,8 @@
       "crownBody": "The top-scoring praxis for this task — held until another entry out-votes it.",
       "inEditingLabel": "IN EDITING",
       "inEditingBody": "This praxis is in editing mode. Points and votes are paused until submitted.",
+      "pendingPublishLabel": "PENDING PUBLISH",
+      "pendingPublishBody": "Waiting on co-authors to submit.",
       "failedTitle": "This praxis was marked as failed."
     },
     "admin": {
@@ -68,10 +70,15 @@
       "failReasonPlaceholder": "Reason for failure (visible to player)...",
       "confirm": "confirm"
     },
+    "byline": {
+      "submitted": "✓ submitted",
+      "drafting": "drafting"
+    },
     "owner": {
       "edit": "edit this praxis",
       "submitting": "...",
       "submit": "Submit",
+      "submittedWaiting": "You've submitted — waiting on co-authors",
       "unsubmit": "unsubmit",
       "confirmPrompt": "Sure? Points & votes will pause.",
       "confirmUnsubmit": "Yes, unsubmit",

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -112,6 +112,10 @@ export function InviteSearch({
                     }}
                   >
                     {member.character_display_name}
+                    {/* Collab submit indicator (#521): who has already submitted. */}
+                    {member.has_submitted && (
+                      <em> · ✓ {t("editPraxis.invite.statusSubmitted")}</em>
+                    )}
                   </span>
                 )),
               ...praxis.invites

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * #521 — collab submit indicators on the shared praxis-detail slots.
+ *
+ * Two invariant slots reflect the collab publish lifecycle (ADR-0012):
+ *   - PraxisStatusBanners swaps the neutral "IN EDITING" banner for a
+ *     "PENDING PUBLISH — waiting on co-authors" banner once submit_proposed_at
+ *     is set (still status=in_progress).
+ *   - PraxisOwnerActions replaces the green Submit control with a
+ *     "you've submitted — waiting on co-authors" state for a member who has
+ *     already submitted an in-editing collab. The edit affordance stays.
+ *
+ * Rendered to static markup; the catalog is initialized so copy keys resolve.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import "../../../i18n";
+import { PraxisStatusBanners, PraxisOwnerActions } from "../shared";
+import type { PraxisDetailState } from "../usePraxisDetail";
+import type {
+  PraxisOut,
+  PraxisMemberOut,
+  PraxisStatus,
+} from "../../../api/praxis";
+import type { CharacterOut, CurrentUser } from "../../../api/auth";
+
+function text(element: ReactElement): string {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return html.replace(/<[^>]*>/g, "");
+}
+
+function member(
+  characterId: number,
+  name: string,
+  hasSubmitted: boolean,
+): PraxisMemberOut {
+  return {
+    id: characterId * 10,
+    praxis_id: 1,
+    character_id: characterId,
+    character_display_name: name,
+    has_submitted: hasSubmitted,
+    joined_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function praxis(
+  members: PraxisMemberOut[],
+  status: PraxisStatus,
+  submitProposedAt: string | null,
+): PraxisOut {
+  return {
+    id: 1,
+    task_id: 7,
+    task_title: "Mangrove",
+    task_point_value: 30,
+    task_level_required: 3,
+    task_faction_slug: null,
+    type: "collab",
+    status,
+    title: "Reforestation",
+    body_text: "Seedlings.",
+    moderation_status: "visible",
+    admin_note: null,
+    flagged_at: null,
+    submitted_at: null,
+    submit_proposed_at: submitProposedAt,
+    created_by_id: 1,
+    created_by_display_name: "Ada",
+    created_by_faction_slug: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    members,
+    invites: [],
+    media_items: [],
+    score: 0,
+    is_top_for_task: false,
+    duel_id: null,
+    can_flag: true,
+    applied_metatasks: [],
+  };
+}
+
+function character(id: number): CharacterOut {
+  return {
+    id,
+    username: `u${id}`,
+    display_name: `Player ${id}`,
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 5,
+    score: 0,
+    all_time_score: 0,
+    faction_slug: null,
+    status: "active",
+    created_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function user(characterId: number): CurrentUser {
+  return {
+    account_id: 1,
+    character: character(characterId),
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: "Era 1",
+  };
+}
+
+/** Minimal PraxisDetailState — only the fields the two slots read matter; the
+ *  rest are stubbed with inert defaults. */
+function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: null,
+    fetchError: null,
+    votes: null,
+    voters: [],
+    duel: null,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: "",
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: "",
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleResubmit: async () => {},
+    handleFlag: async () => {},
+    metatasks: [],
+    metataskLoading: false,
+    metataskError: null,
+    applyingMetataskId: null,
+    removingMetataskId: null,
+    handleApplyMetatask: async () => {},
+    handleRemoveMetatask: async () => {},
+    ...overrides,
+  };
+}
+
+const ADA = () => member(1, "Ada", true);
+const BETH = () => member(2, "Beth", false);
+
+describe("PraxisStatusBanners pending-publish (#521)", () => {
+  it("shows the pending-publish banner when submit_proposed_at is set", () => {
+    const t = text(
+      <PraxisStatusBanners
+        state={state({
+          praxis: praxis([ADA(), BETH()], "in_progress", "2026-01-03T00:00:00Z"),
+        })}
+      />,
+    );
+    expect(t).toContain("PENDING PUBLISH");
+    expect(t).toContain("Waiting on co-authors to submit.");
+    expect(t).not.toContain("IN EDITING");
+  });
+
+  it("shows the neutral IN EDITING banner when not yet proposed", () => {
+    const t = text(
+      <PraxisStatusBanners
+        state={state({
+          praxis: praxis([ADA(), BETH()], "in_progress", null),
+        })}
+      />,
+    );
+    expect(t).toContain("IN EDITING");
+    expect(t).not.toContain("PENDING PUBLISH");
+  });
+});
+
+describe("PraxisOwnerActions submitted-waiting (#521)", () => {
+  it("shows the submitted-waiting state for a member who has submitted", () => {
+    const t = text(
+      <PraxisOwnerActions
+        state={state({
+          isOwner: true,
+          user: user(1), // Ada — has_submitted: true
+          praxis: praxis([ADA(), BETH()], "in_progress", "2026-01-03T00:00:00Z"),
+        })}
+      />,
+    );
+    // Apostrophe is HTML-escaped in static markup; assert the unambiguous tail.
+    expect(t).toContain("submitted — waiting on co-authors");
+    expect(t).not.toContain("Submit");
+  });
+
+  it("still shows the Submit control for a member who has not submitted", () => {
+    const t = text(
+      <PraxisOwnerActions
+        state={state({
+          isOwner: true,
+          user: user(2), // Beth — has_submitted: false
+          praxis: praxis([ADA(), BETH()], "in_progress", "2026-01-03T00:00:00Z"),
+        })}
+      />,
+    );
+    expect(t).toContain("Submit");
+    expect(t).not.toContain("waiting on co-authors");
+  });
+});

--- a/frontend/src/pages/praxisDetail/__tests__/memberByline.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/memberByline.test.tsx
@@ -7,6 +7,8 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect } from "vitest";
+// Initialize the catalog so the collab submit-state markers resolve to English.
+import "../../../i18n";
 import { orderedMembers, MemberByline } from "../shared";
 import type { PraxisOut, PraxisMemberOut } from "../../../api/praxis";
 
@@ -14,18 +16,23 @@ function member(
   characterId: number,
   name: string,
   joinedAt: string,
+  hasSubmitted = false,
 ): PraxisMemberOut {
   return {
     id: characterId * 10,
     praxis_id: 1,
     character_id: characterId,
     character_display_name: name,
-    has_submitted: false,
+    has_submitted: hasSubmitted,
     joined_at: joinedAt,
   };
 }
 
-function praxis(members: PraxisMemberOut[], createdById: number): PraxisOut {
+function praxis(
+  members: PraxisMemberOut[],
+  createdById: number,
+  status: PraxisOut["status"] = "submitted",
+): PraxisOut {
   return {
     id: 1,
     task_id: 7,
@@ -34,7 +41,7 @@ function praxis(members: PraxisMemberOut[], createdById: number): PraxisOut {
     task_level_required: 3,
     task_faction_slug: "ua",
     type: "collab",
-    status: "submitted",
+    status,
     title: "Reforestation",
     body_text: "Seedlings planted along the estuary.",
     moderation_status: "visible",
@@ -64,10 +71,13 @@ const ADA = member(1, "Ada", "2026-01-03T00:00:00Z");
 const BETH = member(2, "Beth", "2026-01-01T00:00:00Z");
 const CY = member(3, "Cy", "2026-01-02T00:00:00Z");
 
-function bylineText(members: PraxisMemberOut[]): string {
+function bylineText(
+  members: PraxisMemberOut[],
+  status: PraxisOut["status"] = "submitted",
+): string {
   const html = renderToStaticMarkup(
     <MemoryRouter>
-      <MemberByline praxis={praxis(members, 1)} />
+      <MemberByline praxis={praxis(members, 1, status)} />
     </MemoryRouter>,
   );
   return html.replace(/<[^>]+>/g, "").replace(/&amp;/g, "&");
@@ -110,5 +120,31 @@ describe("MemberByline join format (#387)", () => {
     );
     expect(html).toContain('href="/characters/1"');
     expect(html).toContain('href="/characters/2"');
+  });
+});
+
+// ─── Collab submit indicators (#521) ─────────────────────────────────────────
+// On an in-editing collab, each member reads "✓ submitted" or "drafting" from
+// has_submitted. A live (submitted) collab and solo/duel praxes stay clean.
+
+describe("MemberByline submit state (#521)", () => {
+  const ADA_SUBMITTED = member(1, "Ada", "2026-01-03T00:00:00Z", true);
+  const BETH_DRAFTING = member(2, "Beth", "2026-01-01T00:00:00Z", false);
+
+  it("marks each member submitted / drafting from has_submitted while in editing", () => {
+    expect(bylineText([ADA_SUBMITTED, BETH_DRAFTING], "in_progress")).toBe(
+      "Ada✓ submitted & Bethdrafting",
+    );
+  });
+
+  it("renders no submit markers once the collab is live (submitted)", () => {
+    const text = bylineText([ADA_SUBMITTED, BETH_DRAFTING], "submitted");
+    expect(text).not.toContain("submitted");
+    expect(text).not.toContain("drafting");
+  });
+
+  it("leaves a solo (single-member) praxis unmarked even while in editing", () => {
+    const text = bylineText([ADA_SUBMITTED], "in_progress");
+    expect(text).toBe("Ada");
   });
 });

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -61,8 +61,12 @@ export function MemberByline({
   /** Optional wrapper for each display name (e.g. Singularity's `NODE_` prefix). */
   renderName?: (name: string) => ReactNode
 }) {
+  const { t } = useTranslation('praxis')
   const members = orderedMembers(praxis)
   const sepStyle = separatorStyle ?? linkStyle
+  // Per-member submit state only reads meaningfully mid-lifecycle on a collab
+  // (>1 member, still in editing). A solo/duel praxis or a live one stays clean.
+  const showSubmitState = members.length > 1 && praxis.status === 'in_progress'
 
   return (
     <span
@@ -89,6 +93,22 @@ export function MemberByline({
             >
               {renderName ? renderName(name) : name}
             </Link>
+            {showSubmitState && (
+              <span
+                className="eyebrow"
+                style={{
+                  marginLeft: 4,
+                  fontSize: 8,
+                  color: member.has_submitted
+                    ? 'var(--color-success)'
+                    : 'var(--color-text-tertiary)',
+                }}
+              >
+                {member.has_submitted
+                  ? t('detail.byline.submitted')
+                  : t('detail.byline.drafting')}
+              </span>
+            )}
           </span>
         )
       })}
@@ -201,12 +221,26 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
           </div>
         </div>
       )}
+      {/* A collab that has been proposed for publish (submit_proposed_at set)
+          is still in editing, but the neutral "IN EDITING" copy under-reports
+          it — swap in the pending-publish wording (ADR-0012). */}
       {praxis.status === 'in_progress' && (
         <div style={{ background: 'rgba(245,158,11,0.1)', border: '2px solid rgba(245,158,11,0.3)', borderRadius: 8, padding: '8px 14px', marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span className="eyebrow">{t('detail.banners.inEditingLabel')}</span>
-          <span className="font-body" style={{ fontSize: 11, color: 'var(--color-warning)', fontWeight: 700 }}>
-            {t('detail.banners.inEditingBody')}
-          </span>
+          {praxis.submit_proposed_at != null ? (
+            <>
+              <span className="eyebrow">{t('detail.banners.pendingPublishLabel')}</span>
+              <span className="font-body" style={{ fontSize: 11, color: 'var(--color-warning)', fontWeight: 700 }}>
+                {t('detail.banners.pendingPublishBody')}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="eyebrow">{t('detail.banners.inEditingLabel')}</span>
+              <span className="font-body" style={{ fontSize: 11, color: 'var(--color-warning)', fontWeight: 700 }}>
+                {t('detail.banners.inEditingBody')}
+              </span>
+            </>
+          )}
         </div>
       )}
       {praxis.moderation_status === 'failed' && praxis.admin_note && (
@@ -230,8 +264,20 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
 
 export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
-  const { praxis, isOwner, withdrawing, showWithdrawConfirm, setShowWithdrawConfirm, withdrawError, handleWithdraw, handleResubmit } = state
+  const { praxis, isOwner, user, withdrawing, showWithdrawConfirm, setShowWithdrawConfirm, withdrawError, handleWithdraw, handleResubmit } = state
   if (!praxis || !isOwner) return null
+
+  // On a collab that hasn't gone live yet, a member who has already submitted
+  // waits on their co-authors — swap their green Submit control for a waiting
+  // state (ADR-0012). Editing stays available via the edit link above.
+  const viewerCharacterId = user?.character?.id
+  const viewerMember =
+    viewerCharacterId != null
+      ? praxis.members.find((member) => member.character_id === viewerCharacterId)
+      : undefined
+  const isCollab = praxis.members.length > 1
+  const viewerSubmittedWaiting =
+    isCollab && praxis.status === 'in_progress' && viewerMember?.has_submitted === true
 
   return (
     <div>
@@ -240,13 +286,19 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
           {t('detail.owner.edit')}
         </Link>
         {praxis.status === 'in_progress' ? (
-          <button
-            onClick={handleResubmit}
-            disabled={withdrawing}
-            style={{ background: 'var(--color-success)', color: 'var(--color-text-on-accent)', fontFamily: "'Courier Prime', monospace", fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.08em', padding: '4px 12px', border: 'none', cursor: 'pointer', borderRadius: 0, opacity: withdrawing ? 0.5 : 1 }}
-          >
-            {withdrawing ? t('detail.owner.submitting') : t('detail.owner.submit')}
-          </button>
+          viewerSubmittedWaiting ? (
+            <span className="eyebrow" style={{ color: 'var(--color-success)', fontWeight: 700 }}>
+              {t('detail.owner.submittedWaiting')}
+            </span>
+          ) : (
+            <button
+              onClick={handleResubmit}
+              disabled={withdrawing}
+              style={{ background: 'var(--color-success)', color: 'var(--color-text-on-accent)', fontFamily: "'Courier Prime', monospace", fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.08em', padding: '4px 12px', border: 'none', cursor: 'pointer', borderRadius: 0, opacity: withdrawing ? 0.5 : 1 }}
+            >
+              {withdrawing ? t('detail.owner.submitting') : t('detail.owner.submit')}
+            </button>
+          )
         ) : !showWithdrawConfirm ? (
           <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
             {t('detail.owner.unsubmit')}


### PR DESCRIPTION
Renders the collab pre-publish lifecycle (Drafting → Pending publish → Live) that already flowed from the backend but nothing displayed.

## Changes
- **Detail (`praxisDetail/shared.tsx`)**: per-member `✓ submitted`/`drafting` byline markers; `Pending publish — waiting on co-authors` banner when `submit_proposed_at` set; owner `You've submitted — waiting on co-authors` state (edit affordance + ADR-0012 consensus reset kept).
- **List card (`CollaborationCard.tsx`)**: small `pending` chip when `submit_proposed_at != null`.
- **Composer (`editPraxis/archetypes/controls.tsx`)**: `✓ submitted` marker per accepted member.
- Solo/duel praxes unaffected.

## Backend note
The issue said frontend-only, but deliverable #2's chip reads `submit_proposed_at`, which `PraxisCardOut` didn't emit — the chip would be permanently inert. Added the one-line, behavior-neutral field to the schema + card builder so the chip works. No logic change.

## i18n / tests
- All new strings are catalog keys (common/praxis/forms.json), no raw JSX literals.
- Vitest: new `collabSubmitIndicators` test + extended `memberByline` test; praxisDetail + components suites green (116 tests). Backend `test_praxes` green (64).

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
