### PR TITLE
Comment author edit/withdraw affordance (#456)

### DIFF
--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -58,3 +58,8 @@ export async function editComment(
   })
   return data
 }
+
+/** Author-only soft-delete → the comment is withdrawn (204, no body). */
+export async function deleteComment(commentId: number): Promise<void> {
+  await api.delete(`/comments/${commentId}`)
+}

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -20,6 +20,7 @@ import {
   ComposerControls,
   MentionText,
 } from './shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from './OwnerControls'
 import UAComment from './voices/UAComment'
 import EverymenComment from './voices/EverymenComment'
 import WowComment from './voices/WowComment'
@@ -51,14 +52,15 @@ export function DefaultComment(props: CommentProps) {
       </div>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const accent = factionCssVar(slug, 'card-accent')
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <div style={{ display: 'flex', gap: 10 }}>
       <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
           <Link
             to={`/characters/${comment.author.id}`}
             style={{ fontWeight: 600, color: accent, textDecoration: 'none' }}
@@ -69,9 +71,14 @@ export function DefaultComment(props: CommentProps) {
             {formatCommentTime(slug, comment.created_at)}
             {comment.is_edited ? ` · ${t('comments.edited')}` : ''}
           </span>
+          <OwnerControls owner={owner} />
         </div>
         <div style={{ marginTop: 2, color: 'var(--color-text-primary)', lineHeight: 1.5 }}>
-          <MentionText body={comment.body_text} mentions={comment.mentions} accent={accent} />
+          {owner.editing ? (
+            <CommentEditor owner={owner} accent={accent} />
+          ) : (
+            <MentionText body={comment.body_text} mentions={comment.mentions} accent={accent} />
+          )}
         </div>
       </div>
     </div>
@@ -90,9 +97,19 @@ export const COMMENT_COMPONENTS: Record<string, CommentComponent> = {
   albescent: AlbescentComment,
 }
 
-function CommentRow({ comment }: { comment: CommentOut }) {
+function CommentRow({
+  comment,
+  onEdited,
+  onWithdrawn,
+}: {
+  comment: CommentOut
+  onEdited: (updated: CommentOut) => void
+  onWithdrawn: (id: number) => void
+}) {
   const Variant = pickVariant(COMMENT_COMPONENTS, comment.author.faction_slug, DefaultComment)
-  return <Variant mode="row" comment={comment} />
+  return (
+    <Variant mode="row" comment={comment} onEdited={onEdited} onWithdrawn={onWithdrawn} />
+  )
 }
 
 function CommentComposer({
@@ -191,7 +208,14 @@ export default function CommentThread({
       )}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
         {comments.map((comment) => (
-          <CommentRow key={comment.id} comment={comment} />
+          <CommentRow
+            key={comment.id}
+            comment={comment}
+            onEdited={(updated) =>
+              setComments((prev) => prev.map((row) => (row.id === updated.id ? updated : row)))
+            }
+            onWithdrawn={(id) => setComments((prev) => prev.filter((row) => row.id !== id))}
+          />
         ))}
       </div>
       {/* Hide the composer below comment level (repo convention: hide, don't disable). */}

--- a/frontend/src/components/comments/OwnerControls.tsx
+++ b/frontend/src/components/comments/OwnerControls.tsx
@@ -1,0 +1,257 @@
+/**
+ * Comment author affordance (#456, extends ADR-0018).
+ *
+ * One NEUTRAL edit/withdraw control, identical across every faction voice — no
+ * per-voice ornament. All the toggle / confirm / edit-state logic lives ONCE
+ * here (in `useOwnerEdit`); each voice opts in by calling the hook and dropping
+ * `<OwnerControls>` in its meta cluster + swapping its body slot for
+ * `<CommentEditor>` while editing. No voice re-implements the state machine.
+ */
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { type CommentOut, deleteComment, editComment } from '../../api/comments'
+import { useAuth } from '../../auth/AuthContext'
+import { ComposerControls } from './shared'
+
+/** The real body cap the backend enforces (NOT the 500 of the composer draft). */
+export const MAX_COMMENT_BODY = 2000
+
+// ── Pure decisions (unit-testable without a DOM) ─────────────────────────────
+
+/** Author-only: the affordance shows solely for the viewer's own comment. */
+export function isCommentOwner(
+  comment: CommentOut,
+  characterId: number | null | undefined,
+): boolean {
+  return characterId != null && characterId === comment.author.id
+}
+
+/** Save is inert on an empty (whitespace-only) draft or while a save is inflight. */
+export function editSaveDisabled(draft: string, saving: boolean): boolean {
+  return saving || draft.trim().length === 0
+}
+
+// ── Shared state machine ─────────────────────────────────────────────────────
+
+type OwnerMode = 'idle' | 'editing' | 'confirm'
+
+export interface OwnerEdit {
+  isOwner: boolean
+  editing: boolean
+  confirming: boolean
+  draft: string
+  setDraft: (value: string) => void
+  saving: boolean
+  withdrawing: boolean
+  error: string | null
+  startEdit: () => void
+  cancelEdit: () => void
+  save: () => void
+  startConfirm: () => void
+  cancelConfirm: () => void
+  confirmWithdraw: () => void
+}
+
+export function useOwnerEdit({
+  comment,
+  onEdited,
+  onWithdrawn,
+}: {
+  comment: CommentOut
+  onEdited?: (updated: CommentOut) => void
+  onWithdrawn?: (id: number) => void
+}): OwnerEdit {
+  const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const isOwner = isCommentOwner(comment, user?.character?.id)
+
+  const [mode, setMode] = useState<OwnerMode>('idle')
+  const [draft, setDraft] = useState(comment.body_text)
+  const [saving, setSaving] = useState(false)
+  const [withdrawing, setWithdrawing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const startEdit = () => {
+    setDraft(comment.body_text)
+    setError(null)
+    setMode('editing')
+  }
+  const cancelEdit = () => {
+    setError(null)
+    setMode('idle')
+  }
+  const save = () => {
+    const body = draft.trim()
+    if (!body || saving) return
+    setSaving(true)
+    setError(null)
+    editComment(comment.id, body)
+      .then((updated) => {
+        onEdited?.(updated)
+        setMode('idle')
+      })
+      .catch(() => setError(t('comments.editError')))
+      .finally(() => setSaving(false))
+  }
+
+  const startConfirm = () => {
+    setError(null)
+    setMode('confirm')
+  }
+  const cancelConfirm = () => {
+    setError(null)
+    setMode('idle')
+  }
+  const confirmWithdraw = () => {
+    if (withdrawing) return
+    setWithdrawing(true)
+    setError(null)
+    deleteComment(comment.id)
+      .then(() => onWithdrawn?.(comment.id))
+      .catch(() => {
+        setError(t('comments.withdrawError'))
+        setWithdrawing(false)
+      })
+  }
+
+  return {
+    isOwner,
+    editing: mode === 'editing',
+    confirming: mode === 'confirm',
+    draft,
+    setDraft,
+    saving,
+    withdrawing,
+    error,
+    startEdit,
+    cancelEdit,
+    save,
+    startConfirm,
+    cancelConfirm,
+    confirmWithdraw,
+  }
+}
+
+// ── Meta-cluster affordance (edit · delete / withdraw-confirm) ────────────────
+
+const linkStyle = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  padding: 0,
+  color: 'var(--color-text-tertiary)',
+} as const
+
+/**
+ * Neutral text affordance for the meta cluster — mirrors the praxis owner "edit"
+ * link (tertiary `.eyebrow`). Self-hides for non-authors and while editing (the
+ * inline editor owns Save/Cancel then).
+ */
+export function OwnerControls({ owner }: { owner: OwnerEdit }) {
+  const { t } = useTranslation('praxis')
+  if (!owner.isOwner || owner.editing) return null
+
+  if (owner.confirming) {
+    return (
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'baseline',
+          flexWrap: 'wrap',
+          gap: 6,
+          fontSize: 11,
+        }}
+      >
+        <span style={{ color: 'var(--color-text-tertiary)' }}>
+          {t('comments.confirmWithdraw')}
+        </span>
+        <button
+          onClick={owner.confirmWithdraw}
+          disabled={owner.withdrawing}
+          className="font-body eyebrow hover:underline"
+          style={{ ...linkStyle, color: 'var(--color-danger)' }}
+        >
+          {t('comments.withdraw')}
+        </button>
+        <span aria-hidden="true" style={{ color: 'var(--color-text-tertiary)' }}>
+          ·
+        </span>
+        <button
+          onClick={owner.cancelConfirm}
+          className="font-body eyebrow hover:underline"
+          style={linkStyle}
+        >
+          {t('comments.keep')}
+        </button>
+        {owner.error && (
+          <span style={{ color: 'var(--color-danger)', width: '100%' }}>{owner.error}</span>
+        )}
+      </span>
+    )
+  }
+
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'baseline', gap: 6 }}>
+      <button
+        onClick={owner.startEdit}
+        aria-label={t('comments.edit')}
+        className="font-body eyebrow hover:underline"
+        style={linkStyle}
+      >
+        {t('comments.edit')}
+      </button>
+      <span aria-hidden="true" style={{ color: 'var(--color-text-tertiary)' }}>
+        ·
+      </span>
+      <button
+        onClick={owner.startConfirm}
+        aria-label={t('comments.delete')}
+        className="font-body eyebrow hover:underline"
+        style={linkStyle}
+      >
+        {t('comments.delete')}
+      </button>
+    </span>
+  )
+}
+
+// ── Body-slot editor (reuses the voice's ComposerControls) ────────────────────
+
+/**
+ * Drop-in replacement for the resting body while editing — the SAME
+ * ComposerControls the voice uses to compose, seeded with the current body,
+ * capped at MAX_COMMENT_BODY, with Save/Cancel. Each voice passes its own
+ * accent/bg/text so the editor keeps the voice's skin.
+ */
+export function CommentEditor({
+  owner,
+  accent,
+  bg,
+  text,
+}: {
+  owner: OwnerEdit
+  accent: string
+  bg?: string
+  text?: string
+}) {
+  const { t } = useTranslation('praxis')
+  return (
+    <div>
+      <ComposerControls
+        value={owner.draft}
+        onChange={owner.setDraft}
+        onSubmit={owner.save}
+        submitting={owner.saving}
+        accent={accent}
+        bg={bg}
+        text={text}
+        maxLength={MAX_COMMENT_BODY}
+        submitLabel={t('comments.save')}
+        onCancel={owner.cancelEdit}
+      />
+      {owner.error && (
+        <p style={{ fontSize: 11, color: 'var(--color-danger)', marginTop: 4 }}>{owner.error}</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
+++ b/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Comment author affordance (#456).
+ *
+ * The stateful toggle/confirm/edit machinery lives once in `useOwnerEdit`; these
+ * tests exercise the pure decisions (owner check, empty-draft guard), the neutral
+ * `<OwnerControls>` affordance in each of its resting/confirm states, the seeded
+ * `<CommentEditor>`, and the new `deleteComment` client. Rendered to static markup
+ * (no DOM) per the comments-test convention; `useAuth` resolves to its anonymous
+ * default so ComposerControls' mention hook renders without a provider.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+// Initialize the i18n catalog so the neutral copy keys resolve to English text.
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import {
+  CommentEditor,
+  OwnerControls,
+  editSaveDisabled,
+  isCommentOwner,
+  type OwnerEdit,
+} from '../OwnerControls'
+
+// Mock the axios instance so the comments client can be exercised without a network.
+vi.mock('../../../api/axios', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn().mockResolvedValue({}) },
+}))
+import api from '../../../api/axios'
+import { deleteComment } from '../../../api/comments'
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'seedlings along the estuary',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: 42,
+    username: 'ada',
+    display_name: 'Ada',
+    avatar_url: null,
+    faction_slug: 'ua',
+  },
+  mentions: [],
+}
+
+function makeOwner(overrides: Partial<OwnerEdit> = {}): OwnerEdit {
+  return {
+    isOwner: true,
+    editing: false,
+    confirming: false,
+    draft: COMMENT.body_text,
+    setDraft: () => {},
+    saving: false,
+    withdrawing: false,
+    error: null,
+    startEdit: () => {},
+    cancelEdit: () => {},
+    save: () => {},
+    startConfirm: () => {},
+    cancelConfirm: () => {},
+    confirmWithdraw: () => {},
+    ...overrides,
+  }
+}
+
+// ── Pure decisions ────────────────────────────────────────────────────────────
+
+describe('isCommentOwner', () => {
+  it('is true only when the viewer character owns the comment', () => {
+    expect(isCommentOwner(COMMENT, 42)).toBe(true)
+    expect(isCommentOwner(COMMENT, 99)).toBe(false)
+    expect(isCommentOwner(COMMENT, null)).toBe(false)
+    expect(isCommentOwner(COMMENT, undefined)).toBe(false)
+  })
+})
+
+describe('editSaveDisabled', () => {
+  it('disables save on an empty/whitespace draft or while saving', () => {
+    expect(editSaveDisabled('', false)).toBe(true)
+    expect(editSaveDisabled('   ', false)).toBe(true)
+    expect(editSaveDisabled('hello', true)).toBe(true)
+    expect(editSaveDisabled('hello', false)).toBe(false)
+  })
+})
+
+// ── OwnerControls affordance ────────────────────────────────────────────────────
+
+describe('OwnerControls', () => {
+  it('renders edit + delete for the author (resting)', () => {
+    const html = renderToStaticMarkup(<OwnerControls owner={makeOwner()} />)
+    expect(html).toContain('edit')
+    expect(html).toContain('delete')
+  })
+
+  it('renders nothing for a non-author', () => {
+    const html = renderToStaticMarkup(<OwnerControls owner={makeOwner({ isOwner: false })} />)
+    expect(html).toBe('')
+  })
+
+  it('renders nothing while editing (the inline editor owns Save/Cancel)', () => {
+    const html = renderToStaticMarkup(<OwnerControls owner={makeOwner({ editing: true })} />)
+    expect(html).toBe('')
+  })
+
+  it('shows the neutral withdraw confirm strip when confirming', () => {
+    const html = renderToStaticMarkup(<OwnerControls owner={makeOwner({ confirming: true })} />)
+    expect(html).toContain('Withdraw this comment?')
+    expect(html).toContain('Withdraw')
+    expect(html).toContain('Keep')
+  })
+})
+
+// ── CommentEditor (seeded reuse of ComposerControls) ────────────────────────────
+
+describe('CommentEditor', () => {
+  it('seeds the composer with the current body and shows Save', () => {
+    const html = renderToStaticMarkup(
+      <CommentEditor owner={makeOwner({ editing: true })} accent="var(--color-accent)" />,
+    )
+    expect(html).toContain('seedlings along the estuary')
+    expect(html).toContain('Save')
+    expect(html).toContain('Cancel')
+  })
+})
+
+// ── deleteComment client ────────────────────────────────────────────────────────
+
+describe('deleteComment', () => {
+  it('issues DELETE /comments/{id}', async () => {
+    await deleteComment(7)
+    expect(vi.mocked(api.delete)).toHaveBeenCalledWith('/comments/7')
+  })
+})

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -17,6 +17,10 @@ import { MentionDropdown, useMentionAutocomplete } from './useMentionAutocomplet
 export interface CommentRowProps {
   mode: 'row'
   comment: CommentOut
+  /** Lift an author edit back into the thread's list (re-renders with is_edited). */
+  onEdited?: (updated: CommentOut) => void
+  /** Lift an author withdrawal back into the thread's list (drops the row). */
+  onWithdrawn?: (id: number) => void
 }
 
 export interface CommentComposerProps {
@@ -102,6 +106,10 @@ export function ComposerControls({
   accent,
   bg = 'transparent',
   text = 'inherit',
+  maxLength,
+  submitLabel,
+  submittingLabel,
+  onCancel,
 }: {
   value: string
   onChange: (value: string) => void
@@ -110,6 +118,13 @@ export function ComposerControls({
   accent: string
   bg?: string
   text?: string
+  /** Cap the body length (edit mode passes MAX_COMMENT_BODY) + light a live count. */
+  maxLength?: number
+  /** Override the default "Post" affordance (edit mode → "Save"). */
+  submitLabel?: string
+  submittingLabel?: string
+  /** When set, renders a neutral Cancel affordance beside submit (edit mode). */
+  onCancel?: () => void
 }) {
   const { t } = useTranslation('praxis')
   const disabled = submitting || value.trim().length === 0
@@ -125,6 +140,7 @@ export function ComposerControls({
           onBlur={mention.close}
           placeholder={t('comments.composerPlaceholder')}
           rows={2}
+          maxLength={maxLength}
           disabled={submitting}
           role="combobox"
           aria-autocomplete="list"
@@ -152,24 +168,58 @@ export function ComposerControls({
           />
         )}
       </div>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 6 }}>
-        <button
-          onClick={onSubmit}
-          disabled={disabled}
-          style={{
-            background: accent,
-            color: '#fff',
-            border: 'none',
-            borderRadius: 4,
-            padding: '4px 14px',
-            cursor: disabled ? 'default' : 'pointer',
-            fontSize: 12,
-            letterSpacing: '0.04em',
-            opacity: disabled ? 0.5 : 1,
-          }}
-        >
-          {submitting ? t('comments.posting') : t('comments.post')}
-        </button>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 8,
+          marginTop: 6,
+        }}
+      >
+        {maxLength != null ? (
+          <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
+            {t('comments.charCount', { count: value.length, max: maxLength })}
+          </span>
+        ) : (
+          <span />
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {onCancel && (
+            <button
+              onClick={onCancel}
+              className="font-body eyebrow hover:underline"
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '4px 6px',
+                color: 'var(--color-text-tertiary)',
+              }}
+            >
+              {t('comments.cancel')}
+            </button>
+          )}
+          <button
+            onClick={onSubmit}
+            disabled={disabled}
+            style={{
+              background: accent,
+              color: '#fff',
+              border: 'none',
+              borderRadius: 4,
+              padding: '4px 14px',
+              cursor: disabled ? 'default' : 'pointer',
+              fontSize: 12,
+              letterSpacing: '0.04em',
+              opacity: disabled ? 0.5 : 1,
+            }}
+          >
+            {submitting
+              ? (submittingLabel ?? t('comments.posting'))
+              : (submitLabel ?? t('comments.post'))}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/comments/voices/AlbescentComment.tsx
+++ b/frontend/src/components/comments/voices/AlbescentComment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 
 /**
  * Albescent — vellum correspondence (ADR-0018). The quietest archetype: warm-white
@@ -53,8 +54,9 @@ export default function AlbescentComment(props: CommentProps) {
       </div>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <div style={frame()}>
       <Letterhead monogram={comment.author.display_name[0]?.toUpperCase() ?? 'A'} />
@@ -65,11 +67,16 @@ export default function AlbescentComment(props: CommentProps) {
         </Link>
       </div>
       <div style={{ borderTop: '1px solid rgba(0,0,0,0.08)', marginTop: 10, paddingTop: 11, fontFamily: SERIF, fontSize: 17, lineHeight: 1.6, letterSpacing: '0.01em', color: INK }}>
-        <MentionText body={comment.body_text} mentions={comment.mentions} accent={INK} />
+        {owner.editing ? (
+          <CommentEditor owner={owner} accent={INK} bg="#ffffff" text={INK} />
+        ) : (
+          <MentionText body={comment.body_text} mentions={comment.mentions} accent={INK} />
+        )}
       </div>
-      <div style={{ marginTop: 11, fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+      <div style={{ marginTop: 11, fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED, display: 'flex', alignItems: 'baseline', gap: 8 }}>
         {formatCommentTime(slug, comment.created_at)}
         {comment.is_edited ? ` · ${t('comments.albescent.edited')}` : ''}
+        <OwnerControls owner={owner} />
       </div>
     </div>
   )

--- a/frontend/src/components/comments/voices/EphemeristsComment.tsx
+++ b/frontend/src/components/comments/voices/EphemeristsComment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 
 /**
  * The Ephemerists — marginalia (ADR-0018). Vellum leaf, engraved Cinzel byline,
@@ -38,8 +39,9 @@ export default function EphemeristsComment(props: CommentProps) {
       </div>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   const body = comment.body_text
   const drop = body[0] ?? ''
   return (
@@ -49,15 +51,20 @@ export default function EphemeristsComment(props: CommentProps) {
         <Link to={`/characters/${comment.author.id}`} style={{ fontSize: 15, fontWeight: 600, letterSpacing: '0.05em', color: 'var(--faction-ephemerists-card-text)', textDecoration: 'none' }}>
           {comment.author.display_name}
         </Link>
-        <span style={{ marginLeft: 'auto', fontSize: 11, fontStyle: 'italic', color: 'var(--faction-ephemerists-card-muted)', whiteSpace: 'nowrap' }}>
+        <span style={{ marginLeft: 'auto', fontSize: 11, fontStyle: 'italic', color: 'var(--faction-ephemerists-card-muted)', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 8 }}>
           {formatCommentTime(slug, comment.created_at)}
           {comment.is_edited ? ` · ${t('comments.ephemerists.edited')}` : ''}
+          <OwnerControls owner={owner} />
         </span>
       </div>
-      <div style={{ fontSize: 16, lineHeight: 1.55 }}>
-        <span style={{ float: 'left', fontSize: 34, lineHeight: 0.72, color: RUBRIC, padding: '4px 8px 0 0', fontWeight: 600 }}>{drop}</span>
-        <MentionText body={body.slice(1)} mentions={comment.mentions} accent="var(--faction-ephemerists-card-accent)" />
-      </div>
+      {owner.editing ? (
+        <CommentEditor owner={owner} accent="var(--faction-ephemerists-card-accent)" bg="rgba(255,255,255,0.35)" text="var(--faction-ephemerists-card-text)" />
+      ) : (
+        <div style={{ fontSize: 16, lineHeight: 1.55 }}>
+          <span style={{ float: 'left', fontSize: 34, lineHeight: 0.72, color: RUBRIC, padding: '4px 8px 0 0', fontWeight: 600 }}>{drop}</span>
+          <MentionText body={body.slice(1)} mentions={comment.mentions} accent="var(--faction-ephemerists-card-accent)" />
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/comments/voices/EverymenComment.tsx
+++ b/frontend/src/components/comments/voices/EverymenComment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 
 /**
  * Everymen — dispatch from the floor (ADR-0018). Union-poster register: red
@@ -39,8 +40,9 @@ export default function EverymenComment(props: CommentProps) {
       </div>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <div style={frame()}>
       {masthead}
@@ -51,13 +53,18 @@ export default function EverymenComment(props: CommentProps) {
             <Link to={`/characters/${comment.author.id}`} style={{ fontFamily: 'var(--faction-everymen-card-font)', fontSize: 18, letterSpacing: '0.04em', color: 'var(--faction-everymen-card-text)', textDecoration: 'none' }}>
               {comment.author.display_name}
             </Link>
-            <span style={{ fontSize: 11, color: 'var(--faction-everymen-card-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', whiteSpace: 'nowrap' }}>
+            <span style={{ fontSize: 11, color: 'var(--faction-everymen-card-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 8 }}>
               {formatCommentTime(slug, comment.created_at)}
               {comment.is_edited ? ` · ${t('comments.everymen.edited')}` : ''}
+              <OwnerControls owner={owner} />
             </span>
           </div>
           <div style={{ fontSize: 15, lineHeight: 1.4, marginTop: 3 }}>
-            <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-everymen-card-accent)" />
+            {owner.editing ? (
+              <CommentEditor owner={owner} accent="var(--faction-everymen-card-accent)" bg="rgba(0,0,0,0.03)" text="var(--faction-everymen-card-text)" />
+            ) : (
+              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-everymen-card-accent)" />
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/comments/voices/SingularityComment.tsx
+++ b/frontend/src/components/comments/voices/SingularityComment.tsx
@@ -4,6 +4,7 @@ import { factionCssVar } from '../../../utils/factions'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 
 /**
  * Singularity — terminal printout (ADR-0018). Dark, green mono, corner brackets,
@@ -56,8 +57,9 @@ export default function SingularityComment(props: CommentProps) {
       </div>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <div style={frame()}>
       <Brackets />
@@ -68,14 +70,21 @@ export default function SingularityComment(props: CommentProps) {
             <Link to={`/characters/${comment.author.id}`} style={{ fontSize: 13, color: 'var(--faction-singularity-card-text)', textDecoration: 'none' }}>
               {comment.author.username}
             </Link>
-            <span style={{ fontSize: 11, color: 'var(--faction-singularity-card-muted)', whiteSpace: 'nowrap' }}>
+            <span style={{ fontSize: 11, color: 'var(--faction-singularity-card-muted)', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 8 }}>
               {formatCommentTime(slug, comment.created_at)}
               {comment.is_edited ? ` [${t('comments.singularity.edited')}]` : ''}
+              <OwnerControls owner={owner} />
             </span>
           </div>
           <div style={{ fontSize: 13, lineHeight: 1.55, marginTop: 4 }}>
-            <span style={{ color: 'var(--faction-singularity-card-muted)' }}>&gt; </span>
-            <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-singularity-card-muted)" />
+            {owner.editing ? (
+              <CommentEditor owner={owner} accent="var(--faction-singularity-card-text)" bg="#0a1f12" text="var(--faction-singularity-card-text)" />
+            ) : (
+              <>
+                <span style={{ color: 'var(--faction-singularity-card-muted)' }}>&gt; </span>
+                <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-singularity-card-muted)" />
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/comments/voices/SnideComment.tsx
+++ b/frontend/src/components/comments/voices/SnideComment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 
 /**
  * S.N.I.D.E. — ransom dispatch (ADR-0018). Reuses the task-card ransom vocabulary:
@@ -72,8 +73,9 @@ export default function SnideComment(props: CommentProps) {
       </div>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <div style={frame()}>
       <Tape />
@@ -84,13 +86,18 @@ export default function SnideComment(props: CommentProps) {
             <Link to={`/characters/${comment.author.id}`} style={{ textDecoration: 'none' }}>
               <Ransom text={comment.author.display_name} size={16} />
             </Link>
-            <span style={{ fontFamily: 'var(--font-body)', fontSize: 10, color: 'var(--faction-snide-card-muted)', whiteSpace: 'nowrap' }}>
+            <span style={{ fontFamily: 'var(--font-body)', fontSize: 10, color: 'var(--faction-snide-card-muted)', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 8 }}>
               {formatCommentTime(slug, comment.created_at)}
               {comment.is_edited ? ` · ${t('comments.snide.edited')}` : ''}
+              <OwnerControls owner={owner} />
             </span>
           </div>
           <div style={{ fontFamily: 'var(--faction-snide-font-cond)', textTransform: 'uppercase', fontSize: 15, lineHeight: 1.4, letterSpacing: '0.02em' }}>
-            <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-snide-acid)" />
+            {owner.editing ? (
+              <CommentEditor owner={owner} accent="var(--faction-snide-pink)" bg="rgba(255,255,255,0.04)" text="var(--faction-snide-card-text)" />
+            ) : (
+              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-snide-acid)" />
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/comments/voices/UAComment.tsx
+++ b/frontend/src/components/comments/voices/UAComment.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 
 /**
  * UA — University of Asthmatics. The gilt salon (ADR-0026, superseding
@@ -66,8 +67,9 @@ export default function UAComment(props: CommentProps) {
       </GiltFrame>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <GiltFrame gap={14}>
       <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
@@ -79,14 +81,19 @@ export default function UAComment(props: CommentProps) {
           <Link to={`/characters/${comment.author.id}`} style={{ fontFamily: SERIF, fontStyle: 'italic', fontWeight: 600, fontSize: 18, color: INK, textDecoration: 'none' }}>
             {comment.author.display_name}
           </Link>
-          <span style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 12, color: SUB, whiteSpace: 'nowrap' }}>
+          <span style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 12, color: SUB, whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 8 }}>
             {formatCommentTime(slug, comment.created_at)}
             {comment.is_edited ? ` · ${t('comments.ua.edited')}` : ''}
+            <OwnerControls owner={owner} />
           </span>
         </div>
         <div style={{ height: 1, background: 'color-mix(in srgb, var(--ua-gold) 55%, transparent)', margin: '8px 0 9px' }} />
         <div style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 16, lineHeight: 1.5, color: INK }}>
-          <MentionText body={comment.body_text} mentions={comment.mentions} accent={ORANGE} />
+          {owner.editing ? (
+            <CommentEditor owner={owner} accent={ORANGE} bg={PAPER_WARM} text={INK} />
+          ) : (
+            <MentionText body={comment.body_text} mentions={comment.mentions} accent={ORANGE} />
+          )}
         </div>
       </div>
     </GiltFrame>

--- a/frontend/src/components/comments/voices/WowComment.tsx
+++ b/frontend/src/components/comments/voices/WowComment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
+import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 
 /**
  * Warriors of Whimsy — `{handle}.exe` (ADR-0018). Reuses the task-card window
@@ -43,23 +44,31 @@ export default function WowComment(props: CommentProps) {
       </Window>
     )
   }
-  const { comment } = props
+  const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
+  const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <Window title={`${comment.author.username}.exe`}>
       <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
         <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontFamily: 'var(--faction-wow-card-font)', fontSize: 20, lineHeight: 1.25, color: 'var(--faction-wow-card-text)' }}>
-            <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-wow-card-accent)" />
+            {owner.editing ? (
+              <CommentEditor owner={owner} accent="var(--faction-wow-card-accent)" bg="var(--faction-wow-notepad-bg)" text="var(--faction-wow-card-text)" />
+            ) : (
+              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-wow-card-accent)" />
+            )}
           </div>
-          <div style={{ marginTop: 6, fontSize: 11, color: 'var(--faction-wow-card-accent)', letterSpacing: '0.04em' }}>
+          <div style={{ marginTop: 6, fontSize: 11, color: 'var(--faction-wow-card-accent)', letterSpacing: '0.04em', display: 'inline-flex', alignItems: 'baseline', flexWrap: 'wrap', gap: 6 }}>
             <Link to={`/characters/${comment.author.id}`} style={{ color: 'inherit', textDecoration: 'none' }}>
               @{comment.author.username}
             </Link>
-            {' · '}
-            {formatCommentTime(slug, comment.created_at)}
-            {comment.is_edited ? ` · ${t('comments.wow.edited')}` : ''}
+            <span>
+              {' · '}
+              {formatCommentTime(slug, comment.created_at)}
+              {comment.is_edited ? ` · ${t('comments.wow.edited')}` : ''}
+            </span>
+            <OwnerControls owner={owner} />
           </div>
         </div>
       </div>

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -300,6 +300,16 @@
     "post": "Post comment",
     "posting": "…",
     "edited": "edited",
+    "edit": "edit",
+    "delete": "delete",
+    "save": "Save",
+    "cancel": "Cancel",
+    "withdraw": "Withdraw",
+    "keep": "Keep",
+    "confirmWithdraw": "Withdraw this comment?",
+    "charCount": "{{count}}/{{max}}",
+    "editError": "Could not save the edit.",
+    "withdrawError": "Could not withdraw the comment.",
     "ua": {
       "house": "University of Asthmatics",
       "edited": "edited"


### PR DESCRIPTION
Author-facing edit + withdraw inside the comment box, across all 7 voices — implementing the issue's settled (Jul-15) design.

## Design
One **neutral** author affordance (`edit` · `delete`), identical across all voices + `DefaultComment`, mirroring the praxis owner-link pattern (`--color-text-tertiary`, `.eyebrow`) — no per-faction ornament (ADR-0018). Author-gated (**hide, not disable**); backend already enforces author-only.

## Single-source, anti-sprawl
All state (idle → editing → confirm; save via `editComment`, withdraw via the new `deleteComment` client) lives once in a shared `useOwnerEdit` hook + `<OwnerControls>`. Each of the 7 voices + DefaultComment opts in with ~3 lines and **zero copied logic**. Edit reuses that voice's `ComposerControls` (extended with optional initial-value/submit props — not forked), so @mention autocomplete + the faction skin come for free; a saved edit flips `is_edited`, lighting each voice's existing edited marker. Withdraw is terminal (confirm → `DELETE` → row drops), no tombstone/undo. `maxLength` 2000 (real `MAX_COMMENT_BODY`).

## Scope
Frontend-only, no backend/migration, no new ADR (extends ADR-0018). Neutral tokens only. Moderator review screen (#237) out of scope.

## Tests
`vitest src/components/comments`: 17 pass (8 new OwnerControls + 9 existing). tsc: no new errors. Catalog keys added under `comments.*` in `praxis.json`.

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
