### PR TITLE
Mobile: Everymen faction treatment (#529)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -132,6 +132,11 @@
         "masthead": "FieldDesk.sys",
         "charEyebrow": "// active_node",
         "questsHeading": "// running_processes"
+      },
+      "everymen": {
+        "masthead": "The Union Desk",
+        "charEyebrow": "On the roll",
+        "questsHeading": "On the job"
       }
     }
   },

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -244,6 +244,9 @@
       "emptyWithSpotlight": "No others on the roll yet.",
       "level": "lvl {{level}}"
     },
+    "mobile": {
+      "eyebrow": "The Union Hall"
+    },
     "invitation": {
       "kicker": "doors are open —",
       "headline": "Join the ranks",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -219,7 +219,13 @@
       "proofOfWork_one": "Proof of Work · {{count}} plate",
       "proofOfWork_other": "Proof of Work · {{count}} plates",
       "crewsMarks": "The Crew's Marks",
-      "ptsFromVotes": "pts from votes"
+      "ptsFromVotes": "pts from votes",
+      "mobile": {
+        "re": "re:",
+        "filed": "filed the report",
+        "plate": "Proof of Work",
+        "appraise": "Mark the work"
+      }
     },
     "singularity": {
       "instance": {

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -27,6 +27,7 @@ import DefaultMobileEditPraxis from "./editPraxis/mobileArchetypes/DefaultEditPr
 import WowMobileEditPraxis from "./editPraxis/mobileArchetypes/WowEditPraxis";
 import UAMobileEditPraxis from "./editPraxis/mobileArchetypes/UaComposer";
 import SingularityMobileEditPraxis from "./editPraxis/mobileArchetypes/SingularityComposer";
+import EverymenMobileEditPraxis from "./editPraxis/mobileArchetypes/EverymenComposer";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
@@ -50,6 +51,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   wow: WowMobileEditPraxis,
   ua: UAMobileEditPraxis,
   singularity: SingularityMobileEditPraxis,
+  everymen: EverymenMobileEditPraxis,
 };
 
 export default function EditPraxis() {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -9,6 +9,7 @@ import { useFactionDetail, type FactionDetailState } from "./factionDetail/useFa
 import UaFactionPage from "./factionDetail/mobileArchetypes/UaFactionPage";
 import SingularityFactionPage from "./factionDetail/mobileArchetypes/SingularityFactionPage";
 import WowFactionPage from "./factionDetail/mobileArchetypes/WowFactionPage";
+import EverymenFactionPage from "./factionDetail/mobileArchetypes/EverymenFactionPage";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import DefaultFactionPage from "./factionDetail/mobileArchetypes/DefaultFactionPage";
 import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
@@ -84,6 +85,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<
   ua: UaFactionPage,
   singularity: SingularityFactionPage,
   wow: WowFactionPage,
+  everymen: EverymenFactionPage,
 };
 
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -14,6 +14,7 @@ import DefaultFieldDesk from './fieldDesk/mobileArchetypes/DefaultFieldDesk'
 import WowFieldDesk from './fieldDesk/mobileArchetypes/WowFieldDesk'
 import UaHome from './fieldDesk/mobileArchetypes/UaHome'
 import SingularityHome from './fieldDesk/mobileArchetypes/SingularityHome'
+import EverymenHome from './fieldDesk/mobileArchetypes/EverymenHome'
 
 /**
  * FieldDesk roster — the authenticated account home (#274). "Whose shoes today?":
@@ -36,6 +37,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileHomeSkin> = {
   wow: WowFieldDesk,
   ua: UaHome,
   singularity: SingularityHome,
+  everymen: EverymenHome,
 }
 
 // Deterministic slight tilt per card — index-keyed so it's stable across renders.

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -19,6 +19,7 @@ import DefaultMobilePraxisDetail from './praxisDetail/mobileArchetypes/DefaultPr
 import WowMobilePraxisDetail from './praxisDetail/mobileArchetypes/WowPraxisDetail'
 import UAMobilePraxisDetail from './praxisDetail/mobileArchetypes/UaPraxisDetail'
 import SingularityMobilePraxisDetail from './praxisDetail/mobileArchetypes/SingularityPraxisDetail'
+import EverymenMobilePraxisDetail from './praxisDetail/mobileArchetypes/EverymenPraxisDetail'
 import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
 import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
 import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
@@ -54,6 +55,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: Pra
   wow: WowMobilePraxisDetail,
   ua: UAMobilePraxisDetail,
   singularity: SingularityMobilePraxisDetail,
+  everymen: EverymenMobilePraxisDetail,
 }
 
 export default function PraxisDetail() {

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -12,6 +12,7 @@ import DefaultTasks from './tasks/mobileArchetypes/DefaultTasks'
 import UaTaskList from './tasks/mobileArchetypes/UaTaskList'
 import SingularityTaskList from './tasks/mobileArchetypes/SingularityTaskList'
 import WowTaskList from './tasks/mobileArchetypes/WowTaskList'
+import EverymenTaskList from './tasks/mobileArchetypes/EverymenTaskList'
 
 type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 
@@ -24,6 +25,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {
   ua: UaTaskList,
   singularity: SingularityTaskList,
   wow: WowTaskList,
+  everymen: EverymenTaskList,
 }
 
 export default function Tasks() {

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
@@ -1,0 +1,342 @@
+import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import MediaArt from '../blocks/MediaArt'
+import { pickArtKey } from '../blocks/useMediaArt'
+import { ErrorBanner, formatAutosave } from '../archetypes/shared'
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from '../archetypes/controls'
+import type { EditPraxisState } from '../useEditPraxis'
+import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+
+/**
+ * Everymen MOBILE composer (#529) — "Stamp & File" on a phone. The same
+ * single-column composer as the Default mobile skin (Write/Preview toggle, fluid
+ * media grid, sticky submit bar) dressed as a union work report: cream newsprint
+ * plates framed in ink, knockout Bebas labels, a red/gold masthead. Ported from
+ * the desktop Everymen archetype; grounds on the `--everymen-*` tokens (flips
+ * with `[data-theme]`). Consumes `useEditPraxis` verbatim — no editor, upload, or
+ * submit logic lives here.
+ */
+
+const INK = 'var(--everymen-ink)'
+const CREAM = 'var(--everymen-cream)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const MUTED = 'var(--everymen-muted)'
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const ACCENT_FONT = 'var(--font-accent)'
+const BODY_FONT = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  display: 'block',
+  fontFamily: BODY_FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+/** A cream newsprint plate framed in union ink, headed by a Bebas title. */
+function Plate({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ background: PAPER, border: `2px solid ${INK}`, padding: 14 }}>
+      <div style={{ fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.06em', color: RED, marginBottom: 10 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default function EverymenComposer({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation('forms')
+  const [tab, setTab] = useState<ComposerTab>('write')
+  const praxis = state.praxis!
+  const task = state.task
+
+  return (
+    <div data-skin="everymen" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: INK, background: PAPER }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 30, lineHeight: 0.95, letterSpacing: '0.02em', color: INK, margin: 0 }}>
+            {t('editPraxis.everymen.pageTitle')}
+          </h1>
+          <span style={{ ...kicker, marginLeft: 'auto' }}>
+            {state.autosaveAt
+              ? t('editPraxis.everymen.autosaveSaved', { ago: formatAutosave(state.autosaveAt) })
+              : t('editPraxis.everymen.autosaveUnsaved')}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: { gap: 4, padding: 3, background: PAPER_DEEP, border: `1.5px solid ${INK}` },
+            buttonStyle: (active) => ({
+              padding: '9px 10px',
+              border: 'none',
+              fontFamily: ACCENT_FONT,
+              fontSize: 14,
+              letterSpacing: '0.08em',
+              background: active ? INK : 'transparent',
+              color: active ? CREAM : MUTED,
+            }),
+          }}
+        />
+      </header>
+
+      {/* For-task reference */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: PAPER_DEEP, border: `1.5px solid ${INK}` }}>
+        <span style={kicker}>{t('editPraxis.everymen.taskRefLabel')}</span>
+        <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.02em', color: INK, textAlign: 'right', flex: 1, lineHeight: 1 }}>
+          {praxis.task_title}
+        </span>
+      </div>
+      <div style={{ ...kicker, color: RED }}>
+        {factionName(task?.primary_faction_slug ?? null)}
+        {task ? ` · ${t('taskMeta.points', { points: task.point_value })}` : ''}
+      </div>
+
+      {tab === 'write' ? (
+        <>
+          <Plate title={t('editPraxis.everymen.titleLabel')}>
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t('editPraxis.everymen.titlePlaceholder'),
+                inputStyle: {
+                  width: '100%',
+                  fontFamily: ACCENT_FONT,
+                  fontSize: 24,
+                  letterSpacing: '0.01em',
+                  color: INK,
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  borderBottom: `1.5px solid ${INK}`,
+                  padding: '2px 0 8px',
+                },
+              }}
+            />
+          </Plate>
+
+          <Plate title={t('editPraxis.everymen.bodyLabel')}>
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t('editPraxis.everymen.bodyPlaceholder'),
+                textareaStyle: {
+                  width: '100%',
+                  fontFamily: BODY_FONT,
+                  fontSize: 14,
+                  lineHeight: 1.6,
+                  color: INK,
+                  background: PAPER_DEEP,
+                  border: `1.5px solid ${INK}`,
+                  padding: '13px 15px',
+                  outline: 'none',
+                  resize: 'vertical',
+                  minHeight: 180,
+                },
+              }}
+            />
+          </Plate>
+
+          {state.showInviteBox && (
+            <Plate title={state.duelMode ? t('editPraxis.everymen.inviteLabelDuel') : t('editPraxis.everymen.inviteLabel')}>
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: BODY_FONT,
+                  inputBg: PAPER_DEEP,
+                  inputColor: INK,
+                  inputBorder: `1.5px solid ${INK}`,
+                  acceptedBg: RED,
+                  acceptedColor: CREAM,
+                  placeholder: t('editPraxis.everymen.invitePlaceholder'),
+                }}
+              />
+            </Plate>
+          )}
+
+          <Plate title={t('editPraxis.everymen.filesLabel')}>
+            <MediaGrid state={state} />
+          </Plate>
+
+          {state.showMetatasks && (
+            <Plate title={t('editPraxis.everymen.metatasksLabel')}>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: { display: 'flex', flexDirection: 'column', gap: 4 },
+                  rowStyle: (selected) => ({
+                    padding: '10px 12px',
+                    background: selected ? PAPER_DEEP : 'transparent',
+                    border: `1.5px solid ${selected ? RED : 'color-mix(in srgb, var(--everymen-ink) 30%, transparent)'}`,
+                  }),
+                  titleColor: INK,
+                  descColor: MUTED,
+                  pointsActiveColor: RED,
+                  pointsIdleColor: MUTED,
+                }}
+              />
+            </Plate>
+          )}
+        </>
+      ) : (
+        <Plate title={t('editPraxis.everymen.previewLabel')}>
+          <div style={{ fontFamily: ACCENT_FONT, fontSize: 24, letterSpacing: '0.01em', color: INK, marginBottom: 10 }}>
+            {state.title || t('editPraxis.everymen.titlePlaceholder')}
+          </div>
+          {state.media.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <MediaGrid state={state} readOnly />
+            </div>
+          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              markdownStyle: { fontFamily: BODY_FONT, fontSize: 14, lineHeight: 1.6, color: INK },
+            }}
+          />
+        </Plate>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      <MobileStickyBar
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 0 4px',
+          background: 'var(--color-nav-bg)',
+          backdropFilter: 'blur(var(--nav-blur))',
+          borderTop: `2px solid ${INK}`,
+        }}
+      >
+        <PublishButton
+          state={state}
+          skin={{
+            idleLabel: t('editPraxis.everymen.publishIdle'),
+            busyLabel: t('editPraxis.everymen.publishBusy'),
+            style: {
+              flex: 1,
+              background: RED,
+              color: CREAM,
+              fontFamily: ACCENT_FONT,
+              fontSize: 16,
+              letterSpacing: '0.08em',
+              padding: '13px 18px',
+              border: `2px solid ${INK}`,
+              cursor: state.submitting ? 'wait' : 'pointer',
+            },
+          }}
+        />
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.everymen.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: MUTED,
+                fontFamily: BODY_FONT,
+                fontSize: 12,
+                textDecoration: 'underline',
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
+      </MobileStickyBar>
+    </div>
+  )
+}
+
+/** Fluid 3-column media grid in the union proof-of-work idiom. */
+function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOnly?: boolean }) {
+  const { t } = useTranslation('forms')
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+      {state.media.map((item) => {
+        const filename = item.file_path.split('/').pop() ?? item.file_path
+        const src = mediaUrl(item.file_path)
+        return (
+          <div key={item.id} style={{ position: 'relative', aspectRatio: '1 / 1', overflow: 'hidden', border: `1.5px solid ${INK}`, background: PAPER_DEEP }}>
+            {item.type === 'image' ? (
+              <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : item.type === 'video' ? (
+              <video src={src} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <MediaArt art={pickArtKey(filename, 'audio')} width={120} height={120} />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t('media.removeAria', { name: filename })}
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  background: GOLD,
+                  border: `1.5px solid ${INK}`,
+                  color: INK,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        )
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: '1 / 1',
+              width: '100%',
+              background: PAPER_DEEP,
+              border: `1.5px dashed ${INK}`,
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 4,
+              fontFamily: ACCENT_FONT,
+              fontSize: 13,
+              letterSpacing: '0.06em',
+              color: RED,
+            },
+            buttonLabel: t('editPraxis.everymen.fileButton'),
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/everymenDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/everymenDispatch.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Mobile composer Everymen dispatch (#529). Asserts the mobile registry resolves
+ * an `everymen` task to the union "Stamp & File" composer, and that every other
+ * faction falls through to the Default mobile composer.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../../EditPraxis'
+import { pickVariant } from '../../../../utils/factionDispatch'
+import DefaultMobileEditPraxis from '../DefaultEditPraxis'
+import EverymenMobileEditPraxis from '../EverymenComposer'
+
+describe('mobile composer Everymen dispatch', () => {
+  it('mobile + an Everymen task resolves to the bespoke Everymen composer', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'everymen', DefaultMobileEditPraxis)).toBe(
+      EverymenMobileEditPraxis,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default composer', () => {
+    for (const slug of ['snide', 'wow', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileEditPraxis)).not.toBe(
+        EverymenMobileEditPraxis,
+      )
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/__tests__/everymenMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/everymenMobileDispatch.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Mobile faction-page Everymen dispatch (#529). Asserts the mobile registry
+ * resolves the `everymen` faction to the union-hall page skin, and that every
+ * other faction (and null) falls through to the single-column DefaultFactionPage.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FactionDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
+import EverymenFactionPage from '../mobileArchetypes/EverymenFactionPage'
+
+describe('mobile faction-page Everymen dispatch', () => {
+  it('mobile + the Everymen faction resolves to the bespoke Everymen page', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'everymen', DefaultFactionPage)).toBe(EverymenFactionPage)
+  })
+
+  it('every other faction falls through to the Default mobile page', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
@@ -1,0 +1,279 @@
+import { useState, type CSSProperties, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { factionName, factionDescription } from '../../../utils/factions'
+import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
+import type { CharacterOut } from '../../../api/auth'
+import type { FactionDetailState } from '../useFactionDetail'
+
+/**
+ * Everymen MOBILE faction page (#529) — the union hall, phone shaped. The same
+ * single-column slots as the Default mobile faction page (a hero with real
+ * member/task counts, top members, recent praxis, and the invite-gated Join
+ * model via `state.membership`, ADR-0019) — only the dress changes: a red
+ * masthead billboard with the cog seal, cream newsprint plates framed in ink,
+ * knockout Bebas headings, gold seals. Grounds on the `--everymen-*` tokens;
+ * flips with `[data-theme]`. Reuses the shared `mobile.*` faction copy so the
+ * slot contract holds. Presentation-only — all data + the join handler arrive via
+ * {@link FactionDetailState}.
+ */
+
+const NA_SLUG = 'na'
+
+const INK = 'var(--everymen-ink)'
+const CREAM = 'var(--everymen-cream)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const MUTED = 'var(--everymen-muted)'
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const ACCENT_FONT = 'var(--font-accent)'
+const BODY_FONT = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: BODY_FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || '?'
+
+/** The Everymen cog seal — a riveted gear, the union's mark. */
+function CogSeal({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden>
+      <g fill={GOLD}>
+        {[0, 45, 90, 135, 180, 225, 270, 315].map((deg) => (
+          <rect key={deg} x="11" y="0.5" width="2" height="5" rx="0.5" transform={`rotate(${deg} 12 12)`} />
+        ))}
+      </g>
+      <circle cx="12" cy="12" r="6.5" fill="none" stroke={GOLD} strokeWidth="2.4" />
+      <circle cx="12" cy="12" r="2" fill={GOLD} />
+    </svg>
+  )
+}
+
+/** Square initials seal — gold face, red glyph, union ink border. */
+function Seal({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        background: GOLD,
+        border: `1.5px solid ${INK}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: ACCENT_FONT,
+        fontSize: size * 0.5,
+        color: RED,
+      }}
+    >
+      {initial(name)}
+    </span>
+  )
+}
+
+function SectionHead({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.04em', color: INK, whiteSpace: 'nowrap' }}>
+        {children}
+      </span>
+      <span style={{ flex: 1, height: 3, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
+    </div>
+  )
+}
+
+const joinButton: CSSProperties = {
+  width: '100%',
+  fontFamily: ACCENT_FONT,
+  fontSize: 17,
+  letterSpacing: '0.08em',
+  color: CREAM,
+  background: RED,
+  border: `2px solid ${INK}`,
+  padding: '13px 16px',
+  cursor: 'pointer',
+}
+
+export default function EverymenFactionPage({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation('factions')
+  const { faction, members, tasks, recentPraxis, membership } = state
+  const [confirming, setConfirming] = useState(false)
+
+  if (!faction) return null
+
+  const name = factionName(faction.slug)
+  const topMembers = [...members].sort((a, b) => b.all_time_score - a.all_time_score).slice(0, 3)
+  const currentSlug = membership.currentFactionSlug
+  const switching = currentSlug && currentSlug !== NA_SLUG
+
+  return (
+    <div data-skin="everymen" className="py-4" style={{ fontFamily: BODY_FONT, color: INK, background: PAPER }} data-testid="mobile-faction-page">
+      {/* Hero — union masthead billboard */}
+      <section style={{ border: `3px solid ${INK}`, background: RED, color: CREAM, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, background: INK, color: GOLD, padding: '8px 14px' }}>
+          <CogSeal size={16} />
+          <span style={{ ...kicker, color: CREAM }}>{t('everymen.mobile.eyebrow')}</span>
+        </div>
+        <div style={{ height: 4, background: GOLD }} />
+        <div style={{ padding: '20px 18px' }}>
+          <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 40, lineHeight: 0.92, letterSpacing: '0.01em', color: CREAM, textShadow: `2px 2px 0 ${INK}`, margin: 0 }}>
+            {name}
+          </h1>
+          <p style={{ fontFamily: BODY_FONT, fontSize: 12, lineHeight: 1.6, color: CREAM, margin: '10px 0 0' }}>
+            {factionDescription(faction.slug)}
+          </p>
+          <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
+            <HeroStat value={members.length} label={t('mobile.membersStat')} />
+            <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
+          </div>
+        </div>
+      </section>
+
+      {membership.state === 'member' && (
+        <p style={{ ...kicker, marginTop: 12, color: RED }}>{t('mobile.memberBadge')}</p>
+      )}
+
+      {/* Top members */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.topMembers')}</SectionHead>
+        {topMembers.length === 0 ? (
+          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topMembers.map((m, index) => (
+              <MemberRow key={m.id} rank={index + 1} member={m} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent praxis */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
+        {recentPraxis.length === 0 ? (
+          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {membership.state === 'gate' && (
+        <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, marginTop: 24 }}>
+          {t('mobile.gateHint', { faction: name })}
+        </p>
+      )}
+
+      {/* Sticky Join — only an eligible viewer can act (ADR-0019). */}
+      {membership.state === 'eligible' && (
+        <MobileStickyBar>
+          {membership.joinError && (
+            <p style={{ fontFamily: BODY_FONT, fontSize: 12, color: RED }}>{membership.joinError}</p>
+          )}
+          {!confirming ? (
+            <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
+              {t('mobile.join', { faction: name })}
+            </button>
+          ) : (
+            <>
+              <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: INK }}>
+                {switching
+                  ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
+                  : t('detail.join.confirm', { faction: name })}
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => void membership.join()}
+                  disabled={membership.joining}
+                  style={{ ...joinButton, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                >
+                  {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirming(false)}
+                  disabled={membership.joining}
+                  style={{
+                    fontFamily: ACCENT_FONT,
+                    fontSize: 15,
+                    letterSpacing: '0.06em',
+                    color: MUTED,
+                    background: PAPER_DEEP,
+                    border: `1.5px solid ${INK}`,
+                    padding: '11px 16px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t('detail.join.cancel')}
+                </button>
+              </div>
+            </>
+          )}
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+function HeroStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={{ flex: '1 1 0', textAlign: 'center', background: INK, border: `1.5px solid ${GOLD}`, padding: '10px 6px' }}>
+      <b style={{ fontFamily: ACCENT_FONT, fontSize: 22, display: 'block', lineHeight: 0.9, color: GOLD }}>
+        {value}
+      </b>
+      <span style={{ ...kicker, marginTop: 5, display: 'block', color: CREAM }}>{label}</span>
+    </div>
+  )
+}
+
+function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
+  const { t } = useTranslation('factions')
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: PAPER,
+        border: `2px solid ${INK}`,
+        borderLeft: `5px solid ${RED}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, color: RED, width: 16, flex: 'none' }}>{rank}</span>
+      <Seal name={member.display_name} size={28} />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: ACCENT_FONT,
+          fontSize: 17,
+          letterSpacing: '0.02em',
+          color: INK,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {member.display_name}
+      </span>
+      <span style={{ ...kicker, flex: 'none', color: RED }}>
+        {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/pages/fieldDesk/__tests__/everymenDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/everymenDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile FieldDesk-home Everymen dispatch (#529). Asserts the parallel mobile
+ * registry resolves an `everymen` carried life to the union-broadsheet home skin,
+ * and that an unregistered faction (and null) still falls through to the Default
+ * mobile home. Mirrors the UA dispatch test.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FieldDesk'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
+import EverymenHome from '../mobileArchetypes/EverymenHome'
+
+describe('mobile FieldDesk-home Everymen dispatch', () => {
+  it('mobile + an Everymen life resolves to the bespoke Everymen home skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'everymen', DefaultFieldDesk)).toBe(EverymenHome)
+  })
+
+  it('mobile + any other slug falls through to the Default home skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
+    }
+  })
+})

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
@@ -1,0 +1,284 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+
+/**
+ * Everymen MOBILE FieldDesk home (#529) — the union broadsheet on a phone. The
+ * carried life becomes the day's front page: a red masthead billboard with the
+ * cog seal and knockout Bebas nameplate, gold points seals for the stat tiles,
+ * and the in-progress work filed as newsprint dispatches. Same content slots as
+ * the Default mobile home (character header, Points/Votes/Era tiles,
+ * active-tasks list, primary actions) — only the dress changes. Grounds on the
+ * `--everymen-*` tokens already in index.css (the set EverymenTaskDetail /
+ * EverymenFactionBody use), so it flips with `[data-theme]` without mutating the
+ * document theme. Presentation-only — all data arrives via
+ * {@link FieldDeskHomeState}.
+ */
+
+const INK = 'var(--everymen-ink)'
+const CREAM = 'var(--everymen-cream)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const MUTED = 'var(--everymen-muted)'
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const ACCENT_FONT = 'var(--font-accent)'
+const BODY_FONT = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: BODY_FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+/** The Everymen cog seal — a riveted gear, the union's mark. */
+function CogSeal({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden>
+      <g fill={GOLD}>
+        {[0, 45, 90, 135, 180, 225, 270, 315].map((deg) => (
+          <rect key={deg} x="11" y="0.5" width="2" height="5" rx="0.5" transform={`rotate(${deg} 12 12)`} />
+        ))}
+      </g>
+      <circle cx="12" cy="12" r="6.5" fill="none" stroke={GOLD} strokeWidth="2.4" />
+      <circle cx="12" cy="12" r="2" fill={GOLD} />
+    </svg>
+  )
+}
+
+/** Cream newsprint plate framed in union ink. */
+function Plate({ children, style }: { children: ReactNode; style?: CSSProperties }) {
+  return (
+    <div
+      style={{
+        background: PAPER,
+        backgroundImage: 'radial-gradient(color-mix(in srgb, var(--everymen-ink) 6%, transparent) 0.6px, transparent 0.9px)',
+        backgroundSize: '5px 5px',
+        border: `2px solid ${INK}`,
+        padding: 16,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: '0.06em', color: INK, whiteSpace: 'nowrap' }}>
+        {title}
+      </span>
+      <span style={{ flex: 1, height: 3, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
+      {trailing}
+    </div>
+  )
+}
+
+export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
+  const { t } = useTranslation('common')
+  const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+
+  const stats = [
+    { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
+    { label: t('fieldDesk.home.stats.votes'), value: votesReceived.toLocaleString() },
+    { label: t('fieldDesk.home.stats.era'), value: eraName || '—' },
+  ]
+
+  return (
+    <div
+      data-skin="everymen"
+      className="page"
+      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: INK, background: PAPER }}
+    >
+      {/* Masthead billboard */}
+      <header style={{ border: `3px solid ${INK}`, background: RED, color: CREAM, overflow: 'hidden' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            background: INK,
+            color: GOLD,
+            padding: '8px 14px',
+          }}
+        >
+          <CogSeal size={16} />
+          <span style={{ fontFamily: ACCENT_FONT, fontSize: 14, letterSpacing: '0.2em' }}>
+            {t('fieldDesk.home.everymen.masthead')}
+          </span>
+          <span style={{ ...kicker, marginLeft: 'auto', color: CREAM }}>{t('nav.home')}</span>
+        </div>
+        <div style={{ height: 4, background: GOLD }} />
+        <h1
+          style={{
+            fontFamily: ACCENT_FONT,
+            fontSize: 34,
+            lineHeight: 0.95,
+            letterSpacing: '0.02em',
+            color: CREAM,
+            textShadow: `2px 2px 0 ${INK}`,
+            margin: 0,
+            padding: '16px 16px 18px',
+          }}
+        >
+          {t('fieldDesk.home.title')}
+        </h1>
+      </header>
+
+      {/* ── The worker on the roll ── */}
+      <Plate>
+        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+          <span style={kicker}>{t('fieldDesk.home.everymen.charEyebrow')}</span>
+          <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: RED, textDecoration: 'none' }}>
+            {t('fieldDesk.home.edit')}
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="shrink-0" style={{ width: 56, height: 56, padding: 3, background: GOLD, border: `2px solid ${INK}` }}>
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="w-full h-full"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : (
+              <span
+                className="flex w-full h-full items-center justify-center"
+                style={{ background: PAPER_DEEP, fontFamily: ACCENT_FONT, fontSize: 26, color: RED }}
+              >
+                {character.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/characters/${character.id}`}
+              className="block truncate"
+              style={{ fontFamily: ACCENT_FONT, fontSize: 28, lineHeight: 0.95, color: INK, textDecoration: 'none' }}
+            >
+              {character.display_name}
+            </Link>
+            <div className="truncate" style={{ ...kicker, marginTop: 5 }}>
+              {t('sidebar.characterCard.factionLevel', {
+                faction: factionName(character.faction_slug),
+                level: character.level,
+              })}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div style={{ fontFamily: ACCENT_FONT, fontSize: 28, lineHeight: 0.9, color: RED }}>
+              {character.score?.toLocaleString() ?? '0'}
+            </div>
+            <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
+          </div>
+        </div>
+
+        {/* Points seals */}
+        <div className="flex gap-2" style={{ marginTop: 16 }}>
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center"
+              style={{ flex: '1 1 0', minWidth: 0, background: PAPER_DEEP, border: `1.5px solid ${INK}`, padding: '11px 6px' }}
+            >
+              <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 22, lineHeight: 0.9, color: INK }}>
+                {stat.value}
+              </div>
+              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      </Plate>
+
+      {/* ── Pending requests ── */}
+      {pendingCount > 0 && (
+        <Link
+          to="/updates?filter=requests"
+          className="flex items-center justify-between"
+          style={{ background: PAPER, border: `1.5px solid ${INK}`, padding: '10px 16px', fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.04em', color: INK, textDecoration: 'none' }}
+        >
+          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
+          <span aria-hidden style={{ color: RED }}>›</span>
+        </Link>
+      )}
+
+      {/* ── On the job ── */}
+      <Plate>
+        <SectionHead
+          title={t('fieldDesk.home.everymen.questsHeading')}
+          trailing={
+            <Link to="/tasks" style={{ ...kicker, color: RED, textDecoration: 'none' }}>
+              {t('fieldDesk.home.viewAll')}
+            </Link>
+          }
+        />
+
+        {activeTasks.length === 0 ? (
+          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>
+            {t('fieldDesk.home.questsEmpty')}
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {activeTasks.map((praxis, index) => (
+              <Link
+                key={praxis.id}
+                to={`/praxes/${praxis.id}/edit`}
+                className="flex items-center gap-3"
+                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid color-mix(in srgb, var(--everymen-ink) 20%, transparent)`, textDecoration: 'none' }}
+              >
+                <span className="shrink-0" style={{ width: 10, height: 10, background: RED }} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 18, lineHeight: 1.05, color: INK }}>
+                    {praxis.task_title}
+                  </div>
+                  <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
+                    {t('fieldDesk.home.taskMeta', {
+                      faction: factionName(praxis.task_faction_slug),
+                      points: praxis.task_point_value,
+                    })}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0"
+                  style={{ fontFamily: BODY_FONT, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: '4px 9px' }}
+                >
+                  {t(`praxisType.${praxis.type}`)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </Plate>
+
+      {/* ── Primary actions ── */}
+      <div className="flex gap-2.5">
+        <Link
+          to="/tasks"
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: '0.08em', padding: 14, color: CREAM, background: RED, border: `2px solid ${INK}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.browseTasks')}
+        </Link>
+        {canProposeTask && (
+          <Link
+            to="/propose-task"
+            className="flex-1 flex items-center justify-center gap-2"
+            style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: '0.08em', padding: 14, color: INK, background: PAPER_DEEP, border: `2px solid ${INK}`, textDecoration: 'none' }}
+          >
+            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+            <span>{t('actions.proposeTask')}</span>
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDispatch.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Mobile praxis-detail Everymen dispatch (#529). Asserts the mobile registry
+ * resolves an `everymen`-task praxis to the union work-report skin, that other
+ * factions fall through to the Default mobile detail, and the desktop archetype
+ * is untouched.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG, ARCHETYPE_BY_SLUG } from '../../PraxisDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
+import EverymenMobilePraxisDetail from '../mobileArchetypes/EverymenPraxisDetail'
+import EverymenDesktopPraxisDetail from '../archetypes/EverymenPraxisDetail'
+
+describe('mobile praxis-detail Everymen dispatch', () => {
+  it('mobile + an Everymen praxis resolves to the bespoke Everymen mobile skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'everymen', DefaultMobilePraxisDetail)).toBe(
+      EverymenMobilePraxisDetail,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default mobile skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobilePraxisDetail)).toBe(
+        DefaultMobilePraxisDetail,
+      )
+    }
+  })
+
+  it('desktop keeps its own Everymen archetype, never the mobile skin', () => {
+    const desktop = pickVariant(ARCHETYPE_BY_SLUG, 'everymen', DefaultMobilePraxisDetail)
+    expect(desktop).toBe(EverymenDesktopPraxisDetail)
+    expect(desktop).not.toBe(EverymenMobilePraxisDetail)
+  })
+})

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
@@ -1,0 +1,145 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import { formatTimestamp } from '../../../utils/dates'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisVoterBreakdown,
+  MemberByline,
+} from '../shared'
+import { MobileStarVote } from './shared'
+
+/**
+ * Everymen MOBILE praxis-detail skin (#529) — a filed work report, phone shaped.
+ * The proof of work sits in a union ledger plate; a knockout Bebas finding
+ * headline, the report body, and a thumb-sized "mark the work" caster follow.
+ * Renders the same invariant CONTENT + behavior slots as every archetype (the
+ * shared praxisDetail module) — only the dress changes. Grounds on the
+ * `--everymen-*` tokens; flips with `[data-theme]`.
+ */
+
+const INK = 'var(--everymen-ink)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const MUTED = 'var(--everymen-muted)'
+const PAPER = 'var(--everymen-paper)'
+const ACCENT_FONT = 'var(--font-accent)'
+const BODY_FONT = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: BODY_FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+/** Cream ledger plate framed in union ink, headed by a Bebas title. */
+function Plate({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ background: PAPER, border: `2px solid ${INK}`, padding: 14 }}>
+      <div style={{ fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.06em', color: RED, marginBottom: 10 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default function EverymenPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <div data-skin="everymen" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: INK, background: PAPER }}>
+      {/* Behavior slots (invariant) */}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
+
+      {/* Byline row */}
+      <div className="flex items-center gap-3">
+        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+          <span
+            className="flex items-center justify-center"
+            style={{ width: 42, height: 42, background: GOLD, border: `2px solid ${INK}`, color: RED, fontFamily: ACCENT_FONT, fontSize: 22 }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <MemberByline
+            praxis={praxis}
+            linkStyle={{ fontFamily: ACCENT_FONT, fontSize: 20, letterSpacing: '0.02em', color: INK, lineHeight: 1, textDecoration: 'none' }}
+          />
+          <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
+            {t('detail.everymen.mobile.filed')} · {formatTimestamp(sealedDate)}
+          </div>
+        </div>
+      </div>
+
+      {/* Proof of work — full media inside */}
+      {praxis.media_items.length > 0 && (
+        <Plate title={t('detail.everymen.mobile.plate')}>
+          <MediaGallery media={praxis.media_items} layout="grid" />
+        </Plate>
+      )}
+
+      {/* Finding headline */}
+      <div>
+        <div style={{ ...kicker, marginBottom: 4, color: RED }}>{t('detail.everymen.theWork')}</div>
+        <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 34, lineHeight: 0.95, letterSpacing: '0.01em', margin: 0, color: INK, overflowWrap: 'anywhere' }}>
+          {praxis.title ?? t('detail.everymen.untitled')}
+        </h1>
+      </div>
+
+      {/* Owner actions (invariant) */}
+      <PraxisOwnerActions state={state} />
+
+      {/* re: task link */}
+      <div style={{ fontFamily: BODY_FONT, fontSize: 12, color: MUTED }}>
+        {t('detail.everymen.mobile.re')}{' '}
+        <Link to={`/tasks/${praxis.task_id}`} style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: '0.02em', color: RED, textDecoration: 'none' }}>
+          {praxis.task_title}
+        </Link>
+      </div>
+
+      {/* Report body */}
+      {praxis.body_text && (
+        <MarkdownPreview
+          source={praxis.body_text}
+          className="markdown-preview"
+          style={{ fontFamily: BODY_FONT, fontSize: 14, lineHeight: 1.75, color: INK }}
+        />
+      )}
+
+      {/* The crew's marks — vote caster */}
+      <Plate title={t('detail.everymen.crewsMarks')}>
+        <div className="flex items-center justify-center" style={{ marginBottom: 12, fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.04em', color: INK }}>
+          {t('detail.everymen.mobile.appraise')}
+        </div>
+        <MobileStarVote
+          praxisId={praxis.id}
+          points={votes?.total_score}
+          totalVotes={votes?.total_votes}
+          accent={RED}
+          accentFont={ACCENT_FONT}
+        />
+      </Plate>
+
+      {/* Flag + voter breakdown (invariant) */}
+      <PraxisFlagBlock state={state} />
+      <PraxisVoterBreakdown state={state} />
+    </div>
+  )
+}

--- a/frontend/src/pages/tasks/__tests__/everymenDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/everymenDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile task-browse Everymen dispatch (#529). The browse page dispatches on the
+ * VIEWING life's faction; this asserts an `everymen` viewer resolves to the union
+ * jobs-board skin while every other viewer (and logged-out null) falls through to
+ * the Default mobile browse skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../Tasks'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultTasks from '../mobileArchetypes/DefaultTasks'
+import EverymenTaskList from '../mobileArchetypes/EverymenTaskList'
+
+describe('mobile task-browse Everymen dispatch', () => {
+  it('mobile + an Everymen viewer resolves to the bespoke Everymen browse skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'everymen', DefaultTasks)).toBe(EverymenTaskList)
+  })
+
+  it('mobile + any other viewer falls through to the Default browse skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
+    }
+  })
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/EverymenTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/EverymenTaskList.tsx
@@ -1,0 +1,226 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../../api/tasks'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import type { TasksState } from '../useTasks'
+
+/**
+ * Everymen MOBILE task-browse skin (#529) — the union jobs board on a phone. The
+ * same scannable single-column list + touch-native filter chip rows as the
+ * Default browse skin (status / faction / level), dressed as posted work orders
+ * on cream newsprint with a red ledger rail and a gold points seal. Dispatched by
+ * the VIEWING life's faction (an Everymen member browsing tasks), so it consumes
+ * the shared `useTasks()` state verbatim — a chip tap mutates the same filter
+ * state that keys the read. Grounds on the `--everymen-*` tokens; flips with
+ * `[data-theme]`.
+ */
+
+const INK = 'var(--everymen-ink)'
+const CREAM = 'var(--everymen-cream)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const MUTED = 'var(--everymen-muted)'
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const ACCENT_FONT = 'var(--font-accent)'
+const BODY_FONT = 'var(--font-body)'
+
+const kicker: CSSProperties = {
+  fontFamily: BODY_FONT,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+export default function EverymenTaskList({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div data-skin="everymen" className="py-4" style={{ fontFamily: BODY_FONT, color: INK, background: PAPER }} data-testid="mobile-tasks-browse">
+      <div style={{ ...kicker, color: RED }}>{t('everymen.masthead')}</div>
+      <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 32, lineHeight: 0.95, letterSpacing: '0.02em', color: INK, margin: '2px 0 0' }}>
+        {tc('nav.tasks')}
+      </h1>
+      <div style={{ height: 3, margin: '9px 0 12px', background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
+      <p style={{ ...kicker, marginBottom: 12 }}>{t('mobile.count', { count: tasks.length })}</p>
+
+      <ChipRow label={tc('filters.status')}>
+        {statusFilters.map((option) => (
+          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
+            {option}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('mobile.allFactions')}
+        </Chip>
+        {sortFactionsByRainbowOrder(factions).map((f) => (
+          <Chip
+            key={f.slug}
+            on={faction === f.slug}
+            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
+            tint={factionCssVar(f.slug)}
+          >
+            {factionName(f.slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.level')}>
+        <Chip on={level === ''} onClick={() => setLevel('')}>
+          {t('mobile.anyLevel')}
+        </Chip>
+        {levelFilters.map((lvl) => (
+          <Chip key={lvl} on={level === lvl} onClick={() => setLevel(level === lvl ? '' : lvl)}>
+            {tc('filters.levelAtLeast', { level: lvl })}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <div className="mt-4">
+        {loading ? (
+          <p style={{ fontFamily: ACCENT_FONT, fontSize: 16, color: MUTED }}>{t('listPage.loading')}</p>
+        ) : error ? (
+          <p style={{ fontFamily: BODY_FONT, fontSize: 12, color: RED, border: `1.5px solid ${RED}`, padding: '8px 12px' }}>
+            {t('mobile.loadError')}
+          </p>
+        ) : tasks.length === 0 ? (
+          <p style={{ fontFamily: ACCENT_FONT, fontSize: 16, color: MUTED }}>{t('listPage.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {tasks.map((task) => (
+              <WorkOrder key={task.id} task={task} points={displayPointsFor(task)} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span style={{ ...kicker, flex: 'none' }}>{label}</span>
+      <div className="flex gap-2" style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: BODY_FONT,
+        fontSize: 10,
+        fontWeight: on ? 700 : 400,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        color: on ? CREAM : INK,
+        background: on ? INK : PAPER_DEEP,
+        border: `1.5px solid ${INK}`,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && <i style={{ width: 8, height: 8, flex: 'none', background: tint }} />}
+      {children}
+    </button>
+  )
+}
+
+function WorkOrder({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  const color = factionCssVar(task.primary_faction_slug)
+  return (
+    <Link
+      to={`/tasks/${task.id}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        padding: '14px 16px',
+        background: PAPER,
+        backgroundImage: 'radial-gradient(color-mix(in srgb, var(--everymen-ink) 6%, transparent) 0.6px, transparent 0.9px)',
+        backgroundSize: '5px 5px',
+        border: `2px solid ${INK}`,
+        borderLeft: `5px solid ${color}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, ...kicker, color }}>
+        <i style={{ width: 7, height: 7, background: color, flex: 'none' }} />
+        {factionName(task.primary_faction_slug)}
+      </span>
+
+      <h2 style={{ fontFamily: ACCENT_FONT, fontSize: 22, lineHeight: 1, letterSpacing: '0.01em', color: INK, margin: 0 }}>
+        {task.title}
+      </h2>
+
+      {task.description && (
+        <p
+          style={{
+            fontFamily: BODY_FONT,
+            fontSize: 13,
+            lineHeight: 1.5,
+            color: MUTED,
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {task.description}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
+        <span style={{ fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.04em', color: INK, background: GOLD, padding: '3px 10px' }}>
+          {t('mobile.points', { points })}
+        </span>
+        <span style={{ ...kicker }}>{t('mobile.level', { level: task.level_required })}</span>
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
Closes #529

## What
The Everymen union-broadsheet mobile skin, registered into the **five** mobile surfaces where it was missing. Task detail already shipped as the Everymen pilot (#497), so this completes the set.

Each surface's parallel `MOBILE_ARCHETYPE_BY_SLUG` gains an `everymen:` entry (existing keys untouched). Presentation only — same hooks, data, and DOM slots as the Default/UA skins.

| Surface | New skin |
|---|---|
| Home (`FieldDesk`) | `fieldDesk/mobileArchetypes/EverymenHome.tsx` |
| Tasks | `tasks/mobileArchetypes/EverymenTaskList.tsx` |
| Praxis detail | `praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx` |
| Composer (`EditPraxis`) | `editPraxis/mobileArchetypes/EverymenComposer.tsx` |
| Faction page | `factionDetail/mobileArchetypes/EverymenFactionPage.tsx` |

## Idiom
Union broadsheet — red mastheads with the cog seal, knockout Bebas headlines on cream newsprint, gold points seals, ink-framed work-order plates. Single-column, no fixed-px layout grids. Grounds on the `--everymen-*` tokens already in `index.css`, so every surface flips with the `[data-theme]` cascade without mutating the document theme. No hex, no `dark ? a : b`.

## Copy
Reuses existing `everymen.*` catalog keys; adds small mobile subtrees only (`fieldDesk.home.everymen`, `detail.everymen.mobile`, `factions everymen.mobile.eyebrow`). All text via `useTranslation` (ADR-0032 / eslint-clean).

## Verification
- `npm run lint` — green
- `npm test` (vitest) — **404 passed**, incl. the auto-iterating slot-invariant tests now covering the Everymen skins + five new per-surface dispatch tests
- `tsc --noEmit` — 0 new errors from this change. (Pre-existing, unrelated: 12 errors in `AlbescentInvitation.tsx` present on clean `main`.)

## Notes
- Two UA fall-through dispatch tests updated to drop `everymen` from their "falls through to Default" lists, now that it resolves to its own skin.
- Other factions + all desktop archetypes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
