### PR TITLE
Add useResource hook for read-once pages (#491)

### DIFF
--- a/frontend/src/hooks/__tests__/useResource.test.ts
+++ b/frontend/src/hooks/__tests__/useResource.test.ts
@@ -1,0 +1,51 @@
+/**
+ * #491 — the read-once fetch state machine. Tests the extracted pure
+ * orchestration (`runResource`): loading→data and loading→error transitions,
+ * error-cleared-first on every run (the "clears on refetch" guarantee), and
+ * the cancel guard that drops a resolved/rejected result mid-flight.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { runResource } from '../useResource'
+
+function handlers() {
+  const calls: string[] = []
+  return {
+    calls,
+    onStart: vi.fn(() => calls.push('start')),
+    onData: vi.fn((d: unknown) => calls.push(`data:${d}`)),
+    onError: vi.fn((e: Error) => calls.push(`error:${e.message}`)),
+    onSettle: vi.fn(() => calls.push('settle')),
+  }
+}
+
+describe('runResource', () => {
+  it('success: start → data → settle, in order', async () => {
+    const h = handlers()
+    await runResource(() => Promise.resolve(42), h)
+    expect(h.calls).toEqual(['start', 'data:42', 'settle'])
+    expect(h.onError).not.toHaveBeenCalled()
+  })
+
+  it('failure: start → error → settle, and onStart runs first so a prior error is cleared before the new attempt', async () => {
+    const h = handlers()
+    await runResource(() => Promise.reject(new Error('boom')), h)
+    expect(h.calls).toEqual(['start', 'error:boom', 'settle'])
+    expect(h.onData).not.toHaveBeenCalled()
+  })
+
+  it('normalizes a non-Error rejection into an Error', async () => {
+    const h = handlers()
+    await runResource(() => Promise.reject('nope'), h)
+    expect(h.onError).toHaveBeenCalledOnce()
+    expect(h.onError.mock.calls[0][0]).toBeInstanceOf(Error)
+    expect(h.onError.mock.calls[0][0].message).toBe('nope')
+  })
+
+  it('cancel guard: onStart still fires, but onData/onSettle are skipped once cancelled', async () => {
+    const h = handlers()
+    await runResource(() => Promise.resolve(1), h, () => true)
+    expect(h.calls).toEqual(['start'])
+    expect(h.onData).not.toHaveBeenCalled()
+    expect(h.onSettle).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useResource.ts
+++ b/frontend/src/hooks/useResource.ts
@@ -79,7 +79,6 @@ export function useResource<T>(
     }
     // fetchFn is an inline closure per call site; `deps` is the explicit re-run
     // key (mirrors the pages this replaces).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...deps, reloadNonce])
 
   return { data, loading, error, refetch }

--- a/frontend/src/hooks/useResource.ts
+++ b/frontend/src/hooks/useResource.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState, type DependencyList } from 'react'
+
+export interface UseResourceResult<T> {
+  data: T | null
+  loading: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+export interface ResourceHandlers<T> {
+  onStart: () => void
+  onData: (data: T) => void
+  onError: (error: Error) => void
+  onSettle: () => void
+}
+
+/**
+ * Pure async orchestration behind {@link useResource}, extracted so the state
+ * machine is testable without a DOM (the repo tests hooks via extracted pure
+ * functions). Order: `onStart` first (flip loading, clear prior error), then
+ * exactly one of `onData` / `onError`, then `onSettle` — all after-fetch
+ * callbacks skipped once `isCancelled()` is true (dep change / unmount race).
+ */
+export async function runResource<T>(
+  fetchFn: () => Promise<T>,
+  handlers: ResourceHandlers<T>,
+  isCancelled: () => boolean = () => false,
+): Promise<void> {
+  handlers.onStart()
+  try {
+    const result = await fetchFn()
+    if (!isCancelled()) handlers.onData(result)
+  } catch (err: unknown) {
+    if (!isCancelled()) {
+      handlers.onError(err instanceof Error ? err : new Error(String(err)))
+    }
+  } finally {
+    if (!isCancelled()) handlers.onSettle()
+  }
+}
+
+/**
+ * Fetch state for a simple read-once page: runs `fetchFn` on mount, whenever
+ * `deps` change, and on `refetch()`. Every run flips `loading` true and clears
+ * any prior `error` first — the correct-on-edge default several call sites
+ * currently forget.
+ *
+ * `error` is the raw Error; each page renders its own copy (e.g. via
+ * `extractError`). No enabled/skip guard, no error-swallow mode, no
+ * pagination — a site that needs those stays hand-rolled.
+ */
+export function useResource<T>(
+  fetchFn: () => Promise<T>,
+  deps: DependencyList,
+): UseResourceResult<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+  const [reloadNonce, setReloadNonce] = useState(0)
+  const refetch = useCallback(() => setReloadNonce((n) => n + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    void runResource(
+      fetchFn,
+      {
+        onStart: () => {
+          setLoading(true)
+          setError(null)
+        },
+        onData: setData,
+        onError: setError,
+        onSettle: () => setLoading(false),
+      },
+      () => cancelled,
+    )
+    return () => {
+      cancelled = true
+    }
+    // fetchFn is an inline closure per call site; `deps` is the explicit re-run
+    // key (mirrors the pages this replaces).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, reloadNonce])
+
+  return { data, loading, error, refetch }
+}

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -12,9 +12,10 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { getCharacter, type CharacterOut } from "../api/characters";
-import { listPraxes, type PraxisCardOut } from "../api/praxis";
-import { listTasks, type TaskOut } from "../api/tasks";
+import { getCharacter } from "../api/characters";
+import { listPraxes } from "../api/praxis";
+import { listTasks } from "../api/tasks";
+import { useResource } from "../hooks/useResource";
 import {
   listRelationships,
   createRelationship,
@@ -36,38 +37,28 @@ export default function CharacterProfile() {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();
   const gameConfig = useGameConfig();
-  const [character, setCharacter] = useState<CharacterOut | null>(null);
-  const [submissions, setSubmissions] = useState<PraxisCardOut[]>([]);
-  const [proposedTasks, setProposedTasks] = useState<TaskOut[]>([]);
+  const { data, loading, error } = useResource(
+    () => {
+      const cid = Number(id);
+      return Promise.all([
+        getCharacter(cid),
+        listPraxes({ character_id: cid }),
+        listTasks({ created_by: cid }),
+      ]);
+    },
+    [id],
+  );
+  const character = data?.[0] ?? null;
+  const submissions = data?.[1] ?? [];
+  const proposedTasks = data?.[2] ?? [];
   const [relationship, setRelationship] = useState<RelationshipListItem | null>(
     null,
   );
   const [relationshipLoading, setRelationshipLoading] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [fetchError, setFetchError] = useState<string | null>(null);
 
   // Theme the page backdrop to this character's faction (falls back to the
   // global watercolor until loaded / for factions with no backdrop variant).
   useFactionBackdrop(character?.faction_slug);
-
-  useEffect(() => {
-    if (!id) return;
-    const cid = parseInt(id, 10);
-    Promise.all([
-      getCharacter(cid),
-      listPraxes({ character_id: cid }),
-      listTasks({ created_by: cid }),
-    ])
-      .then(([c, s, t]) => {
-        setCharacter(c);
-        setSubmissions(s);
-        setProposedTasks(t);
-      })
-      .catch((err) =>
-        setFetchError(extractError(err, "Couldn't load this character.")),
-      )
-      .finally(() => setLoading(false));
-  }, [id]);
 
   useEffect(() => {
     if (!id || !user?.character) return;
@@ -154,11 +145,11 @@ export default function CharacterProfile() {
 
   if (loading)
     return <div className="py-8 font-body text-muted">{t("states.loading")}</div>;
-  if (fetchError)
+  if (error)
     return (
       <div className="py-8">
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-          {fetchError}{" "}
+          {extractError(error, "Couldn't load this character.")}{" "}
           <button
             onClick={() => window.location.reload()}
             className="underline"

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { getLeaderboard } from '../api/leaderboard'
-import type { CharacterOut } from '../api/auth'
+import { useResource } from '../hooks/useResource'
 import PageTitle from '../components/ui/PageTitle'
 import LevelPill from '../components/ui/LevelPill'
 import { useAuth } from '../auth/AuthContext'
@@ -20,17 +20,9 @@ const RANK_STYLES = [
 export default function Leaderboard() {
   const { t } = useTranslation('common')
   const { user } = useAuth()
-  const [characters, setCharacters] = useState<CharacterOut[]>([])
   const [scoreMode, setScoreMode] = useState<'era' | 'alltime'>('era')
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-
-  useEffect(() => {
-    getLeaderboard({ limit: 50 })
-      .then(setCharacters)
-      .catch((err) => setFetchError(extractError(err, "Couldn't load the leaderboard.")))
-      .finally(() => setLoading(false))
-  }, [])
+  const { data, loading, error } = useResource(() => getLeaderboard({ limit: 50 }), [])
+  const characters = data ?? []
 
   const sorted = [...characters].sort((a, b) =>
     scoreMode === 'era' ? b.score - a.score : b.all_time_score - a.all_time_score
@@ -47,9 +39,9 @@ export default function Leaderboard() {
 
       {loading ? (
         <p className="font-body text-muted">{t('leaderboard.loading')}</p>
-      ) : fetchError ? (
+      ) : error ? (
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-          {fetchError}{' '}
+          {extractError(error, "Couldn't load the leaderboard.")}{' '}
           <button onClick={() => window.location.reload()} className="underline">{t('states.tryRefreshing')}</button>
         </p>
       ) : characters.length === 0 ? (

--- a/frontend/src/pages/Praxes.tsx
+++ b/frontend/src/pages/Praxes.tsx
@@ -1,32 +1,25 @@
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { listPraxes, type PraxisCardOut } from '../api/praxis'
+import { listPraxes } from '../api/praxis'
 import PraxisCard from '../components/PraxisCard'
 import CollaborationCard from '../components/CollaborationCard'
 import PageTitle from '../components/ui/PageTitle'
 import { extractError } from '../utils/errors'
+import { useResource } from '../hooks/useResource'
 
 export default function Praxes() {
   const { t } = useTranslation('praxis')
   const { t: tc } = useTranslation('common')
-  const [soloItems, setSoloItems] = useState<PraxisCardOut[]>([])
-  const [collabItems, setCollabItems] = useState<PraxisCardOut[]>([])
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-
-  useEffect(() => {
-    Promise.all([
-      listPraxes({ type: 'solo', status: 'submitted' }),
-      listPraxes({ type: 'collab', status: 'submitted' }),
-      listPraxes({ type: 'duel', status: 'submitted' }),
-    ])
-      .then(([solo, collab, duel]) => {
-        setSoloItems(solo)
-        setCollabItems([...collab, ...duel])
-      })
-      .catch((err) => setFetchError(extractError(err, "Couldn't load praxes.")))
-      .finally(() => setLoading(false))
-  }, [])
+  const { data, loading, error } = useResource(
+    () =>
+      Promise.all([
+        listPraxes({ type: 'solo', status: 'submitted' }),
+        listPraxes({ type: 'collab', status: 'submitted' }),
+        listPraxes({ type: 'duel', status: 'submitted' }),
+      ]),
+    [],
+  )
+  const soloItems = data ? data[0] : []
+  const collabItems = data ? [...data[1], ...data[2]] : []
 
   const isEmpty = soloItems.length === 0 && collabItems.length === 0
 
@@ -39,9 +32,9 @@ export default function Praxes() {
 
       {loading ? (
         <p className="font-body text-muted">{t('listPage.loading')}</p>
-      ) : fetchError ? (
+      ) : error ? (
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-          {fetchError}{' '}
+          {extractError(error, "Couldn't load praxes.")}{' '}
           <button onClick={() => window.location.reload()} className="underline">{tc('states.tryRefreshing')}</button>
         </p>
       ) : isEmpty ? (

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { listTasks, type TaskOut } from '../api/tasks'
+import { listTasks } from '../api/tasks'
 import { createPraxis } from '../api/praxis'
 import { getFactions, type FactionOut } from '../api/factions'
 import { getGameConfig, type FactionConfigOut } from '../api/gameConfig'
@@ -13,6 +13,7 @@ import FilterLevelNodes from '../components/ui/FilterLevelNodes'
 import { extractError } from '../utils/errors'
 import { useAuth } from '../auth/AuthContext'
 import { computeDisplayPoints } from '../utils/points'
+import { useResource } from '../hooks/useResource'
 
 const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
 
@@ -23,14 +24,11 @@ export default function Tasks() {
   const navigate = useNavigate()
   const characterId = user?.character?.id
 
-  const [tasks, setTasks] = useState<TaskOut[]>([])
   const [factions, setFactions] = useState<FactionOut[]>([])
   const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
   const [status, setStatus] = useState('All')
   const [faction, setFaction] = useState('')
   const [level, setLevel] = useState<number | ''>('')
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
   const [signupMsg, setSignupMsg] = useState<{ id: number; msg: string; ok: boolean } | null>(null)
 
   useEffect(() => {
@@ -40,19 +38,17 @@ export default function Tasks() {
       .catch(() => {})
   }, [])
 
-  useEffect(() => {
-    setLoading(true)
-    setFetchError(null)
-    listTasks({
-      status: status === 'All' ? undefined : status,
-      faction: faction || undefined,
-      level: level === '' ? undefined : level,
-      exclude_character_id: characterId,
-    })
-      .then(setTasks)
-      .catch((err) => setFetchError(extractError(err, "Couldn't load tasks.")))
-      .finally(() => setLoading(false))
-  }, [status, faction, level, characterId])
+  const { data, loading, error } = useResource(
+    () =>
+      listTasks({
+        status: status === 'All' ? undefined : status,
+        faction: faction || undefined,
+        level: level === '' ? undefined : level,
+        exclude_character_id: characterId,
+      }),
+    [status, faction, level, characterId],
+  )
+  const tasks = data ?? []
 
   const handleSignup = async (id: number) => {
     setSignupMsg(null)
@@ -87,9 +83,9 @@ export default function Tasks() {
 
       {loading ? (
         <p className="font-body text-muted">{t('listPage.loading')}</p>
-      ) : fetchError ? (
+      ) : error ? (
         <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-          {fetchError}{' '}
+          {extractError(error, "Couldn't load tasks.")}{' '}
           <button onClick={() => window.location.reload()} className="underline">{tc('states.tryRefreshing')}</button>
         </p>
       ) : tasks.length === 0 ? (


### PR DESCRIPTION
One small hook for the genuinely uniform read-once fetch pattern. Grilled scope (per #491): honest small version, no premature "converge all 12 sites" abstraction.

## Hook
`useResource<T>(fetchFn, deps)` → `{ data, loading, error, refetch }`. Every run flips `loading` true and **clears any prior `error` first** — the correct-on-edge default several sites currently forget. `error` is the raw `Error`; each page renders its own copy.

Async orchestration is extracted into a pure `runResource()` helper so the state machine is unit-testable without a DOM — matching the repo's extract-pure-logic hook-test convention (`useFormFactor` → `formFactorFor`, etc.). No `@testing-library`/`renderHook`/jsdom added.

## Applied to the 4 uniform sites
`Leaderboard`, `Praxes`, `Tasks` (main task read only), `CharacterProfile` (main character read only). Left hand-rolled per the issue: the auth-gated/swallowing bespoke hooks, `Updates` (pagination), `Factions` (secondary fetch), and all `useXxxDetail` hooks.

## Verify
- `runResource` unit test: start→data→settle, start→error→settle (error cleared first), non-Error normalization, cancel guard. 4 pass.
- `tsc --noEmit`: no new errors on changed files.
- vitest `src/hooks src/pages`: 102 pass.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
