### PR TITLE
Mobile: Settings screen — real controls (#520)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import FactionDetail from './pages/FactionDetail'
 import AlbescentSecretPlaceholder from './pages/AlbescentSecretPlaceholder'
 import Updates from './pages/Updates'
 import Praxes from './pages/Praxes'
+import Settings from './pages/Settings'
 import Admin from './pages/Admin'
 import CreateCharacter from './pages/CreateCharacter'
 import EditCharacter from './pages/EditCharacter'
@@ -87,6 +88,16 @@ export default function App() {
           element={
             <ProtectedRoute>
               <Updates />
+            </ProtectedRoute>
+          }
+        />
+        {/* Mobile-only Settings surface (#520). The page redirects to `/` on
+            desktop, which keeps the desktop NavBar controls the sole path. */}
+        <Route
+          path="/settings"
+          element={
+            <ProtectedRoute>
+              <Settings />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/layout/MobileLayout.tsx
+++ b/frontend/src/components/layout/MobileLayout.tsx
@@ -1,21 +1,24 @@
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { useAuth } from '../../auth/AuthContext'
 import MobileTabBar from './MobileTabBar'
 
 /**
  * Mobile shell: a minimal top wordmark bar, full-bleed main (no sidebar, no
  * desktop grid), and the bottom MobileTabBar. Secondary controls (theme,
- * logout, admin, profile) move behind a More affordance per the design issue
- * (#495); the shared frame (backdrop, watchers, effects) lives in Layout.
+ * logout, admin, profile) move behind the Settings affordance per the design
+ * issue (#495/#520); the shared frame (backdrop, watchers, effects) lives in
+ * Layout.
  */
 export default function MobileLayout({ children }: { children: ReactNode }) {
   const { t } = useTranslation('common')
+  const { user } = useAuth()
 
   return (
     <>
       <header
-        className="sticky top-0 flex items-center px-4 h-12"
+        className="sticky top-0 flex items-center justify-between px-4 h-12"
         style={{
           zIndex: 10,
           background: 'var(--color-nav-bg)',
@@ -26,6 +29,23 @@ export default function MobileLayout({ children }: { children: ReactNode }) {
         <Link to="/" className="font-display italic" style={{ fontSize: 18, color: 'var(--color-text-primary)', textDecoration: 'none' }}>
           {t('brand')}
         </Link>
+        {/* Settings / More affordance — the phone path to theme + sign out +
+            character management (#520). Only meaningful when signed in. */}
+        {user && (
+          <Link
+            to="/settings"
+            aria-label={t('settings.title')}
+            className="eyebrow"
+            style={{
+              fontSize: 10,
+              color: 'var(--color-text-secondary)',
+              textDecoration: 'none',
+              padding: '4px 2px',
+            }}
+          >
+            {t('settings.open')}
+          </Link>
+        )}
       </header>
 
       {/* Full-bleed main; bottom padding clears the fixed tab bar + safe area. */}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,16 +1,23 @@
 import { useCallback, useEffect, useState } from 'react'
 
-type Theme = 'light' | 'dark'
+export type Theme = 'light' | 'dark'
 
-const STORAGE_KEY = 'wz-theme'
+export const THEME_STORAGE_KEY = 'wz-theme'
 
 function getInitialTheme(): Theme {
-  const stored = localStorage.getItem(STORAGE_KEY)
+  const stored = localStorage.getItem(THEME_STORAGE_KEY)
   if (stored === 'light' || stored === 'dark') return stored
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
 }
 
-function applyTheme(theme: Theme): void {
+/** The opposite theme — the single source of the toggle's flip decision. */
+export function nextTheme(theme: Theme): Theme {
+  return theme === 'light' ? 'dark' : 'light'
+}
+
+/** Paint the `[data-theme]` cascade. Exported so behaviour tests can exercise
+ *  the exact flip the toggle performs without a React hook runtime. */
+export function applyTheme(theme: Theme): void {
   document.documentElement.setAttribute('data-theme', theme)
 }
 
@@ -27,8 +34,8 @@ export function useTheme() {
 
   const toggle = useCallback(() => {
     setTheme((previous) => {
-      const next = previous === 'light' ? 'dark' : 'light'
-      localStorage.setItem(STORAGE_KEY, next)
+      const next = nextTheme(previous)
+      localStorage.setItem(THEME_STORAGE_KEY, next)
       return next
     })
   }, [])

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -251,5 +251,23 @@
     "summary_one": "{{count}} vote · {{points}} pts",
     "summary_other": "{{count}} votes · {{points}} pts",
     "saveError": "Could not save your vote. Please try again."
+  },
+  "settings": {
+    "title": "Settings",
+    "open": "Settings",
+    "account": {
+      "eyebrow": "Signed in as",
+      "viewProfile": "View profile",
+      "noCharacter": "No character yet"
+    },
+    "characters": {
+      "label": "Characters",
+      "hint": "Switch or edit your lives"
+    },
+    "appearance": {
+      "eyebrow": "Appearance",
+      "darkMode": "Dark mode"
+    },
+    "signOut": "Sign out"
   }
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,44 @@
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../auth/AuthContext'
+import { logout } from '../api/auth'
+import { useTheme } from '../hooks/useTheme'
+import { useFormFactor } from '../hooks/useFormFactor'
+import DefaultSettings from './settings/mobileArchetypes/DefaultSettings'
+
+/**
+ * Sign-out action, extracted so the wiring is unit-testable in a DOM-less env:
+ * end the session via the existing auth client, then refetch so the app drops
+ * back to the logged-out state. No new auth logic — `logout` is reused verbatim.
+ */
+export function runSignOut(logout: () => Promise<void>, refetch: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    await logout()
+    await refetch()
+  }
+}
+
+/**
+ * Settings (#520) — a MOBILE-only surface. Desktop keeps its NavBar controls
+ * (theme, logout) untouched, so on desktop this route simply redirects home;
+ * there is no new desktop settings page. On a phone it renders the Default (na)
+ * settings reflow with real controls only (ADR-0035): account header, character
+ * management, the reused dark-mode toggle, and sign out.
+ */
+export default function Settings() {
+  const formFactor = useFormFactor()
+  const { user, refetch } = useAuth()
+  const { theme, toggle } = useTheme()
+
+  if (formFactor !== 'mobile') {
+    return <Navigate to="/" replace />
+  }
+
+  return (
+    <DefaultSettings
+      character={user?.character ?? null}
+      dark={theme === 'dark'}
+      onToggleTheme={toggle}
+      onSignOut={runSignOut(logout, refetch)}
+    />
+  )
+}

--- a/frontend/src/pages/settings/__tests__/defaultSettings.test.tsx
+++ b/frontend/src/pages/settings/__tests__/defaultSettings.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Mobile Settings behaviour + slot invariant (#520). Runs in the repo's DOM-less
+ * node env (renderToStaticMarkup), so interaction is proven against the extracted
+ * seams the screen wires to, not synthetic clicks:
+ *   - the dark-mode toggle delegates to `useTheme`'s `nextTheme`/`applyTheme`,
+ *     which flip the real `[data-theme]` cascade (exercised via a document shim);
+ *   - sign-out runs the extracted `runSignOut`, which invokes the reused `logout`;
+ *   - the render shows ONLY real controls — the parked notifications / privacy /
+ *     about rows are absent (ADR-0035).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+// Initialize the i18n catalog so shared copy keys resolve to English text.
+import '../../../i18n'
+import DefaultSettings from '../mobileArchetypes/DefaultSettings'
+import { runSignOut } from '../../Settings'
+import { nextTheme, applyTheme } from '../../../hooks/useTheme'
+import type { CharacterOut } from '../../../api/auth'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+function character(overrides: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    id: 7,
+    username: 'nova',
+    display_name: 'Nova',
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 3,
+    score: 120,
+    all_time_score: 120,
+    faction_slug: 'everymen',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const noop = () => {}
+
+describe('mobile Settings — real controls only', () => {
+  it('renders the account header, character link, dark-mode toggle and sign out', () => {
+    const { html, text } = render(
+      <DefaultSettings character={character()} dark={false} onToggleTheme={noop} onSignOut={noop} />,
+    )
+    expect(text, 'title').toContain('Settings')
+    expect(text, 'account name').toContain('Nova')
+    expect(text, 'view-profile link').toContain('View profile')
+    expect(html, 'character-management link').toContain('href="/characters/7/edit"')
+    expect(text, 'characters row').toContain('Characters')
+    expect(text, 'appearance').toContain('Dark mode')
+    expect(html, 'theme toggle control').toContain('data-testid="settings-theme-toggle"')
+    expect(text, 'sign out').toContain('Sign out')
+  })
+
+  it('omits the parked notifications / privacy / about rows', () => {
+    const { text } = render(
+      <DefaultSettings character={character()} dark={false} onToggleTheme={noop} onSignOut={noop} />,
+    )
+    const lower = text.toLowerCase()
+    expect(lower).not.toContain('notification')
+    expect(lower).not.toContain('privacy')
+    expect(lower).not.toContain('about')
+  })
+
+  it('links a character-less account into creation instead', () => {
+    const { html, text } = render(
+      <DefaultSettings character={null} dark={false} onToggleTheme={noop} onSignOut={noop} />,
+    )
+    expect(html).toContain('href="/characters/create"')
+    expect(text).toContain('No character yet')
+  })
+
+  it('reflects the live theme on the toggle (aria-checked)', () => {
+    const light = render(
+      <DefaultSettings character={character()} dark={false} onToggleTheme={noop} onSignOut={noop} />,
+    )
+    expect(light.html).toContain('aria-checked="false"')
+
+    const dark = render(
+      <DefaultSettings character={character()} dark onToggleTheme={noop} onSignOut={noop} />,
+    )
+    expect(dark.html).toContain('aria-checked="true"')
+  })
+})
+
+describe('mobile Settings — dark-mode toggle flips [data-theme]', () => {
+  it('flips the cascade attribute via the reused theme mechanism', () => {
+    // Minimal document shim: the toggle composes nextTheme + applyTheme, which
+    // is exactly what useTheme().toggle runs. Prove the flip end to end.
+    const attrs: Record<string, string> = {}
+    const previousDocument = (globalThis as { document?: unknown }).document
+    ;(globalThis as { document?: unknown }).document = {
+      documentElement: {
+        setAttribute: (name: string, value: string) => {
+          attrs[name] = value
+        },
+      },
+    }
+    try {
+      let theme: 'light' | 'dark' = 'light'
+      applyTheme(theme)
+      expect(attrs['data-theme']).toBe('light')
+
+      // One toggle press.
+      theme = nextTheme(theme)
+      applyTheme(theme)
+      expect(theme).toBe('dark')
+      expect(attrs['data-theme']).toBe('dark')
+
+      // And back.
+      theme = nextTheme(theme)
+      applyTheme(theme)
+      expect(attrs['data-theme']).toBe('light')
+    } finally {
+      ;(globalThis as { document?: unknown }).document = previousDocument
+    }
+  })
+})
+
+describe('mobile Settings — sign out invokes logout', () => {
+  it('runSignOut ends the session via the reused auth client, then refetches', async () => {
+    const logout = vi.fn().mockResolvedValue(undefined)
+    const refetch = vi.fn().mockResolvedValue(undefined)
+    await runSignOut(logout, refetch)()
+    expect(logout).toHaveBeenCalledOnce()
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/pages/settings/mobileArchetypes/DefaultSettings.tsx
+++ b/frontend/src/pages/settings/mobileArchetypes/DefaultSettings.tsx
@@ -1,0 +1,226 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { CharacterOut } from '../../../api/auth'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+
+export interface DefaultSettingsProps {
+  character: CharacterOut | null
+  /** Current theme, so the dark-mode switch reflects the live cascade. */
+  dark: boolean
+  /** Reused verbatim from `useTheme().toggle` — flips `[data-theme]` + persists. */
+  onToggleTheme: () => void
+  /** Reused auth sign-out (`logout()` + refetch). */
+  onSignOut: () => void
+}
+
+/**
+ * Default (na) MOBILE Settings screen (#520). Single-column, one-hand reflow of
+ * the design's settings idiom, but ADR-0035 real-fields-only: it surfaces ONLY
+ * controls backed by real state — account header, a link into character
+ * management, the dark-mode toggle (which reuses the existing `useTheme`
+ * persistence, no new store), and sign out. The design's notifications /
+ * privacy / about rows are PARKED and deliberately not rendered.
+ *
+ * Presentation-only: all state/handlers arrive as props; copy resolves from the
+ * `common` catalog. Desktop is unaffected — the container routes desktop away.
+ */
+export default function DefaultSettings({ character, dark, onToggleTheme, onSignOut }: DefaultSettingsProps) {
+  const { t } = useTranslation('common')
+
+  // Character management: the carried life's own management surface, or create
+  // one if there is none yet. (#516's dedicated mobile route falls through here
+  // until it lands.)
+  const charactersHref = character ? `/characters/${character.id}/edit` : '/characters/create'
+
+  return (
+    <div data-testid="mobile-settings" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <header>
+        <h1
+          className="font-display italic"
+          style={{ fontSize: 30, lineHeight: 1, color: 'var(--color-text-primary)', margin: 0 }}
+        >
+          {t('settings.title')}
+        </h1>
+      </header>
+
+      {/* ── Account header ── */}
+      <section
+        style={{
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-xl)',
+          padding: 16,
+        }}
+      >
+        <div className="eyebrow" style={{ fontSize: 9, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+          {t('settings.account.eyebrow')}
+        </div>
+        {character ? (
+          <div className="flex items-center gap-3.5">
+            <div
+              className="shrink-0 rounded-full"
+              style={{ width: 52, height: 52, padding: 3, background: 'var(--faction-default-ring)' }}
+            >
+              {character.avatar_url ? (
+                <img
+                  src={mediaUrl(character.avatar_url)}
+                  alt={character.display_name}
+                  className="w-full h-full rounded-full"
+                  style={{ objectFit: 'cover' }}
+                />
+              ) : (
+                <div
+                  className="w-full h-full rounded-full"
+                  style={{
+                    background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${factionCssVar(character.faction_slug)})`,
+                  }}
+                />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div
+                className="font-display italic truncate"
+                style={{ fontSize: 22, lineHeight: 1.05, color: 'var(--color-text-primary)' }}
+              >
+                {character.display_name}
+              </div>
+              <div
+                className="truncate"
+                style={{
+                  marginTop: 4,
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 10,
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: 'var(--color-text-secondary)',
+                }}
+              >
+                {t('sidebar.characterCard.factionLevel', {
+                  faction: factionName(character.faction_slug),
+                  level: character.level,
+                })}
+              </div>
+            </div>
+            <Link
+              to={`/characters/${character.id}`}
+              className="shrink-0 eyebrow"
+              style={{
+                fontSize: 9,
+                color: 'var(--color-text-secondary)',
+                textDecoration: 'none',
+                border: '1px solid var(--color-border-strong)',
+                borderRadius: 999,
+                padding: '6px 11px',
+              }}
+            >
+              {t('settings.account.viewProfile')}
+            </Link>
+          </div>
+        ) : (
+          <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: 0 }}>
+            {t('settings.account.noCharacter')}
+          </p>
+        )}
+      </section>
+
+      {/* ── Characters — link into character management ── */}
+      <Link
+        to={charactersHref}
+        className="font-body flex items-center gap-3"
+        style={{
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-xl)',
+          padding: '16px',
+          textDecoration: 'none',
+        }}
+      >
+        <div className="min-w-0 flex-1">
+          <div style={{ fontSize: 15, color: 'var(--color-text-primary)' }}>{t('settings.characters.label')}</div>
+          <div style={{ marginTop: 2, fontSize: 11, color: 'var(--color-text-secondary)' }}>
+            {t('settings.characters.hint')}
+          </div>
+        </div>
+        <span aria-hidden style={{ color: 'var(--color-text-tertiary)', fontSize: 18, lineHeight: 1 }}>
+          ›
+        </span>
+      </Link>
+
+      {/* ── Appearance — Dark mode ── */}
+      <section
+        style={{
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-xl)',
+          padding: '16px',
+        }}
+      >
+        <div className="eyebrow" style={{ fontSize: 9, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+          {t('settings.appearance.eyebrow')}
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="font-body flex-1" style={{ fontSize: 15, color: 'var(--color-text-primary)' }}>
+            {t('settings.appearance.darkMode')}
+          </span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={dark}
+            aria-label={t('settings.appearance.darkMode')}
+            data-testid="settings-theme-toggle"
+            onClick={onToggleTheme}
+            style={{
+              flex: 'none',
+              width: 46,
+              height: 28,
+              borderRadius: 999,
+              border: '1px solid var(--color-border-strong)',
+              background: dark ? 'var(--color-text-primary)' : 'var(--color-bg-surface-alt)',
+              position: 'relative',
+              cursor: 'pointer',
+              padding: 0,
+              transition: 'background 150ms',
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                position: 'absolute',
+                top: 2,
+                left: dark ? 20 : 2,
+                width: 22,
+                height: 22,
+                borderRadius: '50%',
+                background: dark ? 'var(--color-bg-page)' : 'var(--color-text-tertiary)',
+                transition: 'left 150ms',
+              }}
+            />
+          </button>
+        </div>
+      </section>
+
+      {/* ── Sign out ── */}
+      <button
+        type="button"
+        onClick={onSignOut}
+        data-testid="settings-sign-out"
+        className="font-body"
+        style={{
+          padding: 15,
+          borderRadius: 12,
+          fontSize: 12,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          fontWeight: 700,
+          color: 'var(--color-text-primary)',
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border-strong)',
+          cursor: 'pointer',
+        }}
+      >
+        {t('settings.signOut')}
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #520

## Mobile Settings screen — real controls (ADR-0035)

A phone-only Settings surface, reached from a **Settings** affordance added to
the right of the mobile top bar (shown only when signed in). Single-column
Default (na) reflow that renders **only controls backed by real state**:

- **Account header** — avatar, name, faction/level, and a *View profile* link.
- **Characters** — links into character management (the carried life's edit
  path, or create when there is none; falls through here until #516's route
  lands).
- **Appearance — Dark mode** — a toggle wired to the existing useTheme().toggle;
  persistence is reused verbatim (no new settings store).
- **Sign out** — the existing logout() + auth refetch.

The design's **notifications / privacy / about** rows are parked and not
rendered. Desktop is untouched — the /settings route redirects home off the
mobile breakpoint, so the desktop NavBar stays the only desktop path.

### Notes
- New: pages/Settings.tsx (form-factor gate + extracted runSignOut),
  pages/settings/mobileArchetypes/DefaultSettings.tsx (presentation-only).
- useTheme.ts gains behaviour-preserving exports (nextTheme, applyTheme) so the
  flip is unit-testable in the repo's DOM-less node env.
- Tests: dark-mode toggle flips [data-theme], sign-out invokes logout, parked
  rows absent, character-less account links to creation.

### Verification
- eslint src — clean.
- vitest run — 43 files / 319 tests pass (6 new).
- No new backend endpoints consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
