### PR TITLE
Add --space-* token scale + migrate 3 components off the raw-style ratchet (#579)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -95,7 +95,13 @@ Use `factionCssVar(slug, 'card-font')` in components. Never hardcode the font fa
 
 **Type scale** is defined as CSS variables (`--text-xs` through `--text-4xl`). Use the variable names, not raw pixel values.
 
+**Content-text floor:** real content — titles, scores, body copy — uses `--text-2xl` (18px) or larger. The smaller tokens (`--text-xs`–`--text-xl`, 8–14px) are reserved for labels, eyebrows, and badges only. Don't render readable content below `--text-2xl`.
+
 **Eyebrow / label text:** Courier Prime, `--text-sm` (9px), uppercase, letter-spacing 0.15em, `var(--color-text-tertiary)`. Use the `.eyebrow` class.
+
+**Spacing scale** is defined as CSS variables `--space-xs` (4px), `--space-sm` (8px), `--space-md` (12px), `--space-lg` (16px), `--space-xl` (24px), `--space-2xl` (32px) — same shape as `--radius-*`. Use these token names for `padding` / `margin` / `gap`, never raw pixel values. The scale is global and theme-independent; faction identity comes from font, colour, and ornament, never from a bespoke size or spacing.
+
+Both rules (type scale + spacing scale) are enforced by the `no-raw-style-values` ESLint rule, with existing violations grandfathered into a shrinking exemption list (`frontend/.eslint-legacy-raw-styles.txt`).
 
 ---
 

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -12,7 +12,6 @@ src/components/cards/EverymenTaskCard.tsx
 src/components/cards/FactionCard.tsx
 src/components/cards/FactionSelectCard.tsx
 src/components/cards/SingularityFactionHero.tsx
-src/components/cards/SingularityTaskCard.tsx
 src/components/cards/SnideFactionHero.tsx
 src/components/cards/SnideMasthead.tsx
 src/components/cards/SNIDETaskCard.tsx

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -55,8 +55,6 @@ src/components/layout/MobileTabBar.tsx
 src/components/LevelUpPopup.tsx
 src/components/MediaGallery.tsx
 src/components/NavBar.tsx
-src/components/PraxisCard.tsx
-src/components/praxisCard/shared.tsx
 src/components/snide/snideAtoms.tsx
 src/components/TaskCard.tsx
 src/components/ui/FilterFactionTabs.tsx

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -52,7 +52,6 @@ src/components/imageEdit/ImageEditModal.tsx
 src/components/InvitationLetterPopup.tsx
 src/components/layout/MobileLayout.tsx
 src/components/layout/MobileTabBar.tsx
-src/components/layout/Sidebar.tsx
 src/components/LevelUpPopup.tsx
 src/components/MediaGallery.tsx
 src/components/NavBar.tsx

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -87,7 +87,7 @@ function PraxisBody({
           display: "flex",
           justifyContent: "space-between",
           alignItems: "flex-start",
-          gap: 10,
+          gap: "var(--space-md)",
         }}
       >
         <div style={{ flex: 1, minWidth: 0 }}>
@@ -102,7 +102,7 @@ function PraxisBody({
           showCrown={showCrown}
         />
       </div>
-      <PraxisStats praxis={praxis} style={{ color: muted, marginTop: 8 }} />
+      <PraxisStats praxis={praxis} style={{ color: muted, marginTop: "var(--space-sm)" }} />
       <PraxisByline praxis={praxis} style={{ color: muted }} />
     </>
   );
@@ -121,7 +121,7 @@ function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
     <div
       style={{
         ...frameBase,
-        padding: 5,
+        padding: "var(--space-xs)",
         background: "var(--ua-gilt)",
         boxShadow:
           "0 12px 26px color-mix(in srgb, var(--ua-ink) 22%, transparent), inset 0 0 0 1px color-mix(in srgb, white 45%, transparent)",
@@ -132,7 +132,7 @@ function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
           position: "relative",
           background: factionCssVar("ua", "card-bg"),
           border: "1px solid color-mix(in srgb, var(--ua-ink) 30%, transparent)",
-          padding: "16px 17px 14px",
+          padding: "var(--space-lg)",
           fontFamily: "'EB Garamond', serif",
           color: factionCssVar("ua", "card-text"),
           backgroundImage:
@@ -143,11 +143,11 @@ function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         <div
           style={{
             fontFamily: "'Marcellus SC', serif",
-            fontSize: 8,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.12em",
             textTransform: "uppercase",
             color: factionCssVar("ua", "card-accent"),
-            marginBottom: 6,
+            marginBottom: "var(--space-sm)",
           }}
         >
           {t("card.masthead.ua")}
@@ -176,7 +176,7 @@ function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         clipPath:
           "polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)",
         position: "relative",
-        padding: "14px 16px 28px 28px",
+        padding: "var(--space-lg) var(--space-lg) var(--space-2xl) var(--space-2xl)",
         fontFamily: "'Special Elite', serif",
         color: factionCssVar("everymen", "card-text"),
         backgroundImage:
@@ -247,7 +247,7 @@ function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
           background: factionCssVar("wow", "card-bg"),
           border: "1.5px solid rgba(0,0,0,0.12)",
           transform: "rotate(-2deg)",
-          padding: "22px 14px 16px",
+          padding: "var(--space-xl) var(--space-lg) var(--space-lg)",
           fontFamily: "'Courier Prime', monospace",
           color: factionCssVar("wow", "card-text"),
           zIndex: 2,
@@ -291,7 +291,7 @@ function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         ...frameBase,
         background: factionCssVar("snide", "card-bg"),
         position: "relative",
-        padding: "14px 14px 16px",
+        padding: "var(--space-lg)",
         fontFamily: "'Special Elite', serif",
         color: factionCssVar("snide", "card-text"),
         transition: "background 150ms, color 150ms",
@@ -361,8 +361,8 @@ function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
           zIndex: 2,
           display: "flex",
           alignItems: "center",
-          gap: 8,
-          padding: "7px 14px 6px",
+          gap: "var(--space-sm)",
+          padding: "var(--space-sm) var(--space-lg) var(--space-sm)",
           borderBottom: "1px solid var(--eph-gold-deep)",
           boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)",
         }}
@@ -371,7 +371,7 @@ function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
         <span
           style={{
             fontFamily: "var(--eph-serif)",
-            fontSize: 8.5,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.18em",
             textTransform: "uppercase",
             color: "var(--eph-rubric)",
@@ -380,7 +380,7 @@ function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
           {t("card.masthead.ephemerists")}
         </span>
       </div>
-      <div style={{ position: "relative", zIndex: 2, padding: "10px 14px 14px" }}>
+      <div style={{ position: "relative", zIndex: 2, padding: "var(--space-md) var(--space-lg) var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
@@ -401,8 +401,8 @@ function SingularityHoles() {
       style={{
         display: "flex",
         justifyContent: "center",
-        gap: 6,
-        padding: "4px 0",
+        gap: "var(--space-sm)",
+        padding: "var(--space-xs) 0",
       }}
     >
       {Array.from({ length: 5 }).map((_, index) => (
@@ -492,15 +492,15 @@ function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
       />
       <SingularityHoles />
       <div
-        style={{ padding: "6px 16px 12px", position: "relative", zIndex: 2 }}
+        style={{ padding: "var(--space-sm) var(--space-lg) var(--space-md)", position: "relative", zIndex: 2 }}
       >
         <div
           style={{
-            fontSize: 8,
+            fontSize: "var(--text-xs)",
             color: "var(--faction-singularity-card-muted)",
             textTransform: "uppercase",
             letterSpacing: "0.15em",
-            marginBottom: 8,
+            marginBottom: "var(--space-sm)",
           }}
         >
           {t("card.masthead.singularity")}
@@ -510,7 +510,7 @@ function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
               width: 5,
               height: 9,
               background: "var(--faction-singularity-card-text)",
-              marginLeft: 3,
+              marginLeft: "var(--space-xs)",
               verticalAlign: "middle",
               animation: "blink 1s step-end infinite",
             }}
@@ -573,8 +573,8 @@ function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
           position: "relative",
           display: "flex",
           alignItems: "center",
-          gap: 8,
-          padding: "9px 15px 7px",
+          gap: "var(--space-sm)",
+          padding: "var(--space-sm) var(--space-lg) var(--space-sm)",
           borderBottom: `1px solid ${ink(7)}`,
         }}
       >
@@ -582,7 +582,7 @@ function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
         <span
           style={{
             fontFamily: "var(--faction-albescent-mono)",
-            fontSize: 8,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.22em",
             textTransform: "uppercase",
             color: ink(30),
@@ -591,7 +591,7 @@ function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
           {t("card.masthead.albescent")}
         </span>
       </div>
-      <div style={{ position: "relative", padding: "12px 15px 14px" }}>
+      <div style={{ position: "relative", padding: "var(--space-md) var(--space-lg) var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
@@ -626,7 +626,7 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
       style={{
         ...frameBase,
         borderRadius: 10,
-        padding: 5,
+        padding: "var(--space-xs)",
         background: "var(--faction-default-rainbow)",
         boxShadow: "0 12px 26px -14px rgba(0,0,0,0.4)",
       }}
@@ -637,17 +637,17 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
           background: "var(--faction-default-card-bg)",
           color: "var(--faction-default-card-text)",
           borderRadius: 5,
-          padding: "14px 16px",
+          padding: "var(--space-lg)",
         }}
       >
         <div
           style={{
             display: "flex",
             alignItems: "center",
-            gap: 8,
-            marginBottom: 10,
+            gap: "var(--space-sm)",
+            marginBottom: "var(--space-md)",
             fontFamily: "'Courier Prime', monospace",
-            fontSize: 8.5,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.22em",
             textTransform: "uppercase",
             color: "var(--faction-default-card-muted)",

--- a/frontend/src/components/cards/SingularityTaskCard.tsx
+++ b/frontend/src/components/cards/SingularityTaskCard.tsx
@@ -25,8 +25,8 @@ function SprocketHoles() {
       style={{
         display: "flex",
         justifyContent: "center",
-        gap: 6,
-        padding: "4px 0",
+        gap: "var(--space-sm)",
+        padding: "var(--space-xs) 0",
       }}
     >
       {Array.from({ length: 5 }).map((_, index) => (
@@ -125,15 +125,21 @@ export default function SingularityTaskCard({
 
       <SprocketHoles />
 
-      <div style={{ padding: "4px 12px 8px", position: "relative", zIndex: 2 }}>
+      <div
+        style={{
+          padding: "var(--space-xs) var(--space-md) var(--space-sm)",
+          position: "relative",
+          zIndex: 2,
+        }}
+      >
         {/* Header */}
         <div
           style={{
-            fontSize: 7,
+            fontSize: "var(--text-xs)",
             color: "var(--faction-singularity-card-muted)",
             textTransform: "uppercase",
             letterSpacing: "0.15em",
-            marginBottom: 6,
+            marginBottom: "var(--space-sm)",
           }}
         >
           {i18n.t("feed:identity.singularity.protocol")}
@@ -143,7 +149,7 @@ export default function SingularityTaskCard({
               width: 5,
               height: 9,
               background: "var(--faction-singularity-card-text)",
-              marginLeft: 3,
+              marginLeft: "var(--space-xs)",
               verticalAlign: "middle",
               animation: "blink 1s step-end infinite",
             }}
@@ -156,8 +162,8 @@ export default function SingularityTaskCard({
         >
           <div
             style={{
-              fontSize: "var(--text-sm)",
-              marginBottom: 6,
+              fontSize: "var(--text-2xl)",
+              marginBottom: "var(--space-sm)",
               lineHeight: 1.3,
               overflowWrap: "anywhere",
             }}
@@ -172,7 +178,7 @@ export default function SingularityTaskCard({
             fontSize: "var(--text-xs)",
             color: "var(--faction-singularity-card-muted)",
             lineHeight: 1.6,
-            marginBottom: 6,
+            marginBottom: "var(--space-sm)",
           }}
         >
           <div>
@@ -180,7 +186,7 @@ export default function SingularityTaskCard({
             <span
               style={{
                 color: "var(--faction-singularity-card-text)",
-                fontSize: "var(--text-md)",
+                fontSize: "var(--text-2xl)",
                 fontWeight: 700,
               }}
             >
@@ -197,10 +203,10 @@ export default function SingularityTaskCard({
         {task.description && (
           <div
             style={{
-              fontSize: 7,
+              fontSize: "var(--text-xs)",
               color: "var(--faction-singularity-card-muted)",
               lineHeight: 1.4,
-              marginBottom: 6,
+              marginBottom: "var(--space-sm)",
               overflow: "hidden",
               display: "-webkit-box",
               WebkitLineClamp: 2,
@@ -219,12 +225,12 @@ export default function SingularityTaskCard({
               color: "var(--faction-singularity-card-text)",
               border: "1px solid var(--faction-singularity-card-text)",
               fontFamily: factionCssVar("singularity", "card-font"),
-              fontSize: 7,
+              fontSize: "var(--text-xs)",
               textTransform: "uppercase",
               letterSpacing: "0.1em",
-              padding: "2px 8px",
+              padding: "var(--space-xs) var(--space-sm)",
               cursor: "pointer",
-              marginBottom: 4,
+              marginBottom: "var(--space-xs)",
             }}
           >
             {">"} {i18n.t("feed:taskCard.singularity.signup")}
@@ -236,15 +242,15 @@ export default function SingularityTaskCard({
             display: "flex",
             justifyContent: "flex-end",
             borderTop: "1px solid var(--faction-singularity-border-hard)",
-            paddingTop: 5,
+            paddingTop: "var(--space-xs)",
           }}
         >
           <span
             style={{
               border: "1px solid var(--faction-singularity-card-text)",
               color: "var(--faction-singularity-card-text)",
-              fontSize: 7,
-              padding: "1px 6px",
+              fontSize: "var(--text-xs)",
+              padding: "var(--space-xs) var(--space-sm)",
               borderRadius: 6,
               textTransform: "uppercase",
             }}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -21,12 +21,12 @@ const panelStyle: CSSProperties = {
   background: 'var(--color-bg-surface)',
   border: '1px solid var(--color-border)',
   borderRadius: 'var(--radius-xl)',
-  padding: 18,
+  padding: 'var(--space-lg)',
 }
 
 const sectionLabel: CSSProperties = {
   fontFamily: 'var(--font-body)',
-  fontSize: 10,
+  fontSize: 'var(--text-base)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: 'var(--color-text-secondary)',
@@ -105,13 +105,13 @@ export default function Sidebar() {
               className="hover:opacity-80"
               style={{
                 fontFamily: 'var(--font-body)',
-                fontSize: 10,
+                fontSize: 'var(--text-base)',
                 letterSpacing: '0.16em',
                 textTransform: 'uppercase',
                 color: 'var(--faction-default-card-muted)',
                 textDecoration: 'none',
                 borderBottom: '1px solid var(--color-border-strong)',
-                paddingBottom: 1,
+                paddingBottom: 'var(--space-xs)',
               }}
             >
               {t('sidebar.characterCard.edit')}
@@ -122,7 +122,7 @@ export default function Sidebar() {
             {/* avatar in a rainbow ring (unaffiliated / all-paths mark) */}
             <div
               className="shrink-0 rounded-full"
-              style={{ width: 58, height: 58, padding: 3, background: 'var(--faction-default-ring)' }}
+              style={{ width: 58, height: 58, padding: 'var(--space-xs)', background: 'var(--faction-default-ring)' }}
             >
               {character.avatar_url ? (
                 <img
@@ -144,16 +144,16 @@ export default function Sidebar() {
               <Link
                 to={`/characters/${character.id}`}
                 className="font-display italic block truncate"
-                style={{ fontSize: 24, lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                style={{ fontSize: 'var(--text-3xl)', lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
               >
                 {character.display_name}
               </Link>
               <div
                 className="truncate"
                 style={{
-                  marginTop: 5,
+                  marginTop: 'var(--space-xs)',
                   fontFamily: 'var(--font-body)',
-                  fontSize: 10,
+                  fontSize: 'var(--text-base)',
                   letterSpacing: '0.16em',
                   textTransform: 'uppercase',
                   color: 'var(--color-text-secondary)',
@@ -180,17 +180,17 @@ export default function Sidebar() {
                   background: 'var(--color-bg-surface)',
                   border: '1px solid var(--color-border)',
                   borderRadius: 9,
-                  padding: '11px 8px',
+                  padding: 'var(--space-md) var(--space-sm)',
                 }}
               >
-                <div className="font-display" style={{ fontSize: 22, lineHeight: 1, color: 'var(--color-text-primary)' }}>
+                <div className="font-display" style={{ fontSize: 'var(--text-2xl)', lineHeight: 1, color: 'var(--color-text-primary)' }}>
                   {stat.value}
                 </div>
                 <div
                   style={{
-                    marginTop: 6,
+                    marginTop: 'var(--space-sm)',
                     fontFamily: 'var(--font-body)',
-                    fontSize: 8,
+                    fontSize: 'var(--text-xs)',
                     letterSpacing: '0.2em',
                     textTransform: 'uppercase',
                     color: 'var(--color-text-secondary)',
@@ -245,7 +245,7 @@ export default function Sidebar() {
                 <Link
                   to={`/praxes/${praxis.id}/edit`}
                   className="font-display min-w-0"
-                  style={{ fontSize: 17, lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                  style={{ fontSize: 'var(--text-2xl)', lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
                 >
                   {praxis.task_title}
                 </Link>
@@ -253,11 +253,11 @@ export default function Sidebar() {
                   className="shrink-0"
                   style={{
                     fontFamily: 'var(--font-body)',
-                    fontSize: 9,
+                    fontSize: 'var(--text-sm)',
                     letterSpacing: '0.16em',
                     textTransform: 'uppercase',
                     color: 'var(--faction-default-card-muted)',
-                    padding: '4px 9px',
+                    padding: 'var(--space-xs) var(--space-sm)',
                     border: '1px solid var(--color-border-strong)',
                     borderRadius: 999,
                   }}
@@ -286,7 +286,7 @@ export default function Sidebar() {
           </div>
           <p
             className="font-body text-right"
-            style={{ fontSize: 10, letterSpacing: '0.08em', color: 'var(--color-text-secondary)', marginTop: 8 }}
+            style={{ fontSize: 'var(--text-base)', letterSpacing: '0.08em', color: 'var(--color-text-secondary)', marginTop: 'var(--space-sm)' }}
           >
             {t('sidebar.activeTasks.slots', { count: slotCount, max: maxTaskSlots })}
           </p>
@@ -319,7 +319,7 @@ export default function Sidebar() {
                   ? t('sidebar.globalActivity.kickerNewTask')
                   : item.actor_display_name
               const titleStyle: CSSProperties = {
-                fontSize: 14,
+                fontSize: 'var(--text-2xl)',
                 lineHeight: 1.3,
                 color: 'var(--color-text-primary)',
                 textDecoration: 'none',
@@ -329,7 +329,7 @@ export default function Sidebar() {
                   key={`${item.type}-${index}`}
                   className="flex gap-3"
                   style={{
-                    padding: '13px 0',
+                    padding: 'var(--space-md) 0',
                     borderBottom: isLast ? undefined : '1px solid var(--color-border)',
                   }}
                 >
@@ -339,7 +339,7 @@ export default function Sidebar() {
                     style={{
                       width: 6,
                       height: 6,
-                      marginTop: 5,
+                      marginTop: 'var(--space-xs)',
                       borderRadius: 2,
                       background: 'var(--faction-default-rainbow)',
                       backgroundSize: '600% 100%',
@@ -350,11 +350,11 @@ export default function Sidebar() {
                     <div
                       style={{
                         fontFamily: 'var(--font-body)',
-                        fontSize: 9,
+                        fontSize: 'var(--text-sm)',
                         letterSpacing: '0.18em',
                         textTransform: 'uppercase',
                         color: 'var(--color-text-secondary)',
-                        marginBottom: 3,
+                        marginBottom: 'var(--space-xs)',
                       }}
                     >
                       {kicker}
@@ -368,7 +368,7 @@ export default function Sidebar() {
                         {title}
                       </div>
                     )}
-                    <div className="font-body" style={{ marginTop: 3, fontSize: 10, color: 'var(--color-text-tertiary)' }}>
+                    <div className="font-body" style={{ marginTop: 'var(--space-xs)', fontSize: 'var(--text-base)', color: 'var(--color-text-tertiary)' }}>
                       {relativeTime(item.timestamp)}
                     </div>
                   </div>
@@ -385,9 +385,9 @@ export default function Sidebar() {
         className="font-display w-full flex items-center justify-center gap-2.5 hover:opacity-90"
         style={{
           boxSizing: 'border-box',
-          padding: 14,
+          padding: 'var(--space-lg)',
           borderRadius: 11,
-          fontSize: 14,
+          fontSize: 'var(--text-xl)',
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           color: 'var(--color-bg-page)',
@@ -396,7 +396,7 @@ export default function Sidebar() {
           textDecoration: 'none',
         }}
       >
-        <span style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+        <span style={{ fontSize: 'var(--text-xl)', lineHeight: 1 }}>+</span>
         <span>{t('actions.proposeTask')}</span>
       </Link>
     </aside>
@@ -405,11 +405,11 @@ export default function Sidebar() {
 
 const REQUEST_BUTTON_BASE: CSSProperties = {
   fontFamily: "'Courier Prime', monospace",
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   fontWeight: 700,
   textTransform: 'uppercase',
   letterSpacing: '0.08em',
-  padding: '3px 8px',
+  padding: 'var(--space-xs) var(--space-sm)',
 }
 
 /**
@@ -458,7 +458,7 @@ function PendingRequestRow({
           <Link
             to={`/characters/${actorId}`}
             className="font-body block truncate"
-            style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            style={{ fontSize: 'var(--text-base)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
           >
             {item.actor_display_name}
           </Link>
@@ -471,7 +471,7 @@ function PendingRequestRow({
           </Link>
         </div>
       </div>
-      <div className="flex items-center gap-1.5" style={{ marginTop: 4, marginLeft: 32 }}>
+      <div className="flex items-center gap-1.5" style={{ marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}>
         <button
           onClick={() => respond(accept)}
           disabled={loading}
@@ -502,7 +502,7 @@ function PendingRequestRow({
       {error && (
         <span
           className="eyebrow block"
-          style={{ color: 'var(--color-danger)', marginTop: 3, marginLeft: 32 }}
+          style={{ color: 'var(--color-danger)', marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}
         >
           {error}
         </span>

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -28,7 +28,7 @@ export function PraxisTitle({
     <Link to={`/praxes/${praxis.id}`}>
       <h3
         className="font-display font-semibold leading-tight hover:underline"
-        style={{ fontSize: "var(--text-lg)", marginBottom: 6, ...style }}
+        style={{ fontSize: "var(--text-2xl)", marginBottom: "var(--space-sm)", ...style }}
       >
         {praxis.title}
       </h3>
@@ -68,8 +68,8 @@ export function PraxisByline({
       className="flex justify-between items-center font-body"
       style={{
         fontSize: "var(--text-xs)",
-        marginTop: 8,
-        paddingTop: 6,
+        marginTop: "var(--space-sm)",
+        paddingTop: "var(--space-sm)",
         borderTop: "1px dashed rgba(128,128,128,0.3)",
         ...style,
       }}
@@ -130,7 +130,7 @@ export function PraxisScoreHero({
         justifyContent: "center",
         flexShrink: 0,
         minWidth: 54,
-        padding: "6px 10px",
+        padding: "var(--space-sm) var(--space-md)",
         border: `2px solid ${border ?? "currentColor"}`,
         borderRadius: 4,
         transform: "rotate(-3deg)",
@@ -149,17 +149,17 @@ export function PraxisScoreHero({
           style={{ position: "absolute", top: -13, right: -12, zIndex: 3 }}
         />
       )}
-      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)", whiteSpace: "nowrap" }}>
+      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-2xl)", whiteSpace: "nowrap" }}>
         {base}
-        <span style={{ opacity: 0.55, margin: "0 2px" }}>+</span>
+        <span style={{ opacity: 0.55, margin: "0 var(--space-xs)" }}>+</span>
         {votePoints}
       </span>
       <span
         style={{
-          fontSize: 7,
+          fontSize: "var(--text-xs)",
           letterSpacing: "0.16em",
           textTransform: "uppercase",
-          marginTop: 3,
+          marginTop: "var(--space-xs)",
           opacity: 0.8,
         }}
       >
@@ -234,8 +234,8 @@ export function AdminOverlay({
             position: "absolute",
             top: 8,
             right: 8,
-            fontSize: 7,
-            padding: "1px 5px",
+            fontSize: "var(--text-xs)",
+            padding: "var(--space-xs) var(--space-xs)",
             border: "1px solid rgba(220,38,38,0.4)",
             color: "var(--color-danger)",
             background: "rgba(220,38,38,0.05)",
@@ -251,8 +251,8 @@ export function AdminOverlay({
             position: "absolute",
             top: 8,
             right: 8,
-            fontSize: 7,
-            padding: "1px 5px",
+            fontSize: "var(--text-xs)",
+            padding: "var(--space-xs) var(--space-xs)",
             border: "1px solid rgba(245,158,11,0.4)",
             color: "var(--color-warning)",
             background: "rgba(245,158,11,0.05)",
@@ -268,8 +268,8 @@ export function AdminOverlay({
             position: "absolute",
             top: 8,
             right: 8,
-            fontSize: 7,
-            padding: "1px 5px",
+            fontSize: "var(--text-xs)",
+            padding: "var(--space-xs) var(--space-xs)",
             border: "1px solid rgba(107,114,128,0.4)",
             color: "var(--color-text-secondary)",
             background: "rgba(107,114,128,0.05)",
@@ -284,7 +284,7 @@ export function AdminOverlay({
           style={{
             fontSize: "var(--text-xs)",
             color: "var(--color-danger)",
-            marginBottom: 4,
+            marginBottom: "var(--space-xs)",
           }}
         >
           {moderateError}
@@ -297,15 +297,15 @@ export function AdminOverlay({
             top: 8,
             right: 8,
             display: "flex",
-            gap: 4,
+            gap: "var(--space-xs)",
           }}
         >
           <button
             onClick={onHide}
             className="eyebrow"
             style={{
-              fontSize: 7,
-              padding: "1px 5px",
+              fontSize: "var(--text-xs)",
+              padding: "var(--space-xs) var(--space-xs)",
               border: "1px solid rgba(220,38,38,0.3)",
               color: "var(--color-danger)",
               background: "rgba(220,38,38,0.05)",
@@ -318,8 +318,8 @@ export function AdminOverlay({
             onClick={onFail}
             className="eyebrow"
             style={{
-              fontSize: 7,
-              padding: "1px 5px",
+              fontSize: "var(--text-xs)",
+              padding: "var(--space-xs) var(--space-xs)",
               border: "1px solid rgba(245,158,11,0.3)",
               color: "var(--color-warning)",
               background: "rgba(245,158,11,0.05)",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -278,6 +278,16 @@
   --radius-lg: 12px;
   --radius-xl: 14px;
 
+  /* Spacing scale for padding/margin/gap. Global (never per-faction) and
+     theme-independent, same as --radius-* and --text-* — a faction picks a font
+     and colour, not a new scale (SPEC-faction-ui-profile.md). */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+  --space-2xl: 32px;
+
   /* ── Filter stamp dashed-border (inverts with active state bg) ── */
   --stamp-active-dashed: rgba(255, 255, 255, 0.2);
   --stamp-inactive-dashed: rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
Implements issue #579 commits 1–6. **Stacked on #582** (base branch `claude/dedupe-praxiscard-frame-582`); GitHub auto-retargets to `main` when #582 merges.

## Commits

1. **`--space-*` tokens** — `--space-xs..2xl` (4/8/12/16/24/32) added to `index.css` next to `--radius-*`. Sizes are global and theme-independent, so defined once in `:root` (the `--radius-*`/`--text-*` precedent), not duplicated under `[data-theme=dark]`.
2. **Docs** — `WORLD_ZERO_STYLE.md`: content-text floor (`--text-2xl` for titles/scores/body; `--text-xs`–`--text-xl` for labels) + a Spacing-scale section.
3. **ESLint rule — already landed by #588.** The `no-raw-style-values` rule (fontSize/padding/margin/gap) + the `.eslint-legacy-raw-styles.txt` ratchet already exist on `main`, so commit 3 needs no new code. Noted here rather than re-adding it.
4. **SingularityTaskCard** — title + points → `--text-2xl`; eyebrow/description/button/badge → label-tier; spacing → `--space-*`. Off the exemption list.
5. **Sidebar** — off the exemption list.
6. **PraxisCard + praxisCard/shared** — off the exemption list. `badgeArt.tsx` was already token-clean (no raw values, not exempted) → no change.

## ⚠️ Needs visual spot-check (per the issue's own testing note)

Deliberate content-floor enlargements to eyeball before merge:
- Praxis-card **titles + score-hero number**: 12px → 18px, across all 8 faction cards (via the shared slots).
- **SingularityTaskCard** title/points → 18px (the reported 9px/7px fix).
- **Sidebar**: active-task title 17→18, global-activity title 14→18, display name 24→28.

Off-scale values were snapped to the nearest token (ties round up). Layout tightness from larger text is tracked separately as #577.

## Verification

- `npx eslint src` — clean (all four migrated files pass with no exemption)
- `npm run build` — green
- `npx vitest run` — 528 passed

Out of scope (per the issue): the remaining ~185 files drain incrementally; not touched here.

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
