### PR TITLE
Mobile: Albescent faction treatment (#528)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -142,6 +142,11 @@
         "masthead": "The Codex Desk",
         "charEyebrow": "On the road",
         "questsHeading": "Surveys underway"
+      },
+      "albescent": {
+        "masthead": "The Desk",
+        "charEyebrow": "On record",
+        "questsHeading": "In hand"
       }
     }
   },

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -52,6 +52,9 @@
     }
   },
   "albescent": {
+    "mobile": {
+      "eyebrow": "The Record"
+    },
     "sealed": {
       "eyebrow": "— no such account —",
       "line": "You know not what you seek."

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -415,6 +415,7 @@
       "pointsLabel": "{{points}} pts on return",
       "modeLabel": "The Manner",
       "modeMeta": "how was it attended?",
+      "taskRefLabel": "In answer to",
       "mode": {
         "solo": { "label": "Alone", "desc": "no witness present" },
         "collab": { "label": "In Concord", "desc": "attended together" },

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -327,7 +327,14 @@
       "plates": "Plates · {{count}}",
       "bearWitness": "Bear Witness",
       "witnessPrompt": "How completely was this account attended?",
-      "fromWitnesses": "FROM WITNESSES"
+      "fromWitnesses": "FROM WITNESSES",
+      "acquiringHand": "the keeper's hand",
+      "mobile": {
+        "plate": "The Plates",
+        "theAccount": "The account",
+        "re": "re:",
+        "witness": "Bear witness"
+      }
     }
   },
   "comments": {

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -349,6 +349,8 @@
   },
   "albescent": {
     "faction": "Albescent",
+    "masthead": "The Record",
+    "statusOpen": "open · in confidence",
     "correspondence": "Correspondence №{{number}} · in confidence",
     "stats": {
       "standing": "Standing",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -29,6 +29,7 @@ import UAMobileEditPraxis from "./editPraxis/mobileArchetypes/UaComposer";
 import SingularityMobileEditPraxis from "./editPraxis/mobileArchetypes/SingularityComposer";
 import EverymenMobileEditPraxis from "./editPraxis/mobileArchetypes/EverymenComposer";
 import EphemeristsMobileEditPraxis from "./editPraxis/mobileArchetypes/EphemeristsComposer";
+import AlbescentMobileEditPraxis from "./editPraxis/mobileArchetypes/AlbescentComposer";
 
 type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 
@@ -54,6 +55,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   singularity: SingularityMobileEditPraxis,
   everymen: EverymenMobileEditPraxis,
   ephemerists: EphemeristsMobileEditPraxis,
+  albescent: AlbescentMobileEditPraxis,
 };
 
 export default function EditPraxis() {

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -11,6 +11,7 @@ import SingularityFactionPage from "./factionDetail/mobileArchetypes/Singularity
 import WowFactionPage from "./factionDetail/mobileArchetypes/WowFactionPage";
 import EverymenFactionPage from "./factionDetail/mobileArchetypes/EverymenFactionPage";
 import EphemeristsFactionPage from "./factionDetail/mobileArchetypes/EphemeristsFactionPage";
+import AlbescentFactionPage from "./factionDetail/mobileArchetypes/AlbescentFactionPage";
 import DefaultFactionBody from "./factionDetail/archetypes/DefaultFactionBody";
 import DefaultFactionPage from "./factionDetail/mobileArchetypes/DefaultFactionPage";
 import EverymenFactionBody from "./factionDetail/archetypes/EverymenFactionBody";
@@ -88,6 +89,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<
   wow: WowFactionPage,
   everymen: EverymenFactionPage,
   ephemerists: EphemeristsFactionPage,
+  albescent: AlbescentFactionPage,
 };
 
 export default function FactionDetail({ slug: slugProp }: { slug?: string } = {}) {

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -16,6 +16,7 @@ import UaHome from './fieldDesk/mobileArchetypes/UaHome'
 import SingularityHome from './fieldDesk/mobileArchetypes/SingularityHome'
 import EverymenHome from './fieldDesk/mobileArchetypes/EverymenHome'
 import EphemeristsHome from './fieldDesk/mobileArchetypes/EphemeristsHome'
+import AlbescentHome from './fieldDesk/mobileArchetypes/AlbescentHome'
 
 /**
  * FieldDesk roster — the authenticated account home (#274). "Whose shoes today?":
@@ -40,6 +41,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileHomeSkin> = {
   singularity: SingularityHome,
   everymen: EverymenHome,
   ephemerists: EphemeristsHome,
+  albescent: AlbescentHome,
 }
 
 // Deterministic slight tilt per card — index-keyed so it's stable across renders.

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -21,6 +21,7 @@ import UAMobilePraxisDetail from './praxisDetail/mobileArchetypes/UaPraxisDetail
 import SingularityMobilePraxisDetail from './praxisDetail/mobileArchetypes/SingularityPraxisDetail'
 import EverymenMobilePraxisDetail from './praxisDetail/mobileArchetypes/EverymenPraxisDetail'
 import EphemeristsMobilePraxisDetail from './praxisDetail/mobileArchetypes/EphemeristsPraxisDetail'
+import AlbescentMobilePraxisDetail from './praxisDetail/mobileArchetypes/AlbescentPraxisDetail'
 import EphemeristsPraxisDetail from './praxisDetail/archetypes/EphemeristsPraxisDetail'
 import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
 import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
@@ -58,6 +59,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: Pra
   singularity: SingularityMobilePraxisDetail,
   everymen: EverymenMobilePraxisDetail,
   ephemerists: EphemeristsMobilePraxisDetail,
+  albescent: AlbescentMobilePraxisDetail,
 }
 
 export default function PraxisDetail() {

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -20,6 +20,7 @@ import UAMobileTaskDetail from "./taskDetail/mobileArchetypes/UaTaskDetail";
 import SingularityMobileTaskDetail from "./taskDetail/mobileArchetypes/SingularityTaskDetail";
 import WowMobileTaskDetail from "./taskDetail/mobileArchetypes/WowTaskDetail";
 import EphemeristsMobileTaskDetail from "./taskDetail/mobileArchetypes/EphemeristsTaskDetail";
+import AlbescentMobileTaskDetail from "./taskDetail/mobileArchetypes/AlbescentTaskDetail";
 import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
@@ -53,6 +54,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   singularity: SingularityMobileTaskDetail,
   wow: WowMobileTaskDetail,
   ephemerists: EphemeristsMobileTaskDetail,
+  albescent: AlbescentMobileTaskDetail,
 };
 
 export default function TaskDetail() {

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -14,6 +14,7 @@ import SingularityTaskList from './tasks/mobileArchetypes/SingularityTaskList'
 import WowTaskList from './tasks/mobileArchetypes/WowTaskList'
 import EverymenTaskList from './tasks/mobileArchetypes/EverymenTaskList'
 import EphemeristsTaskList from './tasks/mobileArchetypes/EphemeristsTaskList'
+import AlbescentTaskList from './tasks/mobileArchetypes/AlbescentTaskList'
 
 type MobileSkin = (props: { state: TasksState }) => JSX.Element | null
 
@@ -28,6 +29,7 @@ export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {
   wow: WowTaskList,
   everymen: EverymenTaskList,
   ephemerists: EphemeristsTaskList,
+  albescent: AlbescentTaskList,
 }
 
 export default function Tasks() {

--- a/frontend/src/pages/editPraxis/mobileArchetypes/AlbescentComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/AlbescentComposer.tsx
@@ -1,0 +1,348 @@
+import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import MediaArt from '../blocks/MediaArt'
+import { pickArtKey } from '../blocks/useMediaArt'
+import { ErrorBanner, formatAutosave } from '../archetypes/shared'
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from '../archetypes/controls'
+import AlbescentMark from '../../../components/cards/AlbescentMark'
+import type { EditPraxisState } from '../useEditPraxis'
+import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+
+/**
+ * Albescent MOBILE composer (#528) — "File an Account" on a phone. The same
+ * single-column composer as the Default mobile skin (Write/Preview toggle, fluid
+ * media grid, sticky submit bar) dressed as quiet cotton correspondence: the
+ * surveyor's Mark, hairline sheets, Cormorant-italic titles, one hue of ink.
+ * Ported from the desktop Albescent archetype; grounds on the
+ * `--faction-albescent-*` tokens (always-light). Consumes `useEditPraxis`
+ * verbatim — no editor, upload, or submit logic lives here.
+ */
+
+const INK = 'var(--faction-albescent-card-text)'
+const SHEET = 'var(--faction-albescent-card-bg)'
+const PAGE = 'var(--faction-albescent-page)'
+const FONT = 'var(--faction-albescent-card-font)'
+const MONO = 'var(--faction-albescent-mono)'
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  display: 'block',
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: ink(30),
+}
+
+/** A cotton sheet headed by a quiet mono title. */
+function Sheet({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: 14 }}>
+      <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.22em', textTransform: 'uppercase', color: ink(40), marginBottom: 10 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default function AlbescentComposer({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation('forms')
+  const [tab, setTab] = useState<ComposerTab>('write')
+  const praxis = state.praxis!
+  const task = state.task
+
+  return (
+    <div data-skin="albescent" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: PAGE }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <AlbescentMark size={22} />
+          <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 27, lineHeight: 1, color: INK, margin: 0 }}>
+            {t('editPraxis.albescent.pageTitle')}
+          </h1>
+          <span style={{ ...kicker, marginLeft: 'auto' }}>
+            {state.autosaveAt
+              ? t('editPraxis.albescent.autosaveSaved', { ago: formatAutosave(state.autosaveAt) })
+              : t('editPraxis.albescent.autosaveUnsaved')}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: { gap: 0, border: `1px solid ${ink(14)}` },
+            buttonStyle: (active) => ({
+              padding: '9px 10px',
+              border: 'none',
+              fontFamily: MONO,
+              fontSize: 10,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              background: active ? INK : 'transparent',
+              color: active ? PAGE : ink(45),
+            }),
+          }}
+        />
+      </header>
+
+      {/* In-answer-to reference */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: SHEET, border: `1px solid ${ink(10)}` }}>
+        <span style={kicker}>{t('editPraxis.albescent.taskRefLabel')}</span>
+        <span style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 16, color: INK, textAlign: 'right', flex: 1, lineHeight: 1.15 }}>
+          {praxis.task_title}
+        </span>
+      </div>
+      <div style={{ ...kicker, letterSpacing: '0.14em', color: ink(45) }}>
+        {factionName(task?.primary_faction_slug ?? null)}
+        {task ? ` · ${t('taskMeta.points', { points: task.point_value })}` : ''}
+      </div>
+
+      {tab === 'write' ? (
+        <>
+          <Sheet title={t('editPraxis.albescent.titleLabel')}>
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t('editPraxis.albescent.titlePlaceholder'),
+                inputStyle: {
+                  width: '100%',
+                  fontFamily: FONT,
+                  fontStyle: 'italic',
+                  fontSize: 22,
+                  fontWeight: 300,
+                  color: INK,
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  borderBottom: `1px solid ${ink(12)}`,
+                  padding: '2px 0 8px',
+                },
+              }}
+            />
+          </Sheet>
+
+          <Sheet title={t('editPraxis.albescent.bodyLabel')}>
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t('editPraxis.albescent.bodyPlaceholder'),
+                textareaStyle: {
+                  width: '100%',
+                  fontFamily: FONT,
+                  fontStyle: 'italic',
+                  fontSize: 15,
+                  lineHeight: 1.65,
+                  color: INK,
+                  background: ink(2),
+                  border: `1px solid ${ink(10)}`,
+                  padding: '13px 15px',
+                  outline: 'none',
+                  resize: 'vertical',
+                  minHeight: 180,
+                },
+              }}
+            />
+          </Sheet>
+
+          {state.showInviteBox && (
+            <Sheet title={state.duelMode ? t('editPraxis.albescent.inviteLabelDuel') : t('editPraxis.albescent.inviteLabel')}>
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: MONO,
+                  inputBg: ink(2),
+                  inputColor: INK,
+                  inputBorder: `1px solid ${ink(10)}`,
+                  acceptedBg: INK,
+                  acceptedColor: PAGE,
+                  placeholder: t('editPraxis.albescent.invitePlaceholder'),
+                }}
+              />
+            </Sheet>
+          )}
+
+          <Sheet title={t('editPraxis.albescent.filesLabel')}>
+            <MediaGrid state={state} />
+          </Sheet>
+
+          {state.showMetatasks && (
+            <Sheet title={t('editPraxis.albescent.metatasksLabel')}>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: { display: 'flex', flexDirection: 'column', gap: 4 },
+                  rowStyle: (selected) => ({
+                    padding: '10px 12px',
+                    background: selected ? ink(3) : 'transparent',
+                    border: `1px solid ${selected ? ink(24) : ink(10)}`,
+                  }),
+                  titleColor: INK,
+                  descColor: ink(45),
+                  pointsActiveColor: ink(60),
+                  pointsIdleColor: ink(40),
+                }}
+              />
+            </Sheet>
+          )}
+        </>
+      ) : (
+        <Sheet title={t('editPraxis.albescent.previewLabel')}>
+          <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 22, color: INK, marginBottom: 10 }}>
+            {state.title || t('editPraxis.albescent.titlePlaceholder')}
+          </div>
+          {state.media.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <MediaGrid state={state} readOnly />
+            </div>
+          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              markdownStyle: { fontFamily: FONT, fontStyle: 'italic', fontSize: 15, lineHeight: 1.65, color: ink(72) },
+            }}
+          />
+        </Sheet>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      <MobileStickyBar
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 0 4px',
+          background: 'var(--color-nav-bg)',
+          backdropFilter: 'blur(var(--nav-blur))',
+          borderTop: `1px solid ${ink(14)}`,
+        }}
+      >
+        <PublishButton
+          state={state}
+          skin={{
+            idleLabel: t('editPraxis.albescent.publishIdle'),
+            busyLabel: t('editPraxis.albescent.publishBusy'),
+            style: {
+              flex: 1,
+              background: INK,
+              color: PAGE,
+              fontFamily: MONO,
+              fontSize: 11,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              padding: '13px 18px',
+              border: `1px solid ${INK}`,
+              cursor: state.submitting ? 'wait' : 'pointer',
+            },
+          }}
+        />
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.albescent.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: ink(40),
+                fontFamily: FONT,
+                fontStyle: 'italic',
+                fontSize: 14,
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
+      </MobileStickyBar>
+    </div>
+  )
+}
+
+/** Fluid 3-column media grid in the filed-plates idiom. */
+function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOnly?: boolean }) {
+  const { t } = useTranslation('forms')
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+      {state.media.map((item) => {
+        const filename = item.file_path.split('/').pop() ?? item.file_path
+        const src = mediaUrl(item.file_path)
+        return (
+          <div key={item.id} style={{ position: 'relative', aspectRatio: '1 / 1', overflow: 'hidden', border: `1px solid ${ink(12)}`, background: ink(3) }}>
+            {item.type === 'image' ? (
+              <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : item.type === 'video' ? (
+              <video src={src} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <MediaArt art={pickArtKey(filename, 'audio')} width={120} height={120} />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t('media.removeAria', { name: filename })}
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  borderRadius: '50%',
+                  background: SHEET,
+                  border: `1px solid ${ink(20)}`,
+                  color: ink(55),
+                  fontSize: 12,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        )
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: '1 / 1',
+              width: '100%',
+              background: ink(2),
+              border: `1.5px dashed ${ink(16)}`,
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 4,
+              fontFamily: MONO,
+              fontSize: 9,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: ink(50),
+            },
+            buttonLabel: t('editPraxis.albescent.fileButton'),
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/albescentDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/albescentDispatch.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Mobile composer Albescent dispatch (#528). Asserts the mobile registry resolves
+ * an `albescent` task to the Record's "File an Account" composer, and that every
+ * other faction falls through to the Default mobile composer.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../../EditPraxis'
+import { pickVariant } from '../../../../utils/factionDispatch'
+import DefaultMobileEditPraxis from '../DefaultEditPraxis'
+import AlbescentMobileEditPraxis from '../AlbescentComposer'
+
+describe('mobile composer Albescent dispatch', () => {
+  it('mobile + an Albescent task resolves to the bespoke Albescent composer', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'albescent', DefaultMobileEditPraxis)).toBe(
+      AlbescentMobileEditPraxis,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default composer', () => {
+    for (const slug of ['snide', 'wow', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileEditPraxis)).not.toBe(
+        AlbescentMobileEditPraxis,
+      )
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/__tests__/albescentMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/albescentMobileDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile faction-page Albescent dispatch (#528). Asserts the mobile registry
+ * resolves the `albescent` faction to the Record page skin, and that every other
+ * faction (and null) falls through to the single-column DefaultFactionPage.
+ * Mirrors the other surfaces' albescent-dispatch tests.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FactionDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
+import AlbescentFactionPage from '../mobileArchetypes/AlbescentFactionPage'
+
+describe('mobile faction-page Albescent dispatch', () => {
+  it('mobile + the Albescent faction resolves to the bespoke Albescent page', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'albescent', DefaultFactionPage)).toBe(AlbescentFactionPage)
+  })
+
+  it('every other faction falls through to the Default mobile page', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFactionPage)).toBe(DefaultFactionPage)
+    }
+  })
+})

--- a/frontend/src/pages/factionDetail/mobileArchetypes/AlbescentFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/AlbescentFactionPage.tsx
@@ -1,0 +1,271 @@
+import { useState, type CSSProperties, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import AlbescentMark from '../../../components/cards/AlbescentMark'
+import { factionName, factionDescription } from '../../../utils/factions'
+import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
+import type { CharacterOut } from '../../../api/auth'
+import type { FactionDetailState } from '../useFactionDetail'
+
+/**
+ * Albescent MOBILE faction page (#528) — the Record, phone shaped. The same
+ * single-column slots as the Default mobile faction page (a hero with real
+ * member/task counts, top members, recent praxis, and the invite-gated Join model
+ * via `state.membership`, ADR-0019) — only the dress changes: cotton sheets, the
+ * surveyor's Mark, hairlines, Cormorant-italic titles, one hue of ink and no
+ * colour. Grounds on the `--faction-albescent-*` tokens; always-light. Reuses the
+ * shared `mobile.*` faction copy so the slot contract holds. Presentation-only —
+ * all data + the join handler arrive via {@link FactionDetailState}.
+ */
+
+const NA_SLUG = 'na'
+
+const INK = 'var(--faction-albescent-card-text)'
+const SHEET = 'var(--faction-albescent-card-bg)'
+const PAGE = 'var(--faction-albescent-page)'
+const FONT = 'var(--faction-albescent-card-font)'
+const MONO = 'var(--faction-albescent-mono)'
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: ink(30),
+}
+
+const initial = (name: string) => name.trim().charAt(0).toUpperCase() || '?'
+
+/** A quiet witness circle — cotton face, ink italic glyph. */
+function Witness({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: ink(4),
+        border: `1px solid ${ink(14)}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: FONT,
+        fontStyle: 'italic',
+        fontWeight: 300,
+        fontSize: size * 0.42,
+        color: ink(55),
+      }}
+    >
+      {initial(name)}
+    </span>
+  )
+}
+
+function SectionHead({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+      <span style={{ fontFamily: MONO, fontSize: 9, letterSpacing: '0.2em', textTransform: 'uppercase', color: ink(40) }}>
+        {children}
+      </span>
+      <span style={{ flex: 1, height: 1, background: ink(8) }} />
+    </div>
+  )
+}
+
+const joinButton: CSSProperties = {
+  width: '100%',
+  fontFamily: MONO,
+  fontSize: 11,
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: PAGE,
+  background: INK,
+  border: `1px solid ${INK}`,
+  padding: '13px 16px',
+  cursor: 'pointer',
+}
+
+export default function AlbescentFactionPage({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation('factions')
+  const { faction, members, tasks, recentPraxis, membership } = state
+  const [confirming, setConfirming] = useState(false)
+
+  if (!faction) return null
+
+  const name = factionName(faction.slug)
+  const topMembers = [...members].sort((a, b) => b.all_time_score - a.all_time_score).slice(0, 3)
+  const currentSlug = membership.currentFactionSlug
+  const switching = currentSlug && currentSlug !== NA_SLUG
+
+  return (
+    <div data-skin="albescent" className="py-4" style={{ fontFamily: MONO, color: INK, background: PAGE }} data-testid="mobile-faction-page">
+      {/* Hero — cotton sheet, centred */}
+      <section
+        style={{
+          background: SHEET,
+          border: `1px solid ${ink(10)}`,
+          boxShadow: '0 2px 24px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)',
+          padding: '30px 20px 26px',
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 14 }}>
+          <AlbescentMark size={34} />
+        </div>
+        <div style={{ ...kicker, letterSpacing: '0.3em', color: ink(40) }}>{t('albescent.mobile.eyebrow')}</div>
+        <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 34, lineHeight: 1.08, color: INK, margin: '6px 0 0' }}>
+          {name}
+        </h1>
+        <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, lineHeight: 1.6, color: ink(52), margin: '10px auto 0', maxWidth: 320 }}>
+          {factionDescription(faction.slug)}
+        </p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 18, justifyContent: 'center' }}>
+          <HeroStat value={members.length} label={t('mobile.membersStat')} />
+          <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
+        </div>
+      </section>
+
+      {membership.state === 'member' && (
+        <p style={{ ...kicker, marginTop: 12, color: ink(45) }}>{t('mobile.memberBadge')}</p>
+      )}
+
+      {/* Top members */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.topMembers')}</SectionHead>
+        {topMembers.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: ink(45), margin: 0 }}>{t('mobile.membersEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {topMembers.map((m, index) => (
+              <MemberRow key={m.id} rank={index + 1} member={m} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent praxis */}
+      <section className="mt-6">
+        <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
+        {recentPraxis.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: ink(45), margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recentPraxis.map((p) => (
+              <PraxisCard key={p.id} praxis={p} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {membership.state === 'gate' && (
+        <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: ink(45), marginTop: 24 }}>
+          {t('mobile.gateHint', { faction: name })}
+        </p>
+      )}
+
+      {/* Sticky Join — only an eligible viewer can act (ADR-0019). */}
+      {membership.state === 'eligible' && (
+        <MobileStickyBar>
+          {membership.joinError && (
+            <p style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+          )}
+          {!confirming ? (
+            <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
+              {t('mobile.join', { faction: name })}
+            </button>
+          ) : (
+            <>
+              <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: INK }}>
+                {switching
+                  ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
+                  : t('detail.join.confirm', { faction: name })}
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => void membership.join()}
+                  disabled={membership.joining}
+                  style={{ ...joinButton, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                >
+                  {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirming(false)}
+                  disabled={membership.joining}
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: 10,
+                    letterSpacing: '0.12em',
+                    textTransform: 'uppercase',
+                    color: ink(45),
+                    background: 'transparent',
+                    border: `1px solid ${ink(14)}`,
+                    padding: '11px 16px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t('detail.join.cancel')}
+                </button>
+              </div>
+            </>
+          )}
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}
+
+function HeroStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={{ flex: '0 1 120px', textAlign: 'center', border: `1px solid ${ink(9)}`, padding: '10px 14px' }}>
+      <b style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 20, display: 'block', lineHeight: 1, color: INK }}>
+        {value}
+      </b>
+      <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
+    </div>
+  )
+}
+
+function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
+  const { t } = useTranslation('factions')
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: SHEET,
+        border: `1px solid ${ink(10)}`,
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 16, color: ink(45), width: 16, flex: 'none' }}>{rank}</span>
+      <Witness name={member.display_name} size={28} />
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: FONT,
+          fontStyle: 'italic',
+          fontSize: 15,
+          color: INK,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {member.display_name}
+      </span>
+      <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.08em', textTransform: 'uppercase', color: ink(38), flex: 'none' }}>
+        {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/pages/fieldDesk/__tests__/albescentDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/albescentDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile FieldDesk-home Albescent dispatch (#528). Asserts the parallel mobile
+ * registry resolves an `albescent` carried life to the Record's desk skin, and
+ * that an unregistered faction (and null) still falls through to the Default
+ * mobile home. Mirrors the UA dispatch test.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../FieldDesk'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
+import AlbescentHome from '../mobileArchetypes/AlbescentHome'
+
+describe('mobile FieldDesk-home Albescent dispatch', () => {
+  it('mobile + an Albescent life resolves to the bespoke Albescent home skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'albescent', DefaultFieldDesk)).toBe(AlbescentHome)
+  })
+
+  it('mobile + any other slug falls through to the Default home skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
+    }
+  })
+})

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
@@ -1,0 +1,229 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import AlbescentMark from '../../../components/cards/AlbescentMark'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+
+/**
+ * Albescent MOBILE FieldDesk home (#528) — the Record's desk on a phone. The
+ * carried life and its in-hand work become plain cotton sheets: hairline
+ * borders, the surveyor's Mark, Cormorant Garamond italic, one hue of ink and no
+ * colour. Same content slots as the Default mobile home (character header,
+ * Points/Votes/Era tiles, active-tasks list, primary actions) — only the dress
+ * changes. Grounds on the `--faction-albescent-*` tokens already in index.css;
+ * always-light (Albescent never dims). Presentation-only — all data arrives via
+ * {@link FieldDeskHomeState}.
+ */
+
+const INK = 'var(--faction-albescent-card-text)'
+const SHEET = 'var(--faction-albescent-card-bg)'
+const PAGE = 'var(--faction-albescent-page)'
+const FONT = 'var(--faction-albescent-card-font)' // Cormorant Garamond
+const MONO = 'var(--faction-albescent-mono)' // Courier Prime
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.28em',
+  textTransform: 'uppercase',
+  color: ink(30),
+}
+
+/** A plain cotton sheet — hairline border, the faction's only container idiom. */
+function Sheet({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        background: SHEET,
+        border: `1px solid ${ink(10)}`,
+        boxShadow: '0 2px 18px rgba(0,0,0,0.045), 0 1px 3px rgba(0,0,0,0.04)',
+        padding: 18,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) {
+  const { t } = useTranslation('common')
+  const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
+
+  const stats = [
+    { label: t('fieldDesk.home.stats.points'), value: character.score?.toLocaleString() ?? '0' },
+    { label: t('fieldDesk.home.stats.votes'), value: votesReceived.toLocaleString() },
+    { label: t('fieldDesk.home.stats.era'), value: eraName || '—' },
+  ]
+
+  return (
+    <div
+      data-skin="albescent"
+      className="page"
+      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: PAGE }}
+    >
+      {/* Masthead — the Mark and a hairline */}
+      <header>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+          <AlbescentMark size={26} />
+          <div style={kicker}>{t('nav.home')}</div>
+        </div>
+        <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 32, lineHeight: 1, color: INK, margin: 0 }}>
+          {t('fieldDesk.home.albescent.masthead')}
+        </h1>
+        <div style={{ height: 1, marginTop: 10, background: ink(10) }} />
+      </header>
+
+      {/* ── The keeper's sheet ── */}
+      <Sheet>
+        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+          <span style={kicker}>{t('fieldDesk.home.albescent.charEyebrow')}</span>
+          <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: ink(50), textDecoration: 'none', borderBottom: `1px solid ${ink(20)}` }}>
+            {t('fieldDesk.home.edit')}
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div
+            className="shrink-0 flex items-center justify-center rounded-full"
+            style={{ width: 52, height: 52, borderRadius: '50%', overflow: 'hidden', border: `1px solid ${ink(14)}`, background: ink(4) }}
+          >
+            {character.avatar_url ? (
+              <img
+                src={mediaUrl(character.avatar_url)}
+                alt={character.display_name}
+                className="w-full h-full"
+                style={{ objectFit: 'cover' }}
+              />
+            ) : (
+              <span style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 22, color: ink(55) }}>
+                {character.display_name[0]?.toUpperCase()}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/characters/${character.id}`}
+              className="block truncate"
+              style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 25, lineHeight: 1.05, color: INK, textDecoration: 'none' }}
+            >
+              {character.display_name}
+            </Link>
+            <div className="truncate" style={{ ...kicker, marginTop: 5, letterSpacing: '0.14em' }}>
+              {t('sidebar.characterCard.factionLevel', {
+                faction: factionName(character.faction_slug),
+                level: character.level,
+              })}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 26, lineHeight: 1, color: ink(60) }}>
+              {character.score?.toLocaleString() ?? '0'}
+            </div>
+            <div style={{ ...kicker, marginTop: 3 }}>{t('fieldDesk.home.stats.points')}</div>
+          </div>
+        </div>
+
+        <div className="flex gap-2" style={{ marginTop: 16 }}>
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="text-center"
+              style={{ flex: '1 1 0', minWidth: 0, border: `1px solid ${ink(9)}`, padding: '11px 6px' }}
+            >
+              <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 20, lineHeight: 1, color: INK }}>
+                {stat.value}
+              </div>
+              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      </Sheet>
+
+      {/* ── Pending requests ── */}
+      {pendingCount > 0 && (
+        <Link
+          to="/updates?filter=requests"
+          className="flex items-center justify-between"
+          style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: '11px 16px', fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: INK, textDecoration: 'none' }}
+        >
+          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
+          <span aria-hidden style={{ color: ink(40) }}>→</span>
+        </Link>
+      )}
+
+      {/* ── Work in hand ── */}
+      <Sheet>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+          <span style={{ fontFamily: MONO, fontSize: 9, letterSpacing: '0.2em', textTransform: 'uppercase', color: ink(40) }}>
+            {t('fieldDesk.home.albescent.questsHeading')}
+          </span>
+          <span style={{ flex: 1, height: 1, background: ink(8) }} />
+          <Link to="/tasks" style={{ ...kicker, color: ink(50), textDecoration: 'none', borderBottom: `1px solid ${ink(20)}` }}>
+            {t('fieldDesk.home.viewAll')}
+          </Link>
+        </div>
+
+        {activeTasks.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: ink(45), margin: 0 }}>
+            {t('fieldDesk.home.questsEmpty')}
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {activeTasks.map((praxis, index) => (
+              <Link
+                key={praxis.id}
+                to={`/praxes/${praxis.id}/edit`}
+                className="flex items-center gap-3"
+                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${ink(8)}`, textDecoration: 'none' }}
+              >
+                <AlbescentMark size={14} opacity={0.7} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 17, lineHeight: 1.2, color: INK }}>
+                    {praxis.task_title}
+                  </div>
+                  <div className="truncate" style={{ ...kicker, marginTop: 3, letterSpacing: '0.14em' }}>
+                    {t('fieldDesk.home.taskMeta', {
+                      faction: factionName(praxis.task_faction_slug),
+                      points: praxis.task_point_value,
+                    })}
+                  </div>
+                </div>
+                <span
+                  className="shrink-0"
+                  style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.14em', textTransform: 'uppercase', color: ink(35), padding: '4px 9px', border: `1px solid ${ink(12)}` }}
+                >
+                  {t(`praxisType.${praxis.type}`)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </Sheet>
+
+      {/* ── Primary actions ── */}
+      <div className="flex gap-2.5">
+        <Link
+          to="/tasks"
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: PAGE, background: INK, border: `1px solid ${INK}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.browseTasks')}
+        </Link>
+        {canProposeTask && (
+          <Link
+            to="/propose-task"
+            className="flex-1 flex items-center justify-center gap-2"
+            style={{ fontFamily: MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: ink(55), background: 'transparent', border: `1px solid ${ink(16)}`, textDecoration: 'none' }}
+          >
+            <span aria-hidden style={{ fontSize: 13, lineHeight: 1 }}>+</span>
+            <span>{t('actions.proposeTask')}</span>
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/__tests__/albescentDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/albescentDispatch.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Mobile praxis-detail Albescent dispatch (#528). Asserts the mobile registry
+ * resolves an `albescent`-task praxis to the Record's filed-account skin, that
+ * other factions fall through to the Default mobile detail, and the desktop
+ * archetype is untouched.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG, ARCHETYPE_BY_SLUG } from '../../PraxisDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
+import AlbescentMobilePraxisDetail from '../mobileArchetypes/AlbescentPraxisDetail'
+import AlbescentDesktopPraxisDetail from '../archetypes/AlbescentPraxisDetail'
+
+describe('mobile praxis-detail Albescent dispatch', () => {
+  it('mobile + an Albescent praxis resolves to the bespoke Albescent mobile skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'albescent', DefaultMobilePraxisDetail)).toBe(
+      AlbescentMobilePraxisDetail,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default mobile skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobilePraxisDetail)).toBe(
+        DefaultMobilePraxisDetail,
+      )
+    }
+  })
+
+  it('desktop keeps its own Albescent archetype, never the mobile skin', () => {
+    const desktop = pickVariant(ARCHETYPE_BY_SLUG, 'albescent', DefaultMobilePraxisDetail)
+    expect(desktop).toBe(AlbescentDesktopPraxisDetail)
+    expect(desktop).not.toBe(AlbescentMobilePraxisDetail)
+  })
+})

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/AlbescentPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/AlbescentPraxisDetail.tsx
@@ -1,0 +1,156 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import { formatTimestamp } from '../../../utils/dates'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisVoterBreakdown,
+  MemberByline,
+} from '../shared'
+import { MobileStarVote } from './shared'
+
+/**
+ * Albescent MOBILE praxis-detail skin (#528) — a filed account in the Register,
+ * phone-shaped. A cotton sheet holds the returned work (full media); a
+ * Cormorant-italic finding, the account body, and a thumb-sized "bear witness"
+ * caster follow. Renders the same invariant CONTENT + behavior slots as every
+ * archetype (the shared praxisDetail module) — only the dress changes: the
+ * surveyor's Mark, hairlines, one hue of ink, no colour. Grounds on
+ * `--faction-albescent-*` tokens; always-light.
+ */
+
+const INK = 'var(--faction-albescent-card-text)'
+const SHEET = 'var(--faction-albescent-card-bg)'
+const PAGE = 'var(--faction-albescent-page)'
+const FONT = 'var(--faction-albescent-card-font)'
+const MONO = 'var(--faction-albescent-mono)'
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: ink(30),
+}
+
+/** Quiet mono section divider, e.g. "The Plates" / "Bear witness". */
+function Divider({ label }: { label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '4px 0 4px' }}>
+      <div style={{ height: 1, flex: 1, background: ink(8) }} />
+      <span style={{ ...kicker, whiteSpace: 'nowrap' }}>{label}</span>
+      <div style={{ height: 1, flex: 1, background: ink(8) }} />
+    </div>
+  )
+}
+
+/** A cotton sheet holding filed evidence. */
+function Sheet({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: 12 }}>{children}</div>
+  )
+}
+
+export default function AlbescentPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes } = state
+  if (!praxis) return null
+
+  const sealedDate = praxis.submitted_at ?? praxis.created_at
+  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+
+  return (
+    <div data-skin="albescent" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: PAGE }}>
+      {/* Behavior slots (invariant) */}
+      <PraxisStatusBanners state={state} />
+      <PraxisAdminBar state={state} />
+
+      {/* Byline row */}
+      <div className="flex items-center gap-3">
+        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+          <span
+            className="flex items-center justify-center rounded-full"
+            style={{ width: 40, height: 40, background: ink(4), border: `1px solid ${ink(14)}`, color: ink(55), fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 18 }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+        </Link>
+        <div className="min-w-0 flex-1">
+          <MemberByline
+            praxis={praxis}
+            linkStyle={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 18, color: INK, lineHeight: 1, textDecoration: 'none' }}
+          />
+          <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
+            {t('detail.albescent.acquiringHand')} · {formatTimestamp(sealedDate)}
+          </div>
+        </div>
+      </div>
+
+      {/* Filed plates — full media inside */}
+      {praxis.media_items.length > 0 && (
+        <div>
+          <Divider label={t('detail.albescent.mobile.plate')} />
+          <Sheet>
+            <MediaGallery media={praxis.media_items} layout="grid" />
+          </Sheet>
+        </div>
+      )}
+
+      {/* The finding */}
+      <div>
+        <div style={{ ...kicker, marginBottom: 4, color: ink(40) }}>{t('detail.albescent.mobile.theAccount')}</div>
+        <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 30, lineHeight: 1.1, margin: 0, color: INK, overflowWrap: 'anywhere' }}>
+          {praxis.title ?? t('detail.albescent.untitled')}
+        </h1>
+      </div>
+
+      {/* Owner actions (invariant) */}
+      <PraxisOwnerActions state={state} />
+
+      {/* re: task link */}
+      <div style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 13, color: ink(48) }}>
+        {t('detail.albescent.mobile.re')}{' '}
+        <Link to={`/tasks/${praxis.task_id}`} style={{ color: ink(72), textDecoration: 'none', borderBottom: `1px solid ${ink(20)}` }}>
+          {praxis.task_title}
+        </Link>
+      </div>
+
+      {/* Account body */}
+      {praxis.body_text && (
+        <MarkdownPreview
+          source={praxis.body_text}
+          className="markdown-preview"
+          style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, lineHeight: 1.7, color: ink(62) }}
+        />
+      )}
+
+      {/* Bear witness caster */}
+      <div>
+        <Divider label={t('detail.albescent.mobile.witness')} />
+        <div className="flex items-center justify-center" style={{ margin: '10px 0 12px', fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: ink(50) }}>
+          {t('detail.albescent.witnessPrompt')}
+        </div>
+        <MobileStarVote
+          praxisId={praxis.id}
+          points={votes?.total_score}
+          totalVotes={votes?.total_votes}
+          accent={INK}
+          accentFont={FONT}
+        />
+      </div>
+
+      {/* Flag + voter breakdown (invariant) */}
+      <PraxisFlagBlock state={state} />
+      <PraxisVoterBreakdown state={state} />
+    </div>
+  )
+}

--- a/frontend/src/pages/taskDetail/__tests__/albescentDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/albescentDispatch.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Mobile task-detail Albescent dispatch (#528). Asserts the mobile registry
+ * resolves an `albescent` task to the Record's correspondence skin, that other
+ * factions fall through to the Default mobile detail, and that the desktop
+ * archetype is untouched.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG, ARCHETYPE_BY_SLUG } from '../../TaskDetail'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultMobileTaskDetail from '../mobileArchetypes/DefaultTaskDetail'
+import AlbescentMobileTaskDetail from '../mobileArchetypes/AlbescentTaskDetail'
+import AlbescentDesktopTaskDetail from '../archetypes/AlbescentTaskDetail'
+
+describe('mobile task-detail Albescent dispatch', () => {
+  it('mobile + an Albescent task resolves to the bespoke Albescent mobile skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'albescent', DefaultMobileTaskDetail)).toBe(
+      AlbescentMobileTaskDetail,
+    )
+  })
+
+  it('mobile + any other slug falls through to the Default mobile skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultMobileTaskDetail)).toBe(
+        DefaultMobileTaskDetail,
+      )
+    }
+  })
+
+  it('desktop keeps its own Albescent archetype, never the mobile skin', () => {
+    const desktop = pickVariant(ARCHETYPE_BY_SLUG, 'albescent', DefaultMobileTaskDetail)
+    expect(desktop).toBe(AlbescentDesktopTaskDetail)
+    expect(desktop).not.toBe(AlbescentMobileTaskDetail)
+  })
+})

--- a/frontend/src/pages/taskDetail/mobileArchetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/AlbescentTaskDetail.tsx
@@ -1,0 +1,286 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import PraxisCard from '../../../components/PraxisCard'
+import AlbescentMark from '../../../components/cards/AlbescentMark'
+import { MobileStickyBar, MobileStickyCaption } from './shared'
+import type { TaskDetailState } from '../useTaskDetail'
+
+/**
+ * Albescent MOBILE task-detail skin (#528) — the correspondence on a phone. A
+ * plain cotton sheet holds the surveyor's Mark, a Cormorant-italic title, and
+ * the standing/worth/returned plates; "The Ask" carries the brief and "Inscribed
+ * in the Register" the wall of returned accounts (the finest is most-witnessed).
+ * To take a task is to "Acknowledge" it, via a stamped sticky action bar pinned
+ * above the tab bar. Single-column, no fixed-px grid. Reuses the same
+ * {@link TaskDetailState}, the shared mobile sticky bar, and the `albescent.*`
+ * copy + `--faction-albescent-*` tokens as the desktop archetype. Always-light.
+ */
+
+const INK = 'var(--faction-albescent-card-text)'
+const SHEET = 'var(--faction-albescent-card-bg)'
+const PAGE = 'var(--faction-albescent-page)'
+const FONT = 'var(--faction-albescent-card-font)'
+const MONO = 'var(--faction-albescent-mono)'
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: ink(30),
+}
+
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+      <h2 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 500, fontSize: 20, margin: 0, color: INK, whiteSpace: 'nowrap' }}>
+        {title}
+      </h2>
+      <span style={{ flex: 1, height: 1, background: ink(8) }} />
+      {trailing}
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <div style={{ ...kicker, marginBottom: 5 }}>{label}</div>
+      <div style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 20, color: INK }}>{value}</div>
+    </div>
+  )
+}
+
+export default function AlbescentTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation('tasks')
+  const {
+    task,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    slotsOpen,
+    maxTaskSlots,
+    modifiedPoints,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state
+
+  if (!task) return null
+
+  const correspondenceNo = String(task.id).padStart(4, '0')
+  const topId = submissions.length
+    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
+    : null
+
+  return (
+    <div className="py-4" style={{ fontFamily: MONO, color: INK, background: PAGE, marginLeft: -16, marginRight: -16, paddingLeft: 16, paddingRight: 16 }}>
+      {/* Breadcrumb */}
+      <nav className="mb-3" style={{ fontFamily: MONO, fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color: ink(38) }}>
+        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>
+          {t('default.breadcrumb')}
+        </Link>
+        <span aria-hidden style={{ margin: '0 6px', opacity: 0.5 }}>/</span>
+        <span style={{ color: ink(60) }}>{task.title}</span>
+      </nav>
+
+      {/* Hero — cotton sheet, centred */}
+      <div
+        style={{
+          background: SHEET,
+          border: `1px solid ${ink(10)}`,
+          boxShadow: '0 2px 24px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)',
+          padding: '34px 26px 30px',
+          textAlign: 'center',
+          marginBottom: 20,
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 16 }}>
+          <AlbescentMark size={38} />
+        </div>
+        <div style={{ ...kicker, letterSpacing: '0.32em', color: ink(45), marginBottom: 6 }}>{t('albescent.faction')}</div>
+        <div style={{ ...kicker, letterSpacing: '0.24em', color: ink(30), marginBottom: 20 }}>
+          {t('albescent.correspondence', { number: correspondenceNo })}
+        </div>
+        <div style={{ width: 48, height: 1, background: ink(12), margin: '0 auto 20px' }} />
+        <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 500, fontSize: 32, lineHeight: 1.16, color: INK, margin: '0 auto 20px', overflowWrap: 'anywhere' }}>
+          {task.title}
+        </h1>
+        <div style={{ width: 48, height: 1, background: ink(12), margin: '0 auto 22px' }} />
+        <div style={{ display: 'flex', justifyContent: 'center', gap: 26, flexWrap: 'wrap' }}>
+          <Stat label={t('albescent.stats.standing')} value={t('albescent.stats.standingValue', { level: task.level_required })} />
+          <Stat label={t('albescent.stats.worth')} value={t('albescent.stats.worthValue', { points: modifiedPoints })} />
+          <Stat label={t('albescent.stats.returned')} value={`${submissions.length}`} />
+        </div>
+      </div>
+
+      {/* The Ask — brief */}
+      <section style={{ marginBottom: 20 }}>
+        <SectionHead
+          title={t('albescent.askHeading')}
+          trailing={
+            <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 12, color: ink(45), whiteSpace: 'nowrap' }}>
+              {t('albescent.askGloss')}
+            </span>
+          }
+        />
+        <div style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: '18px 20px' }}>
+          <p style={{ fontFamily: FONT, fontSize: 16, lineHeight: 1.7, color: task.description ? ink(72) : ink(45), margin: 0, whiteSpace: 'pre-wrap' }}>
+            {task.description || t('albescent.askEmpty')}
+          </p>
+        </div>
+      </section>
+
+      {/* Inscribed in the Register — returned accounts */}
+      <section>
+        <SectionHead
+          title={t('albescent.registerHeading')}
+          trailing={
+            <div style={{ display: 'flex' }}>
+              {(['score', 'recent'] as const).map((sort) => {
+                const on = submissionSort === sort
+                return (
+                  <button
+                    key={sort}
+                    onClick={() => setSubmissionSort(sort)}
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: 8,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      padding: '5px 10px',
+                      background: on ? INK : 'transparent',
+                      color: on ? PAGE : ink(45),
+                      border: `1px solid ${on ? INK : ink(14)}`,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {sort === 'score' ? t('albescent.sort.mostWitnessed') : t('albescent.sort.recent')}
+                  </button>
+                )
+              })}
+            </div>
+          }
+        />
+        {sortedSubmissions.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: ink(45), margin: 0 }}>{t('albescent.empty')}</p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-5">
+              {sortedSubmissions.slice(0, 4).map((s) => (
+                <div key={s.id} style={{ position: 'relative', paddingTop: s.id === topId ? 16 : 0 }}>
+                  {s.id === topId && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: -4,
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        zIndex: 3,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        whiteSpace: 'nowrap',
+                        background: INK,
+                        color: PAGE,
+                        fontFamily: FONT,
+                        fontStyle: 'italic',
+                        fontSize: 12,
+                        letterSpacing: '0.04em',
+                        padding: '2px 12px',
+                      }}
+                    >
+                      <span aria-hidden style={{ fontSize: 12, lineHeight: 1 }}>⚜</span>
+                      {t('albescent.mostWitnessed')}
+                    </div>
+                  )}
+                  <PraxisCard praxis={s} />
+                </div>
+              ))}
+            </div>
+            {submissions.length > 4 && (
+              <div style={{ marginTop: 16 }}>
+                <Link
+                  to={`/praxes?task_id=${task.id}`}
+                  style={{ fontFamily: MONO, fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: ink(55), textDecoration: 'none', borderBottom: `1px solid ${ink(20)}`, paddingBottom: 2 }}
+                >
+                  {t('albescent.viewAll', { count: submissions.length })}
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Sticky action bar — Acknowledge */}
+      {canSignUp && (
+        <MobileStickyBar>
+          {signupError && (
+            <div style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)', padding: '8px 12px', background: ink(3), border: `1px solid ${ink(14)}` }}>
+              {signupError}
+            </div>
+          )}
+          <button
+            onClick={handleSignup}
+            style={{
+              width: '100%',
+              background: INK,
+              color: PAGE,
+              fontFamily: MONO,
+              fontSize: 12,
+              letterSpacing: '0.18em',
+              textTransform: 'uppercase',
+              padding: '14px 20px',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            {t('albescent.signup.cta', { points: modifiedPoints })}
+          </button>
+          <MobileStickyCaption color={ink(40)}>
+            {t('albescent.signup.meta', { open: slotsOpen, max: maxTaskSlots, level: task.level_required })}
+          </MobileStickyCaption>
+        </MobileStickyBar>
+      )}
+
+      {mySubmission && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: ink(65), flex: 1 }}>
+            {t('albescent.submitted.text')}
+          </span>
+          <Link
+            to={`/praxes/${mySubmission.id}/edit`}
+            style={{ fontFamily: MONO, fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase', padding: '10px 18px', background: INK, color: PAGE, textDecoration: 'none' }}
+          >
+            {t('albescent.submitted.edit')}
+          </Link>
+        </MobileStickyBar>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <button
+            onClick={handleDrop}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: MONO, fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: ink(40) }}
+          >
+            {t('albescent.inProgress.drop')}
+          </button>
+          <Link
+            to={`/praxes/${inProgressPraxisId}/edit`}
+            style={{ marginLeft: 'auto', fontFamily: MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', padding: '12px 20px', background: INK, color: PAGE, textDecoration: 'none' }}
+          >
+            {t('albescent.inProgress.continue')}
+          </Link>
+        </MobileStickyBar>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/tasks/__tests__/albescentDispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/albescentDispatch.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Mobile task-browse Albescent dispatch (#528). The browse page dispatches on the
+ * VIEWING life's faction; this asserts an `albescent` viewer resolves to the
+ * Record's Ledger browse skin while every other viewer (and logged-out null)
+ * falls through to the Default mobile browse skin.
+ */
+import { describe, it, expect } from 'vitest'
+import { MOBILE_ARCHETYPE_BY_SLUG } from '../../Tasks'
+import { pickVariant } from '../../../utils/factionDispatch'
+import DefaultTasks from '../mobileArchetypes/DefaultTasks'
+import AlbescentTaskList from '../mobileArchetypes/AlbescentTaskList'
+
+describe('mobile task-browse Albescent dispatch', () => {
+  it('mobile + an Albescent viewer resolves to the bespoke Albescent browse skin', () => {
+    expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, 'albescent', DefaultTasks)).toBe(AlbescentTaskList)
+  })
+
+  it('mobile + any other viewer falls through to the Default browse skin', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_ARCHETYPE_BY_SLUG, slug, DefaultTasks)).toBe(DefaultTasks)
+    }
+  })
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/AlbescentTaskList.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/AlbescentTaskList.tsx
@@ -1,0 +1,225 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../../api/tasks'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import AlbescentMark from '../../../components/cards/AlbescentMark'
+import type { TasksState } from '../useTasks'
+
+/**
+ * Albescent MOBILE task-browse skin (#528) — the Ledger on a phone. The same
+ * scannable single-column list + touch-native filter chip rows as the Default
+ * browse skin (status / faction / level), dressed as quiet cotton entries: the
+ * surveyor's Mark, hairline borders, Cormorant italic, one hue of ink. Dispatched
+ * by the VIEWING life's faction (an Albescent keeper browsing tasks), so it
+ * consumes the shared `useTasks()` state verbatim — a chip tap mutates the same
+ * filter state that keys the read. Grounds on the `--faction-albescent-*` tokens;
+ * always-light.
+ */
+
+const INK = 'var(--faction-albescent-card-text)'
+const SHEET = 'var(--faction-albescent-card-bg)'
+const PAGE = 'var(--faction-albescent-page)'
+const FONT = 'var(--faction-albescent-card-font)'
+const MONO = 'var(--faction-albescent-mono)'
+/** A near-black ink wash at the given opacity — the whole palette is one hue. */
+const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
+
+const kicker: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 8,
+  letterSpacing: '0.28em',
+  textTransform: 'uppercase',
+  color: ink(30),
+}
+
+export default function AlbescentTaskList({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    tasks,
+    loading,
+    error,
+    factions,
+    statusFilters,
+    levelFilters,
+    status,
+    setStatus,
+    faction,
+    setFaction,
+    level,
+    setLevel,
+    displayPointsFor,
+  } = state
+
+  return (
+    <div data-skin="albescent" className="py-4" style={{ fontFamily: MONO, color: INK, background: PAGE }} data-testid="mobile-tasks-browse">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 2 }}>
+        <AlbescentMark size={22} />
+        <div style={kicker}>{t('albescent.masthead')}</div>
+      </div>
+      <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 30, lineHeight: 1.05, color: INK, margin: '4px 0 0' }}>
+        {tc('nav.tasks')}
+      </h1>
+      <div style={{ height: 1, margin: '9px 0 12px', background: ink(10) }} />
+      <p style={{ ...kicker, marginBottom: 12 }}>{t('mobile.count', { count: tasks.length })}</p>
+
+      <ChipRow label={tc('filters.status')}>
+        {statusFilters.map((option) => (
+          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
+            {option}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.faction')}>
+        <Chip on={faction === ''} onClick={() => setFaction('')}>
+          {t('mobile.allFactions')}
+        </Chip>
+        {sortFactionsByRainbowOrder(factions).map((f) => (
+          <Chip
+            key={f.slug}
+            on={faction === f.slug}
+            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
+            tint={factionCssVar(f.slug)}
+          >
+            {factionName(f.slug)}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <ChipRow label={tc('filters.level')}>
+        <Chip on={level === ''} onClick={() => setLevel('')}>
+          {t('mobile.anyLevel')}
+        </Chip>
+        {levelFilters.map((lvl) => (
+          <Chip key={lvl} on={level === lvl} onClick={() => setLevel(level === lvl ? '' : lvl)}>
+            {tc('filters.levelAtLeast', { level: lvl })}
+          </Chip>
+        ))}
+      </ChipRow>
+
+      <div className="mt-4">
+        {loading ? (
+          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: ink(45) }}>{t('listPage.loading')}</p>
+        ) : error ? (
+          <p style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)', border: `1px solid ${ink(14)}`, padding: '8px 12px' }}>
+            {t('mobile.loadError')}
+          </p>
+        ) : tasks.length === 0 ? (
+          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: ink(45) }}>{t('listPage.empty')}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {tasks.map((task) => (
+              <EntryPlate key={task.id} task={task} points={displayPointsFor(task)} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChipRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <span style={{ ...kicker, flex: 'none' }}>{label}</span>
+      <div className="flex gap-2" style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  on,
+  onClick,
+  tint,
+  children,
+}: {
+  on: boolean
+  onClick: () => void
+  tint?: string
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontFamily: MONO,
+        fontSize: 9,
+        letterSpacing: '0.1em',
+        textTransform: 'uppercase',
+        color: on ? PAGE : ink(45),
+        background: on ? INK : SHEET,
+        border: `1px solid ${on ? INK : ink(14)}`,
+        borderRadius: 0,
+        padding: '8px 14px',
+        minHeight: 36,
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      }}
+    >
+      {tint && <i style={{ width: 8, height: 8, borderRadius: '50%', flex: 'none', background: tint }} />}
+      {children}
+    </button>
+  )
+}
+
+function EntryPlate({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  return (
+    <Link
+      to={`/tasks/${task.id}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        padding: '16px 18px',
+        background: SHEET,
+        border: `1px solid ${ink(10)}`,
+        boxShadow: '0 2px 18px rgba(0,0,0,0.045), 0 1px 3px rgba(0,0,0,0.04)',
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+        <AlbescentMark size={16} opacity={0.75} />
+        <i style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.22em', textTransform: 'uppercase', color: ink(24), fontStyle: 'normal' }}>
+          {factionName(task.primary_faction_slug)}
+        </i>
+      </span>
+
+      <h2 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 19, lineHeight: 1.28, color: INK, margin: 0, overflowWrap: 'anywhere' }}>
+        {task.title}
+      </h2>
+
+      {task.description && (
+        <p
+          style={{
+            fontFamily: MONO,
+            fontSize: 10,
+            lineHeight: 1.6,
+            color: ink(42),
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {task.description}
+        </p>
+      )}
+
+      <div className="flex items-center justify-between" style={{ marginTop: 2, borderTop: `1px solid ${ink(7)}`, paddingTop: 10 }}>
+        <span style={{ ...kicker, letterSpacing: '0.2em', color: ink(24) }}>{t('mobile.level', { level: task.level_required })}</span>
+        <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 16, color: ink(55) }}>{t('mobile.points', { points })}</span>
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
Closes #528

## What

Registers a bespoke **Albescent** ("The Record") mobile skin across all **six** form-factor-dispatched surfaces, mirroring the merged UA treatment (#525). Each skin is a presentation-only archetype over the same hook/state as the Default skin, added under the `albescent` key of that surface's mobile `MOBILE_ARCHETYPE_BY_SLUG` registry (existing keys left untouched).

| Surface | New skin |
|---|---|
| Home (`FieldDesk`) | `fieldDesk/mobileArchetypes/AlbescentHome` |
| Tasks browse (`Tasks`) | `tasks/mobileArchetypes/AlbescentTaskList` |
| Task detail (`TaskDetail`) | `taskDetail/mobileArchetypes/AlbescentTaskDetail` |
| Praxis detail (`PraxisDetail`) | `praxisDetail/mobileArchetypes/AlbescentPraxisDetail` |
| Composer (`EditPraxis`) | `editPraxis/mobileArchetypes/AlbescentComposer` |
| Faction page (`FactionDetail`) | `factionDetail/mobileArchetypes/AlbescentFactionPage` |

## Idiom

Hushed vellum — the surveyor's Mark (concentric cross-hair `AlbescentMark`), hairline rules, Cormorant Garamond italic display, one hue of near-black ink via `color-mix` washes (no colour, no hex), witness circles. Always-light: grounds on the `--faction-albescent-*` tokens already in `index.css`; never mutates `[data-theme]`. Single-column, no fixed-px layout grids. Design corrections applied (points stamp, no difficulty dots / slots). Albescent is a first-class "The Record" skin — no `albescent → ua` alias reintroduced.

## Copy

New strings added under existing `albescent.*` catalogs in `common.json`, `factions.json`, `tasks.json`, `praxis.json`, `forms.json`. No raw strings (ADR-0032).

## Verification (worktree, via node_modules junction)

- `npx tsc --noEmit` — **0 new errors**. The 12 remaining are pre-existing on `origin/main` (all in `components/AlbescentInvitation.tsx`, from a duplicate `invitation` JSON key — unrelated to this change; confirmed by stashing to a clean baseline).
- `npx eslint` on all changed files — **clean**.
- `npx vitest run` — **411 passed / 62 files**. Includes the six new per-surface `albescent` dispatch tests and the existing registry-walking slot invariants (which now render the Albescent skins too).

No backend / API / hook change. Other factions + desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
