### PR TITLE
Mobile: FieldDesk home dashboard — Default + WOW pilot (#500)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -72,7 +72,30 @@
     "gateHint": "Reach Lvl {{gateLevel}} on a life you already carry{{eraSuffix}}.",
     "gateHintEra": " — the gate set by {{eraName}}",
     "levelsToGo_one": "{{count}} level to go.",
-    "levelsToGo_other": "{{count}} levels to go."
+    "levelsToGo_other": "{{count}} levels to go.",
+    "home": {
+      "title": "FieldDesk",
+      "charEyebrow": "You",
+      "edit": "Edit",
+      "questsHeading": "In progress",
+      "questsEmpty": "Nothing in progress yet — pick up a task.",
+      "viewAll": "All tasks",
+      "taskMeta": "{{faction}} · +{{points}} pts",
+      "stats": {
+        "points": "Points",
+        "votes": "Votes",
+        "era": "Era"
+      },
+      "pending_one": "{{count}} pending request",
+      "pending_other": "{{count}} pending requests",
+      "browseTasks": "Browse Tasks",
+      "wow": {
+        "charWindow": "you",
+        "questsWindow": "quests",
+        "charEyebrow": "you",
+        "questsHeading": "quests"
+      }
+    }
   },
   "about": {
     "title": "About World Zero",

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -7,12 +7,32 @@ import type { CharacterOut } from '../api/auth'
 import CredentialCard from '../components/CredentialCard'
 import AlbescentInvitation from '../components/AlbescentInvitation'
 import { mediaUrl } from '../utils/media'
+import { pickVariant } from '../utils/factionDispatch'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { useFieldDeskHome, type FieldDeskHomeState } from './fieldDesk/useFieldDeskHome'
+import DefaultFieldDesk from './fieldDesk/mobileArchetypes/DefaultFieldDesk'
+import WowFieldDesk from './fieldDesk/mobileArchetypes/WowFieldDesk'
 
 /**
  * FieldDesk roster — the authenticated account home (#274). "Whose shoes today?":
  * step back into an existing life or begin a new one. Rendered at `/` when authed
  * (App routes a logged-out visitor to the marketing Home instead).
+ *
+ * On a phone (#500) the carried life gets a mobile-native home instead of the
+ * roster: `useFormFactor() === 'mobile'` dispatches through
+ * MOBILE_ARCHETYPE_BY_SLUG to a per-faction skin (Default fallback), mirroring
+ * the TaskDetail mobile seam. A brand-new account with no active life still
+ * falls through to the roster below so it can create one.
  */
+
+type MobileHomeSkin = (props: { state: FieldDeskHomeState }) => JSX.Element
+
+// Only factions with a bespoke mobile home are listed; everything else (incl.
+// na) falls through to DefaultFieldDesk. Grows one row per faction skin (#500 +
+// per-faction follow-ups), exactly like MOBILE_ARCHETYPE_BY_SLUG in TaskDetail.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileHomeSkin> = {
+  wow: WowFieldDesk,
+}
 
 // Deterministic slight tilt per card — index-keyed so it's stable across renders.
 const TILTS = [-2.5, 1.8, -1.2, 2.4, -2.0, 1.4]
@@ -24,6 +44,11 @@ export default function FieldDesk() {
   const [lives, setLives] = useState<CharacterOut[]>([])
   const [loading, setLoading] = useState(true)
   const [switching, setSwitching] = useState<number | null>(null)
+
+  // Mobile home dispatch (#500). Hooks run unconditionally; the branch below
+  // only fires once a carried life exists — otherwise we render the roster.
+  const formFactor = useFormFactor()
+  const homeState = useFieldDeskHome()
 
   useEffect(() => {
     void getMyCharacters()
@@ -49,6 +74,12 @@ export default function FieldDesk() {
   const unlocked = lives.length === 0 || (user?.can_create_additional_character ?? false)
   const highestLevel = lives.reduce((max, life) => Math.max(max, life.level), 0)
   const levelsToGo = Math.max(0, gateLevel - highestLevel)
+
+  // Phone + a carried life → the mobile-native home skin for that faction.
+  if (formFactor === 'mobile' && homeState) {
+    const Skin = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, homeState.character.faction_slug, DefaultFieldDesk)
+    return <Skin state={homeState} />
+  }
 
   return (
     <div className="page" style={pageStyle}>

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * FieldDesk form-factor dispatch (#500) — the home twin of the TaskDetail
+ * mobile-dispatch seam. Renders <FieldDesk /> with useFormFactor mocked and the
+ * home hooks stubbed, and pins:
+ *   - phone + a carried life → the mobile home skin for that faction
+ *     (wow → its bespoke skin; an unregistered faction → the Default skin),
+ *   - desktop → the existing roster ("Whose shoes today?"), untouched.
+ * The auth + data hooks are mocked so the composing useFieldDeskHome runs for
+ * real over controlled inputs (no network, single SSR pass).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CurrentUser, CharacterOut } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({
+  formFactor: 'desktop' as 'mobile' | 'desktop',
+  user: null as CurrentUser | null,
+}))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: mocks.user, refetch: async () => {} }),
+}))
+vi.mock('../../../hooks/useMyActiveTasks', () => ({
+  useMyActiveTasks: () => ({ activeTasks: [], loading: false, refetch: () => {} }),
+}))
+vi.mock('../../../hooks/useMyCharacterStats', () => ({
+  useMyCharacterStats: () => ({ votesReceived: 0, loading: false }),
+}))
+vi.mock('../../../hooks/usePendingRequests', () => ({
+  usePendingRequests: () => ({ pendingRequests: [], loading: false, refetch: () => {} }),
+}))
+vi.mock('../../../api/me', () => ({
+  getMyCharacters: async () => [],
+  setActiveCharacter: async () => {},
+}))
+
+// Imported after the mocks are registered.
+import FieldDesk from '../../FieldDesk'
+
+function character(faction_slug: string | null): CharacterOut {
+  return {
+    id: 42,
+    username: 'molly',
+    display_name: 'Mollusk',
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 4,
+    score: 340,
+    all_time_score: 900,
+    faction_slug,
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function currentUser(faction_slug: string | null): CurrentUser {
+  return {
+    account_id: 1,
+    character: character(faction_slug),
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: true,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: 'Era 3',
+  }
+}
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FieldDesk />
+    </MemoryRouter>,
+  )
+}
+
+describe('FieldDesk form-factor dispatch', () => {
+  it('renders the WOW bespoke home skin on mobile for a WOW life', () => {
+    mocks.formFactor = 'mobile'
+    mocks.user = currentUser('wow')
+    expect(render()).toContain('data-skin="wow"')
+  })
+
+  it('falls through to the Default home skin on mobile for an unregistered faction', () => {
+    mocks.formFactor = 'mobile'
+    mocks.user = currentUser('snide')
+    const html = render()
+    expect(html).toContain('data-skin="default"')
+    expect(html).not.toContain('data-skin="wow"')
+  })
+
+  it('renders the desktop roster on desktop (skin dispatch untouched)', () => {
+    mocks.formFactor = 'desktop'
+    mocks.user = currentUser('wow')
+    const html = render()
+    expect(html).not.toContain('data-skin=')
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Whose shoes today?')
+  })
+})

--- a/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Mobile FieldDesk-home slot invariant — the home twin of the taskDetail
+ * mobileArchetypeSlots test. Walks MOBILE_ARCHETYPE_BY_SLUG plus the Default
+ * mobile home and asserts each skin emits the invariant content slots from the
+ * (hand-built) FieldDeskHomeState: character header (name + faction + level +
+ * points), the Points/Votes/Era stat tiles, the active-tasks list, the empty
+ * state, and the primary actions. Presentation-only — the skins take state, so
+ * no hooks or network are involved.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so shared copy keys resolve to English text.
+import '../../../i18n'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FieldDesk'
+import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+import type { CharacterOut } from '../../../api/auth'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { factionName } from '../../../utils/factions'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'molly',
+  display_name: 'Mollusk',
+  bio: null,
+  avatar_url: null,
+  location: null,
+  level: 4,
+  score: 340,
+  all_time_score: 900,
+  faction_slug: 'wow',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const ACTIVE_TASK: PraxisCardOut = {
+  id: 55,
+  task_id: 7,
+  task_title: 'Sunday Soup',
+  task_point_value: 30,
+  task_level_required: 1,
+  type: 'solo',
+  status: 'in_progress',
+  title: null,
+  moderation_status: 'visible',
+  created_by_id: 42,
+  created_by_display_name: 'Mollusk',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  submitted_at: null,
+  member_count: 1,
+  score: 0,
+  voter_count: 0,
+  is_top_for_task: false,
+  task_faction_slug: 'wow',
+}
+
+function baseState(overrides: Partial<FieldDeskHomeState> = {}): FieldDeskHomeState {
+  return {
+    character: CHARACTER,
+    eraName: 'Era 3',
+    votesReceived: 12,
+    activeTasks: [ACTIVE_TASK],
+    pendingCount: 2,
+    loadingTasks: false,
+    canProposeTask: true,
+    ...overrides,
+  }
+}
+
+const archetypes = { ...MOBILE_ARCHETYPE_BY_SLUG, __default__: DefaultFieldDesk }
+
+describe('mobile FieldDesk-home content-slot invariant', () => {
+  for (const [slug, Skin] of Object.entries(archetypes)) {
+    it(`${slug} renders the character header + stat tiles`, () => {
+      const { html, text } = render(<Skin state={baseState()} />)
+      expect(text, 'character name slot').toContain('Mollusk')
+      expect(text, 'faction slot').toContain(factionName('wow'))
+      expect(text, 'points/score slot').toContain('340')
+      expect(text, 'votes slot').toContain('12')
+      expect(text, 'era slot').toContain('Era 3')
+      expect(html, 'profile link slot').toContain('href="/characters/42"')
+      expect(html, 'edit link slot').toContain('href="/characters/42/edit"')
+    })
+
+    it(`${slug} renders the active-tasks list (continue link)`, () => {
+      const { html, text } = render(<Skin state={baseState()} />)
+      expect(text, 'active task title slot').toContain('Sunday Soup')
+      expect(html, 'continue-in-progress slot').toContain('href="/praxes/55/edit"')
+    })
+
+    it(`${slug} renders the empty state when no active tasks`, () => {
+      const { text } = render(<Skin state={baseState({ activeTasks: [] })} />)
+      expect(text.toLowerCase(), 'empty-tasks slot').toContain('nothing in progress')
+    })
+
+    it(`${slug} renders the primary Browse Tasks action`, () => {
+      const { html, text } = render(<Skin state={baseState()} />)
+      expect(text.toLowerCase(), 'browse-tasks slot').toContain('browse tasks')
+      expect(html, 'tasks link slot').toContain('href="/tasks"')
+    })
+
+    it(`${slug} shows the propose action only when permitted`, () => {
+      const permitted = render(<Skin state={baseState({ canProposeTask: true })} />)
+      expect(permitted.html, 'propose shown when permitted').toContain('href="/propose-task"')
+      const denied = render(<Skin state={baseState({ canProposeTask: false })} />)
+      expect(denied.html, 'propose hidden when not permitted').not.toContain('href="/propose-task"')
+    })
+  }
+})

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -1,0 +1,306 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+
+/**
+ * Default (na) MOBILE FieldDesk home — the account's carried life at a glance,
+ * one-hand and single-column (#500). Character header (avatar in the all-paths
+ * rainbow ring + name + faction/level + points), three stat tiles, the
+ * in-progress task list, and one or two primary actions. Every faction falls
+ * through here until it registers a bespoke mobile home skin (mirrors the
+ * taskDetail mobile Default). Presentation-only: all data arrives via
+ * {@link FieldDeskHomeState}; copy resolves from the `common` catalog.
+ *
+ * Layout is flex/relative — no fixed-px grid drives the page structure
+ * (SPEC-faction-ui-profile §1a).
+ */
+export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState }) {
+  const { t } = useTranslation('common')
+  const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+
+  const stats = [
+    { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
+    { label: t('fieldDesk.home.stats.votes'), value: votesReceived.toLocaleString() },
+    { label: t('fieldDesk.home.stats.era'), value: eraName || '—' },
+  ]
+
+  return (
+    <div data-skin="default" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {/* App-bar row: kicker + FieldDesk title */}
+      <header>
+        <div className="eyebrow" style={{ fontSize: 8, color: 'var(--color-text-secondary)' }}>
+          {t('nav.home')}
+        </div>
+        <h1 className="font-display italic" style={{ fontSize: 30, lineHeight: 1, color: 'var(--color-text-primary)', margin: 0 }}>
+          {t('fieldDesk.home.title')}
+        </h1>
+      </header>
+
+      {/* ── Character card ── */}
+      <section
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-xl)',
+          padding: 16,
+        }}
+      >
+        <span
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 3,
+            opacity: 0.9,
+            background: 'var(--faction-default-rainbow)',
+          }}
+        />
+        <div className="flex items-center justify-between mb-4" style={{ marginTop: 4 }}>
+          <span className="eyebrow" style={{ fontSize: 9, color: 'var(--color-text-secondary)' }}>
+            {t('fieldDesk.home.charEyebrow')}
+          </span>
+          <Link
+            to={`/characters/${character.id}/edit`}
+            className="eyebrow"
+            style={{ fontSize: 9, color: 'var(--faction-default-card-muted)', textDecoration: 'none' }}
+          >
+            {t('fieldDesk.home.edit')}
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3.5">
+          <div
+            className="shrink-0 rounded-full"
+            style={{ width: 56, height: 56, padding: 3, background: 'var(--faction-default-ring)' }}
+          >
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="w-full h-full rounded-full"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : (
+              <div
+                className="w-full h-full rounded-full"
+                style={{
+                  background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${factionCssVar(character.faction_slug)})`,
+                }}
+              />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/characters/${character.id}`}
+              className="font-display italic block truncate"
+              style={{ fontSize: 24, lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            >
+              {character.display_name}
+            </Link>
+            <div
+              className="truncate"
+              style={{
+                marginTop: 5,
+                fontFamily: 'var(--font-body)',
+                fontSize: 10,
+                letterSpacing: '0.14em',
+                textTransform: 'uppercase',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              {t('sidebar.characterCard.factionLevel', {
+                faction: factionName(character.faction_slug),
+                level: character.level,
+              })}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div className="font-display" style={{ fontSize: 26, lineHeight: 1, color: 'var(--color-text-primary)' }}>
+              {character.score?.toLocaleString() ?? '0'}
+            </div>
+            <div className="eyebrow" style={{ fontSize: 8, color: 'var(--color-text-secondary)' }}>
+              {t('fieldDesk.home.stats.points')}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-2" style={{ marginTop: 16 }}>
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center"
+              style={{
+                flex: '1 1 0',
+                background: 'var(--color-bg-surface-alt)',
+                border: '1px solid var(--color-border)',
+                borderRadius: 9,
+                padding: '11px 6px',
+                minWidth: 0,
+              }}
+            >
+              <div className="font-display truncate" style={{ fontSize: 20, lineHeight: 1, color: 'var(--color-text-primary)' }}>
+                {stat.value}
+              </div>
+              <div
+                className="eyebrow"
+                style={{ marginTop: 6, fontSize: 8, color: 'var(--color-text-secondary)' }}
+              >
+                {stat.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Pending requests pill (only when there are any) ── */}
+      {pendingCount > 0 && (
+        <Link
+          to="/updates?filter=requests"
+          className="font-body flex items-center justify-between"
+          style={{
+            background: 'var(--color-bg-surface)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 999,
+            padding: '10px 16px',
+            fontSize: 12,
+            color: 'var(--color-text-primary)',
+            textDecoration: 'none',
+          }}
+        >
+          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
+          <span aria-hidden style={{ color: 'var(--color-text-tertiary)' }}>›</span>
+        </Link>
+      )}
+
+      {/* ── In-progress tasks ── */}
+      <section
+        style={{
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-xl)',
+          padding: 16,
+        }}
+      >
+        <div className="flex items-center gap-2.5 mb-3">
+          <span className="eyebrow" style={{ fontSize: 9, color: 'var(--color-text-secondary)' }}>
+            {t('fieldDesk.home.questsHeading')}
+          </span>
+          <span style={{ flex: 1, height: 1, background: 'linear-gradient(90deg, var(--color-border-strong), transparent)' }} />
+          <Link
+            to="/tasks"
+            className="eyebrow"
+            style={{ fontSize: 9, color: 'var(--faction-default-card-muted)', textDecoration: 'none' }}
+          >
+            {t('fieldDesk.home.viewAll')}
+          </Link>
+        </div>
+
+        {activeTasks.length === 0 ? (
+          <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+            {t('fieldDesk.home.questsEmpty')}
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {activeTasks.map((praxis, index) => (
+              <Link
+                key={praxis.id}
+                to={`/praxes/${praxis.id}/edit`}
+                className="flex items-center gap-3"
+                style={{
+                  padding: '12px 0',
+                  borderTop: index === 0 ? undefined : '1px solid var(--color-border)',
+                  textDecoration: 'none',
+                }}
+              >
+                <span
+                  className="shrink-0"
+                  style={{ width: 10, height: 10, borderRadius: 3, background: factionCssVar(praxis.task_faction_slug) }}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="font-display truncate" style={{ fontSize: 17, lineHeight: 1.2, color: 'var(--color-text-primary)' }}>
+                    {praxis.task_title}
+                  </div>
+                  <div
+                    className="truncate"
+                    style={{
+                      marginTop: 3,
+                      fontFamily: 'var(--font-body)',
+                      fontSize: 9,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      color: 'var(--color-text-secondary)',
+                    }}
+                  >
+                    {t('fieldDesk.home.taskMeta', {
+                      faction: factionName(praxis.task_faction_slug),
+                      points: praxis.task_point_value,
+                    })}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0 eyebrow"
+                  style={{
+                    fontSize: 8,
+                    color: 'var(--faction-default-card-muted)',
+                    padding: '4px 9px',
+                    border: '1px solid var(--color-border-strong)',
+                    borderRadius: 999,
+                  }}
+                >
+                  {t(`praxisType.${praxis.type}`)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Primary actions ── */}
+      <div className="flex gap-2.5">
+        <Link
+          to="/tasks"
+          className="font-body flex-1 flex items-center justify-center"
+          style={{
+            padding: 15,
+            borderRadius: 12,
+            fontSize: 12,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            fontWeight: 700,
+            color: 'var(--color-bg-page)',
+            background: 'var(--color-text-primary)',
+            border: '1px solid var(--color-text-primary)',
+            textDecoration: 'none',
+          }}
+        >
+          {t('fieldDesk.home.browseTasks')}
+        </Link>
+        {canProposeTask && (
+          <Link
+            to="/propose-task"
+            className="font-body flex-1 flex items-center justify-center gap-2"
+            style={{
+              padding: 15,
+              borderRadius: 12,
+              fontSize: 12,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--color-text-primary)',
+              background: 'var(--color-bg-surface)',
+              border: '1px solid var(--color-border-strong)',
+              textDecoration: 'none',
+            }}
+          >
+            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+            <span>{t('actions.proposeTask')}</span>
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -1,0 +1,351 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+
+/**
+ * Warriors of Whimsy MOBILE FieldDesk home (#500) — the scrapbook window idiom
+ * on a phone: the carried life and its in-progress quests each become a little
+ * pink "window" (traffic-light dots + sparkle-titled bar, a dotted board and an
+ * inner notepad), taped to a rose board. Same content slots as the Default
+ * mobile home — character header, stat tiles, active-tasks list, primary
+ * actions — only the dress changes. Ported from the Field Kit `wow-treatment`
+ * §02 home; grounds entirely on the `--faction-wow-*` window tokens already in
+ * index.css (same set WowTaskDetail uses). Presentation-only.
+ */
+
+const PINK = 'var(--faction-wow)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const DOT = 'var(--faction-wow-dot)'
+const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const BODY = 'var(--font-body)' // Courier Prime
+const ON_ACCENT = 'var(--color-text-on-accent)'
+
+/** The kit's four-point sparkle. */
+function Sparkle({ size, color, style }: { size: number; color: string; style?: CSSProperties }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style} aria-hidden>
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+/** A pink window: dotted title bar + dotted board wrapping an inner notepad. */
+function Window({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section
+      style={{
+        borderRadius: 16,
+        overflow: 'hidden',
+        border: `2px solid ${WIN_BORDER}`,
+        boxShadow: `0 8px 22px color-mix(in srgb, ${PINK} 22%, transparent)`,
+      }}
+    >
+      {/* title bar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          padding: '8px 12px',
+          background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+          borderBottom: `2px solid ${WIN_BORDER}`,
+        }}
+      >
+        {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+          <span
+            key={c}
+            style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }}
+          />
+        ))}
+        <span
+          style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 18, color: TITLE_TEXT }}
+        >
+          <Sparkle size={11} color={TITLE_TEXT} />
+          {title}
+        </span>
+      </div>
+      {/* dotted board */}
+      <div
+        style={{
+          padding: 12,
+          background: BODY_BG,
+          backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+          backgroundSize: '13px 13px',
+        }}
+      >
+        <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: 13 }}>
+          {children}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+const pinkButton: CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 7,
+  fontFamily: BODY,
+  fontSize: 12,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  fontWeight: 700,
+  padding: 15,
+  borderRadius: 14,
+  color: ON_ACCENT,
+  border: `1.5px solid ${WIN_BORDER}`,
+  background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+  textDecoration: 'none',
+}
+
+const ghostButton: CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  fontFamily: BODY,
+  fontSize: 12,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  padding: 15,
+  borderRadius: 14,
+  color: TITLE_TEXT,
+  border: `1.5px solid ${NOTEPAD_BORDER}`,
+  background: NOTEPAD_BG,
+  textDecoration: 'none',
+}
+
+export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
+  const { t } = useTranslation('common')
+  const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+
+  const stats = [
+    { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
+    { label: t('fieldDesk.home.stats.votes'), value: votesReceived.toLocaleString() },
+    { label: t('fieldDesk.home.stats.era'), value: eraName || '—' },
+  ]
+
+  return (
+    <div
+      data-skin="wow"
+      className="page"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 14,
+        fontFamily: BODY,
+        color: CARD_TEXT,
+        background: BODY_BG,
+        backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+        backgroundSize: '15px 15px',
+      }}
+    >
+      <header>
+        <div className="eyebrow" style={{ fontSize: 8, color: CARD_MUTED }}>{t('nav.home')}</div>
+        <h1 style={{ fontFamily: SCRIPT, fontSize: 34, lineHeight: 0.9, color: TITLE_TEXT, margin: 0 }}>
+          {t('fieldDesk.home.title')}
+        </h1>
+      </header>
+
+      {/* ── Character window ── */}
+      <Window title={t('fieldDesk.home.wow.charWindow')}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+          <span className="eyebrow" style={{ fontSize: 9, color: CARD_MUTED }}>
+            {t('fieldDesk.home.wow.charEyebrow')}
+          </span>
+          <Link
+            to={`/characters/${character.id}/edit`}
+            className="eyebrow"
+            style={{ fontSize: 9, color: PINK, textDecoration: 'none' }}
+          >
+            {t('fieldDesk.home.edit')}
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="shrink-0" style={{ width: 56, height: 56, borderRadius: '50%', padding: 3, background: PINK }}>
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="w-full h-full rounded-full"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : (
+              <span
+                className="flex w-full h-full items-center justify-center rounded-full"
+                style={{
+                  background: 'radial-gradient(circle at 35% 28%, var(--faction-wow-title-from), var(--faction-wow))',
+                  fontFamily: SCRIPT,
+                  fontSize: 24,
+                  color: ON_ACCENT,
+                }}
+              >
+                {character.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/characters/${character.id}`}
+              className="block truncate"
+              style={{ fontFamily: SCRIPT, fontSize: 30, lineHeight: 0.95, color: TITLE_TEXT, textDecoration: 'none' }}
+            >
+              {character.display_name}
+            </Link>
+            <div
+              className="truncate"
+              style={{ marginTop: 4, fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}
+            >
+              {t('sidebar.characterCard.factionLevel', {
+                faction: factionName(character.faction_slug),
+                level: character.level,
+              })}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div style={{ fontFamily: SCRIPT, fontSize: 30, lineHeight: 1, color: TITLE_TEXT }}>
+              {character.score?.toLocaleString() ?? '0'}
+            </div>
+            <div className="eyebrow" style={{ fontSize: 8, color: CARD_MUTED }}>
+              {t('fieldDesk.home.stats.points')}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-2" style={{ marginTop: 14 }}>
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center"
+              style={{
+                flex: '1 1 0',
+                minWidth: 0,
+                background: 'var(--faction-wow-scrap-mid)',
+                border: `1px solid ${NOTEPAD_BORDER}`,
+                borderRadius: 12,
+                padding: '11px 6px',
+              }}
+            >
+              <div className="truncate" style={{ fontFamily: SCRIPT, fontSize: 24, lineHeight: 1, color: TITLE_TEXT }}>
+                {stat.value}
+              </div>
+              <div className="eyebrow" style={{ marginTop: 5, fontSize: 8, color: CARD_MUTED }}>
+                {stat.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Window>
+
+      {/* ── Pending requests ── */}
+      {pendingCount > 0 && (
+        <Link
+          to="/updates?filter=requests"
+          className="flex items-center justify-between"
+          style={{
+            background: NOTEPAD_BG,
+            border: `1.5px solid ${NOTEPAD_BORDER}`,
+            borderRadius: 999,
+            padding: '10px 16px',
+            fontSize: 12,
+            color: TITLE_TEXT,
+            textDecoration: 'none',
+          }}
+        >
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+            <Sparkle size={12} color={PINK} />
+            {t('fieldDesk.home.pending', { count: pendingCount })}
+          </span>
+          <span aria-hidden style={{ color: CARD_MUTED }}>›</span>
+        </Link>
+      )}
+
+      {/* ── Quests window ── */}
+      <Window title={t('fieldDesk.home.wow.questsWindow')}>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 8 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 20, color: TITLE_TEXT }}>
+            <Sparkle size={12} color={PINK} />
+            {t('fieldDesk.home.wow.questsHeading')}
+          </span>
+          <span style={{ flex: 1, height: 2, background: `repeating-linear-gradient(90deg, ${PINK} 0 8px, transparent 8px 14px)` }} />
+          <Link to="/tasks" className="eyebrow" style={{ fontSize: 9, color: PINK, textDecoration: 'none' }}>
+            {t('fieldDesk.home.viewAll')}
+          </Link>
+        </div>
+
+        {activeTasks.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>
+            {t('fieldDesk.home.questsEmpty')}
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {activeTasks.map((praxis, index) => (
+              <Link
+                key={praxis.id}
+                to={`/praxes/${praxis.id}/edit`}
+                className="flex items-center gap-3"
+                style={{
+                  padding: '12px 0',
+                  borderTop: index === 0 ? undefined : `1px solid ${NOTEPAD_BORDER}`,
+                  textDecoration: 'none',
+                }}
+              >
+                <span className="shrink-0" style={{ width: 10, height: 10, borderRadius: 3, background: PINK }} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate" style={{ fontFamily: SCRIPT, fontSize: 20, lineHeight: 1, color: TITLE_TEXT }}>
+                    {praxis.task_title}
+                  </div>
+                  <div
+                    className="truncate"
+                    style={{ marginTop: 4, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: CARD_MUTED }}
+                  >
+                    {t('fieldDesk.home.taskMeta', {
+                      faction: factionName(praxis.task_faction_slug),
+                      points: praxis.task_point_value,
+                    })}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0 eyebrow"
+                  style={{ fontSize: 8, color: PINK, padding: '4px 9px', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 999 }}
+                >
+                  {t(`praxisType.${praxis.type}`)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </Window>
+
+      {/* ── Primary actions ── */}
+      <div className="flex gap-2.5">
+        <Link to="/tasks" style={pinkButton}>
+          <Sparkle size={13} color={ON_ACCENT} />
+          {t('fieldDesk.home.browseTasks')}
+        </Link>
+        {canProposeTask && (
+          <Link to="/propose-task" style={ghostButton}>
+            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+            {t('actions.proposeTask')}
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
+++ b/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
@@ -1,0 +1,60 @@
+import { useAuth } from '../../auth/AuthContext'
+import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
+import { useMyCharacterStats } from '../../hooks/useMyCharacterStats'
+import { usePendingRequests } from '../../hooks/usePendingRequests'
+import type { CharacterOut } from '../../api/auth'
+import type { PraxisCardOut } from '../../api/praxis'
+
+/**
+ * Composed read-model for the MOBILE FieldDesk home (#500).
+ *
+ * Pure composition over the existing home hooks — the same three the desktop
+ * Sidebar consumes (`useMyActiveTasks` / `useMyCharacterStats` /
+ * `usePendingRequests`) plus the carried character from auth. No new data
+ * logic: it only bundles what those hooks already return so the mobile skins
+ * can stay presentation-only and slot-invariant (mirrors `useTaskDetail`, whose
+ * `state` every TaskDetail archetype renders).
+ *
+ * Returns `null` when there is no active character — the caller falls back to
+ * the desktop roster ("whose shoes today?") so a brand-new account still lands
+ * somewhere it can create a life.
+ */
+export interface FieldDeskHomeState {
+  /** The carried life — guaranteed non-null (the hook returns null otherwise). */
+  character: CharacterOut
+  /** Current era label from /auth/me (e.g. "Era 3"); '' when unknown. */
+  eraName: string
+  /** Votes this life has received (the "Votes" stat tile). */
+  votesReceived: number
+  /** In-progress praxes (membership-scoped) — the active-tasks list. */
+  activeTasks: PraxisCardOut[]
+  /** Count of pending collab invites + duel challenges. */
+  pendingCount: number
+  /** Whether the active-tasks list is still loading. */
+  loadingTasks: boolean
+  /** Server-computed: may this life propose a task (drives the secondary CTA)? */
+  canProposeTask: boolean
+}
+
+export function useFieldDeskHome(): FieldDeskHomeState | null {
+  const { user } = useAuth()
+  const character = user?.character ?? null
+
+  // Hooks run unconditionally (React rules); a null character just means the
+  // downstream values are their empty defaults and we return null below.
+  const { activeTasks, loading: loadingTasks } = useMyActiveTasks()
+  const { votesReceived } = useMyCharacterStats(character?.id)
+  const { pendingRequests } = usePendingRequests()
+
+  if (!character) return null
+
+  return {
+    character,
+    eraName: user?.era_name ?? '',
+    votesReceived,
+    activeTasks,
+    pendingCount: pendingRequests.length,
+    loadingTasks,
+    canProposeTask: user?.can_propose_task ?? false,
+  }
+}


### PR DESCRIPTION
A mobile-native home dashboard behind the #494 form-factor seam. On a phone, `FieldDesk` dispatches via `pickVariant(MOBILE_ARCHETYPE_BY_SLUG, faction_slug, DefaultFieldDesk)` (mirroring the TaskDetail reference); on desktop the existing roster is untouched.

## What
- `useFieldDeskHome` — a composing hook over the existing `useMyActiveTasks` / `useMyCharacterStats` / `usePendingRequests` (+ carried character). Presentation only, no new data logic; mirrors `useTaskDetail` so skins are testable with a hand-built state.
- `DefaultFieldDesk` (na) — single-column home: character header (avatar, name, faction·level, points), stat tiles, pending-requests pill, in-progress task list, Browse/Propose actions. Flex/relative layout per SPEC §1a.
- `WowFieldDesk` — the pilot bespoke skin (WOW is the only faction with a full home treatment in the #495 Field Kit; window-card idiom on `--faction-wow-*` tokens). Registered in `MOBILE_ARCHETYPE_BY_SLUG`.

## Constraints honored
Desktop path unchanged; faction colors via `factionCssVar()` (no hex); faction names via `factionName(slug)`; all copy via `t()` catalog keys (`fieldDesk.home` block).

## Tests
Dispatch test (mobile+wow → WOW, mobile+other → Default, desktop → roster) + slot-invariant test. tsc: no new errors. Full vitest: 275 pass.

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
