### PR TITLE
Mobile: Praxis feed + detail — Default + WOW pilot (#499)

### DIFF
--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -9,6 +9,17 @@
     "loading": "Loading praxis...",
     "empty": "No praxes yet. Be the first."
   },
+  "mobileFeed": {
+    "unaffiliated": "Unaffiliated",
+    "untitled": "Untitled praxis",
+    "byline": "{{faction}} · {{time}}",
+    "tally_one": "{{points}} pts · {{count}} vote",
+    "tally_other": "{{points}} pts · {{count}} votes"
+  },
+  "mobileDetail": {
+    "back": "Praxis",
+    "ratePrompt": "Rate this proof"
+  },
   "card": {
     "ptsAndVotes": "pts + votes",
     "level": "L{{level}}",

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -54,6 +54,9 @@
     "tally_one": "{{count}} vote · <1>{{points}}</1> pts",
     "tally_other": "{{count}} votes · <1>{{points}}</1> pts",
     "saveError": "Could not save your vote. Please try again.",
+    "mobile": {
+      "rateAria": "Rate {{value}} of 5"
+    },
     "ephemerists": {
       "rateAria": "Mark {{value}} — {{label}}"
     },

--- a/frontend/src/pages/Praxes.tsx
+++ b/frontend/src/pages/Praxes.tsx
@@ -1,27 +1,26 @@
 import { useTranslation } from 'react-i18next'
-import { listPraxes } from '../api/praxis'
 import PraxisCard from '../components/PraxisCard'
 import CollaborationCard from '../components/CollaborationCard'
 import PageTitle from '../components/ui/PageTitle'
 import { extractError } from '../utils/errors'
-import { useResource } from '../hooks/useResource'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { usePraxes } from './praxes/usePraxes'
+import MobilePraxisFeed from './praxes/MobilePraxisFeed'
 
+/**
+ * Praxis feed. `usePraxes()` owns the 3-way (solo / collab / duel) fetch; on a
+ * phone (#499) `useFormFactor() === 'mobile'` swaps the wrapped desktop card
+ * grid for the single-column mobile proof stream. Desktop renders exactly as
+ * before.
+ */
 export default function Praxes() {
   const { t } = useTranslation('praxis')
   const { t: tc } = useTranslation('common')
-  const { data, loading, error } = useResource(
-    () =>
-      Promise.all([
-        listPraxes({ type: 'solo', status: 'submitted' }),
-        listPraxes({ type: 'collab', status: 'submitted' }),
-        listPraxes({ type: 'duel', status: 'submitted' }),
-      ]),
-    [],
-  )
-  const soloItems = data ? data[0] : []
-  const collabItems = data ? [...data[1], ...data[2]] : []
+  const formFactor = useFormFactor()
+  const state = usePraxes()
+  const { soloItems, collabItems, loading, error, isEmpty } = state
 
-  const isEmpty = soloItems.length === 0 && collabItems.length === 0
+  if (formFactor === 'mobile') return <MobilePraxisFeed state={state} />
 
   return (
     <div className="py-8">

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -13,7 +13,10 @@ import { Navigate, useParams } from 'react-router-dom'
 import { usePraxisDetail } from './praxisDetail/usePraxisDetail'
 import type { PraxisDetailState } from './praxisDetail/usePraxisDetail'
 import { pickVariant } from '../utils/factionDispatch'
+import { useFormFactor } from '../hooks/useFormFactor'
 import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
+import DefaultMobilePraxisDetail from './praxisDetail/mobileArchetypes/DefaultPraxisDetail'
+import WowMobilePraxisDetail from './praxisDetail/mobileArchetypes/WowPraxisDetail'
 import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
 import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
 import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
@@ -40,10 +43,20 @@ export const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDeta
   albescent: AlbescentPraxisDetail,
 }
 
+/**
+ * Parallel MOBILE registry (#499). Every faction falls through to the Default
+ * mobile skin until it registers a bespoke one; WOW is the pilot (its Field Kit
+ * praxis-detail treatment), mirroring the mobile FieldDesk + TaskDetail seams.
+ */
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDetailState }>> = {
+  wow: WowMobilePraxisDetail,
+}
+
 export default function PraxisDetail() {
   const { t } = useTranslation('praxis')
   const { id } = useParams<{ id: string }>()
   const state = usePraxisDetail(id)
+  const formFactor = useFormFactor()
 
   if (state.loading) return <div className="py-8 font-body text-muted">{t('detail.loading')}</div>
   if (state.fetchError) return (
@@ -63,7 +76,10 @@ export default function PraxisDetail() {
     return <Navigate to={`/praxes/${state.praxis.id}/edit`} replace />
   }
 
-  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, state.praxis.task_faction_slug, DefaultPraxisDetail)
+  const Archetype =
+    formFactor === 'mobile'
+      ? pickVariant(MOBILE_ARCHETYPE_BY_SLUG, state.praxis.task_faction_slug, DefaultMobilePraxisDetail)
+      : pickVariant(ARCHETYPE_BY_SLUG, state.praxis.task_faction_slug, DefaultPraxisDetail)
   return (
     <>
       {/* Duel cross-link is neutral chrome above every archetype (#313); one

--- a/frontend/src/pages/__tests__/praxesFeedDispatch.test.tsx
+++ b/frontend/src/pages/__tests__/praxesFeedDispatch.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Praxis-feed form-factor dispatch (#499) — renders <Praxes /> with useFormFactor
+ * mocked and pins:
+ *   - phone → the single-column mobile proof stream (data-feed="mobile"),
+ *   - desktop → the existing wrapped card list (its intro copy, no mobile marker).
+ * SSR (renderToStaticMarkup) never runs effects, so the feed sits in its loading
+ * state — enough to prove which surface the dispatch selected. listPraxes is
+ * mocked so no axios call is attempted.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../i18n'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+vi.mock('../../api/praxis', () => ({
+  listPraxes: async () => [],
+}))
+
+// Imported after the mocks are registered.
+import Praxes from '../Praxes'
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Praxes />
+    </MemoryRouter>,
+  )
+}
+
+describe('praxis-feed form-factor dispatch', () => {
+  it('renders the mobile proof stream on mobile', () => {
+    mocks.formFactor = 'mobile'
+    expect(render()).toContain('data-feed="mobile"')
+  })
+
+  it('renders the desktop card list on desktop (untouched)', () => {
+    mocks.formFactor = 'desktop'
+    const html = render()
+    expect(html).not.toContain('data-feed="mobile"')
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Proof of action')
+  })
+})

--- a/frontend/src/pages/praxes/MobilePraxisFeed.tsx
+++ b/frontend/src/pages/praxes/MobilePraxisFeed.tsx
@@ -1,0 +1,133 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../api/praxis'
+import { factionCssVar, factionName } from '../../utils/factions'
+import { relativeTime } from '../../utils/dates'
+import type { PraxesFeedState } from './usePraxes'
+
+/**
+ * Mobile praxis feed (#499) — a single-column vertical proof-card stream. Each
+ * card carries the author, a faction tint (via factionCssVar), the finding
+ * title, and the earned score. Solo + collab/duel are merged into one stream,
+ * matching the Field Kit §05 praxis feed; every card taps into the detail page.
+ *
+ * Presentation-only: data arrives via {@link PraxesFeedState}. The list schema
+ * (PraxisCardOut) carries no media thumbnail and no vote average, so the card
+ * leads with the faction-tinted title + score rather than the mock's photo /
+ * star-average (the average was retired in #375; a thumbnail would need a new
+ * backend field, out of scope here). Single-column, no fixed-px layout grid
+ * (SPEC-faction-ui-profile §1a).
+ */
+export default function MobilePraxisFeed({ state }: { state: PraxesFeedState }) {
+  const { t } = useTranslation('praxis')
+  const { t: tc } = useTranslation('common')
+  const { soloItems, collabItems, loading, error, isEmpty } = state
+
+  const items = [...soloItems, ...collabItems]
+
+  return (
+    <div data-feed="mobile" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <header>
+        <div className="eyebrow" style={{ fontSize: 8, color: 'var(--color-text-secondary)' }}>
+          {tc('nav.praxis')}
+        </div>
+        <h1
+          className="font-display italic"
+          style={{ fontSize: 30, lineHeight: 1, color: 'var(--color-text-primary)', margin: 0 }}
+        >
+          {t('listPage.title')}
+        </h1>
+      </header>
+
+      {loading ? (
+        <p className="font-body text-muted">{t('listPage.loading')}</p>
+      ) : error ? (
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+          {t('detail.errors.load')}{' '}
+          <button onClick={() => window.location.reload()} className="underline">
+            {tc('states.tryRefreshing')}
+          </button>
+        </p>
+      ) : isEmpty ? (
+        <p className="font-body text-muted">{t('listPage.empty')}</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {items.map((praxis) => (
+            <MobileProofCard key={`${praxis.type}-${praxis.id}`} praxis={praxis} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** One faction-tinted proof card in the feed. */
+function MobileProofCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const tint = factionCssVar(praxis.task_faction_slug, 'card-accent')
+  const facName = praxis.task_faction_slug ? factionName(praxis.task_faction_slug) : t('mobileFeed.unaffiliated')
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <Link
+      to={`/praxes/${praxis.id}`}
+      className="font-body"
+      style={{
+        display: 'block',
+        background: 'var(--color-bg-surface)',
+        border: '1px solid var(--color-border)',
+        borderLeft: `4px solid ${tint}`,
+        borderRadius: 'var(--radius-xl)',
+        padding: 16,
+        textDecoration: 'none',
+        color: 'var(--color-text-primary)',
+      }}
+    >
+      {/* Author + faction tint + time */}
+      <div className="flex items-center gap-3" style={{ marginBottom: 12 }}>
+        <span
+          className="shrink-0 flex items-center justify-center rounded-full"
+          style={{
+            width: 34,
+            height: 34,
+            background: tint,
+            color: 'var(--color-text-on-accent)',
+            fontFamily: 'var(--font-display)',
+            fontStyle: 'italic',
+            fontSize: 15,
+          }}
+          aria-hidden
+        >
+          {initial}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate" style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+            {praxis.created_by_display_name}
+          </div>
+          <div
+            className="truncate eyebrow"
+            style={{ marginTop: 2, fontSize: 9, color: 'var(--color-text-tertiary)' }}
+          >
+            {t('mobileFeed.byline', { faction: facName, time: relativeTime(praxis.created_at) })}
+          </div>
+        </div>
+      </div>
+
+      {/* Finding title */}
+      <div
+        className="font-display italic"
+        style={{ fontSize: 20, lineHeight: 1.2, color: 'var(--color-text-primary)' }}
+      >
+        {praxis.title || t('mobileFeed.untitled')}
+      </div>
+
+      {/* Score tally — earned points + vote count (#375: no average) */}
+      <div
+        className="eyebrow"
+        style={{ marginTop: 10, fontSize: 10, color: tint }}
+      >
+        {t('mobileFeed.tally', { points: praxis.score, count: praxis.voter_count })}
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/pages/praxes/usePraxes.ts
+++ b/frontend/src/pages/praxes/usePraxes.ts
@@ -1,0 +1,37 @@
+/**
+ * usePraxes — the praxis-feed data lift shared by the desktop list and the
+ * mobile stream (#499). Extracted verbatim from the old inline Praxes.tsx body
+ * so both form factors read the same 3-way (solo / collab / duel) fetch; the
+ * desktop page renders exactly as before. Collab + duel are merged into one
+ * `collabItems` bucket, matching the pre-extraction behaviour.
+ */
+import { listPraxes, type PraxisCardOut } from '../../api/praxis'
+import { useResource } from '../../hooks/useResource'
+
+export interface PraxesFeedState {
+  /** Solo submitted praxes. */
+  soloItems: PraxisCardOut[]
+  /** Collab + duel submitted praxes, concatenated (collab first). */
+  collabItems: PraxisCardOut[]
+  loading: boolean
+  error: Error | null
+  /** True when neither bucket has any entry (drives the empty state). */
+  isEmpty: boolean
+}
+
+export function usePraxes(): PraxesFeedState {
+  const { data, loading, error } = useResource(
+    () =>
+      Promise.all([
+        listPraxes({ type: 'solo', status: 'submitted' }),
+        listPraxes({ type: 'collab', status: 'submitted' }),
+        listPraxes({ type: 'duel', status: 'submitted' }),
+      ]),
+    [],
+  )
+  const soloItems = data ? data[0] : []
+  const collabItems = data ? [...data[1], ...data[2]] : []
+  const isEmpty = soloItems.length === 0 && collabItems.length === 0
+
+  return { soloItems, collabItems, loading, error, isEmpty }
+}

--- a/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Mobile praxis-read content-slot invariant — the mobile twin of
+ * archetypeSlots.test. Walks MOBILE_ARCHETYPE_BY_SLUG (the WOW pilot) plus the
+ * Default mobile skin and asserts each still emits the invariant CONTENT slots:
+ * the finding title, the account body, the re-task link, and the author byline.
+ * The shared Task Crown banner is checked separately. Rendered to static markup
+ * (no DOM); `useAuth` resolves to its anonymous default, so the vote caster
+ * shows its login gate rather than throwing.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../PraxisDetail'
+import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisOut } from '../../../api/praxis'
+import type { VoteSummary } from '../../../api/votes'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+const PRAXIS: PraxisOut = {
+  id: 1,
+  task_id: 7,
+  task_title: 'Mangrove',
+  task_point_value: 30,
+  task_level_required: 3,
+  task_faction_slug: 'wow',
+  type: 'solo',
+  status: 'submitted',
+  title: 'Reforestation',
+  body_text: 'Seedlings planted along the estuary.',
+  moderation_status: 'visible',
+  admin_note: null,
+  flagged_at: null,
+  submitted_at: '2026-01-02T00:00:00Z',
+  submit_proposed_at: null,
+  created_by_id: 3,
+  created_by_display_name: 'Ada',
+  created_by_faction_slug: 'wow',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+  members: [],
+  invites: [],
+  media_items: [],
+  score: 42,
+  is_top_for_task: false,
+  duel_id: null,
+  can_flag: true,
+  applied_metatasks: [],
+}
+
+const VOTES: VoteSummary = { praxis_id: 1, total_votes: 4, total_score: 16 }
+
+function state(): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: PRAXIS,
+    fetchError: null,
+    votes: VOTES,
+    voters: [],
+    duel: null,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: '',
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleResubmit: async () => {},
+    handleFlag: async () => {},
+    metatasks: [],
+    metataskLoading: false,
+    metataskError: null,
+    applyingMetataskId: null,
+    removingMetataskId: null,
+    handleApplyMetatask: async () => {},
+    handleRemoveMetatask: async () => {},
+  }
+}
+
+const archetypes = { ...MOBILE_ARCHETYPE_BY_SLUG, __default__: DefaultMobilePraxisDetail }
+
+describe('mobile praxis-read content-slot invariant', () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders the finding, account body, task link, and author byline`, () => {
+      const { html, text } = render(<Archetype state={state()} />)
+      expect(text, 'finding/title slot').toContain('Reforestation')
+      expect(text, 'account-body slot').toContain('Seedlings')
+      expect(html, 're-task-link slot').toContain('href="/tasks/7"')
+      expect(html, 'author-byline slot').toContain('href="/characters/3"')
+    })
+  }
+})
+
+describe('mobile praxis-read Task Crown hero', () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} shows the crown hero iff is_top_for_task`, () => {
+      const crowned = state()
+      crowned.praxis = { ...PRAXIS, is_top_for_task: true }
+      expect(render(<Archetype state={crowned} />).text).toContain('TASK CROWN')
+      expect(render(<Archetype state={state()} />).text).not.toContain('TASK CROWN')
+    })
+  }
+})

--- a/frontend/src/pages/praxisDetail/__tests__/mobileStarVote.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileStarVote.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * MobileStarVote wiring (#499) — the touch-tuned star caster is a presentational
+ * shell over the shared useVote hook (castVote/refetch), so it records exactly
+ * like every faction vote UI. SSR (renderToStaticMarkup, no DOM) can't fire a
+ * click, so this asserts the wiring structurally:
+ *   - a logged-in viewer gets the five interactive rate buttons (the caster),
+ *   - an anonymous viewer gets the shared login gate instead.
+ * useAuth + castVote are mocked so the control runs over controlled inputs.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({
+  user: null as CurrentUser | null,
+  castVote: vi.fn(async () => ({}) as unknown),
+}))
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: mocks.user, refetch: async () => {} }),
+}))
+vi.mock('../../../api/votes', () => ({
+  castVote: mocks.castVote,
+}))
+
+import { MobileStarVote } from '../mobileArchetypes/shared'
+
+function currentUser(): CurrentUser {
+  return {
+    account_id: 1,
+    character: {
+      id: 9,
+      username: 'ada',
+      display_name: 'Ada',
+      bio: null,
+      avatar_url: null,
+      location: null,
+      level: 4,
+      score: 100,
+      all_time_score: 100,
+      faction_slug: 'wow',
+      status: 'active',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: 'Era 3',
+  }
+}
+
+function render(): string {
+  return renderToStaticMarkup(<MobileStarVote praxisId={55} points={16} totalVotes={4} />)
+}
+
+describe('MobileStarVote', () => {
+  it('renders the five interactive rate buttons for a logged-in viewer', () => {
+    mocks.user = currentUser()
+    const html = render()
+    expect((html.match(/aria-label="Rate \d of 5"/g) ?? []).length).toBe(5)
+    expect(html).toContain('<button')
+  })
+
+  it('renders the shared login gate for an anonymous viewer', () => {
+    mocks.user = null
+    const html = render()
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Log in to vote')
+    expect(html).not.toContain('aria-label="Rate 1 of 5"')
+  })
+})

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
@@ -1,0 +1,147 @@
+/**
+ * Default MOBILE praxis-detail skin (#499) — single-column, thumb-first. Renders
+ * the same invariant CONTENT slots as the desktop archetypes (finding title,
+ * account body, re-task link, author byline, media, vote caster) plus the shared
+ * behavior slots (admin bar, banners, owner actions, flag, voter breakdown), so
+ * the slot guard holds. Every faction falls through here until it registers a
+ * bespoke mobile skin. Consumes the same {@link PraxisDetailState} verbatim;
+ * comments are mounted once by the PraxisDetail dispatcher below every skin.
+ *
+ * Single-column flex layout, no fixed-px grid (SPEC-faction-ui-profile §1a).
+ */
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import { factionCssVar } from '../../../utils/factions'
+import { formatTimestamp } from '../../../utils/dates'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisVoterBreakdown,
+  MemberByline,
+} from '../shared'
+import { MobileStarVote } from './shared'
+
+export default function DefaultPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const accent = factionCssVar(praxis.task_faction_slug, 'card-accent')
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <div data-skin="default" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {/* Breadcrumb */}
+      <nav
+        className="font-body"
+        style={{ fontSize: 10, letterSpacing: '0.08em', color: 'var(--color-text-tertiary)' }}
+      >
+        <Link to="/tasks" style={{ color: accent, textDecoration: 'none' }}>
+          {t('detail.default.breadcrumbTasks')}
+        </Link>
+        {' › '}
+        <span style={{ color: 'var(--color-text-primary)' }}>{t('mobileDetail.back')}</span>
+      </nav>
+
+      {/* Behavior slots (invariant) */}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
+
+      {/* Byline block */}
+      <div className="flex items-center gap-3">
+        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+          <span
+            className="flex items-center justify-center rounded-full"
+            style={{
+              width: 40,
+              height: 40,
+              background: accent,
+              color: 'var(--color-text-on-accent)',
+              fontFamily: 'var(--font-display)',
+              fontStyle: 'italic',
+              fontSize: 17,
+            }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <MemberByline
+            praxis={praxis}
+            linkClassName="font-display italic"
+            linkStyle={{ fontSize: 15, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+          />
+          <span className="eyebrow" style={{ fontSize: 9, color: 'var(--color-text-tertiary)' }}>
+            {formatTimestamp(praxis.created_at)}
+          </span>
+        </div>
+      </div>
+
+      {/* Finding title */}
+      <h1
+        className="font-display italic font-medium"
+        style={{ fontSize: 26, lineHeight: 1.2, color: 'var(--color-text-primary)', margin: 0 }}
+      >
+        {praxis.title}
+      </h1>
+
+      {/* Owner actions (invariant) */}
+      <PraxisOwnerActions state={state} />
+
+      {/* Task context link */}
+      <Link
+        to={`/tasks/${praxis.task_id}`}
+        className="sidebar-card font-body flex items-center gap-2"
+        style={{
+          borderLeft: `4px solid ${accent}`,
+          borderRadius: '0 8px 8px 0',
+          padding: '10px 14px',
+          textDecoration: 'none',
+        }}
+      >
+        <span className="eyebrow" style={{ fontSize: 8 }}>{t('detail.default.completingTask')}</span>
+        <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+          {praxis.task_title}
+        </span>
+        <span style={{ fontSize: 9, color: 'var(--color-text-tertiary)', marginLeft: 'auto' }}>
+          {t('detail.default.points', { points: praxis.task_point_value })}
+        </span>
+      </Link>
+
+      {/* Full media */}
+      {praxis.media_items.length > 0 && <MediaGallery media={praxis.media_items} />}
+
+      {/* Account body */}
+      {praxis.body_text && (
+        <MarkdownPreview
+          source={praxis.body_text}
+          className="font-display markdown-preview"
+          style={{ fontSize: 15, lineHeight: 1.75, color: 'var(--color-text-primary)' }}
+        />
+      )}
+
+      {/* Touch star-vote */}
+      <div className="sidebar-card" style={{ padding: '16px 14px' }}>
+        <div className="eyebrow" style={{ textAlign: 'center', marginBottom: 12, color: 'var(--color-text-secondary)' }}>
+          {t('mobileDetail.ratePrompt')}
+        </div>
+        <MobileStarVote
+          praxisId={praxis.id}
+          points={votes?.total_score}
+          totalVotes={votes?.total_votes}
+          accent={accent}
+        />
+      </div>
+
+      {/* Flag + voter breakdown (invariant) */}
+      <PraxisFlagBlock state={state} />
+      <PraxisVoterBreakdown state={state} />
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/WowPraxisDetail.tsx
@@ -1,0 +1,213 @@
+/**
+ * Warriors of Whimsy MOBILE praxis-detail skin (#499) — the praxis.exe window on
+ * a phone: a pink computer-witch window (traffic-light title bar, dotted board,
+ * inner notepad) holds the full media, then a Caveat "finding" headline, the
+ * account body, and a big thumb-sized star caster. Single-column; ported from
+ * the Field Kit `wow-treatment` §05 praxis detail. Renders the same invariant
+ * CONTENT + behavior slots as every archetype (shared module) — only the dress
+ * changes. Grounds on the `--faction-wow-*` tokens already in index.css (same
+ * set WowPraxisDetail / WowFieldDesk use). Presentation-only.
+ */
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import { formatTimestamp } from '../../../utils/dates'
+import { factionName } from '../../../utils/factions'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisVoterBreakdown,
+  MemberByline,
+} from '../shared'
+import { MobileStarVote } from './shared'
+
+const PINK = 'var(--faction-wow)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const DOT = 'var(--faction-wow-dot)'
+const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const BODY = 'var(--font-body)' // Courier Prime
+const ON_ACCENT = 'var(--color-text-on-accent)'
+
+/** The kit's four-point sparkle. */
+function Sparkle({ size, color, style }: { size: number; color: string; style?: CSSProperties }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style} aria-hidden>
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+/** A pink window: dotted title bar + dotted board wrapping an inner notepad. */
+function Window({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section
+      style={{
+        borderRadius: 16,
+        overflow: 'hidden',
+        border: `2px solid ${WIN_BORDER}`,
+        boxShadow: `0 8px 22px color-mix(in srgb, ${PINK} 22%, transparent)`,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          padding: '8px 12px',
+          background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+          borderBottom: `2px solid ${WIN_BORDER}`,
+        }}
+      >
+        {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+          <span
+            key={c}
+            style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }}
+          />
+        ))}
+        <span
+          style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 18, color: TITLE_TEXT }}
+        >
+          <Sparkle size={11} color={TITLE_TEXT} />
+          {title}
+        </span>
+      </div>
+      <div
+        style={{
+          padding: 12,
+          background: BODY_BG,
+          backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+          backgroundSize: '13px 13px',
+        }}
+      >
+        <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: 13 }}>
+          {children}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default function WowPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <div
+      data-skin="wow"
+      className="page"
+      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY, color: CARD_TEXT, background: BODY_BG }}
+    >
+      {/* Behavior slots (invariant) */}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
+
+      {/* Byline row */}
+      <div className="flex items-center gap-3">
+        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+          <span
+            className="flex items-center justify-center rounded-full"
+            style={{
+              width: 40,
+              height: 40,
+              background: `linear-gradient(150deg, ${PINK}, var(--faction-wow-card-muted))`,
+              border: `1.5px solid ${WIN_BORDER}`,
+              color: ON_ACCENT,
+              fontFamily: SCRIPT,
+              fontSize: 20,
+            }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <MemberByline
+            praxis={praxis}
+            linkStyle={{ fontFamily: SCRIPT, fontSize: 22, color: TITLE_TEXT, lineHeight: 1, textDecoration: 'none' }}
+          />
+          <div className="truncate" style={{ marginTop: 2, fontSize: 9, color: CARD_MUTED, letterSpacing: '0.06em' }}>
+            {t('mobileFeed.byline', { faction: factionName(praxis.created_by_faction_slug), time: formatTimestamp(sealedDate) })}
+          </div>
+        </div>
+      </div>
+
+      {/* praxis.exe window — full media inside */}
+      {praxis.media_items.length > 0 && (
+        <Window title={t('detail.wow.windows.keepsakes')}>
+          <MediaGallery media={praxis.media_items} layout="grid" />
+        </Window>
+      )}
+
+      {/* Finding headline */}
+      <div>
+        <div style={{ fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.2em', color: CARD_MUTED, marginBottom: 4 }}>
+          {t('detail.wow.theFinding')}
+        </div>
+        <h1 style={{ fontFamily: SCRIPT, fontWeight: 700, fontSize: 34, lineHeight: 1.12, margin: 0, color: TITLE_TEXT, overflowWrap: 'anywhere' }}>
+          {praxis.title ?? t('detail.wow.untitled')}
+        </h1>
+      </div>
+
+      {/* Owner actions (invariant) */}
+      <PraxisOwnerActions state={state} />
+
+      {/* re: task link */}
+      <div style={{ fontSize: 9.5, color: CARD_MUTED, letterSpacing: '0.04em' }}>
+        {t('detail.wow.re')}{' '}
+        <Link to={`/tasks/${praxis.task_id}`} style={{ color: TITLE_TEXT, fontWeight: 700, textDecoration: 'none' }}>
+          {praxis.task_title}
+        </Link>{' '}
+        {t('detail.wow.lvlSealed', { level: praxis.task_level_required, date: formatTimestamp(sealedDate) })}
+      </div>
+
+      {/* Account body */}
+      {praxis.body_text && (
+        <MarkdownPreview
+          source={praxis.body_text}
+          className="markdown-preview"
+          style={{ fontFamily: BODY, fontSize: 13, lineHeight: 1.75, color: CARD_TEXT }}
+        />
+      )}
+
+      {/* hearts.exe — the touch star caster */}
+      <Window title={t('detail.wow.windows.hearts')}>
+        <div
+          className="flex items-center justify-center gap-2"
+          style={{ marginBottom: 12, fontFamily: SCRIPT, fontSize: 22, color: TITLE_TEXT }}
+        >
+          <Sparkle size={13} color={PINK} />
+          {t('detail.wow.sendLove')}
+        </div>
+        <MobileStarVote
+          praxisId={praxis.id}
+          points={votes?.total_score}
+          totalVotes={votes?.total_votes}
+          accent={PINK}
+          accentFont={SCRIPT}
+        />
+      </Window>
+
+      {/* Flag + voter breakdown (invariant) */}
+      <PraxisFlagBlock state={state} />
+      <PraxisVoterBreakdown state={state} />
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
@@ -1,0 +1,101 @@
+/**
+ * Shared mobile praxis-detail chrome (#499).
+ *
+ * MobileStarVote — a thumb-sized 1-5 star caster. It is a presentational shell
+ * over the existing {@link useVote} hook (exactly like the faction vote UIs), so
+ * casting still records through castVote/refetch — no voting logic is
+ * reimplemented here. The only mobile-specific change is larger touch targets
+ * (48px star buttons) for the feed-detail surface. Logged-out viewers get the
+ * shared VoteLoginGate; the points/vote tally reuses the shared VoteSummary
+ * (#375: a running tally, never an average).
+ */
+import { useTranslation } from 'react-i18next'
+import { useVote } from '../../../components/vote/useVote'
+import { VoteLoginGate, VoteSummary } from '../../../components/vote/VoteShell'
+
+const STAR_TILE = 48
+
+/** Filled or outline star glyph. */
+function StarGlyph({ filled, color, size = 34 }: { filled: boolean; color: string; size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M12 2.5l2.9 6.1 6.6.8-4.9 4.6 1.3 6.5L12 18.9 6.1 21l1.3-6.5-4.9-4.6 6.6-.8z"
+        fill={filled ? color : 'none'}
+        stroke={color}
+        strokeWidth={filled ? 1 : 1.6}
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export function MobileStarVote({
+  praxisId,
+  currentValue,
+  points,
+  totalVotes,
+  accent = 'var(--color-accent)',
+  accentFont = 'var(--font-display)',
+}: {
+  praxisId: number
+  currentValue?: number
+  points?: number | null
+  totalVotes?: number
+  /** Faction tint for filled stars + the tally figure. */
+  accent?: string
+  accentFont?: string
+}) {
+  const { t } = useTranslation('votes')
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+
+  if (!user) return <VoteLoginGate />
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 6, justifyContent: 'center' }}>
+        {[1, 2, 3, 4, 5].map((value) => {
+          const filled = selected >= value
+          return (
+            <button
+              key={value}
+              type="button"
+              disabled={saving}
+              onClick={() => void vote(value)}
+              aria-label={t('chrome.mobile.rateAria', { value })}
+              style={{
+                width: STAR_TILE,
+                height: STAR_TILE,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: 0,
+                border: 'none',
+                background: 'transparent',
+                cursor: saving ? 'default' : 'pointer',
+              }}
+            >
+              <StarGlyph filled={filled} color={filled ? accent : 'var(--color-text-tertiary)'} />
+            </button>
+          )
+        })}
+      </div>
+
+      <div style={{ textAlign: 'center' }}>
+        <VoteSummary
+          selected={selected}
+          points={points}
+          totalVotes={totalVotes}
+          error={error}
+          theme={{
+            muted: 'var(--color-text-tertiary)',
+            accent,
+            accentFont,
+            avgFontSize: 15,
+            errorColor: 'var(--color-danger)',
+          }}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Two mobile social surfaces behind the #494 form-factor seam.

## Feed
`Praxes.tsx` dispatches on `useFormFactor()` to a single-column proof-card stream (author, faction tint via `factionCssVar`, relative time, finding title, earned-score tally). Feed logic lifted into a shared `usePraxes()` hook (the same 3-way solo/collab/duel `useResource` fetch) — desktop renders identically.

## Detail
`PraxisDetail.tsx` dispatches via `pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultPraxisDetail)` to a Default mobile skin + **WOW pilot** (the Field Kit gives WOW the bespoke `praxis.exe` treatment). `usePraxisDetail` reused verbatim; the shared `CommentThread` mounts below every skin. **`MobileStarVote`** is a touch-tuned (48px) shell over the existing `useVote` hook + shared vote gate/summary — no voting logic reimplemented.

## Product notes (flagged for design)
- No media thumbnail on feed cards — the list schema `PraxisCardOut` carries no media path (would need a backend field; out of scope for a frontend-only change).
- Feed cards lead with earned-score tally, not a star average — vote averages were retired in #375.

## Constraints
Desktop feed + archetypes untouched; copy via `t()` (`praxis.mobileFeed/mobileDetail`, `votes.chrome.mobile`); no hardcoded hex; single-column.

## Tests
Feed dispatch + detail slot-invariant (Default + WOW) + star-vote wiring. tsc: no new errors. vitest: 172 pass.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
