### PR TITLE
Mobile: UA faction treatment (#525)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -122,6 +122,11 @@
         "questsWindow": "quests",
         "charEyebrow": "you",
         "questsHeading": "quests"
+      },
+      "ua": {
+        "masthead": "The Salon Desk",
+        "charEyebrow": "In residence",
+        "questsHeading": "At the easel"
       }
     }
   },

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -463,6 +463,9 @@
       "emptyWithSpotlight": "No other names on the wall yet.",
       "level": "Anno {{anno}}"
     },
+    "mobile": {
+      "eyebrow": "The Gilt Salon"
+    },
     "invitation": {
       "kicker": "the salon is enrolling",
       "headline": "Take up the brush",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -346,6 +346,8 @@
         "collab": { "label": "Atelier", "desc": "a joint acquisition" },
         "duel": { "label": "Salon Duel", "desc": "a contested acquisition" }
       },
+      "taskRefLabel": "Re: the commission",
+      "previewLabel": "As it will hang",
       "inviteLabel": "The other hands",
       "inviteLabelDuel": "The challenger",
       "invitePlaceholder": "name or @handle",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -170,7 +170,14 @@
         "patronsTotal_other": "{{count}} patrons · total",
         "pts": "{{points}} pts"
       },
-      "patronage": "The Patronage"
+      "patronage": "The Patronage",
+      "mobile": {
+        "back": "The Salon",
+        "re": "re:",
+        "theAcquisition": "The acquisition",
+        "plate": "The Plate",
+        "appraise": "Offer an appraisal"
+      }
     },
     "ephemerists": {
       "motto": "finding · testament · codex",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -25,6 +25,7 @@ import UAEditPraxis from "./editPraxis/archetypes/UAEditPraxis";
 import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
 import DefaultMobileEditPraxis from "./editPraxis/mobileArchetypes/DefaultEditPraxis";
 import WowMobileEditPraxis from "./editPraxis/mobileArchetypes/WowEditPraxis";
+import UAMobileEditPraxis from "./editPraxis/mobileArchetypes/UaComposer";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
@@ -46,6 +47,7 @@ const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
 // composers land incrementally, exactly like the desktop archetypes above.
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   wow: WowMobileEditPraxis,
+  ua: UAMobileEditPraxis,
 };
 
 export default function EditPraxis() {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -6,6 +6,7 @@ import { factionCssVar, factionName, factionDescription } from "../utils/faction
 import { pickVariant } from "../utils/factionDispatch";
 import { useFormFactor } from "../hooks/useFormFactor";
 import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFactionDetail";
+import UaFactionPage from "./factionDetail/mobileArchetypes/UaFactionPage";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import DefaultFactionPage from "./factionDetail/mobileArchetypes/DefaultFactionPage";
 import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
@@ -69,21 +70,24 @@ const FACTION_BODIES: Record<string, ComponentType<{ state: FactionDetailState }
   albescent: AlbescentFactionBody,
 };
 
-// Parallel MOBILE registry — the phone twin of FACTION_BODIES. Empty today: every
-// mobile render falls through to the single-column DefaultFactionPage skin. The
-// per-faction mobile follow-ups register their bespoke `factionPage/mobileArchetypes/*`
-// skins here (keyed by slug), exactly as the desktop bodies register in FACTION_BODIES.
+// Parallel MOBILE registry — the phone twin of FACTION_BODIES. Every mobile
+// render falls through to the single-column DefaultFactionPage skin unless a
+// faction registers its bespoke `factionDetail/mobileArchetypes/*` page here
+// (keyed by slug), exactly as the desktop bodies register in FACTION_BODIES. UA
+// is the first (its gilt-salon page, #525).
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<
   string,
   ComponentType<{ state: FactionDetailState }>
-> = {};
+> = {
+  ua: UaFactionPage,
+};
 
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {
   const { t } = useTranslation("factions");
   const { slug: slugParam } = useParams<{ slug: string }>();
   const slug = slugProp ?? slugParam;
-  const formFactor = useFormFactor();
   const state = useFactionDetail(slug);
+  const formFactor = useFormFactor();
   const { loading, faction, fetchError, members, tasks, recentPraxis } = state;
 
   if (loading)

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -12,6 +12,7 @@ import { useFormFactor } from '../hooks/useFormFactor'
 import { useFieldDeskHome, type FieldDeskHomeState } from './fieldDesk/useFieldDeskHome'
 import DefaultFieldDesk from './fieldDesk/mobileArchetypes/DefaultFieldDesk'
 import WowFieldDesk from './fieldDesk/mobileArchetypes/WowFieldDesk'
+import UaHome from './fieldDesk/mobileArchetypes/UaHome'
 
 /**
  * FieldDesk roster — the authenticated account home (#274). "Whose shoes today?":
@@ -32,6 +33,7 @@ type MobileHomeSkin = (props: { state: FieldDeskHomeState }) => JSX.Element
 // per-faction follow-ups), exactly like MOBILE_ARCHETYPE_BY_SLUG in TaskDetail.
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileHomeSkin> = {
   wow: WowFieldDesk,
+  ua: UaHome,
 }
 
 // Deterministic slight tilt per card — index-keyed so it's stable across renders.

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -17,6 +17,7 @@ import { useFormFactor } from '../hooks/useFormFactor'
 import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
 import DefaultMobilePraxisDetail from './praxisDetail/mobileArchetypes/DefaultPraxisDetail'
 import WowMobilePraxisDetail from './praxisDetail/mobileArchetypes/WowPraxisDetail'
+import UAMobilePraxisDetail from './praxisDetail/mobileArchetypes/UaPraxisDetail'
 import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
 import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
 import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
@@ -50,6 +51,7 @@ export const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDeta
  */
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDetailState }>> = {
   wow: WowMobilePraxisDetail,
+  ua: UAMobilePraxisDetail,
 }
 
 export default function PraxisDetail() {

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -16,6 +16,7 @@ import { useTaskDetail, type TaskDetailState } from "./taskDetail/useTaskDetail"
 import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
 import DefaultMobileTaskDetail from "./taskDetail/mobileArchetypes/DefaultTaskDetail";
 import EverymenMobileTaskDetail from "./taskDetail/mobileArchetypes/EverymenTaskDetail";
+import UAMobileTaskDetail from "./taskDetail/mobileArchetypes/UaTaskDetail";
 import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
@@ -45,6 +46,7 @@ export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
 // falls through to the Default mobile skin. Everymen is the first pilot (#497).
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   everymen: EverymenMobileTaskDetail,
+  ua: UAMobileTaskDetail,
 };
 
 export default function TaskDetail() {

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -9,21 +9,26 @@ import { useFormFactor } from '../hooks/useFormFactor'
 import { pickVariant } from '../utils/factionDispatch'
 import { useTasks, type TasksState } from './tasks/useTasks'
 import DefaultTasks from './tasks/mobileArchetypes/DefaultTasks'
+import UaTaskList from './tasks/mobileArchetypes/UaTaskList'
 
 type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 
-// Parallel MOBILE registry, mirroring TaskDetail. Task browse isn't dispatched
-// by a single faction slug the way detail is, so this stays empty and every
-// render falls through to the Default mobile browse skin; bespoke faction
-// browse skins can register here later (#496–#500).
-export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {}
+// Parallel MOBILE registry, mirroring TaskDetail. Task browse shows every
+// faction's tasks, so — unlike task/praxis detail — it has no single task slug
+// to dispatch on; instead the VIEWING life's faction picks the skin, so a UA
+// member reads the catalogue in the gilt salon (#525). Unregistered factions
+// (and logged-out visitors) fall through to the Default mobile browse skin.
+export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {
+  ua: UaTaskList,
+}
 
 export default function Tasks() {
   const state = useTasks()
   const formFactor = useFormFactor()
 
   if (formFactor === 'mobile') {
-    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, null, DefaultTasks)
+    const viewerSlug = state.user?.character?.faction_slug ?? null
+    const Mobile = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, viewerSlug, DefaultTasks)
     return <Mobile state={state} />
   }
 

--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -1,0 +1,357 @@
+import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import MediaArt from '../blocks/MediaArt'
+import { pickArtKey } from '../blocks/useMediaArt'
+import { ErrorBanner, formatAutosave } from '../archetypes/shared'
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from '../archetypes/controls'
+import type { EditPraxisState } from '../useEditPraxis'
+import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+
+/**
+ * Universal Assembly MOBILE composer (#525) — "Submit to the Salon" on a
+ * phone. The same single-column composer as the Default mobile skin
+ * (Write/Preview toggle, fluid media grid, sticky submit bar) dressed in gilt
+ * salon chrome: parchment plates in gold-leaf frames, engraved kickers, Cormorant
+ * italic titles. Ported from the desktop UA Atelier archetype; grounds on the
+ * `--faction-ua-*` / `--ua-*` tokens (always-light). Consumes `useEditPraxis`
+ * verbatim — no editor, upload, or submit logic lives here.
+ */
+
+const PAPER = 'var(--faction-ua-card-bg)'
+const PAPER_WARM = 'var(--ua-paper-warm)'
+const WALL = 'var(--ua-wall)'
+const INK = 'var(--faction-ua-card-text)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const SUB = 'var(--faction-ua-card-muted)'
+const MUTED = 'var(--ua-muted)'
+const GOLD = 'var(--ua-gold)'
+const GOLD_PALE = 'var(--ua-gold-pale)'
+const LINE = 'var(--ua-line)'
+const GILT = 'var(--ua-gilt)'
+const DISPLAY = 'var(--faction-ua-card-font)'
+const ENGRAVED = 'var(--font-faction-engraved)'
+const MONO = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  display: 'block',
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.22em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+/** A parchment plate in the gilt sandwich frame, headed by an engraved title. */
+function Plate({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ padding: 7, background: GILT, boxShadow: '0 8px 20px rgba(60,40,10,.16), inset 0 0 0 1px rgba(255,255,255,0.45)' }}>
+      <div style={{ padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+        <div style={{ background: PAPER, border: `1px solid ${LINE}`, padding: 14 }}>
+          <div style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: ACCENT, marginBottom: 10 }}>
+            {title}
+          </div>
+          {children}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default function UaComposer({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation('forms')
+  const [tab, setTab] = useState<ComposerTab>('write')
+  const praxis = state.praxis!
+  const task = state.task
+
+  return (
+    <div data-skin="ua" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: WALL }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 28, lineHeight: 1, color: INK, margin: 0 }}>
+            {t('editPraxis.ua.pageTitle')}
+          </h1>
+          <span style={{ ...kicker, marginLeft: 'auto' }}>
+            {state.autosaveAt
+              ? t('editPraxis.ua.autosaveSaved', { ago: formatAutosave(state.autosaveAt) })
+              : t('editPraxis.ua.autosaveUnsaved')}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: { gap: 4, padding: 3, background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999 },
+            buttonStyle: (active) => ({
+              padding: '9px 10px',
+              borderRadius: 999,
+              border: 'none',
+              fontFamily: ENGRAVED,
+              fontSize: 11,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              background: active ? ACCENT : 'transparent',
+              color: active ? PAPER_WARM : SUB,
+            }),
+          }}
+        />
+      </header>
+
+      {/* For-commission reference */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: PAPER, border: `1px solid ${LINE}` }}>
+        <span style={kicker}>{t('editPraxis.ua.taskRefLabel')}</span>
+        <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 16, color: INK, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
+          {praxis.task_title}
+        </span>
+      </div>
+      <div style={{ ...kicker, color: ACCENT }}>
+        {factionName(task?.primary_faction_slug ?? null)}
+        {task ? ` · ${t('taskMeta.points', { points: task.point_value })}` : ''}
+      </div>
+
+      {tab === 'write' ? (
+        <>
+          <Plate title={t('editPraxis.ua.titleLabel')}>
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t('editPraxis.ua.titlePlaceholder'),
+                inputStyle: {
+                  width: '100%',
+                  fontFamily: DISPLAY,
+                  fontStyle: 'italic',
+                  fontSize: 22,
+                  fontWeight: 700,
+                  color: INK,
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  borderBottom: `1px solid ${LINE}`,
+                  padding: '2px 0 8px',
+                },
+              }}
+            />
+          </Plate>
+
+          <Plate title={t('editPraxis.ua.bodyLabel', { words: state.wordCount })}>
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t('editPraxis.ua.bodyPlaceholder'),
+                textareaStyle: {
+                  width: '100%',
+                  fontFamily: DISPLAY,
+                  fontSize: 15,
+                  lineHeight: 1.6,
+                  color: INK,
+                  background: PAPER_WARM,
+                  border: `1px solid ${LINE}`,
+                  padding: '13px 15px',
+                  outline: 'none',
+                  resize: 'vertical',
+                  minHeight: 180,
+                },
+              }}
+            />
+          </Plate>
+
+          {state.showInviteBox && (
+            <Plate title={state.duelMode ? t('editPraxis.ua.inviteLabelDuel') : t('editPraxis.ua.inviteLabel')}>
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: MONO,
+                  inputBg: PAPER_WARM,
+                  inputColor: INK,
+                  inputBorder: `1px solid ${LINE}`,
+                  acceptedBg: ACCENT,
+                  acceptedColor: PAPER_WARM,
+                  placeholder: t('editPraxis.ua.invitePlaceholder'),
+                }}
+              />
+            </Plate>
+          )}
+
+          <Plate title={t('editPraxis.ua.filesLabel')}>
+            <MediaGrid state={state} />
+          </Plate>
+
+          {state.showMetatasks && (
+            <Plate title={t('editPraxis.ua.metatasksLabel')}>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: { display: 'flex', flexDirection: 'column', gap: 4 },
+                  rowStyle: (selected) => ({
+                    padding: '10px 12px',
+                    background: selected ? PAPER_WARM : 'transparent',
+                    border: `1px solid ${selected ? ACCENT : LINE}`,
+                  }),
+                  titleColor: INK,
+                  descColor: SUB,
+                  pointsActiveColor: ACCENT,
+                  pointsIdleColor: SUB,
+                }}
+              />
+            </Plate>
+          )}
+        </>
+      ) : (
+        <Plate title={t('editPraxis.ua.previewLabel')}>
+          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 22, color: INK, marginBottom: 10 }}>
+            {state.title || t('editPraxis.ua.titlePlaceholder')}
+          </div>
+          {state.media.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <MediaGrid state={state} readOnly />
+            </div>
+          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              markdownStyle: { fontFamily: DISPLAY, fontSize: 15, lineHeight: 1.6, color: INK },
+            }}
+          />
+        </Plate>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      <MobileStickyBar
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 0 4px',
+          background: 'var(--color-nav-bg)',
+          backdropFilter: 'blur(var(--nav-blur))',
+          borderTop: `1px solid ${GOLD}`,
+        }}
+      >
+        <PublishButton
+          state={state}
+          skin={{
+            idleLabel: t('editPraxis.ua.publishIdle'),
+            busyLabel: t('editPraxis.ua.publishBusy'),
+            style: {
+              flex: 1,
+              background: ACCENT,
+              color: PAPER_WARM,
+              fontFamily: ENGRAVED,
+              fontSize: 12,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              padding: '13px 18px',
+              border: `1px solid ${ACCENT}`,
+              cursor: state.submitting ? 'wait' : 'pointer',
+            },
+          }}
+        />
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.ua.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: MUTED,
+                fontFamily: DISPLAY,
+                fontStyle: 'italic',
+                fontSize: 14,
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
+      </MobileStickyBar>
+    </div>
+  )
+}
+
+/** Fluid 3-column media grid in the salon plate idiom. */
+function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOnly?: boolean }) {
+  const { t } = useTranslation('forms')
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+      {state.media.map((item) => {
+        const filename = item.file_path.split('/').pop() ?? item.file_path
+        const src = mediaUrl(item.file_path)
+        return (
+          <div key={item.id} style={{ position: 'relative', aspectRatio: '1 / 1', overflow: 'hidden', border: `1px solid ${GOLD}`, background: PAPER_WARM }}>
+            {item.type === 'image' ? (
+              <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : item.type === 'video' ? (
+              <video src={src} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <MediaArt art={pickArtKey(filename, 'audio')} width={120} height={120} />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t('media.removeAria', { name: filename })}
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  borderRadius: '50%',
+                  background: PAPER,
+                  border: `1px solid ${ACCENT}`,
+                  color: ACCENT,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        )
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: '1 / 1',
+              width: '100%',
+              background: PAPER_WARM,
+              border: `1.5px dashed ${GOLD}`,
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 4,
+              fontFamily: ENGRAVED,
+              fontSize: 10,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: ACCENT,
+            },
+            buttonLabel: t('editPraxis.ua.fileButton'),
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -20,7 +20,7 @@ import type { EditPraxisState } from '../useEditPraxis'
 import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
 
 /**
- * Universal Assembly MOBILE composer (#525) — "Submit to the Salon" on a
+ * University of Asthmatics MOBILE composer (#525) — "Submit to the Salon" on a
  * phone. The same single-column composer as the Default mobile skin
  * (Write/Preview toggle, fluid media grid, sticky submit bar) dressed in gilt
  * salon chrome: parchment plates in gold-leaf frames, engraved kickers, Cormorant

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Mobile composer UA dispatch (#525). Asserts the mobile registry resolves a `ua`
+ * task to the gilt-salon "Submit to the Salon" composer, and that every other
+ * faction falls through to the Default mobile composer.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../../EditPraxis'
+import { pickVariant } from '../../../../utils/factionDispatch'
+import DefaultMobileEditPraxis from '../DefaultEditPraxis'
+import UAMobileEditPraxis from '../UaComposer'
+
+describe('mobile composer UA dispatch', () => {
+  it('mobile + a UA task resolves to the bespoke UA composer', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ua', DefaultMobileEditPraxis)).toBe(
+      UAMobileEditPraxis,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default composer', () => {
+    for (const slug of ['snide', 'wow', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileEditPraxis)).not.toBe(
+        UAMobileEditPraxis,
+      )
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile faction-page UA dispatch (#525). Asserts the #518 mobile registry
+ * resolves the `ua` faction to the gilt-salon page skin, and that every other
+ * faction (and null) falls through to the single-column DefaultFactionPage.
+ * Mirrors the other surfaces' ua-dispatch tests.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FactionDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
+import UaFactionPage from '../mobileArchetypes/UaFactionPage'
+
+describe('mobile faction-page UA dispatch', () => {
+  it('mobile + the UA faction resolves to the bespoke UA page', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ua', DefaultFactionPage)).toBe(UaFactionPage)
+  })
+
+  it('every other faction falls through to the Default mobile page', () => {
+    for (const slug of ['snide', 'wow', 'everymen', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
@@ -8,7 +8,7 @@ import type { CharacterOut } from '../../../api/auth'
 import type { FactionDetailState } from '../useFactionDetail'
 
 /**
- * Universal Assembly MOBILE faction page (#525) — the gilt salon, phone shaped.
+ * University of Asthmatics MOBILE faction page (#525) — the gilt salon, phone shaped.
  * The same single-column slots as the Default mobile faction page (a hero with
  * real member/task counts, top members, recent praxis, and the invite-gated Join
  * model via `state.membership`, ADR-0019) — only the dress changes: parchment

--- a/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
@@ -1,0 +1,284 @@
+import { useState, type CSSProperties, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { factionName, factionDescription } from '../../../utils/factions'
+import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
+import type { CharacterOut } from '../../../api/auth'
+import type { FactionDetailState } from '../useFactionDetail'
+
+/**
+ * Universal Assembly MOBILE faction page (#525) — the gilt salon, phone shaped.
+ * The same single-column slots as the Default mobile faction page (a hero with
+ * real member/task counts, top members, recent praxis, and the invite-gated Join
+ * model via `state.membership`, ADR-0019) — only the dress changes: parchment
+ * plates in gold-leaf frames, engraved (Cinzel) kickers, Cormorant-italic titles,
+ * amber accents. Grounds on the `--faction-ua-*` / `--ua-*` tokens; always-light
+ * (UA never dims). Reuses the shared `mobile.*` faction copy so the slot contract
+ * holds. Presentation-only — all data + the join handler arrive via
+ * {@link FactionDetailState}.
+ */
+
+const NA_SLUG = 'na'
+
+const PAPER = 'var(--faction-ua-card-bg)'
+const PAPER_WARM = 'var(--ua-paper-warm)'
+const WALL = 'var(--ua-wall)'
+const INK = 'var(--faction-ua-card-text)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const SUB = 'var(--faction-ua-card-muted)'
+const MUTED = 'var(--ua-muted)'
+const GOLD = 'var(--ua-gold)'
+const GOLD_LT = 'var(--ua-gold-lt)'
+const GOLD_PALE = 'var(--ua-gold-pale)'
+const LINE = 'var(--ua-line)'
+const GILT = 'var(--ua-gilt)'
+const DISPLAY = 'var(--faction-ua-card-font)'
+const ENGRAVED = 'var(--font-faction-engraved)'
+const MONO = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || '?'
+
+/** Circular initials medallion — parchment face, amber italic glyph. */
+function Medallion({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: PAPER_WARM,
+        border: `1px solid ${GOLD_LT}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: DISPLAY,
+        fontStyle: 'italic',
+        fontWeight: 700,
+        fontSize: size * 0.42,
+        color: ACCENT,
+      }}
+    >
+      {initial(name)}
+    </span>
+  )
+}
+
+function SectionHead({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ fontFamily: ENGRAVED, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
+        {children}
+      </span>
+      <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+    </div>
+  )
+}
+
+const joinButton: CSSProperties = {
+  width: '100%',
+  fontFamily: ENGRAVED,
+  fontSize: 13,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: PAPER_WARM,
+  background: ACCENT,
+  border: `1px solid ${ACCENT}`,
+  padding: '13px 16px',
+  boxShadow: '0 6px 16px rgba(194,84,31,.28)',
+  cursor: 'pointer',
+}
+
+export default function UaFactionPage({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation('factions')
+  const { faction, members, tasks, recentPraxis, membership } = state
+  const [confirming, setConfirming] = useState(false)
+
+  if (!faction) return null
+
+  const name = factionName(faction.slug)
+  const topMembers = [...members].sort((a, b) => b.all_time_score - a.all_time_score).slice(0, 3)
+  const currentSlug = membership.currentFactionSlug
+  const switching = currentSlug && currentSlug !== NA_SLUG
+
+  return (
+    <div data-skin="ua" className="py-4" style={{ fontFamily: MONO, color: INK, background: WALL }} data-testid="mobile-faction-page">
+      {/* Hero — gilt-framed parchment masthead */}
+      <section style={{ padding: 8, background: GILT, boxShadow: '0 12px 28px rgba(60,40,10,.2), inset 0 0 0 1px rgba(255,255,255,0.45)' }}>
+        <div style={{ padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+          <div
+            style={{
+              position: 'relative',
+              overflow: 'hidden',
+              background: PAPER,
+              backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
+              backgroundSize: '5px 5px',
+              border: `1px solid ${LINE}`,
+              padding: '20px 18px',
+            }}
+          >
+            <div style={{ ...kicker, color: ACCENT }}>{t('ua.mobile.eyebrow')}</div>
+            <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 34, lineHeight: 1.05, color: INK, margin: '4px 0 0' }}>
+              {name}
+            </h1>
+            <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 13, lineHeight: 1.6, color: SUB, margin: '8px 0 0' }}>
+              {factionDescription(faction.slug)}
+            </p>
+            <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
+              <HeroStat value={members.length} label={t('mobile.membersStat')} />
+              <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {membership.state === 'member' && (
+        <p style={{ ...kicker, marginTop: 12, color: GOLD }}>{t('mobile.memberBadge')}</p>
+      )}
+
+      {/* Top members */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.topMembers')}</SectionHead>
+        {topMembers.length === 0 ? (
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topMembers.map((m, index) => (
+              <MemberRow key={m.id} rank={index + 1} member={m} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent praxis */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
+        {recentPraxis.length === 0 ? (
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {membership.state === 'gate' && (
+        <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, marginTop: 24 }}>
+          {t('mobile.gateHint', { faction: name })}
+        </p>
+      )}
+
+      {/* Sticky Join — only an eligible viewer can act (ADR-0019). */}
+      {membership.state === 'eligible' && (
+        <MobileStickyBar>
+          {membership.joinError && (
+            <p style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+          )}
+          {!confirming ? (
+            <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
+              {t('mobile.join', { faction: name })}
+            </button>
+          ) : (
+            <>
+              <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: INK }}>
+                {switching
+                  ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
+                  : t('detail.join.confirm', { faction: name })}
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => void membership.join()}
+                  disabled={membership.joining}
+                  style={{ ...joinButton, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                >
+                  {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirming(false)}
+                  disabled={membership.joining}
+                  style={{
+                    fontFamily: ENGRAVED,
+                    fontSize: 11,
+                    letterSpacing: '0.1em',
+                    textTransform: 'uppercase',
+                    color: SUB,
+                    background: 'transparent',
+                    border: `1px solid ${LINE}`,
+                    padding: '11px 16px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t('detail.join.cancel')}
+                </button>
+              </div>
+            </>
+          )}
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+function HeroStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={{ flex: '1 1 0', textAlign: 'center', background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: '10px 6px' }}>
+      <b style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 20, display: 'block', lineHeight: 1, color: INK }}>
+        {value}
+      </b>
+      <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
+    </div>
+  )
+}
+
+function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
+  const { t } = useTranslation('factions')
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: PAPER,
+        border: `1px solid ${LINE}`,
+        borderLeft: `4px solid ${ACCENT}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 16, color: ACCENT, width: 16, flex: 'none' }}>{rank}</span>
+      <Medallion name={member.display_name} size={28} />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: DISPLAY,
+          fontStyle: 'italic',
+          fontSize: 15,
+          color: INK,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {member.display_name}
+      </span>
+      <span style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.06em', color: GOLD, flex: 'none' }}>
+        {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile FieldDesk-home UA dispatch (#525). Asserts the parallel mobile registry
+ * resolves a `ua` carried life to the gilt-salon home skin, and that an
+ * unregistered faction (and null) still falls through to the Default mobile home.
+ * Mirrors the taskDetail mobileArchetypeDispatch pattern.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FieldDesk'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
+import UaHome from '../mobileArchetypes/UaHome'
+
+describe('mobile FieldDesk-home UA dispatch', () => {
+  it('mobile + a UA life resolves to the bespoke UA home skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ua', DefaultFieldDesk)).toBe(UaHome)
+  })
+
+  it('mobile + any other slug falls through to the Default home skin', () => {
+    for (const slug of ['snide', 'everymen', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
+    }
+  })
+})

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -1,0 +1,245 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+
+/**
+ * Universal Assembly MOBILE FieldDesk home (#525) — the gilt salon on a
+ * phone. The carried life and its in-progress commissions become parchment
+ * plates set in a gold-leaf frame, headed by an engraved masthead. Same content
+ * slots as the Default mobile home (character header, Points/Votes/Era stat
+ * tiles, active-tasks list, primary actions) — only the dress changes. Grounds
+ * on the `--faction-ua-*` / `--ua-*` tokens already in index.css (the set
+ * UAFeedFrame / UaFactionBody use) and is always-light: UA never dims.
+ * Presentation-only — all data arrives via {@link FieldDeskHomeState}.
+ */
+
+const PAPER = 'var(--faction-ua-card-bg)'
+const PAPER_WARM = 'var(--ua-paper-warm)'
+const WALL = 'var(--ua-wall)'
+const INK = 'var(--faction-ua-card-text)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const SUB = 'var(--faction-ua-card-muted)'
+const MUTED = 'var(--ua-muted)'
+const GOLD = 'var(--ua-gold)'
+const GOLD_PALE = 'var(--ua-gold-pale)'
+const LINE = 'var(--ua-line)'
+const GILT = 'var(--ua-gilt)'
+const DISPLAY = 'var(--faction-ua-card-font)'
+const ENGRAVED = 'var(--font-faction-engraved)'
+const MONO = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+/** Parchment plate set in the salon's gold-leaf sandwich frame. */
+function Plate({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        padding: 8,
+        background: GILT,
+        boxShadow: '0 10px 24px rgba(60,40,10,.18), inset 0 0 0 1px rgba(255,255,255,0.45)',
+      }}
+    >
+      <div style={{ padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+        <div
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            background: PAPER,
+            backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
+            backgroundSize: '5px 5px',
+            border: `1px solid ${LINE}`,
+            padding: 16,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function UaHome({ state }: { state: FieldDeskHomeState }) {
+  const { t } = useTranslation('common')
+  const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+
+  const stats = [
+    { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
+    { label: t('fieldDesk.home.stats.votes'), value: votesReceived.toLocaleString() },
+    { label: t('fieldDesk.home.stats.era'), value: eraName || '—' },
+  ]
+
+  return (
+    <div
+      data-skin="ua"
+      className="page"
+      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: WALL }}
+    >
+      {/* Engraved masthead */}
+      <header>
+        <div style={kicker}>{t('nav.home')}</div>
+        <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 32, lineHeight: 1, color: INK, margin: '2px 0 0' }}>
+          {t('fieldDesk.home.ua.masthead')}
+        </h1>
+        <div style={{ height: 1, marginTop: 9, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+      </header>
+
+      {/* ── Sitter plate ── */}
+      <Plate>
+        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+          <span style={kicker}>{t('fieldDesk.home.ua.charEyebrow')}</span>
+          <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: ACCENT, textDecoration: 'none' }}>
+            {t('fieldDesk.home.edit')}
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="shrink-0" style={{ width: 56, height: 56, borderRadius: '50%', padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="w-full h-full rounded-full"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : (
+              <span
+                className="flex w-full h-full items-center justify-center rounded-full"
+                style={{ background: PAPER_WARM, fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 24, color: ACCENT }}
+              >
+                {character.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/characters/${character.id}`}
+              className="block truncate"
+              style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 26, lineHeight: 1, color: INK, textDecoration: 'none' }}
+            >
+              {character.display_name}
+            </Link>
+            <div className="truncate" style={{ marginTop: 5, fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: SUB }}>
+              {t('sidebar.characterCard.factionLevel', {
+                faction: factionName(character.faction_slug),
+                level: character.level,
+              })}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 26, lineHeight: 1, color: INK }}>
+              {character.score?.toLocaleString() ?? '0'}
+            </div>
+            <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
+          </div>
+        </div>
+
+        <div className="flex gap-2" style={{ marginTop: 16 }}>
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center"
+              style={{ flex: '1 1 0', minWidth: 0, background: PAPER_WARM, border: `1px solid ${LINE}`, padding: '11px 6px' }}
+            >
+              <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 20, lineHeight: 1, color: INK }}>
+                {stat.value}
+              </div>
+              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      </Plate>
+
+      {/* ── Pending requests ── */}
+      {pendingCount > 0 && (
+        <Link
+          to="/updates?filter=requests"
+          className="flex items-center justify-between"
+          style={{ background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999, padding: '10px 16px', fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: INK, textDecoration: 'none' }}
+        >
+          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
+          <span aria-hidden style={{ color: ACCENT }}>›</span>
+        </Link>
+      )}
+
+      {/* ── Commissions at the easel ── */}
+      <Plate>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+          <span style={{ fontFamily: ENGRAVED, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
+            {t('fieldDesk.home.ua.questsHeading')}
+          </span>
+          <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+          <Link to="/tasks" style={{ ...kicker, color: ACCENT, textDecoration: 'none' }}>
+            {t('fieldDesk.home.viewAll')}
+          </Link>
+        </div>
+
+        {activeTasks.length === 0 ? (
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 15, color: SUB, margin: 0 }}>
+            {t('fieldDesk.home.questsEmpty')}
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {activeTasks.map((praxis, index) => (
+              <Link
+                key={praxis.id}
+                to={`/praxes/${praxis.id}/edit`}
+                className="flex items-center gap-3"
+                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
+              >
+                <span className="shrink-0" style={{ width: 9, height: 9, borderRadius: '50%', background: ACCENT }} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 17, lineHeight: 1.15, color: INK }}>
+                    {praxis.task_title}
+                  </div>
+                  <div className="truncate" style={{ marginTop: 3, fontFamily: ENGRAVED, fontSize: 8.5, letterSpacing: '0.1em', textTransform: 'uppercase', color: SUB }}>
+                    {t('fieldDesk.home.taskMeta', {
+                      faction: factionName(praxis.task_faction_slug),
+                      points: praxis.task_point_value,
+                    })}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0"
+                  style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: GOLD, padding: '4px 9px', border: `1px solid ${LINE}` }}
+                >
+                  {t(`praxisType.${praxis.type}`)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </Plate>
+
+      {/* ── Primary actions ── */}
+      <div className="flex gap-2.5">
+        <Link
+          to="/tasks"
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PAPER_WARM, background: ACCENT, border: `1px solid ${ACCENT}`, boxShadow: '0 6px 16px rgba(194,84,31,.28)', textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.browseTasks')}
+        </Link>
+        {canProposeTask && (
+          <Link
+            to="/propose-task"
+            className="flex-1 flex items-center justify-center gap-2"
+            style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: INK, background: PAPER, border: `1px solid ${LINE}`, textDecoration: 'none' }}
+          >
+            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+            <span>{t('actions.proposeTask')}</span>
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -6,7 +6,7 @@ import { mediaUrl } from '../../../utils/media'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
- * Universal Assembly MOBILE FieldDesk home (#525) — the gilt salon on a
+ * University of Asthmatics MOBILE FieldDesk home (#525) — the gilt salon on a
  * phone. The carried life and its in-progress commissions become parchment
  * plates set in a gold-leaf frame, headed by an engraved masthead. Same content
  * slots as the Default mobile home (character header, Points/Votes/Era stat

--- a/frontend/src/pages/praxisDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaDispatch.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Mobile praxis-detail UA dispatch (#525). Asserts the mobile registry resolves a
+ * `ua`-task praxis to the gilt-salon acquisition skin, that other factions fall
+ * through to the Default mobile detail, and the desktop archetype is untouched.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG, ARCHETYPE_BY_SLUG } from '../../PraxisDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
+import UAMobilePraxisDetail from '../mobileArchetypes/UaPraxisDetail'
+import UADesktopPraxisDetail from '../archetypes/UAPraxisDetail'
+
+describe('mobile praxis-detail UA dispatch', () => {
+  it('mobile + a UA praxis resolves to the bespoke UA mobile skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ua', DefaultMobilePraxisDetail)).toBe(
+      UAMobilePraxisDetail,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default mobile skin', () => {
+    for (const slug of ['snide', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobilePraxisDetail)).toBe(
+        DefaultMobilePraxisDetail,
+      )
+    }
+  })
+
+  it('desktop keeps its own UA archetype, never the mobile skin', () => {
+    const desktop = pickVariant(ARCHETYPE_BY_SLUG, 'ua', DefaultMobilePraxisDetail)
+    expect(desktop).toBe(UADesktopPraxisDetail)
+    expect(desktop).not.toBe(UAMobilePraxisDetail)
+  })
+})

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
@@ -16,7 +16,7 @@ import {
 import { MobileStarVote } from './shared'
 
 /**
- * Universal Assembly MOBILE praxis-detail skin (#525) — an acquisition
+ * University of Asthmatics MOBILE praxis-detail skin (#525) — an acquisition
  * hung in the salon, phone-shaped. A gilt-framed plate holds the exhibited work
  * (full media); a Cormorant-italic finding headline, the account body, and a
  * thumb-sized appraisal caster follow. Renders the same invariant CONTENT +

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
@@ -1,0 +1,156 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import { formatTimestamp } from '../../../utils/dates'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisVoterBreakdown,
+  MemberByline,
+} from '../shared'
+import { MobileStarVote } from './shared'
+
+/**
+ * Universal Assembly MOBILE praxis-detail skin (#525) — an acquisition
+ * hung in the salon, phone-shaped. A gilt-framed plate holds the exhibited work
+ * (full media); a Cormorant-italic finding headline, the account body, and a
+ * thumb-sized appraisal caster follow. Renders the same invariant CONTENT +
+ * behavior slots as every archetype (the shared praxisDetail module) — only the
+ * dress changes. Grounds on `--faction-ua-*` / `--ua-*` tokens; always-light.
+ */
+
+const PAPER = 'var(--faction-ua-card-bg)'
+const PAPER_WARM = 'var(--ua-paper-warm)'
+const WALL = 'var(--ua-wall)'
+const INK = 'var(--faction-ua-card-text)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const SUB = 'var(--faction-ua-card-muted)'
+const MUTED = 'var(--ua-muted)'
+const GOLD = 'var(--ua-gold)'
+const GOLD_PALE = 'var(--ua-gold-pale)'
+const LINE = 'var(--ua-line)'
+const GILT = 'var(--ua-gilt)'
+const DISPLAY = 'var(--faction-ua-card-font)'
+const ENGRAVED = 'var(--font-faction-engraved)'
+const MONO = 'var(--font-body)'
+
+/** Exhibited plate — the gilt sandwich frame around a parchment body. */
+function Plate({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ padding: 8, background: GILT, boxShadow: '0 10px 24px rgba(60,40,10,.18), inset 0 0 0 1px rgba(255,255,255,0.45)' }}>
+      <div style={{ padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+        <div style={{ background: PAPER, border: `1px solid ${LINE}`, padding: 13 }}>
+          <div style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: ACCENT, marginBottom: 10 }}>
+            {title}
+          </div>
+          {children}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <div data-skin="ua" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: WALL }}>
+      {/* Behavior slots (invariant) */}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
+
+      {/* Byline row */}
+      <div className="flex items-center gap-3">
+        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+          <span
+            className="flex items-center justify-center rounded-full"
+            style={{ width: 42, height: 42, background: PAPER_WARM, border: `1px solid ${GOLD}`, boxShadow: `0 0 0 3px ${PAPER_WARM}, 0 0 0 4px ${GOLD_PALE}`, color: ACCENT, fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 20 }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <MemberByline
+            praxis={praxis}
+            linkStyle={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 18, color: INK, lineHeight: 1, textDecoration: 'none' }}
+          />
+          <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
+            {t('detail.ua.acquiringHand')} · {formatTimestamp(sealedDate)}
+          </div>
+        </div>
+      </div>
+
+      {/* Exhibited plate — full media inside */}
+      {praxis.media_items.length > 0 && (
+        <Plate title={t('detail.ua.mobile.plate')}>
+          <MediaGallery media={praxis.media_items} layout="grid" />
+        </Plate>
+      )}
+
+      {/* Finding headline */}
+      <div>
+        <div style={{ ...kicker, marginBottom: 4, color: SUB }}>{t('detail.ua.mobile.theAcquisition')}</div>
+        <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 30, lineHeight: 1.1, margin: 0, color: INK, overflowWrap: 'anywhere' }}>
+          {praxis.title ?? t('detail.ua.untitled')}
+        </h1>
+      </div>
+
+      {/* Owner actions (invariant) */}
+      <PraxisOwnerActions state={state} />
+
+      {/* re: task link */}
+      <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 13, color: SUB }}>
+        {t('detail.ua.mobile.re')}{' '}
+        <Link to={`/tasks/${praxis.task_id}`} style={{ color: ACCENT, fontWeight: 700, textDecoration: 'none' }}>
+          {praxis.task_title}
+        </Link>
+      </div>
+
+      {/* Account body */}
+      {praxis.body_text && (
+        <MarkdownPreview
+          source={praxis.body_text}
+          className="markdown-preview"
+          style={{ fontFamily: DISPLAY, fontSize: 15, lineHeight: 1.75, color: INK }}
+        />
+      )}
+
+      {/* Appraisal caster */}
+      <Plate title={t('detail.ua.standing.heading')}>
+        <div className="flex items-center justify-center" style={{ marginBottom: 12, fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 20, color: INK }}>
+          {t('detail.ua.mobile.appraise')}
+        </div>
+        <MobileStarVote
+          praxisId={praxis.id}
+          points={votes?.total_score}
+          totalVotes={votes?.total_votes}
+          accent={ACCENT}
+          accentFont={DISPLAY}
+        />
+      </Plate>
+
+      {/* Flag + voter breakdown (invariant) */}
+      <PraxisFlagBlock state={state} />
+      <PraxisVoterBreakdown state={state} />
+    </div>
+  )
+}

--- a/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Mobile task-detail UA dispatch (#525). Asserts the mobile registry resolves a
+ * `ua` task to the gilt-salon commission skin, that other factions fall through
+ * to the Default mobile detail, and that the desktop archetype is untouched.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  MOBILE_ARCHETYPE_BY_SLUG,
+  ARCHETYPE_BY_SLUG,
+} from "../../TaskDetail";
+import { pickVariant } from "../../../utils/factionDispatch";
+import DefaultMobileTaskDetail from "../mobileArchetypes/DefaultTaskDetail";
+import UAMobileTaskDetail from "../mobileArchetypes/UaTaskDetail";
+import UADesktopTaskDetail from "../archetypes/UATaskDetail";
+
+describe("mobile task-detail UA dispatch", () => {
+  it("mobile + a UA task resolves to the bespoke UA mobile skin", () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, "ua", DefaultMobileTaskDetail)).toBe(
+      UAMobileTaskDetail,
+    );
+  });
+
+  it("mobile + any other slug falls through to the Default mobile skin", () => {
+    for (const slug of ["snide", "na", null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).toBe(
+        DefaultMobileTaskDetail,
+      );
+    }
+  });
+
+  it("desktop keeps its own UA archetype, never the mobile skin", () => {
+    const desktop = pickVariant(ARCHETYPE_BY_SLUG, "ua", DefaultMobileTaskDetail);
+    expect(desktop).toBe(UADesktopTaskDetail);
+    expect(desktop).not.toBe(UAMobileTaskDetail);
+  });
+});

--- a/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
@@ -1,0 +1,307 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { toRoman } from '../../../components/cards/ephemeristsAtoms'
+import { MobileStickyBar, MobileStickyCaption } from './shared'
+import type { TaskDetailState } from '../useTaskDetail'
+
+/**
+ * Universal Assembly MOBILE task-detail skin (#525) — the salon
+ * commission on a phone. A gilt-framed parchment hero (engraved masthead, title
+ * in Cormorant italic, Anno + points plates, the commission brief), the
+ * exhibited works, and a stamped **sticky action bar** ("Submit to the Salon")
+ * pinned above the tab bar. Single-column, no fixed-px grid — the desktop
+ * salon's wide plate would overflow a phone. Reuses the same
+ * {@link TaskDetailState}, the shared mobile sticky bar, and the `ua.*` copy +
+ * `--faction-ua-*` tokens as the desktop archetype. Always-light: UA never dims.
+ */
+
+const PAPER = 'var(--faction-ua-card-bg)'
+const PAPER_WARM = 'var(--ua-paper-warm)'
+const WALL = 'var(--ua-wall)'
+const INK = 'var(--faction-ua-card-text)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const SUB = 'var(--faction-ua-card-muted)'
+const MUTED = 'var(--ua-muted)'
+const GOLD = 'var(--ua-gold)'
+const GOLD_PALE = 'var(--ua-gold-pale)'
+const LINE = 'var(--ua-line)'
+const GILT = 'var(--ua-gilt)'
+const DISPLAY = 'var(--faction-ua-card-font)'
+const ENGRAVED = 'var(--font-faction-engraved)'
+const MONO = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+// "Anno {roman}"; level 0 shows an em-dash (matches the desktop UA convention).
+const anno = (level: number) => (level > 0 ? toRoman(level) : '—')
+
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <h2 style={{ fontFamily: ENGRAVED, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase', margin: 0, color: INK, whiteSpace: 'nowrap' }}>
+        {title}
+      </h2>
+      <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+      {trailing}
+    </div>
+  )
+}
+
+function plate(background: string, textColor: string, border: string, label: string) {
+  return (
+    <span style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.04em', color: textColor, background, border: `1px solid ${border}`, padding: '4px 12px' }}>
+      {label}
+    </span>
+  )
+}
+
+export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation('tasks')
+  const {
+    task,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    topScore,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state
+
+  if (!task) return null
+
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null
+
+  return (
+    <div className="py-4" style={{ fontFamily: MONO, color: INK, background: WALL, marginLeft: -16, marginRight: -16, paddingLeft: 16, paddingRight: 16 }}>
+      {/* Breadcrumb */}
+      <nav className="mb-3" style={{ fontFamily: MONO, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+        <Link to="/tasks" style={{ color: ACCENT, textDecoration: 'none' }}>
+          {t('default.breadcrumb')}
+        </Link>
+        <span aria-hidden style={{ margin: '0 6px', color: GOLD }}>›</span>
+        <span style={{ color: SUB }}>{task.title}</span>
+      </nav>
+
+      {/* Hero — gilt-framed commission plate */}
+      <div style={{ padding: 8, background: GILT, boxShadow: '0 12px 28px rgba(60,40,10,.2), inset 0 0 0 1px rgba(255,255,255,0.45)', marginBottom: 20 }}>
+        <div style={{ padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+          <div
+            style={{
+              position: 'relative',
+              overflow: 'hidden',
+              background: PAPER,
+              backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
+              backgroundSize: '5px 5px',
+              border: `1px solid ${LINE}`,
+              padding: '20px 22px 22px',
+            }}
+          >
+            <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+              <span style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: ACCENT }}>
+                {t('ua.masthead')}
+              </span>
+              <span style={kicker}>{t('ua.statusOpen')}</span>
+            </div>
+
+            <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 34, lineHeight: 1.05, color: INK, margin: 0, overflowWrap: 'anywhere' }}>
+              {task.title}
+            </h1>
+            <div style={{ height: 1, margin: '14px 0 14px', background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+
+            <div className="flex items-center gap-2 flex-wrap">
+              {plate(PAPER_WARM, INK, GOLD, `${t('ua.stats.anno')} ${anno(task.level_required)}`)}
+              {plate(ACCENT, PAPER_WARM, ACCENT, t('mobile.points', { points: modifiedPoints }))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* The Commission — brief */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('ua.commissionHeading')} />
+        <div style={{ background: PAPER, border: `1px solid ${LINE}`, padding: '18px 20px' }}>
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 15, lineHeight: 1.75, color: task.description ? INK : SUB, margin: 0, whiteSpace: 'pre-wrap' }}>
+            {task.description || t('ua.commissionEmpty')}
+          </p>
+        </div>
+      </section>
+
+      {/* The Standing — read-only aggregate */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('ua.critiqueHeading')} />
+        {voteCount > 0 ? (
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12 }}>
+            <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 44, lineHeight: 0.85, color: ACCENT }}>
+              {topScore}
+            </span>
+            <div style={{ paddingBottom: 5 }}>
+              <div style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.06em', textTransform: 'uppercase', color: INK }}>
+                {t('ua.critique.finest')}
+              </div>
+              <div style={{ ...kicker, marginTop: 2 }}>{t('ua.critique.appraised', { count: voteCount })}</div>
+            </div>
+          </div>
+        ) : (
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, margin: 0 }}>{t('ua.critique.none')}</p>
+        )}
+      </section>
+
+      {/* Works exhibited (completions) */}
+      <section>
+        <SectionHead
+          title={t('ua.salonWallHeading')}
+          trailing={
+            <div style={{ display: 'flex' }}>
+              {(['score', 'recent'] as const).map((sort) => {
+                const on = submissionSort === sort
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: 8,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      padding: '5px 10px',
+                      background: on ? ACCENT : 'transparent',
+                      color: on ? PAPER_WARM : MUTED,
+                      border: `1px solid ${on ? ACCENT : LINE}`,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {sort === 'score' ? t('ua.sort.finest') : t('ua.sort.recent')}
+                  </button>
+                )
+              })}
+            </div>
+          }
+        />
+        {sortedSubmissions.length === 0 ? (
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, margin: 0 }}>{t('ua.empty')}</p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4">
+              {sortedSubmissions.slice(0, 4).map((s) => (
+                <div key={s.id} style={{ position: 'relative', paddingTop: s.id === topId ? 16 : 0 }}>
+                  {s.id === topId && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: -4,
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        zIndex: 3,
+                        whiteSpace: 'nowrap',
+                        background: GOLD,
+                        color: PAPER_WARM,
+                        fontFamily: ENGRAVED,
+                        fontSize: 10,
+                        letterSpacing: '0.1em',
+                        textTransform: 'uppercase',
+                        padding: '2px 12px',
+                        boxShadow: '0 3px 8px rgba(60,40,10,0.3)',
+                      }}
+                    >
+                      {t('ua.finestHand')}
+                    </div>
+                  )}
+                  <PraxisCard praxis={s} />
+                </div>
+              ))}
+            </div>
+            {submissions.length > 4 && (
+              <div style={{ marginTop: 16 }}>
+                <Link to={`/praxes?task_id=${task.id}`} style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.06em', color: ACCENT, textDecoration: 'none' }}>
+                  {t('ua.viewAll', { count: submissions.length })}
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Sticky action bar */}
+      {canSignUp && (
+        <MobileStickyBar>
+          {signupError && (
+            <div style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)', padding: '8px 12px', background: 'var(--faction-ua-light)', border: `1px solid ${LINE}` }}>
+              {signupError}
+            </div>
+          )}
+          <button
+            onClick={handleSignup}
+            style={{
+              width: '100%',
+              background: ACCENT,
+              color: PAPER_WARM,
+              fontFamily: ENGRAVED,
+              fontSize: 14,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              padding: '14px 20px',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            {t('ua.signup.cta', { points: modifiedPoints })}
+          </button>
+          <MobileStickyCaption color={MUTED}>
+            {t('ua.signup.meta', { open: slotsOpen, max: maxTaskSlots, level: task.level_required })}
+          </MobileStickyCaption>
+        </MobileStickyBar>
+      )}
+
+      {mySubmission && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 15, color: GOLD, flex: 1 }}>
+            {t('ua.submitted.text')}
+          </span>
+          <Link
+            to={`/praxes/${mySubmission.id}/edit`}
+            style={{ fontFamily: ENGRAVED, fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '10px 18px', background: INK, color: PAPER_WARM, textDecoration: 'none' }}
+          >
+            {t('ua.submitted.edit')}
+          </Link>
+        </MobileStickyBar>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <button
+            onClick={handleDrop}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: MONO, fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}
+          >
+            {t('ua.inProgress.drop')}
+          </button>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{ marginLeft: 'auto', fontFamily: ENGRAVED, fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '12px 20px', background: ACCENT, color: PAPER_WARM, textDecoration: 'none' }}
+          >
+            {t('ua.inProgress.continue')}
+          </Link>
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
@@ -7,7 +7,7 @@ import { MobileStickyBar, MobileStickyCaption } from './shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
- * Universal Assembly MOBILE task-detail skin (#525) — the salon
+ * University of Asthmatics MOBILE task-detail skin (#525) — the salon
  * commission on a phone. A gilt-framed parchment hero (engraved masthead, title
  * in Cormorant italic, Anno + points plates, the commission brief), the
  * exhibited works, and a stamped **sticky action bar** ("Submit to the Salon")

--- a/frontend/src/pages/tasks/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/uaDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile task-browse UA dispatch (#525). The browse page shows every faction's
+ * tasks, so — unlike detail — it dispatches on the VIEWING life's faction. This
+ * asserts a `ua` viewer resolves to the gilt-salon browse skin while every other
+ * viewer (and logged-out null) falls through to the Default mobile browse skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../Tasks'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultTasks from '../mobileArchetypes/DefaultTasks'
+import UaTaskList from '../mobileArchetypes/UaTaskList'
+
+describe('mobile task-browse UA dispatch', () => {
+  it('mobile + a UA viewer resolves to the bespoke UA browse skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ua', DefaultTasks)).toBe(UaTaskList)
+  })
+
+  it('mobile + any other viewer falls through to the Default browse skin', () => {
+    for (const slug of ['snide', 'wow', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
+    }
+  })
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/UaTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/UaTaskList.tsx
@@ -6,7 +6,7 @@ import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../..
 import type { TasksState } from '../useTasks'
 
 /**
- * Universal Assembly MOBILE task-browse skin (#525) — the salon
+ * University of Asthmatics MOBILE task-browse skin (#525) — the salon
  * prospectus on a phone. The same scannable single-column list + touch-native
  * filter chip rows as the Default browse skin (status / faction / level),
  * dressed as parchment commission plates on a gilt rail. Dispatched by the

--- a/frontend/src/pages/tasks/mobileArchetypes/UaTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/UaTaskList.tsx
@@ -1,0 +1,230 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../../api/tasks'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import type { TasksState } from '../useTasks'
+
+/**
+ * Universal Assembly MOBILE task-browse skin (#525) — the salon
+ * prospectus on a phone. The same scannable single-column list + touch-native
+ * filter chip rows as the Default browse skin (status / faction / level),
+ * dressed as parchment commission plates on a gilt rail. Dispatched by the
+ * VIEWING life's faction (a UA member browsing tasks), so it consumes the shared
+ * `useTasks()` state verbatim — a chip tap mutates the same filter state that
+ * keys the read. Grounds on the `--faction-ua-*` / `--ua-*` tokens; always-light.
+ */
+
+const PAPER = 'var(--faction-ua-card-bg)'
+const PAPER_WARM = 'var(--ua-paper-warm)'
+const WALL = 'var(--ua-wall)'
+const INK = 'var(--faction-ua-card-text)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const SUB = 'var(--faction-ua-card-muted)'
+const MUTED = 'var(--ua-muted)'
+const GOLD = 'var(--ua-gold)'
+const LINE = 'var(--ua-line)'
+const DISPLAY = 'var(--faction-ua-card-font)'
+const ENGRAVED = 'var(--font-faction-engraved)'
+const MONO = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+export default function UaTaskList({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div data-skin="ua" className="py-4" style={{ fontFamily: MONO, color: INK, background: WALL }} data-testid="mobile-tasks-browse">
+      <div style={kicker}>{t('ua.masthead')}</div>
+      <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 30, lineHeight: 1.05, color: INK, margin: '2px 0 0' }}>
+        {tc('nav.tasks')}
+      </h1>
+      <div style={{ height: 1, margin: '9px 0 12px', background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+      <p style={{ ...kicker, marginBottom: 12 }}>{t('mobile.count', { count: tasks.length })}</p>
+
+      <ChipRow label={tc('filters.status')}>
+        {statusFilters.map((option) => (
+          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
+            {option}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('mobile.allFactions')}
+        </Chip>
+        {sortFactionsByRainbowOrder(factions).map((f) => (
+          <Chip
+            key={f.slug}
+            on={faction === f.slug}
+            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
+            tint={factionCssVar(f.slug)}
+          >
+            {factionName(f.slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.level')}>
+        <Chip on={level === ''} onClick={() => setLevel('')}>
+          {t('mobile.anyLevel')}
+        </Chip>
+        {levelFilters.map((lvl) => (
+          <Chip key={lvl} on={level === lvl} onClick={() => setLevel(level === lvl ? '' : lvl)}>
+            {tc('filters.levelAtLeast', { level: lvl })}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <div className="mt-4">
+        {loading ? (
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 15, color: SUB }}>{t('listPage.loading')}</p>
+        ) : error ? (
+          <p style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)', border: `1px solid ${LINE}`, padding: '8px 12px' }}>
+            {t('mobile.loadError')}
+          </p>
+        ) : tasks.length === 0 ? (
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 15, color: SUB }}>{t('listPage.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {tasks.map((task) => (
+              <CommissionPlate key={task.id} task={task} points={displayPointsFor(task)} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span style={{ ...kicker, flex: 'none' }}>{label}</span>
+      <div className="flex gap-2" style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: ENGRAVED,
+        fontSize: 10,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        color: on ? PAPER_WARM : SUB,
+        background: on ? ACCENT : PAPER,
+        border: `1px solid ${on ? ACCENT : LINE}`,
+        borderRadius: 999,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && <i style={{ width: 8, height: 8, borderRadius: '50%', flex: 'none', background: tint }} />}
+      {children}
+    </button>
+  )
+}
+
+function CommissionPlate({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  const color = factionCssVar(task.primary_faction_slug)
+  return (
+    <Link
+      to={`/tasks/${task.id}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        padding: '14px 16px',
+        background: PAPER,
+        backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
+        backgroundSize: '5px 5px',
+        border: `1px solid ${LINE}`,
+        borderLeft: `4px solid ${color}`,
+        boxShadow: `inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px var(--ua-gold-pale)`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
+        <i style={{ width: 7, height: 7, borderRadius: '50%', background: color, flex: 'none' }} />
+        {factionName(task.primary_faction_slug)}
+      </span>
+
+      <h2 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 19, lineHeight: 1.15, color: INK, margin: 0 }}>
+        {task.title}
+      </h2>
+
+      {task.description && (
+        <p
+          style={{
+            fontFamily: DISPLAY,
+            fontStyle: 'italic',
+            fontSize: 13,
+            lineHeight: 1.5,
+            color: SUB,
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {task.description}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
+        <span style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.04em', color: INK, background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>
+          {t('mobile.points', { points })}
+        </span>
+        <span style={{ ...kicker, color: MUTED }}>{t('mobile.level', { level: task.level_required })}</span>
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
Closes #525

Registers the Universal Assembly (UA) **gilt-salon** mobile skin into each of the six mobile-surface registries, so a UA life reads the whole app in one coherent idiom on a phone. Presentation-only: every skin reuses the existing hook/state contract and copy keys and fills the same DOM slots the Default skin fills (mirrors ADR-0016). No backend/API/hook change.

## Surfaces
| Surface | New skin | Registry entry |
|---|---|---|
| FieldDesk home | fieldDesk/mobileArchetypes/UaHome | MOBILE_ARCHETYPE_BY_SLUG += ua |
| Tasks browse | tasks/mobileArchetypes/UaTaskList | MOBILE_ARCHETYPE_BY_SLUG += ua |
| Task detail | taskDetail/mobileArchetypes/UaTaskDetail | MOBILE_ARCHETYPE_BY_SLUG += ua |
| Praxis detail | praxisDetail/mobileArchetypes/UaPraxisDetail | MOBILE_ARCHETYPE_BY_SLUG += ua |
| Composer | editPraxis/mobileArchetypes/UaComposer | MOBILE_ARCHETYPE_BY_SLUG += ua |
| Faction page | factionDetail/mobileArchetypes/UaFactionPage | MOBILE_ARCHETYPE_BY_SLUG += ua (the #518 seam) |

## Notes
- **Idiom**: parchment plates in gold-leaf sandwich frames, engraved (Cinzel) kickers, Cormorant-italic titles, amber appraisal/points stamps. All colors resolve to `--faction-ua-*` / `--ua-*` tokens; always-light (never dims), no `data-theme` mutation.
- **Corrections applied** (design README): points shown as the real base+modified stamp, no vote average; no difficulty dots / slots-capacity; real fields only.
- **i18n**: every visible string routes through the catalogs. Reuses the existing desktop `ua.*` copy where it already exists (task detail, praxis detail, composer), plus the shared `mobile.*` faction-page copy from #518; adds small mobile-only keys where needed.
- **Faction page** rides the existing `MOBILE_ARCHETYPE_BY_SLUG` seam from #518 (Default fallback), so `UaFactionPage` honors that surface's slot contract (real member/task stats, top members, recent praxis, invite-gated Join) in salon dress.
- **Tasks browse** has no single task slug, so it dispatches on the **viewing life's** faction; non-UA and logged-out fall through to the Default browse skin.
- **Tests**: a ua-dispatch test per surface, plus the pre-existing auto-walked slot invariants (fieldDesk / tasks / taskDetail / praxisDetail / factionDetail) now also cover the UA skins.

## Verification
- `npm run lint` (ADR-0032 raw-string gate): clean
- `npm test` (vitest): 380 passed / 56 files
- `tsc --noEmit`: no new errors in touched files (pre-existing AlbescentInvitation.tsx errors are unrelated and present on main)

Note: the repo-wide legacy "University of Asthmatics" naming (existing UA components, i18n catalogs, an existing test) is left untouched as out-of-scope; all six new skin files use the "Universal Assembly" / neutral "UA" naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
