### PR TITLE
Mobile: Players directory + profile (#517)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -30,7 +30,16 @@
     "nextLevel": "next · lvl {{level}}",
     "ptsToNext": "{{score}} / {{threshold}} pts",
     "badgesHeading": "Badges",
-    "badgesEarned": "{{count}} earned"
+    "badgesEarned": "{{count}} earned",
+    "mobile": {
+      "tabPraxis": "Praxis",
+      "tabTasks": "Tasks",
+      "stats": {
+        "points": "Points",
+        "praxis": "Praxis",
+        "tasks": "Tasks"
+      }
+    }
   },
   "leaderboard": {
     "loading": "Loading...",
@@ -38,7 +47,17 @@
     "soloEyebrow": "Era I · Roll call",
     "soloBody": "You're the first player on World Zero. The rankings will fill in as others arrive — until then, the board is yours alone.",
     "rankingsSoFar": "Rankings so far",
-    "youFactionLevel": "{{faction}} · Level {{level}}"
+    "youFactionLevel": "{{faction}} · Level {{level}}",
+    "mobile": {
+      "count": "{{count}} players",
+      "sortEra": "Era",
+      "sortAllTime": "All-time",
+      "allFactions": "All",
+      "factionLevel": "{{faction}} · Lv {{level}}",
+      "points": "pts",
+      "empty": "No players match this filter.",
+      "loadError": "Couldn't load the leaderboard."
+    }
   },
   "collaborationCard": {
     "duel": "Duel",
@@ -178,6 +197,7 @@
     "faction": "faction:",
     "level": "level:",
     "status": "status:",
+    "sort": "sort:",
     "levelAtLeast": "{{level}}+"
   },
   "level": {

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -25,18 +25,31 @@ import {
 } from "../api/relationships";
 import { useAuth } from "../auth/AuthContext";
 import { useGameConfig } from "../hooks/useGameConfig";
+import { useFormFactor } from "../hooks/useFormFactor";
+import { pickVariant } from "../utils/factionDispatch";
 import { extractError } from "../utils/errors";
 import { factionCssVar } from "../utils/factions";
 import { useFactionBackdrop } from "../components/backdrop/BackdropContext";
 import FactionProfileBody, {
+  type ProfileBodyProps,
   type ProfileProgression,
 } from "./characterProfile/FactionProfileBody";
+import DefaultProfile from "./characterProfile/mobileArchetypes/DefaultProfile";
+
+// Parallel MOBILE profile registry, mirroring FACTION_PROFILE_BODIES. Empty for
+// now — every phone render falls through to the Default (na) mobile profile
+// skin (#517); bespoke faction mobile profiles register here in follow-ups.
+export const MOBILE_PROFILE_BY_SLUG: Record<
+  string,
+  (props: ProfileBodyProps) => JSX.Element
+> = {};
 
 export default function CharacterProfile() {
   const { t } = useTranslation("common");
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();
   const gameConfig = useGameConfig();
+  const formFactor = useFormFactor();
   const { data, loading, error } = useResource(
     () => {
       const cid = Number(id);
@@ -320,13 +333,24 @@ export default function CharacterProfile() {
       </div>
     ) : null;
 
-  return (
-    <FactionProfileBody
-      character={character}
-      submissions={submissions}
-      proposedTasks={proposedTasks}
-      progression={progression}
-      identityActions={identityActions}
-    />
-  );
+  const bodyProps: ProfileBodyProps = {
+    character,
+    submissions,
+    proposedTasks,
+    progression,
+    identityActions,
+  };
+
+  // Phone → the mobile-native profile skin (Default fallback until a faction
+  // registers its own); desktop → the existing faction-dispatched body.
+  if (formFactor === "mobile") {
+    const Mobile = pickVariant(
+      MOBILE_PROFILE_BY_SLUG,
+      character.faction_slug,
+      DefaultProfile,
+    );
+    return <Mobile {...bodyProps} />;
+  }
+
+  return <FactionProfileBody {...bodyProps} />;
 }

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -9,6 +9,43 @@ import { useAuth } from '../auth/AuthContext'
 import { factionCssVar, factionName } from '../utils/factions'
 import { extractError } from '../utils/errors'
 import { mediaUrl } from '../utils/media'
+import type { CharacterOut, CurrentUser } from '../api/auth'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { pickVariant } from '../utils/factionDispatch'
+import DefaultPlayers, {
+  type PlayersDirectoryProps,
+} from './players/mobileArchetypes/DefaultPlayers'
+
+type MobileSkin = (props: PlayersDirectoryProps) => JSX.Element
+
+// Parallel MOBILE registry, mirroring Tasks. The players directory isn't keyed
+// by a single faction slug, so this stays empty and every phone render falls
+// through to the Default directory skin; bespoke faction directories can
+// register here later.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {}
+
+export default function Leaderboard() {
+  const { user } = useAuth()
+  const { data, loading, error } = useResource(() => getLeaderboard({ limit: 50 }), [])
+  const formFactor = useFormFactor()
+  const characters = data ?? []
+
+  if (formFactor === 'mobile') {
+    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, null, DefaultPlayers)
+    return (
+      <Mobile
+        characters={characters}
+        loading={loading}
+        error={error}
+        myCharId={user?.character?.id ?? null}
+      />
+    )
+  }
+
+  return (
+    <DesktopLeaderboard characters={characters} loading={loading} error={error} user={user} />
+  )
+}
 
 // Rank colors reference CSS vars defined in index.css (--rank-gold, --rank-silver, --rank-bronze)
 const RANK_STYLES = [
@@ -17,12 +54,19 @@ const RANK_STYLES = [
   { color: 'var(--rank-bronze)', bgSubtle: 'rgba(136,136,136,0.08)', textFaint: 'rgba(136,136,136,0.13)' },
 ]
 
-export default function Leaderboard() {
+function DesktopLeaderboard({
+  characters,
+  loading,
+  error,
+  user,
+}: {
+  characters: CharacterOut[]
+  loading: boolean
+  error: Error | null
+  user: CurrentUser | null
+}) {
   const { t } = useTranslation('common')
-  const { user } = useAuth()
   const [scoreMode, setScoreMode] = useState<'era' | 'alltime'>('era')
-  const { data, loading, error } = useResource(() => getLeaderboard({ limit: 50 }), [])
-  const characters = data ?? []
 
   const sorted = [...characters].sort((a, b) =>
     scoreMode === 'era' ? b.score - a.score : b.all_time_score - a.all_time_score

--- a/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
@@ -1,0 +1,259 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { BadgeOut } from '../../../api/auth'
+import { badgeArtFor } from '../../../components/badges/badgeArt'
+import PraxisCard from '../../../components/PraxisCard'
+import TaskCard from '../../../components/TaskCard'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import type { ProfileBodyProps } from '../FactionProfileBody'
+
+type Segment = 'praxis' | 'tasks'
+
+/**
+ * Default MOBILE public-profile skin (#517) — a phone-native reflow of the
+ * desktop CharacterProfile that CONSUMES the same #459 player-profile contract
+ * (identity, badges, friend/foe, dropped role/about): a centred credential
+ * header, a real-fields stats row, badges (hidden when empty), the friend/foe
+ * control, and a segmented Praxis / Tasks toggle over the existing PraxisCard /
+ * TaskCard components stacked single-column. Presentation only — renders no
+ * field the contract doesn't expose. Every faction falls through here until it
+ * registers a bespoke mobile profile skin.
+ */
+export default function DefaultProfile({
+  character,
+  submissions,
+  proposedTasks,
+  identityActions,
+}: ProfileBodyProps) {
+  const { t } = useTranslation('common')
+  const [segment, setSegment] = useState<Segment>('praxis')
+  const badges = character.badges ?? []
+  const color = factionCssVar(character.faction_slug)
+
+  return (
+    <div className="py-4" data-testid="mobile-profile">
+      {/* ── ① Identity — centred credential header ── */}
+      <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        {character.avatar_url ? (
+          <img
+            src={mediaUrl(character.avatar_url)}
+            alt={character.display_name}
+            style={{
+              width: 84,
+              height: 84,
+              borderRadius: '50%',
+              objectFit: 'cover',
+              border: `2px solid ${factionCssVar(character.faction_slug, 'border')}`,
+            }}
+          />
+        ) : (
+          <span
+            aria-hidden
+            style={{
+              width: 84,
+              height: 84,
+              borderRadius: '50%',
+              background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${color})`,
+              border: `2px solid ${factionCssVar(character.faction_slug, 'border')}`,
+            }}
+          />
+        )}
+        <h1
+          className="font-display italic font-medium"
+          style={{ fontSize: 26, marginTop: 12, color: 'var(--color-text-primary)', overflowWrap: 'anywhere' }}
+        >
+          {character.display_name}
+        </h1>
+        <div className="eyebrow" style={{ marginTop: 5, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          <i style={{ width: 8, height: 8, borderRadius: 2, background: color, flex: 'none' }} />
+          {t('leaderboard.mobile.factionLevel', {
+            faction: factionName(character.faction_slug),
+            level: character.level,
+          })}
+        </div>
+
+        {/* friend/foe — kept feature (#459), faction-skinned, folded under identity */}
+        {identityActions && <div style={{ marginTop: 14, maxWidth: 220, width: '100%' }}>{identityActions}</div>}
+      </div>
+
+      {/* ── Stats row — real fields only ── */}
+      <div
+        style={{
+          display: 'flex',
+          margin: '18px 0',
+          border: '1px solid var(--color-border)',
+          borderRadius: 12,
+          background: 'var(--color-bg-surface-alt)',
+          overflow: 'hidden',
+        }}
+      >
+        <Stat label={t('profile.mobile.stats.points')} value={character.score} />
+        <Stat label={t('profile.mobile.stats.praxis')} value={submissions.length} divider />
+        <Stat label={t('profile.mobile.stats.tasks')} value={proposedTasks.length} divider />
+      </div>
+
+      {/* ── ③ Badges — hidden entirely when empty ── */}
+      {badges.length > 0 && (
+        <div style={{ marginBottom: 18 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+            <h2 className="font-display italic" style={{ fontSize: 18, color: 'var(--color-text-primary)' }}>
+              {t('profile.badgesHeading')}
+            </h2>
+            <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)' }}>
+              {t('profile.badgesEarned', { count: badges.length })}
+            </span>
+          </div>
+          <div
+            style={{
+              border: '1px solid var(--color-border)',
+              borderRadius: 12,
+              background: 'var(--color-bg-surface-alt)',
+              padding: '2px 14px',
+            }}
+          >
+            {badges.map((badge, index) => (
+              <BadgeRow key={badge.key} badge={badge} last={index === badges.length - 1} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Segmented Praxis / Tasks toggle ── */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 4,
+          padding: 4,
+          borderRadius: 999,
+          background: 'var(--color-bg-surface-alt)',
+          border: '1px solid var(--color-border)',
+          marginBottom: 14,
+        }}
+      >
+        <SegTab on={segment === 'praxis'} onClick={() => setSegment('praxis')}>
+          {t('profile.mobile.tabPraxis')}
+        </SegTab>
+        <SegTab on={segment === 'tasks'} onClick={() => setSegment('tasks')}>
+          {t('profile.mobile.tabTasks')}
+        </SegTab>
+      </div>
+
+      {/* ── Content — reuse the existing cards, stacked single-column ── */}
+      {segment === 'praxis' ? (
+        submissions.length === 0 ? (
+          <p className="font-body text-muted">{t('profile.praxisEmptyTitle')}</p>
+        ) : (
+          <div className="flex flex-col gap-4 items-stretch">
+            {submissions.map((praxis) => (
+              <PraxisCard key={praxis.id} praxis={praxis} />
+            ))}
+          </div>
+        )
+      ) : proposedTasks.length === 0 ? (
+        <p className="font-body text-muted">{t('profile.proposedTasksEmpty')}</p>
+      ) : (
+        <div className="flex flex-col gap-4 items-stretch">
+          {proposedTasks.map((task) => (
+            <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Stat({ label, value, divider }: { label: string; value: number; divider?: boolean }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        textAlign: 'center',
+        padding: '12px 6px',
+        borderLeft: divider ? '1px solid var(--color-border)' : undefined,
+      }}
+    >
+      <div className="font-display italic" style={{ fontSize: 22, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+        {value}
+      </div>
+      <div className="eyebrow" style={{ color: 'var(--color-text-tertiary)', marginTop: 2 }}>
+        {label}
+      </div>
+    </div>
+  )
+}
+
+function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
+  const Art = badgeArtFor(badge.key)
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 11,
+        padding: '10px 0',
+        borderBottom: last ? 'none' : '1px solid var(--color-border)',
+      }}
+    >
+      <span
+        style={{
+          flexShrink: 0,
+          width: 34,
+          height: 34,
+          borderRadius: '50%',
+          padding: 2.5,
+          background: 'var(--faction-default-ring)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          boxSizing: 'border-box',
+        }}
+      >
+        <span
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: '50%',
+            background: 'var(--color-bg-surface-alt)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          <Art size={16} />
+        </span>
+      </span>
+      <div className="font-display italic" style={{ fontSize: 15, color: 'var(--color-text-primary)' }}>
+        {badge.name}
+      </div>
+    </div>
+  )
+}
+
+function SegTab({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 1,
+        fontFamily: "'Courier Prime', monospace",
+        fontSize: 11,
+        fontWeight: on ? 700 : 400,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        color: on ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
+        background: on ? 'var(--color-text-primary)' : 'transparent',
+        border: 'none',
+        borderRadius: 999,
+        padding: '9px 0',
+        minHeight: 36,
+        cursor: 'pointer',
+      }}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/pages/characterProfile/mobileArchetypes/__tests__/defaultProfile.test.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/__tests__/defaultProfile.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Mobile public profile (#517) — form-factor dispatch + the Default mobile
+ * profile content-slot invariant. The dispatch test renders <CharacterProfile/>
+ * with the data + form-factor hooks mocked (phone → the Default mobile skin,
+ * desktop → the existing faction-dispatched body). The content test renders the
+ * Default mobile skin directly to pin the reused #459 contract fields: identity,
+ * the real-fields stats row, badges, friend/foe, and the segmented Praxis/Tasks
+ * toggle over the shared PraxisCard/TaskCard.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../../i18n'
+import type { CharacterOut } from '../../../../api/auth'
+import type { PraxisCardOut } from '../../../../api/praxis'
+import type { TaskOut } from '../../../../api/tasks'
+import type { ProfileBodyProps } from '../../FactionProfileBody'
+
+const mocks = vi.hoisted(() => ({
+  formFactor: 'desktop' as 'mobile' | 'desktop',
+  character: null as CharacterOut | null,
+}))
+
+vi.mock('../../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+vi.mock('../../../../hooks/useResource', () => ({
+  useResource: () => ({
+    data: [mocks.character, [], []],
+    loading: false,
+    error: null,
+    refetch: () => {},
+  }),
+}))
+vi.mock('../../../../hooks/useGameConfig', () => ({
+  useGameConfig: () => ({ level_thresholds: [0, 100, 200, 300, 400] }),
+}))
+vi.mock('../../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}))
+
+import CharacterProfile from '../../../CharacterProfile'
+import DefaultProfile from '../DefaultProfile'
+
+function html(element: ReactElement): { html: string; text: string } {
+  const out = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html: out, text: out.replace(/<[^>]*>/g, '') }
+}
+
+function character(overrides: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    id: 7,
+    username: 'reza',
+    display_name: 'Reza',
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 7,
+    score: 1880,
+    all_time_score: 2400,
+    faction_slug: 'ephemerists',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [{ key: 'sock_puppet', name: 'Sock Puppet' }],
+    ...overrides,
+  }
+}
+
+function praxis(overrides: Partial<PraxisCardOut> = {}): PraxisCardOut {
+  return {
+    id: 101,
+    task_id: 5,
+    task_title: 'Map a hidden gap',
+    task_point_value: 20,
+    task_level_required: 2,
+    type: 'solo',
+    status: 'submitted',
+    title: 'A quiet finding',
+    moderation_status: 'visible',
+    created_by_id: 7,
+    created_by_display_name: 'Reza',
+    created_at: '2026-01-02T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+    submitted_at: '2026-01-02T00:00:00Z',
+    member_count: 1,
+    score: 32,
+    voter_count: 3,
+    is_top_for_task: false,
+    task_faction_slug: 'ephemerists',
+    ...overrides,
+  }
+}
+
+function task(overrides: Partial<TaskOut> = {}): TaskOut {
+  return {
+    id: 55,
+    title: 'Plant a tree',
+    description: 'Dig a hole and plant a native sapling.',
+    point_value: 20,
+    level_required: 2,
+    status: 'active',
+    task_type: 'standard',
+    created_by: 7,
+    primary_faction_slug: 'ephemerists',
+    metatask_faction_slug: null,
+    is_task_vision_eligible: false,
+    created_at: '2026-01-01T00:00:00Z',
+    can_submit_praxis: true,
+    allowed_modes: ['solo'],
+    eligible_for_current_user: true,
+    ...overrides,
+  }
+}
+
+function renderPage(): { html: string; text: string } {
+  return {
+    html: renderToStaticMarkup(
+      <MemoryRouter initialEntries={['/characters/7']}>
+        <Routes>
+          <Route path="/characters/:id" element={<CharacterProfile />} />
+        </Routes>
+      </MemoryRouter>,
+    ),
+    text: '',
+  }
+}
+
+describe('public profile form-factor dispatch', () => {
+  it('renders the Default mobile profile skin on mobile', () => {
+    mocks.formFactor = 'mobile'
+    mocks.character = character({ faction_slug: null })
+    expect(renderPage().html).toContain('data-testid="mobile-profile"')
+  })
+
+  it('renders the desktop faction-dispatched body on desktop (untouched)', () => {
+    mocks.formFactor = 'desktop'
+    mocks.character = character({ faction_slug: null })
+    const out = renderPage().html
+    expect(out).not.toContain('data-testid="mobile-profile"')
+    expect(out).toContain('Unaffiliated · faction pending')
+  })
+})
+
+describe('Default mobile profile content slots', () => {
+  const props: ProfileBodyProps = {
+    character: character(),
+    submissions: [praxis()],
+    proposedTasks: [task()],
+    progression: null,
+    identityActions: <div>Friend</div>,
+  }
+
+  it('renders identity, stats, badges and friend/foe from the #459 contract', () => {
+    const { text } = html(<DefaultProfile {...props} />)
+    expect(text, 'name').toContain('Reza')
+    expect(text, 'stats row').toContain('Points')
+    expect(text, 'badge').toContain('Sock Puppet')
+    expect(text, 'friend/foe control').toContain('Friend')
+  })
+
+  it('offers a segmented Praxis/Tasks toggle over the reused cards', () => {
+    const { text } = html(<DefaultProfile {...props} />)
+    // Praxis is the default segment → the reused PraxisCard renders.
+    expect(text, 'praxis card').toContain('Map a hidden gap')
+    expect(text, 'tasks tab present').toContain('Tasks')
+  })
+})

--- a/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Mobile players directory (#517) — form-factor dispatch + the directory→profile
+ * navigation contract. Mirrors the Tasks mobile-browse test: renders <Leaderboard/>
+ * with useFormFactor mocked (phone → the Default directory skin, desktop → the
+ * existing podium/table board), then renders the Default directory skin directly
+ * over controlled rows to pin the scannable list + the /characters/:id links a tap
+ * follows to the public profile.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CharacterOut, CurrentUser } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({
+  formFactor: 'desktop' as 'mobile' | 'desktop',
+}))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: null as CurrentUser | null }),
+}))
+vi.mock('../../../api/leaderboard', () => ({
+  getLeaderboard: async () => [],
+}))
+
+import Leaderboard from '../../Leaderboard'
+import DefaultPlayers from '../mobileArchetypes/DefaultPlayers'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+function player(overrides: Partial<CharacterOut>): CharacterOut {
+  return {
+    id: 1,
+    username: 'wren',
+    display_name: 'Wren',
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 3,
+    score: 320,
+    all_time_score: 900,
+    faction_slug: 'everymen',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const PLAYERS: CharacterOut[] = [
+  player({ id: 11, display_name: 'Perpetua', faction_slug: 'everymen', score: 2140 }),
+  player({ id: 22, display_name: 'Reza', faction_slug: 'ephemerists', score: 1880 }),
+  player({ id: 33, display_name: 'Molly', faction_slug: null, score: 340 }),
+]
+
+describe('players directory form-factor dispatch', () => {
+  it('renders the Default directory skin on mobile', () => {
+    mocks.formFactor = 'mobile'
+    const { html } = render(<Leaderboard />)
+    expect(html).toContain('data-testid="mobile-players-directory"')
+  })
+
+  it('renders the desktop podium board on desktop (untouched)', () => {
+    mocks.formFactor = 'desktop'
+    const { html, text } = render(<Leaderboard />)
+    expect(html).not.toContain('data-testid="mobile-players-directory"')
+    // PageTitle eyebrow is desktop-only chrome.
+    expect(text).toContain('Era I')
+  })
+})
+
+describe('Default players directory content + navigation', () => {
+  it('renders a scannable rank/name/points row per player', () => {
+    const { text } = render(
+      <DefaultPlayers characters={PLAYERS} loading={false} error={null} myCharId={22} />,
+    )
+    expect(text).toContain('Perpetua')
+    expect(text).toContain('Reza')
+    expect(text).toContain('2140')
+  })
+
+  it('links every row to its public profile (directory → profile)', () => {
+    const { html } = render(
+      <DefaultPlayers characters={PLAYERS} loading={false} error={null} myCharId={null} />,
+    )
+    expect(html).toContain('href="/characters/11"')
+    expect(html).toContain('href="/characters/22"')
+    expect(html).toContain('href="/characters/33"')
+  })
+
+  it('offers a sort chip row + a faction filter chip per present faction', () => {
+    const { text } = render(
+      <DefaultPlayers characters={PLAYERS} loading={false} error={null} myCharId={null} />,
+    )
+    const lower = text.toLowerCase()
+    expect(lower, 'sort chips').toContain('sort:')
+    expect(lower, 'faction chips').toContain('faction:')
+    expect(text, 'unaffiliated present').toContain('Unaffiliated')
+  })
+
+  it('renders the empty state when no players match', () => {
+    const { text } = render(
+      <DefaultPlayers characters={[]} loading={false} error={null} myCharId={null} />,
+    )
+    expect(text).toContain('No players match this filter.')
+  })
+})

--- a/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
+++ b/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
@@ -1,0 +1,273 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { CharacterOut } from '../../../api/auth'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+
+export interface PlayersDirectoryProps {
+  characters: CharacterOut[]
+  loading: boolean
+  error: Error | null
+  /** The viewer's own character id, highlighted in the list. */
+  myCharId: number | null
+}
+
+type ScoreMode = 'era' | 'alltime'
+
+/** Unaffiliated players carry a null faction_slug; normalise to a stable chip
+ *  key so the "All / <faction>" filter can include them. factionName(null)
+ *  already resolves to the Unaffiliated copy. */
+const UNAFFILIATED = 'na'
+const slugKey = (slug: string | null): string => slug ?? UNAFFILIATED
+
+/**
+ * Default MOBILE players-directory skin (#517) — a scannable single-column
+ * ranking (rank · avatar · faction tint · level · points) with phone-native
+ * filter chips (sort by era/all-time score, filter by faction), NOT the desktop
+ * podium + table. A row taps through to the public profile. Mirrors the
+ * DefaultTasks mobile browse idiom; consumes the same leaderboard read the
+ * desktop board uses (presentation-only, no backend change).
+ */
+export default function DefaultPlayers({ characters, loading, error, myCharId }: PlayersDirectoryProps) {
+  const { t } = useTranslation('common')
+  const [scoreMode, setScoreMode] = useState<ScoreMode>('era')
+  const [faction, setFaction] = useState<string>('')
+
+  const scoreOf = (c: CharacterOut) => (scoreMode === 'era' ? c.score : c.all_time_score)
+  const sorted = [...characters].sort((a, b) => scoreOf(b) - scoreOf(a))
+  const shown = faction === '' ? sorted : sorted.filter((c) => slugKey(c.faction_slug) === faction)
+
+  // Distinct factions present, in canonical rainbow order, for the filter row.
+  const presentSlugs = Array.from(new Set(characters.map((c) => slugKey(c.faction_slug))))
+  const factionChips = sortFactionsByRainbowOrder(presentSlugs.map((slug) => ({ slug })))
+
+  return (
+    <div className="py-4" data-testid="mobile-players-directory">
+      <h1
+        className="font-display italic font-medium mb-1"
+        style={{ fontSize: 26, color: 'var(--color-text-primary)', lineHeight: 1.1 }}
+      >
+        {t('nav.players')}
+      </h1>
+      <p className="eyebrow mb-3">{t('leaderboard.mobile.count', { count: characters.length })}</p>
+
+      {/* Sort chips — era vs all-time score */}
+      <ChipRow label={t('filters.sort')}>
+        <Chip on={scoreMode === 'era'} onClick={() => setScoreMode('era')}>
+          {t('leaderboard.mobile.sortEra')}
+        </Chip>
+        <Chip on={scoreMode === 'alltime'} onClick={() => setScoreMode('alltime')}>
+          {t('leaderboard.mobile.sortAllTime')}
+        </Chip>
+      </ChipRow>
+
+      {/* Faction chips */}
+      <ChipRow label={t('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('leaderboard.mobile.allFactions')}
+        </Chip>
+        {factionChips.map(({ slug }) => (
+          <Chip
+            key={slug}
+            on={faction === slug}
+            onClick={() => setFaction(faction === slug ? '' : slug)}
+            tint={factionCssVar(slug === UNAFFILIATED ? null : slug)}
+          >
+            {factionName(slug === UNAFFILIATED ? null : slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      {/* Results */}
+      <div className="mt-4">
+        {loading ? (
+          <p className="font-body text-muted">{t('leaderboard.loading')}</p>
+        ) : error ? (
+          <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
+            {t('leaderboard.mobile.loadError')}
+          </p>
+        ) : shown.length === 0 ? (
+          <p className="font-body text-muted">{t('leaderboard.mobile.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {shown.map((character, index) => (
+              <PlayerRow
+                key={character.id}
+                character={character}
+                rank={index + 1}
+                points={scoreOf(character)}
+                isMe={character.id === myCharId}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function PlayerRow({
+  character,
+  rank,
+  points,
+  isMe,
+}: {
+  character: CharacterOut
+  rank: number
+  points: number
+  isMe: boolean
+}) {
+  const { t } = useTranslation('common')
+  const color = factionCssVar(character.faction_slug)
+  return (
+    <Link
+      to={`/characters/${character.id}`}
+      className="sidebar-card"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px 10px 16px',
+        borderLeft: `4px solid ${color}`,
+        textDecoration: 'none',
+        background: isMe ? factionCssVar(character.faction_slug, 'light') : undefined,
+      }}
+    >
+      {/* Rank */}
+      <span
+        className="font-display italic"
+        style={{
+          flex: 'none',
+          minWidth: 22,
+          textAlign: 'center',
+          fontSize: 16,
+          fontWeight: 700,
+          color: 'var(--color-text-tertiary)',
+        }}
+      >
+        {rank}
+      </span>
+
+      {/* Avatar */}
+      {character.avatar_url ? (
+        <img
+          src={mediaUrl(character.avatar_url)}
+          alt={character.display_name}
+          style={{ width: 40, height: 40, borderRadius: '50%', objectFit: 'cover', flex: 'none' }}
+        />
+      ) : (
+        <span
+          aria-hidden
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: '50%',
+            flex: 'none',
+            background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${color})`,
+          }}
+        />
+      )}
+
+      {/* Name + faction · level */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          className="font-display italic truncate"
+          style={{ fontSize: 16, color: 'var(--color-text-primary)', lineHeight: 1.15 }}
+        >
+          {character.display_name}
+        </div>
+        <div
+          className="eyebrow"
+          style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}
+        >
+          <i style={{ width: 8, height: 8, borderRadius: 2, background: color, flex: 'none' }} />
+          {t('leaderboard.mobile.factionLevel', {
+            faction: factionName(character.faction_slug),
+            level: character.level,
+          })}
+        </div>
+      </div>
+
+      {/* Points */}
+      <div style={{ flex: 'none', textAlign: 'right' }}>
+        <div
+          className="font-body"
+          style={{ fontSize: 16, fontWeight: 700, color: 'var(--color-text-primary)' }}
+        >
+          {points}
+        </div>
+        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+          {t('leaderboard.mobile.points')}
+        </span>
+      </div>
+    </Link>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span className="eyebrow" style={{ flex: 'none' }}>
+        {label}
+      </span>
+      <div
+        className="flex gap-2"
+        style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: "'Courier Prime', monospace",
+        fontSize: 11,
+        fontWeight: on ? 700 : 400,
+        letterSpacing: '0.05em',
+        textTransform: 'uppercase',
+        color: on ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
+        background: on ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+        border: `1px solid ${on ? 'transparent' : 'var(--color-border-strong)'}`,
+        borderRadius: 999,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && (
+        <i
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 2,
+            flex: 'none',
+            background: tint,
+          }}
+        />
+      )}
+      {children}
+    </button>
+  )
+}


### PR DESCRIPTION
Closes #517

Mobile-native reflow of the Players directory/leaderboard and the public character profile, dispatched on `useFormFactor() === 'mobile'` in `Leaderboard.tsx` and `CharacterProfile.tsx`. Desktop surfaces are unchanged; the phone path renders new Default (na) skins.

## What's here
- **Players directory** (`players/mobileArchetypes/DefaultPlayers.tsx`): single-column ranking (rank, avatar, faction tint via `factionCssVar`, level, points) with phone-native filter chips (sort era/all-time + faction). Rows link to `/characters/:id`.
- **Public profile** (`characterProfile/mobileArchetypes/DefaultProfile.tsx`): centred credential header, real-fields stats row (Points/Praxis/Tasks), badges (hidden when empty), friend/foe control, and a segmented Praxis/Tasks toggle over the reused `PraxisCard`/`TaskCard`. Consumes the #459 contract only — renders no fields it doesn't expose (per README corrections: real fields, friend/foe not Follow, badges from #459).
- Empty `MOBILE_ARCHETYPE_BY_SLUG` / `MOBILE_PROFILE_BY_SLUG` registries + Default fallback, mirroring the Tasks/FieldDesk seam.
- i18n keys added to `common.json`; no hardcoded hex (CSS vars / `--faction-*`); single-column stacking.

## Verification
- `npm run lint` — clean
- `npm test` (vitest) — 44 files / 323 tests pass, incl. new dispatch + directory-to-profile navigation tests
- `tsc --noEmit` — the only errors are 12 pre-existing ones in the untouched `AlbescentInvitation.tsx` (factions-namespace i18n key typing); the changed/new files type-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
