### PR TITLE
Fix desktop sidebar era display, add all-time score stat

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -8,7 +8,6 @@ import { factionCssVar, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
 import type { PraxisType } from '../../api/praxis'
-import { useMyCharacterStats } from '../../hooks/useMyCharacterStats'
 import { usePendingRequests } from '../../hooks/usePendingRequests'
 import { useRespondToRequest } from '../../hooks/useRespondToRequest'
 import { useGameConfig } from '../../hooks/useGameConfig'
@@ -60,7 +59,6 @@ export default function Sidebar() {
   const character = user?.character
 
   const { activeTasks, refetch: refetchActiveTasks } = useMyActiveTasks()
-  const { votesReceived } = useMyCharacterStats(character?.id)
   const { pendingRequests, refetch: refetchPendingRequests } = usePendingRequests()
   const gameConfig = useGameConfig()
   const [globalActivity, setGlobalActivity] = useState<ActivityFeedItem[]>([])
@@ -172,8 +170,8 @@ export default function Sidebar() {
           <div className="grid grid-cols-3 gap-2">
             {[
               { label: t('sidebar.stats.score'), value: character.score?.toLocaleString() ?? '0' },
-              { label: t('sidebar.stats.votes'), value: votesReceived.toLocaleString() },
-              { label: t('sidebar.stats.current'), value: t('sidebar.stats.currentValue') },
+              { label: t('sidebar.stats.allTime'), value: character.all_time_score?.toLocaleString() ?? '0' },
+              { label: t('sidebar.stats.current'), value: user?.era_name ?? '' },
             ].map((stat) => (
               <div
                 key={stat.label}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -260,9 +260,8 @@
     },
     "stats": {
       "score": "Score",
-      "votes": "Votes",
-      "current": "Current",
-      "currentValue": "Era 3"
+      "allTime": "All-Time",
+      "current": "Current"
     },
     "pendingRequests": {
       "heading_one": "Pending Requests · {{count}}",


### PR DESCRIPTION
## Summary
- The desktop sidebar's "Current" stat was a hardcoded i18n placeholder (`sidebar.stats.currentValue` = literal "Era 3") that never read from the backend. It now reads `user.era_name`, matching the pattern already used by the mobile FieldDesk home (`useFieldDeskHome.ts`).
- Swapped the sidebar's "Votes" stat for an all-time score stat (`character.all_time_score`), the same field the Leaderboard's era/all-time toggle already reads. Removed the now-unused `useMyCharacterStats` hook call/import and the dead `votes`/`currentValue` i18n keys from this file's scope.

## Test plan
- [x] `node -e "JSON.parse(...)"` — `common.json` still valid after key edits
- [x] `tsc --noEmit` — same 13 pre-existing, unrelated errors before/after; none in `Sidebar.tsx`
- [x] Grepped for other references to the removed `sidebar.stats.votes` / `sidebar.stats.currentValue` keys — none found
- [ ] Live browser check of the rendered sidebar — not possible in this sandbox (no Docker/Postgres available to log in); worth a manual look before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)