### PR TITLE
Mobile: Singularity faction treatment (#526)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -127,6 +127,11 @@
         "masthead": "The Salon Desk",
         "charEyebrow": "In residence",
         "questsHeading": "At the easel"
+      },
+      "singularity": {
+        "masthead": "FieldDesk.sys",
+        "charEyebrow": "// active_node",
+        "questsHeading": "// running_processes"
       }
     }
   },

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -317,6 +317,9 @@
       "emptyWithSpotlight": "> no other nodes online",
       "level": "lvl {{level}}"
     },
+    "mobile": {
+      "eyebrow": "> ~/faction"
+    },
     "invitation": {
       "kicker": "> PRIVILEGE ELEVATED",
       "headline": "Join the array",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -331,7 +331,20 @@
       "removeButton": "rm",
       "publishIdle": "TRANSMIT SIGNAL",
       "publishBusy": "$ transmitting...",
-      "dropLabel": "[esc] :q"
+      "dropLabel": "[esc] :q",
+      "mobile": {
+        "pageTitle": "> praxis --edit",
+        "autosaveSaved": "[saved {{ago}}]",
+        "autosaveUnsaved": "unsaved",
+        "taskRefLabel": "// function",
+        "titleLabel": "// title",
+        "bodyLabel": "// process_log · {{words}} W",
+        "inviteLabel": "// network",
+        "inviteLabelDuel": "// adversary",
+        "filesLabel": "// artifacts",
+        "metatasksLabel": "// optional_subroutines",
+        "previewLabel": "// render"
+      }
     },
     "ua": {
       "masthead": "University of Asthmatics · Salon Submission №{{number}}",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -241,7 +241,15 @@
       "artifacts_one": "ARTIFACTS · {{count}} file submitted",
       "artifacts_other": "ARTIFACTS · {{count}} files submitted",
       "consensusArray": "CONSENSUS_ARRAY",
-      "crFromSignals": "CR FROM SIGNALS"
+      "crFromSignals": "CR FROM SIGNALS",
+      "mobile": {
+        "node": "signal from node",
+        "output": "// output",
+        "artifacts": "// output_artifacts",
+        "re": "re:",
+        "consensus": "// consensus_signal",
+        "amplify": "> amplify the signal"
+      }
     },
     "snide": {
       "closedCaseFiled": "S.N.I.D.E. · CLOSED CASE · FILED",

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -290,7 +290,13 @@
     },
     "empty": "> No amplification detected. No node has witnessed this yet.",
     "highestSignal": "HIGHEST SIGNAL",
-    "viewAll": "> view all {{count}} logs →"
+    "viewAll": "> view all {{count}} logs →",
+    "mobile": {
+      "listMasthead": "> ls ./functions",
+      "detailEyebrow": "> cat ./function",
+      "briefHeading": "// the_function",
+      "worksHeading": "// signaled_praxis"
+    }
   },
   "ua": {
     "faction": "UA",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -26,6 +26,7 @@ import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
 import DefaultMobileEditPraxis from "./editPraxis/mobileArchetypes/DefaultEditPraxis";
 import WowMobileEditPraxis from "./editPraxis/mobileArchetypes/WowEditPraxis";
 import UAMobileEditPraxis from "./editPraxis/mobileArchetypes/UaComposer";
+import SingularityMobileEditPraxis from "./editPraxis/mobileArchetypes/SingularityComposer";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
@@ -48,6 +49,7 @@ const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   wow: WowMobileEditPraxis,
   ua: UAMobileEditPraxis,
+  singularity: SingularityMobileEditPraxis,
 };
 
 export default function EditPraxis() {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -7,6 +7,7 @@ import { pickVariant } from "../utils/factionDispatch";
 import { useFormFactor } from "../hooks/useFormFactor";
 import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFactionDetail";
 import UaFactionPage from "./factionDetail/mobileArchetypes/UaFactionPage";
+import SingularityFactionPage from "./factionDetail/mobileArchetypes/SingularityFactionPage";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import DefaultFactionPage from "./factionDetail/mobileArchetypes/DefaultFactionPage";
 import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
@@ -80,6 +81,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<
   ComponentType<{ state: FactionDetailState }>
 > = {
   ua: UaFactionPage,
+  singularity: SingularityFactionPage,
 };
 
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -13,6 +13,7 @@ import { useFieldDeskHome, type FieldDeskHomeState } from './fieldDesk/useFieldD
 import DefaultFieldDesk from './fieldDesk/mobileArchetypes/DefaultFieldDesk'
 import WowFieldDesk from './fieldDesk/mobileArchetypes/WowFieldDesk'
 import UaHome from './fieldDesk/mobileArchetypes/UaHome'
+import SingularityHome from './fieldDesk/mobileArchetypes/SingularityHome'
 
 /**
  * FieldDesk roster — the authenticated account home (#274). "Whose shoes today?":
@@ -34,6 +35,7 @@ type MobileHomeSkin = (props: { state: FieldDeskHomeState }) => JSX.Element
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileHomeSkin> = {
   wow: WowFieldDesk,
   ua: UaHome,
+  singularity: SingularityHome,
 }
 
 // Deterministic slight tilt per card — index-keyed so it's stable across renders.

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -18,6 +18,7 @@ import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
 import DefaultMobilePraxisDetail from './praxisDetail/mobileArchetypes/DefaultPraxisDetail'
 import WowMobilePraxisDetail from './praxisDetail/mobileArchetypes/WowPraxisDetail'
 import UAMobilePraxisDetail from './praxisDetail/mobileArchetypes/UaPraxisDetail'
+import SingularityMobilePraxisDetail from './praxisDetail/mobileArchetypes/SingularityPraxisDetail'
 import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
 import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
 import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
@@ -52,6 +53,7 @@ export const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDeta
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDetailState }>> = {
   wow: WowMobilePraxisDetail,
   ua: UAMobilePraxisDetail,
+  singularity: SingularityMobilePraxisDetail,
 }
 
 export default function PraxisDetail() {

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -17,6 +17,7 @@ import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
 import DefaultMobileTaskDetail from "./taskDetail/mobileArchetypes/DefaultTaskDetail";
 import EverymenMobileTaskDetail from "./taskDetail/mobileArchetypes/EverymenTaskDetail";
 import UAMobileTaskDetail from "./taskDetail/mobileArchetypes/UaTaskDetail";
+import SingularityMobileTaskDetail from "./taskDetail/mobileArchetypes/SingularityTaskDetail";
 import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
@@ -47,6 +48,7 @@ export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   everymen: EverymenMobileTaskDetail,
   ua: UAMobileTaskDetail,
+  singularity: SingularityMobileTaskDetail,
 };
 
 export default function TaskDetail() {

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -10,6 +10,7 @@ import { pickVariant } from '../utils/factionDispatch'
 import { useTasks, type TasksState } from './tasks/useTasks'
 import DefaultTasks from './tasks/mobileArchetypes/DefaultTasks'
 import UaTaskList from './tasks/mobileArchetypes/UaTaskList'
+import SingularityTaskList from './tasks/mobileArchetypes/SingularityTaskList'
 
 type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 
@@ -20,6 +21,7 @@ type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 // (and logged-out visitors) fall through to the Default mobile browse skin.
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {
   ua: UaTaskList,
+  singularity: SingularityTaskList,
 }
 
 export default function Tasks() {

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
@@ -1,0 +1,345 @@
+import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import MediaArt from '../blocks/MediaArt'
+import { pickArtKey } from '../blocks/useMediaArt'
+import { ErrorBanner, formatAutosave } from '../archetypes/shared'
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from '../archetypes/controls'
+import type { EditPraxisState } from '../useEditPraxis'
+import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+
+/**
+ * Singularity MOBILE composer (#526) — "TRANSMIT SIGNAL" on a phone. The same
+ * single-column composer as the Default mobile skin (Write/Preview toggle, fluid
+ * media grid, sticky submit bar) dressed as a dark terminal: bracketed readout
+ * panels, `//`-prompted labels, phosphor-green text on a void field. Ported from
+ * the desktop Singularity terminal archetype; consumes `useEditPraxis` verbatim —
+ * no editor, upload, or submit logic lives here.
+ *
+ * Always-dark: every colour resolves to a theme-identical --faction-singularity-*
+ * token; the skin paints its own void field and never mutates data-theme.
+ */
+
+const VOID = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const SIGNAL = 'var(--faction-singularity-card-muted)'
+const BORDER_HARD = 'var(--faction-singularity-border-hard)'
+const FONT = 'var(--font-faction-terminal)'
+
+const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`
+const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  display: 'block',
+  fontFamily: FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: signal(60),
+}
+
+/** Void readout panel headed by a prompt label. */
+function Panel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: 14 }}>
+      <div style={{ fontFamily: FONT, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: PHOSPHOR, marginBottom: 10 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default function SingularityComposer({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation('forms')
+  const [tab, setTab] = useState<ComposerTab>('write')
+  const praxis = state.praxis!
+  const task = state.task
+
+  return (
+    <div data-skin="singularity" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: FONT, color: PHOSPHOR, background: VOID }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <h1 style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.03em', margin: 0 }}>
+            {t('editPraxis.singularity.mobile.pageTitle')}
+          </h1>
+          <span style={{ ...kicker, marginLeft: 'auto' }}>
+            {state.autosaveAt
+              ? t('editPraxis.singularity.mobile.autosaveSaved', { ago: formatAutosave(state.autosaveAt) })
+              : t('editPraxis.singularity.mobile.autosaveUnsaved')}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: { gap: 4, padding: 3, background: VOID, border: `1px solid ${signal(38)}` },
+            buttonStyle: (active) => ({
+              padding: '9px 10px',
+              border: 'none',
+              fontFamily: FONT,
+              fontSize: 11,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              background: active ? PHOSPHOR : 'transparent',
+              color: active ? VOID : signal(60),
+            }),
+          }}
+        />
+      </header>
+
+      {/* For-function reference */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: VOID, border: `1px solid ${signal(38)}` }}>
+        <span style={kicker}>{t('editPraxis.singularity.mobile.taskRefLabel')}</span>
+        <span style={{ fontFamily: FONT, fontSize: 14, color: PHOSPHOR, textAlign: 'right', flex: 1, lineHeight: 1.2 }}>
+          {praxis.task_title}
+        </span>
+      </div>
+      <div style={{ ...kicker, color: SIGNAL }}>
+        {factionName(task?.primary_faction_slug ?? null)}
+        {task ? ` · ${t('taskMeta.points', { points: task.point_value })}` : ''}
+      </div>
+
+      {tab === 'write' ? (
+        <>
+          <Panel title={t('editPraxis.singularity.mobile.titleLabel')}>
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t('editPraxis.singularity.titlePlaceholder'),
+                inputStyle: {
+                  width: '100%',
+                  fontFamily: FONT,
+                  fontSize: 18,
+                  color: PHOSPHOR,
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  borderBottom: `1px solid ${signal(38)}`,
+                  padding: '2px 0 8px',
+                },
+              }}
+            />
+          </Panel>
+
+          <Panel title={t('editPraxis.singularity.mobile.bodyLabel', { words: state.wordCount })}>
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t('editPraxis.singularity.bodyPlaceholder'),
+                textareaStyle: {
+                  width: '100%',
+                  fontFamily: FONT,
+                  fontSize: 13,
+                  lineHeight: 1.6,
+                  color: PHOSPHOR,
+                  background: signal(6),
+                  border: `1px solid ${signal(38)}`,
+                  padding: '13px 15px',
+                  outline: 'none',
+                  resize: 'vertical',
+                  minHeight: 180,
+                },
+              }}
+            />
+          </Panel>
+
+          {state.showInviteBox && (
+            <Panel title={state.duelMode ? t('editPraxis.singularity.mobile.inviteLabelDuel') : t('editPraxis.singularity.mobile.inviteLabel')}>
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: FONT,
+                  inputBg: signal(6),
+                  inputColor: PHOSPHOR,
+                  inputBorder: `1px solid ${signal(38)}`,
+                  acceptedBg: PHOSPHOR,
+                  acceptedColor: VOID,
+                  placeholder: t('editPraxis.singularity.invitePlaceholder'),
+                }}
+              />
+            </Panel>
+          )}
+
+          <Panel title={t('editPraxis.singularity.mobile.filesLabel')}>
+            <MediaGrid state={state} />
+          </Panel>
+
+          {state.showMetatasks && (
+            <Panel title={t('editPraxis.singularity.mobile.metatasksLabel')}>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: { display: 'flex', flexDirection: 'column', gap: 4 },
+                  rowStyle: (selected) => ({
+                    padding: '10px 12px',
+                    background: selected ? signal(12) : 'transparent',
+                    border: `1px solid ${selected ? PHOSPHOR : signal(30)}`,
+                  }),
+                  titleColor: PHOSPHOR,
+                  descColor: signal(60),
+                  pointsActiveColor: PHOSPHOR,
+                  pointsIdleColor: SIGNAL,
+                }}
+              />
+            </Panel>
+          )}
+        </>
+      ) : (
+        <Panel title={t('editPraxis.singularity.mobile.previewLabel')}>
+          <div style={{ fontFamily: FONT, fontSize: 18, color: PHOSPHOR, marginBottom: 10 }}>
+            {'> '}
+            {state.title || t('editPraxis.singularity.titlePlaceholder')}
+          </div>
+          {state.media.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <MediaGrid state={state} readOnly />
+            </div>
+          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              markdownStyle: { fontFamily: FONT, fontSize: 13, lineHeight: 1.6, color: phosphor(80) },
+            }}
+          />
+        </Panel>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      <MobileStickyBar
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 0 4px',
+          background: 'var(--color-nav-bg)',
+          backdropFilter: 'blur(var(--nav-blur))',
+          borderTop: `1px solid ${BORDER_HARD}`,
+        }}
+      >
+        <PublishButton
+          state={state}
+          skin={{
+            idleLabel: t('editPraxis.singularity.publishIdle'),
+            busyLabel: t('editPraxis.singularity.publishBusy'),
+            style: {
+              flex: 1,
+              background: PHOSPHOR,
+              color: VOID,
+              fontFamily: FONT,
+              fontSize: 12,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              padding: '13px 18px',
+              border: `1px solid ${PHOSPHOR}`,
+              boxShadow: `0 0 16px ${phosphor(30)}`,
+              cursor: state.submitting ? 'wait' : 'pointer',
+            },
+          }}
+        />
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.singularity.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: signal(60),
+                fontFamily: FONT,
+                fontSize: 13,
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
+      </MobileStickyBar>
+    </div>
+  )
+}
+
+/** Fluid 3-column media grid in the terminal readout idiom. */
+function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOnly?: boolean }) {
+  const { t } = useTranslation('forms')
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+      {state.media.map((item) => {
+        const filename = item.file_path.split('/').pop() ?? item.file_path
+        const src = mediaUrl(item.file_path)
+        return (
+          <div key={item.id} style={{ position: 'relative', aspectRatio: '1 / 1', overflow: 'hidden', border: `1px solid ${signal(38)}`, background: signal(6) }}>
+            {item.type === 'image' ? (
+              <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : item.type === 'video' ? (
+              <video src={src} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <MediaArt art={pickArtKey(filename, 'audio')} width={120} height={120} />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t('media.removeAria', { name: filename })}
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  background: VOID,
+                  border: `1px solid ${PHOSPHOR}`,
+                  color: PHOSPHOR,
+                  fontSize: 12,
+                  lineHeight: 1,
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        )
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: '1 / 1',
+              width: '100%',
+              background: signal(6),
+              border: `1.5px dashed ${signal(38)}`,
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 4,
+              fontFamily: FONT,
+              fontSize: 10,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: PHOSPHOR,
+            },
+            buttonLabel: t('editPraxis.singularity.fileButton'),
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/singularityDispatch.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Mobile composer Singularity dispatch (#526) — asserts the MOBILE registry
+ * routes a Singularity task's composer to its bespoke terminal skin (distinct
+ * from the desktop archetype), while other slugs fall through to the Default
+ * mobile composer.
+ */
+import { describe, it, expect } from 'vitest'
+import { pickVariant } from '../../../../utils/factionDispatch'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../../EditPraxis'
+import DefaultMobileEditPraxis from '../DefaultEditPraxis'
+import SingularityMobileEditPraxis from '../SingularityComposer'
+import SingularityDesktopEditPraxis from '../../archetypes/SingularityEditPraxis'
+
+describe('mobile composer Singularity dispatch', () => {
+  it('resolves singularity to the bespoke terminal mobile composer', () => {
+    const skin = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'singularity', DefaultMobileEditPraxis)
+    expect(skin).toBe(SingularityMobileEditPraxis)
+    expect(skin).not.toBe(SingularityDesktopEditPraxis)
+  })
+
+  it('falls through to the Default mobile composer for other slugs', () => {
+    for (const slug of ['na', 'snide', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileEditPraxis)).toBe(DefaultMobileEditPraxis)
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/singularityDispatch.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Mobile faction-page Singularity dispatch (#526) — asserts the MOBILE registry
+ * routes the Singularity faction page to its bespoke terminal skin, while other
+ * slugs fall through to the Default mobile faction page.
+ */
+import { describe, it, expect } from 'vitest'
+import { pickVariant } from '../../../utils/factionDispatch'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FactionDetail'
+import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
+import SingularityFactionPage from '../mobileArchetypes/SingularityFactionPage'
+
+describe('mobile faction-page Singularity dispatch', () => {
+  it('resolves singularity to the bespoke terminal faction page', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'singularity', DefaultFactionPage)).toBe(SingularityFactionPage)
+  })
+
+  it('falls through to the Default mobile faction page for other slugs', () => {
+    for (const slug of ['na', 'everymen', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
@@ -1,0 +1,269 @@
+import { useState, type CSSProperties, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { factionName, factionDescription } from '../../../utils/factions'
+import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
+import type { CharacterOut } from '../../../api/auth'
+import type { FactionDetailState } from '../useFactionDetail'
+
+/**
+ * Singularity MOBILE faction page (#526) — the dark terminal, phone shaped. The
+ * same single-column slots as the Default mobile faction page (a hero with real
+ * member/task counts, primary nodes, recent praxis, and the invite-gated Join
+ * model via `state.membership`, ADR-0019) — only the dress changes: bracketed
+ * readout panels, `>`-prompts, phosphor-green text on a void field.
+ *
+ * Always-dark: every colour resolves to a theme-identical --faction-singularity-*
+ * token; the skin paints its own void field and never mutates data-theme. Reuses
+ * the shared `mobile.*` faction copy so the slot contract holds. Presentation-only
+ * — all data + the join handler arrive via {@link FactionDetailState}.
+ */
+
+const NA_SLUG = 'na'
+
+const VOID = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const SIGNAL = 'var(--faction-singularity-card-muted)'
+const BORDER_HARD = 'var(--faction-singularity-border-hard)'
+const AMBER = 'var(--underline-1)'
+const FONT = 'var(--font-faction-terminal)'
+
+const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`
+const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: signal(60),
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || '?'
+
+/** Signal-ringed initials node glyph. */
+function NodeGlyph({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: signal(14),
+        border: `1px solid ${BORDER_HARD}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: FONT,
+        fontSize: size * 0.36,
+        color: SIGNAL,
+      }}
+    >
+      {initial(name)}
+    </span>
+  )
+}
+
+function SectionHead({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: PHOSPHOR }}>
+        {children}
+      </span>
+      <span style={{ flex: 1, height: 1, background: signal(30) }} />
+    </div>
+  )
+}
+
+const joinButton: CSSProperties = {
+  width: '100%',
+  fontFamily: FONT,
+  fontSize: 13,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: VOID,
+  background: PHOSPHOR,
+  border: `1px solid ${PHOSPHOR}`,
+  padding: '13px 16px',
+  boxShadow: `0 0 16px ${phosphor(30)}`,
+  cursor: 'pointer',
+}
+
+export default function SingularityFactionPage({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation('factions')
+  const { faction, members, tasks, recentPraxis, membership } = state
+  const [confirming, setConfirming] = useState(false)
+
+  if (!faction) return null
+
+  const name = factionName(faction.slug)
+  const topMembers = [...members].sort((a, b) => b.all_time_score - a.all_time_score).slice(0, 3)
+  const currentSlug = membership.currentFactionSlug
+  const switching = currentSlug && currentSlug !== NA_SLUG
+
+  return (
+    <div data-skin="singularity" className="py-4" style={{ fontFamily: FONT, color: PHOSPHOR, background: VOID }} data-testid="mobile-faction-page">
+      {/* Hero — bracketed readout masthead */}
+      <section style={{ position: 'relative', overflow: 'hidden', background: VOID, border: `1px solid ${BORDER_HARD}`, padding: '20px 18px' }}>
+        <div
+          aria-hidden
+          style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: `repeating-linear-gradient(to bottom, transparent, transparent 2px, ${phosphor(1.2)} 2px, ${phosphor(1.2)} 4px)` }}
+        />
+        <div style={{ position: 'relative' }}>
+          <div style={{ ...kicker, color: PHOSPHOR }}>{t('singularity.mobile.eyebrow')}</div>
+          <h1 style={{ fontFamily: FONT, fontSize: 26, lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', margin: '6px 0 0' }}>
+            {'> '}
+            {name}
+          </h1>
+          <p style={{ fontFamily: FONT, fontSize: 11, lineHeight: 1.7, color: phosphor(60), margin: '10px 0 0' }}>
+            {factionDescription(faction.slug)}
+          </p>
+          <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
+            <HeroStat value={members.length} label={t('mobile.membersStat')} />
+            <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
+          </div>
+        </div>
+      </section>
+
+      {membership.state === 'member' && (
+        <p style={{ ...kicker, marginTop: 12, color: AMBER }}>{t('mobile.memberBadge')}</p>
+      )}
+
+      {/* Primary nodes */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.topMembers')}</SectionHead>
+        {topMembers.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50), margin: 0 }}>{t('mobile.membersEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topMembers.map((m, index) => (
+              <MemberRow key={m.id} rank={index + 1} member={m} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent praxis */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
+        {recentPraxis.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50), margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {membership.state === 'gate' && (
+        <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(55), marginTop: 24 }}>
+          {t('mobile.gateHint', { faction: name })}
+        </p>
+      )}
+
+      {/* Sticky Join — only an eligible viewer can act (ADR-0019). */}
+      {membership.state === 'eligible' && (
+        <MobileStickyBar>
+          {membership.joinError && (
+            <p style={{ fontFamily: FONT, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+          )}
+          {!confirming ? (
+            <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
+              {t('mobile.join', { faction: name })}
+            </button>
+          ) : (
+            <>
+              <p style={{ fontFamily: FONT, fontSize: 12, lineHeight: 1.6, color: phosphor(72) }}>
+                {switching
+                  ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
+                  : t('detail.join.confirm', { faction: name })}
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => void membership.join()}
+                  disabled={membership.joining}
+                  style={{ ...joinButton, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                >
+                  {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirming(false)}
+                  disabled={membership.joining}
+                  style={{
+                    fontFamily: FONT,
+                    fontSize: 11,
+                    letterSpacing: '0.1em',
+                    textTransform: 'uppercase',
+                    color: signal(60),
+                    background: 'transparent',
+                    border: `1px solid ${signal(38)}`,
+                    padding: '11px 16px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t('detail.join.cancel')}
+                </button>
+              </div>
+            </>
+          )}
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+function HeroStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={{ flex: '1 1 0', textAlign: 'center', background: signal(8), border: `1px solid ${signal(28)}`, padding: '10px 6px' }}>
+      <b style={{ fontFamily: FONT, fontSize: 18, display: 'block', lineHeight: 1, color: PHOSPHOR }}>
+        {value}
+      </b>
+      <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
+    </div>
+  )
+}
+
+function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
+  const { t } = useTranslation('factions')
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: VOID,
+        border: `1px solid ${signal(38)}`,
+        borderLeft: `3px solid ${PHOSPHOR}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ fontFamily: FONT, fontSize: 14, color: SIGNAL, width: 16, flex: 'none' }}>{rank}</span>
+      <NodeGlyph name={member.display_name} size={28} />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: FONT,
+          fontSize: 13,
+          color: PHOSPHOR,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {member.display_name}
+      </span>
+      <span style={{ fontFamily: FONT, fontSize: 9, letterSpacing: '0.04em', color: AMBER, flex: 'none' }}>
+        {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/pages/fieldDesk/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/singularityDispatch.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Mobile FieldDesk-home Singularity dispatch (#526) — asserts the registry
+ * routes a Singularity node's carried life to its bespoke terminal home skin,
+ * and that an unregistered slug still falls through to the Default mobile home.
+ */
+import { describe, it, expect } from 'vitest'
+import { pickVariant } from '../../../utils/factionDispatch'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FieldDesk'
+import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
+import SingularityHome from '../mobileArchetypes/SingularityHome'
+
+describe('mobile FieldDesk-home Singularity dispatch', () => {
+  it('resolves singularity to the bespoke terminal home skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'singularity', DefaultFieldDesk)).toBe(SingularityHome)
+  })
+
+  it('falls through to the Default mobile home for other slugs', () => {
+    for (const slug of ['na', 'snide', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
+    }
+  })
+})

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
@@ -1,0 +1,258 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+
+/**
+ * Singularity MOBILE FieldDesk home (#526) — the dark terminal on a phone. The
+ * carried life and its running functions become bracketed readout panels on a
+ * void field: a prompt-headed masthead, corner-bracketed node panel with signal
+ * stat cells, an active-functions list, and prompt-styled actions. Same content
+ * slots as the Default mobile home (character header, Points/Votes/Era tiles,
+ * active-tasks list, primary actions) — only the dress changes.
+ *
+ * Singularity is ALWAYS DARK: every colour resolves to a --faction-singularity-*
+ * token that reads identically in both themes, so the skin paints its own void
+ * container and never mutates data-theme. Presentation-only — all data arrives
+ * via {@link FieldDeskHomeState}.
+ */
+
+const VOID = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const SIGNAL = 'var(--faction-singularity-card-muted)'
+const BORDER_HARD = 'var(--faction-singularity-border-hard)'
+const AMBER = 'var(--underline-1)'
+const FONT = 'var(--font-faction-terminal)'
+
+const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`
+const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: FONT,
+  fontSize: 8,
+  letterSpacing: '0.22em',
+  textTransform: 'uppercase',
+  color: signal(60),
+}
+
+/** Blinking terminal cursor block. */
+function Cursor() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        width: 6,
+        height: 11,
+        marginLeft: 4,
+        verticalAlign: 'middle',
+        background: PHOSPHOR,
+        animation: 'blink 1s step-end infinite',
+      }}
+    />
+  )
+}
+
+/** Void readout panel with a signal-blue hairline and corner brackets. */
+function Panel({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ position: 'relative', overflow: 'hidden', background: VOID, border: `1px solid ${signal(42)}`, padding: 16 }}>
+      {/* Scanline overlay */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background: `repeating-linear-gradient(to bottom, transparent, transparent 2px, ${phosphor(1.2)} 2px, ${phosphor(1.2)} 4px)`,
+        }}
+      />
+      <div style={{ position: 'relative' }}>{children}</div>
+    </div>
+  )
+}
+
+export default function SingularityHome({ state }: { state: FieldDeskHomeState }) {
+  const { t } = useTranslation('common')
+  const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+
+  const stats = [
+    { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
+    { label: t('fieldDesk.home.stats.votes'), value: votesReceived.toLocaleString() },
+    { label: t('fieldDesk.home.stats.era'), value: eraName || '—' },
+  ]
+
+  return (
+    <div
+      data-skin="singularity"
+      className="page"
+      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: FONT, color: PHOSPHOR, background: VOID }}
+    >
+      {/* Prompt masthead */}
+      <header>
+        <div style={kicker}>{t('nav.home')}</div>
+        <h1 style={{ fontFamily: FONT, fontSize: 26, lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.04em', margin: '4px 0 0' }}>
+          {'> '}
+          {t('fieldDesk.home.singularity.masthead')}
+          <Cursor />
+        </h1>
+        <div style={{ height: 1, marginTop: 10, background: `linear-gradient(90deg, ${BORDER_HARD}, transparent)` }} />
+      </header>
+
+      {/* ── Node panel ── */}
+      <Panel>
+        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+          <span style={kicker}>{t('fieldDesk.home.singularity.charEyebrow')}</span>
+          <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: PHOSPHOR, textDecoration: 'none' }}>
+            {t('fieldDesk.home.edit')}
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div
+            className="shrink-0"
+            style={{ width: 52, height: 52, borderRadius: '50%', border: `1px solid ${BORDER_HARD}`, background: signal(14), overflow: 'hidden' }}
+          >
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="w-full h-full"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : (
+              <span
+                className="flex w-full h-full items-center justify-center"
+                style={{ fontFamily: FONT, fontSize: 20, color: SIGNAL }}
+              >
+                {character.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/characters/${character.id}`}
+              className="block truncate"
+              style={{ fontFamily: FONT, fontSize: 20, lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', textDecoration: 'none' }}
+            >
+              {character.display_name}
+            </Link>
+            <div className="truncate" style={{ marginTop: 5, fontFamily: FONT, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
+              {t('sidebar.characterCard.factionLevel', {
+                faction: factionName(character.faction_slug),
+                level: character.level,
+              })}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1, color: PHOSPHOR }}>
+              {character.score?.toLocaleString() ?? '0'}
+            </div>
+            <div style={{ ...kicker, marginTop: 3 }}>{t('fieldDesk.home.stats.points')}</div>
+          </div>
+        </div>
+
+        <div className="flex gap-2" style={{ marginTop: 16 }}>
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center"
+              style={{ flex: '1 1 0', minWidth: 0, background: signal(8), border: `1px solid ${signal(28)}`, padding: '11px 6px' }}
+            >
+              <div className="truncate" style={{ fontFamily: FONT, fontSize: 18, lineHeight: 1, color: PHOSPHOR }}>
+                {stat.value}
+              </div>
+              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      </Panel>
+
+      {/* ── Pending requests ── */}
+      {pendingCount > 0 && (
+        <Link
+          to="/updates?filter=requests"
+          className="flex items-center justify-between"
+          style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: '11px 16px', fontFamily: FONT, fontSize: 12, color: PHOSPHOR, textDecoration: 'none' }}
+        >
+          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
+          <span aria-hidden style={{ color: SIGNAL }}>›</span>
+        </Link>
+      )}
+
+      {/* ── Running functions ── */}
+      <Panel>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+          <span style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: PHOSPHOR }}>
+            {t('fieldDesk.home.singularity.questsHeading')}
+          </span>
+          <span style={{ flex: 1, height: 1, background: signal(30) }} />
+          <Link to="/tasks" style={{ ...kicker, color: SIGNAL, textDecoration: 'none' }}>
+            {t('fieldDesk.home.viewAll')}
+          </Link>
+        </div>
+
+        {activeTasks.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(45), margin: 0 }}>
+            {t('fieldDesk.home.questsEmpty')}
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {activeTasks.map((praxis, index) => (
+              <Link
+                key={praxis.id}
+                to={`/praxes/${praxis.id}/edit`}
+                className="flex items-center gap-3"
+                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${signal(14)}`, textDecoration: 'none' }}
+              >
+                <span className="shrink-0" style={{ fontFamily: FONT, fontSize: 13, color: PHOSPHOR }}>›</span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate" style={{ fontFamily: FONT, fontSize: 14, lineHeight: 1.2, color: PHOSPHOR }}>
+                    {praxis.task_title}
+                  </div>
+                  <div className="truncate" style={{ marginTop: 3, fontFamily: FONT, fontSize: 8.5, letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
+                    {t('fieldDesk.home.taskMeta', {
+                      faction: factionName(praxis.task_faction_slug),
+                      points: praxis.task_point_value,
+                    })}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0"
+                  style={{ fontFamily: FONT, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: '4px 9px', border: `1px solid ${signal(30)}` }}
+                >
+                  {t(`praxisType.${praxis.type}`)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </Panel>
+
+      {/* ── Primary actions ── */}
+      <div className="flex gap-2.5">
+        <Link
+          to="/tasks"
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: FONT, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: VOID, background: PHOSPHOR, border: `1px solid ${PHOSPHOR}`, boxShadow: `0 0 16px ${phosphor(30)}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.browseTasks')}
+        </Link>
+        {canProposeTask && (
+          <Link
+            to="/propose-task"
+            className="flex-1 flex items-center justify-center gap-2"
+            style={{ fontFamily: FONT, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PHOSPHOR, background: 'transparent', border: `1px solid ${signal(40)}`, textDecoration: 'none' }}
+          >
+            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+            <span>{t('actions.proposeTask')}</span>
+          </Link>
+        )}
+      </div>
+
+      <style>{'@keyframes blink { 50% { opacity: 0; } }'}</style>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDispatch.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Mobile praxis-detail Singularity dispatch (#526) — asserts the MOBILE registry
+ * routes a Singularity praxis to its bespoke terminal skin (distinct from the
+ * desktop archetype), while other slugs fall through to the Default mobile skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { pickVariant } from '../../../utils/factionDispatch'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../PraxisDetail'
+import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
+import SingularityMobilePraxisDetail from '../mobileArchetypes/SingularityPraxisDetail'
+import SingularityDesktopPraxisDetail from '../archetypes/SingularityPraxisDetail'
+
+describe('mobile praxis-detail Singularity dispatch', () => {
+  it('resolves singularity to the bespoke terminal mobile skin', () => {
+    const skin = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'singularity', DefaultMobilePraxisDetail)
+    expect(skin).toBe(SingularityMobilePraxisDetail)
+    expect(skin).not.toBe(SingularityDesktopPraxisDetail)
+  })
+
+  it('falls through to the Default mobile skin for other slugs', () => {
+    for (const slug of ['na', 'ephemerists', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobilePraxisDetail)).toBe(DefaultMobilePraxisDetail)
+    }
+  })
+})

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/SingularityPraxisDetail.tsx
@@ -1,0 +1,155 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import { formatTimestamp } from '../../../utils/dates'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisVoterBreakdown,
+  MemberByline,
+} from '../shared'
+import { MobileStarVote } from './shared'
+
+/**
+ * Singularity MOBILE praxis-detail skin (#526) — a generated signal, phone
+ * shaped. A bracketed readout panel holds the output artifacts (full media); a
+ * `>`-prefixed finding, the process log body, and a thumb-sized amplify caster
+ * follow. Renders the same invariant CONTENT + behavior slots as every archetype
+ * (the shared praxisDetail module) — only the dress changes.
+ *
+ * Always-dark: every colour resolves to a theme-identical --faction-singularity-*
+ * token; the skin paints its own void field and never mutates data-theme.
+ */
+
+const VOID = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const SIGNAL = 'var(--faction-singularity-card-muted)'
+const BORDER_HARD = 'var(--faction-singularity-border-hard)'
+const FONT = 'var(--font-faction-terminal)'
+
+const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`
+const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: signal(60),
+}
+
+/** Void readout panel with a signal hairline, headed by a prompt title. */
+function Panel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ position: 'relative', overflow: 'hidden', background: VOID, border: `1px solid ${signal(42)}`, padding: 13 }}>
+      <div
+        aria-hidden
+        style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: `repeating-linear-gradient(to bottom, transparent, transparent 2px, ${phosphor(1.2)} 2px, ${phosphor(1.2)} 4px)` }}
+      />
+      <div style={{ position: 'relative' }}>
+        <div style={{ fontFamily: FONT, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: PHOSPHOR, marginBottom: 10 }}>
+          {title}
+        </div>
+        {children}
+      </div>
+    </section>
+  )
+}
+
+export default function SingularityPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <div data-skin="singularity" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: FONT, color: PHOSPHOR, background: VOID }}>
+      {/* Behavior slots (invariant) */}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
+
+      {/* Byline row */}
+      <div className="flex items-center gap-3">
+        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+          <span
+            className="flex items-center justify-center rounded-full"
+            style={{ width: 42, height: 42, background: signal(14), border: `1px solid ${BORDER_HARD}`, color: SIGNAL, fontFamily: FONT, fontSize: 18 }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <MemberByline
+            praxis={praxis}
+            linkStyle={{ fontFamily: FONT, fontSize: 16, color: PHOSPHOR, lineHeight: 1, textDecoration: 'none' }}
+          />
+          <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
+            {t('detail.singularity.mobile.node')} · {formatTimestamp(sealedDate)}
+          </div>
+        </div>
+      </div>
+
+      {/* Output artifacts — full media inside */}
+      {praxis.media_items.length > 0 && (
+        <Panel title={t('detail.singularity.mobile.artifacts')}>
+          <MediaGallery media={praxis.media_items} layout="grid" />
+        </Panel>
+      )}
+
+      {/* Finding */}
+      <div>
+        <div style={{ ...kicker, marginBottom: 4, color: SIGNAL }}>{t('detail.singularity.mobile.output')}</div>
+        <h1 style={{ fontFamily: FONT, fontSize: 24, lineHeight: 1.2, margin: 0, color: PHOSPHOR, letterSpacing: '0.02em', overflowWrap: 'anywhere' }}>
+          {'> '}
+          {praxis.title ?? t('detail.singularity.untitled')}
+        </h1>
+      </div>
+
+      {/* Owner actions (invariant) */}
+      <PraxisOwnerActions state={state} />
+
+      {/* re: task link */}
+      <div style={{ fontFamily: FONT, fontSize: 12, color: phosphor(60) }}>
+        {t('detail.singularity.mobile.re')}{' '}
+        <Link to={`/tasks/${praxis.task_id}`} style={{ color: PHOSPHOR, textDecoration: 'none' }}>
+          {praxis.task_title}
+        </Link>
+      </div>
+
+      {/* Process-log body */}
+      {praxis.body_text && (
+        <MarkdownPreview
+          source={praxis.body_text}
+          className="markdown-preview"
+          style={{ fontFamily: FONT, fontSize: 13, lineHeight: 1.7, color: phosphor(80) }}
+        />
+      )}
+
+      {/* Amplify caster */}
+      <Panel title={t('detail.singularity.mobile.consensus')}>
+        <div className="flex items-center justify-center" style={{ marginBottom: 12, fontFamily: FONT, fontSize: 13, color: PHOSPHOR }}>
+          {t('detail.singularity.mobile.amplify')}
+        </div>
+        <MobileStarVote
+          praxisId={praxis.id}
+          points={votes?.total_score}
+          totalVotes={votes?.total_votes}
+          accent={PHOSPHOR}
+          accentFont={FONT}
+        />
+      </Panel>
+
+      {/* Flag + voter breakdown (invariant) */}
+      <PraxisFlagBlock state={state} />
+      <PraxisVoterBreakdown state={state} />
+    </div>
+  )
+}

--- a/frontend/src/pages/taskDetail/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDispatch.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Mobile task-detail Singularity dispatch (#526) — asserts the MOBILE registry
+ * routes a Singularity task to its bespoke terminal skin (distinct from the
+ * desktop archetype), while other slugs fall through to the Default mobile skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { pickVariant } from '../../../utils/factionDispatch'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../TaskDetail'
+import DefaultMobileTaskDetail from '../mobileArchetypes/DefaultTaskDetail'
+import SingularityMobileTaskDetail from '../mobileArchetypes/SingularityTaskDetail'
+import SingularityDesktopTaskDetail from '../archetypes/SingularityTaskDetail'
+
+describe('mobile task-detail Singularity dispatch', () => {
+  it('resolves singularity to the bespoke terminal mobile skin', () => {
+    const skin = pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'singularity', DefaultMobileTaskDetail)
+    expect(skin).toBe(SingularityMobileTaskDetail)
+    expect(skin).not.toBe(SingularityDesktopTaskDetail)
+  })
+
+  it('falls through to the Default mobile skin for other slugs', () => {
+    for (const slug of ['na', 'wow', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).toBe(DefaultMobileTaskDetail)
+    }
+  })
+})

--- a/frontend/src/pages/taskDetail/mobileArchetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/SingularityTaskDetail.tsx
@@ -1,0 +1,309 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { MobileStickyBar, MobileStickyCaption } from './shared'
+import type { TaskDetailState } from '../useTaskDetail'
+
+/**
+ * Singularity MOBILE task-detail skin (#526) — an open function on a phone. A
+ * bracketed readout hero (prompt eyebrow, `>`-prefixed title, a CLASS line with
+ * level + credits), the function brief, the consensus signal, the signaled
+ * praxis, and a prompt-styled **sticky action bar** ("> JOIN ARRAY") pinned above
+ * the tab bar. Single-column, no fixed-px grid. Reuses the same
+ * {@link TaskDetailState}, the shared mobile sticky bar, and the `singularity.*`
+ * copy + --faction-singularity-* tokens as the desktop archetype.
+ *
+ * Always-dark: every colour resolves to a theme-identical --faction-singularity-*
+ * token; the skin paints its own void field and never mutates data-theme.
+ */
+
+const VOID = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const SIGNAL = 'var(--faction-singularity-card-muted)'
+const BORDER_HARD = 'var(--faction-singularity-border-hard)'
+const FONT = 'var(--font-faction-terminal)'
+
+const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`
+const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: signal(60),
+}
+
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <h2 style={{ fontFamily: FONT, fontSize: 13, letterSpacing: '0.04em', textTransform: 'uppercase', margin: 0, color: PHOSPHOR, whiteSpace: 'nowrap' }}>
+        {title}
+      </h2>
+      <span style={{ flex: 1, height: 1, background: signal(30) }} />
+      {trailing}
+    </div>
+  )
+}
+
+export default function SingularityTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation('tasks')
+  const {
+    task,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    topScore,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state
+
+  if (!task) return null
+
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null
+
+  return (
+    <div className="py-4" style={{ fontFamily: FONT, color: PHOSPHOR, background: VOID, marginLeft: -16, marginRight: -16, paddingLeft: 16, paddingRight: 16 }}>
+      {/* Breadcrumb */}
+      <nav className="mb-3" style={{ fontFamily: FONT, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
+        <Link to="/tasks" style={{ color: PHOSPHOR, textDecoration: 'none' }}>
+          {t('default.breadcrumb')}
+        </Link>
+        <span aria-hidden style={{ margin: '0 6px', color: SIGNAL }}>/</span>
+        <span style={{ color: phosphor(60) }}>{task.title}</span>
+      </nav>
+
+      {/* Hero — bracketed readout panel */}
+      <div style={{ position: 'relative', overflow: 'hidden', background: VOID, border: `1px solid ${BORDER_HARD}`, padding: '20px 20px 22px', marginBottom: 20 }}>
+        {/* Corner brackets */}
+        <Bracket pos="tl" />
+        <Bracket pos="tr" />
+        <Bracket pos="bl" />
+        <Bracket pos="br" />
+        <div
+          aria-hidden
+          style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: `repeating-linear-gradient(to bottom, transparent, transparent 2px, ${phosphor(1.2)} 2px, ${phosphor(1.2)} 4px)` }}
+        />
+        <div style={{ position: 'relative' }}>
+          <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+            <span style={{ ...kicker, color: PHOSPHOR }}>{t('singularity.mobile.detailEyebrow')}</span>
+            <span style={kicker}>{t('singularity.statusOpen')}</span>
+          </div>
+
+          <h1 style={{ fontFamily: FONT, fontSize: 24, lineHeight: 1.2, color: PHOSPHOR, letterSpacing: '0.02em', margin: 0, overflowWrap: 'anywhere' }}>
+            {'> '}
+            {task.title}
+          </h1>
+          <div style={{ height: 1, margin: '14px 0', background: signal(30) }} />
+          <div style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.06em', color: signal(70) }}>
+            {t('singularity.class', { level: task.level_required, points: modifiedPoints })}
+          </div>
+        </div>
+      </div>
+
+      {/* The function — brief */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('singularity.mobile.briefHeading')} />
+        <div style={{ background: VOID, border: `1px solid ${signal(38)}`, padding: '16px 18px' }}>
+          <p style={{ fontFamily: FONT, fontSize: 12, lineHeight: 1.7, color: task.description ? phosphor(72) : phosphor(45), margin: 0, whiteSpace: 'pre-wrap' }}>
+            {task.description || t('singularity.observationEmpty')}
+          </p>
+        </div>
+      </section>
+
+      {/* The consensus — read-only aggregate */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('singularity.consensusHeading')} />
+        {voteCount > 0 ? (
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12 }}>
+            <span style={{ fontFamily: FONT, fontSize: 40, lineHeight: 0.85, color: PHOSPHOR }}>
+              {topScore}
+            </span>
+            <div style={{ paddingBottom: 5 }}>
+              <div style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', color: SIGNAL }}>
+                {t('singularity.consensus.peakSignal')}
+              </div>
+              <div style={{ ...kicker, marginTop: 2 }}>{t('singularity.consensus.sealed', { count: voteCount })}</div>
+            </div>
+          </div>
+        ) : (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50), margin: 0 }}>{t('singularity.consensus.none')}</p>
+        )}
+      </section>
+
+      {/* Signaled praxis (completions) */}
+      <section>
+        <SectionHead
+          title={t('singularity.mobile.worksHeading')}
+          trailing={
+            <div style={{ display: 'flex' }}>
+              {(['score', 'recent'] as const).map((sort) => {
+                const on = submissionSort === sort
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: FONT,
+                      fontSize: 8,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      padding: '5px 10px',
+                      background: on ? PHOSPHOR : 'transparent',
+                      color: on ? VOID : signal(60),
+                      border: `1px solid ${on ? PHOSPHOR : signal(35)}`,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {sort === 'score' ? t('singularity.sort.highestSignal') : t('singularity.sort.recent')}
+                  </button>
+                )
+              })}
+            </div>
+          }
+        />
+        {sortedSubmissions.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50), margin: 0 }}>{t('singularity.empty')}</p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4">
+              {sortedSubmissions.slice(0, 4).map((s) => (
+                <div key={s.id} style={{ position: 'relative', paddingTop: s.id === topId ? 16 : 0 }}>
+                  {s.id === topId && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: -4,
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        zIndex: 3,
+                        whiteSpace: 'nowrap',
+                        background: PHOSPHOR,
+                        color: VOID,
+                        fontFamily: FONT,
+                        fontSize: 9,
+                        letterSpacing: '0.1em',
+                        textTransform: 'uppercase',
+                        padding: '2px 12px',
+                        boxShadow: `0 0 12px ${phosphor(40)}`,
+                      }}
+                    >
+                      {t('singularity.highestSignal')}
+                    </div>
+                  )}
+                  <PraxisCard praxis={s} />
+                </div>
+              ))}
+            </div>
+            {submissions.length > 4 && (
+              <div style={{ marginTop: 16 }}>
+                <Link to={`/praxes?task_id=${task.id}`} style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.06em', color: SIGNAL, textDecoration: 'none' }}>
+                  {t('singularity.viewAll', { count: submissions.length })}
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Sticky action bar */}
+      {canSignUp && (
+        <MobileStickyBar>
+          {signupError && (
+            <div style={{ fontFamily: FONT, fontSize: 12, color: 'var(--color-danger)', padding: '8px 12px', background: signal(10), border: `1px solid ${signal(40)}` }}>
+              {signupError}
+            </div>
+          )}
+          <button
+            onClick={handleSignup}
+            style={{
+              width: '100%',
+              background: PHOSPHOR,
+              color: VOID,
+              fontFamily: FONT,
+              fontSize: 14,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              padding: '14px 20px',
+              border: 'none',
+              boxShadow: `0 0 16px ${phosphor(35)}`,
+              cursor: 'pointer',
+            }}
+          >
+            {t('singularity.signup.cta', { points: modifiedPoints })}
+          </button>
+          <MobileStickyCaption color={signal(60)}>
+            {t('singularity.signup.note', { open: slotsOpen, max: maxTaskSlots })}
+          </MobileStickyCaption>
+        </MobileStickyBar>
+      )}
+
+      {mySubmission && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <span style={{ fontFamily: FONT, fontSize: 12, color: PHOSPHOR, flex: 1 }}>
+            {t('singularity.submitted.note')}
+          </span>
+          <Link
+            to={`/praxes/${mySubmission.id}/edit`}
+            style={{ fontFamily: FONT, fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '10px 18px', background: VOID, color: PHOSPHOR, border: `1px solid ${PHOSPHOR}`, textDecoration: 'none' }}
+          >
+            {t('singularity.submitted.edit')}
+          </Link>
+        </MobileStickyBar>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <button
+            onClick={handleDrop}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: FONT, fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}
+          >
+            {t('singularity.inProgress.drop')}
+          </button>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{ marginLeft: 'auto', fontFamily: FONT, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '12px 20px', background: PHOSPHOR, color: VOID, textDecoration: 'none' }}
+          >
+            {t('singularity.inProgress.continue')}
+          </Link>
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+/** One corner bracket of the terminal readout frame. */
+function Bracket({ pos }: { pos: 'tl' | 'tr' | 'bl' | 'br' }) {
+  const base: CSSProperties = { position: 'absolute', width: 10, height: 10, pointerEvents: 'none' }
+  const top = pos[0] === 't'
+  const left = pos[1] === 'l'
+  return (
+    <span
+      aria-hidden
+      style={{
+        ...base,
+        top: top ? 3 : undefined,
+        bottom: top ? undefined : 3,
+        left: left ? 3 : undefined,
+        right: left ? undefined : 3,
+        borderTop: top ? `1px solid ${PHOSPHOR}` : undefined,
+        borderBottom: top ? undefined : `1px solid ${PHOSPHOR}`,
+        borderLeft: left ? `1px solid ${PHOSPHOR}` : undefined,
+        borderRight: left ? undefined : `1px solid ${PHOSPHOR}`,
+      }}
+    />
+  )
+}

--- a/frontend/src/pages/tasks/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/singularityDispatch.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Mobile task-browse Singularity dispatch (#526) — asserts the registry routes a
+ * Singularity node browsing tasks to its bespoke terminal browse skin, and that
+ * an unregistered viewer slug still falls through to the Default browse skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { pickVariant } from '../../../utils/factionDispatch'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../Tasks'
+import DefaultTasks from '../mobileArchetypes/DefaultTasks'
+import SingularityTaskList from '../mobileArchetypes/SingularityTaskList'
+
+describe('mobile task-browse Singularity dispatch', () => {
+  it('resolves singularity to the bespoke terminal browse skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'singularity', DefaultTasks)).toBe(SingularityTaskList)
+  })
+
+  it('falls through to the Default browse skin for other slugs', () => {
+    for (const slug of ['na', 'snide', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
+    }
+  })
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/SingularityTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/SingularityTaskList.tsx
@@ -1,0 +1,225 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../../api/tasks'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import type { TasksState } from '../useTasks'
+
+/**
+ * Singularity MOBILE task-browse skin (#526) — the terminal directory on a
+ * phone. The same scannable single-column list + touch-native filter chip rows
+ * as the Default browse skin (status / faction / level), dressed as bracketed
+ * readout cards on a void field. Dispatched by the VIEWING life's faction (a
+ * Singularity node browsing tasks), so it consumes the shared `useTasks()` state
+ * verbatim — a chip tap mutates the same filter state that keys the read.
+ *
+ * Always-dark: every colour resolves to a --faction-singularity-* token that
+ * reads identically in both themes; the skin paints its own void container and
+ * never mutates data-theme.
+ */
+
+const VOID = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const SIGNAL = 'var(--faction-singularity-card-muted)'
+const BORDER_HARD = 'var(--faction-singularity-border-hard)'
+const FONT = 'var(--font-faction-terminal)'
+
+const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`
+const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: FONT,
+  fontSize: 8,
+  letterSpacing: '0.22em',
+  textTransform: 'uppercase',
+  color: signal(60),
+}
+
+export default function SingularityTaskList({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div data-skin="singularity" className="py-4" style={{ fontFamily: FONT, color: PHOSPHOR, background: VOID }} data-testid="mobile-tasks-browse">
+      <div style={kicker}>{t('singularity.mobile.listMasthead')}</div>
+      <h1 style={{ fontFamily: FONT, fontSize: 24, lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', margin: '2px 0 0' }}>
+        {tc('nav.tasks')}
+      </h1>
+      <div style={{ height: 1, margin: '9px 0 12px', background: `linear-gradient(90deg, ${BORDER_HARD}, transparent)` }} />
+      <p style={{ ...kicker, marginBottom: 12 }}>{t('mobile.count', { count: tasks.length })}</p>
+
+      <ChipRow label={tc('filters.status')}>
+        {statusFilters.map((option) => (
+          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
+            {option}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('mobile.allFactions')}
+        </Chip>
+        {sortFactionsByRainbowOrder(factions).map((f) => (
+          <Chip
+            key={f.slug}
+            on={faction === f.slug}
+            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
+            tint={factionCssVar(f.slug)}
+          >
+            {factionName(f.slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.level')}>
+        <Chip on={level === ''} onClick={() => setLevel('')}>
+          {t('mobile.anyLevel')}
+        </Chip>
+        {levelFilters.map((lvl) => (
+          <Chip key={lvl} on={level === lvl} onClick={() => setLevel(level === lvl ? '' : lvl)}>
+            {tc('filters.levelAtLeast', { level: lvl })}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <div className="mt-4">
+        {loading ? (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50) }}>{t('listPage.loading')}</p>
+        ) : error ? (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: 'var(--color-danger)', border: `1px solid ${signal(40)}`, padding: '8px 12px' }}>
+            {t('mobile.loadError')}
+          </p>
+        ) : tasks.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50) }}>{t('listPage.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {tasks.map((task) => (
+              <ReadoutCard key={task.id} task={task} points={displayPointsFor(task)} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span style={{ ...kicker, flex: 'none' }}>{label}</span>
+      <div className="flex gap-2" style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: FONT,
+        fontSize: 10,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        color: on ? VOID : signal(70),
+        background: on ? PHOSPHOR : 'transparent',
+        border: `1px solid ${on ? PHOSPHOR : signal(35)}`,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && <i style={{ width: 8, height: 8, flex: 'none', background: tint }} />}
+      {children}
+    </button>
+  )
+}
+
+function ReadoutCard({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  const color = factionCssVar(task.primary_faction_slug)
+  return (
+    <Link
+      to={`/tasks/${task.id}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        padding: '14px 16px',
+        background: VOID,
+        border: `1px solid ${signal(38)}`,
+        borderLeft: `3px solid ${color}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: FONT, fontSize: 8, letterSpacing: '0.14em', textTransform: 'uppercase', color: SIGNAL }}>
+        <i style={{ width: 7, height: 7, background: color, flex: 'none' }} />
+        {factionName(task.primary_faction_slug)}
+      </span>
+
+      <h2 style={{ fontFamily: FONT, fontSize: 15, lineHeight: 1.3, color: PHOSPHOR, margin: 0, overflowWrap: 'anywhere' }}>
+        {'> '}
+        {task.title}
+      </h2>
+
+      {task.description && (
+        <p
+          style={{
+            fontFamily: FONT,
+            fontSize: 11,
+            lineHeight: 1.5,
+            color: phosphor(55),
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {task.description}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3" style={{ marginTop: 2, borderTop: `1px solid ${signal(20)}`, paddingTop: 8 }}>
+        <span style={{ fontFamily: FONT, fontSize: 12, letterSpacing: '0.04em', color: PHOSPHOR, border: `1px solid ${signal(38)}`, padding: '3px 9px' }}>
+          {t('mobile.points', { points })}
+        </span>
+        <span style={{ ...kicker }}>{t('mobile.level', { level: task.level_required })}</span>
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
Closes #526

Registers Singularity's bespoke **dark-terminal** mobile skin into each of the six form-factor-dispatched surfaces, keyed `singularity` in every surface's MOBILE `MOBILE_ARCHETYPE_BY_SLUG` (existing `ua`/`wow`/`everymen` entries untouched). Mirrors the merged UA treatment (#525). Presentation-only — reuses the existing hooks, shared blocks, and copy contract; **no backend/API/hook change**.

## Idiom
Grounds on the real Singularity idiom + theme-identical `--faction-singularity-*` tokens: void field, phosphor-green text, signal-blue chrome, bracketed readout panels, `>`/`//` prompts, scanlines, blinking cursor, Share Tech Mono. Native-dark — each skin paints its own void container and never mutates `data-theme`.

## Surfaces
- **Home / FieldDesk** — `SingularityHome`: prompt masthead, bracketed node panel + signal stat cells, running-functions list, prompt actions.
- **Tasks browse** — `SingularityTaskList`: terminal directory, readout task cards, touch-native status/faction/level chips.
- **Task detail** — `SingularityTaskDetail`: corner-bracketed readout hero (CLASS line: level + credits), function brief, consensus signal, signaled praxis, sticky `> JOIN ARRAY` bar.
- **Praxis detail** — `SingularityPraxisDetail`: node byline, output-artifacts panel, `>`-prefixed finding, process-log body, amplify star caster; reuses all shared behavior blocks (Task Crown, admin, owner, flag, voter breakdown).
- **Composer** — `SingularityComposer`: Write/Preview toggle, `//`-labelled readout panels, fluid media grid, sticky TRANSMIT SIGNAL bar; reuses the shared controls.
- **Faction page** — `SingularityFactionPage`: bracketed hero + real member/task counts, primary nodes, recent praxis, invite-gated Join (ADR-0019).

## Corrections applied
`{base} + {votePoints}` (no vote average), no difficulty dots/slots, real domain fields only.

## Verification
- `npm run lint` (raw-string gate) — passes.
- `npm test` (vitest) — 62 files / 409 tests pass, incl. 6 new per-surface `singularityDispatch` tests + the registry-iterating slot invariants now covering `singularity`.
- `tsc --noEmit` — new files type-clean; the only remaining errors are pre-existing in `AlbescentInvitation.tsx` (untouched; CI runs eslint + vitest, not tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
