### PR TITLE
Mobile: Updates activity stream (#532)

### DIFF
--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -4,6 +4,21 @@
     "loading": "Loading...",
     "empty": "No updates yet. Activity from friends, foes, and the community will appear here."
   },
+  "mobile": {
+    "title": "Updates",
+    "eyebrow": "Activity Feed",
+    "loadMore": "Load older updates",
+    "loadingMore": "Loading…",
+    "loadMoreError": "Couldn't load more updates.",
+    "filter": {
+      "all": "All",
+      "friends": "Friends",
+      "foes": "Foes",
+      "yourStuff": "Yours",
+      "global": "Global",
+      "requests": "Requests"
+    }
+  },
   "badge": {
     "friend": "Friend",
     "foe": "Foe",

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -1,100 +1,49 @@
-import { useEffect, useState, useCallback } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { getActivityFeed, type ActivityFeedItem, type FeedCounts } from '../api/activityFeed'
 import PageTitle from '../components/ui/PageTitle'
 import FeedCardRouter from '../components/feed/FeedCardRouter'
 import FeedDateDivider, { getDateLabel } from '../components/feed/FeedDateDivider'
-import { extractError } from '../utils/errors'
+import { useFormFactor } from '../hooks/useFormFactor'
+import {
+  useUpdates,
+  getCount,
+  ROW_1_FILTERS,
+  ROW_2_FILTERS,
+  type FeedFilter,
+  type UpdatesState,
+} from './updates/useUpdates'
+import MobileUpdates from './updates/MobileUpdates'
 
-type FeedFilter = 'All' | 'Friends' | 'Foes' | 'Your Stuff' | 'Global' | 'Requests'
-
-const ROW_1_FILTERS: FeedFilter[] = ['All', 'Friends', 'Foes', 'Your Stuff']
-const ROW_2_FILTERS: FeedFilter[] = ['Global', 'Requests']
-
-/** Map UI filter name to API filter param. */
-const FILTER_API_MAP: Record<FeedFilter, string> = {
-  'All': 'all',
-  'Friends': 'friends',
-  'Foes': 'foes',
-  'Your Stuff': 'your_stuff',
-  'Global': 'global',
-  'Requests': 'requests',
-}
-
-/** Map filter name to the key in FeedCounts. */
-function getCount(filter: FeedFilter, counts: FeedCounts): number {
-  switch (filter) {
-    case 'All': return counts.all
-    case 'Friends': return counts.friends
-    case 'Foes': return counts.foes
-    case 'Your Stuff': return counts.your_stuff
-    case 'Global': return counts.global_count
-    case 'Requests': return counts.requests
-  }
-}
-
+/**
+ * Activity feed. `useUpdates()` owns the filter-tab fetch + cursor pagination;
+ * on a phone (#532) `useFormFactor() === 'mobile'` swaps the desktop tab bar for
+ * a scroll-native single-column stream. Both surfaces render the SAME items
+ * through the SAME per-faction FeedCardRouter frames — a mixed, multi-faction
+ * stream, presentation-only. Desktop renders exactly as before.
+ */
 export default function Updates() {
+  const formFactor = useFormFactor()
+  const state = useUpdates()
+
+  if (formFactor === 'mobile') return <MobileUpdates state={state} />
+
+  return <DesktopUpdates state={state} />
+}
+
+function DesktopUpdates({ state }: { state: UpdatesState }) {
   const { t } = useTranslation('feed')
   const { t: tc } = useTranslation('common')
-  const [searchParams] = useSearchParams()
-  const [items, setItems] = useState<ActivityFeedItem[]>([])
-  const [counts, setCounts] = useState<FeedCounts>({ all: 0, friends: 0, foes: 0, your_stuff: 0, global_count: 0, requests: 0 })
-  // Deep-link the initial tab from ?filter=<api value> (e.g. Sidebar → Requests).
-  const [filter, setFilter] = useState<FeedFilter>(() => {
-    const apiFilter = searchParams.get('filter')
-    return (Object.keys(FILTER_API_MAP) as FeedFilter[]).find(
-      (name) => FILTER_API_MAP[name] === apiFilter,
-    ) ?? 'All'
-  })
-  const [loading, setLoading] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
-  const [nextCursor, setNextCursor] = useState<string | null>(null)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
-
-  const fetchFeed = useCallback(async (feedFilter: FeedFilter, cursor?: string) => {
-    const response = await getActivityFeed({
-      filter: FILTER_API_MAP[feedFilter],
-      before: cursor,
-      limit: 20,
-    })
-    return response
-  }, [])
-
-  // Initial load + filter changes
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    setFetchError(null)
-    setLoadMoreError(null)
-    fetchFeed(filter).then((response) => {
-      if (cancelled) return
-      setItems(response.items)
-      setCounts(response.counts)
-      setNextCursor(response.next_cursor)
-      setLoading(false)
-    }).catch((err) => {
-      if (cancelled) return
-      setFetchError(extractError(err, "Couldn't load the activity feed."))
-      setLoading(false)
-    })
-    return () => { cancelled = true }
-  }, [filter, fetchFeed])
-
-  const loadMore = async () => {
-    if (!nextCursor || loadingMore) return
-    setLoadingMore(true)
-    setLoadMoreError(null)
-    try {
-      const response = await fetchFeed(filter, nextCursor)
-      setItems((prev) => [...prev, ...response.items])
-      setNextCursor(response.next_cursor)
-    } catch (err) {
-      setLoadMoreError(extractError(err, "Couldn't load more updates."))
-    }
-    setLoadingMore(false)
-  }
+  const {
+    items,
+    counts,
+    filter,
+    setFilter,
+    loading,
+    loadingMore,
+    nextCursor,
+    fetchError,
+    loadMoreError,
+    loadMore,
+  } = state
 
   /** Insert date dividers between items when the date changes. */
   const renderFeedWithDividers = () => {
@@ -217,7 +166,7 @@ export default function Updates() {
               padding: '8px 16px',
             }}
           >
-            {loadingMore ? 'Loading...' : 'Load Older Updates \u2192'}
+            {loadingMore ? 'Loading...' : 'Load Older Updates →'}
           </button>
         </div>
       )}

--- a/frontend/src/pages/updates/MobileUpdates.tsx
+++ b/frontend/src/pages/updates/MobileUpdates.tsx
@@ -1,0 +1,193 @@
+import { useTranslation } from 'react-i18next'
+import FeedCardRouter from '../../components/feed/FeedCardRouter'
+import FeedDateDivider, { getDateLabel } from '../../components/feed/FeedDateDivider'
+import {
+  ALL_FILTERS,
+  getCount,
+  type FeedFilter,
+  type UpdatesState,
+} from './useUpdates'
+
+/**
+ * Mobile Updates stream (#532). One scroll-native, single-column activity feed
+ * where EACH card keeps its OWN faction frame — the exact mixed, multi-faction
+ * stream desktop renders, not seven per-faction screens. Presentation-only: it
+ * reuses the shared `useUpdates()` fetch and the per-item FeedCardRouter (which
+ * already wraps every row in the acting faction's frame via
+ * `context_faction_slug`), touch-tuned for a 375px viewport.
+ */
+
+/** Full `feed` catalog key for each filter's chip label (spaces aren't keys). */
+const FILTER_LABEL_KEY = {
+  'All': 'mobile.filter.all',
+  'Friends': 'mobile.filter.friends',
+  'Foes': 'mobile.filter.foes',
+  'Your Stuff': 'mobile.filter.yourStuff',
+  'Global': 'mobile.filter.global',
+  'Requests': 'mobile.filter.requests',
+} as const satisfies Record<FeedFilter, string>
+
+export default function MobileUpdates({ state }: { state: UpdatesState }) {
+  const { t } = useTranslation('feed')
+  const { t: tc } = useTranslation('common')
+  const {
+    items,
+    counts,
+    filter,
+    setFilter,
+    loading,
+    loadingMore,
+    nextCursor,
+    fetchError,
+    loadMoreError,
+    loadMore,
+  } = state
+
+  return (
+    <div className="py-4" data-feed="mobile" data-testid="mobile-updates">
+      <p className="eyebrow mb-1">{t('mobile.eyebrow')}</p>
+      <h1
+        className="font-display italic font-medium mb-3"
+        style={{ fontSize: 26, color: 'var(--color-text-primary)', lineHeight: 1.1 }}
+      >
+        {t('mobile.title')}
+      </h1>
+
+      {/* Filter chips — one horizontal-scroll row of touch targets. */}
+      <div
+        className="flex gap-2 mb-4"
+        style={{ overflowX: 'auto', paddingBottom: 4, scrollbarWidth: 'none' }}
+      >
+        {ALL_FILTERS.map((option) => {
+          const active = filter === option
+          const count = getCount(option, counts)
+          const isRequests = option === 'Requests'
+          const hasRedBadge = isRequests && count > 0
+          return (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setFilter(option)}
+              style={{
+                flex: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 11,
+                fontWeight: active ? 700 : 400,
+                letterSpacing: '0.05em',
+                textTransform: 'uppercase',
+                color: active ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
+                background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+                border: `1px solid ${active ? 'transparent' : 'var(--color-border-strong)'}`,
+                borderRadius: 999,
+                padding: '9px 15px',
+                minHeight: 38,
+                whiteSpace: 'nowrap',
+                cursor: 'pointer',
+              }}
+            >
+              {t(FILTER_LABEL_KEY[option])}
+              {count > 0 && (
+                <span
+                  style={{
+                    background: hasRedBadge
+                      ? 'var(--color-danger)'
+                      : active
+                        ? 'var(--color-bg-surface)'
+                        : 'var(--color-bg-surface-alt)',
+                    color: hasRedBadge ? 'var(--color-text-on-accent)' : 'var(--color-text-primary)',
+                    fontSize: 9,
+                    fontWeight: 700,
+                    padding: '1px 6px',
+                    borderRadius: 999,
+                    minWidth: 16,
+                    textAlign: 'center',
+                  }}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Stream — single column; every card keeps its own faction frame. */}
+      {loading ? (
+        <p className="font-body text-muted">{t('page.loading')}</p>
+      ) : fetchError ? (
+        <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+          {fetchError}{' '}
+          <button onClick={() => window.location.reload()} className="underline">
+            {tc('states.tryRefreshing')}
+          </button>
+        </p>
+      ) : items.length === 0 ? (
+        <div className="sidebar-card" style={{ padding: 20, textAlign: 'center' }}>
+          <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+            {t('page.empty')}
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {renderStream(items)}
+        </div>
+      )}
+
+      {loadMoreError && !loading && !fetchError && (
+        <p className="font-body text-sm text-red-600" style={{ textAlign: 'center', marginTop: 12 }}>
+          {loadMoreError}
+        </p>
+      )}
+
+      {nextCursor && !loading && !fetchError && (
+        <div style={{ marginTop: 20 }}>
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loadingMore}
+            style={{
+              width: '100%',
+              fontFamily: "'Courier Prime', monospace",
+              fontSize: 12,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              background: 'var(--color-bg-surface)',
+              color: 'var(--color-text-primary)',
+              border: '1px solid var(--color-border-strong)',
+              borderRadius: 0,
+              minHeight: 48,
+              cursor: loadingMore ? 'not-allowed' : 'pointer',
+              padding: '12px 16px',
+            }}
+          >
+            {loadingMore ? t('mobile.loadingMore') : t('mobile.loadMore')}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Single-column list with date dividers, one FeedCardRouter per item. */
+function renderStream(items: UpdatesState['items']): React.ReactNode[] {
+  const elements: React.ReactNode[] = []
+  let lastDateLabel = ''
+
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index]
+    const dateLabel = getDateLabel(item.timestamp)
+
+    if (dateLabel !== lastDateLabel) {
+      elements.push(<FeedDateDivider key={`divider-${dateLabel}-${index}`} label={dateLabel} />)
+      lastDateLabel = dateLabel
+    }
+
+    elements.push(<FeedCardRouter key={`${item.type}-${item.timestamp}-${index}`} item={item} />)
+  }
+
+  return elements
+}

--- a/frontend/src/pages/updates/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/updates/__tests__/dispatch.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Updates form-factor dispatch (#532) — renders <Updates /> with useFormFactor
+ * mocked and pins:
+ *   - phone → the single-column mobile activity stream (data-feed="mobile"),
+ *   - desktop → the existing filter-tab feed (its "Updates" title, no marker).
+ * SSR (renderToStaticMarkup) never runs effects, so the feed sits in its loading
+ * state — enough to prove which surface the dispatch selected. getActivityFeed is
+ * mocked so no axios call is attempted.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+vi.mock('../../../api/activityFeed', () => ({
+  getActivityFeed: async () => ({
+    items: [],
+    counts: { all: 0, friends: 0, foes: 0, your_stuff: 0, global_count: 0, requests: 0 },
+    next_cursor: null,
+  }),
+}))
+
+// Imported after the mocks are registered.
+import Updates from '../../Updates'
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Updates />
+    </MemoryRouter>,
+  )
+}
+
+describe('Updates form-factor dispatch', () => {
+  it('renders the mobile activity stream on mobile', () => {
+    mocks.formFactor = 'mobile'
+    expect(render()).toContain('data-feed="mobile"')
+  })
+
+  it('renders the desktop filter-tab feed on desktop (untouched)', () => {
+    mocks.formFactor = 'desktop'
+    const html = render()
+    expect(html).not.toContain('data-feed="mobile"')
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Updates')
+  })
+})

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Mobile Updates = a MIXED, multi-faction stream (#532), not seven per-faction
+ * screens. Renders MobileUpdates with a feed whose items carry DIFFERENT
+ * `context_faction_slug` values and proves each card keeps its OWN faction frame
+ * (distinct WOW / UA / SNIDE chrome coexisting in one render) — never one
+ * uniform tint. Reuses the shared FeedCardRouter + normalizeFeedItem path.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import MobileUpdates from '../MobileUpdates'
+import type { UpdatesState } from '../useUpdates'
+import type { ActivityFeedItem } from '../../../api/activityFeed'
+
+function completion(slug: string, id: number, title: string): ActivityFeedItem {
+  return {
+    type: 'friend_completion',
+    timestamp: '2026-01-01T00:00:00Z',
+    actor_display_name: 'Ada',
+    actor_faction_slug: slug,
+    actor_avatar_url: null,
+    payload: { character_id: id, praxis_id: id, task_title: title, task_point_value: 40 },
+    context_faction_slug: slug,
+  }
+}
+
+function baseState(overrides: Partial<UpdatesState>): UpdatesState {
+  return {
+    items: [],
+    counts: { all: 3, friends: 3, foes: 0, your_stuff: 0, global_count: 0, requests: 0 },
+    filter: 'All',
+    setFilter: () => {},
+    loading: false,
+    loadingMore: false,
+    nextCursor: null,
+    fetchError: null,
+    loadMoreError: null,
+    loadMore: async () => {},
+    ...overrides,
+  }
+}
+
+function render(state: UpdatesState): { html: string; text: string } {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <MobileUpdates state={state} />
+    </MemoryRouter>,
+  )
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+describe('mobile Updates mixed multi-faction stream', () => {
+  const items = [
+    completion('wow', 1, 'Cast a small spell'),
+    completion('ua', 2, 'Hang the canvas'),
+    completion('snide', 3, 'Map the boring'),
+  ]
+
+  it('renders a single-column stream marked as the mobile surface', () => {
+    const { html } = render(baseState({ items }))
+    expect(html).toContain('data-feed="mobile"')
+  })
+
+  it('keeps each card in its OWN faction frame — WOW + UA chrome coexist', () => {
+    const { text, html } = render(baseState({ items }))
+    // Distinct per-faction frame markers appearing TOGETHER in one render
+    // prove a mixed stream, not one uniform tint.
+    expect(text, 'WOW window chrome').toContain('whimsy.exe')
+    expect(text, 'UA salon masthead').toContain('University of Asthmatics')
+    expect(html, 'SNIDE dossier tokens').toContain('--faction-snide')
+    expect(html, 'WOW scrapbook tokens').toContain('--faction-wow')
+  })
+
+  it('renders every card body (the shared FeedRowContent rows)', () => {
+    const { text } = render(baseState({ items }))
+    expect(text).toContain('Cast a small spell')
+    expect(text).toContain('Hang the canvas')
+    expect(text).toContain('Map the boring')
+  })
+
+  it('shows the empty state when the stream is empty', () => {
+    const { text } = render(baseState({ items: [] }))
+    expect(text).toContain('No updates yet')
+  })
+})

--- a/frontend/src/pages/updates/useUpdates.ts
+++ b/frontend/src/pages/updates/useUpdates.ts
@@ -1,0 +1,122 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { getActivityFeed, type ActivityFeedItem, type FeedCounts } from '../../api/activityFeed'
+import { extractError } from '../../utils/errors'
+
+export type FeedFilter = 'All' | 'Friends' | 'Foes' | 'Your Stuff' | 'Global' | 'Requests'
+
+export const ROW_1_FILTERS: FeedFilter[] = ['All', 'Friends', 'Foes', 'Your Stuff']
+export const ROW_2_FILTERS: FeedFilter[] = ['Global', 'Requests']
+export const ALL_FILTERS: FeedFilter[] = [...ROW_1_FILTERS, ...ROW_2_FILTERS]
+
+/** Map UI filter name to API filter param. */
+export const FILTER_API_MAP: Record<FeedFilter, string> = {
+  'All': 'all',
+  'Friends': 'friends',
+  'Foes': 'foes',
+  'Your Stuff': 'your_stuff',
+  'Global': 'global',
+  'Requests': 'requests',
+}
+
+/** Map filter name to the key in FeedCounts. */
+export function getCount(filter: FeedFilter, counts: FeedCounts): number {
+  switch (filter) {
+    case 'All': return counts.all
+    case 'Friends': return counts.friends
+    case 'Foes': return counts.foes
+    case 'Your Stuff': return counts.your_stuff
+    case 'Global': return counts.global_count
+    case 'Requests': return counts.requests
+  }
+}
+
+export interface UpdatesState {
+  items: ActivityFeedItem[]
+  counts: FeedCounts
+  filter: FeedFilter
+  setFilter: (filter: FeedFilter) => void
+  loading: boolean
+  loadingMore: boolean
+  nextCursor: string | null
+  fetchError: string | null
+  loadMoreError: string | null
+  loadMore: () => Promise<void>
+}
+
+/**
+ * Shared Updates state — the one activity-feed fetch (filter tabs + cursor
+ * pagination) consumed by both the desktop page and the mobile stream (#532).
+ * Presentation-only split: the mobile branch renders the SAME items through the
+ * SAME per-faction FeedCardRouter frames, so no data/API change is needed.
+ */
+export function useUpdates(): UpdatesState {
+  const [searchParams] = useSearchParams()
+  const [items, setItems] = useState<ActivityFeedItem[]>([])
+  const [counts, setCounts] = useState<FeedCounts>({ all: 0, friends: 0, foes: 0, your_stuff: 0, global_count: 0, requests: 0 })
+  // Deep-link the initial tab from ?filter=<api value> (e.g. Sidebar → Requests).
+  const [filter, setFilter] = useState<FeedFilter>(() => {
+    const apiFilter = searchParams.get('filter')
+    return ALL_FILTERS.find((name) => FILTER_API_MAP[name] === apiFilter) ?? 'All'
+  })
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+
+  const fetchFeed = useCallback(async (feedFilter: FeedFilter, cursor?: string) => {
+    return getActivityFeed({
+      filter: FILTER_API_MAP[feedFilter],
+      before: cursor,
+      limit: 20,
+    })
+  }, [])
+
+  // Initial load + filter changes
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setFetchError(null)
+    setLoadMoreError(null)
+    fetchFeed(filter).then((response) => {
+      if (cancelled) return
+      setItems(response.items)
+      setCounts(response.counts)
+      setNextCursor(response.next_cursor)
+      setLoading(false)
+    }).catch((err) => {
+      if (cancelled) return
+      setFetchError(extractError(err, "Couldn't load the activity feed."))
+      setLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [filter, fetchFeed])
+
+  const loadMore = async () => {
+    if (!nextCursor || loadingMore) return
+    setLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const response = await fetchFeed(filter, nextCursor)
+      setItems((prev) => [...prev, ...response.items])
+      setNextCursor(response.next_cursor)
+    } catch (err) {
+      setLoadMoreError(extractError(err, "Couldn't load more updates."))
+    }
+    setLoadingMore(false)
+  }
+
+  return {
+    items,
+    counts,
+    filter,
+    setFilter,
+    loading,
+    loadingMore,
+    nextCursor,
+    fetchError,
+    loadMoreError,
+    loadMore,
+  }
+}


### PR DESCRIPTION
Closes #532

## What
Adds a mobile branch to the Updates activity feed. On a phone, the desktop filter-tab feed is swapped for a scroll-native single-column stream where **each card keeps its own faction frame** — a mixed, multi-faction stream exactly like desktop, not seven per-faction screens.

## How
- Extract the activity-feed fetch (filter tabs + cursor pagination) into a shared **useUpdates()** hook, consumed by both surfaces.
- **MobileUpdates** renders the SAME items through the SAME per-item FeedCardRouter (which already wraps every row in the acting faction's frame via context_faction_slug) + FeedDateDivider, touch-tuned for 375px: horizontal-scroll filter chips (38px targets), single-column stacking, a full-width 48px "load older" button. No fixed-px inline grids for layout structure.
- Updates.tsx dispatches on useFormFactor() === 'mobile' (mirrors Tasks/Praxes). The desktop path is the unchanged prior JSX, moved into DesktopUpdates.
- Presentation-only: no data/API change, no feed-frame redesign, no per-faction full-screen treatment.

## i18n / tokens
- New copy under feed:mobile.* (title, chip labels, load-more). All visible strings via useTranslation.
- All colors resolve to theme tokens; no hardcoded hex, no dark/light ternaries.

## Tests
- dispatch.test.tsx — phone renders the mobile stream (data-feed="mobile"); desktop renders the untouched tab feed.
- mixedStream.test.tsx — items with different context_faction_slug render distinct WOW / UA / SNIDE frames together in one stream (not one uniform tint), plus each row body and the empty state.

## Verification
- vitest: 288 tests pass; my updates tests 6/6 green. (5 unrelated test files fail to load locally — remark-gfm / react-easy-crop from #513/#514 not in the stale local node_modules; environmental.)
- tsc --noEmit: clean for all touched files (pre-existing errors only, from the same missing packages + AlbescentInvitation).
- eslint is CI-only (not installed locally); new strings are i18n'd and no raw JSX literals were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
