### PR TITLE
Mobile: Edit-praxis composer — Default + WOW pilot (#498)

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -124,6 +124,11 @@
       "table": "table"
     },
     "dropTask": "drop task",
+    "mobile": {
+      "write": "Write",
+      "preview": "Preview",
+      "viewToggleAria": "Switch between write and preview"
+    },
     "na": {
       "masthead": "casual proof board",
       "pageTitle": "edit praxis",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import PageTitle from "../components/ui/PageTitle";
 import ImageEditModal from "../components/imageEdit/ImageEditModal";
 import { pickVariant } from "../utils/factionDispatch";
+import { useFormFactor } from "../hooks/useFormFactor";
 import {
   useEditPraxis,
   type EditPraxisState,
@@ -22,6 +23,8 @@ import DefaultEditPraxis from "./editPraxis/archetypes/DefaultEditPraxis";
 import EverymenEditPraxis from "./editPraxis/archetypes/EverymenEditPraxis";
 import UAEditPraxis from "./editPraxis/archetypes/UAEditPraxis";
 import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
+import DefaultMobileEditPraxis from "./editPraxis/mobileArchetypes/DefaultEditPraxis";
+import WowMobileEditPraxis from "./editPraxis/mobileArchetypes/WowEditPraxis";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
@@ -38,10 +41,18 @@ const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   albescent: AlbescentEditPraxis,
 };
 
+// Parallel MOBILE registry (#498). WOW is the pilot bespoke phone composer; every
+// other faction falls through to the Default mobile skin. Bespoke faction mobile
+// composers land incrementally, exactly like the desktop archetypes above.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
+  wow: WowMobileEditPraxis,
+};
+
 export default function EditPraxis() {
   const { t } = useTranslation("forms");
   const { id } = useParams<{ id: string }>();
   const state = useEditPraxis(id);
+  const formFactor = useFormFactor();
 
   if (state.loading) {
     return (
@@ -65,7 +76,10 @@ export default function EditPraxis() {
   }
 
   const slug = state.task?.primary_faction_slug ?? null;
-  const Archetype = pickVariant(ARCHETYPE_BY_SLUG, slug, DefaultEditPraxis);
+  const Archetype =
+    formFactor === "mobile"
+      ? pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileEditPraxis)
+      : pickVariant(ARCHETYPE_BY_SLUG, slug, DefaultEditPraxis);
 
   return (
     <>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
@@ -1,0 +1,438 @@
+/**
+ * Default MOBILE composer (#498) — full-screen, single-column, thumb-first.
+ * A Write/Preview segmented toggle swaps the editor for a live markdown preview;
+ * an obvious fluid media grid drives the FilePicker → ImageEditModal crop path
+ * (owned by the EditPraxis wrapper); a sticky submit bar rides above the tab
+ * bar. Consumes `useEditPraxis` verbatim — no editor, upload, or submit logic
+ * lives here. Every faction falls through to this skin until it registers a
+ * bespoke mobile composer.
+ */
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { mediaUrl } from "../../../utils/media";
+import { factionName } from "../../../utils/factions";
+import MediaArt from "../blocks/MediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
+import { ErrorBanner, formatAutosave } from "../archetypes/shared";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from "../archetypes/controls";
+import type { EditPraxisState } from "../useEditPraxis";
+import { MobileStickyBar, SegToggle, type ComposerTab } from "./shared";
+
+const ACCENT = "var(--faction-default)";
+const SURFACE = "var(--color-bg-surface)";
+const BORDER = "var(--color-border)";
+const INK = "var(--color-text-primary)";
+const MUTED = "var(--color-text-secondary)";
+const FAINT = "var(--color-text-tertiary)";
+
+const eyebrow: React.CSSProperties = {
+  fontFamily: "var(--font-body)",
+  fontSize: 9,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+  color: FAINT,
+};
+
+export default function DefaultEditPraxis({
+  state,
+}: {
+  state: EditPraxisState;
+}) {
+  const { t } = useTranslation("forms");
+  const [tab, setTab] = useState<ComposerTab>("write");
+  const praxis = state.praxis!;
+  const task = state.task;
+
+  return (
+    <div
+      data-skin="default"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        fontFamily: "var(--font-body)",
+        color: INK,
+      }}
+    >
+      {/* Title + Write/Preview toggle */}
+      <header style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+          <h1
+            className="font-display italic"
+            style={{ fontSize: 26, lineHeight: 1, color: INK, margin: 0 }}
+          >
+            {t("editPraxis.na.pageTitle")}
+          </h1>
+          <span style={{ ...eyebrow, marginLeft: "auto" }}>
+            {state.autosaveAt
+              ? t("editPraxis.na.autosaveSaved", {
+                  ago: formatAutosave(state.autosaveAt),
+                })
+              : t("editPraxis.na.autosaveUnsaved")}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: {
+              gap: 3,
+              padding: 3,
+              background: SURFACE,
+              border: `1px solid ${BORDER}`,
+              borderRadius: 999,
+            },
+            buttonStyle: (active) => ({
+              padding: "8px 10px",
+              borderRadius: 999,
+              border: "none",
+              fontFamily: "var(--font-body)",
+              fontSize: 11,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              fontWeight: active ? 700 : 400,
+              background: active ? ACCENT : "transparent",
+              color: active ? "var(--color-text-on-accent)" : MUTED,
+            }),
+          }}
+        />
+      </header>
+
+      {/* For-task reference */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 10,
+          padding: "11px 14px",
+          background: SURFACE,
+          border: `1px solid ${BORDER}`,
+          borderRadius: 12,
+        }}
+      >
+        <span style={eyebrow}>{t("editPraxis.na.taskRefLabel")}</span>
+        <span
+          className="font-display italic"
+          style={{ fontSize: 15, color: INK, textAlign: "right", flex: 1 }}
+        >
+          {praxis.task_title}
+        </span>
+      </div>
+      <div style={{ ...eyebrow, color: ACCENT }}>
+        {factionName(task?.primary_faction_slug ?? null)}
+        {task ? ` · ${t("taskMeta.points", { points: task.point_value })}` : ""}
+      </div>
+
+      {tab === "write" ? (
+        <>
+          {/* Title */}
+          <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <span style={eyebrow}>{t("editPraxis.na.titleLabel")}</span>
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t("editPraxis.na.titlePlaceholder"),
+                inputStyle: {
+                  width: "100%",
+                  fontFamily: "var(--font-body)",
+                  fontSize: 16,
+                  color: INK,
+                  background: SURFACE,
+                  border: `1px solid ${BORDER}`,
+                  borderRadius: 10,
+                  padding: "12px 14px",
+                  outline: "none",
+                },
+              }}
+            />
+          </label>
+
+          {/* Body */}
+          <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <span style={eyebrow}>
+              {t("editPraxis.na.bodyLabel", { words: state.wordCount })}
+            </span>
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t("editPraxis.na.bodyPlaceholder"),
+                textareaStyle: {
+                  width: "100%",
+                  fontFamily: "var(--font-body)",
+                  fontSize: 15,
+                  lineHeight: 1.55,
+                  color: INK,
+                  background: SURFACE,
+                  border: `1px solid ${BORDER}`,
+                  borderRadius: 10,
+                  padding: "12px 14px",
+                  outline: "none",
+                  resize: "vertical",
+                  minHeight: 180,
+                },
+              }}
+            />
+          </label>
+
+          {/* Invite (collab / duel) */}
+          {state.showInviteBox && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <span style={eyebrow}>
+                {state.duelMode
+                  ? t("editPraxis.na.inviteLabelDuel")
+                  : t("editPraxis.na.inviteLabel")}
+              </span>
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: "var(--font-body)",
+                  inputBg: SURFACE,
+                  inputColor: INK,
+                  inputBorder: `1px solid ${BORDER}`,
+                  acceptedBg: ACCENT,
+                  acceptedColor: "var(--color-text-on-accent)",
+                  placeholder: t("editPraxis.na.invitePlaceholder"),
+                }}
+              />
+            </div>
+          )}
+
+          {/* Media grid + add */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <span style={eyebrow}>{t("editPraxis.na.filesLabel")}</span>
+            <MediaGrid state={state} />
+          </div>
+
+          {/* Metatasks */}
+          {state.showMetatasks && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <span style={eyebrow}>{t("editPraxis.na.metatasksLabel")}</span>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: {
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 4,
+                  },
+                  rowStyle: (selected) => ({
+                    padding: "10px 12px",
+                    background: selected ? "var(--faction-default-light)" : SURFACE,
+                    border: `1px solid ${selected ? ACCENT : BORDER}`,
+                    borderRadius: 10,
+                  }),
+                  titleColor: INK,
+                  descColor: MUTED,
+                  pointsActiveColor: ACCENT,
+                  pointsIdleColor: MUTED,
+                }}
+              />
+            </div>
+          )}
+        </>
+      ) : (
+        // Preview
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div
+            className="font-display italic"
+            style={{ fontSize: 20, color: INK }}
+          >
+            {state.title || t("editPraxis.na.titlePlaceholder")}
+          </div>
+          {state.media.length > 0 && <MediaGrid state={state} readOnly />}
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: {
+                background: SURFACE,
+                border: `1px solid ${BORDER}`,
+                borderRadius: 10,
+                padding: "14px 16px",
+              },
+              markdownStyle: {
+                fontFamily: "var(--font-body)",
+                fontSize: 15,
+                lineHeight: 1.6,
+                color: INK,
+              },
+            }}
+          />
+        </div>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      {/* Sticky submit bar */}
+      <MobileStickyBar
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "12px 0 4px",
+          background: "var(--color-nav-bg)",
+          backdropFilter: "blur(var(--nav-blur))",
+          borderTop: `1px solid ${BORDER}`,
+        }}
+      >
+        <PublishButton
+          state={state}
+          skin={{
+            idleLabel: t("editPraxis.na.publishIdle"),
+            busyLabel: t("editPraxis.na.publishBusy"),
+            style: {
+              flex: 1,
+              background: ACCENT,
+              color: "var(--color-text-on-accent)",
+              fontFamily: "var(--font-body)",
+              fontSize: 13,
+              fontWeight: 700,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              padding: "13px 18px",
+              border: "none",
+              borderRadius: 12,
+              cursor: state.submitting ? "wait" : "pointer",
+            },
+          }}
+        />
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.na.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: FAINT,
+                fontFamily: "var(--font-body)",
+                fontSize: 11,
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
+        )}
+      </MobileStickyBar>
+    </div>
+  );
+}
+
+/** Fluid 3-column media grid: existing items (with remove) + the add tile. */
+function MediaGrid({
+  state,
+  readOnly = false,
+}: {
+  state: EditPraxisState;
+  readOnly?: boolean;
+}) {
+  const { t } = useTranslation("forms");
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gap: 8,
+      }}
+    >
+      {state.media.map((item) => {
+        const filename = item.file_path.split("/").pop() ?? item.file_path;
+        const src = mediaUrl(item.file_path);
+        return (
+          <div
+            key={item.id}
+            style={{
+              position: "relative",
+              aspectRatio: "1 / 1",
+              overflow: "hidden",
+              borderRadius: 10,
+              border: `1px solid ${BORDER}`,
+              background: SURFACE,
+            }}
+          >
+            {item.type === "image" ? (
+              <img
+                src={src}
+                alt=""
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : item.type === "video" ? (
+              <video
+                src={src}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : (
+              <MediaArt
+                art={pickArtKey(filename, "audio")}
+                width={120}
+                height={120}
+              />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t("media.removeAria", { name: filename })}
+                style={{
+                  position: "absolute",
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  borderRadius: "50%",
+                  background: "var(--color-bg-page)",
+                  border: `1px solid ${BORDER}`,
+                  color: INK,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        );
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: "1 / 1",
+              width: "100%",
+              background: SURFACE,
+              border: `1.5px dashed ${BORDER}`,
+              borderRadius: 10,
+              cursor: "pointer",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 4,
+              fontFamily: "var(--font-body)",
+              fontSize: 11,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: MUTED,
+            },
+            buttonLabel: t("editPraxis.na.fileButton"),
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
@@ -1,0 +1,553 @@
+/**
+ * Warriors of Whimsy MOBILE composer (#498 pilot) — the scrapbook `.exe` window
+ * idiom on a phone. Same single-column composer as the Default mobile skin
+ * (Write/Preview toggle, fluid media grid, sticky submit bar) dressed in the
+ * pink window chrome: dotted board, notepad panels, sparkle-titled bars.
+ * Ported from the Field Kit `wow-treatment` composer; grounds on the
+ * `--faction-wow-*` tokens already in index.css (the set WowFieldDesk /
+ * WowEditPraxis desktop use). Consumes `useEditPraxis` verbatim — no editor,
+ * upload, or submit logic lives here. Presentation-only.
+ */
+import { useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { factionName } from "../../../utils/factions";
+import { mediaUrl } from "../../../utils/media";
+import MediaArt from "../blocks/MediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
+import { ErrorBanner, formatAutosave } from "../archetypes/shared";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from "../archetypes/controls";
+import type { EditPraxisState } from "../useEditPraxis";
+import { MobileStickyBar, SegToggle, type ComposerTab } from "./shared";
+
+const PINK = "var(--faction-wow)";
+const PINK_DEEP = "var(--faction-wow-card-accent)";
+const TITLE_TEXT = "var(--faction-wow-title-text)";
+const CARD_TEXT = "var(--faction-wow-card-text)";
+const CARD_MUTED = "var(--faction-wow-card-muted)";
+const WIN_BORDER = "var(--faction-wow-win-border)";
+const NOTEPAD_BG = "var(--faction-wow-notepad-bg)";
+const NOTEPAD_BORDER = "var(--faction-wow-notepad-border)";
+const BODY_BG = "var(--faction-wow-body-bg)";
+const DOT = "var(--faction-wow-dot)";
+const SCRIPT = "var(--faction-wow-card-font)";
+const BODY = "var(--font-body)";
+const ON_ACCENT = "var(--color-text-on-accent)";
+
+function Sparkle({
+  size,
+  color,
+  style,
+}: {
+  size: number;
+  color: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style} aria-hidden>
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+const eyebrow: CSSProperties = {
+  display: "block",
+  fontFamily: BODY,
+  fontSize: 9,
+  letterSpacing: "0.18em",
+  textTransform: "uppercase",
+  color: PINK_DEEP,
+};
+
+/** A pink window: sparkle title bar + dotted board wrapping an inner notepad. */
+function Window({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section
+      style={{
+        borderRadius: 16,
+        overflow: "hidden",
+        border: `2px solid ${WIN_BORDER}`,
+        boxShadow: `0 8px 22px color-mix(in srgb, ${PINK} 22%, transparent)`,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 7,
+          padding: "8px 12px",
+          background:
+            "linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))",
+          borderBottom: `2px solid ${WIN_BORDER}`,
+        }}
+      >
+        {[
+          "var(--faction-wow-scrap-deep)",
+          "var(--faction-wow-tape)",
+          "var(--faction-wow-ivy-leaf)",
+        ].map((color) => (
+          <span
+            key={color}
+            style={{
+              width: 9,
+              height: 9,
+              borderRadius: "50%",
+              background: color,
+              border: "1.2px solid rgba(255,255,255,0.7)",
+            }}
+          />
+        ))}
+        <span
+          style={{
+            marginLeft: "auto",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 5,
+            fontFamily: SCRIPT,
+            fontSize: 18,
+            color: TITLE_TEXT,
+          }}
+        >
+          <Sparkle size={11} color={TITLE_TEXT} />
+          {title}
+        </span>
+      </div>
+      <div
+        style={{
+          padding: 12,
+          background: BODY_BG,
+          backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+          backgroundSize: "13px 13px",
+        }}
+      >
+        <div
+          style={{
+            background: NOTEPAD_BG,
+            border: `1.5px solid ${NOTEPAD_BORDER}`,
+            borderRadius: 9,
+            padding: 13,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation("forms");
+  const [tab, setTab] = useState<ComposerTab>("write");
+  const praxis = state.praxis!;
+  const task = state.task;
+
+  return (
+    <div
+      data-skin="wow"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        fontFamily: BODY,
+        color: CARD_TEXT,
+        background: BODY_BG,
+        backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+        backgroundSize: "15px 15px",
+      }}
+    >
+      <header style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <h1
+            style={{
+              fontFamily: SCRIPT,
+              fontSize: 34,
+              lineHeight: 0.9,
+              color: TITLE_TEXT,
+              margin: 0,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            {t("editPraxis.wow.pageTitle")}
+            <Sparkle size={16} color={PINK} />
+          </h1>
+          <span style={{ ...eyebrow, color: CARD_MUTED, marginLeft: "auto" }}>
+            {state.autosaveAt
+              ? t("editPraxis.wow.autosaveSaved", {
+                  ago: formatAutosave(state.autosaveAt),
+                })
+              : t("editPraxis.wow.autosaveUnsaved")}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: {
+              gap: 4,
+              padding: 3,
+              background: NOTEPAD_BG,
+              border: `1.5px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 999,
+            },
+            buttonStyle: (active) => ({
+              padding: "9px 10px",
+              borderRadius: 999,
+              border: active ? `1.5px solid ${PINK_DEEP}` : "1.5px solid transparent",
+              fontFamily: BODY,
+              fontSize: 11,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              fontWeight: 700,
+              background: active
+                ? `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`
+                : "transparent",
+              color: active ? ON_ACCENT : CARD_MUTED,
+            }),
+          }}
+        />
+      </header>
+
+      {/* For-quest reference */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 10,
+          padding: "11px 14px",
+          background: NOTEPAD_BG,
+          border: `1.5px solid ${NOTEPAD_BORDER}`,
+          borderRadius: 12,
+        }}
+      >
+        <span style={eyebrow}>{t("editPraxis.wow.taskRefLabel")}</span>
+        <span
+          style={{
+            fontFamily: SCRIPT,
+            fontSize: 20,
+            color: TITLE_TEXT,
+            textAlign: "right",
+            flex: 1,
+            lineHeight: 1.05,
+          }}
+        >
+          {praxis.task_title}
+        </span>
+      </div>
+      <div style={{ ...eyebrow, color: PINK_DEEP }}>
+        {factionName(task?.primary_faction_slug ?? null)}
+        {task ? ` · ${t("taskMeta.points", { points: task.point_value })}` : ""}
+      </div>
+
+      {tab === "write" ? (
+        <>
+          <Window title={t("editPraxis.wow.titleLabel")}>
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t("editPraxis.wow.titlePlaceholder"),
+                inputStyle: {
+                  width: "100%",
+                  fontFamily: SCRIPT,
+                  fontSize: 24,
+                  fontWeight: 700,
+                  color: TITLE_TEXT,
+                  background: "transparent",
+                  border: "none",
+                  outline: "none",
+                  borderBottom: `2px solid ${NOTEPAD_BORDER}`,
+                  padding: "2px 0 8px",
+                },
+              }}
+            />
+          </Window>
+
+          <Window title={t("editPraxis.wow.bodyLabel", { words: state.wordCount })}>
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t("editPraxis.wow.bodyPlaceholder"),
+                textareaStyle: {
+                  width: "100%",
+                  fontFamily: BODY,
+                  fontSize: 15,
+                  lineHeight: 1.55,
+                  color: CARD_TEXT,
+                  background: BODY_BG,
+                  border: `1.5px solid ${NOTEPAD_BORDER}`,
+                  borderRadius: 7,
+                  padding: "13px 15px",
+                  outline: "none",
+                  resize: "vertical",
+                  minHeight: 180,
+                },
+              }}
+            />
+          </Window>
+
+          {state.showInviteBox && (
+            <Window
+              title={
+                state.duelMode
+                  ? t("editPraxis.wow.inviteLabelDuel")
+                  : t("editPraxis.wow.inviteLabel")
+              }
+            >
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: BODY,
+                  inputBg: BODY_BG,
+                  inputColor: CARD_TEXT,
+                  inputBorder: `1.5px solid ${NOTEPAD_BORDER}`,
+                  acceptedBg: PINK,
+                  acceptedColor: ON_ACCENT,
+                  placeholder: t("editPraxis.wow.invitePlaceholder"),
+                }}
+              />
+            </Window>
+          )}
+
+          <Window title={t("editPraxis.wow.filesLabel", { pasted: state.media.length })}>
+            <MediaGrid state={state} />
+          </Window>
+
+          {state.showMetatasks && (
+            <Window title={t("editPraxis.wow.metatasksLabel")}>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: {
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 4,
+                  },
+                  rowStyle: (selected) => ({
+                    padding: "10px 12px",
+                    background: selected ? BODY_BG : "transparent",
+                    border: `1.5px solid ${selected ? PINK_DEEP : "transparent"}`,
+                    borderRadius: 7,
+                  }),
+                  titleColor: CARD_TEXT,
+                  descColor: CARD_MUTED,
+                  pointsActiveColor: PINK_DEEP,
+                  pointsIdleColor: CARD_MUTED,
+                }}
+              />
+            </Window>
+          )}
+        </>
+      ) : (
+        <Window title={t("editPraxis.wow.previewLabel")}>
+          <div
+            style={{
+              fontFamily: SCRIPT,
+              fontSize: 22,
+              color: TITLE_TEXT,
+              marginBottom: 10,
+            }}
+          >
+            {state.title || t("editPraxis.wow.titlePlaceholder")}
+          </div>
+          {state.media.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <MediaGrid state={state} readOnly />
+            </div>
+          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              markdownStyle: {
+                fontFamily: BODY,
+                fontSize: 15,
+                lineHeight: 1.6,
+                color: CARD_TEXT,
+              },
+            }}
+          />
+        </Window>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      <MobileStickyBar
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "12px 0 4px",
+          background: "var(--color-nav-bg)",
+          backdropFilter: "blur(var(--nav-blur))",
+          borderTop: `1.5px solid ${WIN_BORDER}`,
+        }}
+      >
+        <PublishButton
+          state={state}
+          skin={{
+            ornament: <Sparkle size={13} color={ON_ACCENT} />,
+            idleLabel: t("editPraxis.wow.publishIdle"),
+            busyLabel: t("editPraxis.wow.publishBusy"),
+            style: {
+              flex: 1,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 7,
+              background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`,
+              color: ON_ACCENT,
+              fontFamily: BODY,
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              padding: "13px 18px",
+              border: `1.5px solid ${PINK_DEEP}`,
+              borderRadius: 14,
+              cursor: state.submitting ? "wait" : "pointer",
+            },
+          }}
+        />
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.wow.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: CARD_MUTED,
+                fontFamily: SCRIPT,
+                fontSize: 18,
+                fontWeight: 700,
+                cursor: "pointer",
+              },
+            }}
+          />
+        )}
+      </MobileStickyBar>
+    </div>
+  );
+}
+
+/** Fluid 3-column media grid in the WOW notepad idiom. */
+function MediaGrid({
+  state,
+  readOnly = false,
+}: {
+  state: EditPraxisState;
+  readOnly?: boolean;
+}) {
+  const { t } = useTranslation("forms");
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gap: 8,
+      }}
+    >
+      {state.media.map((item) => {
+        const filename = item.file_path.split("/").pop() ?? item.file_path;
+        const src = mediaUrl(item.file_path);
+        return (
+          <div
+            key={item.id}
+            style={{
+              position: "relative",
+              aspectRatio: "1 / 1",
+              overflow: "hidden",
+              borderRadius: 9,
+              border: `1.5px solid ${NOTEPAD_BORDER}`,
+              background: BODY_BG,
+            }}
+          >
+            {item.type === "image" ? (
+              <img
+                src={src}
+                alt=""
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : item.type === "video" ? (
+              <video
+                src={src}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : (
+              <MediaArt
+                art={pickArtKey(filename, "audio")}
+                width={120}
+                height={120}
+              />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t("media.removeAria", { name: filename })}
+                style={{
+                  position: "absolute",
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  borderRadius: "50%",
+                  background: NOTEPAD_BG,
+                  border: `1.5px solid ${PINK}`,
+                  color: PINK,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        );
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: "1 / 1",
+              width: "100%",
+              background: BODY_BG,
+              border: `2px dashed ${NOTEPAD_BORDER}`,
+              borderRadius: 9,
+              cursor: "pointer",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 4,
+              fontFamily: SCRIPT,
+              fontSize: 16,
+              fontWeight: 700,
+              color: PINK,
+            },
+            buttonLabel: t("editPraxis.wow.fileButton"),
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Edit-praxis form-factor dispatch (#498) — the composer twin of the TaskDetail
+ * / FieldDesk mobile-dispatch seams. Renders <EditPraxis /> with useFormFactor
+ * mocked and useEditPraxis stubbed, and pins:
+ *   - phone + the WOW pilot → its bespoke mobile composer (data-skin="wow"),
+ *   - phone + an unregistered faction → the Default mobile composer,
+ *   - desktop → the existing desktop archetype (skin dispatch untouched).
+ * It also asserts each mobile skin surfaces the body editor, media-add, and
+ * submit slots from the mocked state. renderToStaticMarkup needs no DOM.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import type { EditPraxisState } from "../../useEditPraxis";
+import type { PraxisOut } from "../../../../api/praxis";
+import type { TaskOut } from "../../../../api/tasks";
+
+const mocks = vi.hoisted(() => ({
+  formFactor: "desktop" as "mobile" | "desktop",
+  state: null as EditPraxisState | null,
+}));
+
+vi.mock("../../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mocks.formFactor,
+}));
+vi.mock("../../useEditPraxis", () => ({
+  useEditPraxis: () => mocks.state,
+}));
+
+// Imported after the mocks are registered.
+import EditPraxis from "../../../EditPraxis";
+
+function task(slug: string | null): TaskOut {
+  return {
+    id: 7,
+    title: "A Very Human Thing",
+    description: "Do a small honest thing.",
+    point_value: 20,
+    level_required: 1,
+    status: "active",
+    task_type: "standard",
+    created_by: 3,
+    primary_faction_slug: slug,
+    metatask_faction_slug: null,
+    is_task_vision_eligible: false,
+    created_at: "2026-01-01T00:00:00Z",
+    can_submit_praxis: true,
+    allowed_modes: ["solo"],
+    eligible_for_current_user: true,
+  };
+}
+
+const praxis = {
+  id: 55,
+  task_id: 7,
+  task_title: "A Very Human Thing",
+  type: "solo",
+  status: "in_progress",
+  title: "I helped a stranger",
+  body_text: "## What I did\n\nCaught the papers.",
+  moderation_status: "visible",
+  duel_id: null,
+  members: [],
+  invites: [],
+  media_items: [],
+} as unknown as PraxisOut;
+
+function baseState(slug: string | null): EditPraxisState {
+  return {
+    loading: false,
+    praxis,
+    task: task(slug),
+    error: "",
+    setError: () => {},
+    title: "I helped a stranger",
+    setTitle: () => {},
+    body: "## What I did\n\nCaught the papers.",
+    setBody: () => {},
+    wordCount: 4,
+    media: [],
+    fileError: "",
+    handleFileChange: () => {},
+    removeMedia: async () => {},
+    pendingImage: null,
+    confirmImageEdit: async () => {},
+    cancelImageEdit: () => {},
+    switchingMode: null,
+    changeMode: async () => {},
+    inviteQuery: "",
+    setInviteQuery: () => {},
+    inviteResults: [],
+    inviteOpen: false,
+    setInviteOpen: () => {},
+    inviting: false,
+    sendInvite: async () => {},
+    cancelInvite: async () => {},
+    duel: null,
+    sendChallenge: async () => {},
+    cancelDuel: async () => {},
+    metaTasks: [],
+    appliedMetatasks: new Set(),
+    applyingMetatask: null,
+    toggleMetatask: async () => {},
+    submitting: false,
+    publish: async () => {},
+    cancel: async () => {},
+    autosaveAt: null,
+    saveStatus: "idle",
+    isPublished: false,
+    controlsLocked: false,
+    modeIsLocked: false,
+    showInviteBox: false,
+    showMetatasks: false,
+    duelMode: false,
+    duelChipVisible: false,
+    currentCharacterId: 3,
+  };
+}
+
+function render(slug: string | null): string {
+  mocks.state = baseState(slug);
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EditPraxis />
+    </MemoryRouter>,
+  );
+}
+
+describe("edit-praxis form-factor dispatch", () => {
+  it("renders the WOW bespoke composer on mobile for a WOW task", () => {
+    mocks.formFactor = "mobile";
+    expect(render("wow")).toContain('data-skin="wow"');
+  });
+
+  it("falls through to the Default mobile composer for an unregistered faction", () => {
+    mocks.formFactor = "mobile";
+    const html = render("snide");
+    expect(html).toContain('data-skin="default"');
+    expect(html).not.toContain('data-skin="wow"');
+  });
+
+  it("renders the desktop archetype on desktop (skin dispatch untouched)", () => {
+    mocks.formFactor = "desktop";
+    const html = render("wow");
+    expect(html).not.toContain("data-skin=");
+    // wow.exe desktop window chrome, not the mobile skin.
+    expect(html).toContain("wow.exe");
+  });
+});
+
+describe("mobile composer content slots", () => {
+  for (const [label, slug] of [
+    ["Default", "snide"],
+    ["WOW", "wow"],
+  ] as const) {
+    it(`${label} mobile composer renders body editor + media-add + submit`, () => {
+      mocks.formFactor = "mobile";
+      const html = render(slug);
+      expect(html, "body editor slot").toContain("<textarea");
+      expect(html, "media-add slot").toContain('type="file"');
+      // Submit affordance: the faction-voiced publish label from the mocked state.
+      const text = html.replace(/<[^>]*>/g, "").toLowerCase();
+      expect(text, "submit slot").toMatch(/tack it up|cast it into the world/);
+    });
+  }
+});

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Submit wiring (#498) — proves the mobile composer's submit affordance routes
+ * to the hook's own `publish`, never a reimplemented submit path. The shared
+ * `PublishButton` is replaced with a double that records the props it receives;
+ * the composer must hand it the mocked `useEditPraxis` state, and firing the
+ * button's action must call that state's `publish`. Runs headless (no DOM):
+ * renderToStaticMarkup forces the render, then we invoke the captured action.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import type { EditPraxisState } from "../../useEditPraxis";
+import type { PraxisOut } from "../../../../api/praxis";
+import type { TaskOut } from "../../../../api/tasks";
+
+const captured = vi.hoisted(() => ({
+  state: null as EditPraxisState | null,
+}));
+
+// Partial-mock the shared controls: keep the real body editor + file picker,
+// swap PublishButton for a double that records the state it was handed.
+vi.mock("../../archetypes/controls", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../../archetypes/controls")>();
+  return {
+    ...actual,
+    PublishButton: ({ state }: { state: EditPraxisState }) => {
+      captured.state = state;
+      return null;
+    },
+  };
+});
+
+import DefaultMobileEditPraxis from "../DefaultEditPraxis";
+import WowMobileEditPraxis from "../WowEditPraxis";
+
+const praxis = {
+  id: 55,
+  task_id: 7,
+  task_title: "A Very Human Thing",
+  type: "solo",
+  status: "in_progress",
+  title: "Draft",
+  body_text: "body",
+  moderation_status: "visible",
+  duel_id: null,
+  members: [],
+  invites: [],
+  media_items: [],
+} as unknown as PraxisOut;
+
+const task: TaskOut = {
+  id: 7,
+  title: "A Very Human Thing",
+  description: "Do a small honest thing.",
+  point_value: 20,
+  level_required: 1,
+  status: "active",
+  task_type: "standard",
+  created_by: 3,
+  primary_faction_slug: "wow",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+function stateWith(publish: () => Promise<void>): EditPraxisState {
+  return {
+    loading: false,
+    praxis,
+    task,
+    error: "",
+    setError: () => {},
+    title: "Draft",
+    setTitle: () => {},
+    body: "body",
+    setBody: () => {},
+    wordCount: 1,
+    media: [],
+    fileError: "",
+    handleFileChange: () => {},
+    removeMedia: async () => {},
+    pendingImage: null,
+    confirmImageEdit: async () => {},
+    cancelImageEdit: () => {},
+    switchingMode: null,
+    changeMode: async () => {},
+    inviteQuery: "",
+    setInviteQuery: () => {},
+    inviteResults: [],
+    inviteOpen: false,
+    setInviteOpen: () => {},
+    inviting: false,
+    sendInvite: async () => {},
+    cancelInvite: async () => {},
+    duel: null,
+    sendChallenge: async () => {},
+    cancelDuel: async () => {},
+    metaTasks: [],
+    appliedMetatasks: new Set(),
+    applyingMetatask: null,
+    toggleMetatask: async () => {},
+    submitting: false,
+    publish,
+    cancel: async () => {},
+    autosaveAt: null,
+    saveStatus: "idle",
+    isPublished: false,
+    controlsLocked: false,
+    modeIsLocked: false,
+    showInviteBox: false,
+    showMetatasks: false,
+    duelMode: false,
+    duelChipVisible: false,
+    currentCharacterId: 3,
+  };
+}
+
+describe("mobile composer submit wiring", () => {
+  for (const [label, Skin] of [
+    ["Default", DefaultMobileEditPraxis],
+    ["WOW", WowMobileEditPraxis],
+  ] as const) {
+    it(`${label} hands the submit control the hook's publish handler`, () => {
+      captured.state = null;
+      const publish = vi.fn(async () => {});
+      const state = stateWith(publish);
+      renderToStaticMarkup(<Skin state={state} />);
+
+      // The mock mutates captured.state during render; cast the read so control
+      // flow doesn't narrow it to the reset `null`.
+      const observed = captured.state as EditPraxisState | null;
+
+      // The composer rendered the shared submit control with the real state…
+      expect(observed).not.toBeNull();
+      expect(observed?.publish).toBe(publish);
+
+      // …and triggering that submit calls the hook's handler, not a local one.
+      expect(publish).not.toHaveBeenCalled();
+      void observed!.publish();
+      expect(publish).toHaveBeenCalledTimes(1);
+    });
+  }
+});

--- a/frontend/src/pages/editPraxis/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/shared.tsx
@@ -1,0 +1,99 @@
+/**
+ * Shared mobile-composer primitives (#498). The two phone skins (Default + the
+ * WOW pilot) diverge visually but share three load-bearing behaviours: the
+ * Write/Preview segmented toggle, the fluid media grid, and the sticky submit
+ * bar that must ride above the fixed MobileTabBar (and, on a phone, the
+ * on-screen keyboard). Kept here so both skins stay thin and neither
+ * re-implements the viewport plumbing.
+ */
+import type { CSSProperties, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+// The fixed MobileTabBar + its safe-area padding occupy this much at the bottom
+// of the viewport (mirrors MobileLayout's <main> bottom padding). The submit
+// bar rides just above it via env(safe-area-inset-bottom).
+export const MOBILE_TABBAR_CLEARANCE =
+  "calc(3.5rem + env(safe-area-inset-bottom))";
+
+/**
+ * Sticky submit bar pinned above the fixed tab bar. Sticky (in-flow), not
+ * fixed, so it never overlaps content — it flows at the end of the scroll and
+ * pins to `bottom` while the body scrolls under it. When the keyboard opens the
+ * layout viewport shrinks and the sticky element rides up with it, keeping the
+ * submit affordance reachable.
+ */
+export function MobileStickyBar({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        position: "sticky",
+        bottom: MOBILE_TABBAR_CLEARANCE,
+        zIndex: 8,
+        marginTop: 20,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export type ComposerTab = "write" | "preview";
+
+export interface SegToggleSkin {
+  containerStyle?: CSSProperties;
+  buttonStyle?: (active: boolean) => CSSProperties;
+}
+
+/**
+ * Write / Preview segmented control. Owns the a11y wiring (tablist / tab /
+ * aria-selected); each skin paints the pill via `buttonStyle`.
+ */
+export function SegToggle({
+  tab,
+  setTab,
+  skin,
+}: {
+  tab: ComposerTab;
+  setTab: (next: ComposerTab) => void;
+  skin: SegToggleSkin;
+}) {
+  const { t } = useTranslation("forms");
+  const options: { key: ComposerTab; label: string }[] = [
+    { key: "write", label: t("editPraxis.mobile.write") },
+    { key: "preview", label: t("editPraxis.mobile.preview") },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label={t("editPraxis.mobile.viewToggleAria")}
+      style={{ display: "flex", ...skin.containerStyle }}
+    >
+      {options.map((option) => {
+        const active = tab === option.key;
+        return (
+          <button
+            key={option.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => setTab(option.key)}
+            style={{
+              flex: 1,
+              cursor: "pointer",
+              ...(skin.buttonStyle ? skin.buttonStyle(active) : {}),
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
The "post your proof" create flow, mobile-native, behind the #494 form-factor seam — the single most important thing a player does from a phone.

## What
`EditPraxis.tsx` dispatches on `useFormFactor()` to a **Default mobile composer** + **WOW pilot**: full-screen single-column focus, a Write/Preview toggle, a fluid media-add grid, and a **sticky submit bar** that stays above the on-screen keyboard and the fixed tab bar (`env(safe-area-inset-bottom)`).

## Reuse (no reimplementation)
Both skins consume `useEditPraxis` verbatim and route all editing/media/submit through the existing shared blocks — `BodyTextarea` (the #513 markdown toolbar), `MarkdownPreview`, `FilePicker` → `ImageEditModal` crop (#514), `InviteSearch`, `PublishButton`, etc. No new editor, upload, crop, or submit logic; the ADR-0012 collab consensus-reset-on-edit stays entirely in the hook. Desktop archetypes untouched.

## Constraints
Copy via `t()` (`forms.editPraxis.mobile` + reused faction keys); no hardcoded hex; single-column, no fixed-px grids.

## Tests
Dispatch (mobile+wow → WOW, mobile+other → Default, desktop → archetype) + slot-render + submit-wiring (submit calls the hook's publish). tsc: no new errors. vitest: 41 pass.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
