### PR TITLE
Mobile: Task detail — Default + Everymen pilot (#497)

### DIFF
--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -15,6 +15,7 @@ import { useFormFactor } from "../hooks/useFormFactor";
 import { useTaskDetail, type TaskDetailState } from "./taskDetail/useTaskDetail";
 import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
 import DefaultMobileTaskDetail from "./taskDetail/mobileArchetypes/DefaultTaskDetail";
+import EverymenMobileTaskDetail from "./taskDetail/mobileArchetypes/EverymenTaskDetail";
 import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
@@ -39,10 +40,12 @@ export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   albescent: AlbescentTaskDetail,
 };
 
-// Parallel MOBILE registry. Empty for now — every faction falls through to the
-// Default mobile skin; bespoke faction mobile skins land incrementally (#496–
-// #500) exactly like the desktop archetypes above.
-export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {};
+// Parallel MOBILE registry. Bespoke faction mobile skins land incrementally
+// (#496–#500) exactly like the desktop archetypes above; every unlisted faction
+// falls through to the Default mobile skin. Everymen is the first pilot (#497).
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
+  everymen: EverymenMobileTaskDetail,
+};
 
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();

--- a/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Mobile task-detail DISPATCH + sign-up wiring.
+ *
+ * TaskDetail.tsx selects the archetype with two `pickVariant` calls (mobile vs.
+ * desktop registry). This test asserts that selection directly:
+ *   · mobile + the pilot faction (everymen) → its bespoke mobile skin;
+ *   · mobile + any other slug (incl. null) → the Default mobile skin;
+ *   · desktop → the existing desktop archetype, never the mobile skin.
+ *
+ * It also guards that the mobile skins keep routing sign-up through the injected
+ * `handleSignup` (the useTaskDetail handler that createPraxis → navigates to
+ * `/praxes/:id/edit`). The node test env has no DOM, so we build each skin's
+ * element tree directly (react-i18next stubbed to a plain t) and walk it for the
+ * sign-up button, asserting its onClick is exactly that handler.
+ */
+import type { ReactElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+
+// Stub only the i18n hook so the skins can be invoked as plain functions (no
+// React renderer / hook dispatcher) when we walk their element trees below.
+// The rest of react-i18next (initReactI18next, used by ../../../i18n) is real.
+vi.mock("react-i18next", async (importActual) => {
+  const actual = await importActual<typeof import("react-i18next")>();
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) };
+});
+// factionName/factionCssVar read the raw i18n instance, not the hook — init it.
+import "../../../i18n";
+
+import { MOBILE_ARCHETYPE_BY_SLUG, ARCHETYPE_BY_SLUG } from "../../TaskDetail";
+import { pickVariant } from "../../../utils/factionDispatch";
+import DefaultMobileTaskDetail from "../mobileArchetypes/DefaultTaskDetail";
+import EverymenMobileTaskDetail from "../mobileArchetypes/EverymenTaskDetail";
+import DefaultDesktopTaskDetail from "../archetypes/DefaultTaskDetail";
+import EverymenDesktopTaskDetail from "../archetypes/EverymenTaskDetail";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut } from "../../../api/tasks";
+
+const TASK: TaskOut = {
+  id: 7,
+  title: "Reforestation",
+  description: "Mangrove",
+  point_value: 30,
+  level_required: 3,
+  status: "active",
+  task_type: "standard",
+  created_by: 3,
+  primary_faction_slug: "everymen",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+function baseState(overrides: Partial<TaskDetailState>): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    slotsOpen: 13,
+    maxTaskSlots: 17,
+    factionMultiplier: 1.0,
+    modifiedPoints: 4242,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+// Depth-first search for the element whose onClick is the given handler.
+function findOnClick(
+  node: unknown,
+  handler: () => void,
+): ((...args: unknown[]) => void) | null {
+  if (!node || typeof node !== "object") return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = findOnClick(child, handler);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  const props = (node as ReactElement).props as
+    | { onClick?: (...args: unknown[]) => void; children?: unknown }
+    | undefined;
+  if (props?.onClick === handler) return props.onClick;
+  return props ? findOnClick(props.children, handler) : null;
+}
+
+describe("mobile task-detail dispatch", () => {
+  it("mobile + the pilot faction resolves to the bespoke Everymen skin", () => {
+    expect(
+      pickVariant(MOBILE_ARCHETYPE_BY_SLUG, "everymen", DefaultMobileTaskDetail),
+    ).toBe(EverymenMobileTaskDetail);
+  });
+
+  it("mobile + any other slug falls through to the Default mobile skin", () => {
+    for (const slug of ["snide", "wow", "na", null]) {
+      expect(
+        pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail),
+      ).toBe(DefaultMobileTaskDetail);
+    }
+  });
+
+  it("desktop keeps its own archetype and never the mobile skin", () => {
+    const desktop = pickVariant(
+      ARCHETYPE_BY_SLUG,
+      "everymen",
+      DefaultDesktopTaskDetail,
+    );
+    expect(desktop).toBe(EverymenDesktopTaskDetail);
+    expect(desktop).not.toBe(EverymenMobileTaskDetail);
+  });
+});
+
+describe("mobile sign-up wires to the edit-praxis handler", () => {
+  for (const [label, Skin] of [
+    ["Default", DefaultMobileTaskDetail],
+    ["Everymen", EverymenMobileTaskDetail],
+  ] as const) {
+    it(`${label} sign-up button calls handleSignup`, () => {
+      const handleSignup = vi.fn();
+      const tree = Skin({ state: baseState({ canSignUp: true, handleSignup }) });
+      const onClick = findOnClick(tree, handleSignup);
+      expect(onClick, "sign-up onClick wired to handleSignup").toBe(handleSignup);
+      onClick?.();
+      expect(handleSignup).toHaveBeenCalledTimes(1);
+    });
+  }
+});

--- a/frontend/src/pages/taskDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -2,9 +2,9 @@
  * Mobile task-detail slot invariant — the mobile twin of archetypeSlots.test.
  * Walks the MOBILE_ARCHETYPE_BY_SLUG registry plus the Default mobile skin and
  * asserts each still emits the invariant content slots (title, description,
- * all-tasks breadcrumb, sort toggle, signup CTA, edit/continue controls). The
- * registry is empty today, so this mainly guards the Default fallback and any
- * bespoke mobile skin added later (#496–#500).
+ * all-tasks breadcrumb, sort toggle, signup CTA, edit/continue controls). Guards
+ * the Default fallback plus every bespoke mobile skin — Everymen is the first
+ * (#497); the rest land in #496–#500.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";

--- a/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
@@ -3,17 +3,18 @@ import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import LevelPill from "../../../components/ui/LevelPill";
 import DefaultSigil from "../../../components/cards/DefaultSigil";
-import { factionName } from "../../../utils/factions";
+import { factionCssVar, factionName } from "../../../utils/factions";
+import { MobileStickyBar, MobileStickyCaption } from "./shared";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
- * Default MOBILE task-detail skin — single-column, thumb-first, no fixed-px
- * two-column grid (the desktop Default's `width:240` sidebar would crush the
- * main column on a phone). Renders the same content slots as the desktop
- * archetypes (title, description, breadcrumb, sort toggle, signup CTA, edit /
- * continue controls) so the slot-invariant guard holds; reuses the existing
- * `tasks` copy keys verbatim. Every faction falls through here until it
- * registers a bespoke mobile skin (#496–#500).
+ * Default MOBILE task-detail skin — the na (Unaffiliated) language of the Field
+ * Kit (#495): single-column, thumb-first, no fixed-px two-column grid. A tinted
+ * hero (title, faction, level, points, description), the completed-praxis list,
+ * and a **sticky bottom action bar** that carries the one primary verb (sign up
+ * / continue / edit) above the tab bar while the body scrolls. Consumes the same
+ * {@link TaskDetailState} + copy keys as the desktop archetypes; every faction
+ * without a bespoke mobile skin falls through here (#496–#500).
  */
 export default function DefaultTaskDetail({ state }: { state: TaskDetailState }) {
   const { t } = useTranslation("tasks");
@@ -38,7 +39,11 @@ export default function DefaultTaskDetail({ state }: { state: TaskDetailState })
 
   if (!task) return null;
 
-  const color = "var(--faction-default)";
+  // Tint by the task's own faction; na / unknown falls back to the neutral
+  // default token (this skin backs na + every faction without a bespoke skin).
+  const slug = task.primary_faction_slug;
+  const color =
+    slug && slug !== "na" ? factionCssVar(slug) : "var(--faction-default)";
 
   return (
     <div className="py-4">
@@ -97,82 +102,6 @@ export default function DefaultTaskDetail({ state }: { state: TaskDetailState })
         )}
       </div>
 
-      {/* Signup CTA */}
-      {canSignUp && (
-        <div className="sidebar-card mb-4" style={{ padding: "16px 18px" }}>
-          <button
-            onClick={handleSignup}
-            style={{
-              width: "100%",
-              background: color,
-              color: "var(--color-text-on-accent)",
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 14,
-              fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: "0.12em",
-              padding: "12px 20px",
-              border: "none",
-              cursor: "pointer",
-            }}
-          >
-            {t("default.signup.cta", { points: modifiedPoints })}
-          </button>
-          <div className="eyebrow flex justify-between" style={{ marginTop: 6 }}>
-            <span>{t("default.signup.slots", { open: slotsOpen, max: maxTaskSlots })}</span>
-            <span>{t("default.signup.levelRequired", { level: task.level_required })} {t("default.signup.met")}</span>
-          </div>
-          {signupError && (
-            <div
-              className="font-body"
-              style={{ fontSize: 12, color: "var(--color-danger)", marginTop: 8, padding: "8px 12px", background: "rgba(220,38,38,0.06)", border: "1px solid rgba(220,38,38,0.2)" }}
-            >
-              {signupError}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Submitted */}
-      {mySubmission && (
-        <div className="sidebar-card mb-4 flex items-center gap-3" style={{ padding: "14px 18px" }}>
-          <span className="eyebrow flex-1" style={{ color }}>{t("default.submitted.badge")}</span>
-          <Link to={`/praxes/${mySubmission.id}/edit`} className="btn-outline" style={{ fontSize: 9, padding: "6px 14px" }}>
-            {t("default.submitted.edit")}
-          </Link>
-        </div>
-      )}
-
-      {/* In progress */}
-      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
-        <div className="sidebar-card mb-4 flex items-center gap-3" style={{ padding: "14px 18px" }}>
-          <span className="eyebrow flex-1" style={{ color }}>{t("default.inProgress.badge")}</span>
-          <Link
-            to={`/praxes/${inProgressPraxisId}/edit`}
-            style={{
-              background: color,
-              color: "var(--color-text-on-accent)",
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: 12,
-              fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              padding: "8px 16px",
-              textDecoration: "none",
-            }}
-          >
-            {t("default.inProgress.continue")}
-          </Link>
-          <button
-            onClick={handleDrop}
-            className="eyebrow"
-            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--color-text-tertiary)" }}
-          >
-            {t("default.inProgress.drop")}
-          </button>
-        </div>
-      )}
-
       {/* Completed praxis */}
       <div className="mt-2">
         <div className="flex items-center justify-between mb-3">
@@ -223,6 +152,79 @@ export default function DefaultTaskDetail({ state }: { state: TaskDetailState })
           </>
         )}
       </div>
+
+      {/* Sticky action bar — the mobile CTA pattern; carries the one primary verb. */}
+      {canSignUp && (
+        <MobileStickyBar>
+          {signupError && (
+            <div
+              className="font-body"
+              style={{ fontSize: 12, color: "var(--color-danger)", padding: "8px 12px", background: "var(--faction-default-light)", border: "1px solid var(--color-border)" }}
+            >
+              {signupError}
+            </div>
+          )}
+          <button
+            onClick={handleSignup}
+            style={{
+              width: "100%",
+              background: color,
+              color: "var(--color-text-on-accent)",
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 14,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.12em",
+              padding: "14px 20px",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            {t("default.signup.cta", { points: modifiedPoints })}
+          </button>
+          <MobileStickyCaption>
+            {t("default.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
+          </MobileStickyCaption>
+        </MobileStickyBar>
+      )}
+
+      {mySubmission && (
+        <MobileStickyBar style={{ flexDirection: "row", alignItems: "center" }}>
+          <span className="eyebrow flex-1" style={{ color }}>{t("default.submitted.badge")}</span>
+          <Link to={`/praxes/${mySubmission.id}/edit`} className="btn-outline" style={{ fontSize: 9, padding: "8px 18px" }}>
+            {t("default.submitted.edit")}
+          </Link>
+        </MobileStickyBar>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <MobileStickyBar style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+          <button
+            onClick={handleDrop}
+            className="eyebrow"
+            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--color-text-tertiary)" }}
+          >
+            {t("default.inProgress.drop")}
+          </button>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{
+              marginLeft: "auto",
+              background: color,
+              color: "var(--color-text-on-accent)",
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 12,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              padding: "12px 20px",
+              textDecoration: "none",
+            }}
+          >
+            {t("default.inProgress.continue")}
+          </Link>
+        </MobileStickyBar>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/taskDetail/mobileArchetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/EverymenTaskDetail.tsx
@@ -1,0 +1,451 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import PraxisCard from "../../../components/PraxisCard";
+import { MobileStickyBar, MobileStickyCaption } from "./shared";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * Everymen MOBILE task-detail skin — the FIRST bespoke faction mobile skin
+ * (#497). The union WORK ORDER, phone-shaped: a red masthead billboard with the
+ * cog seal and knockout Bebas headline, the typewritten "Order" body, the
+ * filed work reports, and a stamped **sticky action bar** ("Report for duty")
+ * pinned above the tab bar. Single-column, no fixed-px grid — the desktop
+ * broadsheet's wide poster would overflow a 375px viewport. Reuses the same
+ * {@link TaskDetailState}, the shared mobile sticky bar, and the exact
+ * everymen.* copy keys + `--everymen-*` tokens as the desktop archetype, so the
+ * surface flips with the theme without mutating the document theme.
+ */
+
+const INK = "var(--everymen-ink)";
+const CREAM = "var(--everymen-cream)";
+const RED = "var(--everymen-red)";
+const RED_DEEP = "var(--everymen-red-deep)";
+const GOLD = "var(--everymen-gold)";
+const OLIVE = "var(--everymen-olive)";
+const MUTED = "var(--everymen-muted)";
+const PAPER = "var(--everymen-paper)";
+const ACCENT_FONT = "var(--font-accent)";
+const BODY_FONT = "var(--font-body)";
+
+/** The Everymen cog seal — a riveted gear, the union's mark. */
+function CogSeal({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <g fill={GOLD}>
+        {[0, 45, 90, 135, 180, 225, 270, 315].map((deg) => (
+          <rect
+            key={deg}
+            x="11"
+            y="0.5"
+            width="2"
+            height="5"
+            rx="0.5"
+            transform={`rotate(${deg} 12 12)`}
+          />
+        ))}
+      </g>
+      <circle cx="12" cy="12" r="6.5" fill="none" stroke={GOLD} strokeWidth="2.4" />
+      <circle cx="12" cy="12" r="2" fill={GOLD} />
+    </svg>
+  );
+}
+
+/** Section header — Bebas heading with the red/gold picket rule. */
+function SectionHead({
+  title,
+  trailing,
+}: {
+  title: string;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+      <h2
+        style={{
+          fontFamily: ACCENT_FONT,
+          fontSize: 20,
+          letterSpacing: "0.04em",
+          margin: 0,
+          color: INK,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {title}
+      </h2>
+      <span
+        style={{
+          flex: 1,
+          height: 3,
+          background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)`,
+        }}
+      />
+      {trailing}
+    </div>
+  );
+}
+
+export default function EverymenTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation("tasks");
+  const {
+    task,
+    signups,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    topScore,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  if (!task) return null;
+
+  const statusVoice =
+    task.status === "active" ? t("everymen.statusOpen") : task.status;
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null;
+
+  const stamp = (background: string, textColor: string, label: string) => (
+    <span
+      style={{
+        background,
+        color: textColor,
+        fontFamily: ACCENT_FONT,
+        fontSize: 16,
+        letterSpacing: "0.06em",
+        padding: "4px 12px",
+      }}
+    >
+      {label}
+    </span>
+  );
+
+  return (
+    <div
+      className="py-4"
+      style={{ fontFamily: BODY_FONT, color: INK, background: PAPER, marginLeft: -16, marginRight: -16, paddingLeft: 16, paddingRight: 16 }}
+    >
+      {/* Breadcrumb */}
+      <nav
+        className="mb-3"
+        style={{
+          fontFamily: BODY_FONT,
+          fontSize: 10,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: MUTED,
+        }}
+      >
+        <Link to="/tasks" style={{ color: RED, textDecoration: "none" }}>
+          {t("everymen.breadcrumb")}
+        </Link>
+        <span style={{ opacity: 0.5, margin: "0 6px" }}>›</span>
+        <span style={{ color: RED }}>{task.title}</span>
+      </nav>
+
+      {/* Hero — union billboard */}
+      <div style={{ position: "relative", overflow: "hidden", border: `3px solid ${INK}`, background: RED, color: CREAM, marginBottom: 20 }}>
+        {/* sunburst rays */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            pointerEvents: "none",
+            opacity: 0.5,
+            background: `repeating-conic-gradient(from 0deg at 24% 30%, ${RED_DEEP} 0deg 7deg, transparent 7deg 14deg)`,
+          }}
+        />
+        {/* seal + status banner */}
+        <div
+          style={{
+            position: "relative",
+            zIndex: 2,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 10,
+            flexWrap: "wrap",
+            background: INK,
+            padding: "8px 14px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8, color: GOLD }}>
+            <CogSeal size={16} />
+            <span style={{ fontFamily: ACCENT_FONT, fontSize: 14, letterSpacing: "0.2em" }}>
+              {t("everymen.masthead")}
+            </span>
+          </div>
+          <span
+            style={{
+              fontSize: 8,
+              letterSpacing: "0.14em",
+              textTransform: "uppercase",
+              color: CREAM,
+              border: `1.5px solid ${GOLD}`,
+              padding: "2px 8px",
+            }}
+          >
+            {statusVoice}
+          </span>
+        </div>
+        <div style={{ height: 4, background: GOLD, position: "relative", zIndex: 2 }} />
+        <div style={{ position: "relative", zIndex: 2, padding: "20px 18px 22px" }}>
+          <div
+            style={{
+              fontFamily: ACCENT_FONT,
+              fontSize: 46,
+              lineHeight: 0.92,
+              letterSpacing: "0.01em",
+              color: CREAM,
+              textShadow: `2px 2px 0 ${INK}`,
+              overflowWrap: "anywhere",
+            }}
+          >
+            {task.title}
+          </div>
+          <div style={{ height: 3, background: GOLD, width: 96, margin: "16px 0 14px" }} />
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            {stamp(INK, CREAM, t("everymen.levelValue", { level: task.level_required }))}
+            {stamp(GOLD, INK, t("everymen.pointsValue", { points: modifiedPoints }))}
+          </div>
+          <div style={{ fontFamily: BODY_FONT, fontSize: 10, letterSpacing: "0.06em", color: CREAM, marginTop: 12 }}>
+            {t("everymen.onView", { signups: signups.length, completed: submissions.length })}
+          </div>
+        </div>
+      </div>
+
+      {/* The Order — the work-order body */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t("everymen.orderHeading")} />
+        <div style={{ border: `1.5px solid ${INK}`, background: PAPER, padding: "18px 20px" }}>
+          <p
+            style={{
+              fontFamily: BODY_FONT,
+              fontSize: 13,
+              lineHeight: 1.75,
+              color: INK,
+              margin: 0,
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {task.description || t("everymen.orderEmpty")}
+          </p>
+        </div>
+      </section>
+
+      {/* Hall verdict (read-only aggregate) */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t("everymen.verdictHeading")} />
+        {voteCount > 0 ? (
+          <div style={{ display: "flex", alignItems: "flex-end", gap: 12 }}>
+            <span style={{ fontFamily: ACCENT_FONT, fontSize: 44, lineHeight: 0.8, color: RED }}>
+              {topScore}
+            </span>
+            <div style={{ paddingBottom: 5 }}>
+              <div style={{ fontFamily: ACCENT_FONT, fontSize: 14, letterSpacing: "0.06em", color: INK }}>
+                {t("everymen.verdict.topMark")}
+              </div>
+              <div style={{ fontFamily: BODY_FONT, fontSize: 10, letterSpacing: "0.06em", color: MUTED }}>
+                {t("everymen.verdict.reports", { count: voteCount })}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>
+            {t("everymen.verdict.none")}
+          </p>
+        )}
+      </section>
+
+      {/* Work reports filed (completions) */}
+      <section>
+        <SectionHead
+          title={t("everymen.reportsHeading")}
+          trailing={
+            <div style={{ display: "flex" }}>
+              {(["score", "recent"] as const).map((sort) => {
+                const on = submissionSort === sort;
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: BODY_FONT,
+                      fontSize: 9,
+                      fontWeight: 700,
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      padding: "5px 10px",
+                      background: on ? INK : "transparent",
+                      color: on ? CREAM : MUTED,
+                      border: `1.5px solid ${
+                        on ? INK : "color-mix(in srgb, var(--everymen-ink) 30%, transparent)"
+                      }`,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {sort === "score" ? t("everymen.sort.topRated") : t("everymen.sort.recent")}
+                  </button>
+                );
+              })}
+            </div>
+          }
+        />
+        {sortedSubmissions.length === 0 ? (
+          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>
+            {t("everymen.empty")}
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4">
+              {sortedSubmissions.slice(0, 4).map((s) => (
+                <div key={s.id} style={{ position: "relative", paddingTop: s.id === topId ? 18 : 0 }}>
+                  {s.id === topId && (
+                    <div
+                      style={{
+                        position: "absolute",
+                        top: -4,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        zIndex: 3,
+                        whiteSpace: "nowrap",
+                        background: GOLD,
+                        color: INK,
+                        fontFamily: ACCENT_FONT,
+                        fontSize: 12,
+                        letterSpacing: "0.1em",
+                        padding: "2px 12px",
+                        boxShadow: "0 3px 8px rgba(0,0,0,0.3)",
+                      }}
+                    >
+                      <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span>{" "}
+                      {t("everymen.bestInHall")}
+                    </div>
+                  )}
+                  <PraxisCard praxis={s} />
+                </div>
+              ))}
+            </div>
+            {submissions.length > 4 && (
+              <div style={{ marginTop: 16 }}>
+                <Link
+                  to={`/praxes?task_id=${task.id}`}
+                  style={{ fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: "0.06em", color: RED, textDecoration: "none" }}
+                >
+                  {t("everymen.viewAll", { count: submissions.length })}
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Sticky action bar — stamped CTA / signed-on state */}
+      {canSignUp && (
+        <MobileStickyBar>
+          {signupError && (
+            <div
+              className="font-body"
+              style={{ fontSize: 12, color: RED_DEEP, padding: "8px 12px", background: "color-mix(in srgb, var(--everymen-red) 8%, transparent)", border: `1px solid ${RED}` }}
+            >
+              {signupError}
+            </div>
+          )}
+          <button
+            onClick={handleSignup}
+            style={{
+              width: "100%",
+              background: RED,
+              color: CREAM,
+              fontFamily: BODY_FONT,
+              fontSize: 13,
+              fontWeight: 700,
+              letterSpacing: "0.14em",
+              textTransform: "uppercase",
+              padding: "14px 20px",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            {t("everymen.signup.cta")}
+          </button>
+          <MobileStickyCaption color={MUTED}>
+            {t("everymen.signup.meta", { points: modifiedPoints, open: slotsOpen, max: maxTaskSlots })}
+          </MobileStickyCaption>
+        </MobileStickyBar>
+      )}
+
+      {mySubmission && (
+        <MobileStickyBar style={{ flexDirection: "row", alignItems: "center" }}>
+          <span style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: "0.08em", color: OLIVE, flex: 1 }}>
+            {t("everymen.submitted.text")}
+          </span>
+          <Link
+            to={`/praxes/${mySubmission.id}/edit`}
+            style={{
+              fontFamily: BODY_FONT,
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              padding: "10px 18px",
+              background: INK,
+              color: CREAM,
+              textDecoration: "none",
+            }}
+          >
+            {t("everymen.submitted.edit")}
+          </Link>
+        </MobileStickyBar>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <MobileStickyBar style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+          <button
+            onClick={handleDrop}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontFamily: BODY_FONT,
+              fontSize: 10,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: MUTED,
+            }}
+          >
+            {t("everymen.inProgress.drop")}
+          </button>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{
+              marginLeft: "auto",
+              fontFamily: BODY_FONT,
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              padding: "12px 20px",
+              background: RED,
+              color: CREAM,
+              textDecoration: "none",
+            }}
+          >
+            {t("everymen.inProgress.continue")}
+          </Link>
+        </MobileStickyBar>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/shared.tsx
@@ -1,0 +1,76 @@
+import type { CSSProperties, ReactNode } from "react";
+
+/**
+ * Shared primitives for the MOBILE task-detail skins.
+ *
+ * The Field Kit (#495) gives every detail screen a fixed bottom **sticky action
+ * bar** (`.sticky-cta`) so the primary verb (sign up / continue / edit) stays
+ * thumb-reachable while the body scrolls. Factoring it here means each faction
+ * mobile skin (Default, Everymen, and the later #496–#500 skins) reuses the same
+ * pinning + safe-area math instead of re-deriving it. Kept deliberately small —
+ * a container that pins and a caption line — so it doesn't harden into a
+ * layout framework.
+ */
+
+/**
+ * Sticky bottom action bar. Pins just above the fixed {@link MobileTabBar}
+ * (~3.5rem) and clears the home-indicator safe area; goes full-bleed by
+ * cancelling the mobile shell's 16px gutter. Stacks its children in a column so
+ * a skin can drop an error line or caption above the action row.
+ */
+export function MobileStickyBar({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        position: "sticky",
+        bottom: "calc(3.5rem + env(safe-area-inset-bottom))",
+        marginLeft: -16,
+        marginRight: -16,
+        marginTop: 20,
+        padding: "12px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        background: "var(--color-nav-bg)",
+        backdropFilter: "blur(var(--nav-blur))",
+        borderTop: "1px solid var(--color-border)",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A tracked, muted caption — the meta line under a sticky CTA ("earn up to N
+ * pts · X of Y slots open"). Uppercase micro-label per the Field Kit type scale.
+ */
+export function MobileStickyCaption({
+  children,
+  color,
+}: {
+  children: ReactNode;
+  color?: string;
+}) {
+  return (
+    <div
+      className="font-body"
+      style={{
+        fontSize: 10,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: color ?? "var(--color-text-tertiary)",
+        textAlign: "center",
+      }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Turns the #494 Default mobile task-detail stub into a real screen and adds the first bespoke faction mobile skin.

## What
- **`DefaultTaskDetail`** (na) fleshed out: tinted hero (title/faction/level/points/description via `factionCssVar`), completed-praxis list with sort toggle, and the primary verb (sign-up / continue / edit + error) in a **sticky bottom action bar** — the mobile CTA pattern. Sign-up still routes to edit-praxis via `useTaskDetail`'s handler.
- **`EverymenTaskDetail`** — the pilot bespoke skin (Everymen is the faction the #495 Field Kit gives a task-detail treatment). Registered in `MOBILE_ARCHETYPE_BY_SLUG`. Reuses the desktop archetype's `everymen.*` copy + `--everymen-*` tokens.
- **`mobileArchetypes/shared.tsx`** — minimal `MobileStickyBar`/`MobileStickyCaption` for reuse by later faction skins.

## Constraints
`useTaskDetail` reused verbatim (no data changes); desktop archetypes untouched; all copy via existing `t()` keys (none added); no hardcoded hex; single-column, no fixed-px grids.

## Tests
Dispatch (mobile+everymen → bespoke, mobile+other → Default, desktop → desktop archetype) + slot-invariant + sign-up-routes-to-edit-praxis. tsc: no new errors. vitest `src/pages/taskDetail`: 45 pass.

Note: the sticky bar clears the tab bar via `calc(3.5rem + safe-area)` — a shared `--mobile-tabbar-height` token would be the clean follow-up (styling, not blocking).

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
