### PR TITLE
Mobile: Tasks browse — Default skin + dispatch (#496)

### DIFF
--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -3,6 +3,14 @@
     "loading": "Loading tasks...",
     "empty": "No tasks match your filters."
   },
+  "mobile": {
+    "count": "{{count}} shown",
+    "allFactions": "All",
+    "anyLevel": "Any",
+    "loadError": "Couldn't load tasks.",
+    "points": "+{{points}} pts",
+    "level": "Lvl {{level}}"
+  },
   "detail": {
     "loading": "Loading...",
     "fetchError": "<0>Try refreshing.</0>",

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,68 +1,56 @@
-import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { listTasks } from '../api/tasks'
-import { createPraxis } from '../api/praxis'
-import { getFactions, type FactionOut } from '../api/factions'
-import { getGameConfig, type FactionConfigOut } from '../api/gameConfig'
 import TaskCard from '../components/TaskCard'
 import PageTitle from '../components/ui/PageTitle'
 import FilterStamps from '../components/ui/FilterStamps'
 import FilterFactionTabs from '../components/ui/FilterFactionTabs'
 import FilterLevelNodes from '../components/ui/FilterLevelNodes'
 import { extractError } from '../utils/errors'
-import { useAuth } from '../auth/AuthContext'
-import { computeDisplayPoints } from '../utils/points'
-import { useResource } from '../hooks/useResource'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { pickVariant } from '../utils/factionDispatch'
+import { useTasks, type TasksState } from './tasks/useTasks'
+import DefaultTasks from './tasks/mobileArchetypes/DefaultTasks'
 
-const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
+type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
+
+// Parallel MOBILE registry, mirroring TaskDetail. Task browse isn't dispatched
+// by a single faction slug the way detail is, so this stays empty and every
+// render falls through to the Default mobile browse skin; bespoke faction
+// browse skins can register here later (#496–#500).
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {}
 
 export default function Tasks() {
-  const { t } = useTranslation('tasks')
-  const { t: tc } = useTranslation('common')
-  const { user } = useAuth()
-  const navigate = useNavigate()
-  const characterId = user?.character?.id
+  const state = useTasks()
+  const formFactor = useFormFactor()
 
-  const [factions, setFactions] = useState<FactionOut[]>([])
-  const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
-  const [status, setStatus] = useState('All')
-  const [faction, setFaction] = useState('')
-  const [level, setLevel] = useState<number | ''>('')
-  const [signupMsg, setSignupMsg] = useState<{ id: number; msg: string; ok: boolean } | null>(null)
-
-  useEffect(() => {
-    getFactions().then(setFactions).catch(() => {})
-    getGameConfig()
-      .then((config) => setFactionConfigs(config.factions))
-      .catch(() => {})
-  }, [])
-
-  const { data, loading, error } = useResource(
-    () =>
-      listTasks({
-        status: status === 'All' ? undefined : status,
-        faction: faction || undefined,
-        level: level === '' ? undefined : level,
-        exclude_character_id: characterId,
-      }),
-    [status, faction, level, characterId],
-  )
-  const tasks = data ?? []
-
-  const handleSignup = async (id: number) => {
-    setSignupMsg(null)
-    try {
-      const praxis = await createPraxis({ task_id: id, type: 'solo' })
-      navigate(`/praxes/${praxis.id}/edit`)
-    } catch (err) {
-      setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
-    }
+  if (formFactor === 'mobile') {
+    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, null, DefaultTasks)
+    return <Mobile state={state} />
   }
 
-  const statusFilters = ['All', 'active']
-  if (user?.can_see_retired_tasks) statusFilters.push('retired')
-  if (user?.can_see_pending_tasks) statusFilters.push('pending')
+  return <DesktopTasks state={state} />
+}
+
+function DesktopTasks({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    user,
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    signupMsg,
+    handleSignup,
+    displayPointsFor,
+  } = state
 
   return (
     <div className="py-8">
@@ -72,7 +60,7 @@ export default function Tasks() {
       <div className="flex flex-col gap-2.5 mb-6">
         <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
         <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
-        <FilterLevelNodes levels={LEVEL_FILTERS} value={level} onChange={setLevel} />
+        <FilterLevelNodes levels={levelFilters} value={level} onChange={setLevel} />
       </div>
 
       {signupMsg && (
@@ -97,12 +85,7 @@ export default function Tasks() {
             <TaskCard
               key={task.id}
               task={task}
-              displayPoints={computeDisplayPoints(
-                task.point_value,
-                user?.character?.faction_slug,
-                task.primary_faction_slug,
-                factionConfigs,
-              )}
+              displayPoints={displayPointsFor(task)}
               onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
             />
           ))}

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tasks form-factor dispatch — useFormFactor mocked 'mobile' selects the Default
+ * mobile browse skin; 'desktop' keeps the existing flex-wrap list. Mirrors the
+ * TaskDetail dispatch seam (#494/#496). useTasks is mocked to a canned state so
+ * the branch under test renders without hitting the network / auth context.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { TasksState } from '../useTasks'
+
+// Mutable form factor the mocked hook reports; each test sets it before render.
+const dispatch: { formFactor: 'mobile' | 'desktop' } = { formFactor: 'desktop' }
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => dispatch.formFactor,
+}))
+
+// Canned, empty task set: exercises the dispatch branch without rendering
+// TaskCard (which needs auth/admin contexts) — an empty list hits each branch's
+// own empty state instead.
+const CANNED: TasksState = {
+  user: null,
+  tasks: [],
+  loading: false,
+  error: null,
+  factions: [{ slug: 'everymen' }],
+  factionConfigs: [],
+  levelFilters: [0, 1, 2, 3, 4, 5],
+  statusFilters: ['All', 'active'],
+  status: 'All',
+  setStatus: () => {},
+  faction: '',
+  setFaction: () => {},
+  level: '',
+  setLevel: () => {},
+  signupMsg: null,
+  handleSignup: async () => {},
+  displayPointsFor: () => 0,
+}
+
+vi.mock('../useTasks', () => ({
+  useTasks: () => CANNED,
+  LEVEL_FILTERS: [0, 1, 2, 3, 4, 5],
+}))
+
+import Tasks from '../../Tasks'
+
+function html(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Tasks />
+    </MemoryRouter>,
+  )
+}
+
+describe('Tasks form-factor dispatch', () => {
+  it('renders the Default mobile browse skin on mobile', () => {
+    dispatch.formFactor = 'mobile'
+    expect(html()).toContain('mobile-tasks-browse')
+  })
+
+  it('renders the existing desktop list on desktop', () => {
+    dispatch.formFactor = 'desktop'
+    const out = html()
+    expect(out, 'no mobile skin').not.toContain('mobile-tasks-browse')
+    // The desktop rubber-stamp status filter (FilterStamps) is desktop-only chrome.
+    expect(out.toLowerCase(), 'desktop status filter').toContain('status:')
+  })
+})

--- a/frontend/src/pages/tasks/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/mobileArchetypeSlots.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Mobile task-browse slot invariant — the browse twin of the task-detail
+ * mobileArchetypeSlots test. Walks MOBILE_ARCHETYPE_BY_SLUG plus the Default
+ * mobile browse skin and asserts each emits the invariant browse slots
+ * (scannable task cards with title, points and a /tasks/:id link, plus the
+ * touch-native status/faction/level filter chip rows). Also proves the rendered
+ * set is driven by the shared hook's `tasks` — swapping the filtered array
+ * swaps the cards. The registry is empty today, so this mainly guards the
+ * Default fallback and any bespoke browse skin added later.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so shared copy keys resolve to English text.
+import '../../../i18n'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../Tasks'
+import DefaultTasks from '../mobileArchetypes/DefaultTasks'
+import type { TasksState } from '../useTasks'
+import type { TaskOut } from '../../../api/tasks'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+function task(overrides: Partial<TaskOut>): TaskOut {
+  return {
+    id: 11,
+    title: 'Plant a tree',
+    description: 'Dig a hole and plant a native sapling.',
+    point_value: 20,
+    level_required: 2,
+    status: 'active',
+    task_type: 'standard',
+    created_by: 1,
+    primary_faction_slug: 'everymen',
+    metatask_faction_slug: null,
+    is_task_vision_eligible: false,
+    created_at: '2026-01-01T00:00:00Z',
+    can_submit_praxis: true,
+    allowed_modes: ['solo'],
+    eligible_for_current_user: true,
+    ...overrides,
+  }
+}
+
+const TASK_A = task({ id: 11, title: 'Plant a tree', primary_faction_slug: 'everymen' })
+const TASK_B = task({ id: 22, title: 'Map a hidden gap', primary_faction_slug: 'snide', point_value: 40 })
+
+function baseState(overrides: Partial<TasksState>): TasksState {
+  return {
+    user: null,
+    tasks: [TASK_A, TASK_B],
+    loading: false,
+    error: null,
+    factions: [{ slug: 'everymen' }, { slug: 'snide' }, { slug: 'wow' }],
+    factionConfigs: [],
+    levelFilters: [0, 1, 2, 3, 4, 5],
+    statusFilters: ['All', 'active'],
+    status: 'All',
+    setStatus: () => {},
+    faction: '',
+    setFaction: () => {},
+    level: '',
+    setLevel: () => {},
+    signupMsg: null,
+    handleSignup: async () => {},
+    displayPointsFor: (t) => t.point_value,
+    ...overrides,
+  }
+}
+
+const archetypes = { ...MOBILE_ARCHETYPE_BY_SLUG, __default__: DefaultTasks }
+
+describe('mobile task-browse content-slot invariant', () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders scannable cards with title, points + detail link`, () => {
+      const { html, text } = render(<Archetype state={baseState({})} />)
+      expect(text, 'title slot').toContain('Plant a tree')
+      expect(text, 'points slot').toContain('+20 pts')
+      expect(html, 'detail-link slot').toContain('href="/tasks/11"')
+    })
+
+    it(`${slug} renders the touch-native status/faction/level filter chips`, () => {
+      const { text } = render(<Archetype state={baseState({})} />)
+      const lower = text.toLowerCase()
+      expect(lower, 'status filter').toContain('status:')
+      expect(lower, 'faction filter').toContain('faction:')
+      expect(lower, 'level filter').toContain('level:')
+    })
+
+    it(`${slug} renders the empty state when no tasks match`, () => {
+      const { text } = render(<Archetype state={baseState({ tasks: [] })} />)
+      expect(text).toContain('No tasks match your filters.')
+    })
+
+    it(`${slug} renders exactly the task set the hook provides (filter → set)`, () => {
+      // A filter change narrows the shared `tasks` array; the skin renders it verbatim.
+      const narrowed = render(<Archetype state={baseState({ tasks: [TASK_A] })} />)
+      expect(narrowed.text, 'kept card').toContain('Plant a tree')
+      expect(narrowed.text, 'filtered-out card').not.toContain('Map a hidden gap')
+
+      const widened = render(<Archetype state={baseState({ tasks: [TASK_A, TASK_B] })} />)
+      expect(widened.text).toContain('Plant a tree')
+      expect(widened.text).toContain('Map a hidden gap')
+    })
+  }
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -1,0 +1,243 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../../api/tasks'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import type { TasksState } from '../useTasks'
+
+/**
+ * Default MOBILE task-browse skin — a scannable single-column card list with
+ * phone-native filter chips (horizontal-scroll rows for status / faction /
+ * level), NOT the desktop sidebar. Consumes the shared `useTasks()` state so a
+ * chip tap updates the same filter state that keys the task read, and the
+ * rendered set changes. Every faction falls through here until it registers a
+ * bespoke mobile skin. Mirrors the DefaultTaskDetail mobile idiom (#496–#500).
+ */
+export default function DefaultTasks({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div className="py-4" data-testid="mobile-tasks-browse">
+      <h1
+        className="font-display italic font-medium mb-1"
+        style={{ fontSize: 26, color: 'var(--color-text-primary)', lineHeight: 1.1 }}
+      >
+        {tc('nav.tasks')}
+      </h1>
+      <p className="eyebrow mb-3">{t('mobile.count', { count: tasks.length })}</p>
+
+      {/* Status chips */}
+      <ChipRow label={tc('filters.status')}>
+        {statusFilters.map((option) => (
+          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
+            {option}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      {/* Faction chips */}
+      <ChipRow label={tc('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('mobile.allFactions')}
+        </Chip>
+        {sortFactionsByRainbowOrder(factions).map((f) => (
+          <Chip
+            key={f.slug}
+            on={faction === f.slug}
+            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
+            tint={factionCssVar(f.slug)}
+          >
+            {factionName(f.slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      {/* Level chips */}
+      <ChipRow label={tc('filters.level')}>
+        <Chip on={level === ''} onClick={() => setLevel('')}>
+          {t('mobile.anyLevel')}
+        </Chip>
+        {levelFilters.map((lvl) => (
+          <Chip key={lvl} on={level === lvl} onClick={() => setLevel(level === lvl ? '' : lvl)}>
+            {tc('filters.levelAtLeast', { level: lvl })}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      {/* Results */}
+      <div className="mt-4">
+        {loading ? (
+          <p className="font-body text-muted">{t('listPage.loading')}</p>
+        ) : error ? (
+          <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+            {t('mobile.loadError')}
+          </p>
+        ) : tasks.length === 0 ? (
+          <p className="font-body text-muted">{t('listPage.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {tasks.map((task) => (
+              <MobileTaskCard key={task.id} task={task} points={displayPointsFor(task)} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span className="eyebrow" style={{ flex: 'none' }}>
+        {label}
+      </span>
+      <div
+        className="flex gap-2"
+        style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: "'Courier Prime', monospace",
+        fontSize: 11,
+        fontWeight: on ? 700 : 400,
+        letterSpacing: '0.05em',
+        textTransform: 'uppercase',
+        color: on ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
+        background: on ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+        border: `1px solid ${on ? 'transparent' : 'var(--color-border-strong)'}`,
+        borderRadius: 999,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && (
+        <i
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 2,
+            flex: 'none',
+            background: tint,
+          }}
+        />
+      )}
+      {children}
+    </button>
+  )
+}
+
+function MobileTaskCard({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  const color = factionCssVar(task.primary_faction_slug)
+  return (
+    <Link
+      to={`/tasks/${task.id}`}
+      className="sidebar-card"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        padding: '14px 16px 14px 18px',
+        borderLeft: `4px solid ${color}`,
+        textDecoration: 'none',
+      }}
+    >
+      {/* Faction tag */}
+      <span
+        className="eyebrow"
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color }}
+      >
+        <i style={{ width: 8, height: 8, borderRadius: 2, background: color, flex: 'none' }} />
+        {factionName(task.primary_faction_slug)}
+      </span>
+
+      {/* Title */}
+      <h2
+        className="font-display italic font-medium"
+        style={{ fontSize: 18, lineHeight: 1.15, color: 'var(--color-text-primary)' }}
+      >
+        {task.title}
+      </h2>
+
+      {/* Description — clamp to two lines */}
+      {task.description && (
+        <p
+          className="font-body"
+          style={{
+            fontSize: 13,
+            lineHeight: 1.5,
+            color: 'var(--color-text-secondary)',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {task.description}
+        </p>
+      )}
+
+      {/* Footer — points + level */}
+      <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
+        <span
+          style={{
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 12,
+            fontWeight: 700,
+            color: 'var(--color-text-primary)',
+            background: 'var(--color-bg-surface-alt)',
+            border: '1px solid var(--color-border)',
+            padding: '3px 9px',
+          }}
+        >
+          {t('mobile.points', { points })}
+        </span>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {t('mobile.level', { level: task.level_required })}
+        </span>
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -1,0 +1,140 @@
+/**
+ * useTasks — the shared task-browse data + filter state, extracted verbatim from
+ * the legacy Tasks.tsx so the desktop list and the mobile browse skin consume
+ * one source of truth (mirrors useTaskDetail for the detail page).
+ *
+ * Behaviour preserved 1:1 from the original page: the factions/factionConfigs
+ * fetch on mount, the status/faction/level filter state, the `useResource` task
+ * read keyed on those filters + the viewer's character id, and the signup →
+ * navigate-to-edit handler with its inline message. No behaviour change — the
+ * desktop page renders identically off this hook.
+ */
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { listTasks, type TaskOut } from '../../api/tasks'
+import { createPraxis } from '../../api/praxis'
+import { getFactions, type FactionOut } from '../../api/factions'
+import { getGameConfig, type FactionConfigOut } from '../../api/gameConfig'
+import { extractError } from '../../utils/errors'
+import { useAuth } from '../../auth/AuthContext'
+import { computeDisplayPoints } from '../../utils/points'
+import { useResource } from '../../hooks/useResource'
+import type { CurrentUser } from '../../api/auth'
+
+export const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
+
+export interface SignupMessage {
+  id: number
+  msg: string
+  ok: boolean
+}
+
+export interface TasksState {
+  // Viewer
+  user: CurrentUser | null
+
+  // Data
+  tasks: TaskOut[]
+  loading: boolean
+  error: Error | null
+
+  // Reference data
+  factions: FactionOut[]
+  factionConfigs: FactionConfigOut[]
+  levelFilters: number[]
+  statusFilters: string[]
+
+  // Filter state
+  status: string
+  setStatus: (status: string) => void
+  faction: string
+  setFaction: (faction: string) => void
+  level: number | ''
+  setLevel: (level: number | '') => void
+
+  // Signup
+  signupMsg: SignupMessage | null
+  handleSignup: (id: number) => Promise<void>
+
+  // Derived helper — the modified point value for a task given the viewer's faction.
+  displayPointsFor: (task: TaskOut) => number
+}
+
+export function useTasks(): TasksState {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const characterId = user?.character?.id
+
+  const [factions, setFactions] = useState<FactionOut[]>([])
+  const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
+  const [status, setStatus] = useState('All')
+  const [faction, setFaction] = useState('')
+  const [level, setLevel] = useState<number | ''>('')
+  const [signupMsg, setSignupMsg] = useState<SignupMessage | null>(null)
+
+  useEffect(() => {
+    getFactions().then(setFactions).catch(() => {})
+    getGameConfig()
+      .then((config) => setFactionConfigs(config.factions))
+      .catch(() => {})
+  }, [])
+
+  const { data, loading, error } = useResource(
+    () =>
+      listTasks({
+        status: status === 'All' ? undefined : status,
+        faction: faction || undefined,
+        level: level === '' ? undefined : level,
+        exclude_character_id: characterId,
+      }),
+    [status, faction, level, characterId],
+  )
+  const tasks = data ?? []
+
+  const handleSignup = async (id: number) => {
+    setSignupMsg(null)
+    try {
+      const praxis = await createPraxis({ task_id: id, type: 'solo' })
+      navigate(`/praxes/${praxis.id}/edit`)
+    } catch (err) {
+      setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
+    }
+  }
+
+  const statusFilters = ['All', 'active']
+  if (user?.can_see_retired_tasks) statusFilters.push('retired')
+  if (user?.can_see_pending_tasks) statusFilters.push('pending')
+
+  const displayPointsFor = (task: TaskOut): number =>
+    computeDisplayPoints(
+      task.point_value,
+      user?.character?.faction_slug,
+      task.primary_faction_slug,
+      factionConfigs,
+    )
+
+  return {
+    user,
+
+    tasks,
+    loading,
+    error,
+
+    factions,
+    factionConfigs,
+    levelFilters: LEVEL_FILTERS,
+    statusFilters,
+
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+
+    signupMsg,
+    handleSignup,
+
+    displayPointsFor,
+  }
+}


### PR DESCRIPTION
Mobile-native Tasks browse behind the #494 form-factor seam.

## What
- **`useTasks()`** — a shared hook (pure lift from `Tasks.tsx`): the `useResource` task read keyed on `[status, faction, level, characterId]`, the factions/gameConfig mount effect, filter state + setters, `handleSignup`, and a `displayPointsFor` helper. No behavior change — desktop renders identically via an internal `DesktopTasks`.
- **`DefaultTasks`** mobile skin: single-column scannable `.sidebar-card` task cards (faction tint via `factionCssVar`, `factionName(slug)`, title, clamped description, points/level), each a `Link` to the task, plus touch-native horizontal filter-chip rows (status/faction/level) wired to the shared hook — a chip tap re-keys the read and changes the set.
- **Dispatch** in `Tasks.tsx`: `useFormFactor() === 'mobile'` → `pickVariant(MOBILE_ARCHETYPE_BY_SLUG, null, DefaultTasks)` (browse isn't per-faction-dispatched, so Default-only); desktop → the existing flex-wrap `TaskCard` list, unchanged.

## Constraints
Copy via `t()` (`tasks.mobile.*` + reused `common:filters.*`); no hardcoded hex; faction names by slug; single-column, no fixed-px layout grids.

## Tests
Dispatch + slot-invariant + filter-drives-set tests. tsc: no new errors. Full vitest: 268 pass. Desktop parity verified (JSX reproduced exactly).

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
