### PR TITLE
Markdown toolbar + remark-gfm rendering (#513)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "react-dom": "^18.3.1",
         "react-i18next": "^17.0.9",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.24.0"
+        "react-router-dom": "^6.24.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.49.0",
@@ -3435,6 +3436,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3442,6 +3453,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -3462,6 +3501,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3674,6 +3814,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -4754,6 +5015,24 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -4781,6 +5060,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^17.0.9",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.24.0"
+    "react-router-dom": "^6.24.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -109,6 +109,20 @@
       "cancelChallengeAria": "cancel challenge",
       "rescindInviteAria": "rescind invite to {{name}}"
     },
+    "toolbar": {
+      "label": "formatting",
+      "bold": "bold",
+      "italic": "italic",
+      "strikethrough": "strikethrough",
+      "heading": "heading",
+      "unorderedList": "bulleted list",
+      "orderedList": "numbered list",
+      "link": "link",
+      "blockquote": "quote",
+      "inlineCode": "inline code",
+      "codeBlock": "code block",
+      "table": "table"
+    },
     "dropTask": "drop task",
     "na": {
       "masthead": "casual proof board",

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -11,6 +11,8 @@ import LevelPill from "../../../components/ui/LevelPill";
 import { factionCssVar, factionName } from "../../../utils/factions";
 import type { PraxisType } from "../../../api/praxis";
 import MarkdownPreview from "../blocks/MarkdownPreview";
+import { applyMarkdown } from "../blocks/markdownToolbar";
+import type { MarkdownCommand } from "../blocks/markdownToolbar";
 import type { EditPraxisState } from "../useEditPraxis";
 
 export interface InviteSearchSkin {
@@ -447,7 +449,48 @@ export interface BodyTextareaSkin {
   textareaStyle: CSSProperties;
   rows?: number;
   placeholder?: string;
+  /** Optional override for the toolbar wrapper (e.g. archetype spacing). */
+  toolbarStyle?: CSSProperties;
+  /** Optional override for each toolbar button. */
+  toolbarButtonStyle?: CSSProperties;
 }
+
+// Toolbar buttons in render order. Each glyph is referenced through
+// `button.glyph` (an identifier expression, not JSX text) so it never trips
+// i18next/no-literal-string; the accessible name comes from the t() labelKey.
+const BODY_TOOLBAR_BUTTONS = [
+  { command: "bold", glyph: "B", labelKey: "editPraxis.toolbar.bold" },
+  { command: "italic", glyph: "I", labelKey: "editPraxis.toolbar.italic" },
+  {
+    command: "strikethrough",
+    glyph: "S",
+    labelKey: "editPraxis.toolbar.strikethrough",
+  },
+  { command: "heading", glyph: "H", labelKey: "editPraxis.toolbar.heading" },
+  {
+    command: "unorderedList",
+    glyph: "•",
+    labelKey: "editPraxis.toolbar.unorderedList",
+  },
+  {
+    command: "orderedList",
+    glyph: "1.",
+    labelKey: "editPraxis.toolbar.orderedList",
+  },
+  { command: "link", glyph: "🔗", labelKey: "editPraxis.toolbar.link" },
+  { command: "blockquote", glyph: "❝", labelKey: "editPraxis.toolbar.blockquote" },
+  {
+    command: "inlineCode",
+    glyph: "</>",
+    labelKey: "editPraxis.toolbar.inlineCode",
+  },
+  { command: "codeBlock", glyph: "{ }", labelKey: "editPraxis.toolbar.codeBlock" },
+  { command: "table", glyph: "▦", labelKey: "editPraxis.toolbar.table" },
+] as const satisfies ReadonlyArray<{
+  command: MarkdownCommand;
+  glyph: string;
+  labelKey: string;
+}>;
 
 export function BodyTextarea({
   state,
@@ -456,14 +499,72 @@ export function BodyTextarea({
   state: EditPraxisState;
   skin: BodyTextareaSkin;
 }) {
+  const { t } = useTranslation("forms");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const runCommand = (command: MarkdownCommand) => {
+    const el = textareaRef.current;
+    if (!el) return;
+    const result = applyMarkdown(command, {
+      text: state.body,
+      selectionStart: el.selectionStart,
+      selectionEnd: el.selectionEnd,
+    });
+    state.setBody(result.text);
+    // Restore the caret/selection after React commits the new value.
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(result.selectionStart, result.selectionEnd);
+    });
+  };
+
+  const buttonStyle: CSSProperties = {
+    minWidth: 26,
+    padding: "3px 7px",
+    fontSize: 12,
+    fontWeight: 700,
+    lineHeight: 1.2,
+    background: "var(--color-bg-surface)",
+    color: "var(--color-text-secondary)",
+    border: "1px solid var(--color-border)",
+    cursor: "pointer",
+    ...skin.toolbarButtonStyle,
+  };
+
   return (
-    <textarea
-      value={state.body}
-      onChange={(event) => state.setBody(event.target.value)}
-      rows={skin.rows}
-      placeholder={skin.placeholder}
-      style={skin.textareaStyle}
-    />
+    <div>
+      <div
+        role="toolbar"
+        aria-label={t("editPraxis.toolbar.label")}
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 4,
+          marginBottom: 8,
+          ...skin.toolbarStyle,
+        }}
+      >
+        {BODY_TOOLBAR_BUTTONS.map((button) => (
+          <button
+            key={button.command}
+            type="button"
+            onClick={() => runCommand(button.command)}
+            aria-label={t(button.labelKey)}
+            style={buttonStyle}
+          >
+            {button.glyph}
+          </button>
+        ))}
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={state.body}
+        onChange={(event) => state.setBody(event.target.value)}
+        rows={skin.rows}
+        placeholder={skin.placeholder}
+        style={skin.textareaStyle}
+      />
+    </div>
   );
 }
 

--- a/frontend/src/pages/editPraxis/blocks/MarkdownPreview.tsx
+++ b/frontend/src/pages/editPraxis/blocks/MarkdownPreview.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 interface MarkdownPreviewProps {
   source: string;
@@ -21,7 +22,7 @@ export default function MarkdownPreview({
   if (!source.trim()) return null;
   return (
     <div className={className} style={style}>
-      <ReactMarkdown>{source}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{source}</ReactMarkdown>
     </div>
   );
 }

--- a/frontend/src/pages/editPraxis/blocks/__tests__/MarkdownPreview.gfm.test.tsx
+++ b/frontend/src/pages/editPraxis/blocks/__tests__/MarkdownPreview.gfm.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * #513 — MarkdownPreview now feeds react-markdown the remark-gfm plugin, so
+ * GitHub-flavored markdown (tables, task lists, strikethrough) renders. The
+ * repo renders component tests with renderToStaticMarkup: react-markdown runs
+ * synchronously under SSR, so the gfm HTML appears in the string.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import MarkdownPreview from "../MarkdownPreview";
+
+function html(source: string): string {
+  return renderToStaticMarkup(<MarkdownPreview source={source} />);
+}
+
+describe("MarkdownPreview with remark-gfm", () => {
+  it("renders a gfm table as a real <table>", () => {
+    const out = html(
+      "| A | B |\n| --- | --- |\n| 1 | 2 |\n",
+    );
+    expect(out).toContain("<table>");
+    expect(out).toContain("<th>A</th>");
+    expect(out).toContain("<td>1</td>");
+  });
+
+  it("renders a task list with checkbox inputs", () => {
+    const out = html("- [x] done\n- [ ] todo\n");
+    expect(out).toContain("<input");
+    expect(out).toContain('type="checkbox"');
+    expect(out).toContain("checked");
+  });
+
+  it("renders ~~strikethrough~~ as <del>", () => {
+    const out = html("this is ~~gone~~ now");
+    expect(out).toContain("<del>gone</del>");
+  });
+
+  it("returns nothing for an empty source", () => {
+    expect(html("   ")).toBe("");
+  });
+});

--- a/frontend/src/pages/editPraxis/blocks/__tests__/markdownToolbar.test.ts
+++ b/frontend/src/pages/editPraxis/blocks/__tests__/markdownToolbar.test.ts
@@ -1,0 +1,110 @@
+/**
+ * #513 — the pure markdown-toolbar transforms. No DOM: each case feeds a value
+ * + selection range and asserts the returned text and selection.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  applyMarkdown,
+  type MarkdownSelection,
+} from "../markdownToolbar";
+
+function sel(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+): MarkdownSelection {
+  return { text, selectionStart, selectionEnd };
+}
+
+describe("applyMarkdown — inline wraps", () => {
+  it("wraps a selection in ** for bold", () => {
+    const result = applyMarkdown("bold", sel("the quick fox", 4, 9));
+    expect(result.text).toBe("the **quick** fox");
+    // Selection stays on the wrapped word (after the opening **).
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe(
+      "quick",
+    );
+    expect(result.selectionStart).toBe(6);
+    expect(result.selectionEnd).toBe(11);
+  });
+
+  it("inserts a bold placeholder at the caret on an empty selection", () => {
+    const result = applyMarkdown("bold", sel("", 0, 0));
+    expect(result.text).toBe("**bold**");
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe(
+      "bold",
+    );
+  });
+
+  it("wraps a selection in single * for italic", () => {
+    const result = applyMarkdown("italic", sel("hi there", 3, 8));
+    expect(result.text).toBe("hi *there*");
+  });
+
+  it("wraps a selection in ~~ for strikethrough", () => {
+    const result = applyMarkdown("strikethrough", sel("nope", 0, 4));
+    expect(result.text).toBe("~~nope~~");
+  });
+
+  it("wraps a selection in backticks for inline code", () => {
+    const result = applyMarkdown("inlineCode", sel("run npm ci now", 4, 10));
+    expect(result.text).toBe("run `npm ci` now");
+  });
+});
+
+describe("applyMarkdown — line prefixes", () => {
+  it("prefixes each selected line for a bulleted list", () => {
+    const result = applyMarkdown("unorderedList", sel("one\ntwo\nthree", 0, 13));
+    expect(result.text).toBe("- one\n- two\n- three");
+  });
+
+  it("numbers each selected line for an ordered list", () => {
+    const result = applyMarkdown("orderedList", sel("one\ntwo\nthree", 0, 13));
+    expect(result.text).toBe("1. one\n2. two\n3. three");
+  });
+
+  it("prefixes the current line with ## for a heading", () => {
+    const result = applyMarkdown("heading", sel("Title", 0, 5));
+    expect(result.text).toBe("## Title");
+  });
+
+  it("prefixes with > for a blockquote, expanding to the line start", () => {
+    // Caret mid-line: the prefix lands at the beginning of that line.
+    const result = applyMarkdown("blockquote", sel("hello world", 6, 6));
+    expect(result.text).toBe("> hello world");
+  });
+});
+
+describe("applyMarkdown — link, code block, table", () => {
+  it("wraps the selection as [sel](url) and selects the url", () => {
+    const result = applyMarkdown("link", sel("see the docs", 4, 12));
+    expect(result.text).toBe("see [the docs](url)");
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe(
+      "url",
+    );
+  });
+
+  it("inserts a link skeleton on an empty selection", () => {
+    const result = applyMarkdown("link", sel("", 0, 0));
+    expect(result.text).toBe("[text](url)");
+  });
+
+  it("wraps the selection in a fenced code block", () => {
+    const result = applyMarkdown("codeBlock", sel("x = 1", 0, 5));
+    expect(result.text).toBe("```\nx = 1\n```");
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe(
+      "x = 1",
+    );
+  });
+
+  it("inserts a gfm table skeleton at the caret", () => {
+    const result = applyMarkdown("table", sel("", 0, 0));
+    expect(result.text).toContain("| Column 1 | Column 2 |");
+    expect(result.text).toContain("| --- | --- |");
+    expect(result.text).toContain("| Cell 1 | Cell 2 |");
+    // The inserted skeleton is the returned selection.
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe(
+      result.text,
+    );
+  });
+});

--- a/frontend/src/pages/editPraxis/blocks/markdownToolbar.ts
+++ b/frontend/src/pages/editPraxis/blocks/markdownToolbar.ts
@@ -1,0 +1,186 @@
+/**
+ * Pure markdown-transform helpers powering the body-textarea formatting toolbar
+ * (#513). Each transform takes the current textarea value plus the selection
+ * range and returns a new value with an updated selection, so the React
+ * component only has to read the DOM selection, call the transform, push the
+ * result through `state.setBody`, and restore the selection. Keeping the logic
+ * here (a plain .ts module, no DOM) makes every wrap/prefix/insert rule unit
+ * testable in isolation.
+ */
+
+/** A textarea value paired with a selection range. */
+export interface MarkdownSelection {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+/** Every formatting action the toolbar can apply. */
+export type MarkdownCommand =
+  | "bold"
+  | "italic"
+  | "strikethrough"
+  | "heading"
+  | "unorderedList"
+  | "orderedList"
+  | "link"
+  | "blockquote"
+  | "inlineCode"
+  | "codeBlock"
+  | "table";
+
+// Placeholder content inserted when the selection is empty. This is document
+// text the author immediately overtypes (the transform selects it), not UI
+// chrome, so it lives as plain markdown here rather than in an i18n catalog.
+const PLACEHOLDER = {
+  bold: "bold",
+  italic: "italic",
+  strikethrough: "strikethrough",
+  heading: "Heading",
+  code: "code",
+  linkText: "text",
+  linkUrl: "url",
+  listItem: "list item",
+  quote: "quote",
+} as const;
+
+const TABLE_SKELETON =
+  "| Column 1 | Column 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |\n";
+
+/** Wrap the selection (or an inserted placeholder) in `before`/`after`. */
+function wrap(
+  current: MarkdownSelection,
+  before: string,
+  after: string,
+  placeholder: string,
+): MarkdownSelection {
+  const { text, selectionStart, selectionEnd } = current;
+  const selected = text.slice(selectionStart, selectionEnd) || placeholder;
+  const nextText =
+    text.slice(0, selectionStart) +
+    before +
+    selected +
+    after +
+    text.slice(selectionEnd);
+  const start = selectionStart + before.length;
+  return {
+    text: nextText,
+    selectionStart: start,
+    selectionEnd: start + selected.length,
+  };
+}
+
+/**
+ * Prefix every line touched by the selection. `makePrefix` receives the
+ * zero-based index of the line within the selection (used for numbered lists).
+ */
+function prefixLines(
+  current: MarkdownSelection,
+  makePrefix: (lineIndex: number) => string,
+  placeholder: string,
+): MarkdownSelection {
+  const { text, selectionStart, selectionEnd } = current;
+  const lineStart = text.lastIndexOf("\n", selectionStart - 1) + 1;
+  const block = text.slice(lineStart, selectionEnd) || placeholder;
+  const prefixed = block
+    .split("\n")
+    .map((line, index) => makePrefix(index) + line)
+    .join("\n");
+  const nextText = text.slice(0, lineStart) + prefixed + text.slice(selectionEnd);
+  return {
+    text: nextText,
+    selectionStart: lineStart,
+    selectionEnd: lineStart + prefixed.length,
+  };
+}
+
+/** Replace the selection with `content`, selecting the inserted content. */
+function insert(
+  current: MarkdownSelection,
+  content: string,
+): MarkdownSelection {
+  const { text, selectionStart, selectionEnd } = current;
+  const nextText =
+    text.slice(0, selectionStart) + content + text.slice(selectionEnd);
+  return {
+    text: nextText,
+    selectionStart,
+    selectionEnd: selectionStart + content.length,
+  };
+}
+
+/** Build a `[selection](url)` link, selecting the `url` placeholder. */
+function link(current: MarkdownSelection): MarkdownSelection {
+  const { text, selectionStart, selectionEnd } = current;
+  const label = text.slice(selectionStart, selectionEnd) || PLACEHOLDER.linkText;
+  const prefix = `[${label}](`;
+  const inserted = `${prefix}${PLACEHOLDER.linkUrl})`;
+  const nextText =
+    text.slice(0, selectionStart) + inserted + text.slice(selectionEnd);
+  const urlStart = selectionStart + prefix.length;
+  return {
+    text: nextText,
+    selectionStart: urlStart,
+    selectionEnd: urlStart + PLACEHOLDER.linkUrl.length,
+  };
+}
+
+/** Wrap the selection in a fenced code block, selecting its content. */
+function codeBlock(current: MarkdownSelection): MarkdownSelection {
+  const { text, selectionStart, selectionEnd } = current;
+  const content = text.slice(selectionStart, selectionEnd) || PLACEHOLDER.code;
+  const before = "```\n";
+  const after = "\n```";
+  const nextText =
+    text.slice(0, selectionStart) +
+    before +
+    content +
+    after +
+    text.slice(selectionEnd);
+  const start = selectionStart + before.length;
+  return {
+    text: nextText,
+    selectionStart: start,
+    selectionEnd: start + content.length,
+  };
+}
+
+/** Apply a formatting command, returning the new value + selection. */
+export function applyMarkdown(
+  command: MarkdownCommand,
+  current: MarkdownSelection,
+): MarkdownSelection {
+  switch (command) {
+    case "bold":
+      return wrap(current, "**", "**", PLACEHOLDER.bold);
+    case "italic":
+      return wrap(current, "*", "*", PLACEHOLDER.italic);
+    case "strikethrough":
+      return wrap(current, "~~", "~~", PLACEHOLDER.strikethrough);
+    case "inlineCode":
+      return wrap(current, "`", "`", PLACEHOLDER.code);
+    case "heading":
+      return prefixLines(current, () => "## ", PLACEHOLDER.heading);
+    case "blockquote":
+      return prefixLines(current, () => "> ", PLACEHOLDER.quote);
+    case "unorderedList":
+      return prefixLines(current, () => "- ", PLACEHOLDER.listItem);
+    case "orderedList":
+      return prefixLines(
+        current,
+        (lineIndex) => `${lineIndex + 1}. `,
+        PLACEHOLDER.listItem,
+      );
+    case "link":
+      return link(current);
+    case "codeBlock":
+      return codeBlock(current);
+    case "table":
+      return insert(current, TABLE_SKELETON);
+    default: {
+      // Exhaustiveness guard: a new command must be handled above.
+      const unreachable: never = command;
+      return unreachable;
+    }
+  }
+}

--- a/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
@@ -15,7 +15,7 @@
  */
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
 import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
@@ -187,12 +187,11 @@ export default function AlbescentPraxisDetail({ state }: { state: PraxisDetailSt
         {praxis.body_text && (
           <>
             <Divider label={t('detail.albescent.account')} />
-            <div
+            <MarkdownPreview
+              source={praxis.body_text}
               className="markdown-preview"
               style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, lineHeight: 1.7, color: ink(62) }}
-            >
-              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-            </div>
+            />
           </>
         )}
 

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -1,11 +1,11 @@
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import ReactMarkdown from 'react-markdown'
 import MediaGallery from '../../../components/MediaGallery'
 import { formatTimestamp } from '../../../utils/dates'
 import VoteUI from '../../../components/vote/VoteUI'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 
 /** Style Guide §12.3 */
 const RAINBOW_COLORS = ['var(--underline-1)', 'var(--underline-2)', 'var(--underline-3)', 'var(--underline-4)', 'var(--underline-5)', 'var(--underline-6)', 'var(--underline-1)', 'var(--underline-2)']
@@ -127,12 +127,11 @@ export default function DefaultPraxisDetail({
 
       {/* ── Body Text (§12.6) — uses ReactMarkdown for rich content ── */}
       {praxis.body_text && (
-        <div
+        <MarkdownPreview
+          source={praxis.body_text}
           className="font-display mb-6 markdown-preview"
           style={{ fontSize: 15, lineHeight: 1.75, color: 'var(--color-text-primary)' }}
-        >
-          <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-        </div>
+        />
       )}
 
       {/* ── Voting (§13 preview — full redesign in Phase 8) ── */}

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -11,7 +11,7 @@
  */
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
 import EphemeristsVote from '../../../components/vote/EphemeristsVote'
 import { EphMark, EphEyebrow, Foxing, LapisLastWord, toRoman } from '../../../components/cards/ephemeristsAtoms'
@@ -238,7 +238,8 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
                 {t('detail.ephemerists.theAccount')}
               </span>
             </div>
-            <div
+            <MarkdownPreview
+              source={praxis.body_text}
               className="markdown-preview"
               style={{
                 fontFamily: 'var(--eph-script)',
@@ -247,9 +248,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
                 lineHeight: 1.8,
                 color: 'var(--eph-vellum-text)',
               }}
-            >
-              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-            </div>
+            />
           </div>
         )}
 

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -17,7 +17,7 @@
  */
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
 import EverymenVote from '../../../components/vote/EverymenVote'
 import { factionCssVar } from '../../../utils/factions'
@@ -199,7 +199,8 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
         {praxis.body_text && (
           <>
             <SectionHead>{t('detail.everymen.theWork')}</SectionHead>
-            <div
+            <MarkdownPreview
+              source={praxis.body_text}
               className="markdown-preview"
               style={{
                 fontFamily: BODY,
@@ -207,9 +208,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
                 lineHeight: 1.7,
                 color: 'var(--everymen-paper-text)',
               }}
-            >
-              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-            </div>
+            />
           </>
         )}
 

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -17,7 +17,7 @@
  */
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
 import SingularityVote from '../../../components/vote/SingularityVote'
 import { factionCssVar } from '../../../utils/factions'
@@ -365,7 +365,8 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
           {praxis.body_text && (
             <>
               <SgDivider label={t('detail.singularity.processLog')} />
-              <div
+              <MarkdownPreview
+                source={praxis.body_text}
                 className="markdown-preview"
                 style={{
                   fontSize: 11,
@@ -373,9 +374,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
                   color: 'color-mix(in srgb, var(--faction-singularity-card-accent) 78%, transparent)',
                   marginBottom: 8,
                 }}
-              >
-                <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-              </div>
+              />
             </>
           )}
 

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -14,7 +14,7 @@
  */
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
 import SnideVote from '../../../components/vote/SnideVote'
 import { factionCssVar } from '../../../utils/factions'
@@ -302,7 +302,8 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
             >
               {t('detail.snide.theConfession')}
             </span>
-            <div
+            <MarkdownPreview
+              source={praxis.body_text}
               className="markdown-preview"
               style={{
                 border: `1.5px solid ${PAPER_INK}`,
@@ -316,9 +317,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
                 fontSize: 13,
                 lineHeight: '28px',
               }}
-            >
-              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-            </div>
+            />
           </div>
         )}
 

--- a/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
@@ -19,7 +19,7 @@
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
 import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
@@ -366,7 +366,8 @@ export default function UAPraxisDetail({ state }: { state: PraxisDetailState }) 
               </span>
               <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
             </div>
-            <div
+            <MarkdownPreview
+              source={praxis.body_text}
               className="markdown-preview"
               style={{
                 fontFamily: SERIF,
@@ -374,9 +375,7 @@ export default function UAPraxisDetail({ state }: { state: PraxisDetailState }) 
                 lineHeight: 1.85,
                 color: 'var(--ua-sub)',
               }}
-            >
-              <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-            </div>
+            />
           </div>
         )}
 

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -16,7 +16,7 @@ import type { CSSProperties } from 'react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
 import WowVote from '../../../components/vote/WowVote'
 import { factionCssVar } from '../../../utils/factions'
@@ -328,12 +328,11 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
             {praxis.body_text && (
               <>
                 <Divider label={t('detail.wow.whatIDid')} />
-                <div
+                <MarkdownPreview
+                  source={praxis.body_text}
                   className="markdown-preview"
                   style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.75, color: CARD_TEXT }}
-                >
-                  <ReactMarkdown>{praxis.body_text}</ReactMarkdown>
-                </div>
+                />
               </>
             )}
 


### PR DESCRIPTION
Richer markdown editing without leaving markdown. `body_text` stays markdown — no backend, no migration.

## Enrich rendering (one config point)
- `remark-gfm` (`^4.0.1`) configured once in `MarkdownPreview.tsx`.
- **Root-cause routing:** the 8 detail archetypes each called `<ReactMarkdown>` directly, bypassing the wrapper. All 8 now render body through `MarkdownPreview` (typography className/style preserved), so gfm tables/task-lists/strikethrough/autolinks reach both the live editor preview and published praxes from one place.

## Toolbar
`BodyTextarea` gains a formatting toolbar (bold, italic, strikethrough, heading, bulleted/numbered list, link, quote, inline code, code block, table) that wraps/inserts markdown at the selection. The insert logic is a pure `applyMarkdown()` helper (DOM-free, unit-tested). Icon buttons carry localized `aria-label`s.

## Tests
- `markdownToolbar` helper: wrap/prefix/insert rules incl. empty-caret placeholders, list line-prefixing, `[sel](url)`, table skeleton.
- `MarkdownPreview` gfm: table, task-list checkbox, `~~strike~~` → `<del>`.
- vitest: 54 pass. tsc: 0 new errors.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
