### PR TITLE
Mobile bespoke per-faction praxis cards + widen PraxisCardOut (#573)

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -66,7 +66,7 @@ from services.praxis import (
 )
 from services.media import process_and_save_media
 from services.vote import cast_vote_on_praxis
-from services.vote_tally import crowned_praxis_ids
+from services.vote_tally import crowned_praxis_ids, viewer_votes_for
 
 logger = logging.getLogger(__name__)
 
@@ -122,8 +122,16 @@ async def list_praxes_route(
     )
     # Task Crown (ADR-0028): one windowed query for the whole page — not per card.
     crowned = await crowned_praxis_ids({praxis.task_id for praxis in praxes}, session)
+    # Viewer's own votes (#573): one batched query for the whole page — not per card.
+    viewer_votes = (
+        await viewer_votes_for({praxis.id for praxis in praxes}, viewer.id, session)
+        if viewer
+        else {}
+    )
     return [
-        await build_praxis_card_out(praxis, session, crowned_ids=crowned)
+        await build_praxis_card_out(
+            praxis, session, crowned_ids=crowned, viewer_votes=viewer_votes
+        )
         for praxis in praxes
     ]
 

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -97,6 +97,12 @@ class PraxisCardOut(BaseModel):
     voter_count: int = 0
     is_top_for_task: bool = False  # Task Crown: top submitted praxis for its task (ADR-0028)
     task_faction_slug: Optional[str] = None
+    # Full-fidelity fields for bespoke mobile praxis cards (#573).
+    body_text: Optional[str] = None
+    created_by_faction_slug: Optional[str] = None  # author's member faction; actor-scoped byline
+    members: List[PraxisMemberOut] = []
+    media_items: List[MediaItemOut] = []
+    viewer_vote: Optional[int] = None  # the authenticated viewer's own cast value (1-5), None if unvoted/anonymous
 
     model_config = {"from_attributes": True}
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -249,6 +249,7 @@ async def build_praxis_card_out(
     era: EraConfig = CURRENT_ERA,
     *,
     crowned_ids: Optional[set[int]] = None,
+    viewer_votes: Optional[dict[int, int]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
 
@@ -257,6 +258,11 @@ async def build_praxis_card_out(
     ``crowned_ids`` are the Task Crown holders (ADR-0028); list routes
     precompute them once via :func:`~services.vote_tally.crowned_praxis_ids`
     so the crown never becomes a per-card query.
+
+    ``viewer_votes`` maps praxis id → the viewer's own cast value (#573); list
+    routes precompute it once via :func:`~services.vote_tally.viewer_votes_for`
+    so the viewer's highlight never becomes a per-card query. ``None`` (anonymous
+    viewer) leaves ``viewer_vote`` unset.
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -292,6 +298,11 @@ async def build_praxis_card_out(
         voter_count=tally.voter_count,
         is_top_for_task=praxis.id in crowned_ids,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
+        body_text=praxis.body_text,
+        created_by_faction_slug=praxis.created_by.faction_slug if praxis.created_by else None,
+        members=[_build_member_out(m) for m in praxis.members],
+        media_items=[MediaItemOut.model_validate(item) for item in praxis.media_items],
+        viewer_vote=viewer_votes.get(praxis.id) if viewer_votes else None,
     )
 
 
@@ -423,6 +434,7 @@ async def list_praxes(
     if status is not None:
         query = query.where(Praxis.status == status)
 
+    query = query.options(selectinload(Praxis.media_items))
     query = query.order_by(Praxis.created_at.desc()).limit(limit).offset(offset)
     result = await session.execute(query)
     praxes = list(result.scalars().all())

--- a/backend/services/vote_tally.py
+++ b/backend/services/vote_tally.py
@@ -60,6 +60,21 @@ def get_tally(tallies: dict[int, VoteTally], praxis_id: int) -> VoteTally:
     return tallies.get(praxis_id, _EMPTY_TALLY)
 
 
+async def viewer_votes_for(
+    praxis_ids: Collection[int], viewer_character_id: int, session: AsyncSession,
+) -> dict[int, int]:
+    """This viewer's own cast value per praxis, one batched query (not per-card)."""
+    if not praxis_ids:
+        return {}
+    result = await session.execute(
+        select(Vote.praxis_id, Vote.value).where(
+            Vote.praxis_id.in_(praxis_ids),
+            Vote.voter_character_id == viewer_character_id,
+        )
+    )
+    return dict(result.all())
+
+
 async def crowned_praxis_ids(
     task_ids: Collection[int],
     session: AsyncSession,

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -2245,3 +2245,142 @@ async def test_change_type_takeover_clears_pending_publish_window(
     assert body["status"] == "in_progress"
     assert body["submit_proposed_at"] is None
     assert all(not m["has_submitted"] for m in body["members"])
+
+
+# ---------------------------------------------------------------------------
+# Full-fidelity card fields for mobile praxis cards (#573)
+# ---------------------------------------------------------------------------
+
+
+def _find_card(cards: list[dict], praxis_id: int) -> dict:
+    match = next((card for card in cards if card["id"] == praxis_id), None)
+    assert match is not None, f"praxis {praxis_id} missing from list"
+    return match
+
+
+@pytest.mark.asyncio
+async def test_card_out_includes_full_fidelity_fields(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """A /praxes list row carries body_text, created_by_faction_slug, and members (#573)."""
+    create_resp = await client.post(
+        "/praxes",
+        json={
+            "task_id": active_task.id,
+            "type": "solo",
+            "title": "Card Fidelity",
+            "body_text": "the full proof text",
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    # Read as the author-member so the in_progress praxis is visible (ADR-0024).
+    list_resp = await client.get(
+        "/praxes", params={"task_id": active_task.id}, headers=auth_headers
+    )
+    assert list_resp.status_code == 200
+    card = _find_card(list_resp.json(), praxis_id)
+
+    assert card["body_text"] == "the full proof text"
+    # character is seeded in the 'ua' faction by the conftest fixture.
+    assert card["created_by_faction_slug"] == "ua"
+    member_names = [m["character_display_name"] for m in card["members"]]
+    assert character.display_name in member_names
+    assert card["media_items"] == []
+
+
+@pytest.mark.asyncio
+async def test_card_out_viewer_vote_none_for_anonymous(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """viewer_vote is None on an anonymous (unauthenticated) list read (#573)."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Anon View"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+    # Submit so an anonymous viewer can see it (in_progress is member-only).
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+
+    list_resp = await client.get("/praxes", params={"task_id": active_task.id})
+    assert list_resp.status_code == 200
+    card = _find_card(list_resp.json(), praxis_id)
+    assert card["viewer_vote"] is None
+
+
+@pytest.mark.asyncio
+async def test_card_out_viewer_vote_none_when_not_voted(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """viewer_vote is None for an authenticated viewer who has not voted (#573)."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Not Voted"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+
+    # character reads the list but has cast no vote.
+    list_resp = await client.get(
+        "/praxes", params={"task_id": active_task.id}, headers=auth_headers
+    )
+    assert list_resp.status_code == 200
+    card = _find_card(list_resp.json(), praxis_id)
+    assert card["viewer_vote"] is None
+
+
+@pytest.mark.asyncio
+async def test_card_out_viewer_vote_reflects_cast_value(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """viewer_vote equals the viewer's own cast value once they have voted (#573)."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Voted Card"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+
+    # character casts a 3-star vote.
+    vote_resp = await client.post(
+        f"/praxes/{praxis_id}/vote", json={"value": 3}, headers=auth_headers
+    )
+    assert vote_resp.status_code == 200
+
+    # The voter sees their own value pre-highlighted...
+    voter_list = await client.get(
+        "/praxes", params={"task_id": active_task.id}, headers=auth_headers
+    )
+    assert voter_list.status_code == 200
+    assert _find_card(voter_list.json(), praxis_id)["viewer_vote"] == 3
+
+    # ...but the author (a different viewer, who did not vote) does not.
+    author_list = await client.get(
+        "/praxes", params={"task_id": active_task.id}, headers=auth_headers2
+    )
+    assert author_list.status_code == 200
+    assert _find_card(author_list.json(), praxis_id)["viewer_vote"] is None

--- a/backend/tests/unit/test_vote_tally.py
+++ b/backend/tests/unit/test_vote_tally.py
@@ -1,6 +1,8 @@
 """Unit tests for services.vote_tally — pure helpers only."""
 
-from services.vote_tally import VoteTally, get_tally
+import pytest
+
+from services.vote_tally import VoteTally, get_tally, viewer_votes_for
 
 
 def test_get_tally_returns_empty_when_missing():
@@ -22,3 +24,37 @@ def test_vote_tally_is_frozen():
         assert False, "Expected FrozenInstanceError"
     except Exception:
         pass  # frozen dataclasses raise FrozenInstanceError on mutation
+
+
+@pytest.mark.asyncio
+async def test_viewer_votes_for_empty_ids_short_circuits():
+    """Empty praxis_ids returns {} without touching the session (#573)."""
+
+    class _ExplodingSession:
+        async def execute(self, *args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("execute should not be called for empty ids")
+
+    result = await viewer_votes_for([], 1, _ExplodingSession())
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_viewer_votes_for_maps_praxis_to_value():
+    """Rows (praxis_id, value) map into a dict keyed by praxis id (#573)."""
+
+    class _FakeResult:
+        def all(self):
+            return [(10, 4), (11, 2)]
+
+    class _FakeSession:
+        def __init__(self):
+            self.captured = None
+
+        async def execute(self, statement):
+            self.captured = statement
+            return _FakeResult()
+
+    session = _FakeSession()
+    result = await viewer_votes_for([10, 11], 7, session)
+    assert result == {10: 4, 11: 2}
+    assert session.captured is not None  # a query was issued for non-empty ids

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -194,3 +194,12 @@ src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
 src/pages/tasks/mobileArchetypes/cards/WowMobileTaskCard.tsx
 src/pages/Updates.tsx
 src/pages/updates/MobileUpdates.tsx
+src/components/praxisCard/mobile/shared.tsx
+src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
+src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
+src/components/praxisCard/mobile/SnideMobilePraxisCard.tsx
+src/components/praxisCard/mobile/EphemeristsMobilePraxisCard.tsx
+src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
+src/components/praxisCard/mobile/EverymenMobilePraxisCard.tsx
+src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
+src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -102,6 +102,18 @@ export interface PraxisCardOut {
   /** Task Crown — top-scoring submitted praxis for its task (ADR-0028). */
   is_top_for_task: boolean
   task_faction_slug: string | null
+  // Full-fidelity fields for the bespoke mobile praxis cards (#573). The list
+  // schema now emits these; older callers simply ignore them.
+  /** Proof body excerpt — clamped to 1–2 lines in the mobile card. */
+  body_text?: string | null
+  /** Author's own member faction — drives the actor-scoped byline. */
+  created_by_faction_slug?: string | null
+  /** Crew roster (owner + collaborators); empty/absent on solo. */
+  members?: PraxisMemberOut[]
+  /** Attached proof media (images / video / audio). */
+  media_items?: MediaItemOut[]
+  /** The authenticated viewer's own cast value (1–5); null/absent if unvoted. */
+  viewer_vote?: number | null
 }
 
 export interface PraxisCreate {

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -186,8 +186,9 @@ function UACard({
 
 // ─── Warriors of Whimsy ".exe" window atoms ──────────────────────────────────────────────
 
-/** A small sparkle glyph used in the wow.exe title bar. */
-function WowSparkle({
+/** A small sparkle glyph used in the wow.exe title bar. Exported so the mobile
+ *  Warriors-of-Whimsy praxis card can reuse the mark (#573) without a new SVG. */
+export function WowSparkle({
   size = 10,
   color,
 }: {

--- a/frontend/src/components/praxisCard/__tests__/rosterNames.test.ts
+++ b/frontend/src/components/praxisCard/__tests__/rosterNames.test.ts
@@ -1,0 +1,41 @@
+/**
+ * rosterNames (#573/#587) — the shared crew-name cap helper. Returns every
+ * display name up to the cap plus the overflow count of the "+N more" tail.
+ */
+import { describe, it, expect } from 'vitest'
+import { rosterNames, ROSTER_NAME_CAP } from '../shared'
+
+const makeMembers = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({ display_name: `Player ${index + 1}` }))
+
+describe('rosterNames', () => {
+  it('returns every name and zero overflow at or below the cap', () => {
+    const members = makeMembers(3)
+    const { names, overflow } = rosterNames(members)
+    expect(names).toEqual(['Player 1', 'Player 2', 'Player 3'])
+    expect(overflow).toBe(0)
+  })
+
+  it('returns exactly the cap of names at the boundary', () => {
+    const { names, overflow } = rosterNames(makeMembers(ROSTER_NAME_CAP))
+    expect(names).toHaveLength(ROSTER_NAME_CAP)
+    expect(overflow).toBe(0)
+  })
+
+  it('caps names and counts the overflow above the cap', () => {
+    const { names, overflow } = rosterNames(makeMembers(ROSTER_NAME_CAP + 4))
+    expect(names).toHaveLength(ROSTER_NAME_CAP)
+    expect(overflow).toBe(4)
+  })
+
+  it('honours an explicit lower cap', () => {
+    const { names, overflow } = rosterNames(makeMembers(5), 2)
+    expect(names).toEqual(['Player 1', 'Player 2'])
+    expect(overflow).toBe(3)
+  })
+
+  it('coerces missing display names to empty strings', () => {
+    const { names } = rosterNames([{ display_name: null }, {}])
+    expect(names).toEqual(['', ''])
+  })
+})

--- a/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../../api/praxis'
+import AlbescentMark from '../../cards/AlbescentMark'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * Albescent MOBILE praxis card (#573) — a filed account in the Register: a pure
+ * cotton sheet, a hairline architectural inset, the surveyor's Mark and a quiet
+ * "Account · filed" running head, then Cormorant italic. First-class identity —
+ * the explicit dispatcher entry beats the albescent→ua alias. Reads its own
+ * --faction-albescent-* tokens directly (always-light, one hue of ink).
+ */
+const ink = (pct: number) => `color-mix(in srgb, var(--faction-albescent-card-text) ${pct}%, transparent)`
+
+export default function AlbescentMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const theme: MobileSlotTheme = {
+    ink: 'var(--faction-albescent-card-text)',
+    muted: ink(42),
+    accent: ink(55),
+    paper: 'var(--faction-albescent-card-bg)',
+    displayFont: 'var(--faction-albescent-card-font)',
+    bodyFont: 'var(--faction-albescent-mono)',
+    titleStyle: { fontStyle: 'italic', fontWeight: 300 },
+  }
+  return (
+    <div
+      style={{
+        position: 'relative',
+        background: 'var(--faction-albescent-card-bg)',
+        color: 'var(--faction-albescent-card-text)',
+        border: `1px solid ${ink(10)}`,
+        boxShadow: '0 2px 18px rgba(0,0,0,0.055), 0 1px 3px rgba(0,0,0,0.04)',
+        padding: '14px 16px',
+      }}
+    >
+      <div style={{ position: 'absolute', inset: 5, border: `1px solid ${ink(5)}`, pointerEvents: 'none' }} />
+      <div
+        style={{
+          position: 'relative',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginBottom: 12,
+          fontFamily: 'var(--faction-albescent-mono)',
+          fontSize: 9,
+          letterSpacing: '0.22em',
+          textTransform: 'uppercase',
+          color: ink(30),
+        }}
+      >
+        <AlbescentMark size={14} />
+        {t('card.masthead.albescent')}
+      </div>
+      <div style={{ position: 'relative' }}>
+        <MobilePraxisBody praxis={praxis} theme={theme} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../../api/praxis'
+import DefaultSigil from '../../cards/DefaultSigil'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * Default MOBILE praxis card (#573) — the spectrum fallback skin for `na` /
+ * unaffiliated proof and any task faction without a bespoke card. A clean sheet
+ * banded in the spectrum rainbow and marked with the seven-segment ring.
+ * Mirrors the desktop DefaultPraxisCard; --faction-default-* tokens, flips
+ * light/dark.
+ */
+export default function DefaultMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const theme: MobileSlotTheme = {
+    ink: 'var(--faction-default-card-text)',
+    muted: 'var(--faction-default-card-muted)',
+    accent: 'var(--faction-default-card-accent)',
+    paper: 'var(--faction-default-card-bg)',
+    displayFont: "'Courier Prime', monospace",
+    bodyFont: "'Courier Prime', monospace",
+  }
+  return (
+    <div style={{ borderRadius: 10, padding: 4, background: 'var(--faction-default-rainbow)' }}>
+      <div
+        style={{
+          position: 'relative',
+          background: 'var(--faction-default-card-bg)',
+          color: 'var(--faction-default-card-text)',
+          borderRadius: 6,
+          padding: '16px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 12,
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 9,
+            letterSpacing: '0.2em',
+            textTransform: 'uppercase',
+            color: 'var(--faction-default-card-muted)',
+          }}
+        >
+          <DefaultSigil size={18} />
+          {t('card.masthead.default')}
+        </div>
+        <MobilePraxisBody praxis={praxis} theme={theme} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/EphemeristsMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/EphemeristsMobilePraxisCard.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { EphMark, Foxing } from '../../cards/ephemeristsAtoms'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * The Ephemerists MOBILE praxis card (#573) — a sealed ephemeris entry: a foxed
+ * vellum leaf with a lapis-ruled running head, the watching-wanderer sigil, and
+ * rubric-accented text. Mirrors the desktop Ephemerists praxis frame; --eph-*
+ * tokens, theme-aware through the cascade.
+ */
+export default function EphemeristsMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const theme: MobileSlotTheme = {
+    ink: 'var(--eph-vellum-text)',
+    muted: 'var(--eph-muted)',
+    accent: 'var(--eph-rubric)',
+    paper: 'var(--eph-vellum)',
+    displayFont: 'var(--eph-display)',
+    bodyFont: 'var(--eph-serif)',
+  }
+  return (
+    <div
+      style={{
+        position: 'relative',
+        overflow: 'hidden',
+        background: 'var(--eph-vellum)',
+        color: 'var(--eph-vellum-text)',
+        border: '1px solid color-mix(in srgb, var(--eph-vellum-text) 30%, transparent)',
+        boxShadow: '0 1px 0 rgba(0,0,0,0.04), 0 8px 20px -16px rgba(0,0,0,0.6)',
+      }}
+    >
+      <Foxing opacity={0.4} />
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '10px 16px',
+          borderBottom: '1px solid var(--eph-gold-deep)',
+          boxShadow: '0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)',
+          fontFamily: 'var(--eph-serif)',
+          fontSize: 9,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: 'var(--eph-rubric)',
+        }}
+      >
+        <EphMark size={13} color="var(--eph-lapis)" />
+        {t('card.masthead.ephemerists')}
+      </div>
+      <div style={{ position: 'relative', zIndex: 2, padding: '14px 16px' }}>
+        <MobilePraxisBody praxis={praxis} theme={theme} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/EverymenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/EverymenMobilePraxisCard.tsx
@@ -1,0 +1,47 @@
+import type { PraxisCardOut } from '../../../api/praxis'
+import { factionCssVar } from '../../../utils/factions'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * Everymen MOBILE praxis card (#573) — a filed work order on ruled cream
+ * newsprint: a red margin rule, faint horizontal lines, typewriter voice. No
+ * sigil (the faction carries none). Mirrors the desktop Everymen praxis frame;
+ * --faction-everymen-* tokens, flips with [data-theme].
+ */
+export default function EverymenMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const theme: MobileSlotTheme = {
+    ink: factionCssVar('everymen', 'card-text'),
+    muted: factionCssVar('everymen', 'card-muted'),
+    accent: factionCssVar('everymen', 'card-accent'),
+    paper: factionCssVar('everymen', 'card-bg'),
+    displayFont: "'Special Elite', serif",
+    bodyFont: "'Special Elite', serif",
+  }
+  return (
+    <div
+      style={{
+        position: 'relative',
+        background: factionCssVar('everymen', 'card-bg'),
+        color: factionCssVar('everymen', 'card-text'),
+        border: '1px solid var(--color-border)',
+        borderLeft: `4px solid ${factionCssVar('everymen', 'card-accent')}`,
+        padding: '16px 16px 14px 22px',
+        backgroundImage:
+          'repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.08) 17px, rgba(100,140,200,0.08) 18px)',
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          left: 14,
+          top: 0,
+          bottom: 0,
+          width: 1,
+          background: 'rgba(220,80,80,0.2)',
+        }}
+      />
+      <MobilePraxisBody praxis={praxis} theme={theme} />
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/MobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/MobilePraxisCard.tsx
@@ -1,0 +1,39 @@
+import type { ComponentType } from 'react'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { pickVariant } from '../../../utils/factionDispatch'
+import UaMobilePraxisCard from './UaMobilePraxisCard'
+import WowMobilePraxisCard from './WowMobilePraxisCard'
+import SnideMobilePraxisCard from './SnideMobilePraxisCard'
+import EphemeristsMobilePraxisCard from './EphemeristsMobilePraxisCard'
+import SingularityMobilePraxisCard from './SingularityMobilePraxisCard'
+import EverymenMobilePraxisCard from './EverymenMobilePraxisCard'
+import AlbescentMobilePraxisCard from './AlbescentMobilePraxisCard'
+import DefaultMobilePraxisCard from './DefaultMobilePraxisCard'
+
+type MobilePraxisCardProps = { praxis: PraxisCardOut }
+
+/**
+ * Per-item MOBILE praxis-card dispatch (#573). Each proof in the mobile stream
+ * picks its own bespoke faction skin from its item's `task_faction_slug` —
+ * mirroring the desktop `PraxisCard` per-item dispatch — so a mixed feed shows
+ * every faction's own card archetype instead of theming the whole page. One card
+ * per faction renders solo, collab, AND duel: the roster and mode chip are the
+ * only conditional slots. Unregistered / factionless slugs fall through to the
+ * Default mobile card.
+ */
+export const MOBILE_PRAXIS_CARD_BY_SLUG: Record<string, ComponentType<MobilePraxisCardProps>> = {
+  ua: UaMobilePraxisCard,
+  wow: WowMobilePraxisCard,
+  snide: SnideMobilePraxisCard,
+  ephemerists: EphemeristsMobilePraxisCard,
+  singularity: SingularityMobilePraxisCard,
+  everymen: EverymenMobilePraxisCard,
+  // First-class Albescent identity (#232 slice 1). The explicit entry beats the
+  // albescent→ua alias in pickVariant, so it renders immediately.
+  albescent: AlbescentMobilePraxisCard,
+}
+
+export default function MobilePraxisCard({ praxis }: MobilePraxisCardProps) {
+  const Card = pickVariant(MOBILE_PRAXIS_CARD_BY_SLUG, praxis.task_faction_slug, DefaultMobilePraxisCard)
+  return <Card praxis={praxis} />
+}

--- a/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * Singularity MOBILE praxis card (#573) — a terminal readout on a scanline void:
+ * bracketed corners, a blinking prompt masthead, mono phosphor. No sigil (the
+ * faction carries none). Mirrors the desktop Singularity praxis frame;
+ * --faction-singularity-* tokens read identically in both themes (always-dark).
+ */
+export default function SingularityMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const theme: MobileSlotTheme = {
+    ink: 'var(--faction-singularity-card-text)',
+    muted: 'var(--faction-singularity-card-muted)',
+    accent: 'var(--faction-singularity-card-accent)',
+    paper: 'var(--faction-singularity-card-bg)',
+    displayFont: "'Share Tech Mono', monospace",
+    bodyFont: "'Share Tech Mono', monospace",
+  }
+  return (
+    <div
+      style={{
+        position: 'relative',
+        background: 'var(--faction-singularity-card-bg)',
+        border: '1px solid var(--faction-singularity-border-hard)',
+        color: 'var(--faction-singularity-card-text)',
+        padding: '16px',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          inset: 0,
+          backgroundImage:
+            'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)',
+          pointerEvents: 'none',
+          zIndex: 1,
+        }}
+      />
+      <div style={{ position: 'relative', zIndex: 2 }}>
+        <div
+          style={{
+            marginBottom: 12,
+            fontFamily: "'Share Tech Mono', monospace",
+            fontSize: 9,
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase',
+            color: 'var(--faction-singularity-card-muted)',
+          }}
+        >
+          {t('card.masthead.singularity')}
+          <span
+            style={{
+              display: 'inline-block',
+              width: 5,
+              height: 9,
+              marginLeft: 4,
+              background: 'var(--faction-singularity-card-text)',
+              verticalAlign: 'middle',
+              animation: 'blink 1s step-end infinite',
+            }}
+          />
+        </div>
+        <MobilePraxisBody praxis={praxis} theme={theme} />
+      </div>
+      <style>{'@keyframes blink { 50% { opacity: 0; } }'}</style>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/SnideMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/SnideMobilePraxisCard.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { factionCssVar } from '../../../utils/factions'
+import { SnideSigil } from '../../snide/snideAtoms'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+const TORN_CLIP =
+  'polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)'
+
+/**
+ * S.N.I.D.E. MOBILE praxis card (#573) — a dark evidence file with a torn top
+ * edge, a strip of tape, and the struck-through circle-S sigil. Mirrors the
+ * desktop SNIDE praxis frame; --faction-snide-* tokens, native-dark.
+ */
+export default function SnideMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const accent = factionCssVar('snide', 'card-accent')
+  const theme: MobileSlotTheme = {
+    ink: factionCssVar('snide', 'card-text'),
+    muted: factionCssVar('snide', 'card-muted'),
+    accent,
+    paper: factionCssVar('snide', 'card-bg'),
+    displayFont: 'var(--faction-snide-font-cond)',
+    bodyFont: 'var(--faction-snide-font-type)',
+  }
+  return (
+    <div
+      style={{
+        position: 'relative',
+        background: factionCssVar('snide', 'card-bg'),
+        color: factionCssVar('snide', 'card-text'),
+        border: `1px solid ${factionCssVar('snide', 'border')}`,
+        padding: '18px 16px 14px',
+        boxShadow: '5px 6px 0 rgba(0,0,0,.5)',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: -1,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: 'var(--color-bg-page)',
+          clipPath: TORN_CLIP,
+        }}
+      />
+      <div className="snide-tape" style={{ top: -8, left: 20, transform: 'rotate(-8deg)' }} />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginBottom: 12,
+          fontFamily: 'var(--faction-snide-font-type)',
+          fontSize: 9,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: accent,
+        }}
+      >
+        <SnideSigil size={16} color={accent} />
+        {t('card.masthead.snide')}
+      </div>
+      <MobilePraxisBody praxis={praxis} theme={theme} />
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { factionCssVar } from '../../../utils/factions'
+import { UACrest } from '../../cards/UACrest'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * University of Asthmatics MOBILE praxis card (#573) — a gilt-salon acquisition
+ * plate: gold-leaf frame, parchment ground with a faint dotted tooth, an
+ * engraved "Acquisition · filed" running head with the salon crest. Mirrors the
+ * desktop UA praxis frame; all colours via --ua-* tokens (always-light).
+ */
+export default function UaMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const theme: MobileSlotTheme = {
+    ink: factionCssVar('ua', 'card-text'),
+    muted: factionCssVar('ua', 'card-muted'),
+    accent: factionCssVar('ua', 'card-accent'),
+    paper: factionCssVar('ua', 'card-bg'),
+    displayFont: "'Playfair Display', serif",
+    bodyFont: "'EB Garamond', serif",
+    titleStyle: { fontStyle: 'italic' },
+  }
+  return (
+    <div style={{ padding: 4, background: 'var(--ua-gilt)', borderRadius: 2 }}>
+      <div
+        style={{
+          position: 'relative',
+          background: factionCssVar('ua', 'card-bg'),
+          border: '1px solid color-mix(in srgb, var(--ua-ink) 30%, transparent)',
+          padding: '16px 16px 14px',
+          backgroundImage:
+            'radial-gradient(color-mix(in srgb, var(--ua-ink) 4%, transparent) 1px, transparent 1px)',
+          backgroundSize: '5px 5px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 12,
+            fontFamily: "'Marcellus SC', serif",
+            fontSize: 9,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: factionCssVar('ua', 'card-accent'),
+          }}
+        >
+          <UACrest width={16} height={19} />
+          {t('card.masthead.ua')}
+        </div>
+        <MobilePraxisBody praxis={praxis} theme={theme} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
@@ -1,0 +1,78 @@
+import type { PraxisCardOut } from '../../../api/praxis'
+import { factionCssVar } from '../../../utils/factions'
+import { WowSparkle } from '../../cards/FactionCard'
+import i18n from '../../../i18n'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * Warriors of Whimsy MOBILE praxis card (#573) — a taped scrap of the proof
+ * board: a torn pink strip peeking behind the tilted notepad, a strip of tape,
+ * sparkle marks. Mirrors the desktop WOW praxis frame; --faction-wow-* tokens,
+ * always-light.
+ */
+export default function WowMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const accent = factionCssVar('wow', 'card-accent')
+  const theme: MobileSlotTheme = {
+    ink: factionCssVar('wow', 'card-text'),
+    muted: factionCssVar('wow', 'card-muted'),
+    accent,
+    paper: factionCssVar('wow', 'card-bg'),
+    displayFont: 'var(--faction-wow-card-font)',
+    bodyFont: "'Courier Prime', monospace",
+  }
+  return (
+    <div style={{ position: 'relative', paddingTop: 8 }}>
+      <div
+        style={{
+          position: 'absolute',
+          top: 2,
+          left: -3,
+          right: -3,
+          height: 26,
+          background: 'var(--faction-wow-scrap-mid)',
+          border: '1.5px solid rgba(0,0,0,0.12)',
+          transform: 'rotate(-3deg)',
+        }}
+      />
+      <div
+        style={{
+          position: 'relative',
+          background: factionCssVar('wow', 'card-bg'),
+          border: '1.5px solid rgba(0,0,0,0.12)',
+          padding: '18px 16px 14px',
+          zIndex: 2,
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: -6,
+            left: '50%',
+            transform: 'translateX(-50%) rotate(-2deg)',
+            width: 54,
+            height: 14,
+            background: 'var(--faction-wow-tape)',
+            borderRadius: 1,
+          }}
+        />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginBottom: 12,
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 9,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: accent,
+          }}
+        >
+          <WowSparkle size={11} color={accent} />
+          {i18n.t('feed:identity.wow.windowTitle')}
+        </div>
+        <MobilePraxisBody praxis={praxis} theme={theme} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
+++ b/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Per-item MOBILE praxis-card dispatch (#573). The mobile praxis stream no
+ * longer themes the whole page to one faction — each card picks its own bespoke
+ * skin from its item's `task_faction_slug`, mirroring the desktop PraxisCard
+ * per-item dispatch. This asserts every real slug resolves to its bespoke card
+ * and that unregistered / factionless slugs fall through to the Default card.
+ */
+import { describe, it, expect } from 'vitest'
+import { pickVariant } from '../../../../utils/factionDispatch'
+import { MOBILE_PRAXIS_CARD_BY_SLUG } from '../MobilePraxisCard'
+import DefaultMobilePraxisCard from '../DefaultMobilePraxisCard'
+import UaMobilePraxisCard from '../UaMobilePraxisCard'
+import WowMobilePraxisCard from '../WowMobilePraxisCard'
+import SnideMobilePraxisCard from '../SnideMobilePraxisCard'
+import EphemeristsMobilePraxisCard from '../EphemeristsMobilePraxisCard'
+import SingularityMobilePraxisCard from '../SingularityMobilePraxisCard'
+import EverymenMobilePraxisCard from '../EverymenMobilePraxisCard'
+import AlbescentMobilePraxisCard from '../AlbescentMobilePraxisCard'
+
+const CARD_BY_SLUG = {
+  ua: UaMobilePraxisCard,
+  wow: WowMobilePraxisCard,
+  snide: SnideMobilePraxisCard,
+  ephemerists: EphemeristsMobilePraxisCard,
+  singularity: SingularityMobilePraxisCard,
+  everymen: EverymenMobilePraxisCard,
+  albescent: AlbescentMobilePraxisCard,
+} as const
+
+describe('mobile praxis-card per-item dispatch', () => {
+  for (const [slug, Card] of Object.entries(CARD_BY_SLUG)) {
+    it(`a ${slug} praxis resolves to its bespoke mobile card`, () => {
+      expect(pickVariant(MOBILE_PRAXIS_CARD_BY_SLUG, slug, DefaultMobilePraxisCard)).toBe(Card)
+    })
+  }
+
+  it('an unregistered / factionless praxis falls through to the Default mobile card', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
+      expect(pickVariant(MOBILE_PRAXIS_CARD_BY_SLUG, slug, DefaultMobilePraxisCard)).toBe(
+        DefaultMobilePraxisCard,
+      )
+    }
+  })
+})

--- a/frontend/src/components/praxisCard/mobile/shared.tsx
+++ b/frontend/src/components/praxisCard/mobile/shared.tsx
@@ -1,0 +1,458 @@
+import type { CSSProperties } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { factionName } from '../../../utils/factions'
+import { relativeTime } from '../../../utils/dates'
+import { mediaUrl } from '../../../utils/media'
+import { rosterNames } from '../shared'
+import { TaskCrown } from '../../cards/TaskCrown'
+import VoteUI from '../../vote/VoteUI'
+
+/**
+ * Bespoke MOBILE praxis-card shared slots (#573).
+ *
+ * Mirrors the desktop `components/praxisCard/shared.tsx` split: each faction's
+ * mobile card owns a bespoke FRAME (fonts, chrome, tokens); the CONTENT is these
+ * touch-native structural slots — byline, task reference, title, body excerpt,
+ * crew roster, mode chip, media gallery, vote footer — composed by the faction
+ * card (via {@link MobilePraxisBody}). Single column, no fixed-px layout grid
+ * (SPEC-faction-ui-profile §1a). Colours come only from the theme tokens each
+ * card passes in — never a hardcoded hue.
+ */
+
+/** The per-faction voice each slot dresses itself in. Every value is a CSS var. */
+export interface MobileSlotTheme {
+  /** Primary text / ink. */
+  ink: string
+  /** Secondary / muted text. */
+  muted: string
+  /** Faction accent — byline label, avatar ring, chip. */
+  accent: string
+  /** The card's paper colour — avatar disc + Task Crown inner disc. */
+  paper: string
+  /** Display font for the title. */
+  displayFont?: string
+  /** Body font for the excerpt + meta. */
+  bodyFont?: string
+  /** Title-specific overrides (italic, weight, colour). */
+  titleStyle?: CSSProperties
+}
+
+/** A round avatar disc showing the first initial — the faction accent ring. */
+function AvatarInitial({
+  name,
+  theme,
+  size = 34,
+}: {
+  name: string | null | undefined
+  theme: MobileSlotTheme
+  size?: number
+}) {
+  const initial = (name?.trim()?.[0] ?? '?').toUpperCase()
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 'none',
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: theme.paper,
+        border: `1.5px solid ${theme.accent}`,
+        color: theme.accent,
+        fontFamily: theme.displayFont,
+        fontSize: size * 0.44,
+        fontWeight: 700,
+        lineHeight: 1,
+      }}
+    >
+      {initial}
+    </span>
+  )
+}
+
+/**
+ * Slot: the author byline — avatar initial + name (linked to the character),
+ * then the author's own faction and a relative timestamp. Actor-scoped: uses
+ * `created_by_faction_slug` (the author's member faction), not the task faction.
+ */
+export function MobileByline({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  const { t } = useTranslation('praxis')
+  const name = praxis.created_by_display_name || `#${praxis.created_by_id}`
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      <AvatarInitial name={name} theme={theme} />
+      <span style={{ display: 'flex', flexDirection: 'column', minWidth: 0, gap: 1 }}>
+        <Link
+          to={`/characters/${praxis.created_by_id}`}
+          className="hover:underline"
+          style={{
+            fontFamily: theme.displayFont,
+            fontSize: 14,
+            fontWeight: 600,
+            color: theme.ink,
+            textDecoration: 'none',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {name}
+        </Link>
+        <span
+          style={{
+            fontFamily: theme.bodyFont,
+            fontSize: 10,
+            letterSpacing: '0.04em',
+            color: theme.muted,
+          }}
+        >
+          {t('mobileFeed.byline', {
+            faction: factionName(praxis.created_by_faction_slug),
+            time: relativeTime(praxis.created_at),
+          })}
+        </span>
+      </span>
+    </div>
+  )
+}
+
+/** Slot: the task this proof answers — "Re · {title}", linked to the task. */
+export function MobileTaskRef({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  const { t } = useTranslation('praxis')
+  return (
+    <Link
+      to={`/tasks/${praxis.task_id}`}
+      className="hover:underline"
+      style={{
+        fontFamily: theme.bodyFont,
+        fontSize: 11,
+        letterSpacing: '0.02em',
+        color: theme.accent,
+        textDecoration: 'none',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {t('mobileCard.taskRef', { title: praxis.task_title })}
+    </Link>
+  )
+}
+
+/** Slot: the praxis title in the faction display font, linked to the detail. */
+export function MobileTitle({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  const { t } = useTranslation('praxis')
+  return (
+    <Link to={`/praxes/${praxis.id}`} style={{ textDecoration: 'none' }}>
+      <h3
+        className="hover:underline"
+        style={{
+          fontFamily: theme.displayFont,
+          fontSize: 20,
+          lineHeight: 1.15,
+          color: theme.ink,
+          margin: 0,
+          overflowWrap: 'anywhere',
+          ...theme.titleStyle,
+        }}
+      >
+        {praxis.title || t('mobileCard.untitled')}
+      </h3>
+    </Link>
+  )
+}
+
+/** Slot: a 1–2 line body excerpt, clamped. Renders nothing without body_text. */
+export function MobileBody({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  if (!praxis.body_text) return null
+  return (
+    <p
+      style={{
+        fontFamily: theme.bodyFont,
+        fontSize: 13,
+        lineHeight: 1.5,
+        color: theme.muted,
+        margin: 0,
+        display: '-webkit-box',
+        WebkitLineClamp: 2,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+      }}
+    >
+      {praxis.body_text}
+    </p>
+  )
+}
+
+/**
+ * Slot: the crew roster — overlapping avatar initials plus names (capped via
+ * `rosterNames`, then "+N more"). Collab only: renders nothing on a solo praxis
+ * or when the roster is just the author.
+ */
+export function MobileRoster({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  const { t } = useTranslation('praxis')
+  const members = praxis.members ?? []
+  if (praxis.type !== 'collab' || members.length < 2) return null
+  const { names, overflow } = rosterNames(
+    members.map((member) => ({ display_name: member.character_display_name })),
+  )
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+      <span style={{ display: 'inline-flex' }}>
+        {names.map((name, index) => (
+          <span key={index} style={{ marginLeft: index === 0 ? 0 : -8 }}>
+            <AvatarInitial name={name} theme={theme} size={22} />
+          </span>
+        ))}
+      </span>
+      <span
+        style={{
+          fontFamily: theme.bodyFont,
+          fontSize: 10,
+          color: theme.muted,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+      >
+        {names.join(', ')}
+        {overflow > 0 ? ` ${t('mobileCard.rosterMore', { count: overflow })}` : ''}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Slot: the mode chip — a small duel and/or pending-publish marker. Reuses the
+ * shared collaboration copy (`collaborationCard.duel` / `.pending`, common ns).
+ * Renders nothing on an ordinary solo/collab praxis.
+ */
+export function MobileModeChip({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  const { t } = useTranslation('common')
+  const isDuel = praxis.type === 'duel'
+  const isPending = praxis.submit_proposed_at != null
+  if (!isDuel && !isPending) return null
+  const chip: CSSProperties = {
+    fontFamily: theme.bodyFont,
+    fontSize: 9,
+    letterSpacing: '0.14em',
+    textTransform: 'uppercase',
+    padding: '2px 8px',
+    borderRadius: 3,
+  }
+  return (
+    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+      {isDuel && (
+        <span
+          style={{
+            ...chip,
+            color: 'var(--color-danger)',
+            background: 'color-mix(in srgb, var(--color-danger) 12%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--color-danger) 30%, transparent)',
+          }}
+        >
+          {t('collaborationCard.duel')}
+        </span>
+      )}
+      {isPending && (
+        <span
+          style={{
+            ...chip,
+            color: 'var(--color-warning)',
+            background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--color-warning) 30%, transparent)',
+          }}
+        >
+          {t('collaborationCard.pending')}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Slot: the proof media gallery — up to 3 tiles, with a "+N" badge on the last
+ * when there are more. UNIFORM across every faction (no opt-out). Images render
+ * a thumbnail; video/audio render a faction-styled glyph placeholder (no real
+ * preview, no lightbox — out of scope). Renders nothing without media.
+ */
+export function MobileMediaGallery({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  const { t } = useTranslation('praxis')
+  const items = praxis.media_items ?? []
+  if (items.length === 0) return null
+  const tiles = items.slice(0, 3)
+  const overflow = items.length - tiles.length
+  return (
+    <div style={{ display: 'flex', gap: 6 }}>
+      {tiles.map((item, index) => {
+        const isLast = index === tiles.length - 1
+        const showOverflow = isLast && overflow > 0
+        return (
+          <div
+            key={item.id}
+            style={{
+              position: 'relative',
+              flex: 1,
+              aspectRatio: '1 / 1',
+              overflow: 'hidden',
+              borderRadius: 4,
+              border: `1px solid ${theme.accent}`,
+              background: theme.paper,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {item.type === 'image' ? (
+              <img
+                src={mediaUrl(item.file_path)}
+                alt=""
+                style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+              />
+            ) : (
+              <span
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 2,
+                  color: theme.accent,
+                  fontFamily: theme.bodyFont,
+                }}
+              >
+                <span aria-hidden style={{ fontSize: 20, lineHeight: 1 }}>
+                  {item.type === 'video' ? '▶' : '♪'}
+                </span>
+                <span style={{ fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+                  {item.type === 'video' ? t('mobileCard.mediaVideo') : t('mobileCard.mediaAudio')}
+                </span>
+              </span>
+            )}
+            {showOverflow && (
+              <span
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: 'color-mix(in srgb, black 55%, transparent)',
+                  color: 'white',
+                  fontFamily: theme.displayFont,
+                  fontSize: 18,
+                  fontWeight: 700,
+                }}
+              >
+                {t('mobileCard.mediaMore', { count: overflow })}
+              </span>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * Slot: the vote footer — the real per-faction VoteUI, keyed by the task
+ * faction. Pre-highlights the viewer's own cast (`viewer_vote`); tapping casts
+ * through VoteUI's own useVote path. The 1–5 stamps own their ≥44px hit target.
+ */
+export function MobileVoteFooter({ praxis }: { praxis: PraxisCardOut }) {
+  return (
+    <VoteUI
+      factionSlug={praxis.task_faction_slug}
+      praxisId={praxis.id}
+      currentValue={praxis.viewer_vote ?? undefined}
+      points={praxis.score}
+      totalVotes={praxis.voter_count}
+    />
+  )
+}
+
+/**
+ * The full card anatomy, composed once and wrapped by each faction's bespoke
+ * frame (mirrors the desktop `PraxisBody`). The Task Crown floats top-right when
+ * this is the top-scoring proof for its task; the frame must be position:relative.
+ */
+export function MobilePraxisBody({
+  praxis,
+  theme,
+}: {
+  praxis: PraxisCardOut
+  theme: MobileSlotTheme
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {praxis.is_top_for_task && (
+        <TaskCrown
+          size={30}
+          innerBg={theme.paper}
+          glyphColor={theme.accent}
+          rotate="6deg"
+          style={{ position: 'absolute', top: -10, right: -8, zIndex: 4 }}
+        />
+      )}
+      <MobileByline praxis={praxis} theme={theme} />
+      <MobileTaskRef praxis={praxis} theme={theme} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <MobileTitle praxis={praxis} theme={theme} />
+        <MobileBody praxis={praxis} theme={theme} />
+      </div>
+      <MobileModeChip praxis={praxis} theme={theme} />
+      <MobileRoster praxis={praxis} theme={theme} />
+      <MobileMediaGallery praxis={praxis} theme={theme} />
+      <div style={{ borderTop: `1px solid ${theme.accent}`, paddingTop: 10 }}>
+        <MobileVoteFooter praxis={praxis} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -16,6 +16,26 @@ import { TaskCrown } from "../cards/TaskCrown";
  * a true per-faction dispatch rather than chrome-only.
  */
 
+/**
+ * Roster-name helper — the crew names shown on a collaboration card, capped so a
+ * large crew doesn't overflow the card. Returns up to `cap` display names plus
+ * the overflow count (the "+N more" tail). Shared by the desktop collaboration
+ * surface (#587) and the mobile praxis card (#573) — put it here, not a mobile
+ * copy, so both read the same cap.
+ */
+export const ROSTER_NAME_CAP = 7
+
+export function rosterNames(
+  members: { display_name?: string | null }[],
+  cap = ROSTER_NAME_CAP,
+): { names: string[]; overflow: number } {
+  const names = members
+    .slice(0, cap)
+    .map((member) => member.display_name ?? "")
+  const overflow = Math.max(0, members.length - cap)
+  return { names, overflow }
+}
+
 /** Slot: the praxis title, linked to the praxis detail page. */
 export function PraxisTitle({
   praxis,

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -20,6 +20,14 @@
     "back": "Praxis",
     "ratePrompt": "Rate this proof"
   },
+  "mobileCard": {
+    "taskRef": "Re · {{title}}",
+    "untitled": "Untitled praxis",
+    "rosterMore": "+{{count}} more",
+    "mediaMore": "+{{count}}",
+    "mediaVideo": "video",
+    "mediaAudio": "audio"
+  },
   "card": {
     "ptsAndVotes": "pts + votes",
     "level": "L{{level}}",

--- a/frontend/src/pages/praxes/MobilePraxisFeed.tsx
+++ b/frontend/src/pages/praxes/MobilePraxisFeed.tsx
@@ -1,15 +1,15 @@
 import { useTranslation } from 'react-i18next'
-import PraxisCard from '../../components/PraxisCard'
-import CollaborationCard from '../../components/CollaborationCard'
+import MobilePraxisCard from '../../components/praxisCard/mobile/MobilePraxisCard'
 import type { PraxesFeedState } from './usePraxes'
 
 /**
- * Mobile praxis feed (#499/#565) — a single-column vertical proof stream. Each
- * card picks its own faction skin from its item's data (the bespoke
- * `PraxisCard` / `CollaborationCard` per-item dispatch), so a mixed feed shows
- * every faction's own card archetype instead of theming the whole page to one
- * faction. Solo + collab/duel are merged into one stream, matching the Field
- * Kit §05 praxis feed.
+ * Mobile praxis feed (#499/#565/#573) — a single-column vertical proof stream.
+ * Each card picks its own bespoke faction skin from its item's data (the
+ * per-item `MobilePraxisCard` dispatch), so a mixed feed shows every faction's
+ * own touch-native card archetype instead of theming the whole page to one
+ * faction. Solo + collab/duel are merged into ONE uniform stream — the same
+ * card renders all three modes (roster + mode chip are its only conditional
+ * slots), matching the Field Kit §05 praxis feed.
  *
  * Presentation-only: data arrives via {@link PraxesFeedState}. Single-column, no
  * fixed-px layout grid (SPEC-faction-ui-profile §1a).
@@ -46,11 +46,8 @@ export default function MobilePraxisFeed({ state }: { state: PraxesFeedState }) 
         <p className="font-body text-muted">{t('listPage.empty')}</p>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {soloItems.map((p) => (
-            <PraxisCard key={`praxis-${p.id}`} praxis={p} />
-          ))}
-          {collabItems.map((c) => (
-            <CollaborationCard key={`collab-${c.id}`} collab={c} />
+          {[...soloItems, ...collabItems].map((p) => (
+            <MobilePraxisCard key={`praxis-${p.id}`} praxis={p} />
           ))}
         </div>
       )}


### PR DESCRIPTION
Implements #573. **Stacked on #565** (base `claude/mobile-mixed-feeds-565`); auto-retargets to `main` as parents merge.

## Backend — widen `PraxisCardOut` (no migration)
- `schemas/praxis.py`: added `body_text`, `created_by_faction_slug`, `members[]`, `media_items[]`, `viewer_vote`.
- `services/praxis.py`: `list_praxes()` adds `selectinload(Praxis.media_items)`; `build_praxis_card_out()` gains a `viewer_votes` param and populates the new fields (reuses `_build_member_out`, mirrors `build_praxis_out`).
- `services/vote_tally.py`: new batched `viewer_votes_for()` (one query, not per-card).
- `routers/praxes.py`: computes `viewer_votes` once in the list route and threads it through.

## Frontend — `MobilePraxisCard` dispatcher + 8 bespoke faction cards
- New `components/praxisCard/mobile/`: `shared.tsx` (byline w/ author faction, roster w/ names, media gallery, mode chip, real per-faction `VoteUI` footer), 8 faction cards, and `MobilePraxisCard.tsx` dispatcher (mirrors desktop `PraxisCard.tsx`, explicit-albescent-key-beats-alias).
- Solo/collab/duel unified into one card per faction (roster + mode-chip are the only conditional slots).
- Media gallery: real thumbnails via `mediaUrl()`, cap 3 + "+N", video/audio glyph placeholders, uniform across factions.
- Inline voting: real `VoteUI` wired per card; `viewer_vote` pre-highlights the caster.
- Sigils reused (no new SVG); `WowSparkle` exported.
- `rosterNames()` + `ROSTER_NAME_CAP` added to the **desktop** `praxisCard/shared.tsx` (imported by #587).
- `MobilePraxisFeed` dispatches per item over one merged stream.
- 9 new bespoke card files grandfathered into `.eslint-legacy-raw-styles.txt` (raw-px frames, same pattern as #565's task cards).

## ⚠️ Rebase note: unmerged #590
#590 (collab-consensus rename) also edits `services/praxis.py` and is **still open**. This branch's `praxis.py` edits are deliberately localized (one line in `list_praxes`, one param + field block in `build_praxis_card_out`) to keep the eventual rebase small.

## Verification
- Backend `pytest --cov=. --cov-fail-under=80` — **574 passed, 87% coverage** (4 new integration + 2 new unit tests)
- Frontend `npx eslint src` / `npm run build` / `npx vitest run` — clean / green / **505 passed** (13 new)

Design fidelity of the 8 faction frames is worth a visual spot-check (built from the anatomy spec + faction tokens, not the raw mock).

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
