### PR TITLE
Localize faction name/description; config-canonical identity (#461)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Deeper notes: `docs/spec/SPEC-architecture.md`.
 | Active rule values (signup cap, vote budget, level thresholds, resets) | `backend/eras/era_1.py` (live `ERA_1`; `CURRENT_ERA` resolves here) |
 | Factions, tasks, level ranks/unlocks + taunt structure for the live era | `backend/eras/era_1.py` |
 | Taunt & rank/unlock **wording** (ADR-0031: backend emits keys) | `frontend/src/locales/en/{taunts,progression}.json` |
+| Faction **name/description** wording (ADR-0038: backend emits slug) | `frontend/src/locales/en/factions.json` (`names.<slug>`, `descriptions.<slug>`) |
 | Era config *shape* (dataclass fields) | `backend/game_config.py` |
 | Backend layering, DDD posture, what goes in services vs. routes | `docs/spec/SPEC-backend-architecture.md` |
 | Building a new era | `backend/eras/_template.py` |

--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -35,6 +35,11 @@ from game_config import (
 # Each faction needs a unique slug (lowercase, underscores). The slug is the
 # primary key in the database and must be stable once deployed.
 #
+# Faction names/descriptions are NOT config-owned (ADR-0038): the English words
+# live in frontend/src/locales/en/factions.json (names.<slug>, descriptions.<slug>).
+# Config owns which factions exist + their mechanics; add matching name/description
+# entries there for every slug below.
+#
 # Required system factions (include these in every era):
 #   "ua"       -- an ordinary invite-joinable faction (no starter privilege, ADR-0030)
 #   "na"       -- sentinel for tasks with no faction affiliation
@@ -52,8 +57,6 @@ ERA_N_FACTIONS = {
     #
     # "ua": FactionConfig(
     #     slug="ua",
-    #     name="UA",
-    #     description="The Gilt Salon — an ordinary invite-joinable faction.",
     #     can_always_rejoin=False,
     #     own_task_modifier=1.0,
     #     other_task_modifier=1.0,
@@ -64,8 +67,6 @@ ERA_N_FACTIONS = {
     # ),
     # "na": FactionConfig(
     #     slug="na",
-    #     name="None",
-    #     description="Sentinel for tasks with no specific faction.",
     #     can_always_rejoin=False,
     #     own_task_modifier=1.0, other_task_modifier=1.0,
     #     collab_own_modifier=1.0, collab_other_modifier=1.0,
@@ -76,8 +77,6 @@ ERA_N_FACTIONS = {
     #
     # "your_faction": FactionConfig(
     #     slug="your_faction",
-    #     name="Your Faction",
-    #     description="What makes this faction unique.",
     #     can_always_rejoin=False,
     #     own_task_modifier=1.0,
     #     other_task_modifier=1.0,

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -18,14 +18,15 @@ from game_config import (
 # FACTIONS
 # =============================================================================
 
+# Faction names/descriptions are NOT config-owned (ADR-0038): the English words
+# live in frontend/src/locales/en/factions.json (names.<slug>, descriptions.<slug>).
+#
 # Cross-faction modifiers (other_task_modifier / collab_other_modifier) are
 # deliberately flattened to 1.0 for Era 1 — no faction is penalized for working
 # a task outside its own faction (issue #452). Re-tune in a future era if desired.
 ERA_1_FACTIONS = {
     "ua": FactionConfig(
         slug="ua",
-        name="UA",
-        description="The Gilt Salon — a regal academy. Full points on all tasks.",
         # UA is an ordinary, invite-joinable faction (ADR-0030) — no starter privilege.
         can_always_rejoin=False,
         own_task_modifier=1.0,
@@ -39,8 +40,6 @@ ERA_1_FACTIONS = {
     # tasks below are reassigned to ua.
     "snide": FactionConfig(
         slug="snide",
-        name="S.N.I.D.E.",
-        description="Specialists in one-on-one competition. Bonus points for winning duels.",
         can_always_rejoin=False,
         own_task_modifier=1.0,
         other_task_modifier=1.0,
@@ -51,8 +50,6 @@ ERA_1_FACTIONS = {
     ),
     "wow": FactionConfig(
         slug="wow",
-        name="Warriors of Whimsy",
-        description="Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
         can_always_rejoin=False,
         own_task_modifier=1.1,        # +10% on solo own-faction
         other_task_modifier=1.0,
@@ -63,8 +60,6 @@ ERA_1_FACTIONS = {
     ),
     "ephemerists": FactionConfig(
         slug="ephemerists",
-        name="The Ephemerists",
-        description="Wanderers who set down fleeting truths before the road moves on. Task Vision — access to select retired tasks.",
         can_always_rejoin=False,
         own_task_modifier=1.0,
         other_task_modifier=1.0,
@@ -75,9 +70,6 @@ ERA_1_FACTIONS = {
     ),
     "everymen": FactionConfig(
         slug="everymen",
-        name="Everymen",
-        description="No inner circle, no waiting to be chosen. Reliable hands who "
-        "do the work in front of them and finish what they start.",
         can_always_rejoin=False,
         own_task_modifier=1.0,
         other_task_modifier=1.0,
@@ -88,8 +80,6 @@ ERA_1_FACTIONS = {
     ),
     "singularity": FactionConfig(
         slug="singularity",
-        name="Singularity",
-        description="TBD",
         can_always_rejoin=False,
         own_task_modifier=1.0,
         other_task_modifier=1.0,
@@ -100,8 +90,6 @@ ERA_1_FACTIONS = {
     ),
     "albescent": FactionConfig(
         slug="albescent",
-        name="/Albescent",
-        description="Full points and any meta tasks from any group. Unlock-only.",
         can_always_rejoin=True,       # can always be rejoined after defecting
         own_task_modifier=1.0,
         other_task_modifier=1.0,
@@ -112,8 +100,6 @@ ERA_1_FACTIONS = {
     ),
     "na": FactionConfig(
         slug="na",
-        name="None",
-        description="Sentinel value for tasks with no specific faction affiliation.",
         can_always_rejoin=False,
         own_task_modifier=1.0,
         other_task_modifier=1.0,

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -57,9 +57,11 @@ class TaskDef:
 
 @dataclass(frozen=True)
 class FactionConfig:
+    # Faction name/description prose is NOT config-owned (ADR-0038): the English
+    # words live in frontend/src/locales/en/factions.json (names.<slug>,
+    # descriptions.<slug>). Config owns which factions exist + their mechanics;
+    # the DB Faction row carries slug + status only.
     slug: str
-    name: str
-    description: str
     can_always_rejoin: bool          # True for UA Masters and Albescent
     own_task_modifier: float         # solo own-faction task multiplier
     other_task_modifier: float       # solo other-faction task multiplier

--- a/backend/models/faction.py
+++ b/backend/models/faction.py
@@ -17,10 +17,10 @@ class Faction(TimestampMixin, Base):
     __tablename__ = "faction"
 
     slug: Mapped[str] = mapped_column(String, primary_key=True)
-    name: Mapped[str] = mapped_column(String, nullable=False)
-    description: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     status: Mapped[FactionStatus] = mapped_column(
         Enum(FactionStatus, create_type=False), nullable=False, default=FactionStatus.visible
     )
-    # No multiplier columns: faction rules live in game_config.py, not the DB.
-    # This table exists for FK references and UI display only.
+    # ADR-0038: no name/description columns. Faction name/description prose lives
+    # in frontend/src/locales/en/factions.json (config-canonical identity); the
+    # row carries slug + status only. No multiplier columns either — faction
+    # rules live in game_config.py. This table exists for FK references only.

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -160,8 +160,6 @@ async def admin_create_faction(
     faction = await create_faction(data, session)
     return AdminFactionOut(
         slug=faction.slug,
-        name=faction.name,
-        description=faction.description,
         status=faction.status.value,
         created_at=faction.created_at,
     )

--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -6,9 +6,7 @@ from db import get_db
 from dependencies import (
     get_current_account_optional,
     get_current_character,
-    require_admin,
 )
-from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character
 from models.faction import Faction, FactionStatus
@@ -18,7 +16,6 @@ from schemas.faction import (
     FactionOut,
     FactionPageOut,
     FactionStatusOut,
-    FactionUpdate,
     InvitationLetterOut,
 )
 from services.auth import get_current_account
@@ -28,7 +25,6 @@ from services.faction_service import (
     defect_to_faction,
     get_defection_history,
     get_invitation_status,
-    update_faction,
 )
 from models.invitation_letter import InvitationLetter
 
@@ -56,21 +52,6 @@ async def list_factions(
         for faction in factions
         if faction.slug != ALBESCENT_FACTION_SLUG or reveal_albescent
     ]
-
-
-@router.put("/{slug}", response_model=FactionOut)
-async def update_faction_route(
-    slug: str,
-    data: FactionUpdate,
-    _: Account = Depends(require_admin),
-    session: AsyncSession = Depends(get_db),
-):
-    """Admin-only: update a faction's name and description."""
-    faction = await session.get(Faction, slug)
-    if faction is None:
-        raise HTTPException(status_code=404, detail="Faction not found.")
-    updated = await update_faction(faction, data, session)
-    return FactionOut.model_validate(updated)
 
 
 @router.post("/choose", response_model=FactionOut)
@@ -109,7 +90,6 @@ async def get_faction_status(
     all_factions = [
         FactionStatusOut(
             slug=slug,
-            name=CURRENT_ERA.factions[slug].name if slug in CURRENT_ERA.factions else slug,
             status=status,
         )
         for slug, status in status_map.items()
@@ -138,11 +118,6 @@ async def list_invitations(
     return [
         InvitationLetterOut(
             faction_slug=letter.faction_slug,
-            faction_name=(
-                CURRENT_ERA.factions[letter.faction_slug].name
-                if letter.faction_slug in CURRENT_ERA.factions
-                else letter.faction_slug
-            ),
             delivered_at=letter.delivered_at,
         )
         for letter in letters

--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -17,8 +17,6 @@ async def get_game_config() -> GameConfigOut:
     factions = [
         FactionConfigOut(
             slug=faction.slug,
-            name=faction.name,
-            description=faction.description,
             can_always_rejoin=faction.can_always_rejoin,
             own_task_modifier=faction.own_task_modifier,
             other_task_modifier=faction.other_task_modifier,

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -98,10 +98,11 @@ class OverviewStats(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# ADR-0038: faction name/description prose is not DB-owned. A faction row carries
+# slug + status only; the English words live in
+# frontend/src/locales/en/factions.json.
 class FactionCreate(BaseModel):
     slug: str = Field(..., min_length=2, max_length=30, pattern=r"^[a-z0-9_-]+$")
-    name: str = Field(..., min_length=1, max_length=100)
-    description: str = Field(default="", max_length=500)
     hidden: bool = False
 
 
@@ -109,8 +110,6 @@ class AdminFactionOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     slug: str
-    name: str
-    description: str
     status: str
     created_at: datetime
 

--- a/backend/schemas/faction.py
+++ b/backend/schemas/faction.py
@@ -9,18 +9,14 @@ FactionMembershipStatus = Literal[
 ]
 
 
+# ADR-0038: faction name/description prose is not emitted by the backend. The
+# frontend resolves it from frontend/src/locales/en/factions.json by slug
+# (factionName()/factionDescription()). These schemas carry slug + status only.
 class FactionOut(BaseModel):
     slug: str
-    name: str
-    description: str
     status: str
 
     model_config = {"from_attributes": True}
-
-
-class FactionUpdate(BaseModel):
-    name: str = Field(min_length=1, max_length=100)
-    description: str = Field(default="", max_length=2000)
 
 
 class FactionChoiceRequest(BaseModel):
@@ -29,7 +25,6 @@ class FactionChoiceRequest(BaseModel):
 
 class FactionStatusOut(BaseModel):
     slug: str
-    name: str
     status: FactionMembershipStatus
 
 
@@ -40,7 +35,6 @@ class FactionPageOut(BaseModel):
 
 class InvitationLetterOut(BaseModel):
     faction_slug: str
-    faction_name: str
     delivered_at: datetime
 
     model_config = {"from_attributes": True}

--- a/backend/schemas/game_config.py
+++ b/backend/schemas/game_config.py
@@ -2,9 +2,9 @@ from pydantic import BaseModel
 
 
 class FactionConfigOut(BaseModel):
+    # ADR-0038: no name/description — the frontend resolves faction prose from
+    # frontend/src/locales/en/factions.json by slug.
     slug: str
-    name: str
-    description: str
     can_always_rejoin: bool
     own_task_modifier: float
     other_task_modifier: float

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -173,10 +173,10 @@ async def seed(env: str, yes: bool) -> None:
             )
             if existing.scalar_one_or_none() is None:
                 status = FactionStatus.hidden if slug in HIDDEN_FACTION_SLUGS else FactionStatus.visible
+                # ADR-0038: the row is slug + status only; name/description prose
+                # lives in frontend/src/locales/en/factions.json.
                 session.add(Faction(
                     slug=slug,
-                    name=faction_config.name,
-                    description=faction_config.description,
                     status=status,
                 ))
                 faction_count += 1

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -22,7 +22,6 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from game_config import CURRENT_ERA
 from models.character import Character
 from models.comment import Comment, CommentMention
 from models.era import Era
@@ -529,26 +528,19 @@ def _invitation_letters_query(ctx: FeedContext) -> Select:
     return query.order_by(InvitationLetter.delivered_at.desc()).limit(SUB_QUERY_LIMIT)
 
 
-def _faction_display_name(faction_slug: str) -> str:
-    """Resolve a faction slug to its display name for the current era."""
-    if faction_slug in CURRENT_ERA.factions:
-        return CURRENT_ERA.factions[faction_slug].name
-    return faction_slug
-
-
 def _invitation_letter_item(row: Any) -> ActivityFeedItemDC:
+    # ADR-0038: emit the faction slug only — the frontend card resolves the
+    # faction name from factions.json (factionName(faction_slug)).
     letter: InvitationLetter = row[0]
-    faction_name = _faction_display_name(letter.faction_slug)
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_INVITATION_LETTER,
         timestamp=letter.delivered_at,
-        actor_display_name=faction_name,
+        actor_display_name=letter.faction_slug,
         actor_faction_slug=letter.faction_slug,
         actor_avatar_url=None,
         payload={
             "letter_id": letter.id,
             "faction_slug": letter.faction_slug,
-            "faction_name": faction_name,
         },
     )
 
@@ -577,8 +569,8 @@ def _friend_defections_query(ctx: FeedContext) -> Select:
 
 
 def _friend_defection_item(row: Any) -> ActivityFeedItemDC:
-    old_faction_name = _faction_display_name(row.faction_slug)
-    new_faction_name = _faction_display_name(row.current_faction_slug)
+    # ADR-0038: emit faction slugs only — the frontend resolves both faction
+    # names from factions.json (factionName(<slug>)).
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_FRIEND_DEFECTION,
         timestamp=row.defected_at,
@@ -588,9 +580,7 @@ def _friend_defection_item(row: Any) -> ActivityFeedItemDC:
         payload={
             "character_id": row.character_id,
             "old_faction_slug": row.faction_slug,
-            "old_faction_name": old_faction_name,
             "new_faction_slug": row.current_faction_slug,
-            "new_faction_name": new_faction_name,
         },
     )
 

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -254,8 +254,6 @@ async def create_faction(data: FactionCreate, session: AsyncSession) -> Faction:
 
     faction = Faction(
         slug=data.slug,
-        name=data.name,
-        description=data.description,
         status=FactionStatus.hidden if data.hidden else FactionStatus.visible,
     )
     session.add(faction)

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -12,7 +12,6 @@ from models.faction import Faction, FactionStatus
 from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
 from models.task import Task, TaskType
-from schemas.faction import FactionUpdate
 from services.character import ALBESCENT_FACTION_SLUG, can_start_as_albescent
 from services.era import clear_defection_history_for_era, get_current_era_row, get_or_create_stats
 
@@ -281,20 +280,3 @@ async def get_invitation_status(
             status_map[slug] = "not_invited"
 
     return status_map
-
-
-# ---------------------------------------------------------------------------
-# Admin mutations
-# ---------------------------------------------------------------------------
-
-
-async def update_faction(
-    faction: Faction,
-    data: FactionUpdate,
-    session: AsyncSession,
-) -> Faction:
-    faction.name = data.name
-    faction.description = data.description
-    await session.flush()
-    await session.refresh(faction)
-    return faction

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -205,8 +205,8 @@ async def faction_ua(db_session: AsyncSession) -> Faction:
     from sqlalchemy import select
 
     factions_to_seed = [
-        Faction(slug="ua", name="UA", description="Default starting faction", status=FactionStatus.visible),
-        Faction(slug="na", name="None", description="Sentinel for no faction affiliation", status=FactionStatus.hidden),
+        Faction(slug="ua", status=FactionStatus.visible),
+        Faction(slug="na", status=FactionStatus.hidden),
     ]
     for faction in factions_to_seed:
         result = await db_session.execute(select(Faction).where(Faction.slug == faction.slug))
@@ -227,7 +227,7 @@ async def faction_ephemerists(db_session: AsyncSession) -> Faction:
     result = await db_session.execute(select(Faction).where(Faction.slug == "ephemerists"))
     existing = result.scalar_one_or_none()
     if existing is None:
-        faction = Faction(slug="ephemerists", name="The Ephemerists", description="Task Vision perk", status=FactionStatus.visible)
+        faction = Faction(slug="ephemerists", status=FactionStatus.visible)
         db_session.add(faction)
         await db_session.commit()
         result = await db_session.execute(select(Faction).where(Faction.slug == "ephemerists"))

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -392,8 +392,6 @@ async def test_me_can_start_as_albescent_true_when_level_8_plus(
             db_session.add(
                 Faction(
                     slug=faction_slug,
-                    name=faction_slug,
-                    description=f"{faction_slug} test faction",
                     status=FactionStatus.visible,
                 )
             )

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -320,8 +320,6 @@ async def test_faction_change_via_choose_endpoint(
     # Seed a selectable target faction
     target = Faction(
         slug="testfaction",
-        name="Test Faction",
-        description="A test faction",
         status=FactionStatus.visible,
     )
     db_session.add(target)

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -7,7 +7,6 @@ from models.account import Account
 from models.character import Character
 from models.era import Era
 from models.faction import Faction, FactionStatus
-from models.roles import AccountRole, Role
 
 
 # ---------------------------------------------------------------------------
@@ -36,13 +35,18 @@ async def test_list_factions_structure(
     client: AsyncClient,
     faction_ua: Faction,
 ):
-    """Each faction in the list has the expected fields."""
+    """Each faction in the list has the expected fields.
+
+    ADR-0038: the backend emits slug + status only; name/description prose lives
+    in the frontend factions.json catalog and is never returned here.
+    """
     resp = await client.get("/factions")
     assert resp.status_code == 200
     for faction in resp.json():
         assert "slug" in faction
-        assert "name" in faction
-        assert "description" in faction
+        assert "status" in faction
+        assert "name" not in faction
+        assert "description" not in faction
 
 
 # ---------------------------------------------------------------------------
@@ -132,8 +136,6 @@ async def test_choose_faction_with_invitation_succeeds(
     if existing.scalar_one_or_none() is None:
         db_session.add(FactionModel(
             slug="wow",
-            name="Warriors of Whimsy",
-            description="Collective-minded",
             status=FactionStatus.visible,
         ))
         await db_session.commit()
@@ -184,8 +186,6 @@ async def _seed_faction(session: AsyncSession, slug: str) -> None:
     if existing.scalar_one_or_none() is None:
         session.add(Faction(
             slug=slug,
-            name=slug,
-            description=f"{slug} test faction",
             status=FactionStatus.visible,
         ))
         await session.flush()
@@ -427,69 +427,7 @@ async def test_albescent_reveal_is_sticky_not_derived_from_membership(
     assert "albescent" in [f["slug"] for f in listed.json()]
 
 
-# ---------------------------------------------------------------------------
-# Update faction (admin-only)
-# ---------------------------------------------------------------------------
-
-
-async def _make_admin(account: Account, session: AsyncSession) -> None:
-    role = Role(name="admin", description="Administrator")
-    session.add(role)
-    await session.flush()
-    ar = AccountRole(account_id=account.id, role_id=role.id, granted_by=account.id)
-    session.add(ar)
-    await session.commit()
-
-
-@pytest.mark.asyncio
-async def test_update_faction_admin_success(
-    client: AsyncClient,
-    account: Account,
-    auth_headers: dict,
-    faction_ua: Faction,
-    db_session: AsyncSession,
-):
-    """Admin can update a faction's name and description."""
-    await _make_admin(account, db_session)
-    resp = await client.put(
-        "/factions/ua",
-        json={"name": "United Alliance", "description": "Updated description."},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["name"] == "United Alliance"
-    assert data["description"] == "Updated description."
-    assert data["slug"] == "ua"
-
-
-@pytest.mark.asyncio
-async def test_update_faction_non_admin_forbidden(
-    client: AsyncClient,
-    auth_headers: dict,
-    faction_ua: Faction,
-):
-    """Non-admin accounts get 403 when attempting to update a faction."""
-    resp = await client.put(
-        "/factions/ua",
-        json={"name": "Hijacked", "description": "Nope."},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_update_faction_not_found(
-    client: AsyncClient,
-    account: Account,
-    auth_headers: dict,
-    db_session: AsyncSession,
-):
-    """PUT /factions/{slug} returns 404 for an unknown slug."""
-    await _make_admin(account, db_session)
-    resp = await client.put(
-        "/factions/does_not_exist",
-        json={"name": "Ghost", "description": ""},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 404
+# ADR-0038: the admin faction-copy edit path (PUT /factions/{slug},
+# update_faction, FactionUpdate) has been retired — faction name/description
+# prose is config-canonical and lives in frontend/src/locales/en/factions.json,
+# so there is nothing to edit through the API. No update tests remain.

--- a/backend/tests/integration/test_invitation_delivery.py
+++ b/backend/tests/integration/test_invitation_delivery.py
@@ -55,7 +55,7 @@ async def _letters(db_session: AsyncSession, character: Character) -> set[str]:
 
 async def _seed_faction(db_session: AsyncSession, slug: str) -> None:
     if await db_session.scalar(select(Faction).where(Faction.slug == slug)) is None:
-        db_session.add(Faction(slug=slug, name=slug, description=slug, status=FactionStatus.visible))
+        db_session.add(Faction(slug=slug, status=FactionStatus.visible))
         await db_session.flush()
 
 

--- a/backend/tests/integration/test_me.py
+++ b/backend/tests/integration/test_me.py
@@ -167,7 +167,7 @@ async def test_invited_factions_account_pooled(
     db_session.add(InvitationLetter(character_id=character.id, faction_slug="albescent", era_id=era.id))
     # albescent FK row
     from models.faction import FactionStatus
-    db_session.add(Faction(slug="albescent", name="Albescent", description="x", status=FactionStatus.visible))
+    db_session.add(Faction(slug="albescent", status=FactionStatus.visible))
     await db_session.commit()
 
     resp = await client.get("/me/invited-factions", headers=auth_headers)
@@ -254,7 +254,7 @@ async def test_auth_me_invitations_two_sorted_excludes_sentinels(
     )
     # A sentinel invite is never surfaced.
     db_session.add(
-        Faction(slug="albescent", name="Albescent", description="x", status=FactionStatus.visible)
+        Faction(slug="albescent", status=FactionStatus.visible)
     )
     db_session.add(
         InvitationLetter(

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -153,8 +153,6 @@ async def test_list_praxes_filter_by_faction(
         db_session.add(
             Faction(
                 slug="wow",
-                name="Warriors of Whimsy",
-                description="",
                 status=FactionStatus.visible,
             )
         )
@@ -1527,8 +1525,6 @@ async def test_create_praxis_duplicate_allowed_for_analog(
         db_session.add(
             Faction(
                 slug="everymen",
-                name="Everymen",
-                description="Double Dipper perk",
                 status=FactionStatus.visible,
             )
         )
@@ -1994,7 +1990,7 @@ async def test_everymen_joined_collaborator_can_resign_up(
 
     result = await db_session.execute(sa_select(Faction).where(Faction.slug == "everymen"))
     if result.scalar_one_or_none() is None:
-        db_session.add(Faction(slug="everymen", name="Everymen", description="Double Dipper", status=FactionStatus.visible))
+        db_session.add(Faction(slug="everymen", status=FactionStatus.visible))
         await db_session.commit()
 
     character.faction_slug = "everymen"
@@ -2049,7 +2045,7 @@ async def test_everymen_can_be_invited_despite_active_collab(
 
     result = await db_session.execute(sa_select(Faction).where(Faction.slug == "everymen"))
     if result.scalar_one_or_none() is None:
-        db_session.add(Faction(slug="everymen", name="Everymen", description="Double Dipper", status=FactionStatus.visible))
+        db_session.add(Faction(slug="everymen", status=FactionStatus.visible))
         await db_session.commit()
 
     character2.faction_slug = "everymen"

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -413,8 +413,6 @@ async def test_list_tasks_excludes_hidden_faction_tasks(
     if hidden_result.scalar_one_or_none() is None:
         hidden_faction = Faction(
             slug="hiddenfaction",
-            name="Hidden",
-            description="Not visible",
             status=FactionStatus.hidden,
         )
         db_session.add(hidden_faction)
@@ -455,8 +453,6 @@ async def test_create_praxis_for_hidden_faction_task_rejected(
     if hidden_result.scalar_one_or_none() is None:
         hidden_faction = Faction(
             slug="hiddenfaction3",
-            name="Hidden3",
-            description="Still not visible",
             status=FactionStatus.hidden,
         )
         db_session.add(hidden_faction)
@@ -1115,8 +1111,6 @@ async def test_get_task_can_submit_true_for_analog_with_existing_praxis(
         db_session.add(
             Faction(
                 slug="everymen",
-                name="Everymen",
-                description="Double Dipper",
                 status=FactionStatus.visible,
             )
         )
@@ -1261,7 +1255,7 @@ async def test_get_task_can_submit_true_everymen_as_collaborator(
 
     result = await db_session.execute(select(Faction).where(Faction.slug == "everymen"))
     if result.scalar_one_or_none() is None:
-        db_session.add(Faction(slug="everymen", name="Everymen", description="Double Dipper", status=FactionStatus.visible))
+        db_session.add(Faction(slug="everymen", status=FactionStatus.visible))
         await db_session.commit()
 
     character2.faction_slug = "everymen"
@@ -1469,8 +1463,6 @@ async def test_get_task_metatask_eligibility_different_faction(
         db_session.add(
             Faction(
                 slug="snide",
-                name="Snide",
-                description="Other faction",
                 status=FactionStatus.visible,
             )
         )

--- a/backend/tests/unit/test_i18n_catalog_coverage.py
+++ b/backend/tests/unit/test_i18n_catalog_coverage.py
@@ -34,6 +34,11 @@ def taunts() -> dict:
     return _load("taunts")
 
 
+@pytest.fixture(scope="module")
+def factions() -> dict:
+    return _load("factions")
+
+
 def test_every_rank_key_resolves(progression):
     ranks = progression["ranks"]
     for level, profile in enumerate(CURRENT_ERA.level_profiles):
@@ -66,6 +71,26 @@ def test_default_faction_covers_every_trigger(taunts):
         variants = default.get(trigger.value)
         assert isinstance(variants, list) and variants, (
             f"taunts:default.{trigger.value} must be a non-empty variant list"
+        )
+
+
+def test_every_config_faction_name_and_description_resolves(factions):
+    """ADR-0038 drift guard: faction name/description prose is config-canonical
+    but lives in the frontend factions.json catalog. Every slug the current era
+    defines — with no exceptions, including the ``na`` sentinel — must resolve a
+    non-empty names.<slug> and descriptions.<slug>. The backend is the only
+    layer that can enumerate the full slug set from config, so this lives here.
+    """
+    names = factions.get("names", {})
+    descriptions = factions.get("descriptions", {})
+    for faction_slug in CURRENT_ERA.factions:
+        name = names.get(faction_slug)
+        assert isinstance(name, str) and name.strip(), (
+            f"factions:names.{faction_slug} missing or empty in catalog"
+        )
+        description = descriptions.get(faction_slug)
+        assert isinstance(description, str) and description.strip(), (
+            f"factions:descriptions.{faction_slug} missing or empty in catalog"
         )
 
 

--- a/docs/adr/0038-faction-identity-is-config-canonical.md
+++ b/docs/adr/0038-faction-identity-is-config-canonical.md
@@ -1,0 +1,92 @@
+# ADR-0038 — Faction identity is config-canonical; the DB row is slug + status
+
+**Status:** Accepted
+**Date:** 2026-07-15
+**Relates to:** #461 (this decision), ADR-0031 (backend emits keys; the frontend
+catalog resolves them), ADR-0032 (react-i18next copy catalog), ADR-0030
+(default faction behaviour), #440 (the copy-catalog foundation this rides on)
+
+> **Numbering note.** Issue #461 proposed "ADR-0035" for this decision, but that
+> number was already taken by the mobile-form-factor ADR (and 0036/0037 are
+> feed-sources and flag-reasons). This decision is filed as **0038**, the next
+> free number.
+
+## Context
+
+Faction name/description prose lived in **two** places at once:
+
+- **Config** — `FactionConfig.name` / `.description` in `backend/eras/era_1.py`,
+  served live via `/game-config` and read at feed/router render time.
+- **The database** — `Faction.name` / `Faction.description` columns, seeded from
+  config and mutable through an admin-only `PUT /factions/{slug}` edit path
+  (`update_faction` + `FactionUpdate`).
+
+This dual source of truth is exactly the kind of drift ADR-0031 removed for
+taunts and ranks/unlocks — there ADR-0031 explicitly scoped faction copy *out*,
+flagging it as an unresolved "config vs admin-editable DB" fork. #461 resolves
+that fork. Meanwhile the i18n epic (#440/ADR-0032) had already moved the English
+faction words into `frontend/src/locales/en/factions.json` (slug-keyed `names`
+and `descriptions`), and the frontend now resolves faction name/description via
+`factionName()` / `factionDescription()` off the slug. The backend fields and DB
+columns had become a redundant, drift-prone second copy.
+
+## Decision
+
+Three coupled decisions:
+
+1. **Faction identity is config-canonical.** Config (`CURRENT_ERA.factions`) owns
+   *which factions exist* and their mechanics. The English **name/description
+   prose is not config-owned and not backend-emitted** — it lives only in
+   `frontend/src/locales/en/factions.json` (`names.<slug>`,
+   `descriptions.<slug>`), resolved by slug in the viewer's locale. Mirrors
+   ADR-0031: the backend emits a **slug**, the frontend catalog owns the words.
+
+2. **The DB `Faction` row carries `slug` + `status` (+ timestamps) only.** The
+   `name` and `description` columns are dropped. The row exists for FK targets
+   and status (visible/hidden/deprecated); it holds no prose. `FactionConfig`
+   loses its `name`/`description` fields; every API surface
+   (`FactionOut`, `FactionStatusOut`, `InvitationLetterOut`, `FactionConfigOut`,
+   the activity-feed invitation/defection payloads) stops emitting faction prose
+   and emits the slug instead.
+
+3. **The admin faction-copy edit path is retired.** `PUT /factions/{slug}`, the
+   `update_faction` service, and the `FactionUpdate` schema are removed (zero
+   frontend callers). There is no longer any editable prose on the row to edit;
+   changing a faction's words is a `factions.json` catalog edit. The admin
+   *create* path survives but now writes slug + status only.
+
+**Drift guard.** As with ADR-0031, the backend is the only layer that can
+enumerate the full slug set from config, so a **backend unit test**
+(`tests/unit/test_i18n_catalog_coverage.py`) reads
+`frontend/src/locales/en/factions.json` and asserts `names.<slug>` and
+`descriptions.<slug>` both resolve (non-empty) for **every** slug in
+`CURRENT_ERA.factions` — exceptionless, including the `na` sentinel.
+
+**Migration.** None. Per the pre-launch squash doctrine (`docs/agents/db-migrations.md`,
+Strategy A), the single baseline `0001_squashed` rebuilds the whole schema from the
+live ORM models via `Base.metadata.create_all` — there are no incremental migrations.
+Dropping `name`/`description` from `models/faction.py` removes them from the baseline
+by construction; a fresh `alembic upgrade head` builds `faction` with `slug` + `status`
+only, and `alembic check` reports no drift. Existing dev/worktree DBs are reset via
+`reset_db.sh` (their old prose is discarded — accepted, mirroring #451's taunt-wipe).
+An incremental `DROP COLUMN` migration would in fact break a fresh `upgrade head`,
+since `create_all` never creates the columns for it to drop.
+
+## Alternatives rejected
+
+- **Keep the DB columns, drop only the config fields.** Leaves prose in the
+  database as the source of truth, un-localizable and needing the admin edit
+  path — the opposite of the ADR-0031/0032 direction. Rejected.
+- **Keep config as the source and seed the DB columns from it.** Preserves the
+  dual copy and the drift it invites; the DB prose is never read once the
+  frontend resolves by slug. Rejected.
+- **Preserve `PUT /factions/{slug}` against config-backed copy.** Nothing on the
+  row to edit; would have to write back into `factions.json` from the API.
+  Rejected — catalog edits are a frontend/repo concern.
+
+## Scope
+
+**In:** faction name/description dual-source collapse; DB column drop; admin
+edit-path retirement. **Out (unchanged):** task-content localization (DB rows,
+player-authored free text — still a separate DB-content problem, as ADR-0031
+noted); faction *mechanics* stay config-owned.

--- a/frontend/src/api/factions.ts
+++ b/frontend/src/api/factions.ts
@@ -1,14 +1,15 @@
 import api from './axios'
 
+// Faction name/description prose is no longer backend-emitted (issue #461): the
+// server sends only the slug, and the frozen English words live in the
+// factions.json catalog. Resolve display copy with factionName(slug) /
+// factionDescription(slug) from utils/factions.
 export interface FactionOut {
   slug: string
-  name: string
-  description: string | null
 }
 
 export interface FactionStatusOut {
   slug: string
-  name: string
   status: string // member, invited, not_invited, defected, can_return
 }
 
@@ -19,17 +20,11 @@ export interface FactionPageOut {
 
 export interface InvitationLetterOut {
   faction_slug: string
-  faction_name: string
   delivered_at: string
 }
 
 export async function getFactions(): Promise<FactionOut[]> {
   const res = await api.get<FactionOut[]>('/factions')
-  return res.data
-}
-
-export async function updateFaction(slug: string, data: { name: string; description: string | null }): Promise<FactionOut> {
-  const res = await api.put<FactionOut>(`/factions/${slug}`, data)
   return res.data
 }
 

--- a/frontend/src/api/gameConfig.ts
+++ b/frontend/src/api/gameConfig.ts
@@ -1,9 +1,10 @@
 import api from './axios'
 
+// Faction name/description prose moved to the factions.json catalog (issue
+// #461); /game-config emits only the slug + numeric rules. Resolve display copy
+// with factionName(slug) / factionDescription(slug) from utils/factions.
 export interface FactionConfigOut {
   slug: string
-  name: string
-  description: string
   can_always_rejoin: boolean
   own_task_modifier: number
   other_task_modifier: number

--- a/frontend/src/components/cards/EverymenFactionCard.tsx
+++ b/frontend/src/components/cards/EverymenFactionCard.tsx
@@ -1,11 +1,12 @@
 import type { FactionCardProps } from "./FactionCard";
 import i18n from "../../i18n";
+import { factionName, factionDescription } from "../../utils/factions";
 
 /**
  * EverymenFactionCard — the Everymen faction PREVIEW card.
  *
  * A union recruitment poster: a masthead with the faction name in a big Bebas
- * headline and the motto/blurb pulled from faction.description. Pure preview —
+ * headline and the motto/blurb from factionDescription(slug). Pure preview —
  * the whole card is a link to the faction detail page, where the enlist / leave
  * membership block lives (issue #347). No interactive controls here.
  *
@@ -89,8 +90,7 @@ export default function EverymenCard({
   faction,
   invitationNote,
 }: FactionCardProps) {
-  const blurb =
-    faction.description ?? i18n.t("feed:factionCard.everymen.blurbFallback");
+  const blurb = factionDescription(faction.slug);
 
   const perks = [
     i18n.t("feed:factionCard.everymen.perks.honestPoints"),
@@ -182,7 +182,7 @@ export default function EverymenCard({
             textShadow: "3px 3px 0 var(--everymen-ink)",
           }}
         >
-          {faction.name}
+          {factionName(faction.slug)}
         </h1>
 
         {/* motto plaque */}

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -1,6 +1,6 @@
 import type { FactionOut } from "../../api/factions";
 import i18n from "../../i18n";
-import { factionCssVar } from "../../utils/factions";
+import { factionCssVar, factionName, factionDescription } from "../../utils/factions";
 import EverymenCard from "./EverymenFactionCard";
 import SnideMasthead from "./SnideMasthead";
 import { EphSeal, LapisLastWord } from "./ephemeristsAtoms";
@@ -122,10 +122,8 @@ function UACard({
   invitationNote,
 }: FactionCardProps) {
   const rotation = ROTATIONS[faction.slug.length % ROTATIONS.length];
-  const desc = faction.description
-    ? faction.description.slice(0, 100) +
-      (faction.description.length > 100 ? "…" : "")
-    : "";
+  const fullDesc = factionDescription(faction.slug);
+  const desc = fullDesc.slice(0, 100) + (fullDesc.length > 100 ? "…" : "");
   return (
     <div
       style={{
@@ -172,7 +170,7 @@ function UACard({
           marginBottom: 8,
         }}
       >
-        {faction.name}
+        {factionName(faction.slug)}
       </div>
       {desc && (
         <div
@@ -234,10 +232,8 @@ function WowCard({
   status,
   invitationNote,
 }: FactionCardProps) {
-  const desc = faction.description
-    ? faction.description.slice(0, 100) +
-      (faction.description.length > 100 ? "…" : "")
-    : "";
+  const fullDesc = factionDescription(faction.slug);
+  const desc = fullDesc.slice(0, 100) + (fullDesc.length > 100 ? "…" : "");
   const titleText = "var(--faction-wow-title-text)";
   return (
     <div
@@ -395,7 +391,7 @@ function WowCard({
                 marginBottom: 4,
               }}
             >
-              {faction.name}
+              {factionName(faction.slug)}
             </div>
             {desc && (
               <div
@@ -423,10 +419,8 @@ function SnideCard({
   status,
   invitationNote,
 }: FactionCardProps) {
-  const desc = faction.description
-    ? faction.description.slice(0, 100) +
-      (faction.description.length > 100 ? "…" : "")
-    : "";
+  const fullDesc = factionDescription(faction.slug);
+  const desc = fullDesc.slice(0, 100) + (fullDesc.length > 100 ? "…" : "");
   const words = desc.split(" ");
   const mid = Math.ceil(words.length / 2);
   const col1 = words.slice(0, mid).join(" ");
@@ -480,7 +474,7 @@ function SnideCard({
         }}
       >
         <div style={{ fontSize: "var(--text-lg)", lineHeight: 1.2 }}>
-          {faction.name}
+          {factionName(faction.slug)}
         </div>
         <StatusBadge status={status} slug="snide" />
       </div>
@@ -528,10 +522,8 @@ function EphemeristsCard({
   status,
   invitationNote,
 }: FactionCardProps) {
-  const desc = faction.description
-    ? faction.description.slice(0, 110) +
-      (faction.description.length > 110 ? "…" : "")
-    : "";
+  const fullDesc = factionDescription(faction.slug);
+  const desc = fullDesc.slice(0, 110) + (fullDesc.length > 110 ? "…" : "");
   return (
     <div
       style={{
@@ -583,7 +575,7 @@ function EphemeristsCard({
               textShadow: "1px 1px 0 var(--eph-field-deep)",
             }}
           >
-            <LapisLastWord text={faction.name} />
+            <LapisLastWord text={factionName(faction.slug)} />
           </div>
         </div>
       </div>
@@ -649,10 +641,8 @@ function SingularityCard({
   status,
   invitationNote,
 }: FactionCardProps) {
-  const desc = faction.description
-    ? faction.description.slice(0, 100) +
-      (faction.description.length > 100 ? "…" : "")
-    : "";
+  const fullDesc = factionDescription(faction.slug);
+  const desc = fullDesc.slice(0, 100) + (fullDesc.length > 100 ? "…" : "");
   return (
     <div
       style={{
@@ -761,7 +751,7 @@ function SingularityCard({
         >
           <div style={{ fontSize: "var(--text-md)", lineHeight: 1.3 }}>
             {"> "}
-            {faction.name}
+            {factionName(faction.slug)}
           </div>
           <StatusBadge status={status} slug="singularity" />
         </div>
@@ -836,15 +826,13 @@ export default function FactionCard(props: FactionCardProps) {
                 color: factionCssVar(props.faction.slug),
               }}
             >
-              {props.faction.name}
+              {factionName(props.faction.slug)}
             </div>
             <StatusBadge status={props.status} slug={props.faction.slug} />
           </div>
-          {props.faction.description && (
-            <div className="card-description" style={{ marginBottom: 10 }}>
-              {props.faction.description.slice(0, 100)}
-            </div>
-          )}
+          <div className="card-description" style={{ marginBottom: 10 }}>
+            {factionDescription(props.faction.slug).slice(0, 100)}
+          </div>
         </div>
       );
   }

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { Trans } from "react-i18next";
 import type { ActivityFeedItem } from "../../api/activityFeed";
 import i18n from "../../i18n";
-import { factionColor } from "../../utils/factions";
+import { factionColor, factionName } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function FeedCardInvitationLetter({ item }: Props) {
-  const { faction_slug, faction_name } = item.payload;
+  const { faction_slug } = item.payload;
   const color = factionColor(faction_slug);
 
   return (
@@ -55,7 +55,7 @@ export default function FeedCardInvitationLetter({ item }: Props) {
         <Trans
           ns="feed"
           i18nKey="invitationLetter.sentence"
-          values={{ faction: faction_name }}
+          values={{ faction: factionName(faction_slug) }}
           components={{ 1: <span style={{ color, fontWeight: 700 }} /> }}
         />
       </p>

--- a/frontend/src/components/ui/FilterFactionTabs.tsx
+++ b/frontend/src/components/ui/FilterFactionTabs.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import type { FactionOut } from "../../api/factions";
 import {
   factionCssVar,
+  factionName,
   sortFactionsByRainbowOrder,
 } from "../../utils/factions";
 
@@ -50,7 +51,7 @@ export default function FilterFactionTabs({
               transition: "all 120ms",
             }}
           >
-            {faction.name}
+            {factionName(faction.slug)}
           </button>
         );
       })}

--- a/frontend/src/hooks/useGameConfig.ts
+++ b/frontend/src/hooks/useGameConfig.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { getGameConfig, type GameConfigOut } from '../api/gameConfig'
-import { populateFactionRegistry } from '../utils/factions'
 
 let cachedConfig: GameConfigOut | null = null
 let fetchPromise: Promise<GameConfigOut> | null = null
@@ -21,7 +20,6 @@ export function useGameConfig() {
       fetchPromise = getGameConfig()
         .then((data) => {
           cachedConfig = data
-          populateFactionRegistry(data.factions)
           return data
         })
         .catch(() => {

--- a/frontend/src/locales/README.md
+++ b/frontend/src/locales/README.md
@@ -21,7 +21,7 @@ locales/
 | `common.json` | Shared chrome: nav, buttons, generic labels/errors used across pages |
 | `forms.json` | Form UX copy: validation, character limits, input hints |
 | `votes.json` | Vote-tier labels, per faction (see slug nesting below) |
-| `factions.json` | Faction pages: join flows, rosters, faction-detail copy |
+| `factions.json` | Faction `names`/`descriptions` per slug (backend emits slug — ADR-0038), plus faction pages: join flows, rosters, faction-detail copy |
 | `praxis.json` | Praxis composing/reading: submission, proof, praxis character limits |
 | `tasks.json` | Task cards, task detail, propose-task copy |
 | `feed.json` | Activity-feed cards and frames |
@@ -126,10 +126,27 @@ never sends prose for taunts or ranks/unlocks.
   modulo pick means reordering silently reassigns which taunt an existing row
   renders, and deleting one shifts every later index. Adding to the end is safe.
 
+### Faction names/descriptions (`factions.json`)
+
+Faction **name/description** prose is also backend-emitted-as-slug (ADR-0038):
+config owns which factions exist, the DB `Faction` row carries slug + status
+only, and this catalog owns the words.
+
+- **`names.<slug>`** — the faction's display name (e.g. `names.ua` → "UA").
+- **`descriptions.<slug>`** — the one-line faction blurb.
+
+The frontend resolves these by slug via `factionName()` / `factionDescription()`.
+Every slug the live era defines must have a non-empty `names.<slug>` **and**
+`descriptions.<slug>` — including `na` (unaffiliated). **Append-only per slug:**
+add an entry when a new faction ships; don't drop a slug that config still emits.
+
+### Drift guard
+
 A backend drift-guard test (`backend/tests/unit/test_i18n_catalog_coverage.py`)
-fails if the era config references a rank/unlock key or a
-`(faction_slug, trigger_type)` combo this catalog can't resolve — so a missing
-key is caught in CI, not at render time.
+fails if the era config references a rank/unlock key, a
+`(faction_slug, trigger_type)` taunt combo, or a faction slug whose
+`names`/`descriptions` entry this catalog can't resolve — so a missing key is
+caught in CI, not at render time.
 
 ## Rules of the road
 

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -1,5 +1,24 @@
 {
-  "unaffiliatedName": "Unaffiliated",
+  "names": {
+    "ua": "UA",
+    "snide": "S.N.I.D.E.",
+    "wow": "Warriors of Whimsy",
+    "ephemerists": "The Ephemerists",
+    "everymen": "Everymen",
+    "singularity": "Singularity",
+    "albescent": "/Albescent",
+    "na": "Unaffiliated"
+  },
+  "descriptions": {
+    "ua": "The Gilt Salon — a regal academy. Full points on all tasks.",
+    "snide": "Specialists in one-on-one competition. Bonus points for winning duels.",
+    "wow": "Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
+    "ephemerists": "Wanderers who set down fleeting truths before the road moves on. Task Vision — access to select retired tasks.",
+    "everymen": "No inner circle, no waiting to be chosen. Reliable hands who do the work in front of them and finish what they start.",
+    "singularity": "embrace your digital double",
+    "albescent": "Full points and any meta tasks from any group. Unlock-only.",
+    "na": "Not yet sworn to a faction."
+  },
   "index": {
     "loading": "Loading...",
     "recentInvitations": "Recent Invitations ({{count}})",

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -2,7 +2,7 @@ import { type ComponentType } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "react-router-dom";
 import PageTitle from "../components/ui/PageTitle";
-import { factionCssVar } from "../utils/factions";
+import { factionCssVar, factionName, factionDescription } from "../utils/factions";
 import { pickVariant } from "../utils/factionDispatch";
 import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFactionDetail";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
@@ -98,6 +98,8 @@ export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}
     );
 
   const accent = factionCssVar(faction.slug, "border");
+  const name = factionName(faction.slug);
+  const description = factionDescription(faction.slug);
 
   // A faction may register a bespoke frontispiece in FACTION_HEROES; otherwise
   // (Hero is undefined) the shared title + description chrome is used. The page
@@ -109,15 +111,15 @@ export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}
     <div className="py-8">
       {Hero ? (
         <Hero
-          name={faction.name}
-          description={faction.description}
+          name={name}
+          description={description}
           members={members.length}
           tasks={tasks.length}
           praxes={recentPraxis.length}
         />
       ) : (
         <>
-          <PageTitle title={faction.name} eyebrow={t("detail.eyebrow")} />
+          <PageTitle title={name} eyebrow={t("detail.eyebrow")} />
 
           {/* ── Description ── PLACEHOLDER: design to restyle ── */}
           <div
@@ -125,7 +127,7 @@ export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}
             style={{ borderLeft: `4px solid ${accent}`, padding: "14px 16px" }}
           >
             <p className="font-body text-sm text-ink">
-              {faction.description ?? t("detail.descriptionEmpty")}
+              {description}
             </p>
           </div>
         </>

--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -7,7 +7,7 @@ import PageTitle from '../components/ui/PageTitle'
 import FactionSelectCard from '../components/cards/FactionSelectCard'
 import type { SelectState } from '../components/cards/FactionSelectCard'
 import { extractError } from '../utils/errors'
-import { factionCssVar } from '../utils/factions'
+import { factionCssVar, factionName } from '../utils/factions'
 import { relativeTime } from '../utils/dates'
 import { useAuth } from '../auth/AuthContext'
 
@@ -163,7 +163,7 @@ export default function Factions() {
                       <Trans
                         t={t}
                         i18nKey="index.invitedToJoin"
-                        values={{ faction: inv.faction_name }}
+                        values={{ faction: factionName(inv.faction_slug) }}
                         components={[
                           <span key="0" />,
                           <span key="1" style={{ fontWeight: 700, color: factionCssVar(inv.faction_slug) }} />,

--- a/frontend/src/pages/__tests__/factionMembershipRelocation.test.tsx
+++ b/frontend/src/pages/__tests__/factionMembershipRelocation.test.tsx
@@ -19,11 +19,12 @@ import FactionCard from "../../components/cards/FactionCard";
 import EverymenFactionBody from "../factionDetail/archetypes/EverymenFactionBody";
 import type { FactionDetailState, Membership } from "../factionDetail/useFactionDetail";
 import type { FactionOut } from "../../api/factions";
+import { factionName } from "../../utils/factions";
 
+// Faction name/description prose is no longer on FactionOut (issue #461) — the
+// display copy resolves from the factions.json catalog by slug.
 const FACTION: FactionOut = {
   slug: "everymen",
-  name: "The Everymen",
-  description: "Honest work, honestly done.",
 };
 
 function html(node: React.ReactElement): string {
@@ -43,11 +44,11 @@ describe("faction grid card is a pure preview", () => {
     it(`${slug} card renders the name but no membership buttons`, () => {
       const card = (
         <FactionCard
-          faction={{ ...FACTION, slug, name: `Faction ${slug}` }}
+          faction={{ ...FACTION, slug }}
           status="eligible"
         />
       );
-      expect(text(card), "faction name renders").toContain(`Faction ${slug}`);
+      expect(text(card), "faction name renders").toContain(factionName(slug));
       expect(html(card), "no interactive controls on the grid card").not.toContain(
         "<button",
       );

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -6,7 +6,7 @@ import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { EphMark, Foxing, toRoman } from "../../../components/cards/ephemeristsAtoms";
 import { computeDisplayPoints } from "../../../utils/points";
-import { factionName } from "../../../utils/factions";
+import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -113,7 +113,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
   if (!faction) return null;
 
   // ② apparatus paragraphs — split the single description on blank lines.
-  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const paragraphs = factionDescription(faction.slug).split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
   // ⑥ spotlight = highest all-time score; roster = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
@@ -257,10 +257,10 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
-                            faction: faction.name,
+                            faction: factionName(faction.slug),
                             current: factionName(membership.currentFactionSlug),
                           })
-                        : t("detail.join.confirm", { faction: faction.name })}
+                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
                       <div style={{ fontFamily: SERIF, fontSize: 12, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
@@ -295,7 +295,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                       {t("ephemerists.road.gateTitle")}
                     </div>
                     <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.65, color: TEXT }}>
-                      {t("ephemerists.road.gateBody", { faction: faction.name })}
+                      {t("ephemerists.road.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -5,7 +5,7 @@ import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
-import { factionName } from "../../../utils/factions";
+import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -126,7 +126,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
   if (!faction) return null;
 
   // ② manifesto paragraphs — split the single description on blank lines.
-  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const paragraphs = factionDescription(faction.slug).split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
   // ⑥ spotlight = highest all-time score; roster = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
@@ -265,10 +265,10 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
-                            faction: faction.name,
+                            faction: factionName(faction.slug),
                             current: factionName(membership.currentFactionSlug),
                           })
-                        : t("detail.join.confirm", { faction: faction.name })}
+                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
                       <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
@@ -303,7 +303,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                       {t("everymen.roll.gateTitle")}
                     </div>
                     <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.65, color: INK }}>
-                      {t("everymen.roll.gateBody", { faction: faction.name })}
+                      {t("everymen.roll.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -5,7 +5,7 @@ import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
-import { factionName } from "../../../utils/factions";
+import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -144,7 +144,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
   if (!faction) return null;
 
   // ② manifest paragraphs — split the single description on blank lines.
-  const paragraphs = (faction.description ?? "")
+  const paragraphs = factionDescription(faction.slug)
     .split(/\n\s*\n/)
     .map((p) => p.trim())
     .filter(Boolean);
@@ -339,10 +339,10 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
-                            faction: faction.name,
+                            faction: factionName(faction.slug),
                             current: factionName(membership.currentFactionSlug),
                           })
-                        : t("detail.join.confirm", { faction: faction.name })}
+                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
                       <div style={{ fontFamily: FONT, fontSize: 9, color: "var(--color-danger)", marginBottom: 8 }}>
@@ -397,7 +397,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                       {t("singularity.access.gateKicker")}
                     </div>
                     <div style={{ fontFamily: FONT, fontSize: 20, lineHeight: 1.1, color: PHOSPHOR, letterSpacing: "0.03em", marginBottom: 11 }}>
-                      {t("singularity.access.gateTitle", { faction: faction.name })}
+                      {t("singularity.access.gateTitle", { faction: factionName(faction.slug) })}
                     </div>
                     <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.7, color: phosphor(60) }}>
                       {t("singularity.access.gateBody")}

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -5,7 +5,7 @@ import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
-import { factionName } from "../../../utils/factions";
+import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -175,7 +175,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
   if (!faction) return null;
 
   // ② about paragraphs — split the single description on blank lines.
-  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const paragraphs = factionDescription(faction.slug).split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
   // ⑥ spotlight = highest all-time score; rap sheet = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
@@ -351,10 +351,10 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
-                            faction: faction.name,
+                            faction: factionName(faction.slug),
                             current: factionName(membership.currentFactionSlug),
                           })
-                        : t("detail.join.confirm", { faction: faction.name })}
+                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
                       <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>
@@ -410,7 +410,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                       {t("snide.dispatch.gateTitle")}
                     </div>
                     <div style={{ fontFamily: TYPE, fontSize: 10.5, lineHeight: 1.6, color: "#d8d6c8" }}>
-                      {t("snide.dispatch.gateBody", { faction: faction.name })}
+                      {t("snide.dispatch.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -6,7 +6,7 @@ import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { toRoman } from "../../../components/cards/ephemeristsAtoms";
 import { computeDisplayPoints } from "../../../utils/points";
-import { factionName } from "../../../utils/factions";
+import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -122,7 +122,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
   if (!faction) return null;
 
-  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const paragraphs = factionDescription(faction.slug).split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
   const register = ranked.slice(1);
@@ -257,10 +257,10 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                     {membership.currentFactionSlug &&
                     membership.currentFactionSlug !== "na"
                       ? t("ua.registry.confirmSwitch", {
-                          faction: faction.name,
+                          faction: factionName(faction.slug),
                           current: factionName(membership.currentFactionSlug),
                         })
-                      : t("ua.registry.confirm", { faction: faction.name })}
+                      : t("ua.registry.confirm", { faction: factionName(faction.slug) })}
                   </div>
                   {membership.joinError && (
                     <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
@@ -293,7 +293,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                     {t("ua.registry.gateTitle")}
                   </div>
                   <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.65, color: SUB }}>
-                    {t("ua.registry.gateBody", { faction: faction.name })}
+                    {t("ua.registry.gateBody", { faction: factionName(faction.slug) })}
                   </div>
                 </div>
               )}

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -5,7 +5,7 @@ import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { computeDisplayPoints } from "../../../utils/points";
-import { factionName } from "../../../utils/factions";
+import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -171,7 +171,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
   if (!faction) return null;
 
   // ② manifesto paragraphs — split the single description on blank lines.
-  const paragraphs = (faction.description ?? "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const paragraphs = factionDescription(faction.slug).split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
 
   // ⑥ spotlight = highest all-time score; roster = the rest.
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
@@ -352,10 +352,10 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
-                            faction: faction.name,
+                            faction: factionName(faction.slug),
                             current: factionName(membership.currentFactionSlug),
                           })
-                        : t("detail.join.confirm", { faction: faction.name })}
+                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
                       <div style={{ fontFamily: BODY, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
@@ -416,7 +416,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                       </span>
                     </div>
                     <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.55, color: MUTED }}>
-                      {t("wow.join.gateBody", { faction: faction.name })}
+                      {t("wow.join.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
                 )}

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -9,54 +9,43 @@
  * Use factionCssVar() when you need the CSS variable reference (preferred for styles).
  * Use factionColor() when you need the raw hex value in JS (canvas, SVG generation, etc.).
  *
- * The faction registry is seeded with hardcoded fallback values on startup and overwritten
- * from GET /game-config via populateFactionRegistry() once the API responds. This means
- * all components automatically see live API values after the first fetch without any
- * component-level changes.
+ * The faction registry is a color-only runtime table, seeded from index.css
+ * --faction-* values. Faction NAMES and DESCRIPTIONS are no longer backend-
+ * emitted: the frozen English words live in the factions.json catalog, keyed by
+ * slug (ADR-0031, same split as taunts/ranks), and are resolved via
+ * factionName() / factionDescription().
  */
 import i18n from "../i18n";
 
+// Faction slugs are runtime-dynamic, so the catalog keys (`factions:names.<slug>`
+// / `factions:descriptions.<slug>`) can't be the typed literals t() expects.
+// Resolve through a plain-string view of t — the catalog still owns the words;
+// only the compile-time key check is relaxed for these dynamic lookups. Same
+// pattern as utils/taunts.ts.
+const tString = i18n.t as unknown as (key: string) => string;
+
 export interface FactionConfig {
   slug: string;
-  name: string;
   /** Primary faction color (light mode value — use factionCssVar for theme-aware styles) */
   color: string;
 }
 
-/** Hardcoded fallback — matches index.css --faction-* values exactly. Used on first render
- *  before the API response arrives. Do not use these values directly; call factionColor(). */
+/** Hardcoded color table — matches index.css --faction-* values exactly. The
+ *  API never sends color (ADR-0003: the frontend owns faction color), so this is
+ *  the single source of the JS-side hex. Do not use directly; call factionColor(). */
 const FACTION_FALLBACKS: Record<string, FactionConfig> = {
-  ua: { slug: "ua", name: "UA", color: "#c2541f" },
-  everymen: { slug: "everymen", name: "Everymen", color: "#c1272d" },
-  wow: { slug: "wow", name: "Warriors of Whimsy", color: "#ec5f99" },
-  snide: { slug: "snide", name: "S.N.I.D.E.", color: "#6fae00" },
-  ephemerists: { slug: "ephemerists", name: "The Ephemerists", color: "#1d6e72" },
-  singularity: { slug: "singularity", name: "Singularity", color: "#2563eb" },
+  ua: { slug: "ua", color: "#c2541f" },
+  everymen: { slug: "everymen", color: "#c1272d" },
+  wow: { slug: "wow", color: "#ec5f99" },
+  snide: { slug: "snide", color: "#6fae00" },
+  ephemerists: { slug: "ephemerists", color: "#1d6e72" },
+  singularity: { slug: "singularity", color: "#2563eb" },
   // First-class identity (#232): near-black ink, no hue — the order refuses the palette.
-  albescent: { slug: "albescent", name: "/Albescent", color: "#1c1c1a" },
+  albescent: { slug: "albescent", color: "#1c1c1a" },
 };
 
-/** Live registry — starts as the fallback, overwritten by populateFactionRegistry(). */
-let factionRegistry: Record<string, FactionConfig> = { ...FACTION_FALLBACKS };
-
-/**
- * Called once by useGameConfig when the API response arrives.
- * Updates the runtime registry so all subsequent factionColor() / factionName()
- * calls return API-sourced values without any component changes.
- */
-export function populateFactionRegistry(
-  apiFactions: Array<{ slug: string; name: string }>,
-) {
-  for (const f of apiFactions) {
-    // Preserve the existing fallback color — the API no longer sends color
-    // (ADR-0003: the frontend owns faction color). Only the name is updated.
-    factionRegistry[f.slug] = {
-      ...factionRegistry[f.slug],
-      slug: f.slug,
-      name: f.name,
-    };
-  }
-}
+/** Live registry — color-only, static (nothing hydrates it from the API). */
+const factionRegistry: Record<string, FactionConfig> = { ...FACTION_FALLBACKS };
 
 /**
  * Faction-identity aliases: a derived/retired slug renders with its canonical
@@ -112,12 +101,30 @@ export function factionColor(slug: string | null | undefined): string {
   return factionRegistry[slug ?? ""]?.color ?? "#6b6a7a";
 }
 
-/** Get faction display name by slug, with fallback */
+/**
+ * Get a faction's display name by slug from the factions.json catalog
+ * (`names.<slug>`). A null / unrecognized slug falls back to the "Unaffiliated"
+ * copy under `names.na`. The backend emits only slugs now — never name prose.
+ */
 export function factionName(slug: string | null | undefined): string {
-  // The per-slug names are backend-authored (overwritten by /game-config and
-  // localized in a separate backend issue); only the "no such faction" fallback
-  // is frontend-owned copy, so that one string reads from the catalog.
-  return factionRegistry[slug ?? ""]?.name ?? i18n.t("factions:unaffiliatedName");
+  const key = slug ?? "";
+  if (i18n.exists(`factions:names.${key}`)) {
+    return tString(`factions:names.${key}`);
+  }
+  return i18n.t("factions:names.na");
+}
+
+/**
+ * Get a faction's description by slug from the factions.json catalog
+ * (`descriptions.<slug>`). An unrecognized slug falls back to the shared
+ * "No description yet." copy (`detail.descriptionEmpty`).
+ */
+export function factionDescription(slug: string | null | undefined): string {
+  const key = slug ?? "";
+  if (i18n.exists(`factions:descriptions.${key}`)) {
+    return tString(`factions:descriptions.${key}`);
+  }
+  return i18n.t("factions:detail.descriptionEmpty");
 }
 
 /** Get all factions from the live registry (populated from API after useGameConfig loads) */


### PR DESCRIPTION
Faction name/description prose moves out of the DB and config into the frontend `factions.json` catalog (the slug is the key, per ADR-0031). The backend emits faction **slug** everywhere, never prose; the frontend resolves via `factionName()` / `factionDescription()`. Records **ADR-0038** (the issue said 0035, but that number is taken by mobile-form-factor — renumbered).

## Backend
- **Config:** drop `name`/`description` from `FactionConfig` + all `era_1.py` sites.
- **Schemas:** drop `name`/`description` from `FactionOut` and `FactionConfigOut`, `name` from `FactionStatusOut`, `faction_name` from `InvitationLetterOut`.
- **Routers/services/activity_feed:** emit slug, not prose. Retire the dead admin faction-copy edit path (`PUT /factions/{slug}`, `update_faction`, `FactionUpdate` — zero callers) + its frontend client.
- **DB:** the `Faction` row carries `slug` + `status` only (columns dropped from the model).

## Migration — none (and that's deliberate)
Per the pre-launch squash doctrine (`docs/agents/db-migrations.md`, Strategy A), the single baseline `0001_squashed` rebuilds the whole schema from the live ORM models via `create_all` — there are **no incremental migrations**. Dropping the columns from `models/faction.py` removes them from the baseline by construction. Verified: a fresh `alembic upgrade head` builds `faction` with `slug`+`status` only and `alembic check` reports **no drift**. (An incremental `DROP COLUMN` migration was written first, then removed — it actually *breaks* a fresh `upgrade head`, since `create_all` never creates the columns for it to drop.)

## Frontend
Catalog `names`/`descriptions` sections (all 8 slugs; `na`="Unaffiliated", `singularity`/`na` authored overrides); `factionName`/`factionDescription` helpers; runtime registry demoted to color-only; every consumer resolves by slug; dead `updateFaction` client removed.

## Drift guard + docs
Backend unit test asserts `names.<slug>` + `descriptions.<slug>` resolve for every `CURRENT_ERA.factions` slug (incl. `na`). ADR-0038, CLAUDE.md routing row, `locales/README.md`.

## Verify
- Backend: **563 pass** (incl. drift guard; every `Faction(name=/description=)` fixture updated).
- Frontend: tsc no new errors; vitest green; no remaining readers of dropped fields.
- Migration: fresh `upgrade head` + `alembic check` clean on a throwaway DB.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
