### PR TITLE
Mobile: Character paths — create / switch / edit (#516)

### DIFF
--- a/frontend/src/api/characters.ts
+++ b/frontend/src/api/characters.ts
@@ -51,6 +51,13 @@ export async function updateCharacter(id: number, body: CharacterUpdate): Promis
   return data
 }
 
+/** Soft-delete an owned character (DELETE /characters/{id}, 204). Server rejects
+ *  deleting someone else's life; the account's active life is re-resolved on the
+ *  next /auth/me refetch. */
+export async function deleteCharacter(id: number): Promise<void> {
+  await api.delete(`/characters/${id}`)
+}
+
 export async function uploadCharacterAvatar(id: number, file: File): Promise<CharacterOut> {
   const form = new FormData()
   form.append('file', file)

--- a/frontend/src/components/CharacterSwitcherSheet.tsx
+++ b/frontend/src/components/CharacterSwitcherSheet.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState, type CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../auth/AuthContext'
+import { getMyCharacters, setActiveCharacter } from '../api/me'
+import type { CharacterOut } from '../api/auth'
+import { factionCssVar, factionName } from '../utils/factions'
+import { mediaUrl } from '../utils/media'
+
+/**
+ * MOBILE active-character switcher (#516) — a bottom sheet over Home. Lists the
+ * account's lives (active one checkmarked), swaps the carried life on tap
+ * (`POST /me/active-character` then refetch), and holds the two path actions:
+ * Create new character and Edit this character. Opened from the Home character
+ * card's Switch / avatar caret. Presentation-only over existing endpoints.
+ */
+
+// Decorative edit glyph (aria-hidden icon); a const so the jsx-text-only literal
+// rule doesn't read it as user-facing copy.
+const PENCIL_GLYPH = '✎'
+export default function CharacterSwitcherSheet({
+  open,
+  activeCharacterId,
+  onClose,
+}: {
+  open: boolean
+  activeCharacterId: number
+  onClose: () => void
+}) {
+  const { t } = useTranslation('common')
+  const { refetch } = useAuth()
+  const navigate = useNavigate()
+  const [lives, setLives] = useState<CharacterOut[]>([])
+  const [switching, setSwitching] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    void getMyCharacters().then(setLives).catch(() => setLives([]))
+  }, [open])
+
+  if (!open) return null
+
+  const enterLife = async (id: number) => {
+    if (id === activeCharacterId) {
+      onClose()
+      return
+    }
+    setSwitching(id)
+    try {
+      await setActiveCharacter(id)
+      await refetch()
+      onClose()
+    } finally {
+      setSwitching(null)
+    }
+  }
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label={t('fieldDesk.home.switcher.title')}>
+      <button type="button" aria-label={t('fieldDesk.home.switcher.close')} onClick={onClose} style={scrim} />
+      <div style={sheet}>
+        <span style={grab} />
+        <div style={sheetTitle}>{t('fieldDesk.home.switcher.title')}</div>
+
+        <CharacterSwitcherRows
+          lives={lives}
+          activeCharacterId={activeCharacterId}
+          onSelect={enterLife}
+          switching={switching}
+        />
+
+        <button type="button" onClick={() => navigate('/characters/create')} style={{ ...sheetAction, borderTop: '1px solid var(--color-border)' }}>
+          <span style={actionIcon}>+</span>
+          {t('fieldDesk.home.switcher.createNew')}
+        </button>
+        <button type="button" onClick={() => navigate(`/characters/${activeCharacterId}/edit`)} style={sheetAction}>
+          <span style={actionIcon}>{PENCIL_GLYPH}</span>
+          {t('fieldDesk.home.switcher.editThis')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Presentational roster rows — extracted so the selection surface is testable
+ * without a DOM (renderToStaticMarkup): the active life is checkmarked, every
+ * other life is a tappable row that fires `onSelect(id)`.
+ */
+export function CharacterSwitcherRows({
+  lives,
+  activeCharacterId,
+  onSelect,
+  switching = null,
+}: {
+  lives: CharacterOut[]
+  activeCharacterId: number
+  onSelect: (id: number) => void
+  switching?: number | null
+}) {
+  const { t } = useTranslation('common')
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {lives.map((life) => {
+        const isActive = life.id === activeCharacterId
+        return (
+          <button
+            key={life.id}
+            type="button"
+            onClick={() => onSelect(life.id)}
+            disabled={switching != null}
+            data-testid={`switcher-row-${life.id}`}
+            data-active={isActive ? 'true' : 'false'}
+            style={switchRow}
+          >
+            <span style={{ ...miniRing, background: 'var(--faction-default-ring)' }}>
+              {life.avatar_url ? (
+                <img src={mediaUrl(life.avatar_url)} alt={life.display_name} style={miniAvatarImg} />
+              ) : (
+                <span
+                  style={{
+                    ...miniAvatarImg,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: `linear-gradient(135deg, ${factionCssVar(life.faction_slug, 'light')}, ${factionCssVar(life.faction_slug)})`,
+                    fontFamily: 'var(--faction-default-card-font)',
+                    fontStyle: 'italic',
+                    fontSize: 17,
+                    color: 'var(--color-text-on-accent)',
+                  }}
+                >
+                  {life.display_name[0]?.toUpperCase() ?? '?'}
+                </span>
+              )}
+            </span>
+            <span style={{ flex: 1, minWidth: 0, textAlign: 'left' }}>
+              <span style={rowName}>{life.display_name}</span>
+              <span style={rowMeta}>
+                {t('fieldDesk.home.switcher.meta', {
+                  faction: factionName(life.faction_slug),
+                  level: life.level,
+                  points: life.score,
+                })}
+              </span>
+            </span>
+            {isActive ? (
+              <span aria-hidden style={{ color: 'var(--faction-default-card-muted)', fontSize: 16, flex: 'none' }}>✓</span>
+            ) : (
+              <span style={rowTapHint}>{t('fieldDesk.home.switcher.tapToUse')}</span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// --- token-driven styles ----------------------------------------------------
+
+const scrim: CSSProperties = {
+  position: 'fixed', inset: 0, zIndex: 40, border: 'none', padding: 0,
+  background: 'rgba(0,0,0,0.45)', cursor: 'pointer',
+}
+const sheet: CSSProperties = {
+  position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 41,
+  background: 'var(--color-bg-surface)', borderRadius: '22px 22px 0 0',
+  padding: '10px 16px calc(26px + env(safe-area-inset-bottom))',
+  boxShadow: '0 -12px 34px rgba(0,0,0,0.3)', maxHeight: '80vh', overflowY: 'auto',
+}
+const grab: CSSProperties = {
+  display: 'block', width: 38, height: 4, borderRadius: 999,
+  background: 'var(--color-border-strong)', margin: '2px auto 14px',
+}
+const sheetTitle: CSSProperties = {
+  fontFamily: 'var(--font-display)', fontStyle: 'italic', fontSize: 18,
+  color: 'var(--color-text-primary)', margin: '0 4px 6px',
+}
+const switchRow: CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 12, padding: '12px 4px',
+  borderBottom: '1px solid var(--color-border)', cursor: 'pointer',
+  background: 'none', border: 'none', borderBottomStyle: 'solid',
+  borderBottomWidth: 1, borderBottomColor: 'var(--color-border)', width: '100%',
+}
+const miniRing: CSSProperties = {
+  width: 44, height: 44, borderRadius: '50%', padding: 2, flex: 'none',
+}
+const miniAvatarImg: CSSProperties = {
+  width: '100%', height: '100%', borderRadius: '50%', objectFit: 'cover',
+}
+const rowName: CSSProperties = {
+  display: 'block', fontFamily: 'var(--font-display)', fontStyle: 'italic',
+  fontSize: 16, color: 'var(--color-text-primary)',
+  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+}
+const rowMeta: CSSProperties = {
+  display: 'block', fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase',
+  color: 'var(--color-text-secondary)', marginTop: 3,
+}
+const rowTapHint: CSSProperties = {
+  fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase',
+  color: 'var(--color-text-tertiary)', flex: 'none',
+}
+const sheetAction: CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 12, padding: '15px 4px', width: '100%',
+  color: 'var(--color-text-primary)', fontFamily: 'var(--font-display)',
+  fontStyle: 'italic', fontSize: 15, cursor: 'pointer', background: 'none', border: 'none',
+}
+const actionIcon: CSSProperties = {
+  width: 34, height: 34, borderRadius: '50%', border: '1.5px dashed var(--color-border-strong)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16,
+  color: 'var(--color-text-secondary)', flex: 'none',
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -77,6 +77,15 @@
       "title": "FieldDesk",
       "charEyebrow": "You",
       "edit": "Edit",
+      "switch": "Switch",
+      "switcher": {
+        "title": "Your characters",
+        "close": "Close",
+        "tapToUse": "Tap to use",
+        "meta": "{{faction}} · Level {{level}} · {{points}} pts",
+        "createNew": "Create new character",
+        "editThis": "Edit this character"
+      },
       "questsHeading": "In progress",
       "questsEmpty": "Nothing in progress yet — pick up a task.",
       "viewAll": "All tasks",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -19,7 +19,15 @@
     "submitBusy": "Stepping out…",
     "cancel": "Cancel",
     "startsAt": "starts at Lvl 1 · 0 pts",
-    "previewFallbackName": "Wanderer"
+    "previewFallbackName": "Wanderer",
+    "mobile": {
+      "title": "New character",
+      "step": "Step 1 of 2 · Identity",
+      "addPhoto": "Add photo",
+      "changePhoto": "Change photo",
+      "help": "Upload a photo — it becomes your avatar everywhere. You'll pick a faction after your first task; until then you play as Unaffiliated and every path is open to you.",
+      "submit": "Create character"
+    }
   },
   "editCharacter": {
     "loading": "Loading...",
@@ -46,7 +54,18 @@
     "optional": "· optional",
     "saveBusy": "Saving...",
     "saveIdle": "Save Changes",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "mobile": {
+      "changePhoto": "Change photo",
+      "taglineLabel": "Tagline",
+      "factionLabel": "Faction",
+      "unaffiliated": "Unaffiliated",
+      "factionHelp": "Join a faction from the Factions tab. It re-skins your whole app.",
+      "delete": "Delete this character",
+      "deleteConfirm": "Delete this character? This can't be undone.",
+      "deleteConfirmYes": "Delete",
+      "deleteBusy": "Deleting…"
+    }
   },
   "autosaveAgo": {
     "justNow": "just now",

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -1,101 +1,72 @@
-import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import { useRef, type CSSProperties } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { useAuth } from '../auth/AuthContext'
-import { createCharacter, uploadCharacterAvatar } from '../api/characters'
-import { getInvitedFactions } from '../api/me'
 import { factionCssVar, factionName } from '../utils/factions'
-import { extractError } from '../utils/errors'
 import CredentialCard from '../components/CredentialCard'
 import ImageEditModal from '../components/imageEdit/ImageEditModal'
-import { AVATAR_ASPECT, blobToFile } from '../components/imageEdit/imageEditHelpers'
+import { AVATAR_ASPECT } from '../components/imageEdit/imageEditHelpers'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { pickVariant } from '../utils/factionDispatch'
+import {
+  useCreateCharacter,
+  NAME_MAX,
+  BIO_MAX,
+  type CreateCharacterState,
+} from './characterPaths/useCreateCharacter'
+import DefaultCreateCharacter from './characterPaths/mobileArchetypes/DefaultCreateCharacter'
 
 /**
  * Adaptive Character Creation (#273, ADR-0019). One screen, two renderings: the
  * faction picker appears iff the account holds invitations; otherwise a brand-new
  * account creates a born-unaffiliated ("na") life. One submit path either way.
+ *
+ * On a phone (#516) the same {@link useCreateCharacter} state drives a mobile
+ * skin (full-column form + sticky Create), dispatched through the parallel
+ * registry; every faction falls through to the Default skin. Desktop unchanged.
  */
 
-const NAME_MAX = 22
-const BIO_MAX = 160
-const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
+type MobileSkin = (props: { state: CreateCharacterState }) => JSX.Element
 
-/** Mirror of the server @handle derivation (services/character._derive_unique_username). */
-function previewHandle(displayName: string): string {
-  return displayName.toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 14) || 'wanderer'
-}
+// Only factions with a bespoke mobile create screen register here; na and the
+// rest fall through to DefaultCreateCharacter (mirrors Tasks/FieldDesk).
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {}
 
 export default function CreateCharacter() {
+  const state = useCreateCharacter()
+  const formFactor = useFormFactor()
+
+  if (formFactor === 'mobile') {
+    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, null, DefaultCreateCharacter)
+    return <Mobile state={state} />
+  }
+
+  return <DesktopCreateCharacter state={state} />
+}
+
+function DesktopCreateCharacter({ state }: { state: CreateCharacterState }) {
   const { t } = useTranslation('forms')
-  const { refetch } = useAuth()
   const navigate = useNavigate()
-
-  const [displayName, setDisplayName] = useState('')
-  const [bio, setBio] = useState('')
-  const [factionSlug, setFactionSlug] = useState<string>('') // '' = born na
-  const [invited, setInvited] = useState<string[]>([])
-  const [avatarFile, setAvatarFile] = useState<File | null>(null)
-  const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
-  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
-  const [error, setError] = useState<string | null>(null)
-  const [submitting, setSubmitting] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    void getInvitedFactions().then(setInvited).catch(() => setInvited([]))
-  }, [])
-
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] ?? null
-    e.target.value = ''
-    if (!file) return
-    if (file.size > MAX_AVATAR_SIZE) {
-      setError('Portrait must be under 10 MB.')
-      return
-    }
-    setError(null)
-    // Crop/rotate to a square before it becomes the portrait (#514).
-    setAvatarSource(file)
-  }
-
-  const handleAvatarConfirm = (blob: Blob) => {
-    const source = avatarSource
-    const file = blobToFile(blob, source?.name ?? 'avatar')
-    setAvatarFile(file)
-    setAvatarPreview(URL.createObjectURL(file))
-    setAvatarSource(null)
-  }
-
-  const trimmedName = displayName.trim()
-  const canSubmit = trimmedName.length > 0 && !submitting
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!canSubmit) return
-    setSubmitting(true)
-    setError(null)
-    try {
-      // Never send a faction the account wasn't invited to; '' → born na.
-      const picked = factionSlug && invited.includes(factionSlug) ? factionSlug : undefined
-      const character = await createCharacter({
-        display_name: trimmedName,
-        bio: bio || undefined,
-        faction_slug: picked,
-      })
-      if (avatarFile) {
-        await uploadCharacterAvatar(character.id, avatarFile)
-      }
-      await refetch() // server already set the new life active
-      navigate(`/characters/${character.id}`)
-    } catch (err) {
-      setError(extractError(err))
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  const handle = previewHandle(displayName)
-  const showPicker = invited.length > 0
+  const {
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    factionSlug,
+    setFactionSlug,
+    invited,
+    avatarPreview,
+    avatarSource,
+    setAvatarSource,
+    handleFile,
+    handleAvatarConfirm,
+    error,
+    submitting,
+    canSubmit,
+    handleSubmit,
+    handle,
+    showPicker,
+  } = state
 
   return (
     <div className="page">

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useState, useRef, type CSSProperties } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useRef, type CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { getCharacter, updateCharacter, uploadCharacterAvatar, type CharacterOut } from '../api/characters'
-import { useAuth } from '../auth/AuthContext'
-import { extractError } from '../utils/errors'
 import { mediaUrl } from '../utils/media'
 import DefaultSigil from '../components/cards/DefaultSigil'
 import ImageEditModal from '../components/imageEdit/ImageEditModal'
-import { AVATAR_ASPECT, blobToFile } from '../components/imageEdit/imageEditHelpers'
+import { AVATAR_ASPECT } from '../components/imageEdit/imageEditHelpers'
+import { useFormFactor } from '../hooks/useFormFactor'
+import { pickVariant } from '../utils/factionDispatch'
+import { useEditCharacter, type EditCharacterState } from './characterPaths/useEditCharacter'
+import DefaultEditCharacter from './characterPaths/mobileArchetypes/DefaultEditCharacter'
 
 /**
  * Edit Character — themed in the spectrum default skin for EVERYONE, regardless
@@ -17,8 +18,19 @@ import { AVATAR_ASPECT, blobToFile } from '../components/imageEdit/imageEditHelp
  * fields (display_name, bio, location), the avatar upload, and validation are
  * unchanged. `@handle` is the auto-derived, unique username (ADR-0019): shown
  * read-only, never an input. No pronouns field (a separate feature — new column).
+ *
+ * On a phone (#516) the same {@link useEditCharacter} state drives a mobile skin
+ * (single-column form + Change photo, faction link-out, delete, sticky Save),
+ * dispatched through the parallel registry; every faction falls through to the
+ * Default skin. Desktop unchanged.
  */
 const DISPLAY = 'var(--faction-default-card-font)'
+
+type MobileSkin = (props: { state: EditCharacterState }) => JSX.Element
+
+// Only factions with a bespoke mobile edit screen register here; na and the
+// rest fall through to DefaultEditCharacter (mirrors Tasks/FieldDesk).
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {}
 
 const inputStyle: CSSProperties = {
   width: '100%',
@@ -34,82 +46,41 @@ const inputStyle: CSSProperties = {
 }
 
 export default function EditCharacter() {
+  const state = useEditCharacter()
+  const formFactor = useFormFactor()
+
+  if (formFactor === 'mobile') {
+    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, null, DefaultEditCharacter)
+    return <Mobile state={state} />
+  }
+
+  return <DesktopEditCharacter state={state} />
+}
+
+function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
   const { t } = useTranslation('forms')
-  const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { user, refetch } = useAuth()
-  const [character, setCharacter] = useState<CharacterOut | null>(null)
-  const [displayName, setDisplayName] = useState('')
-  const [bio, setBio] = useState('')
-  const [location, setLocation] = useState('')
-  const [avatarFile, setAvatarFile] = useState<File | null>(null)
-  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(true)
-  const [avatarError, setAvatarError] = useState('')
   const fileRef = useRef<HTMLInputElement>(null)
-
-  const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
-
-  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0] || null
-    e.target.value = ''
-    if (!f) return
-    if (f.size > MAX_AVATAR_SIZE) {
-      setAvatarError('Avatar must be under 10 MB.')
-      return
-    }
-    setAvatarError('')
-    // Crop/rotate to a square before it becomes the avatar (#514).
-    setAvatarSource(f)
-  }
-
-  const handleAvatarConfirm = (blob: Blob) => {
-    setAvatarFile(blobToFile(blob, avatarSource?.name ?? 'avatar'))
-    setAvatarSource(null)
-  }
-
-  useEffect(() => {
-    if (!id) return
-    getCharacter(parseInt(id, 10))
-      .then((c) => {
-        setCharacter(c)
-        setDisplayName(c.display_name)
-        setBio(c.bio || '')
-        setLocation(c.location || '')
-      })
-      .catch((err) => setError(extractError(err, 'Could not load character.')))
-      .finally(() => setLoading(false))
-  }, [id])
-
-  // Only allow editing your own character
-  const isOwner = user?.character?.id === character?.id
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!id || !character) return
-    setSaving(true)
-    setError('')
-    try {
-      const characterId = parseInt(id, 10)
-      if (avatarFile) {
-        await uploadCharacterAvatar(characterId, avatarFile)
-      }
-      const updated = await updateCharacter(characterId, {
-        display_name: displayName,
-        bio: bio || undefined,
-        location: location || undefined,
-      })
-      setCharacter(updated)
-      await refetch()
-      navigate(`/characters/${characterId}`)
-    } catch (err) {
-      setError(extractError(err, 'Could not save changes.'))
-    } finally {
-      setSaving(false)
-    }
-  }
+  const {
+    id,
+    character,
+    loading,
+    isOwner,
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    location,
+    setLocation,
+    avatarSource,
+    setAvatarSource,
+    avatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+    saving,
+    error,
+    handleSubmit,
+  } = state
 
   if (loading) return <div className="py-8 font-body text-muted">{t('editCharacter.loading')}</div>
   if (!character) return <div className="py-8 font-body text-muted">{t('editCharacter.notFound')}</div>

--- a/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Mobile character-paths behaviour (#516). No jsdom in this repo, so we assert
+ * on renderToStaticMarkup output plus the pure payload builder:
+ *  - create yields an UNAFFILIATED life unless an invited faction is picked;
+ *  - the Default mobile create/edit skins emit their invariant slots;
+ *  - the switcher lists the roster, checkmarks the active life, and leaves every
+ *    other life a tappable select row (the selection surface).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so shared copy keys resolve to English text.
+import '../../../i18n'
+import { buildCreatePayload, type CreateCharacterState } from '../useCreateCharacter'
+import type { EditCharacterState } from '../useEditCharacter'
+import DefaultCreateCharacter from '../mobileArchetypes/DefaultCreateCharacter'
+import DefaultEditCharacter from '../mobileArchetypes/DefaultEditCharacter'
+import { CharacterSwitcherRows } from '../../../components/CharacterSwitcherSheet'
+import type { CharacterOut } from '../../../api/auth'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+function character(overrides: Partial<CharacterOut>): CharacterOut {
+  return {
+    id: 1,
+    username: 'molly',
+    display_name: 'Molly',
+    bio: 'Doing very human things.',
+    avatar_url: null,
+    location: null,
+    level: 4,
+    score: 340,
+    all_time_score: 340,
+    faction_slug: null,
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function createState(overrides: Partial<CreateCharacterState>): CreateCharacterState {
+  return {
+    displayName: 'Molly',
+    setDisplayName: () => {},
+    bio: '',
+    setBio: () => {},
+    factionSlug: '',
+    setFactionSlug: () => {},
+    invited: [],
+    avatarPreview: null,
+    avatarSource: null,
+    setAvatarSource: () => {},
+    handleFile: () => {},
+    handleAvatarConfirm: () => {},
+    error: null,
+    submitting: false,
+    canSubmit: true,
+    handleSubmit: () => {},
+    handle: 'molly',
+    showPicker: false,
+    ...overrides,
+  }
+}
+
+function editState(overrides: Partial<EditCharacterState>): EditCharacterState {
+  return {
+    id: '1',
+    character: character({}),
+    loading: false,
+    isOwner: true,
+    displayName: 'Molly',
+    setDisplayName: () => {},
+    bio: 'Doing very human things.',
+    setBio: () => {},
+    location: '',
+    setLocation: () => {},
+    avatarFile: null,
+    avatarSource: null,
+    setAvatarSource: () => {},
+    avatarError: '',
+    handleAvatarChange: () => {},
+    handleAvatarConfirm: () => {},
+    saving: false,
+    error: '',
+    handleSubmit: () => {},
+    deleting: false,
+    handleDelete: () => {},
+    ...overrides,
+  }
+}
+
+describe('buildCreatePayload — born unaffiliated (ADR-0019)', () => {
+  it('sends no faction when none is picked', () => {
+    expect(buildCreatePayload('Wren', '', '', []).faction_slug).toBeUndefined()
+  })
+
+  it('never sends a faction the account was not invited to', () => {
+    expect(buildCreatePayload('Wren', '', 'wow', []).faction_slug).toBeUndefined()
+    expect(buildCreatePayload('Wren', '', 'wow', ['everymen']).faction_slug).toBeUndefined()
+  })
+
+  it('carries an invited faction when picked', () => {
+    expect(buildCreatePayload('Wren', '', 'wow', ['wow']).faction_slug).toBe('wow')
+  })
+
+  it('trims the display name', () => {
+    expect(buildCreatePayload('  Wren  ', '', '', []).display_name).toBe('Wren')
+  })
+})
+
+describe('DefaultCreateCharacter mobile skin', () => {
+  it('renders the name field and a sticky Create action', () => {
+    const { html, text } = render(<DefaultCreateCharacter state={createState({})} />)
+    expect(html, 'name input').toContain('value="Molly"')
+    expect(text, 'sticky create').toContain('Create character')
+    expect(text, 'born-unaffiliated explainer').toContain('Unaffiliated')
+  })
+})
+
+describe('DefaultEditCharacter mobile skin', () => {
+  it('renders name, tagline, faction link-out, delete and sticky Save', () => {
+    const { html, text } = render(<DefaultEditCharacter state={editState({})} />)
+    expect(html, 'name input').toContain('value="Molly"')
+    expect(text, 'tagline label (real bio field)').toContain('Tagline')
+    expect(html, 'tagline value is the bio').toContain('value="Doing very human things."')
+    // Faction is read-only and links out to the Factions surface.
+    expect(html, 'faction link-out').toContain('href="/factions"')
+    expect(text, 'unaffiliated').toContain('Unaffiliated')
+    expect(text, 'delete affordance').toContain('Delete this character')
+    expect(text, 'sticky save').toContain('Save Changes')
+  })
+
+  it('links out to a joined faction detail page', () => {
+    const { html } = render(<DefaultEditCharacter state={editState({ character: character({ faction_slug: 'wow' }) })} />)
+    expect(html).toContain('href="/factions/wow"')
+  })
+})
+
+describe('CharacterSwitcherRows — selection surface', () => {
+  const roster = [character({ id: 1, display_name: 'Molly' }), character({ id: 2, display_name: 'Wren', level: 1, score: 20 })]
+
+  it('lists every life, checkmarks the active one, leaves others tappable', () => {
+    const { html, text } = render(
+      <CharacterSwitcherRows lives={roster} activeCharacterId={1} onSelect={() => {}} />,
+    )
+    expect(text).toContain('Molly')
+    expect(text).toContain('Wren')
+    // Active life is marked; the inactive one advertises the tap-to-switch action.
+    expect(html).toContain('data-active="true"')
+    expect(html).toContain('data-active="false"')
+    // The active row carries the marked flag; the inactive row is the switch target.
+    expect(html).toMatch(/data-testid="switcher-row-1"[^>]*data-active="true"/)
+    expect(html).toMatch(/data-testid="switcher-row-2"[^>]*data-active="false"/)
+    expect(text.toLowerCase()).toContain('tap to use')
+  })
+})

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
@@ -1,0 +1,201 @@
+import { useRef, type CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
+import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
+import { NAME_MAX, type CreateCharacterState } from '../useCreateCharacter'
+
+/**
+ * Default (na) MOBILE character-creation skin (#516). First-run, single-column:
+ * a centred photo-add ring, name field, the born-unaffiliated explainer, an
+ * optional calling picker (only when invited), and a sticky Create bar reachable
+ * one-handed. Presentation-only — the whole submit path lives in
+ * {@link useCreateCharacter}; every faction falls through here.
+ *
+ * Layout is flex/relative single-column — no fixed-px grid drives the page
+ * (SPEC-faction-ui-profile §1a).
+ */
+export default function DefaultCreateCharacter({ state }: { state: CreateCharacterState }) {
+  const { t } = useTranslation('forms')
+  const navigate = useNavigate()
+  const fileRef = useRef<HTMLInputElement>(null)
+  const {
+    displayName,
+    setDisplayName,
+    factionSlug,
+    setFactionSlug,
+    invited,
+    avatarPreview,
+    avatarSource,
+    setAvatarSource,
+    handleFile,
+    handleAvatarConfirm,
+    error,
+    submitting,
+    canSubmit,
+    handleSubmit,
+    handle,
+    showPicker,
+  } = state
+
+  return (
+    <form data-skin="default" data-testid="mobile-create-character" onSubmit={handleSubmit} style={page}>
+      {/* Top row — back + title */}
+      <div style={topRow}>
+        <button type="button" onClick={() => navigate('/')} style={backBtn} aria-label={t('createCharacter.cancel')}>
+          ‹
+        </button>
+        <span className="eyebrow" style={{ fontSize: 10 }}>{t('createCharacter.mobile.title')}</span>
+        <span style={{ width: 28 }} />
+      </div>
+
+      {/* Photo add */}
+      <div style={{ textAlign: 'center' }}>
+        <button type="button" onClick={() => fileRef.current?.click()} style={ringBtn}>
+          <span style={ringInner}>
+            {avatarPreview ? (
+              <img src={avatarPreview} alt={handle} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <span style={{ fontSize: 26, color: 'var(--color-text-secondary)' }}>+</span>
+            )}
+          </span>
+        </button>
+        <div className="eyebrow" style={{ marginTop: 12, fontSize: 9, color: 'var(--faction-default-card-muted)' }}>
+          {avatarPreview ? t('createCharacter.mobile.changePhoto') : t('createCharacter.mobile.addPhoto')}
+        </div>
+        <div className="eyebrow" style={{ marginTop: 6, fontSize: 8, color: 'var(--color-text-tertiary)' }}>
+          {t('createCharacter.mobile.step')}
+        </div>
+      </div>
+      <input ref={fileRef} type="file" accept="image/*" onChange={handleFile} style={{ display: 'none' }} />
+
+      {/* Name */}
+      <div>
+        <label style={label}>{t('createCharacter.nameLabel')}</label>
+        <input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          maxLength={NAME_MAX}
+          placeholder={t('createCharacter.namePlaceholder')}
+          autoFocus
+          style={field}
+        />
+        <div style={metaRow}>
+          <span style={{ color: 'var(--color-text-tertiary)' }}>@{handle}</span>
+          <span style={{ color: displayName.length >= NAME_MAX ? 'var(--color-danger)' : 'var(--color-text-tertiary)' }}>
+            {t('createCharacter.charsLeft', { count: NAME_MAX - displayName.length })}
+          </span>
+        </div>
+      </div>
+
+      {/* Faction picker — only when the account holds invitations (ADR-0019) */}
+      {showPicker && (
+        <div>
+          <label style={label}>{t('createCharacter.callingLabel')}</label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
+            {invited.map((slug) => {
+              const selected = factionSlug === slug
+              return (
+                <button
+                  key={slug}
+                  type="button"
+                  onClick={() => setFactionSlug(selected ? '' : slug)}
+                  style={{
+                    ...pickerCell,
+                    boxShadow: selected ? `0 0 0 2px ${factionCssVar(slug)}` : 'none',
+                  }}
+                >
+                  <span style={{ width: 12, height: 12, borderRadius: '50%', background: factionCssVar(slug), flexShrink: 0 }} />
+                  <span style={{ fontFamily: factionCssVar(slug, 'card-font'), fontSize: 14, color: 'var(--color-text-primary)' }}>
+                    {factionName(slug)}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Born-unaffiliated explainer */}
+      <p style={help}>{t('createCharacter.mobile.help')}</p>
+
+      {error && <p style={errorBox}>{error}</p>}
+
+      {/* Sticky Create bar */}
+      <div style={stickyBar}>
+        <button type="submit" disabled={!canSubmit} style={{ ...primaryBtn, opacity: canSubmit ? 1 : 0.5 }}>
+          {submitting ? t('createCharacter.submitBusy') : t('createCharacter.mobile.submit')}
+        </button>
+      </div>
+
+      {/* Portrait crop/rotate — locked square (#514). */}
+      {avatarSource && (
+        <ImageEditModal
+          key={`${avatarSource.name}-${avatarSource.lastModified}`}
+          file={avatarSource}
+          aspect={AVATAR_ASPECT}
+          onConfirm={handleAvatarConfirm}
+          onCancel={() => setAvatarSource(null)}
+        />
+      )}
+    </form>
+  )
+}
+
+// --- token-driven styles (single column, no hardcoded hex) ------------------
+
+const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 22, paddingBottom: 96 }
+const topRow: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
+const backBtn: CSSProperties = {
+  width: 28, height: 28, background: 'none', border: 'none', cursor: 'pointer',
+  fontSize: 24, lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
+}
+const ringBtn: CSSProperties = {
+  width: 104, height: 104, borderRadius: '50%', padding: 3, cursor: 'pointer',
+  border: 'none', background: 'var(--faction-default-rainbow)',
+}
+const ringInner: CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  width: '100%', height: '100%', borderRadius: '50%', overflow: 'hidden',
+  background: 'var(--color-bg-surface-alt)',
+}
+const label: CSSProperties = {
+  display: 'block', fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+  color: 'var(--color-text-secondary)',
+}
+const field: CSSProperties = {
+  display: 'block', width: '100%', marginTop: 8, boxSizing: 'border-box',
+  background: 'var(--color-bg-page)', border: '1px solid var(--color-border-strong)',
+  borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)', fontSize: 15,
+  color: 'var(--color-text-primary)', padding: '12px 13px',
+}
+const metaRow: CSSProperties = {
+  display: 'flex', justifyContent: 'space-between', marginTop: 6,
+  fontFamily: 'var(--font-body)', fontSize: 10,
+}
+const pickerCell: CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer', width: '100%',
+  background: 'var(--color-bg-surface)', border: '1px solid var(--color-border-strong)',
+  borderRadius: 8, padding: '13px 14px', textAlign: 'left',
+}
+const help: CSSProperties = {
+  fontFamily: 'var(--font-body)', fontSize: 12, lineHeight: 1.6,
+  color: 'var(--color-text-tertiary)', margin: 0,
+}
+const errorBox: CSSProperties = {
+  fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-danger)',
+  border: '1px solid var(--color-danger)', borderRadius: 6, padding: '10px 12px', margin: 0,
+}
+const stickyBar: CSSProperties = {
+  position: 'sticky',
+  bottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
+  marginTop: 'auto',
+  paddingTop: 8,
+}
+const primaryBtn: CSSProperties = {
+  width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 13,
+  letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700,
+  color: 'var(--color-bg-page)', background: 'var(--color-text-primary)',
+  border: 'none', padding: '15px 24px', borderRadius: 12,
+}

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -1,0 +1,235 @@
+import { useRef, useState, type CSSProperties } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { mediaUrl } from '../../../utils/media'
+import { factionName } from '../../../utils/factions'
+import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
+import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
+import type { EditCharacterState } from '../useEditCharacter'
+
+/**
+ * Default (na) MOBILE edit-character skin (#516). Single column: a photo ring
+ * with Change photo, name + tagline (the real `bio` field) inputs, a read-only
+ * faction row that links out to the Factions tab, a delete affordance (two-tap
+ * confirm), and a sticky Save bar. Presentation-only — persist/delete live in
+ * {@link useEditCharacter}; every faction falls through here.
+ *
+ * Layout is flex/relative single-column — no fixed-px grid drives the page
+ * (SPEC-faction-ui-profile §1a).
+ */
+export default function DefaultEditCharacter({ state }: { state: EditCharacterState }) {
+  const { t } = useTranslation('forms')
+  const navigate = useNavigate()
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const {
+    id,
+    character,
+    loading,
+    isOwner,
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    avatarSource,
+    setAvatarSource,
+    avatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+    saving,
+    error,
+    handleSubmit,
+    deleting,
+    handleDelete,
+  } = state
+
+  if (loading) return <p className="font-body text-muted">{t('editCharacter.loading')}</p>
+  if (!character) return <p className="font-body text-muted">{t('editCharacter.notFound')}</p>
+  if (!isOwner) return <p className="font-body text-muted">{t('editCharacter.notOwner')}</p>
+
+  const initial = (displayName.trim()[0] || character.username[0] || '?').toUpperCase()
+  const factionSlug = character.faction_slug
+  const factionHref = factionSlug ? `/factions/${factionSlug}` : '/factions'
+
+  return (
+    <form data-skin="default" data-testid="mobile-edit-character" onSubmit={handleSubmit} style={page}>
+      {/* Top row — back + title */}
+      <div style={topRow}>
+        <button type="button" onClick={() => navigate(`/characters/${id}`)} style={backBtn} aria-label={t('editCharacter.cancel')}>
+          ‹
+        </button>
+        <span className="eyebrow" style={{ fontSize: 10 }}>{t('editCharacter.heading')}</span>
+        <span style={{ width: 28 }} />
+      </div>
+
+      {/* Photo */}
+      <div style={{ textAlign: 'center' }}>
+        <button type="button" onClick={() => fileRef.current?.click()} style={ringBtn}>
+          <span style={ringInner}>
+            {character.avatar_url ? (
+              <img src={mediaUrl(character.avatar_url)} alt={character.username} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <span style={{ fontFamily: 'var(--faction-default-card-font)', fontStyle: 'italic', fontSize: 34, color: 'var(--color-text-primary)' }}>
+                {initial}
+              </span>
+            )}
+          </span>
+        </button>
+        <div className="eyebrow" style={{ marginTop: 12, fontSize: 9, color: 'var(--faction-default-card-muted)' }}>
+          {t('editCharacter.mobile.changePhoto')}
+        </div>
+        {avatarError && <p style={{ ...errorBox, marginTop: 8 }}>{avatarError}</p>}
+      </div>
+      <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarChange} style={{ display: 'none' }} />
+
+      {/* Name */}
+      <div>
+        <label style={label}>{t('editCharacter.displayNameLabel')}</label>
+        <input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          maxLength={50}
+          placeholder={t('editCharacter.displayNamePlaceholder')}
+          style={field}
+        />
+      </div>
+
+      {/* Tagline — the real bio field */}
+      <div>
+        <label style={label}>{t('editCharacter.mobile.taglineLabel')}</label>
+        <input
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          maxLength={500}
+          placeholder={t('editCharacter.storyPlaceholder')}
+          style={field}
+        />
+      </div>
+
+      {/* Faction — read-only link out to Factions */}
+      <div>
+        <label style={label}>{t('editCharacter.mobile.factionLabel')}</label>
+        <Link to={factionHref} style={factionRow}>
+          <span>{factionSlug ? factionName(factionSlug) : t('editCharacter.mobile.unaffiliated')}</span>
+          <span aria-hidden style={{ color: 'var(--color-text-tertiary)' }}>›</span>
+        </Link>
+        <p style={help}>{t('editCharacter.mobile.factionHelp')}</p>
+      </div>
+
+      {/* Delete — two-tap confirm */}
+      {confirmingDelete ? (
+        <div style={confirmRow}>
+          <span style={{ fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-text-secondary)' }}>
+            {t('editCharacter.mobile.deleteConfirm')}
+          </span>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button type="button" onClick={() => setConfirmingDelete(false)} style={confirmCancel}>
+              {t('editCharacter.cancel')}
+            </button>
+            <button type="button" onClick={handleDelete} disabled={deleting} style={confirmDelete}>
+              {deleting ? t('editCharacter.mobile.deleteBusy') : t('editCharacter.mobile.deleteConfirmYes')}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button type="button" onClick={() => setConfirmingDelete(true)} style={deleteBtn}>
+          {t('editCharacter.mobile.delete')}
+        </button>
+      )}
+
+      {error && <p style={errorBox}>{error}</p>}
+
+      {/* Sticky Save bar */}
+      <div style={stickyBar}>
+        <button type="submit" disabled={saving} style={{ ...primaryBtn, opacity: saving ? 0.5 : 1 }}>
+          {saving ? t('editCharacter.saveBusy') : t('editCharacter.saveIdle')}
+        </button>
+      </div>
+
+      {/* Avatar crop/rotate — locked square (#514). */}
+      {avatarSource && (
+        <ImageEditModal
+          key={`${avatarSource.name}-${avatarSource.lastModified}`}
+          file={avatarSource}
+          aspect={AVATAR_ASPECT}
+          onConfirm={handleAvatarConfirm}
+          onCancel={() => setAvatarSource(null)}
+        />
+      )}
+    </form>
+  )
+}
+
+// --- token-driven styles (single column, no hardcoded hex) ------------------
+
+const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 20, paddingBottom: 96 }
+const topRow: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
+const backBtn: CSSProperties = {
+  width: 28, height: 28, background: 'none', border: 'none', cursor: 'pointer',
+  fontSize: 24, lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
+}
+const ringBtn: CSSProperties = {
+  width: 96, height: 96, borderRadius: '50%', padding: 3, cursor: 'pointer',
+  border: 'none', background: 'var(--faction-default-rainbow)',
+}
+const ringInner: CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  width: '100%', height: '100%', borderRadius: '50%', overflow: 'hidden',
+  background: 'var(--faction-default-card-bg)',
+}
+const label: CSSProperties = {
+  display: 'block', fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+  color: 'var(--color-text-secondary)', marginBottom: 8,
+}
+const field: CSSProperties = {
+  display: 'block', width: '100%', boxSizing: 'border-box',
+  background: 'var(--color-bg-page)', border: '1px solid var(--color-border-strong)',
+  borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)', fontSize: 15,
+  color: 'var(--color-text-primary)', padding: '12px 13px',
+}
+const factionRow: CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+  background: 'var(--color-bg-surface-alt)', border: '1px solid var(--color-border-strong)',
+  borderRadius: 8, padding: '12px 13px', textDecoration: 'none',
+  fontFamily: 'var(--font-body)', fontSize: 15, color: 'var(--color-text-secondary)',
+}
+const help: CSSProperties = {
+  fontFamily: 'var(--font-body)', fontSize: 11, lineHeight: 1.6,
+  color: 'var(--color-text-tertiary)', margin: '8px 0 0',
+}
+const deleteBtn: CSSProperties = {
+  width: '100%', cursor: 'pointer', background: 'none', textAlign: 'center',
+  border: '1px solid var(--color-danger)', borderRadius: 8, padding: '12px',
+  fontFamily: 'var(--font-body)', fontSize: 12, letterSpacing: '0.1em',
+  textTransform: 'uppercase', color: 'var(--color-danger)',
+}
+const confirmRow: CSSProperties = {
+  display: 'flex', flexDirection: 'column', gap: 12,
+  border: '1px solid var(--color-danger)', borderRadius: 8, padding: '14px',
+}
+const confirmCancel: CSSProperties = {
+  flex: 1, cursor: 'pointer', background: 'var(--color-bg-surface)',
+  border: '1px solid var(--color-border-strong)', borderRadius: 8, padding: '10px',
+  fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-text-primary)',
+}
+const confirmDelete: CSSProperties = {
+  flex: 1, cursor: 'pointer', background: 'var(--color-danger)', border: 'none',
+  borderRadius: 8, padding: '10px', fontFamily: 'var(--font-body)', fontSize: 12,
+  letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-bg-page)',
+}
+const errorBox: CSSProperties = {
+  fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-danger)',
+  border: '1px solid var(--color-danger)', borderRadius: 6, padding: '10px 12px', margin: 0,
+}
+const stickyBar: CSSProperties = {
+  position: 'sticky',
+  bottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
+  marginTop: 'auto',
+  paddingTop: 8,
+}
+const primaryBtn: CSSProperties = {
+  width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 13,
+  letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700,
+  color: 'var(--color-bg-page)', background: 'var(--color-text-primary)',
+  border: 'none', padding: '15px 24px', borderRadius: 12,
+}

--- a/frontend/src/pages/characterPaths/useCreateCharacter.ts
+++ b/frontend/src/pages/characterPaths/useCreateCharacter.ts
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../../auth/AuthContext'
+import { createCharacter, uploadCharacterAvatar, type CharacterCreate } from '../../api/characters'
+import { getInvitedFactions } from '../../api/me'
+import { extractError } from '../../utils/errors'
+import { blobToFile } from '../../components/imageEdit/imageEditHelpers'
+
+/**
+ * Shared read/write model for Adaptive Character Creation (#273, ADR-0019),
+ * lifted out of CreateCharacter so the desktop screen and the mobile skin
+ * (#516) render the same one submit path. Presentation-only skins consume this;
+ * no faction is ever sent unless the account holds a matching invitation, so a
+ * brand-new account is born unaffiliated ("na").
+ */
+
+export const NAME_MAX = 22
+export const BIO_MAX = 160
+const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
+
+/** Mirror of the server @handle derivation (services/character._derive_unique_username). */
+export function previewHandle(displayName: string): string {
+  return displayName.toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 14) || 'wanderer'
+}
+
+/**
+ * Build the create payload. A faction is only ever carried when the account was
+ * invited to it; otherwise `faction_slug` is undefined → born unaffiliated.
+ */
+export function buildCreatePayload(
+  displayName: string,
+  bio: string,
+  factionSlug: string,
+  invited: string[],
+): CharacterCreate {
+  const picked = factionSlug && invited.includes(factionSlug) ? factionSlug : undefined
+  return {
+    display_name: displayName.trim(),
+    bio: bio || undefined,
+    faction_slug: picked,
+  }
+}
+
+export interface CreateCharacterState {
+  displayName: string
+  setDisplayName: (value: string) => void
+  bio: string
+  setBio: (value: string) => void
+  factionSlug: string
+  setFactionSlug: (value: string) => void
+  invited: string[]
+  avatarPreview: string | null
+  avatarSource: File | null
+  setAvatarSource: (file: File | null) => void
+  handleFile: (event: React.ChangeEvent<HTMLInputElement>) => void
+  handleAvatarConfirm: (blob: Blob) => void
+  error: string | null
+  submitting: boolean
+  canSubmit: boolean
+  handleSubmit: (event: React.FormEvent) => void | Promise<void>
+  handle: string
+  showPicker: boolean
+}
+
+export function useCreateCharacter(): CreateCharacterState {
+  const { refetch } = useAuth()
+  const navigate = useNavigate()
+
+  const [displayName, setDisplayName] = useState('')
+  const [bio, setBio] = useState('')
+  const [factionSlug, setFactionSlug] = useState<string>('') // '' = born na
+  const [invited, setInvited] = useState<string[]>([])
+  const [avatarFile, setAvatarFile] = useState<File | null>(null)
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
+  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    void getInvitedFactions().then(setInvited).catch(() => setInvited([]))
+  }, [])
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null
+    e.target.value = ''
+    if (!file) return
+    if (file.size > MAX_AVATAR_SIZE) {
+      setError('Portrait must be under 10 MB.')
+      return
+    }
+    setError(null)
+    // Crop/rotate to a square before it becomes the portrait (#514).
+    setAvatarSource(file)
+  }
+
+  const handleAvatarConfirm = (blob: Blob) => {
+    const file = blobToFile(blob, avatarSource?.name ?? 'avatar')
+    setAvatarFile(file)
+    setAvatarPreview(URL.createObjectURL(file))
+    setAvatarSource(null)
+  }
+
+  const trimmedName = displayName.trim()
+  const canSubmit = trimmedName.length > 0 && !submitting
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const character = await createCharacter(buildCreatePayload(displayName, bio, factionSlug, invited))
+      if (avatarFile) {
+        await uploadCharacterAvatar(character.id, avatarFile)
+      }
+      await refetch() // server already set the new life active
+      navigate(`/characters/${character.id}`)
+    } catch (err) {
+      setError(extractError(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return {
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    factionSlug,
+    setFactionSlug,
+    invited,
+    avatarPreview,
+    avatarSource,
+    setAvatarSource,
+    handleFile,
+    handleAvatarConfirm,
+    error,
+    submitting,
+    canSubmit,
+    handleSubmit,
+    handle: previewHandle(displayName),
+    showPicker: invited.length > 0,
+  }
+}

--- a/frontend/src/pages/characterPaths/useEditCharacter.ts
+++ b/frontend/src/pages/characterPaths/useEditCharacter.ts
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import {
+  getCharacter,
+  updateCharacter,
+  uploadCharacterAvatar,
+  deleteCharacter,
+  type CharacterOut,
+} from '../../api/characters'
+import { useAuth } from '../../auth/AuthContext'
+import { extractError } from '../../utils/errors'
+import { blobToFile } from '../../components/imageEdit/imageEditHelpers'
+
+/**
+ * Shared read/write model for Edit Character, lifted out of EditCharacter so the
+ * desktop screen and the mobile skin (#516) share one persist path. The three
+ * editable fields (display_name, bio, location), the avatar upload, delete, and
+ * validation live here; skins are presentation-only. `@handle` is the
+ * auto-derived unique username (ADR-0019) — read-only, never an input.
+ */
+
+const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
+
+export interface EditCharacterState {
+  id: string | undefined
+  character: CharacterOut | null
+  loading: boolean
+  isOwner: boolean
+  displayName: string
+  setDisplayName: (value: string) => void
+  bio: string
+  setBio: (value: string) => void
+  location: string
+  setLocation: (value: string) => void
+  avatarFile: File | null
+  avatarSource: File | null
+  setAvatarSource: (file: File | null) => void
+  avatarError: string
+  handleAvatarChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  handleAvatarConfirm: (blob: Blob) => void
+  saving: boolean
+  error: string
+  handleSubmit: (event: React.FormEvent) => void | Promise<void>
+  deleting: boolean
+  handleDelete: () => void | Promise<void>
+}
+
+export function useEditCharacter(): EditCharacterState {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user, refetch } = useAuth()
+  const [character, setCharacter] = useState<CharacterOut | null>(null)
+  const [displayName, setDisplayName] = useState('')
+  const [bio, setBio] = useState('')
+  const [location, setLocation] = useState('')
+  const [avatarFile, setAvatarFile] = useState<File | null>(null)
+  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [avatarError, setAvatarError] = useState('')
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0] || null
+    e.target.value = ''
+    if (!f) return
+    if (f.size > MAX_AVATAR_SIZE) {
+      setAvatarError('Avatar must be under 10 MB.')
+      return
+    }
+    setAvatarError('')
+    // Crop/rotate to a square before it becomes the avatar (#514).
+    setAvatarSource(f)
+  }
+
+  const handleAvatarConfirm = (blob: Blob) => {
+    setAvatarFile(blobToFile(blob, avatarSource?.name ?? 'avatar'))
+    setAvatarSource(null)
+  }
+
+  useEffect(() => {
+    if (!id) return
+    getCharacter(parseInt(id, 10))
+      .then((c) => {
+        setCharacter(c)
+        setDisplayName(c.display_name)
+        setBio(c.bio || '')
+        setLocation(c.location || '')
+      })
+      .catch((err) => setError(extractError(err, 'Could not load character.')))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  // Only allow editing your own character
+  const isOwner = user?.character?.id === character?.id
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!id || !character) return
+    setSaving(true)
+    setError('')
+    try {
+      const characterId = parseInt(id, 10)
+      if (avatarFile) {
+        await uploadCharacterAvatar(characterId, avatarFile)
+      }
+      const updated = await updateCharacter(characterId, {
+        display_name: displayName,
+        bio: bio || undefined,
+        location: location || undefined,
+      })
+      setCharacter(updated)
+      await refetch()
+      navigate(`/characters/${characterId}`)
+    } catch (err) {
+      setError(extractError(err, 'Could not save changes.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!id || !character) return
+    setDeleting(true)
+    setError('')
+    try {
+      await deleteCharacter(parseInt(id, 10))
+      await refetch() // server re-resolves the active life (or none)
+      navigate('/')
+    } catch (err) {
+      setError(extractError(err, 'Could not delete character.'))
+      setDeleting(false)
+    }
+  }
+
+  return {
+    id,
+    character,
+    loading,
+    isOwner,
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    location,
+    setLocation,
+    avatarFile,
+    avatarSource,
+    setAvatarSource,
+    avatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+    saving,
+    error,
+    handleSubmit,
+    deleting,
+    handleDelete,
+  }
+}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionCssVar, factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
@@ -16,9 +18,15 @@ import type { FieldDeskHomeState } from '../useFieldDeskHome'
  * Layout is flex/relative — no fixed-px grid drives the page structure
  * (SPEC-faction-ui-profile §1a).
  */
+
+// Decorative down-caret (aria-hidden) marking the name as a switcher trigger; a
+// const so the jsx-text-only literal rule doesn't read it as user-facing copy.
+const CARET_DOWN = '▾'
+
 export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
   const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+  const [switcherOpen, setSwitcherOpen] = useState(false)
 
   const stats = [
     { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
@@ -64,13 +72,23 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
           <span className="eyebrow" style={{ fontSize: 9, color: 'var(--color-text-secondary)' }}>
             {t('fieldDesk.home.charEyebrow')}
           </span>
-          <Link
-            to={`/characters/${character.id}/edit`}
-            className="eyebrow"
-            style={{ fontSize: 9, color: 'var(--faction-default-card-muted)', textDecoration: 'none' }}
-          >
-            {t('fieldDesk.home.edit')}
-          </Link>
+          <div className="flex items-center" style={{ gap: 14 }}>
+            <button
+              type="button"
+              onClick={() => setSwitcherOpen(true)}
+              className="eyebrow"
+              style={{ fontSize: 9, color: 'var(--faction-default-card-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+            >
+              {t('fieldDesk.home.switch')}
+            </button>
+            <Link
+              to={`/characters/${character.id}/edit`}
+              className="eyebrow"
+              style={{ fontSize: 9, color: 'var(--faction-default-card-muted)', textDecoration: 'none' }}
+            >
+              {t('fieldDesk.home.edit')}
+            </Link>
+          </div>
         </div>
 
         <div className="flex items-center gap-3.5">
@@ -95,13 +113,24 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <Link
-              to={`/characters/${character.id}`}
-              className="font-display italic block truncate"
-              style={{ fontSize: 24, lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-            >
-              {character.display_name}
-            </Link>
+            <div className="flex items-center gap-1.5" style={{ minWidth: 0 }}>
+              <Link
+                to={`/characters/${character.id}`}
+                className="font-display italic block truncate"
+                style={{ fontSize: 24, lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+              >
+                {character.display_name}
+              </Link>
+              {/* ▾ opens the active-character switcher sheet (#516). */}
+              <button
+                type="button"
+                onClick={() => setSwitcherOpen(true)}
+                aria-label={t('fieldDesk.home.switcher.title')}
+                style={{ flex: 'none', background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontSize: 14, lineHeight: 1, color: 'var(--color-text-tertiary)' }}
+              >
+                <span aria-hidden>{CARET_DOWN}</span>
+              </button>
+            </div>
             <div
               className="truncate"
               style={{
@@ -301,6 +330,13 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
           </Link>
         )}
       </div>
+
+      {/* Active-character switcher — bottom sheet over Home (#516). */}
+      <CharacterSwitcherSheet
+        open={switcherOpen}
+        activeCharacterId={character.id}
+        onClose={() => setSwitcherOpen(false)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Closes #516

Adds the three Default (na) **mobile** character-management paths, dispatched on `useFormFactor() === 'mobile'` behind the #494 form-factor seam (mirrors the Tasks / FieldDesk `MOBILE_ARCHETYPE_BY_SLUG` + Default-fallback pattern). Desktop rendering is unchanged; every path is presentation-only over existing endpoints.

## What's here
- **Create** — extracted `useCreateCharacter` (with a pure `buildCreatePayload`) so the desktop screen and a new `DefaultCreateCharacter` mobile skin (single-column: photo-add ring, name, born-unaffiliated explainer, optional invited-faction picker, sticky Create) share one submit path. Born **Unaffiliated** per ADR-0019 — no faction is ever sent unless the account holds a matching invitation.
- **Switch** — new `CharacterSwitcherSheet` bottom sheet over Home: the roster with the active life checkmarked, tap-to-switch, plus **Create new character** / **Edit this character** actions. Opened from the mobile FieldDesk character card's **Switch** button and the name **▾** caret.
- **Edit** — extracted `useEditCharacter` (with a `deleteCharacter` client over the existing `DELETE /characters/{id}`) so the desktop screen and a new `DefaultEditCharacter` mobile skin (photo, name, **Tagline** = real `bio`, read-only faction link-out to Factions, two-tap delete, sticky Save) share persist/delete.

## Notes
- All user-facing copy routed through `forms`/`common` i18n catalogs (ADR-0032 gate green).
- No hardcoded hex; colors via CSS vars / `--faction-*`. Single-column stacks, no fixed-px layout grids.
- The mobile shell keeps its tab bar (Layout-owned); the design's literal "no tab bar" on first-run create is left to the shell and not forced here.

## Verification
- `npm run lint` — clean.
- `npm test` — 321 passed (incl. new `characterPaths.test.tsx`: dispatch slots, unaffiliated payload, switcher selection surface).
- `tsc --noEmit` — the only errors are 12 pre-existing failures in `AlbescentInvitation.tsx` (present on clean `main`, unrelated); these new/changed files add zero type errors. (tsc is not in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
