### PR TITLE
Crop/rotate/zoom images before upload (#514)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "i18next": "^26.3.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-easy-crop": "^6.2.2",
         "react-i18next": "^17.0.9",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.24.0"
@@ -4161,6 +4162,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4633,6 +4640,19 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-6.2.2.tgz",
+      "integrity": "sha512-b0HOicSvLYoNk1yvZTwjH8sNjF5uD9xLtWrSDnv+fx1dXTbwd8bNLQaP6gjXw//A+tni9Mw5KDmPNOEjKF55NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-i18next": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "i18next": "^26.3.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-easy-crop": "^6.2.2",
     "react-i18next": "^17.0.9",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.24.0"

--- a/frontend/src/components/imageEdit/ImageEditModal.tsx
+++ b/frontend/src/components/imageEdit/ImageEditModal.tsx
@@ -1,0 +1,363 @@
+/**
+ * ImageEditModal (#514) — a client-side edit stage shown before an image is
+ * uploaded. Pick an image → preview + crop + rotate + zoom → on Apply the
+ * cropped/rotated region is drawn to a canvas and handed back as a Blob, which
+ * the caller uploads through the EXISTING upload function. "Use original" skips
+ * the canvas entirely and returns the untouched File.
+ *
+ * One reusable component drives both call sites: praxis media (free-form frame
+ * that follows the image's natural ratio) and character avatars (locked 1:1).
+ *
+ * Modal chrome mirrors LevelUpPopup / InvitationLetterPopup: fixed radial-dim
+ * overlay, role="dialog", Escape closes, the primary action autofocuses, no
+ * focus trap. No literal hex — CSS vars only (CLAUDE.md).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
+import Cropper from 'react-easy-crop'
+import type { Area, MediaSize, Point } from 'react-easy-crop'
+import { useTranslation } from 'react-i18next'
+import {
+  cropOutputSize,
+  effectiveAspect,
+  originalUpload,
+  rotateSize,
+  toRadians,
+} from './imageEditHelpers'
+
+const PAPER = 'var(--color-bg-page)'
+const INK = 'var(--color-text-primary)'
+const MUTED = 'var(--color-text-secondary)'
+const FAINT = 'var(--color-text-tertiary)'
+const BORDER = 'var(--color-border-strong)'
+const FONT_DISPLAY = 'var(--font-display)'
+const FONT_BODY = 'var(--font-body)'
+
+const MIN_ZOOM = 1
+const MAX_ZOOM = 4
+const ZOOM_STEP = 0.01
+const ROTATE_STEP = 90
+
+export interface ImageEditModalProps {
+  /** The picked source image. */
+  file: File
+  /**
+   * Locked crop aspect (e.g. 1 for a square avatar). Omit for free-form: the
+   * frame follows the image's natural ratio and the user adjusts by zoom/pan.
+   */
+  aspect?: number
+  /** Receives the edited image (or the original File, via "use original"). */
+  onConfirm: (blob: Blob) => void
+  /** Dismiss without uploading. */
+  onCancel: () => void
+}
+
+/** Load an <img> from an object URL (canvas source). Not unit-tested (needs DOM). */
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.addEventListener('load', () => resolve(image))
+    image.addEventListener('error', (event) => reject(event))
+    image.src = src
+  })
+}
+
+/**
+ * Draw the rotated image into a bounding-box canvas, slice out the crop rect,
+ * and return it as a Blob. Uses the pure geometry helpers so the sizing math is
+ * tested independently of the canvas. Not itself unit-tested (needs a canvas).
+ */
+async function renderCroppedBlob(
+  src: string,
+  cropArea: Area,
+  rotation: number,
+  mimeType: string,
+): Promise<Blob | null> {
+  const image = await loadImage(src)
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+  if (!context) return null
+
+  const boundingBox = rotateSize(image.width, image.height, rotation)
+  canvas.width = boundingBox.width
+  canvas.height = boundingBox.height
+
+  // Rotate around the bounding-box centre, then draw the image centred.
+  context.translate(boundingBox.width / 2, boundingBox.height / 2)
+  context.rotate(toRadians(rotation))
+  context.translate(-image.width / 2, -image.height / 2)
+  context.drawImage(image, 0, 0)
+
+  // croppedAreaPixels are bounding-box relative — lift that region out.
+  const region = context.getImageData(
+    cropArea.x,
+    cropArea.y,
+    cropArea.width,
+    cropArea.height,
+  )
+  const output = cropOutputSize(cropArea)
+  canvas.width = output.width
+  canvas.height = output.height
+  context.putImageData(region, 0, 0)
+
+  // Keep PNG lossless; everything else (photos) exports as JPEG.
+  const outType = mimeType === 'image/png' ? 'image/png' : 'image/jpeg'
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), outType, 0.92)
+  })
+}
+
+export default function ImageEditModal({
+  file,
+  aspect,
+  onConfirm,
+  onCancel,
+}: ImageEditModalProps) {
+  const { t } = useTranslation('common')
+  const [objectUrl, setObjectUrl] = useState<string | null>(null)
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 })
+  const [zoom, setZoom] = useState(MIN_ZOOM)
+  const [rotation, setRotation] = useState(0)
+  const [naturalAspect, setNaturalAspect] = useState<number | undefined>(undefined)
+  const [applying, setApplying] = useState(false)
+  const croppedAreaRef = useRef<Area | null>(null)
+
+  // Object URL for the Cropper source; revoked on unmount / file change.
+  useEffect(() => {
+    const url = URL.createObjectURL(file)
+    setObjectUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [file])
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onCancel])
+
+  const onCropComplete = useCallback((_area: Area, areaPixels: Area) => {
+    croppedAreaRef.current = areaPixels
+  }, [])
+
+  const onMediaLoaded = useCallback((mediaSize: MediaSize) => {
+    if (mediaSize.naturalHeight > 0) {
+      setNaturalAspect(mediaSize.naturalWidth / mediaSize.naturalHeight)
+    }
+  }, [])
+
+  const rotateBy = (delta: number) =>
+    setRotation((previous) => (previous + delta + 360) % 360)
+
+  const handleApply = async () => {
+    const area = croppedAreaRef.current
+    if (!objectUrl || !area) {
+      // Nothing to slice yet — fall back to the untouched file.
+      onConfirm(originalUpload(file))
+      return
+    }
+    setApplying(true)
+    try {
+      const blob = await renderCroppedBlob(objectUrl, area, rotation, file.type)
+      onConfirm(blob ?? originalUpload(file))
+    } catch {
+      onConfirm(originalUpload(file))
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const frameAspect = effectiveAspect(aspect, naturalAspect)
+
+  const card = (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('imageEdit.dialogAria')}
+      style={cardStyle}
+    >
+      <h2 style={headingStyle}>{t('imageEdit.heading')}</h2>
+
+      {/* Crop surface — react-easy-crop fills this absolutely-positioned box. */}
+      <div style={cropSurfaceStyle}>
+        {objectUrl && (
+          <Cropper
+            image={objectUrl}
+            crop={crop}
+            zoom={zoom}
+            rotation={rotation}
+            aspect={frameAspect}
+            minZoom={MIN_ZOOM}
+            maxZoom={MAX_ZOOM}
+            onCropChange={setCrop}
+            onZoomChange={setZoom}
+            onRotationChange={setRotation}
+            onCropComplete={onCropComplete}
+            onMediaLoaded={onMediaLoaded}
+          />
+        )}
+      </div>
+
+      {/* Zoom */}
+      <label style={controlRowStyle}>
+        <span style={controlLabelStyle}>{t('imageEdit.zoomLabel')}</span>
+        <input
+          type="range"
+          min={MIN_ZOOM}
+          max={MAX_ZOOM}
+          step={ZOOM_STEP}
+          value={zoom}
+          aria-label={t('imageEdit.zoomLabel')}
+          onChange={(event) => setZoom(Number(event.target.value))}
+          style={{ flex: 1 }}
+        />
+      </label>
+
+      {/* Rotate — 90° steps cover sideways phone photos. */}
+      <div style={controlRowStyle}>
+        <span style={controlLabelStyle}>{t('imageEdit.rotateLabel')}</span>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" onClick={() => rotateBy(-ROTATE_STEP)} style={ghostButtonStyle}>
+            {t('imageEdit.rotateLeft')}
+          </button>
+          <button type="button" onClick={() => rotateBy(ROTATE_STEP)} style={ghostButtonStyle}>
+            {t('imageEdit.rotateRight')}
+          </button>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div style={actionRowStyle}>
+        <button
+          type="button"
+          autoFocus
+          onClick={() => void handleApply()}
+          disabled={applying}
+          style={{ ...primaryButtonStyle, cursor: applying ? 'wait' : 'pointer' }}
+        >
+          {applying ? t('imageEdit.applying') : t('imageEdit.apply')}
+        </button>
+        <button
+          type="button"
+          onClick={() => onConfirm(originalUpload(file))}
+          disabled={applying}
+          style={ghostButtonStyle}
+        >
+          {t('imageEdit.useOriginal')}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={applying}
+          style={dismissButtonStyle}
+        >
+          {t('imageEdit.cancel')}
+        </button>
+      </div>
+    </div>
+  )
+
+  return (
+    <div onClick={onCancel} style={overlayStyle}>
+      <div onClick={(event) => event.stopPropagation()}>{card}</div>
+    </div>
+  )
+}
+
+// --- styles (token-driven) --------------------------------------------------
+
+const overlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 24,
+  zIndex: 1000,
+  background: 'radial-gradient(ellipse at 50% 42%, rgba(26,18,9,0.30), rgba(26,18,9,0.66))',
+}
+const cardStyle: CSSProperties = {
+  width: 420,
+  maxWidth: '100%',
+  boxSizing: 'border-box',
+  background: PAPER,
+  border: `1px solid ${BORDER}`,
+  borderRadius: 12,
+  padding: '24px 24px 20px',
+  boxShadow: '0 18px 46px -14px rgba(26,18,9,0.5)',
+  fontFamily: FONT_BODY,
+}
+const headingStyle: CSSProperties = {
+  fontFamily: FONT_DISPLAY,
+  fontStyle: 'italic',
+  fontWeight: 600,
+  fontSize: 22,
+  lineHeight: 1.1,
+  color: INK,
+  margin: '0 0 16px',
+}
+const cropSurfaceStyle: CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: 300,
+  background: 'var(--color-bg-surface)',
+  borderRadius: 8,
+  overflow: 'hidden',
+  marginBottom: 16,
+}
+const controlRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  marginBottom: 12,
+}
+const controlLabelStyle: CSSProperties = {
+  fontFamily: FONT_BODY,
+  fontSize: 9,
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: FAINT,
+  flex: 'none',
+  width: 56,
+}
+const actionRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  marginTop: 18,
+}
+const primaryButtonStyle: CSSProperties = {
+  flex: 1,
+  fontFamily: FONT_BODY,
+  textTransform: 'uppercase',
+  letterSpacing: '0.12em',
+  fontSize: 11,
+  fontWeight: 700,
+  padding: '0.6rem 1.2rem',
+  border: 'none',
+  background: INK,
+  color: PAPER,
+}
+const ghostButtonStyle: CSSProperties = {
+  fontFamily: FONT_BODY,
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+  fontSize: 10,
+  padding: '0.5rem 0.9rem',
+  border: `1px solid ${BORDER}`,
+  background: 'transparent',
+  color: INK,
+  cursor: 'pointer',
+}
+const dismissButtonStyle: CSSProperties = {
+  fontFamily: FONT_BODY,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  fontSize: 10,
+  padding: '0.5rem 0.6rem',
+  border: 'none',
+  background: 'transparent',
+  color: MUTED,
+  cursor: 'pointer',
+}

--- a/frontend/src/components/imageEdit/__tests__/imageEditHelpers.test.ts
+++ b/frontend/src/components/imageEdit/__tests__/imageEditHelpers.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure image-edit helpers (#514). No jsdom/canvas in this repo (see
+ * vite.config.ts), so we test the geometry + decision logic directly and leave
+ * the canvas drawing (ImageEditModal.renderCroppedBlob) to manual/e2e.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  AVATAR_ASPECT,
+  blobToFile,
+  cropOutputSize,
+  effectiveAspect,
+  isImageFile,
+  originalUpload,
+  partitionByEditability,
+  rotateSize,
+} from '../imageEditHelpers'
+
+describe('rotateSize — cropped-canvas bounding box', () => {
+  it('is unchanged at 0°', () => {
+    expect(rotateSize(100, 50, 0)).toEqual({ width: 100, height: 50 })
+  })
+
+  it('swaps width/height at 90°', () => {
+    const box = rotateSize(100, 50, 90)
+    expect(box.width).toBeCloseTo(50)
+    expect(box.height).toBeCloseTo(100)
+  })
+
+  it('swaps width/height at 270° too', () => {
+    const box = rotateSize(100, 50, 270)
+    expect(box.width).toBeCloseTo(50)
+    expect(box.height).toBeCloseTo(100)
+  })
+
+  it('is unchanged at 180°', () => {
+    const box = rotateSize(100, 50, 180)
+    expect(box.width).toBeCloseTo(100)
+    expect(box.height).toBeCloseTo(50)
+  })
+})
+
+describe('cropOutputSize — final canvas rect', () => {
+  it('rounds the crop rect to integer pixels', () => {
+    expect(cropOutputSize({ width: 199.4, height: 100.6 })).toEqual({
+      width: 199,
+      height: 101,
+    })
+  })
+
+  it('mirrors the crop rect dimensions given whole numbers', () => {
+    expect(cropOutputSize({ width: 640, height: 480 })).toEqual({
+      width: 640,
+      height: 480,
+    })
+  })
+})
+
+describe('effectiveAspect — avatar locks 1:1, praxis is free-form', () => {
+  it('locks to the avatar aspect even for a wide image', () => {
+    expect(effectiveAspect(AVATAR_ASPECT, 1.78)).toBe(1)
+  })
+
+  it('AVATAR_ASPECT is square', () => {
+    expect(AVATAR_ASPECT).toBe(1)
+  })
+
+  it('follows the natural ratio when unlocked (free-form praxis)', () => {
+    expect(effectiveAspect(undefined, 1.5)).toBe(1.5)
+  })
+
+  it('falls back to square before the media reports its size', () => {
+    expect(effectiveAspect(undefined, undefined)).toBe(1)
+  })
+})
+
+describe('isImageFile / partitionByEditability — which files open the modal', () => {
+  it('treats an image file as editable', () => {
+    expect(isImageFile({ type: 'image/png' })).toBe(true)
+    expect(isImageFile({ type: 'image/jpeg' })).toBe(true)
+  })
+
+  it('does not treat video or audio as editable', () => {
+    expect(isImageFile({ type: 'video/mp4' })).toBe(false)
+    expect(isImageFile({ type: 'audio/mpeg' })).toBe(false)
+  })
+
+  it('an image goes to the modal queue, a video uploads directly', () => {
+    const image = { type: 'image/png', name: 'shot.png' }
+    const video = { type: 'video/mp4', name: 'clip.mp4' }
+    const { toEdit, toUploadDirect } = partitionByEditability([image, video])
+    expect(toEdit).toEqual([image])
+    expect(toUploadDirect).toEqual([video])
+  })
+})
+
+describe('originalUpload — "use original" returns the source File unchanged', () => {
+  it('hands back the exact same File reference', () => {
+    const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })
+    expect(originalUpload(file)).toBe(file)
+  })
+})
+
+describe('blobToFile — wrapping an edited blob for upload', () => {
+  it('passes a File through untouched (the use-original path)', () => {
+    const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })
+    expect(blobToFile(file, 'photo.jpg')).toBe(file)
+  })
+
+  it('names a jpeg blob from the original base name', () => {
+    const blob = new Blob(['bytes'], { type: 'image/jpeg' })
+    const file = blobToFile(blob, 'photo.png')
+    expect(file.name).toBe('photo.jpg')
+    expect(file.type).toBe('image/jpeg')
+  })
+
+  it('keeps png lossless with a .png name', () => {
+    const blob = new Blob(['bytes'], { type: 'image/png' })
+    expect(blobToFile(blob, 'sketch.png').name).toBe('sketch.png')
+  })
+})

--- a/frontend/src/components/imageEdit/imageEditHelpers.ts
+++ b/frontend/src/components/imageEdit/imageEditHelpers.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure helpers for the client-side image edit stage (#514).
+ *
+ * Everything here is DOM-free so it can be unit-tested without a canvas or
+ * jsdom (this repo runs Vitest in the `node` environment — see vite.config.ts).
+ * The canvas drawing itself lives in ImageEditModal.tsx; only the geometry and
+ * the decision logic it depends on live here.
+ */
+import type { Area, Size } from 'react-easy-crop'
+
+/** Locked square aspect for avatars — a portrait crop is always 1:1 (#514). */
+export const AVATAR_ASPECT = 1
+
+/** Degrees → radians. */
+export function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180
+}
+
+/**
+ * Bounding box of a `width`×`height` image rotated by `rotation` degrees. The
+ * cropped-canvas pipeline draws the rotated image into a canvas this size
+ * before slicing out the crop rect, so react-easy-crop's `croppedAreaPixels`
+ * (which are bounding-box relative) line up.
+ */
+export function rotateSize(width: number, height: number, rotation: number): Size {
+  const rad = toRadians(rotation)
+  return {
+    width: Math.abs(Math.cos(rad) * width) + Math.abs(Math.sin(rad) * height),
+    height: Math.abs(Math.sin(rad) * width) + Math.abs(Math.cos(rad) * height),
+  }
+}
+
+/**
+ * The final output canvas dimensions for a crop rect — integer pixels, since a
+ * canvas can't be a fractional size. This is the "cropped-canvas pixel rect"
+ * the modal renders the confirmed blob at.
+ */
+export function cropOutputSize(cropArea: Pick<Area, 'width' | 'height'>): Size {
+  return {
+    width: Math.round(cropArea.width),
+    height: Math.round(cropArea.height),
+  }
+}
+
+/**
+ * The aspect the crop frame should lock to. A caller-supplied `lockAspect`
+ * (e.g. 1 for a square avatar) always wins; otherwise the frame follows the
+ * image's natural ratio so nothing is force-cropped (the "free-form" praxis
+ * case). Falls back to square before the media reports its size.
+ */
+export function effectiveAspect(
+  lockAspect: number | undefined,
+  naturalAspect: number | undefined,
+): number {
+  if (lockAspect && lockAspect > 0) return lockAspect
+  if (naturalAspect && naturalAspect > 0) return naturalAspect
+  return 1
+}
+
+/** True when a picked file is an image — only images get the edit modal. */
+export function isImageFile(file: { type: string }): boolean {
+  return file.type.startsWith('image/')
+}
+
+/**
+ * Split picked files into the ones that open the edit modal (images) and the
+ * ones that upload straight through (video/audio). Keeps original order within
+ * each bucket so the sequential image queue stays predictable.
+ */
+export function partitionByEditability<T extends { type: string }>(
+  files: readonly T[],
+): { toEdit: T[]; toUploadDirect: T[] } {
+  const toEdit: T[] = []
+  const toUploadDirect: T[] = []
+  for (const file of files) {
+    if (isImageFile(file)) toEdit.push(file)
+    else toUploadDirect.push(file)
+  }
+  return { toEdit, toUploadDirect }
+}
+
+/**
+ * "Use original" outcome: the upload is the untouched source File, byte-for-byte
+ * (a File already IS a Blob). Extracted so the identity is unit-testable.
+ */
+export function originalUpload(file: File): Blob {
+  return file
+}
+
+/**
+ * Wrap an edited canvas Blob as an uploadable File, keeping the original base
+ * name so the server records a sensible filename. A Blob that is already a File
+ * ("use original") passes straight through untouched.
+ */
+export function blobToFile(blob: Blob, originalName: string): File {
+  if (blob instanceof File) return blob
+  const extension = blob.type === 'image/png' ? 'png' : 'jpg'
+  const base = originalName.replace(/\.[^./\\]+$/, '') || 'image'
+  return new File([blob], `${base}.${extension}`, { type: blob.type })
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -203,6 +203,18 @@
       "fallbackTaskTitle": "a task"
     }
   },
+  "imageEdit": {
+    "heading": "Adjust your image",
+    "dialogAria": "Edit image before uploading",
+    "zoomLabel": "Zoom",
+    "rotateLabel": "Rotate",
+    "rotateLeft": "Rotate left",
+    "rotateRight": "Rotate right",
+    "apply": "Apply",
+    "applying": "Applying…",
+    "useOriginal": "Use original",
+    "cancel": "Cancel"
+  },
   "voteStamps": {
     "a-start": "a start",
     "solid": "solid",

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -7,6 +7,8 @@ import { getInvitedFactions } from '../api/me'
 import { factionCssVar, factionName } from '../utils/factions'
 import { extractError } from '../utils/errors'
 import CredentialCard from '../components/CredentialCard'
+import ImageEditModal from '../components/imageEdit/ImageEditModal'
+import { AVATAR_ASPECT, blobToFile } from '../components/imageEdit/imageEditHelpers'
 
 /**
  * Adaptive Character Creation (#273, ADR-0019). One screen, two renderings: the
@@ -34,6 +36,7 @@ export default function CreateCharacter() {
   const [invited, setInvited] = useState<string[]>([])
   const [avatarFile, setAvatarFile] = useState<File | null>(null)
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
+  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -44,14 +47,23 @@ export default function CreateCharacter() {
 
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null
-    if (file && file.size > MAX_AVATAR_SIZE) {
+    e.target.value = ''
+    if (!file) return
+    if (file.size > MAX_AVATAR_SIZE) {
       setError('Portrait must be under 10 MB.')
-      e.target.value = ''
       return
     }
     setError(null)
+    // Crop/rotate to a square before it becomes the portrait (#514).
+    setAvatarSource(file)
+  }
+
+  const handleAvatarConfirm = (blob: Blob) => {
+    const source = avatarSource
+    const file = blobToFile(blob, source?.name ?? 'avatar')
     setAvatarFile(file)
-    setAvatarPreview(file ? URL.createObjectURL(file) : null)
+    setAvatarPreview(URL.createObjectURL(file))
+    setAvatarSource(null)
   }
 
   const trimmedName = displayName.trim()
@@ -194,6 +206,17 @@ export default function CreateCharacter() {
           />
         </div>
       </div>
+
+      {/* Portrait crop/rotate — locked square (#514). */}
+      {avatarSource && (
+        <ImageEditModal
+          key={`${avatarSource.name}-${avatarSource.lastModified}`}
+          file={avatarSource}
+          aspect={AVATAR_ASPECT}
+          onConfirm={handleAvatarConfirm}
+          onCancel={() => setAvatarSource(null)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -6,6 +6,8 @@ import { useAuth } from '../auth/AuthContext'
 import { extractError } from '../utils/errors'
 import { mediaUrl } from '../utils/media'
 import DefaultSigil from '../components/cards/DefaultSigil'
+import ImageEditModal from '../components/imageEdit/ImageEditModal'
+import { AVATAR_ASPECT, blobToFile } from '../components/imageEdit/imageEditHelpers'
 
 /**
  * Edit Character — themed in the spectrum default skin for EVERYONE, regardless
@@ -41,6 +43,7 @@ export default function EditCharacter() {
   const [bio, setBio] = useState('')
   const [location, setLocation] = useState('')
   const [avatarFile, setAvatarFile] = useState<File | null>(null)
+  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
@@ -51,13 +54,20 @@ export default function EditCharacter() {
 
   const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0] || null
-    if (f && f.size > MAX_AVATAR_SIZE) {
+    e.target.value = ''
+    if (!f) return
+    if (f.size > MAX_AVATAR_SIZE) {
       setAvatarError('Avatar must be under 10 MB.')
-      e.target.value = ''
       return
     }
     setAvatarError('')
-    setAvatarFile(f)
+    // Crop/rotate to a square before it becomes the avatar (#514).
+    setAvatarSource(f)
+  }
+
+  const handleAvatarConfirm = (blob: Blob) => {
+    setAvatarFile(blobToFile(blob, avatarSource?.name ?? 'avatar'))
+    setAvatarSource(null)
   }
 
   useEffect(() => {
@@ -348,6 +358,17 @@ export default function EditCharacter() {
           </button>
         </div>
       </form>
+
+      {/* Avatar crop/rotate — locked square (#514). */}
+      {avatarSource && (
+        <ImageEditModal
+          key={`${avatarSource.name}-${avatarSource.lastModified}`}
+          file={avatarSource}
+          aspect={AVATAR_ASPECT}
+          onConfirm={handleAvatarConfirm}
+          onCancel={() => setAvatarSource(null)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -8,6 +8,7 @@
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PageTitle from "../components/ui/PageTitle";
+import ImageEditModal from "../components/imageEdit/ImageEditModal";
 import { pickVariant } from "../utils/factionDispatch";
 import {
   useEditPraxis,
@@ -70,6 +71,17 @@ export default function EditPraxis() {
     <>
       <PageTitle title="Edit Praxis" />
       <Archetype state={state} />
+      {/* Praxis images crop/rotate in place before upload (#514), free-form so
+          nothing is force-cropped. Sequential: keyed on identity so each queued
+          image gets a fresh modal. */}
+      {state.pendingImage && (
+        <ImageEditModal
+          key={`${state.pendingImage.name}-${state.pendingImage.lastModified}`}
+          file={state.pendingImage}
+          onConfirm={(blob) => void state.confirmImageEdit(blob)}
+          onCancel={state.cancelImageEdit}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -38,6 +38,10 @@ import { listCharacters, type CharacterOut } from "../../api/characters";
 import { listMetatasks } from "../../api/metaTasks";
 import { useAuth } from "../../auth/AuthContext";
 import { extractError } from "../../utils/errors";
+import {
+  blobToFile,
+  partitionByEditability,
+} from "../../components/imageEdit/imageEditHelpers";
 import i18n from "../../i18n";
 
 export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
@@ -64,6 +68,13 @@ export interface EditPraxisState {
   fileError: string;
   handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   removeMedia: (item: MediaItemOut) => Promise<void>;
+
+  // Image edit stage (#514) — picked images pass through ImageEditModal one at a
+  // time before upload; video/audio skip it. `pendingImage` is the file the modal
+  // is currently editing (null when the queue is empty).
+  pendingImage: File | null;
+  confirmImageEdit: (blob: Blob) => Promise<void>;
+  cancelImageEdit: () => void;
 
   // Mode switching
   switchingMode: PraxisType | null;
@@ -175,6 +186,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [fileError, setFileError] = useState("");
+  // Picked images awaiting the edit modal, oldest first (#514).
+  const [imageEditQueue, setImageEditQueue] = useState<File[]>([]);
 
   const [metaTasks, setMetaTasks] = useState<TaskOut[]>([]);
   const [appliedMetatasks, setAppliedMetatasks] = useState<Set<number>>(
@@ -351,11 +364,12 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       const valid = incoming.filter((f) => f.size <= MAX_FILE_SIZE);
       event.target.value = "";
       if (!idParam || valid.length === 0) return;
-      // Upload immediately so a draft's media persists without a manual save
-      // (the Save Draft button was removed in #297; autosave covers title/body,
-      // and media now lands the moment it's picked — instant visual feedback too).
+      // Images get the crop/rotate edit stage first (#514); video/audio upload
+      // straight through. Uploading immediately keeps a draft's media persisted
+      // without a manual save (autosave covers title/body only; #297).
+      const { toEdit, toUploadDirect } = partitionByEditability(valid);
       const praxisId = parseInt(idParam, 10);
-      for (const file of valid) {
+      for (const file of toUploadDirect) {
         try {
           const uploaded = await uploadPraxisMedia(praxisId, file);
           setMedia((previous) => [...previous, uploaded]);
@@ -368,9 +382,43 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
           );
         }
       }
+      // Queue images for the modal; they're edited + uploaded one at a time.
+      if (toEdit.length > 0) {
+        setImageEditQueue((previous) => [...previous, ...toEdit]);
+      }
     },
     [idParam],
   );
+
+  // ---- Image edit stage (#514): edit → upload → advance the queue ----
+  const pendingImage = imageEditQueue[0] ?? null;
+
+  const confirmImageEdit = useCallback(
+    async (blob: Blob) => {
+      const current = imageEditQueue[0];
+      if (!idParam || !current) return;
+      const praxisId = parseInt(idParam, 10);
+      const file = blobToFile(blob, current.name);
+      try {
+        const uploaded = await uploadPraxisMedia(praxisId, file);
+        setMedia((previous) => [...previous, uploaded]);
+      } catch (err) {
+        setError(
+          extractError(
+            err,
+            i18n.t("forms:editPraxis.errors.upload", { name: current.name }),
+          ),
+        );
+      } finally {
+        setImageEditQueue((previous) => previous.slice(1));
+      }
+    },
+    [idParam, imageEditQueue],
+  );
+
+  const cancelImageEdit = useCallback(() => {
+    setImageEditQueue((previous) => previous.slice(1));
+  }, []);
 
   const removeMedia = useCallback(
     async (item: MediaItemOut) => {
@@ -769,6 +817,10 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     fileError,
     handleFileChange,
     removeMedia,
+
+    pendingImage,
+    confirmImageEdit,
+    cancelImageEdit,
 
     switchingMode,
     changeMode,


### PR DESCRIPTION
A client-side crop/rotate/zoom edit stage before image upload, using `react-easy-crop` (`^6.2.2`). Backends unchanged — the confirmed canvas `Blob` uploads via the existing `uploadPraxisMedia` / `uploadCharacterAvatar`.

## What
- **`ImageEditModal`** (`components/imageEdit/`): react-easy-crop surface + zoom + 90° rotate buttons + "use original" skip; confirm renders the edited region to a canvas `Blob`. Reuses the LevelUpPopup / invitation-letter popup chrome (overlay, `role="dialog"`, Escape, autofocus, CSS-var tokens only).
- **Praxis media** (`editPraxis`): image picks open the modal (free-form aspect) and run **sequentially**; video/audio pass through immediately, unchanged.
- **Avatars** (`CreateCharacter` / `EditCharacter`): modal locks **1:1**.

## Tests
DOM-free crop geometry + is-image/partition helpers extracted to `imageEditHelpers.ts` and unit-tested (17 tests). The repo test env has no jsdom/canvas, so canvas rendering itself isn't unit-tested — no jsdom/canvas deps added. `vitest`: 25 pass. `tsc`: 0 new errors.

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
