### PR TITLE
Mobile: WOW faction treatment (#531)

### DIFF
--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -538,6 +538,9 @@
       "emptyWithSpotlight": "No other witches in the circle yet.",
       "level": "lvl {{level}}"
     },
+    "mobile": {
+      "eyebrow": "wow.exe"
+    },
     "invitation": {
       "kicker": "the circle is recruiting",
       "headline": "Come be a little magic",

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -190,7 +190,11 @@
     },
     "empty": "no spells cast yet. nobody's pulled it off.",
     "mostLoved": "most loved",
-    "viewAll": "see all {{count}} spells ✦"
+    "viewAll": "see all {{count}} spells ✦",
+    "mobile": {
+      "masthead": "quests.exe",
+      "cardMeta": "{{faction}} · +{{points}} pts"
+    }
   },
   "ephemerists": {
     "diagram": {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -8,6 +8,7 @@ import { useFormFactor } from "../hooks/useFormFactor";
 import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFactionDetail";
 import UaFactionPage from "./factionDetail/mobileArchetypes/UaFactionPage";
 import SingularityFactionPage from "./factionDetail/mobileArchetypes/SingularityFactionPage";
+import WowFactionPage from "./factionDetail/mobileArchetypes/WowFactionPage";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import DefaultFactionPage from "./factionDetail/mobileArchetypes/DefaultFactionPage";
 import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
@@ -82,6 +83,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<
 > = {
   ua: UaFactionPage,
   singularity: SingularityFactionPage,
+  wow: WowFactionPage,
 };
 
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -18,6 +18,7 @@ import DefaultMobileTaskDetail from "./taskDetail/mobileArchetypes/DefaultTaskDe
 import EverymenMobileTaskDetail from "./taskDetail/mobileArchetypes/EverymenTaskDetail";
 import UAMobileTaskDetail from "./taskDetail/mobileArchetypes/UaTaskDetail";
 import SingularityMobileTaskDetail from "./taskDetail/mobileArchetypes/SingularityTaskDetail";
+import WowMobileTaskDetail from "./taskDetail/mobileArchetypes/WowTaskDetail";
 import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
@@ -49,6 +50,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   everymen: EverymenMobileTaskDetail,
   ua: UAMobileTaskDetail,
   singularity: SingularityMobileTaskDetail,
+  wow: WowMobileTaskDetail,
 };
 
 export default function TaskDetail() {

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -11,6 +11,7 @@ import { useTasks, type TasksState } from './tasks/useTasks'
 import DefaultTasks from './tasks/mobileArchetypes/DefaultTasks'
 import UaTaskList from './tasks/mobileArchetypes/UaTaskList'
 import SingularityTaskList from './tasks/mobileArchetypes/SingularityTaskList'
+import WowTaskList from './tasks/mobileArchetypes/WowTaskList'
 
 type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 
@@ -22,6 +23,7 @@ type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {
   ua: UaTaskList,
   singularity: SingularityTaskList,
+  wow: WowTaskList,
 }
 
 export default function Tasks() {

--- a/frontend/src/pages/factionDetail/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/singularityDispatch.test.tsx
@@ -15,7 +15,7 @@ describe('mobile faction-page Singularity dispatch', () => {
   })
 
   it('falls through to the Default mobile faction page for other slugs', () => {
-    for (const slug of ['na', 'everymen', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
     }
   })

--- a/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
@@ -16,7 +16,7 @@ describe('mobile faction-page UA dispatch', () => {
   })
 
   it('every other faction falls through to the Default mobile page', () => {
-    for (const slug of ['snide', 'wow', 'everymen', 'na', null]) {
+    for (const slug of ['snide', 'singularity', 'everymen', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
     }
   })

--- a/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
@@ -16,7 +16,7 @@ describe('mobile faction-page UA dispatch', () => {
   })
 
   it('every other faction falls through to the Default mobile page', () => {
-    for (const slug of ['snide', 'singularity', 'everymen', 'na', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
     }
   })

--- a/frontend/src/pages/factionDetail/__tests__/wowMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/wowMobileDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile faction-page WOW dispatch (#531). Asserts the mobile registry resolves
+ * the `wow` faction to the scrapbook coven page skin, and that every other
+ * faction (and null) falls through to the single-column DefaultFactionPage.
+ * Mirrors the other surfaces' wow-dispatch tests.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FactionDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
+import WowFactionPage from '../mobileArchetypes/WowFactionPage'
+
+describe('mobile faction-page WOW dispatch', () => {
+  it('mobile + the WOW faction resolves to the bespoke WOW page', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'wow', DefaultFactionPage)).toBe(WowFactionPage)
+  })
+
+  it('every other faction falls through to the Default mobile page', () => {
+    for (const slug of ['snide', 'everymen', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/__tests__/wowMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/wowMobileDispatch.test.tsx
@@ -16,7 +16,7 @@ describe('mobile faction-page WOW dispatch', () => {
   })
 
   it('every other faction falls through to the Default mobile page', () => {
-    for (const slug of ['snide', 'everymen', 'na', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
     }
   })

--- a/frontend/src/pages/factionDetail/mobileArchetypes/WowFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/WowFactionPage.tsx
@@ -1,0 +1,326 @@
+import { useState, type CSSProperties, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { factionName, factionDescription } from '../../../utils/factions'
+import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
+import type { CharacterOut } from '../../../api/auth'
+import type { FactionDetailState } from '../useFactionDetail'
+
+/**
+ * Warriors of Whimsy MOBILE faction page (#531) — the coven, phone shaped. The
+ * same single-column slots as the Default mobile faction page (a hero with real
+ * member/task counts, top members, recent praxis, and the invite-gated Join model
+ * via `state.membership`, ADR-0019) — only the dress changes: a pink scrapbook
+ * "wow.exe" window hero on a dotted board, Caveat script, sparkle accents, rose
+ * accent. Grounds on the `--faction-wow-*` window tokens already in index.css (the
+ * set the WOW pilots use); always-light. Reuses the shared `mobile.*` faction copy
+ * so the slot contract holds. Presentation-only — all data + the join handler
+ * arrive via {@link FactionDetailState}.
+ */
+
+const NA_SLUG = 'na'
+
+const PINK = 'var(--faction-wow)'
+const PINK_DEEP = 'var(--faction-wow-card-accent)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const DOT = 'var(--faction-wow-dot)'
+const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const BODY = 'var(--font-body)' // Courier Prime
+const ON_ACCENT = 'var(--color-text-on-accent)'
+
+/** The kit's four-point sparkle. */
+function Sparkle({ size, color, style }: { size: number; color: string; style?: CSSProperties }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style} aria-hidden>
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || '?'
+
+/** Circular initials sticker — pink→deep wash face, Caveat glyph. */
+function Avatar({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: `linear-gradient(150deg, var(--faction-wow-title-from), ${PINK})`,
+        border: `1.5px solid ${WIN_BORDER}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: SCRIPT,
+        fontSize: size * 0.5,
+        color: ON_ACCENT,
+      }}
+    >
+      {initial(name)}
+    </span>
+  )
+}
+
+function SectionHead({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontFamily: SCRIPT, fontSize: 24, color: TITLE_TEXT }}>
+        <Sparkle size={13} color={PINK} />
+        {children}
+      </span>
+      <span style={{ flex: 1, height: 2, background: `repeating-linear-gradient(90deg, ${PINK} 0 8px, transparent 8px 14px)` }} />
+    </div>
+  )
+}
+
+const joinButton: CSSProperties = {
+  width: '100%',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 8,
+  fontFamily: BODY,
+  fontSize: 13,
+  fontWeight: 700,
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: ON_ACCENT,
+  background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`,
+  border: `1.5px solid ${PINK_DEEP}`,
+  borderRadius: 14,
+  padding: '13px 16px',
+  boxShadow: `0 6px 16px color-mix(in srgb, ${PINK} 30%, transparent)`,
+  cursor: 'pointer',
+}
+
+export default function WowFactionPage({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation('factions')
+  const { faction, members, tasks, recentPraxis, membership } = state
+  const [confirming, setConfirming] = useState(false)
+
+  if (!faction) return null
+
+  const name = factionName(faction.slug)
+  const topMembers = [...members].sort((a, b) => b.all_time_score - a.all_time_score).slice(0, 3)
+  const currentSlug = membership.currentFactionSlug
+  const switching = currentSlug && currentSlug !== NA_SLUG
+
+  return (
+    <div
+      data-skin="wow"
+      className="py-4"
+      style={{
+        fontFamily: BODY,
+        color: CARD_TEXT,
+        background: BODY_BG,
+        backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+        backgroundSize: '15px 15px',
+        marginLeft: -16,
+        marginRight: -16,
+        paddingLeft: 16,
+        paddingRight: 16,
+      }}
+      data-testid="mobile-faction-page"
+    >
+      {/* Hero — wow.exe window wrapping a pink gradient panel */}
+      <section
+        style={{
+          borderRadius: 16,
+          overflow: 'hidden',
+          border: `2px solid ${WIN_BORDER}`,
+          boxShadow: `0 8px 22px color-mix(in srgb, ${PINK} 22%, transparent)`,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 7,
+            padding: '8px 12px',
+            background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+            borderBottom: `2px solid ${WIN_BORDER}`,
+          }}
+        >
+          {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+            <span key={c} style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }} />
+          ))}
+          <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 18, color: TITLE_TEXT }}>
+            <Sparkle size={11} color={TITLE_TEXT} />
+            {t('wow.mobile.eyebrow')}
+          </span>
+        </div>
+        <div
+          style={{
+            padding: '22px 18px 20px',
+            background: 'linear-gradient(160deg, var(--faction-wow-title-from), var(--faction-wow-card-muted) 60%, var(--faction-wow))',
+            color: TITLE_TEXT,
+          }}
+        >
+          <h1 style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: SCRIPT, fontSize: 36, lineHeight: 0.95, margin: 0 }}>
+            <Sparkle size={18} color={TITLE_TEXT} />
+            {name}
+          </h1>
+          <p style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.6, color: PINK_DEEP, margin: '8px 0 0' }}>
+            {factionDescription(faction.slug)}
+          </p>
+          <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+            <HeroStat value={members.length} label={t('mobile.membersStat')} />
+            <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
+          </div>
+        </div>
+      </section>
+
+      {membership.state === 'member' && (
+        <p style={{ fontFamily: SCRIPT, fontSize: 18, color: PINK, margin: '12px 0 0' }}>{t('mobile.memberBadge')}</p>
+      )}
+
+      {/* Top members */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.topMembers')}</SectionHead>
+        {topMembers.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topMembers.map((m, index) => (
+              <MemberRow key={m.id} rank={index + 1} member={m} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent praxis */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
+        {recentPraxis.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {membership.state === 'gate' && (
+        <p style={{ fontFamily: BODY, fontSize: 12, color: CARD_MUTED, marginTop: 24, lineHeight: 1.6 }}>
+          {t('mobile.gateHint', { faction: name })}
+        </p>
+      )}
+
+      {/* Sticky Join — only an eligible viewer can act (ADR-0019). */}
+      {membership.state === 'eligible' && (
+        <MobileStickyBar>
+          {membership.joinError && (
+            <p style={{ fontFamily: BODY, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+          )}
+          {!confirming ? (
+            <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
+              <Sparkle size={13} color={ON_ACCENT} />
+              {t('mobile.join', { faction: name })}
+            </button>
+          ) : (
+            <>
+              <p style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.6, color: CARD_TEXT }}>
+                {switching
+                  ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
+                  : t('detail.join.confirm', { faction: name })}
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => void membership.join()}
+                  disabled={membership.joining}
+                  style={{ ...joinButton, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                >
+                  {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirming(false)}
+                  disabled={membership.joining}
+                  style={{
+                    fontFamily: BODY,
+                    fontSize: 11,
+                    letterSpacing: '0.1em',
+                    textTransform: 'uppercase',
+                    color: CARD_MUTED,
+                    background: 'transparent',
+                    border: `1.5px solid ${NOTEPAD_BORDER}`,
+                    borderRadius: 12,
+                    padding: '11px 16px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t('detail.join.cancel')}
+                </button>
+              </div>
+            </>
+          )}
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+function HeroStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={{ flex: '1 1 0', textAlign: 'center', background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 12, padding: '11px 6px' }}>
+      <b style={{ fontFamily: SCRIPT, fontSize: 24, display: 'block', lineHeight: 1, color: TITLE_TEXT }}>{value}</b>
+      <span style={{ fontSize: 8, letterSpacing: '0.16em', textTransform: 'uppercase', color: CARD_MUTED, marginTop: 5, display: 'block' }}>
+        {label}
+      </span>
+    </div>
+  )
+}
+
+function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
+  const { t } = useTranslation('factions')
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: NOTEPAD_BG,
+        border: `1.5px solid ${NOTEPAD_BORDER}`,
+        borderRadius: 12,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, width: 16, flex: 'none' }}>{rank}</span>
+      <Avatar name={member.display_name} size={28} />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: SCRIPT,
+          fontSize: 19,
+          color: TITLE_TEXT,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {member.display_name}
+      </span>
+      <span style={{ fontFamily: BODY, fontSize: 9, letterSpacing: '0.04em', color: PINK_DEEP, flex: 'none' }}>
+        {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/pages/fieldDesk/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/singularityDispatch.test.tsx
@@ -15,7 +15,7 @@ describe('mobile FieldDesk-home Singularity dispatch', () => {
   })
 
   it('falls through to the Default mobile home for other slugs', () => {
-    for (const slug of ['na', 'snide', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
     }
   })

--- a/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
@@ -16,7 +16,7 @@ describe('mobile FieldDesk-home UA dispatch', () => {
   })
 
   it('mobile + any other slug falls through to the Default home skin', () => {
-    for (const slug of ['snide', 'everymen', 'na', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
     }
   })

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDispatch.test.tsx
@@ -18,7 +18,7 @@ describe('mobile praxis-detail Singularity dispatch', () => {
   })
 
   it('falls through to the Default mobile skin for other slugs', () => {
-    for (const slug of ['na', 'ephemerists', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobilePraxisDetail)).toBe(DefaultMobilePraxisDetail)
     }
   })

--- a/frontend/src/pages/praxisDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaDispatch.test.tsx
@@ -18,7 +18,7 @@ describe('mobile praxis-detail UA dispatch', () => {
   })
 
   it('mobile + any other slug falls through to the Default mobile skin', () => {
-    for (const slug of ['snide', 'na', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobilePraxisDetail)).toBe(
         DefaultMobilePraxisDetail,
       )

--- a/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
@@ -110,7 +110,7 @@ describe("mobile task-detail dispatch", () => {
   });
 
   it("mobile + any other slug falls through to the Default mobile skin", () => {
-    for (const slug of ["snide", "wow", "na", null]) {
+    for (const slug of ["snide", "singularity", "na", null]) {
       expect(
         pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail),
       ).toBe(DefaultMobileTaskDetail);

--- a/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
@@ -110,7 +110,7 @@ describe("mobile task-detail dispatch", () => {
   });
 
   it("mobile + any other slug falls through to the Default mobile skin", () => {
-    for (const slug of ["snide", "singularity", "na", null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(
         pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail),
       ).toBe(DefaultMobileTaskDetail);

--- a/frontend/src/pages/taskDetail/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDispatch.test.tsx
@@ -18,7 +18,7 @@ describe('mobile task-detail Singularity dispatch', () => {
   })
 
   it('falls through to the Default mobile skin for other slugs', () => {
-    for (const slug of ['na', 'wow', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).toBe(DefaultMobileTaskDetail)
     }
   })

--- a/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
@@ -21,7 +21,7 @@ describe("mobile task-detail UA dispatch", () => {
   });
 
   it("mobile + any other slug falls through to the Default mobile skin", () => {
-    for (const slug of ["snide", "na", null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).toBe(
         DefaultMobileTaskDetail,
       );

--- a/frontend/src/pages/taskDetail/__tests__/wowDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/wowDispatch.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Mobile task-detail WOW dispatch (#531). Asserts the mobile registry resolves a
+ * `wow` task to the quest.exe scrapbook skin, that other factions fall through to
+ * the Default mobile detail, and that the desktop archetype is untouched.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  MOBILE_ARCHETYPE_BY_SLUG,
+  ARCHETYPE_BY_SLUG,
+} from "../../TaskDetail";
+import { pickVariant } from "../../../utils/factionDispatch";
+import DefaultMobileTaskDetail from "../mobileArchetypes/DefaultTaskDetail";
+import WowMobileTaskDetail from "../mobileArchetypes/WowTaskDetail";
+import WowDesktopTaskDetail from "../archetypes/WowTaskDetail";
+
+describe("mobile task-detail WOW dispatch", () => {
+  it("mobile + a WOW task resolves to the bespoke WOW mobile skin", () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, "wow", DefaultMobileTaskDetail)).toBe(
+      WowMobileTaskDetail,
+    );
+  });
+
+  it("mobile + any other slug falls through to the Default mobile skin", () => {
+    for (const slug of ["snide", "na", null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).toBe(
+        DefaultMobileTaskDetail,
+      );
+    }
+  });
+
+  it("desktop keeps its own WOW archetype, never the mobile skin", () => {
+    const desktop = pickVariant(ARCHETYPE_BY_SLUG, "wow", DefaultMobileTaskDetail);
+    expect(desktop).toBe(WowDesktopTaskDetail);
+    expect(desktop).not.toBe(WowMobileTaskDetail);
+  });
+});

--- a/frontend/src/pages/taskDetail/__tests__/wowDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/wowDispatch.test.tsx
@@ -21,7 +21,7 @@ describe("mobile task-detail WOW dispatch", () => {
   });
 
   it("mobile + any other slug falls through to the Default mobile skin", () => {
-    for (const slug of ["snide", "na", null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).toBe(
         DefaultMobileTaskDetail,
       );

--- a/frontend/src/pages/taskDetail/mobileArchetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/WowTaskDetail.tsx
@@ -1,0 +1,342 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { MobileStickyBar, MobileStickyCaption } from './shared'
+import type { TaskDetailState } from '../useTaskDetail'
+
+/**
+ * Warriors of Whimsy MOBILE task-detail skin (#531) — the quest.exe window on a
+ * phone. A pink scrapbook window hero (traffic-light title bar, dotted board,
+ * inner notepad) carries the Caveat title + sparks/level plates, then the "what
+ * we're asking" brief, the love-so-far aggregate, the spells cast (completions),
+ * and a sparkle-stamped **sticky action bar** ("join the party") pinned above the
+ * tab bar. Single-column, no fixed-px grid. Reuses the same {@link TaskDetailState},
+ * the shared mobile sticky bar, and the `wow.*` copy + `--faction-wow-*` tokens as
+ * the desktop archetype and the other WOW pilots. Always-light: WOW is native-light.
+ */
+
+const PINK = 'var(--faction-wow)'
+const PINK_DEEP = 'var(--faction-wow-card-accent)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const DOT = 'var(--faction-wow-dot)'
+const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const BODY = 'var(--font-body)' // Courier Prime
+const ON_ACCENT = 'var(--color-text-on-accent)'
+
+/** The kit's four-point sparkle. */
+function Sparkle({ size, color, style }: { size: number; color: string; style?: CSSProperties }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style} aria-hidden>
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+/** Caveat section heading with a sparkle and a dashed running rule. */
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontFamily: SCRIPT, fontSize: 24, color: TITLE_TEXT, whiteSpace: 'nowrap' }}>
+        <Sparkle size={13} color={PINK} />
+        {title}
+      </span>
+      <span style={{ flex: 1, height: 2, background: `repeating-linear-gradient(90deg, ${PINK} 0 8px, transparent 8px 14px)` }} />
+      {trailing}
+    </div>
+  )
+}
+
+export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation('tasks')
+  const {
+    task,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    topScore,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state
+
+  if (!task) return null
+
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null
+
+  return (
+    <div
+      data-skin="wow"
+      className="py-4"
+      style={{
+        fontFamily: BODY,
+        color: CARD_TEXT,
+        background: BODY_BG,
+        backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+        backgroundSize: '15px 15px',
+        marginLeft: -16,
+        marginRight: -16,
+        paddingLeft: 16,
+        paddingRight: 16,
+      }}
+    >
+      {/* Breadcrumb */}
+      <nav className="mb-3" style={{ fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}>
+        <Link to="/tasks" style={{ color: PINK_DEEP, textDecoration: 'none' }}>
+          {t('wow.breadcrumb')}
+        </Link>
+        <span aria-hidden style={{ margin: '0 6px', color: PINK }}>›</span>
+        <span style={{ fontFamily: SCRIPT, fontSize: 16, color: TITLE_TEXT }}>{task.title}</span>
+      </nav>
+
+      {/* Hero — quest.exe window */}
+      <section
+        style={{
+          borderRadius: 16,
+          overflow: 'hidden',
+          border: `2px solid ${WIN_BORDER}`,
+          boxShadow: `0 8px 22px color-mix(in srgb, ${PINK} 22%, transparent)`,
+          marginBottom: 20,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 7,
+            padding: '8px 12px',
+            background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+            borderBottom: `2px solid ${WIN_BORDER}`,
+          }}
+        >
+          {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+            <span key={c} style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }} />
+          ))}
+          <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 18, color: TITLE_TEXT }}>
+            <Sparkle size={11} color={TITLE_TEXT} />
+            {t('wow.window')}
+          </span>
+        </div>
+        <div
+          style={{
+            position: 'relative',
+            padding: 12,
+            background: BODY_BG,
+            backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+            backgroundSize: '13px 13px',
+          }}
+        >
+          <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: '18px 18px 20px' }}>
+            <div style={{ fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase', color: CARD_MUTED, marginBottom: 8 }}>
+              {task.status === 'active' ? t('wow.statusOpen') : task.status}
+            </div>
+            <h1 style={{ fontFamily: SCRIPT, fontSize: 38, lineHeight: 0.95, color: TITLE_TEXT, margin: '0 0 14px', overflowWrap: 'anywhere' }}>
+              {task.title}
+            </h1>
+            <div className="flex items-center gap-2 flex-wrap">
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 10, letterSpacing: '0.06em', textTransform: 'uppercase', color: CARD_TEXT, background: BODY_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 999, padding: '6px 13px' }}>
+                <Sparkle size={10} color={PINK} />
+                {t('wow.level', { level: task.level_required })}
+              </span>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: SCRIPT, fontSize: 26, color: PINK }}>
+                {t('wow.sparks', { points: modifiedPoints })}
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* What we're asking — brief */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('wow.askingHeading')} />
+        <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: '16px 18px' }}>
+          <p style={{ fontFamily: BODY, fontSize: 13, lineHeight: 1.75, color: task.description ? CARD_TEXT : CARD_MUTED, margin: 0, whiteSpace: 'pre-wrap' }}>
+            {task.description || t('wow.askingEmpty')}
+          </p>
+        </div>
+      </section>
+
+      {/* The love so far — read-only aggregate */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('wow.loveHeading')} />
+        {voteCount > 0 ? (
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12 }}>
+            <span style={{ fontFamily: SCRIPT, fontSize: 48, lineHeight: 0.8, color: PINK }}>{topScore}</span>
+            <div style={{ paddingBottom: 5 }}>
+              <div style={{ fontFamily: SCRIPT, fontSize: 20, color: TITLE_TEXT }}>{t('wow.love.top')}</div>
+              <div style={{ fontSize: 10, color: CARD_MUTED, marginTop: 2 }}>{t('wow.love.adored', { count: voteCount })}</div>
+            </div>
+          </div>
+        ) : (
+          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>{t('wow.love.none')}</p>
+        )}
+      </section>
+
+      {/* Spells cast (completions) */}
+      <section>
+        <SectionHead
+          title={t('wow.spellsHeading', { count: submissions.length })}
+          trailing={
+            <div style={{ display: 'flex' }}>
+              {(['score', 'recent'] as const).map((sort) => {
+                const on = submissionSort === sort
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: BODY,
+                      fontSize: 8,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      padding: '5px 10px',
+                      borderRadius: on ? 8 : 0,
+                      background: on ? `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})` : 'transparent',
+                      color: on ? ON_ACCENT : CARD_MUTED,
+                      border: `1.5px solid ${on ? PINK_DEEP : NOTEPAD_BORDER}`,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {sort === 'score' ? t('wow.sort.mostLoved') : t('wow.sort.recent')}
+                  </button>
+                )
+              })}
+            </div>
+          }
+        />
+        {sortedSubmissions.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>{t('wow.empty')}</p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4">
+              {sortedSubmissions.slice(0, 4).map((s) => (
+                <div key={s.id} style={{ position: 'relative', paddingTop: s.id === topId ? 18 : 0 }}>
+                  {s.id === topId && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: -4,
+                        left: '50%',
+                        transform: 'translateX(-50%) rotate(-2deg)',
+                        zIndex: 3,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 5,
+                        whiteSpace: 'nowrap',
+                        background: PINK,
+                        color: ON_ACCENT,
+                        fontFamily: SCRIPT,
+                        fontSize: 16,
+                        padding: '2px 14px',
+                        borderRadius: 14,
+                        boxShadow: '2px 3px 0 var(--faction-wow-scrap-deep)',
+                      }}
+                    >
+                      <span style={{ fontSize: 12, lineHeight: 1 }}>⚜</span>
+                      {t('wow.mostLoved')}
+                    </div>
+                  )}
+                  <PraxisCard praxis={s} />
+                </div>
+              ))}
+            </div>
+            {submissions.length > 4 && (
+              <div style={{ marginTop: 16 }}>
+                <Link to={`/praxes?task_id=${task.id}`} style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, textDecoration: 'none' }}>
+                  {t('wow.viewAll', { count: submissions.length })}
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Sticky action bar */}
+      {canSignUp && (
+        <MobileStickyBar>
+          {signupError && (
+            <div style={{ fontFamily: BODY, fontSize: 12, color: 'var(--color-danger)', padding: '8px 12px', background: 'var(--faction-wow-light)', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9 }}>
+              {signupError}
+            </div>
+          )}
+          <button
+            onClick={handleSignup}
+            style={{
+              width: '100%',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`,
+              color: ON_ACCENT,
+              fontFamily: BODY,
+              fontSize: 13,
+              fontWeight: 700,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              padding: '14px 20px',
+              border: `1.5px solid ${PINK_DEEP}`,
+              borderRadius: 14,
+              cursor: 'pointer',
+            }}
+          >
+            <Sparkle size={13} color={ON_ACCENT} />
+            {t('wow.signup.cta', { points: modifiedPoints })}
+          </button>
+          <MobileStickyCaption color={CARD_MUTED}>
+            {t('wow.signup.slots', { open: slotsOpen, max: maxTaskSlots })}
+          </MobileStickyCaption>
+        </MobileStickyBar>
+      )}
+
+      {mySubmission && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <span style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, flex: 1 }}>{t('wow.submitted.text')}</span>
+          <Link
+            to={`/praxes/${mySubmission.id}/edit`}
+            style={{ fontFamily: BODY, fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '10px 18px', color: ON_ACCENT, background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`, border: `1.5px solid ${PINK_DEEP}`, borderRadius: 12, textDecoration: 'none' }}
+          >
+            {t('wow.submitted.edit')}
+          </Link>
+        </MobileStickyBar>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <button
+            onClick={handleDrop}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: SCRIPT, fontSize: 18, color: CARD_MUTED }}
+          >
+            {t('wow.inProgress.drop')}
+          </button>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{ marginLeft: 'auto', fontFamily: BODY, fontSize: 11, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '12px 20px', color: ON_ACCENT, background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`, border: `1.5px solid ${PINK_DEEP}`, borderRadius: 14, textDecoration: 'none' }}
+          >
+            {t('wow.inProgress.continue')}
+          </Link>
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/tasks/__tests__/singularityDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/singularityDispatch.test.tsx
@@ -15,7 +15,7 @@ describe('mobile task-browse Singularity dispatch', () => {
   })
 
   it('falls through to the Default browse skin for other slugs', () => {
-    for (const slug of ['na', 'snide', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
     }
   })

--- a/frontend/src/pages/tasks/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/uaDispatch.test.tsx
@@ -16,7 +16,7 @@ describe('mobile task-browse UA dispatch', () => {
   })
 
   it('mobile + any other viewer falls through to the Default browse skin', () => {
-    for (const slug of ['snide', 'singularity', 'na', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
     }
   })

--- a/frontend/src/pages/tasks/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/uaDispatch.test.tsx
@@ -16,7 +16,7 @@ describe('mobile task-browse UA dispatch', () => {
   })
 
   it('mobile + any other viewer falls through to the Default browse skin', () => {
-    for (const slug of ['snide', 'wow', 'na', null]) {
+    for (const slug of ['snide', 'singularity', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
     }
   })

--- a/frontend/src/pages/tasks/__tests__/wowDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/wowDispatch.test.tsx
@@ -17,7 +17,7 @@ describe('mobile task-browse WOW dispatch', () => {
   })
 
   it('mobile + any other viewer falls through to the Default browse skin', () => {
-    for (const slug of ['snide', 'everymen', 'na', null]) {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
     }
   })

--- a/frontend/src/pages/tasks/__tests__/wowDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/wowDispatch.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * Mobile task-browse WOW dispatch (#531). The browse page shows every faction's
+ * tasks, so — unlike detail — it dispatches on the VIEWING life's faction. This
+ * asserts a `wow` viewer resolves to the scrapbook quest-board browse skin while
+ * every other viewer (and logged-out null) falls through to the Default mobile
+ * browse skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../Tasks'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultTasks from '../mobileArchetypes/DefaultTasks'
+import WowTaskList from '../mobileArchetypes/WowTaskList'
+
+describe('mobile task-browse WOW dispatch', () => {
+  it('mobile + a WOW viewer resolves to the bespoke WOW browse skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'wow', DefaultTasks)).toBe(WowTaskList)
+  })
+
+  it('mobile + any other viewer falls through to the Default browse skin', () => {
+    for (const slug of ['snide', 'everymen', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
+    }
+  })
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/WowTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/WowTaskList.tsx
@@ -1,0 +1,278 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../../api/tasks'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import type { TasksState } from '../useTasks'
+
+/**
+ * Warriors of Whimsy MOBILE task-browse skin (#531) — the quest board on a
+ * phone. The same scannable single-column list + touch-native filter chip rows
+ * as the Default browse skin (status / faction / level), dressed as pink
+ * scrapbook "quest" sticker-cards: dotted board, inner notepad, sparkle accents,
+ * Caveat titles. Dispatched by the VIEWING life's faction (a WOW witch browsing
+ * quests), so it consumes the shared `useTasks()` state verbatim — a chip tap
+ * mutates the same filter state that keys the read. Grounds on the
+ * `--faction-wow-*` window tokens already in index.css (the set the WOW pilots
+ * use); always-light. Presentation-only.
+ */
+
+const PINK = 'var(--faction-wow)'
+const PINK_DEEP = 'var(--faction-wow-card-accent)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const DOT = 'var(--faction-wow-dot)'
+const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const BODY = 'var(--font-body)' // Courier Prime
+const ON_ACCENT = 'var(--color-text-on-accent)'
+
+/** The kit's four-point sparkle. */
+function Sparkle({ size, color, style }: { size: number; color: string; style?: CSSProperties }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={style} aria-hidden>
+      <path
+        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+export default function WowTaskList({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div
+      data-skin="wow"
+      className="py-4"
+      style={{
+        fontFamily: BODY,
+        color: CARD_TEXT,
+        background: BODY_BG,
+        backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+        backgroundSize: '15px 15px',
+        marginLeft: -16,
+        marginRight: -16,
+        paddingLeft: 16,
+        paddingRight: 16,
+      }}
+      data-testid="mobile-tasks-browse"
+    >
+      <div style={{ fontSize: 9, letterSpacing: '0.18em', textTransform: 'uppercase', color: PINK_DEEP }}>
+        {t('wow.mobile.masthead')}
+      </div>
+      <h1
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          fontFamily: SCRIPT,
+          fontSize: 34,
+          lineHeight: 0.95,
+          color: TITLE_TEXT,
+          margin: '2px 0 0',
+        }}
+      >
+        {tc('nav.tasks')}
+        <Sparkle size={15} color={PINK} />
+      </h1>
+      <p style={{ fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color: CARD_MUTED, margin: '6px 0 12px' }}>
+        {t('mobile.count', { count: tasks.length })}
+      </p>
+
+      <ChipRow label={tc('filters.status')}>
+        {statusFilters.map((option) => (
+          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
+            {option}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('mobile.allFactions')}
+        </Chip>
+        {sortFactionsByRainbowOrder(factions).map((f) => (
+          <Chip
+            key={f.slug}
+            on={faction === f.slug}
+            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
+            tint={factionCssVar(f.slug)}
+          >
+            {factionName(f.slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.level')}>
+        <Chip on={level === ''} onClick={() => setLevel('')}>
+          {t('mobile.anyLevel')}
+        </Chip>
+        {levelFilters.map((lvl) => (
+          <Chip key={lvl} on={level === lvl} onClick={() => setLevel(level === lvl ? '' : lvl)}>
+            {tc('filters.levelAtLeast', { level: lvl })}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <div className="mt-4">
+        {loading ? (
+          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK }}>{t('listPage.loading')}</p>
+        ) : error ? (
+          <p style={{ fontFamily: BODY, fontSize: 12, color: 'var(--color-danger)', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: '10px 12px' }}>
+            {t('mobile.loadError')}
+          </p>
+        ) : tasks.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK }}>{t('listPage.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {tasks.map((task) => (
+              <QuestCard key={task.id} task={task} points={displayPointsFor(task)} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span style={{ flex: 'none', fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color: CARD_MUTED }}>
+        {label}
+      </span>
+      <div className="flex gap-2" style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: BODY,
+        fontSize: 11,
+        fontWeight: on ? 700 : 400,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        color: on ? ON_ACCENT : CARD_MUTED,
+        background: on ? `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})` : NOTEPAD_BG,
+        border: `1.5px solid ${on ? PINK_DEEP : NOTEPAD_BORDER}`,
+        borderRadius: 999,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && <i style={{ width: 8, height: 8, borderRadius: '50%', flex: 'none', background: tint }} />}
+      {children}
+    </button>
+  )
+}
+
+/** A pink scrapbook quest sticker-card: dotted board + inner notepad. */
+function QuestCard({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  const color = factionCssVar(task.primary_faction_slug)
+  return (
+    <Link
+      to={`/tasks/${task.id}`}
+      style={{
+        display: 'block',
+        borderRadius: 14,
+        overflow: 'hidden',
+        border: `2px solid ${WIN_BORDER}`,
+        boxShadow: `0 6px 16px color-mix(in srgb, ${PINK} 18%, transparent)`,
+        textDecoration: 'none',
+      }}
+    >
+      <div
+        style={{
+          padding: 10,
+          background: BODY_BG,
+          backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+          backgroundSize: '13px 13px',
+        }}
+      >
+        <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: '13px 15px', display: 'flex', flexDirection: 'column', gap: 7 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color }}>
+            <Sparkle size={10} color={color} />
+            {t('wow.mobile.cardMeta', { faction: factionName(task.primary_faction_slug), points })}
+          </span>
+
+          <h2 style={{ fontFamily: SCRIPT, fontSize: 22, lineHeight: 1.05, color: TITLE_TEXT, margin: 0, overflowWrap: 'anywhere' }}>
+            {task.title}
+          </h2>
+
+          {task.description && (
+            <p
+              style={{
+                fontFamily: BODY,
+                fontSize: 12,
+                lineHeight: 1.5,
+                color: CARD_MUTED,
+                margin: 0,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {task.description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
+            <span style={{ fontFamily: BODY, fontSize: 12, fontWeight: 700, color: PINK_DEEP, background: BODY_BG, border: `1px solid ${NOTEPAD_BORDER}`, borderRadius: 999, padding: '3px 11px' }}>
+              {t('mobile.points', { points })}
+            </span>
+            <span style={{ fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}>
+              {t('mobile.level', { level: task.level_required })}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
Closes #531

## What

Registers the **Warriors of Whimsy** (`wow`) whimsy-scrapbook skin into the three mobile surfaces where it was missing, completing the WOW per-faction mobile treatment alongside the existing pilots (Home / Praxis detail / Composer).

| Surface | New skin file |
|---|---|
| Tasks browse (`Tasks.tsx`) | `tasks/mobileArchetypes/WowTaskList.tsx` |
| Task detail (`TaskDetail.tsx`) | `taskDetail/mobileArchetypes/WowTaskDetail.tsx` |
| Faction page (`FactionDetail.tsx`) | `factionDetail/mobileArchetypes/WowFactionPage.tsx` |

Each is added as a `wow:` entry in the surface's **mobile** `MOBILE_ARCHETYPE_BY_SLUG` registry (existing keys untouched; the desktop task-detail collision is handled with a `WowMobileTaskDetail` import alias).

## How

- Presentation-only. Every skin consumes the same `useTasks` / `useTaskDetail` / `useFactionDetail` state and renders the same DOM slots as its `Default*` sibling — single-column, no fixed-px layout grids, sticky action bars via the shared `MobileStickyBar`.
- Mirrors the existing WOW pilots' idiom exactly: pink `.exe` window chrome (traffic-light title bar, dotted board, inner notepad), Caveat script, sparkle accents, rose accent; native-**light**, scoped to each skin's own container.
- No raw strings — reuses existing `wow.*` / shared `mobile.*` i18n keys; adds `tasks:wow.mobile.{masthead,cardMeta}` and `factions:wow.mobile.eyebrow`. No hex; only `--faction-wow-*` / theme tokens.
- No backend / API / hook changes.

## Tests

- New dispatch tests per surface (`wow` → bespoke skin; other slugs → Default; desktop untouched).
- The shared `mobileArchetypeSlots` invariants now also exercise each WOW skin (registry-walked).
- Corrected three pre-existing UA dispatch tests that listed `wow` as an unregistered fall-through example (now registered) → swapped for `singularity`.

## Verification

- `npm run lint` — clean (0).
- `npm test` (vitest) — **397 passed**.
- `tsc --noEmit` — the only errors are pre-existing in `AlbescentInvitation.tsx` (a duplicate `invitation` key in the albescent locale block, untouched here); none in files this PR touches.

## Out of scope

Home / Praxis detail / Composer (already piloted); praxis feed cards + Updates stream; other factions; Default skins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
