### PR TITLE
Mobile: Factions directory + faction page (#518)

### DIFF
--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -570,5 +570,22 @@
     "termsHeading": "Terms of matriculation",
     "dismiss": "Maybe later",
     "confirm": "Confirm"
+  },
+  "mobile": {
+    "loadError": "Couldn't load factions.",
+    "unaffiliatedTitle": "You're Unaffiliated",
+    "unaffiliatedBody": "Every path is open. Join a faction after your first task.",
+    "topMembers": "Top members",
+    "recentPraxis": "Recent praxis",
+    "membersStat": "Members",
+    "tasksStat": "Tasks",
+    "membersEmpty": "No members yet.",
+    "praxisEmpty": "No praxis yet.",
+    "memberStat": "lvl {{level}} · {{score}} pts",
+    "join": "Join {{faction}}",
+    "joining": "Joining…",
+    "confirm": "Confirm",
+    "memberBadge": "You're a member",
+    "gateHint": "Keep completing tasks to earn an invitation to {{faction}}."
   }
 }

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -4,8 +4,10 @@ import { useParams, Link } from "react-router-dom";
 import PageTitle from "../components/ui/PageTitle";
 import { factionCssVar, factionName, factionDescription } from "../utils/factions";
 import { pickVariant } from "../utils/factionDispatch";
+import { useFormFactor } from "../hooks/useFormFactor";
 import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFactionDetail";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
+import DefaultFactionPage from "./factionDetail/mobileArchetypes/DefaultFactionPage";
 import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
 import UaFactionBody from "./factionDetail/archetypes/UaFactionBody";
 import SingularityFactionBody from "./factionDetail/archetypes/SingularityFactionBody";
@@ -67,10 +69,20 @@ const FACTION_BODIES: Record<string, ComponentType<{ state: FactionDetailState }
   albescent: AlbescentFactionBody,
 };
 
+// Parallel MOBILE registry — the phone twin of FACTION_BODIES. Empty today: every
+// mobile render falls through to the single-column DefaultFactionPage skin. The
+// per-faction mobile follow-ups register their bespoke `factionPage/mobileArchetypes/*`
+// skins here (keyed by slug), exactly as the desktop bodies register in FACTION_BODIES.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<
+  string,
+  ComponentType<{ state: FactionDetailState }>
+> = {};
+
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {
   const { t } = useTranslation("factions");
   const { slug: slugParam } = useParams<{ slug: string }>();
   const slug = slugProp ?? slugParam;
+  const formFactor = useFormFactor();
   const state = useFactionDetail(slug);
   const { loading, faction, fetchError, members, tasks, recentPraxis } = state;
 
@@ -96,6 +108,13 @@ export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}
         </Link>
       </div>
     );
+
+  // Phone: dispatch to a single-column mobile skin (Default fallback), keyed by
+  // faction slug so a per-faction mobile treatment can register in the registry.
+  if (formFactor === "mobile") {
+    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, faction.slug, DefaultFactionPage);
+    return <Mobile state={state} />;
+  }
 
   const accent = factionCssVar(faction.slug, "border");
   const name = factionName(faction.slug);

--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -10,6 +10,17 @@ import { extractError } from '../utils/errors'
 import { factionCssVar, factionName } from '../utils/factions'
 import { relativeTime } from '../utils/dates'
 import { useAuth } from '../auth/AuthContext'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { pickVariant } from '../utils/factionDispatch'
+import DefaultFactionsDirectory from './factions/mobileArchetypes/DefaultFactionsDirectory'
+
+type MobileDirectory = () => JSX.Element
+
+// Parallel MOBILE registry, mirroring the faction-page dispatch. The directory
+// isn't keyed by a single faction slug, so this stays empty and every mobile
+// render falls through to the Default directory skin; bespoke faction directory
+// skins can register here later.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileDirectory> = {}
 
 const NA_SLUG = 'na'
 
@@ -32,6 +43,17 @@ const HIDDEN_SLUGS = new Set([NA_SLUG])
  * and orders the cards by that status.
  */
 export default function Factions() {
+  const formFactor = useFormFactor()
+
+  if (formFactor === 'mobile') {
+    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, null, DefaultFactionsDirectory)
+    return <Mobile />
+  }
+
+  return <DesktopFactions />
+}
+
+function DesktopFactions() {
   const { t } = useTranslation('factions')
   const { user } = useAuth()
   const character = user?.character ?? null

--- a/frontend/src/pages/factionDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Mobile faction-page + directory dispatch invariant — the faction twin of the
+ * task-browse mobileArchetypeSlots test. Walks FactionDetail's
+ * MOBILE_ARCHETYPE_BY_SLUG plus the Default mobile faction-page skin and asserts
+ * each emits the invariant slots (colour-washed hero name + tagline, real
+ * member/task stats, top members, recent praxis) and honours the invite-gated
+ * Join model. Also proves Factions' directory registry falls through to the
+ * Default directory skin (banner + heading). Both registries are empty today, so
+ * this mainly guards the Default fallbacks and any bespoke skin added later.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so faction copy keys resolve to English text.
+import '../../../i18n'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FactionDetail'
+import { MOBILE_ARCHETYPE_BY_SLUG as DIRECTORY_BY_SLUG } from '../../Factions'
+import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
+import DefaultFactionsDirectory from '../../factions/mobileArchetypes/DefaultFactionsDirectory'
+import type { FactionDetailState, Membership } from '../useFactionDetail'
+import type { CharacterOut } from '../../../api/auth'
+import type { PraxisCardOut } from '../../../api/praxis'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+const MEMBER: CharacterOut = {
+  id: 7,
+  username: 'ada',
+  display_name: 'Ada',
+  bio: null,
+  avatar_url: null,
+  location: null,
+  level: 4,
+  score: 120,
+  all_time_score: 340,
+  faction_slug: 'everymen',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const PRAXIS: PraxisCardOut = {
+  id: 55,
+  task_id: 11,
+  task_title: 'Plant a tree',
+  task_point_value: 20,
+  task_level_required: 2,
+  type: 'solo',
+  status: 'submitted',
+  title: 'My sapling',
+  moderation_status: 'visible',
+  created_by_id: 7,
+  created_by_display_name: 'Ada',
+  created_at: '2026-01-02T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+  submitted_at: '2026-01-02T00:00:00Z',
+  member_count: 1,
+  score: 24,
+  voter_count: 3,
+  is_top_for_task: false,
+  task_faction_slug: 'everymen',
+}
+
+function membership(overrides: Partial<Membership> = {}): Membership {
+  return {
+    state: 'eligible',
+    currentFactionSlug: null,
+    join: async () => {},
+    joining: false,
+    joinError: null,
+    ...overrides,
+  }
+}
+
+function baseState(overrides: Partial<FactionDetailState> = {}): FactionDetailState {
+  return {
+    slug: 'everymen',
+    loading: false,
+    faction: { slug: 'everymen' },
+    fetchError: null,
+    members: [MEMBER],
+    tasks: [],
+    recentPraxis: [PRAXIS],
+    viewerFactionSlug: null,
+    gameFactions: [],
+    membership: membership(),
+    ...overrides,
+  }
+}
+
+const archetypes = { ...MOBILE_ARCHETYPE_BY_SLUG, __default__: DefaultFactionPage }
+
+describe('mobile faction-page content-slot invariant', () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders hero name, tagline, real stats + entities`, () => {
+      const { text } = render(<Archetype state={baseState()} />)
+      expect(text, 'hero name').toContain('Everymen')
+      expect(text.toLowerCase(), 'members stat').toContain('members')
+      expect(text.toLowerCase(), 'tasks stat').toContain('tasks')
+      expect(text, 'top member').toContain('Ada')
+      expect(text, 'recent praxis').toContain('Plant a tree')
+    })
+
+    it(`${slug} offers Join only to an eligible viewer (invite-gated)`, () => {
+      const eligible = render(<Archetype state={baseState({ membership: membership({ state: 'eligible' }) })} />)
+      expect(eligible.text).toContain('Join Everymen')
+
+      const gated = render(<Archetype state={baseState({ membership: membership({ state: 'gate' }) })} />)
+      expect(gated.text, 'no CTA for gated viewer').not.toContain('Join Everymen')
+
+      const memberView = render(<Archetype state={baseState({ membership: membership({ state: 'member' }) })} />)
+      // renderToStaticMarkup escapes the apostrophe, so match the plain tail.
+      expect(memberView.text, 'member badge').toContain('re a member')
+      expect(memberView.text, 'no CTA for member').not.toContain('Join Everymen')
+    })
+  }
+})
+
+describe('mobile faction directory dispatch', () => {
+  it('registry is an object (bespoke directory skins register here)', () => {
+    expect(typeof DIRECTORY_BY_SLUG).toBe('object')
+  })
+
+  it('Default directory skin renders the heading + unaffiliated banner', () => {
+    const { text } = render(<DefaultFactionsDirectory />)
+    expect(text).toContain('Factions')
+    expect(text).toContain('Unaffiliated')
+  })
+})

--- a/frontend/src/pages/factionDetail/mobileArchetypes/DefaultFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/DefaultFactionPage.tsx
@@ -1,0 +1,242 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { factionCssVar, factionName, factionDescription } from '../../../utils/factions'
+import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
+import type { CharacterOut } from '../../../api/auth'
+import type { FactionDetailState } from '../useFactionDetail'
+
+const NA_SLUG = 'na'
+
+/**
+ * Default MOBILE faction-page skin — the phone twin of the desktop faction
+ * detail. Single-column: a colour-washed hero (the faction wears its colour
+ * while the app chrome stays neutral), real member/task counts, the top members,
+ * recent praxis, and a sticky Join action pinned above the tab bar.
+ *
+ * Join respects the invite-gated model (ADR-0019) via the shared
+ * `state.membership`: only an "eligible" viewer gets the Join CTA (with a
+ * confirm step — switching factions is irreversible); a member sees a standing
+ * badge, a gated viewer a soft hint, and a logged-out / UA non-member nothing.
+ * Bespoke faction page skins register in FactionDetail's MOBILE_ARCHETYPE_BY_SLUG.
+ */
+export default function DefaultFactionPage({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation('factions')
+  const { faction, members, tasks, recentPraxis, membership } = state
+  const [confirming, setConfirming] = useState(false)
+
+  // Guarded non-null by the dispatcher.
+  if (!faction) return null
+
+  const color = factionCssVar(faction.slug)
+  const name = factionName(faction.slug)
+  const topMembers = [...members].sort((a, b) => b.all_time_score - a.all_time_score).slice(0, 3)
+
+  const currentSlug = membership.currentFactionSlug
+  const switching = currentSlug && currentSlug !== NA_SLUG
+
+  return (
+    <div className="py-4" data-testid="mobile-faction-page">
+      {/* Hero — wears the faction colour; app chrome stays neutral. */}
+      <section
+        style={{
+          borderRadius: 14,
+          padding: '20px 16px',
+          background: color,
+          color: 'var(--color-text-on-accent)',
+        }}
+      >
+        <h1 className="font-display italic font-medium" style={{ fontSize: 26, lineHeight: 1.1 }}>
+          {name}
+        </h1>
+        <p className="font-body" style={{ fontSize: 11, opacity: 0.92, marginTop: 5, lineHeight: 1.5 }}>
+          {factionDescription(faction.slug)}
+        </p>
+        <div style={{ display: 'flex', gap: 20, marginTop: 15 }}>
+          <HeroStat value={members.length} label={t('mobile.membersStat')} />
+          <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
+        </div>
+      </section>
+
+      {membership.state === 'member' && (
+        <p
+          className="eyebrow"
+          style={{ marginTop: 12, color: factionCssVar(faction.slug, 'border') }}
+        >
+          {t('mobile.memberBadge')}
+        </p>
+      )}
+
+      {/* Top members */}
+      <section className="mt-6">
+        <h2 className="eyebrow mb-2">{t('mobile.topMembers')}</h2>
+        {topMembers.length === 0 ? (
+          <p className="font-body text-muted text-sm">{t('mobile.membersEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topMembers.map((m, index) => (
+              <MemberRow key={m.id} rank={index + 1} member={m} accent={color} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent praxis */}
+      <section className="mt-6">
+        <h2 className="eyebrow mb-2">{t('mobile.recentPraxis')}</h2>
+        {recentPraxis.length === 0 ? (
+          <p className="font-body text-muted text-sm">{t('mobile.praxisEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {membership.state === 'gate' && (
+        <p className="font-body text-sm text-muted mt-6">
+          {t('mobile.gateHint', { faction: name })}
+        </p>
+      )}
+
+      {/* Sticky Join — only an eligible viewer can act (ADR-0019). */}
+      {membership.state === 'eligible' && (
+        <MobileStickyBar>
+          {membership.joinError && (
+            <p className="font-body text-sm text-red-600">{membership.joinError}</p>
+          )}
+          {!confirming ? (
+            <button
+              type="button"
+              onClick={() => setConfirming(true)}
+              style={JOIN_BUTTON_STYLE}
+            >
+              {t('mobile.join', { faction: name })}
+            </button>
+          ) : (
+            <>
+              <p className="font-body text-sm" style={{ color: 'var(--color-text-primary)' }}>
+                {switching
+                  ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
+                  : t('detail.join.confirm', { faction: name })}
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => void membership.join()}
+                  disabled={membership.joining}
+                  style={{ ...JOIN_BUTTON_STYLE, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                >
+                  {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirming(false)}
+                  disabled={membership.joining}
+                  style={{
+                    fontFamily: 'var(--font-body)',
+                    fontSize: 11,
+                    letterSpacing: '0.08em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-text-secondary)',
+                    background: 'transparent',
+                    border: '1px solid var(--color-border-strong)',
+                    borderRadius: 999,
+                    padding: '10px 16px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t('detail.join.cancel')}
+                </button>
+              </div>
+            </>
+          )}
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+const JOIN_BUTTON_STYLE = {
+  width: '100%',
+  fontFamily: 'var(--font-body)',
+  fontSize: 14,
+  fontWeight: 700,
+  letterSpacing: '0.04em',
+  color: 'var(--color-text-on-accent)',
+  background: 'var(--color-text-primary)',
+  border: 'none',
+  borderRadius: 999,
+  padding: '13px 16px',
+  cursor: 'pointer',
+} as const
+
+function HeroStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div>
+      <b className="font-display italic" style={{ fontSize: 18, display: 'block', lineHeight: 1 }}>
+        {value}
+      </b>
+      <span
+        style={{ fontSize: 8, letterSpacing: '0.16em', textTransform: 'uppercase', opacity: 0.85 }}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
+
+function MemberRow({
+  rank,
+  member,
+  accent,
+}: {
+  rank: number
+  member: CharacterOut
+  accent: string
+}) {
+  const { t } = useTranslation('factions')
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      className="sidebar-card"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        textDecoration: 'none',
+      }}
+    >
+      <span
+        className="font-display italic"
+        style={{ fontSize: 16, color: accent, width: 18, flex: 'none' }}
+      >
+        {rank}
+      </span>
+      <span
+        className="font-body"
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 14,
+          color: 'var(--color-text-primary)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {member.display_name}
+      </span>
+      <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', flex: 'none' }}>
+        {t('mobile.memberStat', {
+          level: member.level,
+          score: member.all_time_score.toLocaleString(),
+        })}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { getFactions, type FactionOut } from '../../../api/factions'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import { useAuth } from '../../../auth/AuthContext'
+import { extractError } from '../../../utils/errors'
+
+const NA_SLUG = 'na'
+
+/**
+ * Default MOBILE factions-directory skin — the phone twin of the desktop
+ * Factions grid. A single-column screen: an "unaffiliated" banner (shown only
+ * while the viewer hasn't sworn to a faction) over a two-up tile grid, each tile
+ * wearing its faction's colour and linking to that faction's detail page where
+ * all membership actions live (#347). Member counts are intentionally dropped —
+ * no cheap per-faction count query exists (ADR-0035: real fields only).
+ *
+ * Self-fetches the (slug-only) faction list; the viewer's current faction comes
+ * from AuthContext, so no extra membership plumbing is needed for the banner.
+ * Bespoke faction directory skins register in Factions' MOBILE_ARCHETYPE_BY_SLUG.
+ */
+export default function DefaultFactionsDirectory() {
+  const { t } = useTranslation('factions')
+  const { t: tc } = useTranslation('common')
+  const { user } = useAuth()
+  const currentSlug = user?.character?.faction_slug ?? null
+  const unaffiliated = !currentSlug || currentSlug === NA_SLUG
+
+  const [factions, setFactions] = useState<FactionOut[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    getFactions()
+      .then((data) => {
+        if (!cancelled) setFactions(data)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(extractError(err, t('mobile.loadError')))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [t])
+
+  const visible = sortFactionsByRainbowOrder(factions.filter((f) => f.slug !== NA_SLUG))
+
+  return (
+    <div className="py-4" data-testid="mobile-factions-directory">
+      <h1
+        className="font-display italic font-medium mb-3"
+        style={{ fontSize: 26, color: 'var(--color-text-primary)', lineHeight: 1.1 }}
+      >
+        {tc('nav.factions')}
+      </h1>
+
+      {unaffiliated && (
+        <section
+          className="sidebar-card mb-4"
+          style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px' }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 34,
+              height: 34,
+              borderRadius: '50%',
+              flex: 'none',
+              background: 'var(--color-bg-surface-alt)',
+              border: '1px solid var(--color-border)',
+            }}
+          />
+          <div>
+            <div
+              className="font-display italic"
+              style={{ fontSize: 16, color: 'var(--color-text-primary)' }}
+            >
+              {t('mobile.unaffiliatedTitle')}
+            </div>
+            <p
+              className="font-body"
+              style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginTop: 2, lineHeight: 1.4 }}
+            >
+              {t('mobile.unaffiliatedBody')}
+            </p>
+          </div>
+        </section>
+      )}
+
+      {loading ? (
+        <p className="font-body text-muted">{t('index.loading')}</p>
+      ) : error ? (
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">{error}</p>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
+          {visible.map((f) => (
+            <Link
+              key={f.slug}
+              to={`/factions/${f.slug}`}
+              style={{
+                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'flex-end',
+                minHeight: 118,
+                padding: 12,
+                borderRadius: 12,
+                textDecoration: 'none',
+                background: factionCssVar(f.slug),
+                color: 'var(--color-text-on-accent)',
+              }}
+            >
+              <span
+                className="font-display italic font-medium"
+                style={{ fontSize: 17, lineHeight: 1.05 }}
+              >
+                {factionName(f.slug)}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #518

Two Default (na) mobile skins for the factions surface, dispatched through the #494 form-factor seam. Desktop rendering is unchanged.

## Factions directory (`DefaultFactionsDirectory`)
- Single-column screen: a "You're Unaffiliated" banner (shown only while the viewer hasn't sworn to a faction) over a 2-up tile grid, each tile wearing its faction colour and linking to `/factions/:slug`.
- Member counts dropped — no cheap per-faction count query exists (ADR-0035, corrections table).
- `Factions.tsx` splits into a form-factor dispatcher + `DesktopFactions`, exporting an empty `MOBILE_ARCHETYPE_BY_SLUG` with a `pickVariant(..., null, Default)` fallback (mirrors `Tasks.tsx`).

## Faction page (`DefaultFactionPage`)
- Colour-washed hero (faction wears its colour, app chrome stays neutral), tagline, real member/task counts, top members, recent praxis (reuses `PraxisCard`).
- Sticky **Join** action via the shared `MobileStickyBar`, driven by `state.membership`: only an eligible viewer gets the CTA (with an irreversible-switch confirm step); member sees a standing badge, a gated viewer a soft hint, logged-out / UA non-member nothing (ADR-0019).
- `FactionDetail.tsx` **exports** `MOBILE_ARCHETYPE_BY_SLUG` (keyed by slug) so the Tier-2 per-faction mobile treatments register their skins; falls back to `DefaultFactionPage`.

## Notes
- All strings go through i18n (new `factions.json` "mobile" keys). Colours resolve to `--faction-*` / theme tokens only, no hardcoded hex.
- Dispatch test mirrors the task-browse slot invariant.
- Verification: `npm run lint` clean, `npx vitest run` 317/317 pass. `tsc` has 37 pre-existing errors from a duplicate `albescent.invitation` key in `factions.json` (unrelated; CI does not run tsc) — my files add zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
