### PR TITLE
Mobile: Ephemerists faction treatment (#527)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -137,6 +137,11 @@
         "masthead": "The Union Desk",
         "charEyebrow": "On the roll",
         "questsHeading": "On the job"
+      },
+      "ephemerists": {
+        "masthead": "The Codex Desk",
+        "charEyebrow": "On the road",
+        "questsHeading": "Surveys underway"
       }
     }
   },

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -173,6 +173,9 @@
       "emptyWithSpotlight": "No other names in the codex yet.",
       "level": "grade {{grade}}"
     },
+    "mobile": {
+      "eyebrow": "The Codex"
+    },
     "invitation": {
       "kicker": "the codex lies open —",
       "headline": "Walk with the keepers",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -196,7 +196,14 @@
       "evidence_one": "The evidence · {{count}} specimen",
       "evidence_other": "The evidence · {{count}} specimens",
       "concordance": "The concordance",
-      "ptsFromVotes": "PTS FROM VOTES"
+      "ptsFromVotes": "PTS FROM VOTES",
+      "acquiringHand": "Filed by the hand of",
+      "mobile": {
+        "plate": "The Evidence",
+        "theFinding": "The finding",
+        "re": "re:",
+        "appraise": "Weigh its concordance"
+      }
     },
     "everymen": {
       "mode": {

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -28,6 +28,7 @@ import WowMobileEditPraxis from "./editPraxis/mobileArchetypes/WowEditPraxis";
 import UAMobileEditPraxis from "./editPraxis/mobileArchetypes/UaComposer";
 import SingularityMobileEditPraxis from "./editPraxis/mobileArchetypes/SingularityComposer";
 import EverymenMobileEditPraxis from "./editPraxis/mobileArchetypes/EverymenComposer";
+import EphemeristsMobileEditPraxis from "./editPraxis/mobileArchetypes/EphemeristsComposer";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
@@ -52,6 +53,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   ua: UAMobileEditPraxis,
   singularity: SingularityMobileEditPraxis,
   everymen: EverymenMobileEditPraxis,
+  ephemerists: EphemeristsMobileEditPraxis,
 };
 
 export default function EditPraxis() {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -10,6 +10,7 @@ import UaFactionPage from "./factionDetail/mobileArchetypes/UaFactionPage";
 import SingularityFactionPage from "./factionDetail/mobileArchetypes/SingularityFactionPage";
 import WowFactionPage from "./factionDetail/mobileArchetypes/WowFactionPage";
 import EverymenFactionPage from "./factionDetail/mobileArchetypes/EverymenFactionPage";
+import EphemeristsFactionPage from "./factionDetail/mobileArchetypes/EphemeristsFactionPage";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import DefaultFactionPage from "./factionDetail/mobileArchetypes/DefaultFactionPage";
 import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
@@ -86,6 +87,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<
   singularity: SingularityFactionPage,
   wow: WowFactionPage,
   everymen: EverymenFactionPage,
+  ephemerists: EphemeristsFactionPage,
 };
 
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -15,6 +15,7 @@ import WowFieldDesk from './fieldDesk/mobileArchetypes/WowFieldDesk'
 import UaHome from './fieldDesk/mobileArchetypes/UaHome'
 import SingularityHome from './fieldDesk/mobileArchetypes/SingularityHome'
 import EverymenHome from './fieldDesk/mobileArchetypes/EverymenHome'
+import EphemeristsHome from './fieldDesk/mobileArchetypes/EphemeristsHome'
 
 /**
  * FieldDesk roster — the authenticated account home (#274). "Whose shoes today?":
@@ -38,6 +39,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileHomeSkin> = {
   ua: UaHome,
   singularity: SingularityHome,
   everymen: EverymenHome,
+  ephemerists: EphemeristsHome,
 }
 
 // Deterministic slight tilt per card — index-keyed so it's stable across renders.

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -20,6 +20,7 @@ import WowMobilePraxisDetail from './praxisDetail/mobileArchetypes/WowPraxisDeta
 import UAMobilePraxisDetail from './praxisDetail/mobileArchetypes/UaPraxisDetail'
 import SingularityMobilePraxisDetail from './praxisDetail/mobileArchetypes/SingularityPraxisDetail'
 import EverymenMobilePraxisDetail from './praxisDetail/mobileArchetypes/EverymenPraxisDetail'
+import EphemeristsMobilePraxisDetail from './praxisDetail/mobileArchetypes/EphemeristsPraxisDetail'
 import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
 import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
 import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
@@ -56,6 +57,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: Pra
   ua: UAMobilePraxisDetail,
   singularity: SingularityMobilePraxisDetail,
   everymen: EverymenMobilePraxisDetail,
+  ephemerists: EphemeristsMobilePraxisDetail,
 }
 
 export default function PraxisDetail() {

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -19,6 +19,7 @@ import EverymenMobileTaskDetail from "./taskDetail/mobileArchetypes/EverymenTask
 import UAMobileTaskDetail from "./taskDetail/mobileArchetypes/UaTaskDetail";
 import SingularityMobileTaskDetail from "./taskDetail/mobileArchetypes/SingularityTaskDetail";
 import WowMobileTaskDetail from "./taskDetail/mobileArchetypes/WowTaskDetail";
+import EphemeristsMobileTaskDetail from "./taskDetail/mobileArchetypes/EphemeristsTaskDetail";
 import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
@@ -51,6 +52,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   ua: UAMobileTaskDetail,
   singularity: SingularityMobileTaskDetail,
   wow: WowMobileTaskDetail,
+  ephemerists: EphemeristsMobileTaskDetail,
 };
 
 export default function TaskDetail() {

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -13,6 +13,7 @@ import UaTaskList from './tasks/mobileArchetypes/UaTaskList'
 import SingularityTaskList from './tasks/mobileArchetypes/SingularityTaskList'
 import WowTaskList from './tasks/mobileArchetypes/WowTaskList'
 import EverymenTaskList from './tasks/mobileArchetypes/EverymenTaskList'
+import EphemeristsTaskList from './tasks/mobileArchetypes/EphemeristsTaskList'
 
 type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 
@@ -26,6 +27,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {
   singularity: SingularityTaskList,
   wow: WowTaskList,
   everymen: EverymenTaskList,
+  ephemerists: EphemeristsTaskList,
 }
 
 export default function Tasks() {

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
@@ -1,0 +1,358 @@
+import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import MediaArt from '../blocks/MediaArt'
+import { pickArtKey } from '../blocks/useMediaArt'
+import { ErrorBanner, formatAutosave } from '../archetypes/shared'
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from '../archetypes/controls'
+import type { EditPraxisState } from '../useEditPraxis'
+import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+
+/**
+ * The Ephemerists MOBILE composer (#527) — "Seal & Enter" on a phone. The same
+ * single-column composer as the Default mobile skin (Write/Preview toggle, fluid
+ * media grid, sticky submit bar) dressed in codex chrome: ledger-ruled vellum
+ * leaves, Cinzel rubric labels, a finding pulled to lapis. Ported from the
+ * desktop Ephemerists Ephemeris-Entry archetype; grounds on the `--eph-*` tokens
+ * (theme-aware). Consumes `useEditPraxis` verbatim — no editor, upload, or submit
+ * logic lives here.
+ */
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const LAPIS = 'var(--eph-lapis)'
+const INK = 'var(--eph-ink)'
+const GOLD = 'var(--eph-gold)'
+const GOLD_DEEP = 'var(--eph-gold-deep)'
+const PARCHMENT = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+const SCRIPT = 'var(--eph-script)'
+
+const kicker: CSSProperties = {
+  display: 'block',
+  fontFamily: DISPLAY,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+/** A ledger leaf bound in a gold-deep hairline, headed by a rubric Cinzel label. */
+function Leaf({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: 14 }}>
+      <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 12, letterSpacing: '0.14em', textTransform: 'uppercase', color: RUBRIC, marginBottom: 10 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default function EphemeristsComposer({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation('forms')
+  const [tab, setTab] = useState<ComposerTab>('write')
+  const praxis = state.praxis!
+  const task = state.task
+
+  return (
+    <div data-skin="ephemerists" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <h1 style={{ fontFamily: DISPLAY, fontWeight: 800, fontSize: 28, lineHeight: 1, color: TEXT, margin: 0 }}>
+            <Trans
+              ns="forms"
+              i18nKey="editPraxis.ephemerists.pageTitle"
+              components={[<span key="0" />, <span key="1" style={{ color: LAPIS }} />]}
+            />
+          </h1>
+          <span style={{ ...kicker, marginLeft: 'auto' }}>
+            {state.autosaveAt
+              ? t('editPraxis.ephemerists.autosaveSaved', { ago: formatAutosave(state.autosaveAt) })
+              : t('editPraxis.ephemerists.autosaveUnsaved')}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: { gap: 4, padding: 3, background: VELLUM, border: `1px solid ${GOLD_DEEP}` },
+            buttonStyle: (active) => ({
+              padding: '9px 10px',
+              border: 'none',
+              fontFamily: DISPLAY,
+              fontSize: 11,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              background: active ? INK : 'transparent',
+              color: active ? PARCHMENT : MUTED,
+            }),
+          }}
+        />
+      </header>
+
+      {/* Observed-task reference */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: VELLUM, border: `1px solid ${GOLD_DEEP}` }}>
+        <span style={kicker}>{t('editPraxis.ephemerists.taskRefLabel')}</span>
+        <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 16, color: TEXT, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
+          {praxis.task_title}
+        </span>
+      </div>
+      <div style={{ ...kicker, color: LAPIS }}>
+        {factionName(task?.primary_faction_slug ?? null)}
+        {task ? ` · ${t('editPraxis.ephemerists.pointsLabel', { points: task.point_value })}` : ''}
+      </div>
+
+      {tab === 'write' ? (
+        <>
+          <Leaf title={t('editPraxis.ephemerists.titleLabel')}>
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t('editPraxis.ephemerists.titlePlaceholder'),
+                inputStyle: {
+                  width: '100%',
+                  fontFamily: DISPLAY,
+                  fontSize: 22,
+                  fontWeight: 700,
+                  color: TEXT,
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  borderBottom: `2px solid ${INK}`,
+                  padding: '2px 0 8px',
+                },
+              }}
+            />
+          </Leaf>
+
+          <Leaf title={t('editPraxis.ephemerists.bodyLabel')}>
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t('editPraxis.ephemerists.bodyPlaceholder'),
+                textareaStyle: {
+                  width: '100%',
+                  fontFamily: SERIF,
+                  fontSize: 15,
+                  lineHeight: 1.65,
+                  color: TEXT,
+                  background: VELLUM_DEEP,
+                  border: `1.5px solid ${INK}`,
+                  padding: '13px 15px',
+                  outline: 'none',
+                  resize: 'vertical',
+                  minHeight: 180,
+                },
+              }}
+            />
+            <div style={{ ...kicker, marginTop: 8, color: MUTED }}>
+              {t('editPraxis.ephemerists.bodyMeta', { words: state.wordCount })}
+            </div>
+          </Leaf>
+
+          {state.showInviteBox && (
+            <Leaf title={state.duelMode ? t('editPraxis.ephemerists.inviteLabelDuel') : t('editPraxis.ephemerists.inviteLabel')}>
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: SERIF,
+                  inputBg: VELLUM_DEEP,
+                  inputColor: TEXT,
+                  inputBorder: `1.5px solid ${INK}`,
+                  acceptedBg: LAPIS,
+                  acceptedColor: PARCHMENT,
+                  placeholder: t('editPraxis.ephemerists.invitePlaceholder'),
+                }}
+              />
+            </Leaf>
+          )}
+
+          <Leaf title={t('editPraxis.ephemerists.filesLabel')}>
+            <MediaGrid state={state} />
+          </Leaf>
+
+          {state.showMetatasks && (
+            <Leaf title={t('editPraxis.ephemerists.metatasksLabel')}>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: { display: 'flex', flexDirection: 'column', gap: 4 },
+                  rowStyle: (selected) => ({
+                    padding: '10px 12px',
+                    background: selected ? VELLUM_DEEP : 'transparent',
+                    border: `1px solid ${selected ? GOLD : GOLD_DEEP}`,
+                  }),
+                  titleColor: TEXT,
+                  descColor: MUTED,
+                  pointsActiveColor: RUBRIC,
+                  pointsIdleColor: MUTED,
+                }}
+              />
+            </Leaf>
+          )}
+        </>
+      ) : (
+        <Leaf title={t('editPraxis.ephemerists.previewLabel')}>
+          <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 22, color: TEXT, marginBottom: 10 }}>
+            {state.title || t('editPraxis.ephemerists.titlePlaceholder')}
+          </div>
+          {state.media.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <MediaGrid state={state} readOnly />
+            </div>
+          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              markdownStyle: { fontFamily: SERIF, fontSize: 15, lineHeight: 1.65, color: TEXT },
+            }}
+          />
+        </Leaf>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      <MobileStickyBar
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 0 4px',
+          background: 'var(--color-nav-bg)',
+          backdropFilter: 'blur(var(--nav-blur))',
+          borderTop: `1px solid ${GOLD}`,
+        }}
+      >
+        <PublishButton
+          state={state}
+          skin={{
+            idleLabel: t('editPraxis.ephemerists.publishIdle'),
+            busyLabel: t('editPraxis.ephemerists.publishBusy'),
+            style: {
+              flex: 1,
+              background: RUBRIC,
+              color: PARCHMENT,
+              fontFamily: DISPLAY,
+              fontWeight: 700,
+              fontSize: 14,
+              letterSpacing: '0.08em',
+              padding: '13px 18px',
+              border: `1px solid ${GOLD}`,
+              cursor: state.submitting ? 'wait' : 'pointer',
+            },
+          }}
+        />
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.ephemerists.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: MUTED,
+                fontFamily: SCRIPT,
+                fontStyle: 'italic',
+                fontSize: 14,
+                textDecoration: 'underline',
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
+      </MobileStickyBar>
+    </div>
+  )
+}
+
+/** Fluid 3-column media grid in the specimen-leaf idiom. */
+function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOnly?: boolean }) {
+  const { t } = useTranslation('forms')
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+      {state.media.map((item) => {
+        const filename = item.file_path.split('/').pop() ?? item.file_path
+        const src = mediaUrl(item.file_path)
+        return (
+          <div key={item.id} style={{ position: 'relative', aspectRatio: '1 / 1', overflow: 'hidden', border: `1px solid ${INK}`, background: VELLUM_DEEP }}>
+            {item.type === 'image' ? (
+              <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : item.type === 'video' ? (
+              <video src={src} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <MediaArt art={pickArtKey(filename, 'audio')} width={120} height={120} />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t('media.removeAria', { name: filename })}
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  borderRadius: '50%',
+                  background: VELLUM,
+                  border: `1.5px solid ${GOLD}`,
+                  color: GOLD,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        )
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: '1 / 1',
+              width: '100%',
+              background: VELLUM_DEEP,
+              border: `1.5px dashed ${INK}`,
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 4,
+              fontFamily: DISPLAY,
+              fontSize: 10,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: RUBRIC,
+            },
+            buttonLabel: t('editPraxis.ephemerists.fileButton'),
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/ephemeristsDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/ephemeristsDispatch.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Mobile composer Ephemerists dispatch (#527). Asserts the mobile registry
+ * resolves an `ephemerists` task to the "Seal & Enter" codex composer, and that
+ * every other faction falls through to the Default mobile composer.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../../EditPraxis'
+import { pickVariant } from '../../../../utils/factionDispatch'
+import DefaultMobileEditPraxis from '../DefaultEditPraxis'
+import EphemeristsMobileEditPraxis from '../EphemeristsComposer'
+
+describe('mobile composer Ephemerists dispatch', () => {
+  it('mobile + an Ephemerists task resolves to the bespoke codex composer', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ephemerists', DefaultMobileEditPraxis)).toBe(
+      EphemeristsMobileEditPraxis,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default composer', () => {
+    for (const slug of ['snide', 'wow', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileEditPraxis)).not.toBe(
+        EphemeristsMobileEditPraxis,
+      )
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/__tests__/ephemeristsMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/ephemeristsMobileDispatch.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Mobile faction-page Ephemerists dispatch (#527). Asserts FactionDetail's
+ * parallel mobile registry resolves the `ephemerists` slug to the vellum-codex
+ * faction page, and that every other faction (and null) falls through to the
+ * single-column Default mobile faction page.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FactionDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
+import EphemeristsFactionPage from '../mobileArchetypes/EphemeristsFactionPage'
+
+describe('mobile faction-page Ephemerists dispatch', () => {
+  it('mobile + the Ephemerists slug resolves to the bespoke codex faction page', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ephemerists', DefaultFactionPage)).toBe(
+      EphemeristsFactionPage,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default faction page', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
@@ -1,0 +1,270 @@
+import { useState, type CSSProperties, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { factionName, factionDescription } from '../../../utils/factions'
+import { EphMark } from '../../../components/cards/ephemeristsAtoms'
+import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
+import type { CharacterOut } from '../../../api/auth'
+import type { FactionDetailState } from '../useFactionDetail'
+
+/**
+ * The Ephemerists MOBILE faction page (#527) — the codex, phone shaped. The same
+ * single-column slots as the Default mobile faction page (a hero with real
+ * member/task counts, top keepers, recent praxis, and the invite-gated Join model
+ * via `state.membership`, ADR-0019) — only the dress changes: ledger-ruled vellum
+ * leaves in gold-deep hairlines, Cinzel labels, lapis-inked keepers. Grounds on
+ * the `--eph-*` tokens; theme-aware through the cascade. Reuses the shared
+ * `mobile.*` faction copy so the slot contract holds. Presentation-only — all
+ * data + the join handler arrive via {@link FactionDetailState}.
+ */
+
+const NA_SLUG = 'na'
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const LAPIS = 'var(--eph-lapis)'
+const INK = 'var(--eph-ink)'
+const GOLD = 'var(--eph-gold)'
+const GOLD_DEEP = 'var(--eph-gold-deep)'
+const PARCHMENT = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+const SCRIPT = 'var(--eph-script)'
+
+const kicker: CSSProperties = {
+  fontFamily: DISPLAY,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || '?'
+
+/** Circular initials medallion — vellum face, rubric Cinzel glyph. */
+function Medallion({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: VELLUM_DEEP,
+        border: `1px solid ${GOLD_DEEP}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: DISPLAY,
+        fontWeight: 700,
+        fontSize: size * 0.42,
+        color: RUBRIC,
+      }}
+    >
+      {initial(name)}
+    </span>
+  )
+}
+
+function SectionHead({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ fontFamily: DISPLAY, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: TEXT }}>
+        {children}
+      </span>
+      <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+    </div>
+  )
+}
+
+const joinButton: CSSProperties = {
+  width: '100%',
+  fontFamily: DISPLAY,
+  fontWeight: 700,
+  fontSize: 13,
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: PARCHMENT,
+  background: INK,
+  border: `1px solid ${GOLD}`,
+  padding: '13px 16px',
+  cursor: 'pointer',
+}
+
+export default function EphemeristsFactionPage({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation('factions')
+  const { faction, members, tasks, recentPraxis, membership } = state
+  const [confirming, setConfirming] = useState(false)
+
+  if (!faction) return null
+
+  const name = factionName(faction.slug)
+  const topMembers = [...members].sort((a, b) => b.all_time_score - a.all_time_score).slice(0, 3)
+  const currentSlug = membership.currentFactionSlug
+  const switching = currentSlug && currentSlug !== NA_SLUG
+
+  return (
+    <div data-skin="ephemerists" className="py-4" style={{ fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }} data-testid="mobile-faction-page">
+      {/* Hero — ledger-ruled vellum masthead */}
+      <section style={{ position: 'relative', overflow: 'hidden', background: VELLUM, border: `1.5px solid ${INK}`, boxShadow: '0 12px 28px rgba(42,29,18,0.18)', padding: '20px 18px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: RUBRIC }}>
+          <EphMark size={13} color={LAPIS} />
+          <span style={{ ...kicker, color: LAPIS }}>{t('ephemerists.mobile.eyebrow')}</span>
+        </div>
+        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 32, lineHeight: 1.05, color: TEXT, margin: '4px 0 0' }}>
+          {name}
+        </h1>
+        <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, lineHeight: 1.6, color: MUTED, margin: '8px 0 0' }}>
+          {factionDescription(faction.slug)}
+        </p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
+          <HeroStat value={members.length} label={t('mobile.membersStat')} />
+          <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
+        </div>
+      </section>
+
+      {membership.state === 'member' && (
+        <p style={{ ...kicker, marginTop: 12, color: RUBRIC }}>{t('mobile.memberBadge')}</p>
+      )}
+
+      {/* Top keepers */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.topMembers')}</SectionHead>
+        {topMembers.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: MUTED, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topMembers.map((m, index) => (
+              <MemberRow key={m.id} rank={index + 1} member={m} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent praxis */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
+        {recentPraxis.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: MUTED, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {membership.state === 'gate' && (
+        <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: MUTED, marginTop: 24 }}>
+          {t('mobile.gateHint', { faction: name })}
+        </p>
+      )}
+
+      {/* Sticky Join — only an eligible viewer can act (ADR-0019). */}
+      {membership.state === 'eligible' && (
+        <MobileStickyBar>
+          {membership.joinError && (
+            <p style={{ fontFamily: SERIF, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+          )}
+          {!confirming ? (
+            <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
+              {t('mobile.join', { faction: name })}
+            </button>
+          ) : (
+            <>
+              <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: TEXT }}>
+                {switching
+                  ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
+                  : t('detail.join.confirm', { faction: name })}
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => void membership.join()}
+                  disabled={membership.joining}
+                  style={{ ...joinButton, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                >
+                  {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirming(false)}
+                  disabled={membership.joining}
+                  style={{
+                    fontFamily: DISPLAY,
+                    fontSize: 11,
+                    letterSpacing: '0.1em',
+                    textTransform: 'uppercase',
+                    color: MUTED,
+                    background: 'transparent',
+                    border: `1px solid ${GOLD_DEEP}`,
+                    padding: '11px 16px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t('detail.join.cancel')}
+                </button>
+              </div>
+            </>
+          )}
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+function HeroStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={{ flex: '1 1 0', textAlign: 'center', background: VELLUM_DEEP, border: `1px solid ${GOLD}`, padding: '10px 6px' }}>
+      <b style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 20, display: 'block', lineHeight: 1, color: TEXT }}>
+        {value}
+      </b>
+      <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
+    </div>
+  )
+}
+
+function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
+  const { t } = useTranslation('factions')
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: VELLUM,
+        border: `1px solid ${GOLD_DEEP}`,
+        borderLeft: `4px solid ${RUBRIC}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 16, color: RUBRIC, width: 16, flex: 'none' }}>{rank}</span>
+      <Medallion name={member.display_name} size={28} />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: DISPLAY,
+          fontWeight: 700,
+          fontSize: 15,
+          color: TEXT,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {member.display_name}
+      </span>
+      <span style={{ fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.06em', color: LAPIS, flex: 'none' }}>
+        {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/pages/fieldDesk/__tests__/ephemeristsDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/ephemeristsDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile FieldDesk-home Ephemerists dispatch (#527). Asserts the parallel mobile
+ * registry resolves an `ephemerists` carried life to the vellum-codex home skin,
+ * and that an unregistered faction (and null) still falls through to the Default
+ * mobile home. Mirrors the UA dispatch test.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FieldDesk'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
+import EphemeristsHome from '../mobileArchetypes/EphemeristsHome'
+
+describe('mobile FieldDesk-home Ephemerists dispatch', () => {
+  it('mobile + an Ephemerists life resolves to the bespoke codex home skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ephemerists', DefaultFieldDesk)).toBe(EphemeristsHome)
+  })
+
+  it('mobile + any other slug falls through to the Default home skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
+    }
+  })
+})

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
@@ -1,0 +1,238 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import { EphMark } from '../../../components/cards/ephemeristsAtoms'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+
+/**
+ * The Ephemerists MOBILE FieldDesk home (#527) — the vellum codex on a phone.
+ * The carried life and its surveys-underway become ledger-ruled leaves bound in
+ * gold-deep hairlines, headed by a Cinzel running-head. Same content slots as the
+ * Default mobile home (character header, Points/Votes/Era stat tiles,
+ * active-tasks list, primary actions) — only the dress changes. Grounds on the
+ * `--eph-*` / `--faction-ephemerists-*` tokens already in index.css (the set the
+ * desktop Ephemerists surfaces read) and is theme-aware through the cascade: the
+ * vellum flips to tobacco in dark, no ternaries. Presentation-only — all data
+ * arrives via {@link FieldDeskHomeState}.
+ */
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const LAPIS = 'var(--eph-lapis)'
+const GOLD = 'var(--eph-gold)'
+const GOLD_DEEP = 'var(--eph-gold-deep)'
+const PARCHMENT = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+const SCRIPT = 'var(--eph-script)'
+
+const kicker: CSSProperties = {
+  fontFamily: DISPLAY,
+  fontSize: 8,
+  letterSpacing: '0.22em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+const goldRule = `linear-gradient(90deg, ${GOLD}, transparent)`
+
+/** A ledger leaf bound in a gold-deep hairline on aged vellum. */
+function Leaf({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        background: VELLUM,
+        border: `1px solid ${GOLD_DEEP}`,
+        boxShadow: '0 10px 24px rgba(42,29,18,0.14)',
+        padding: 16,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }) {
+  const { t } = useTranslation('common')
+  const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+
+  const stats = [
+    { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
+    { label: t('fieldDesk.home.stats.votes'), value: votesReceived.toLocaleString() },
+    { label: t('fieldDesk.home.stats.era'), value: eraName || '—' },
+  ]
+
+  return (
+    <div
+      data-skin="ephemerists"
+      className="page"
+      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }}
+    >
+      {/* Cinzel running-head */}
+      <header>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: RUBRIC }}>
+          <EphMark size={13} color={LAPIS} />
+          <span style={kicker}>{t('nav.home')}</span>
+        </div>
+        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 28, lineHeight: 1.05, color: TEXT, margin: '4px 0 0' }}>
+          {t('fieldDesk.home.ephemerists.masthead')}
+        </h1>
+        <div style={{ height: 1, marginTop: 9, background: goldRule }} />
+      </header>
+
+      {/* ── Observer leaf ── */}
+      <Leaf>
+        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+          <span style={{ ...kicker, color: RUBRIC }}>{t('fieldDesk.home.ephemerists.charEyebrow')}</span>
+          <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: LAPIS, textDecoration: 'none' }}>
+            {t('fieldDesk.home.edit')}
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="shrink-0" style={{ width: 56, height: 56, borderRadius: '50%', padding: 2, background: GOLD_DEEP }}>
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="w-full h-full rounded-full"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : (
+              <span
+                className="flex w-full h-full items-center justify-center rounded-full"
+                style={{ background: VELLUM_DEEP, fontFamily: DISPLAY, fontWeight: 700, fontSize: 24, color: RUBRIC }}
+              >
+                {character.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/characters/${character.id}`}
+              className="block truncate"
+              style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 24, lineHeight: 1, color: TEXT, textDecoration: 'none' }}
+            >
+              {character.display_name}
+            </Link>
+            <div className="truncate" style={{ marginTop: 5, fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
+              {t('sidebar.characterCard.factionLevel', {
+                faction: factionName(character.faction_slug),
+                level: character.level,
+              })}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 24, lineHeight: 1, color: RUBRIC }}>
+              {character.score?.toLocaleString() ?? '0'}
+            </div>
+            <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
+          </div>
+        </div>
+
+        <div className="flex gap-2" style={{ marginTop: 16 }}>
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center"
+              style={{ flex: '1 1 0', minWidth: 0, background: VELLUM_DEEP, border: `1px solid ${GOLD_DEEP}`, padding: '11px 6px' }}
+            >
+              <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 20, lineHeight: 1, color: TEXT }}>
+                {stat.value}
+              </div>
+              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      </Leaf>
+
+      {/* ── Pending requests ── */}
+      {pendingCount > 0 && (
+        <Link
+          to="/updates?filter=requests"
+          className="flex items-center justify-between"
+          style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: '10px 16px', fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: TEXT, textDecoration: 'none' }}
+        >
+          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
+          <span aria-hidden style={{ color: RUBRIC }}>›</span>
+        </Link>
+      )}
+
+      {/* ── Surveys underway ── */}
+      <Leaf>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+          <span style={{ fontFamily: DISPLAY, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: TEXT }}>
+            {t('fieldDesk.home.ephemerists.questsHeading')}
+          </span>
+          <span style={{ flex: 1, height: 1, background: goldRule }} />
+          <Link to="/tasks" style={{ ...kicker, color: LAPIS, textDecoration: 'none' }}>
+            {t('fieldDesk.home.viewAll')}
+          </Link>
+        </div>
+
+        {activeTasks.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: MUTED, margin: 0 }}>
+            {t('fieldDesk.home.questsEmpty')}
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {activeTasks.map((praxis, index) => (
+              <Link
+                key={praxis.id}
+                to={`/praxes/${praxis.id}/edit`}
+                className="flex items-center gap-3"
+                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
+              >
+                <span className="shrink-0" style={{ width: 9, height: 9, borderRadius: '50%', background: RUBRIC }} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 17, lineHeight: 1.15, color: TEXT }}>
+                    {praxis.task_title}
+                  </div>
+                  <div className="truncate" style={{ marginTop: 3, fontFamily: DISPLAY, fontSize: 8.5, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+                    {t('fieldDesk.home.taskMeta', {
+                      faction: factionName(praxis.task_faction_slug),
+                      points: praxis.task_point_value,
+                    })}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0"
+                  style={{ fontFamily: DISPLAY, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: LAPIS, padding: '4px 9px', border: `1px solid ${GOLD_DEEP}` }}
+                >
+                  {t(`praxisType.${praxis.type}`)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </Leaf>
+
+      {/* ── Primary actions ── */}
+      <div className="flex gap-2.5">
+        <Link
+          to="/tasks"
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 12, letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: PARCHMENT, background: RUBRIC, border: `1px solid ${GOLD}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.browseTasks')}
+        </Link>
+        {canProposeTask && (
+          <Link
+            to="/propose-task"
+            className="flex-1 flex items-center justify-center gap-2"
+            style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 12, letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: TEXT, background: VELLUM, border: `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
+          >
+            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+            <span>{t('actions.proposeTask')}</span>
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDispatch.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Mobile praxis-detail Ephemerists dispatch (#527). Asserts the parallel mobile
+ * registry resolves an `ephemerists` task-faction praxis to the vellum-codex
+ * praxis-detail skin, and that every other faction (and null) falls through to
+ * the Default mobile praxis-detail skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../PraxisDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
+import EphemeristsMobilePraxisDetail from '../mobileArchetypes/EphemeristsPraxisDetail'
+
+describe('mobile praxis-detail Ephemerists dispatch', () => {
+  it('mobile + an Ephemerists praxis resolves to the bespoke codex skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ephemerists', DefaultMobilePraxisDetail)).toBe(
+      EphemeristsMobilePraxisDetail,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default praxis-detail skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobilePraxisDetail)).not.toBe(
+        EphemeristsMobilePraxisDetail,
+      )
+    }
+  })
+})

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/EphemeristsPraxisDetail.tsx
@@ -1,0 +1,150 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import { EphMark } from '../../../components/cards/ephemeristsAtoms'
+import { formatTimestamp } from '../../../utils/dates'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisVoterBreakdown,
+  MemberByline,
+} from '../shared'
+import { MobileStarVote } from './shared'
+
+/**
+ * The Ephemerists MOBILE praxis-detail skin (#527) — a sealed ephemeris leaf,
+ * phone-shaped. A ledger-ruled vellum plate holds the filed evidence (full
+ * media); a Cinzel finding headline, the account body, and a thumb-sized
+ * concordance caster follow. Renders the same invariant CONTENT + behavior slots
+ * as every archetype (the shared praxisDetail module) — only the dress changes.
+ * Grounds on `--eph-*` tokens; theme-aware through the cascade.
+ */
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const LAPIS = 'var(--eph-lapis)'
+const GOLD_DEEP = 'var(--eph-gold-deep)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+const SCRIPT = 'var(--eph-script)'
+
+const kicker: CSSProperties = {
+  fontFamily: DISPLAY,
+  fontSize: 8,
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+/** A ledger leaf bound in a gold-deep hairline on aged vellum. */
+function Leaf({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: 13 }}>
+      <div style={{ fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: RUBRIC, marginBottom: 10 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <div data-skin="ephemerists" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }}>
+      {/* Behavior slots (invariant) */}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
+
+      {/* Byline row */}
+      <div className="flex items-center gap-3">
+        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+          <span
+            className="flex items-center justify-center rounded-full"
+            style={{ width: 42, height: 42, background: VELLUM_DEEP, border: `1.5px solid ${GOLD_DEEP}`, color: RUBRIC, fontFamily: DISPLAY, fontWeight: 700, fontSize: 20 }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <MemberByline
+            praxis={praxis}
+            linkStyle={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 18, color: TEXT, lineHeight: 1, textDecoration: 'none' }}
+          />
+          <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
+            {t('detail.ephemerists.acquiringHand')} · {formatTimestamp(sealedDate)}
+          </div>
+        </div>
+        <EphMark size={20} color={LAPIS} />
+      </div>
+
+      {/* Evidence plate — full media inside */}
+      {praxis.media_items.length > 0 && (
+        <Leaf title={t('detail.ephemerists.mobile.plate')}>
+          <MediaGallery media={praxis.media_items} layout="grid" />
+        </Leaf>
+      )}
+
+      {/* Finding headline */}
+      <div>
+        <div style={{ ...kicker, marginBottom: 4, color: LAPIS }}>{t('detail.ephemerists.mobile.theFinding')}</div>
+        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 30, lineHeight: 1.1, margin: 0, color: TEXT, overflowWrap: 'anywhere' }}>
+          {praxis.title ?? t('detail.ephemerists.untitled')}
+        </h1>
+      </div>
+
+      {/* Owner actions (invariant) */}
+      <PraxisOwnerActions state={state} />
+
+      {/* re: task link */}
+      <div style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: MUTED }}>
+        {t('detail.ephemerists.mobile.re')}{' '}
+        <Link to={`/tasks/${praxis.task_id}`} style={{ color: LAPIS, fontWeight: 700, textDecoration: 'none' }}>
+          {praxis.task_title}
+        </Link>
+      </div>
+
+      {/* Account body */}
+      {praxis.body_text && (
+        <MarkdownPreview
+          source={praxis.body_text}
+          className="markdown-preview"
+          style={{ fontFamily: SERIF, fontSize: 15, lineHeight: 1.7, color: TEXT }}
+        />
+      )}
+
+      {/* Concordance caster */}
+      <Leaf title={t('detail.ephemerists.concordance')}>
+        <div className="flex items-center justify-center" style={{ marginBottom: 12, fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 18, color: TEXT }}>
+          {t('detail.ephemerists.mobile.appraise')}
+        </div>
+        <MobileStarVote
+          praxisId={praxis.id}
+          points={votes?.total_score}
+          totalVotes={votes?.total_votes}
+          accent={RUBRIC}
+          accentFont={DISPLAY}
+        />
+      </Leaf>
+
+      {/* Flag + voter breakdown (invariant) */}
+      <PraxisFlagBlock state={state} />
+      <PraxisVoterBreakdown state={state} />
+    </div>
+  )
+}

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDispatch.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Mobile task-detail Ephemerists dispatch (#527). Asserts the parallel mobile
+ * registry resolves an `ephemerists` task to the vellum-codex task-detail skin,
+ * and that every other faction (and null) falls through to the Default mobile
+ * task-detail skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../TaskDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultMobileTaskDetail from '../mobileArchetypes/DefaultTaskDetail'
+import EphemeristsMobileTaskDetail from '../mobileArchetypes/EphemeristsTaskDetail'
+
+describe('mobile task-detail Ephemerists dispatch', () => {
+  it('mobile + an Ephemerists task resolves to the bespoke codex task-detail skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ephemerists', DefaultMobileTaskDetail)).toBe(
+      EphemeristsMobileTaskDetail,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default task-detail skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).not.toBe(
+        EphemeristsMobileTaskDetail,
+      )
+    }
+  })
+})

--- a/frontend/src/pages/taskDetail/mobileArchetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/EphemeristsTaskDetail.tsx
@@ -1,0 +1,285 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import { EphMark, LapisLastWord } from '../../../components/cards/ephemeristsAtoms'
+import { MobileStickyBar, MobileStickyCaption } from './shared'
+import type { TaskDetailState } from '../useTaskDetail'
+
+/**
+ * The Ephemerists MOBILE task-detail skin (#527) — the survey commission on a
+ * phone. A ledger-ruled vellum hero (Cinzel running-head, a title with one word
+ * pulled to lapis, grade + puncta, the commission brief), the sealed ephemerides
+ * (completions), and a stamped **sticky action bar** ("Triangulate the truth")
+ * pinned above the tab bar. Single-column, no fixed-px grid — the desktop
+ * discordant-map plate would overflow a phone. Reuses the same
+ * {@link TaskDetailState}, the shared mobile sticky bar, and the `ephemerists.*`
+ * copy + `--eph-*` tokens as the desktop archetype. Theme-aware via the cascade.
+ */
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const LAPIS = 'var(--eph-lapis)'
+const INK = 'var(--eph-ink)'
+const GOLD = 'var(--eph-gold)'
+const GOLD_DEEP = 'var(--eph-gold-deep)'
+const GOLD_LIGHT = 'var(--eph-gold-light)'
+const PARCHMENT = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+const SCRIPT = 'var(--eph-script)'
+
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <h2 style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 14, letterSpacing: '0.08em', margin: 0, color: TEXT, whiteSpace: 'nowrap' }}>
+        {title}
+      </h2>
+      <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+      {trailing}
+    </div>
+  )
+}
+
+export default function EphemeristsTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation('tasks')
+  const {
+    task,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    topScore,
+    voteCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state
+
+  if (!task) return null
+
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null
+
+  return (
+    <div className="py-4" style={{ fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP, marginLeft: -16, marginRight: -16, paddingLeft: 16, paddingRight: 16 }}>
+      {/* Breadcrumb */}
+      <nav className="mb-3" style={{ fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+        <Link to="/tasks" style={{ color: LAPIS, textDecoration: 'none' }}>
+          {t('ephemerists.breadcrumb')}
+        </Link>
+        <span aria-hidden style={{ margin: '0 6px', color: GOLD }}>›</span>
+        <span style={{ color: RUBRIC }}>{task.title}</span>
+      </nav>
+
+      {/* Hero — ledger-ruled vellum commission */}
+      <div style={{ position: 'relative', overflow: 'hidden', background: VELLUM, border: `1.5px solid ${INK}`, boxShadow: '0 12px 28px rgba(42,29,18,0.18)', padding: '20px 22px 22px', marginBottom: 20 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: GOLD }}>
+            <EphMark size={12} color={GOLD} />
+            {t('ephemerists.masthead')}
+          </span>
+          <span style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 12, color: MUTED }}>{t('ephemerists.statusOpen')}</span>
+        </div>
+
+        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 32, lineHeight: 1.04, color: TEXT, margin: 0, overflowWrap: 'anywhere' }}>
+          <LapisLastWord text={task.title} footnote />
+        </h1>
+        <div style={{ height: 1, margin: '14px 0', background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <span style={{ fontFamily: DISPLAY, fontSize: 12, color: TEXT, background: VELLUM_DEEP, border: `1px solid ${GOLD}`, padding: '4px 12px' }}>
+            {t('ephemerists.grade', { level: task.level_required })}
+          </span>
+          <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 18, color: RUBRIC }}>
+            {modifiedPoints} <span style={{ fontSize: 11, letterSpacing: '0.06em' }}>{t('ephemerists.puncta')}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* The Commission — brief */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('ephemerists.commissionHeading')} />
+        <div style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: '18px 20px' }}>
+          <p style={{ fontFamily: SERIF, fontSize: 15, lineHeight: 1.7, color: task.description ? TEXT : MUTED, margin: 0, whiteSpace: 'pre-wrap' }}>
+            {task.description || t('ephemerists.commissionEmpty')}
+          </p>
+        </div>
+      </section>
+
+      {/* The Credence — read-only aggregate */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead title={t('ephemerists.credenceHeading')} />
+        {voteCount > 0 ? (
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12 }}>
+            <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 44, lineHeight: 0.85, color: RUBRIC }}>
+              {topScore}
+            </span>
+            <div style={{ paddingBottom: 5 }}>
+              <div style={{ fontFamily: DISPLAY, fontSize: 12, letterSpacing: '0.06em', color: TEXT }}>
+                {t('ephemerists.credence.highest')}
+              </div>
+              <div style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 13, color: MUTED, marginTop: 2 }}>
+                {t('ephemerists.credence.weighed', { count: voteCount })}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: MUTED, margin: 0 }}>{t('ephemerists.credence.none')}</p>
+        )}
+      </section>
+
+      {/* Sealed ephemerides (completions) */}
+      <section>
+        <SectionHead
+          title={t('ephemerists.ephemeridesHeading')}
+          trailing={
+            <div style={{ display: 'flex' }}>
+              {(['score', 'recent'] as const).map((sort) => {
+                const on = submissionSort === sort
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: DISPLAY,
+                      fontSize: 8,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      padding: '5px 10px',
+                      background: on ? INK : 'transparent',
+                      color: on ? GOLD_LIGHT : MUTED,
+                      border: `1px solid ${on ? INK : GOLD_DEEP}`,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {sort === 'score' ? t('ephemerists.sort.mostCanonical') : t('ephemerists.sort.recent')}
+                  </button>
+                )
+              })}
+            </div>
+          }
+        />
+        {sortedSubmissions.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: MUTED, margin: 0 }}>{t('ephemerists.empty')}</p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4">
+              {sortedSubmissions.slice(0, 4).map((s) => (
+                <div key={s.id} style={{ position: 'relative', paddingTop: s.id === topId ? 16 : 0 }}>
+                  {s.id === topId && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: -4,
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        zIndex: 3,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 5,
+                        whiteSpace: 'nowrap',
+                        background: INK,
+                        color: GOLD_LIGHT,
+                        fontFamily: DISPLAY,
+                        fontSize: 9,
+                        letterSpacing: '0.12em',
+                        textTransform: 'uppercase',
+                        padding: '3px 12px',
+                        boxShadow: '0 3px 8px rgba(42,29,18,0.35)',
+                      }}
+                    >
+                      <span aria-hidden style={{ fontSize: 12, lineHeight: 1 }}>⚜</span>
+                      {t('ephemerists.mostCanonical')}
+                    </div>
+                  )}
+                  <PraxisCard praxis={s} />
+                </div>
+              ))}
+            </div>
+            {submissions.length > 4 && (
+              <div style={{ marginTop: 16 }}>
+                <Link to={`/praxes?task_id=${task.id}`} style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: RUBRIC, textDecoration: 'none' }}>
+                  {t('ephemerists.viewAll', { count: submissions.length })}
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Sticky action bar */}
+      {canSignUp && (
+        <MobileStickyBar>
+          {signupError && (
+            <div style={{ fontFamily: SERIF, fontSize: 12, color: 'var(--color-danger)', padding: '8px 12px', background: 'var(--faction-ephemerists-light)', border: `1px solid ${GOLD_DEEP}` }}>
+              {signupError}
+            </div>
+          )}
+          <button
+            onClick={handleSignup}
+            style={{
+              width: '100%',
+              background: INK,
+              color: PARCHMENT,
+              fontFamily: SERIF,
+              fontStyle: 'italic',
+              fontSize: 15,
+              letterSpacing: '0.06em',
+              padding: '14px 20px',
+              border: `1px solid ${GOLD}`,
+              cursor: 'pointer',
+            }}
+          >
+            {t('ephemerists.signup.cta', { points: modifiedPoints })}
+          </button>
+          <MobileStickyCaption color={MUTED}>
+            {t('ephemerists.signup.meta', { open: slotsOpen, max: maxTaskSlots, level: task.level_required })}
+          </MobileStickyCaption>
+        </MobileStickyBar>
+      )}
+
+      {mySubmission && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <span style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: RUBRIC, flex: 1 }}>
+            {t('ephemerists.submitted.text')}
+          </span>
+          <Link
+            to={`/praxes/${mySubmission.id}/edit`}
+            style={{ fontFamily: DISPLAY, fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '10px 18px', background: LAPIS, color: PARCHMENT, textDecoration: 'none' }}
+          >
+            {t('ephemerists.submitted.edit')}
+          </Link>
+        </MobileStickyBar>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <button
+            onClick={handleDrop}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: RUBRIC }}
+          >
+            {t('ephemerists.inProgress.drop')}
+          </button>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{ marginLeft: 'auto', fontFamily: DISPLAY, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '12px 20px', background: INK, color: PARCHMENT, textDecoration: 'none' }}
+          >
+            {t('ephemerists.inProgress.continue')}
+          </Link>
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/tasks/__tests__/ephemeristsDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/ephemeristsDispatch.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * Mobile task-browse Ephemerists dispatch (#527). The browse page shows every
+ * faction's tasks, so — unlike detail — it dispatches on the VIEWING life's
+ * faction. This asserts an `ephemerists` viewer resolves to the codex browse skin
+ * while every other viewer (and logged-out null) falls through to the Default
+ * mobile browse skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../Tasks'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultTasks from '../mobileArchetypes/DefaultTasks'
+import EphemeristsTaskList from '../mobileArchetypes/EphemeristsTaskList'
+
+describe('mobile task-browse Ephemerists dispatch', () => {
+  it('mobile + an Ephemerists viewer resolves to the bespoke codex browse skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'ephemerists', DefaultTasks)).toBe(EphemeristsTaskList)
+  })
+
+  it('mobile + any other viewer falls through to the Default browse skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
+    }
+  })
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/EphemeristsTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/EphemeristsTaskList.tsx
@@ -1,0 +1,230 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../../api/tasks'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import { EphMark } from '../../../components/cards/ephemeristsAtoms'
+import type { TasksState } from '../useTasks'
+
+/**
+ * The Ephemerists MOBILE task-browse skin (#527) — the survey register on a
+ * phone. The same scannable single-column list + touch-native filter chip rows as
+ * the Default browse skin (status / faction / level), dressed as ledger-ruled
+ * commission leaves on aged vellum. Dispatched by the VIEWING life's faction (an
+ * Ephemerist browsing tasks), so it consumes the shared `useTasks()` state
+ * verbatim — a chip tap mutates the same filter state that keys the read. Grounds
+ * on the `--eph-*` tokens; theme-aware through the cascade.
+ */
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const LAPIS = 'var(--eph-lapis)'
+const GOLD = 'var(--eph-gold)'
+const GOLD_DEEP = 'var(--eph-gold-deep)'
+const PARCHMENT = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+const SCRIPT = 'var(--eph-script)'
+
+const kicker: CSSProperties = {
+  fontFamily: DISPLAY,
+  fontSize: 8,
+  letterSpacing: '0.22em',
+  textTransform: 'uppercase',
+  color: MUTED,
+}
+
+export default function EphemeristsTaskList({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div data-skin="ephemerists" className="py-4" style={{ fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }} data-testid="mobile-tasks-browse">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: RUBRIC }}>
+        <EphMark size={12} color={LAPIS} />
+        <span style={kicker}>{t('ephemerists.masthead')}</span>
+      </div>
+      <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 28, lineHeight: 1.05, color: TEXT, margin: '4px 0 0' }}>
+        {tc('nav.tasks')}
+      </h1>
+      <div style={{ height: 1, margin: '9px 0 12px', background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+      <p style={{ ...kicker, marginBottom: 12 }}>{t('mobile.count', { count: tasks.length })}</p>
+
+      <ChipRow label={tc('filters.status')}>
+        {statusFilters.map((option) => (
+          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
+            {option}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('mobile.allFactions')}
+        </Chip>
+        {sortFactionsByRainbowOrder(factions).map((f) => (
+          <Chip
+            key={f.slug}
+            on={faction === f.slug}
+            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
+            tint={factionCssVar(f.slug)}
+          >
+            {factionName(f.slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.level')}>
+        <Chip on={level === ''} onClick={() => setLevel('')}>
+          {t('mobile.anyLevel')}
+        </Chip>
+        {levelFilters.map((lvl) => (
+          <Chip key={lvl} on={level === lvl} onClick={() => setLevel(level === lvl ? '' : lvl)}>
+            {tc('filters.levelAtLeast', { level: lvl })}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <div className="mt-4">
+        {loading ? (
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: MUTED }}>{t('listPage.loading')}</p>
+        ) : error ? (
+          <p style={{ fontFamily: SERIF, fontSize: 12, color: 'var(--color-danger)', border: `1px solid ${GOLD_DEEP}`, padding: '8px 12px' }}>
+            {t('mobile.loadError')}
+          </p>
+        ) : tasks.length === 0 ? (
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: MUTED }}>{t('listPage.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {tasks.map((task) => (
+              <CommissionLeaf key={task.id} task={task} points={displayPointsFor(task)} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span style={{ ...kicker, flex: 'none' }}>{label}</span>
+      <div className="flex gap-2" style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: DISPLAY,
+        fontSize: 10,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        color: on ? PARCHMENT : MUTED,
+        background: on ? RUBRIC : VELLUM,
+        border: `1px solid ${on ? RUBRIC : GOLD_DEEP}`,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && <i style={{ width: 8, height: 8, borderRadius: '50%', flex: 'none', background: tint }} />}
+      {children}
+    </button>
+  )
+}
+
+function CommissionLeaf({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  const color = factionCssVar(task.primary_faction_slug)
+  return (
+    <Link
+      to={`/tasks/${task.id}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        padding: '14px 16px',
+        background: VELLUM,
+        border: `1px solid ${GOLD_DEEP}`,
+        borderLeft: `4px solid ${color}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
+        <i style={{ width: 7, height: 7, borderRadius: '50%', background: color, flex: 'none' }} />
+        {factionName(task.primary_faction_slug)}
+      </span>
+
+      <h2 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 19, lineHeight: 1.15, color: TEXT, margin: 0 }}>
+        {task.title}
+      </h2>
+
+      {task.description && (
+        <p
+          style={{
+            fontFamily: SCRIPT,
+            fontStyle: 'italic',
+            fontSize: 14,
+            lineHeight: 1.5,
+            color: MUTED,
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {task.description}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
+        <span style={{ fontFamily: DISPLAY, fontSize: 12, letterSpacing: '0.04em', color: TEXT, background: VELLUM_DEEP, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>
+          {t('mobile.points', { points })}
+        </span>
+        <span style={{ ...kicker, color: MUTED }}>{t('mobile.level', { level: task.level_required })}</span>
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
Closes #527

## Summary

Adds the **Ephemerists** (slug `ephemerists`) per-faction mobile treatment across all six form-factor surfaces, mirroring the merged UA worked example (#525). Each surface dispatches through its MOBILE `MOBILE_ARCHETYPE_BY_SLUG` on `useFormFactor() === 'mobile'`; every new skin is a presentation-only reskin over the existing hooks/state and the same DOM slots as the Default skin. No backend/API/hook changes.

Idiom: the faction's **vellum codex** — Cinzel titles, ledger-ruled leaves bound in gold-deep hairlines, rubric + lapis accents, the `EphMark` sigil, a title word pulled to lapis. Grounded on the real `--eph-*` / `--faction-ephemerists-*` tokens; theme-aware via the `[data-theme]` cascade (vellum flips to tobacco in dark — no `dark ? a : b`).

### Surfaces + new skins
| Surface | New file |
|---|---|
| Home | `fieldDesk/mobileArchetypes/EphemeristsHome.tsx` |
| Tasks | `tasks/mobileArchetypes/EphemeristsTaskList.tsx` |
| Task detail | `taskDetail/mobileArchetypes/EphemeristsTaskDetail.tsx` |
| Praxis detail | `praxisDetail/mobileArchetypes/EphemeristsPraxisDetail.tsx` |
| Composer | `editPraxis/mobileArchetypes/EphemeristsComposer.tsx` |
| Faction page | `factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx` |

Each is added **only** to its surface's MOBILE registry (desktop registries and other factions untouched), imported under an `EphemeristsMobile*` alias where the desktop archetype shares a filename. A `pickVariant` dispatch test ships per surface.

### Copy
Reuses the existing `ephemerists.*` i18n catalog (task/praxis/faction/composer). New keys limited to mobile-only bits: FieldDesk home masthead/eyebrow (`common.json`), praxis-detail plate/finding/appraise labels + `acquiringHand` (`praxis.json`), and a faction-page eyebrow (`factions.json`). No raw strings.

### Corrections applied (per `docs/design/mobile/README.md`)
- No difficulty dots / slots.
- Points shown as `base + votes` (no retired vote average).
- Single-column stacking; no fixed-px layout grids.

## Verification
- `npm run lint` — clean.
- `npm test` (vitest) — 62 files / 409 tests passing, including the invariant slot-walk tests that now exercise all six Ephemerists skins + the six new dispatch tests.
- `tsc --noEmit` — my files are clean; the 12 remaining errors are pre-existing typed-i18n drift in `AlbescentInvitation.tsx` (confirmed identical count on clean `main`; CI does not run tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
