### PR TITLE
Mobile: Tasks browse screen (Default skin + dispatch)

### DIFF
--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -3,6 +3,19 @@
     "loading": "Loading tasks...",
     "empty": "No tasks match your filters."
   },
+  "mobile": {
+    "sortButton": "Sort",
+    "sortSheet": {
+      "heading": "Sort by",
+      "default": "Level & Points",
+      "newest": "Newest"
+    },
+    "points": "{{points}} pts",
+    "taskType": {
+      "standard": "Standard",
+      "metatask": "Metatask"
+    }
+  },
   "detail": {
     "loading": "Loading...",
     "fetchError": "<0>Try refreshing.</0>",

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,72 +1,72 @@
-import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
-import { listTasks, type TaskOut } from '../api/tasks'
-import { createPraxis } from '../api/praxis'
-import { getFactions, type FactionOut } from '../api/factions'
-import { getGameConfig, type FactionConfigOut } from '../api/gameConfig'
-import TaskCard from '../components/TaskCard'
+/**
+ * Tasks browse dispatcher.
+ *
+ * Loads/filters tasks once via `useTasks()` and branches between the
+ * existing desktop flex-wrap `TaskCard` list (per-task faction styling is
+ * handled inside TaskCard/CARD_COMPONENTS — unrelated to this page-level
+ * split) and a single-column mobile skin. Mirrors the TaskDetail dispatcher
+ * (#494).
+ *
+ * Unlike Task Detail, this page shows a *mixed* list of tasks spanning every
+ * faction, so there is no single task-faction to key the page-chrome
+ * dispatch on. Instead we key the mobile archetype on the viewer's own
+ * character's faction (`user?.character?.faction_slug`) — the same "one
+ * faction, coherent idiom across screens" identity FactionDetail's
+ * `viewerFactionSlug` already uses. Bespoke faction mobile skins land
+ * incrementally in #525–#531; every viewer faction falls through to
+ * DefaultTaskList until then.
+ */
 import PageTitle from '../components/ui/PageTitle'
+import TaskCard from '../components/TaskCard'
 import FilterStamps from '../components/ui/FilterStamps'
 import FilterFactionTabs from '../components/ui/FilterFactionTabs'
 import FilterLevelNodes from '../components/ui/FilterLevelNodes'
-import { extractError } from '../utils/errors'
-import { useAuth } from '../auth/AuthContext'
-import { computeDisplayPoints } from '../utils/points'
+import { useTranslation } from 'react-i18next'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { pickVariant } from '../utils/factionDispatch'
+import { useTasks, LEVEL_FILTERS, type TasksState } from './tasks/useTasks'
+import DefaultTaskList from './tasks/mobileArchetypes/DefaultTaskList'
 
-const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
+type TasksArchetype = (props: { state: TasksState }) => JSX.Element | null
+
+// Parallel MOBILE registry. Empty for now — every faction falls through to
+// the Default mobile skin; bespoke faction mobile skins land incrementally
+// (#525–#531), exactly like the taskDetail archetypes' MOBILE_ARCHETYPE_BY_SLUG.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, TasksArchetype> = {}
 
 export default function Tasks() {
   const { t } = useTranslation('tasks')
   const { t: tc } = useTranslation('common')
-  const { user } = useAuth()
-  const navigate = useNavigate()
-  const characterId = user?.character?.id
+  const state = useTasks()
+  const formFactor = useFormFactor()
+  const {
+    tasks,
+    factions,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    statusFilters,
+    loading,
+    fetchError,
+    signupMsg,
+    isLoggedIn,
+    handleSignup,
+    displayPointsFor,
+    viewerFactionSlug,
+  } = state
 
-  const [tasks, setTasks] = useState<TaskOut[]>([])
-  const [factions, setFactions] = useState<FactionOut[]>([])
-  const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
-  const [status, setStatus] = useState('All')
-  const [faction, setFaction] = useState('')
-  const [level, setLevel] = useState<number | ''>('')
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-  const [signupMsg, setSignupMsg] = useState<{ id: number; msg: string; ok: boolean } | null>(null)
-
-  useEffect(() => {
-    getFactions().then(setFactions).catch(() => {})
-    getGameConfig()
-      .then((config) => setFactionConfigs(config.factions))
-      .catch(() => {})
-  }, [])
-
-  useEffect(() => {
-    setLoading(true)
-    setFetchError(null)
-    listTasks({
-      status: status === 'All' ? undefined : status,
-      faction: faction || undefined,
-      level: level === '' ? undefined : level,
-      exclude_character_id: characterId,
-    })
-      .then(setTasks)
-      .catch((err) => setFetchError(extractError(err, "Couldn't load tasks.")))
-      .finally(() => setLoading(false))
-  }, [status, faction, level, characterId])
-
-  const handleSignup = async (id: number) => {
-    setSignupMsg(null)
-    try {
-      const praxis = await createPraxis({ task_id: id, type: 'solo' })
-      navigate(`/praxes/${praxis.id}/edit`)
-    } catch (err) {
-      setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
-    }
+  if (formFactor === 'mobile') {
+    const Archetype = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, viewerFactionSlug, DefaultTaskList)
+    return (
+      <div className="py-8">
+        <PageTitle title="Tasks" eyebrow={`${tasks.length} shown`} />
+        <Archetype state={state} />
+      </div>
+    )
   }
-
-  const statusFilters = ['All', 'active']
-  if (user?.can_see_retired_tasks) statusFilters.push('retired')
-  if (user?.can_see_pending_tasks) statusFilters.push('pending')
 
   return (
     <div className="py-8">
@@ -101,13 +101,8 @@ export default function Tasks() {
             <TaskCard
               key={task.id}
               task={task}
-              displayPoints={computeDisplayPoints(
-                task.point_value,
-                user?.character?.faction_slug,
-                task.primary_faction_slug,
-                factionConfigs,
-              )}
-              onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
+              displayPoints={displayPointsFor(task)}
+              onSignup={isLoggedIn && task.can_submit_praxis ? handleSignup : undefined}
             />
           ))}
         </div>

--- a/frontend/src/pages/__tests__/tasksDispatch.test.tsx
+++ b/frontend/src/pages/__tests__/tasksDispatch.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Tasks browse dispatch guard (#496).
+ *
+ * Mirrors the TaskDetail formFactor branch: mobile viewers get the
+ * single-column DefaultTaskList skin, desktop viewers get the existing
+ * flex-wrap TaskCard list. Stubs useFormFactor so the branch can be forced
+ * either way and mocks the mobile skin with a marker so the assertion pins
+ * dispatch, not DefaultTaskList's own rendering (covered separately by
+ * mobileArchetypeSlots.test.tsx).
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+// Initialize the i18n catalog so nav/tasks copy keys resolve to English text.
+import "../../i18n";
+
+const mockUseFormFactor = vi.fn();
+vi.mock("../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mockUseFormFactor(),
+}));
+
+vi.mock("../tasks/mobileArchetypes/DefaultTaskList", () => ({
+  default: () => <div data-testid="default-task-list-marker" />,
+}));
+
+import Tasks from "../Tasks";
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Tasks />
+    </MemoryRouter>,
+  );
+}
+
+describe("Tasks browse dispatch", () => {
+  it("renders the mobile DefaultTaskList skin when formFactor is mobile", () => {
+    mockUseFormFactor.mockReturnValue("mobile");
+    const html = render();
+    expect(html).toContain('data-testid="default-task-list-marker"');
+  });
+
+  it("renders the existing desktop flex-wrap list when formFactor is desktop", () => {
+    mockUseFormFactor.mockReturnValue("desktop");
+    const html = render();
+    expect(html).not.toContain('data-testid="default-task-list-marker"');
+    // Desktop keeps the faction filter tabs at the top level (Style Guide §5.3),
+    // not nested inside a mobile chip-row skin.
+    expect(html).toContain("faction:");
+  });
+});

--- a/frontend/src/pages/tasks/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/mobileArchetypeSlots.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Mobile tasks-browse slot invariant — the tasks-list twin of
+ * taskDetail/__tests__/mobileArchetypeSlots.test.tsx. Walks the
+ * MOBILE_ARCHETYPE_BY_SLUG registry plus the Default mobile skin and asserts
+ * each still emits the invariant content slots (title, faction, points,
+ * level gate when set, task type) and — per the issue's clarifying comment —
+ * that it does NOT render difficulty dots or slot/capacity counts, neither
+ * of which exists on the Task model. The registry is empty today, so this
+ * mainly guards the Default fallback and any bespoke mobile skin added later
+ * (#496–#500).
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+// Initialize the i18n catalog so shared copy keys resolve to English text.
+import "../../../i18n";
+import { MOBILE_ARCHETYPE_BY_SLUG } from "../../Tasks";
+import DefaultTaskList from "../mobileArchetypes/DefaultTaskList";
+import type { TasksState } from "../useTasks";
+import type { TaskOut } from "../../../api/tasks";
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+const GATED_TASK: TaskOut = {
+  id: 1,
+  title: "Reforest the Ridge",
+  description: "Plant mangroves along the tidal flat.",
+  point_value: 20,
+  level_required: 3,
+  status: "active",
+  task_type: "standard",
+  created_by: 3,
+  primary_faction_slug: "snide",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+const UNGATED_METATASK: TaskOut = {
+  id: 2,
+  title: "Signal Boost",
+  description: "Amplify the array.",
+  point_value: 10,
+  level_required: 0,
+  status: "active",
+  task_type: "metatask",
+  created_by: 3,
+  primary_faction_slug: "ephemerists",
+  metatask_faction_slug: "ephemerists",
+  is_task_vision_eligible: false,
+  created_at: "2026-01-02T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+function baseState(overrides: Partial<TasksState>): TasksState {
+  return {
+    tasks: [GATED_TASK, UNGATED_METATASK],
+    factions: [],
+    factionConfigs: [],
+    status: "All",
+    setStatus: () => {},
+    faction: "",
+    setFaction: () => {},
+    level: "",
+    setLevel: () => {},
+    sort: "",
+    setSort: () => {},
+    statusFilters: ["All", "active"],
+    loading: false,
+    fetchError: null,
+    signupMsg: null,
+    handleSignup: async () => {},
+    isLoggedIn: true,
+    viewerFactionSlug: null,
+    displayPointsFor: (task) => task.point_value,
+    ...overrides,
+  };
+}
+
+const archetypes = { ...MOBILE_ARCHETYPE_BY_SLUG, __default__: DefaultTaskList };
+
+describe("mobile tasks-browse content-slot invariant", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders title, faction, points, and level gate when set`, () => {
+      const { html, text } = render(<Archetype state={baseState({})} />);
+
+      expect(text, "gated task title slot").toContain("Reforest the Ridge");
+      expect(text, "ungated task title slot").toContain("Signal Boost");
+
+      expect(text, "faction slot (snide)").toContain("S.N.I.D.E.");
+      expect(text, "faction slot (ephemerists)").toContain("The Ephemerists");
+
+      expect(text, "points slot").toContain("20 pts");
+      expect(text, "points slot").toContain("10 pts");
+
+      expect(text.toLowerCase(), "level-gate slot (present when level_required > 0)").toContain("lvl 3");
+      expect(text.toLowerCase(), "no level-gate chrome for level_required === 0").not.toContain("lvl 0");
+
+      expect(html, "cards link to task detail").toContain('href="/tasks/1"');
+      expect(html, "cards link to task detail").toContain('href="/tasks/2"');
+    });
+
+    it(`${slug} renders task type (standard/metatask)`, () => {
+      const { text } = render(<Archetype state={baseState({})} />);
+      expect(text, "standard type slot").toMatch(/standard/i);
+      expect(text, "metatask type slot").toMatch(/metatask/i);
+    });
+
+    it(`${slug} does NOT render difficulty dots or slot/capacity counts`, () => {
+      const { text } = render(<Archetype state={baseState({})} />);
+      const lower = text.toLowerCase();
+      expect(lower, "no slot/capacity copy").not.toContain("slots open");
+      expect(lower, "no slot/capacity copy").not.toContain("of 20 slots");
+      expect(lower, "no difficulty copy").not.toContain("difficulty");
+    });
+
+    it(`${slug} renders the empty state when there are no tasks`, () => {
+      const { text } = render(<Archetype state={baseState({ tasks: [] })} />);
+      expect(text).toContain("No tasks match your filters.");
+    });
+
+    it(`${slug} renders the loading state`, () => {
+      const { text } = render(<Archetype state={baseState({ loading: true })} />);
+      expect(text).toContain("Loading tasks...");
+    });
+  }
+});

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTaskList.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import FilterStamps from '../../../components/ui/FilterStamps'
+import FilterFactionTabs from '../../../components/ui/FilterFactionTabs'
+import FilterLevelNodes from '../../../components/ui/FilterLevelNodes'
+import LevelPill from '../../../components/ui/LevelPill'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import { LEVEL_FILTERS, type TasksState } from '../useTasks'
+import SortSheet from './SortSheet'
+
+/**
+ * Default MOBILE tasks-browse skin — single-column card list, thumb-first.
+ * Filters are phone-native horizontally-scrollable chip rows (reusing the
+ * existing FilterStamps/FilterFactionTabs/FilterLevelNodes widgets, each
+ * wrapped in its own `overflow-x: auto` strip) instead of the desktop
+ * sidebar layout, plus a "Sort" control that opens a bottom sheet for the
+ * default (level/points) vs "Newest" toggle already supported by
+ * listTasks(). Cards show faction + points + level gate (when set) + task
+ * type only — no difficulty dots or slot/capacity counts, neither of which
+ * is on the Task model. Tapping a card navigates to the task detail page.
+ * Every faction falls through here until it registers a bespoke mobile skin
+ * (#496–#500).
+ */
+export default function DefaultTaskList({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const [sheetOpen, setSheetOpen] = useState(false)
+
+  const {
+    tasks,
+    factions,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    sort,
+    setSort,
+    statusFilters,
+    loading,
+    fetchError,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div>
+      {/* Filters — phone-native horizontal-scroll chip rows, no desktop sidebar. */}
+      <div className="flex flex-col gap-2 mb-4">
+        <div style={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}>
+          <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
+        </div>
+        <div style={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}>
+          <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
+        </div>
+        <div className="flex items-center gap-2">
+          <div style={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch', flex: 1 }}>
+            <FilterLevelNodes levels={LEVEL_FILTERS} value={level} onChange={setLevel} />
+          </div>
+          <button
+            onClick={() => setSheetOpen(true)}
+            className="eyebrow"
+            style={{
+              flex: 'none',
+              border: '1px solid var(--color-border-strong)',
+              background: 'var(--color-bg-surface)',
+              color: 'var(--color-text-primary)',
+              padding: '5px 10px',
+              cursor: 'pointer',
+            }}
+          >
+            {t('mobile.sortButton')}
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="font-body text-muted">{t('listPage.loading')}</p>
+      ) : fetchError ? (
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+          {fetchError}{' '}
+          <button onClick={() => window.location.reload()} className="underline">
+            {tc('states.tryRefreshing')}
+          </button>
+        </p>
+      ) : tasks.length === 0 ? (
+        <p className="font-body text-muted">{t('listPage.empty')}</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {tasks.map((task) => {
+            const color = factionCssVar(task.primary_faction_slug)
+            return (
+              <Link
+                key={task.id}
+                to={`/tasks/${task.id}`}
+                className="sidebar-card"
+                style={{
+                  display: 'block',
+                  borderLeft: `4px solid ${color}`,
+                  textDecoration: 'none',
+                  color: 'inherit',
+                }}
+              >
+                <div className="card-meta flex items-center gap-2" style={{ color }}>
+                  <span>{factionName(task.primary_faction_slug)}</span>
+                  <span style={{ color: 'var(--color-text-tertiary)' }}>
+                    {task.task_type === 'metatask' ? t('mobile.taskType.metatask') : t('mobile.taskType.standard')}
+                  </span>
+                </div>
+
+                <h3
+                  className="font-display italic font-medium"
+                  style={{ fontSize: 18, color: 'var(--color-text-primary)', margin: '0 0 8px' }}
+                >
+                  {task.title}
+                </h3>
+
+                <div className="card-footer">
+                  <span className="font-body font-bold" style={{ fontSize: 16, color: 'var(--color-text-primary)' }}>
+                    {t('mobile.points', { points: displayPointsFor(task) })}
+                  </span>
+                  {task.level_required > 0 && (
+                    <LevelPill level={task.level_required} factionSlug={task.primary_faction_slug} />
+                  )}
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      )}
+
+      <SortSheet open={sheetOpen} sort={sort} onSelect={setSort} onClose={() => setSheetOpen(false)} />
+    </div>
+  )
+}

--- a/frontend/src/pages/tasks/mobileArchetypes/SortSheet.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/SortSheet.tsx
@@ -1,0 +1,94 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  open: boolean
+  sort: string
+  onSelect: (sort: string) => void
+  onClose: () => void
+}
+
+/**
+ * Minimal self-contained bottom sheet for the mobile Tasks sort control.
+ * There is no shared bottom-sheet component in this repo yet, so this follows
+ * the same self-contained-backdrop pattern as LevelUpPopup: fixed overlay,
+ * dismiss on backdrop tap or Escape. Offers the two sort states listTasks()
+ * already understands (default level/points vs 'newest' — api/tasks.ts).
+ */
+export default function SortSheet({ open, sort, onSelect, onClose }: Props) {
+  const { t } = useTranslation('tasks')
+
+  useEffect(() => {
+    if (!open) return
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const options: { value: string; label: string }[] = [
+    { value: '', label: t('mobile.sortSheet.default') },
+    { value: 'newest', label: t('mobile.sortSheet.newest') },
+  ]
+
+  return (
+    <div
+      role="presentation"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'flex-end',
+        background: 'var(--color-surface-scrim)',
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
+        style={{
+          width: '100%',
+          boxSizing: 'border-box',
+          background: 'var(--color-bg-page)',
+          borderTop: '1px solid var(--color-border)',
+          borderTopLeftRadius: 'var(--radius-xl)',
+          borderTopRightRadius: 'var(--radius-xl)',
+          padding: '18px 18px 28px',
+        }}
+      >
+        <div className="eyebrow mb-3">{t('mobile.sortSheet.heading')}</div>
+        <div className="flex flex-col gap-1">
+          {options.map((option) => {
+            const active = sort === option.value
+            return (
+              <button
+                key={option.value || 'default'}
+                onClick={() => {
+                  onSelect(option.value)
+                  onClose()
+                }}
+                className="font-body"
+                style={{
+                  textAlign: 'left',
+                  padding: '10px 12px',
+                  border: 'none',
+                  background: active ? 'var(--color-text-primary)' : 'transparent',
+                  color: active ? 'var(--color-bg-page)' : 'var(--color-text-primary)',
+                  fontSize: 14,
+                  cursor: 'pointer',
+                }}
+              >
+                {option.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -1,0 +1,158 @@
+/**
+ * useTasks — extracts every piece of state and async behaviour from the
+ * legacy Tasks.tsx (browse/list page) so the desktop flex-wrap list and the
+ * mobile single-column skin can share one data-plumbing contract. Mirrors the
+ * taskDetail/useTaskDetail.ts extraction pattern (#494).
+ *
+ * Behaviour preserved 1:1 from the original page (status/faction/level
+ * filters refetch, signup → navigate-to-edit, per-task display points). The
+ * only addition is `sort`, which was previously never sent to listTasks() —
+ * wiring it through is additive and defaults to the prior (unsorted / level-
+ * points) behaviour, so it is not a behaviour change for existing callers.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { listTasks, type TaskOut } from '../../api/tasks'
+import { createPraxis } from '../../api/praxis'
+import { getFactions, type FactionOut } from '../../api/factions'
+import { getGameConfig, type FactionConfigOut } from '../../api/gameConfig'
+import { extractError } from '../../utils/errors'
+import { useAuth } from '../../auth/AuthContext'
+import { computeDisplayPoints } from '../../utils/points'
+
+/** Level filter node values — shared by the desktop FilterLevelNodes row and
+ *  the mobile chip row so both surfaces filter on the same set. */
+export const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
+
+export interface TasksState {
+  tasks: TaskOut[]
+  factions: FactionOut[]
+  factionConfigs: FactionConfigOut[]
+
+  status: string
+  setStatus: (status: string) => void
+  faction: string
+  setFaction: (faction: string) => void
+  level: number | ''
+  setLevel: (level: number | '') => void
+  /** '' (default) sorts by level/points; 'newest' orders by creation time —
+   *  mirrors TaskFilters['sort'] in api/tasks.ts. */
+  sort: string
+  setSort: (sort: string) => void
+
+  /** Status stamp options available to the current viewer (retired/pending
+   *  gated behind the matching `can_see_*` viewer flags). */
+  statusFilters: string[]
+
+  loading: boolean
+  fetchError: string | null
+
+  signupMsg: { id: number; msg: string; ok: boolean } | null
+  handleSignup: (id: number) => Promise<void>
+
+  /** True once a viewer is authenticated — gates the desktop card's signup CTA. */
+  isLoggedIn: boolean
+
+  /** Viewer's own character's faction. This page shows a *mixed* list of tasks
+   *  across every faction, so unlike Task Detail there is no single task
+   *  faction to key a page-chrome dispatch on; the mobile dispatcher keys on
+   *  this instead (see Tasks.tsx). */
+  viewerFactionSlug: string | null
+
+  displayPointsFor: (task: TaskOut) => number
+}
+
+export function useTasks(): TasksState {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const characterId = user?.character?.id
+
+  const [tasks, setTasks] = useState<TaskOut[]>([])
+  const [factions, setFactions] = useState<FactionOut[]>([])
+  const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
+  const [status, setStatus] = useState('All')
+  const [faction, setFaction] = useState('')
+  const [level, setLevel] = useState<number | ''>('')
+  const [sort, setSort] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [signupMsg, setSignupMsg] = useState<{ id: number; msg: string; ok: boolean } | null>(null)
+
+  useEffect(() => {
+    getFactions().then(setFactions).catch(() => {})
+    getGameConfig()
+      .then((config) => setFactionConfigs(config.factions))
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    setFetchError(null)
+    listTasks({
+      status: status === 'All' ? undefined : status,
+      faction: faction || undefined,
+      level: level === '' ? undefined : level,
+      sort: sort || undefined,
+      exclude_character_id: characterId,
+    })
+      .then(setTasks)
+      .catch((err) => setFetchError(extractError(err, "Couldn't load tasks.")))
+      .finally(() => setLoading(false))
+  }, [status, faction, level, sort, characterId])
+
+  const handleSignup = useCallback(
+    async (id: number) => {
+      setSignupMsg(null)
+      try {
+        const praxis = await createPraxis({ task_id: id, type: 'solo' })
+        navigate(`/praxes/${praxis.id}/edit`)
+      } catch (err) {
+        setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
+      }
+    },
+    [navigate],
+  )
+
+  const statusFilters = ['All', 'active']
+  if (user?.can_see_retired_tasks) statusFilters.push('retired')
+  if (user?.can_see_pending_tasks) statusFilters.push('pending')
+
+  const displayPointsFor = useCallback(
+    (task: TaskOut) =>
+      computeDisplayPoints(
+        task.point_value,
+        user?.character?.faction_slug,
+        task.primary_faction_slug,
+        factionConfigs,
+      ),
+    [user?.character?.faction_slug, factionConfigs],
+  )
+
+  return {
+    tasks,
+    factions,
+    factionConfigs,
+
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    sort,
+    setSort,
+
+    statusFilters,
+
+    loading,
+    fetchError,
+
+    signupMsg,
+    handleSignup,
+
+    isLoggedIn: !!user,
+    viewerFactionSlug: user?.character?.faction_slug ?? null,
+
+    displayPointsFor,
+  }
+}


### PR DESCRIPTION
Closes #496

## What changed
- Extracted `Tasks.tsx`'s data logic into `frontend/src/pages/tasks/useTasks.ts` (`TasksState`) so desktop and the new mobile skin share one contract — mirrors the `useTaskDetail` extraction from #494. Pure refactor of existing behavior, plus an additive `sort` param wired through to the `listTasks()` API (already supported server-side, just never sent before).
- Added `frontend/src/pages/tasks/mobileArchetypes/DefaultTaskList.tsx` — the Default mobile skin: single-column card list, phone-native horizontally-scrollable filter chip rows (status/faction/level), and a `SortSheet.tsx` bottom sheet (default level/points vs "Newest"). Cards show faction, points, level gate (when set), and task type only — **no difficulty dots or slot/capacity counts**, per the issue's clarifying comment (neither exists on the Task model).
- Wired the mobile dispatch branch in `Tasks.tsx`: `useFormFactor()` branches between the existing desktop flex-wrap `TaskCard` list (unchanged) and the mobile skin via a parallel `MOBILE_ARCHETYPE_BY_SLUG` registry (empty for now, same convention as `TaskDetail.tsx`). Since this page shows a *mixed* list of tasks across every faction (unlike Task Detail's single task), the mobile archetype is keyed on the **viewer's own character's faction** rather than any one task's faction — documented inline, and ready for the per-faction follow-ups (#525–#531).
- New locale keys under `frontend/src/locales/en/tasks.json` `mobile.*`.

## Tests
- `frontend/src/pages/tasks/__tests__/mobileArchetypeSlots.test.tsx` — slot-invariant test across the mobile registry + Default: title/faction/points/level-gate/task-type present, difficulty-dot/slot-count copy absent, empty/loading states render.
- `frontend/src/pages/__tests__/tasksDispatch.test.tsx` — dispatch guard: mobile formFactor renders `DefaultTaskList`, desktop renders the existing list.

## Test plan
- [x] `npx vitest run` — 231 passed across 29 files
- [x] `npx tsc --noEmit` — zero errors in any changed/new file (pre-existing unrelated errors elsewhere untouched)
- [x] `npx eslint` — clean on all changed/new files
- [ ] Manual check in a mobile viewport (375px) vs desktop (not yet done in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_0176DsgN5TKF7DjGzg92NBwN)_