### PR TITLE
Rename UA/SNIDE components ALL-CAPS → Title-case (#584)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -174,6 +174,10 @@ Frosted surface: `var(--color-bg-surface)`, backdrop blur, `var(--color-border)`
 
 Full-bleed SVG with blurred ellipses in four corners. Opacity controlled by `--wc-opacity-*` variables so dark mode dims automatically.
 
+### Faction Component Naming
+
+Faction-specific components are named with a **Title-cased slug prefix** — `Ua`, `Snide`, `Wow`, `Everymen`, `Ephemerists`, `Singularity`, `Albescent` — never an ALL-CAPS acronym (`UA`, `SNIDE`). The file name, the component's default export, and any private per-faction helper (sigil, crest, card) all share that Title-cased prefix. Only the lowercase backend **slug** (`ua`, `snide`) stays lowercase — it is the string key in dispatch registries (`FACTION_*_BY_SLUG`, `pickVariant`) and in CSS variables (`--faction-ua-*`), and must never be recased. This keeps a single, greppable identifier per faction across every surface.
+
 ---
 
 ## 8. Dark Mode

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -14,9 +14,9 @@ src/components/cards/FactionSelectCard.tsx
 src/components/cards/SingularityFactionHero.tsx
 src/components/cards/SnideFactionHero.tsx
 src/components/cards/SnideMasthead.tsx
-src/components/cards/SNIDETaskCard.tsx
-src/components/cards/UAFactionHero.tsx
-src/components/cards/UATaskCard.tsx
+src/components/cards/SnideTaskCard.tsx
+src/components/cards/UaFactionHero.tsx
+src/components/cards/UaTaskCard.tsx
 src/components/cards/WowFactionHero.tsx
 src/components/cards/WowTaskCard.tsx
 src/components/CharacterSwitcherSheet.tsx
@@ -30,7 +30,7 @@ src/components/comments/voices/EphemeristsComment.tsx
 src/components/comments/voices/EverymenComment.tsx
 src/components/comments/voices/SingularityComment.tsx
 src/components/comments/voices/SnideComment.tsx
-src/components/comments/voices/UAComment.tsx
+src/components/comments/voices/UaComment.tsx
 src/components/comments/voices/WowComment.tsx
 src/components/CredentialCard.tsx
 src/components/feed/AlbescentFeedFrame.tsx
@@ -45,7 +45,7 @@ src/components/feed/FeedDateDivider.tsx
 src/components/feed/FeedRowContent.tsx
 src/components/feed/SingularityFeedFrame.tsx
 src/components/feed/SnideFeedFrame.tsx
-src/components/feed/UAFeedFrame.tsx
+src/components/feed/UaFeedFrame.tsx
 src/components/feed/WowFeedFrame.tsx
 src/components/home/ActivityTicker.tsx
 src/components/imageEdit/ImageEditModal.tsx
@@ -68,7 +68,7 @@ src/components/vote/EphemeristsVote.tsx
 src/components/vote/EverymenVote.tsx
 src/components/vote/SingularityVote.tsx
 src/components/vote/SnideVote.tsx
-src/components/vote/UAVote.tsx
+src/components/vote/UaVote.tsx
 src/components/vote/VoteShell.tsx
 src/components/vote/WowVote.tsx
 src/pages/Admin.tsx
@@ -98,8 +98,8 @@ src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
 src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
 src/pages/editPraxis/archetypes/shared.tsx
 src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
-src/pages/editPraxis/archetypes/SNIDEEditPraxis.tsx
-src/pages/editPraxis/archetypes/UAEditPraxis.tsx
+src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+src/pages/editPraxis/archetypes/UaEditPraxis.tsx
 src/pages/editPraxis/archetypes/WowEditPraxis.tsx
 src/pages/editPraxis/mobileArchetypes/AlbescentComposer.tsx
 src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
@@ -148,7 +148,7 @@ src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
 src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
 src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
 src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
-src/pages/praxisDetail/archetypes/UAPraxisDetail.tsx
+src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
 src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
 src/pages/praxisDetail/DuelCrossLink.tsx
 src/pages/praxisDetail/mobileArchetypes/AlbescentPraxisDetail.tsx
@@ -170,8 +170,8 @@ src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
 src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
 src/pages/taskDetail/archetypes/shared.tsx
 src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
-src/pages/taskDetail/archetypes/SNIDETaskDetail.tsx
-src/pages/taskDetail/archetypes/UATaskDetail.tsx
+src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+src/pages/taskDetail/archetypes/UaTaskDetail.tsx
 src/pages/taskDetail/archetypes/WowTaskDetail.tsx
 src/pages/taskDetail/mobileArchetypes/AlbescentTaskDetail.tsx
 src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -121,10 +121,10 @@ function PraxisBody({
 /**
  * UA — Gilt salon placard, filed. A gold-framed acquisition plate: gilt-leaf
  * gradient border, parchment ground with a faint dotted tooth, an engraved
- * "Acquisition · filed" regalia line. Matches the UA praxis-read sheet, UAVote,
+ * "Acquisition · filed" regalia line. Matches the UA praxis-read sheet, UaVote,
  * and the DS FactionPraxisCard reference. All colors via --ua-* tokens.
  */
-function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
   return (
     // Gilt frame: gold-leaf gradient border, then the parchment plate.
@@ -681,7 +681,7 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
 // ─── Dispatcher ───────────────────────────────────────────────────────────────
 
 export const PRAXIS_CARD_BY_SLUG: Record<string, ComponentType<ArchetypeProps>> = {
-  ua: UAPraxisCard,
+  ua: UaPraxisCard,
   everymen: EverymenPraxisCard,
   wow: WowPraxisCard,
   snide: SnidePraxisCard,

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -2,9 +2,9 @@ import type { TaskOut } from '../api/tasks'
 import { useAuth } from '../auth/AuthContext'
 import { useAdminMode } from '../auth/AdminModeContext'
 import { updateTaskStatus } from '../api/admin'
-import UATaskCard from './cards/UATaskCard'
+import UaTaskCard from './cards/UaTaskCard'
 import WowTaskCard from './cards/WowTaskCard'
-import SNIDETaskCard from './cards/SNIDETaskCard'
+import SnideTaskCard from './cards/SnideTaskCard'
 import EphemeristsTaskCard from './cards/EphemeristsTaskCard'
 import SingularityTaskCard from './cards/SingularityTaskCard'
 import EverymenTaskCard from './cards/EverymenTaskCard'
@@ -22,10 +22,10 @@ export interface CardProps {
 
 /** Style Guide §6 — one card archetype per faction. */
 export const CARD_COMPONENTS: Record<string, ComponentType<CardProps>> = {
-  ua: UATaskCard,
+  ua: UaTaskCard,
   everymen: EverymenTaskCard,
   wow: WowTaskCard,
-  snide: SNIDETaskCard,
+  snide: SnideTaskCard,
   ephemerists: EphemeristsTaskCard,
   singularity: SingularityTaskCard,
   // First-class Albescent identity (#232 slice 1). The explicit entry beats the

--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -7,7 +7,7 @@ import WowAvatar from './WowAvatar'
 import SnideAvatar from './SnideAvatar'
 import EphemeristsAvatar from './EphemeristsAvatar'
 import SingularityAvatar from './SingularityAvatar'
-import UAAvatar from './UAAvatar'
+import UaAvatar from './UaAvatar'
 import AlbescentAvatar from './AlbescentAvatar'
 import DefaultSigil from '../cards/DefaultSigil'
 
@@ -194,7 +194,7 @@ const FACTION_AVATARS: Record<string, ComponentType<FactionAvatarProps>> = {
   snide: SnideAvatar,
   ephemerists: EphemeristsAvatar,
   singularity: SingularityAvatar,
-  ua: UAAvatar,
+  ua: UaAvatar,
   albescent: AlbescentAvatar,
 }
 

--- a/frontend/src/components/avatar/UaAvatar.tsx
+++ b/frontend/src/components/avatar/UaAvatar.tsx
@@ -1,5 +1,5 @@
 import { BadgedAvatar, type FactionAvatarProps } from "./FactionAvatar";
-import { UACrest } from "../cards/UACrest";
+import { UaCrest } from "../cards/UaCrest";
 
 /**
  * UA (University of Asthmatics) avatar — the Salon "Artist in Residence"
@@ -8,12 +8,12 @@ import { UACrest } from "../cards/UACrest";
  * lower-right as the membership badge.
  *
  * Reuses the shared BadgedAvatar shell (image/initial circle + corner badge)
- * and the repo's own {@link UACrest} for the badge glyph rather than porting a
+ * and the repo's own {@link UaCrest} for the badge glyph rather than porting a
  * separate sigil. UA is ALWAYS LIGHT: its --ua-* / --faction-ua-* tokens are
  * identical in both themes, so the salon styles itself with them and never
  * mutates data-theme. All colors via tokens (never hardcode hex — CLAUDE.md).
  */
-export default function UAAvatar({ character, size }: FactionAvatarProps) {
+export default function UaAvatar({ character, size }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}
@@ -29,7 +29,7 @@ export default function UAAvatar({ character, size }: FactionAvatarProps) {
       // The crest is a shield (100×120 viewBox); render it square at badge
       // scale — BadgedAvatar hands us the inner glyph size and the ring color
       // (unused here; the crest carries its own --ua-* palette).
-      glyph={(s) => <UACrest width={s} height={s} />}
+      glyph={(s) => <UaCrest width={s} height={s} />}
     />
   );
 }

--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -37,10 +37,10 @@ describe("FactionAvatar — UA variant (#200)", () => {
     // Parchment disc ringed in UA gilt tokens (never hardcoded hex).
     expect(html).toContain("var(--ua-orange)");
     expect(html).toContain("var(--faction-ua-card-font)");
-    // The heraldic crest badge is present (UACrest draws --ua-* shield fills).
+    // The heraldic crest badge is present (UaCrest draws --ua-* shield fills).
     expect(html).toContain("var(--ua-gold)");
     expect(html).toContain("var(--ua-paper-warm)");
-    // UACrest markup marker — the shield uses an SVG viewBox unique to the crest.
+    // UaCrest markup marker — the shield uses an SVG viewBox unique to the crest.
     expect(html).toContain('viewBox="0 0 100 120"');
   });
 

--- a/frontend/src/components/backdrop/FactionBackdrop.tsx
+++ b/frontend/src/components/backdrop/FactionBackdrop.tsx
@@ -5,7 +5,7 @@ import WowBackdrop from './WowBackdrop'
 import SnideBackdrop from './SnideBackdrop'
 import EphemeristsBackdrop from './EphemeristsBackdrop'
 import SingularityBackdrop from './SingularityBackdrop'
-import UABackdrop from './UABackdrop'
+import UaBackdrop from './UaBackdrop'
 import AlbescentBackdrop from './AlbescentBackdrop'
 import { useBackdropSlug } from './BackdropContext'
 import { pickVariant } from '../../utils/factionDispatch'
@@ -22,7 +22,7 @@ const FACTION_BACKDROPS: Record<string, ComponentType> = {
   snide: SnideBackdrop,
   ephemerists: EphemeristsBackdrop,
   singularity: SingularityBackdrop,
-  ua: UABackdrop,
+  ua: UaBackdrop,
   albescent: AlbescentBackdrop,
 }
 

--- a/frontend/src/components/backdrop/UaBackdrop.tsx
+++ b/frontend/src/components/backdrop/UaBackdrop.tsx
@@ -24,6 +24,6 @@ const backdropStyle: CSSProperties = {
   backgroundSize: 'auto, auto, 6px 6px',
 }
 
-export default function UABackdrop() {
+export default function UaBackdrop() {
   return <div style={backdropStyle} aria-hidden="true" />
 }

--- a/frontend/src/components/cards/DefaultTaskCard.tsx
+++ b/frontend/src/components/cards/DefaultTaskCard.tsx
@@ -9,7 +9,7 @@ import DefaultSigil from "./DefaultSigil";
  * Where each faction commits to one loud archetype, the default stays
  * deliberately un-committed: a clean sheet wrapped in a thick spectrum band
  * (every faction colour at once = all paths open), marked with the seven-segment
- * ring. Replaces the old borrowed-UA `DEFAULT_CARD = UATaskCard` (#418). All
+ * ring. Replaces the old borrowed-UA `DEFAULT_CARD = UaTaskCard` (#418). All
  * colours via --faction-default-* tokens (no hardcoded hex — CLAUDE.md); flips
  * light/dark through the cascade.
  */

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -116,7 +116,7 @@ function InvitationNote({ slug, note }: { slug: string; note: string }) {
 
 const ROTATIONS = [-2, 1.5, -1, 2.5];
 
-function UACard({
+function UaCard({
   faction,
   status,
   invitationNote,
@@ -781,7 +781,7 @@ function SingularityCard({
 export default function FactionCard(props: FactionCardProps) {
   switch (props.faction.slug) {
     case "ua":
-      return <UACard {...props} />;
+      return <UaCard {...props} />;
     case "wow":
       return <WowCard {...props} />;
     case "snide":

--- a/frontend/src/components/cards/FactionSelectCard.tsx
+++ b/frontend/src/components/cards/FactionSelectCard.tsx
@@ -34,7 +34,7 @@ export interface FactionSelectCardProps {
 // ─── Sigils ───────────────────────────────────────────────────────────────────
 
 let _uaUid = 0;
-function UASigil({ size = 50 }: { size?: number }) {
+function UaSigil({ size = 50 }: { size?: number }) {
   const id = useMemo(() => "uasigil-" + _uaUid++, []);
   const shield = "M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z";
   return (
@@ -67,7 +67,7 @@ function WOWSigil({ size = 22, color = "var(--gestalt-pink)" }: { size?: number;
   );
 }
 
-function SNIDESigil({ size = 48, color = "var(--snide-acid)" }: { size?: number; color?: string }) {
+function SnideSigil({ size = 48, color = "var(--snide-acid)" }: { size?: number; color?: string }) {
   return (
     <svg viewBox="0 0 48 48" width={size} height={size} style={{ display: "block" }}>
       <circle cx="24" cy="24" r="19" fill="none" stroke={color} strokeWidth="3" />
@@ -136,7 +136,7 @@ function AlbescentSigil({ size = 20, color = "var(--faction-albescent-card-text,
 
 // ─── Per-faction archetypes ───────────────────────────────────────────────────
 
-function UASelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
+function UaSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.ua.status.${state}` as const);
   return (
     <div style={{
@@ -154,7 +154,7 @@ function UASelectCard({ state = "locked", members, onVisit }: Omit<FactionSelect
             <div style={{ fontFamily: "var(--font-faction-gilt)", fontStyle: "italic", fontWeight: 800, fontSize: 52, lineHeight: 0.9, letterSpacing: "0.01em", marginTop: 8 }}>{i18n.t("feed:factionSelect.ua.wordmark")}</div>
             <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 12, letterSpacing: "0.24em", color: "var(--ua-sub)", textTransform: "uppercase", marginTop: 3 }}>{i18n.t("feed:factionSelect.ua.subtitle")}</div>
           </div>
-          <UASigil size={44} />
+          <UaSigil size={44} />
         </div>
         <div style={{ height: 2, background: "var(--ua-gilt)", margin: "16px 0 13px", opacity: 0.85 }} />
         <p style={{ margin: 0, fontFamily: "var(--font-faction-gilt)", fontStyle: "italic", fontSize: 16, lineHeight: 1.4, color: "var(--ua-ink)" }}>
@@ -219,7 +219,7 @@ function WOWSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelec
   );
 }
 
-function SNIDESelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
+function SnideSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.snide.status.${state}` as const);
   return (
     <div style={{
@@ -232,7 +232,7 @@ function SNIDESelectCard({ state = "locked", members, onVisit }: Omit<FactionSel
       <div style={{ position: "absolute", top: 14, left: 22, width: 74, height: 20, background: "var(--snide-tape)", transform: "rotate(-6deg)", boxShadow: "0 1px 2px rgba(0,0,0,0.4)" }} />
       <div style={{ position: "relative", flex: 1, padding: "26px 24px 0" }}>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-          <SNIDESigil size={40} color="var(--snide-acid)" />
+          <SnideSigil size={40} color="var(--snide-acid)" />
           <div>
             <div style={{ fontFamily: "var(--font-faction-anton)", fontSize: 34, lineHeight: 0.85, color: "var(--snide-paper)", letterSpacing: "0.02em" }}>{i18n.t("feed:identity.snide.wordmark")}</div>
             <div style={{ fontSize: 10, letterSpacing: "0.14em", color: "var(--snide-acid)", marginTop: 4, textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.snide.masthead")}</div>
@@ -412,9 +412,9 @@ function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit<Factio
 // ─── Switcher ─────────────────────────────────────────────────────────────────
 
 const BY_FACTION: Record<string, (p: Omit<FactionSelectCardProps, "faction">) => JSX.Element> = {
-  ua: UASelectCard,
+  ua: UaSelectCard,
   wow: WOWSelectCard,
-  snide: SNIDESelectCard,
+  snide: SnideSelectCard,
   ephemerists: EphemeristsSelectCard,
   singularity: SingularitySelectCard,
   everymen: EverymenSelectCard,
@@ -431,6 +431,6 @@ const LEGACY_SLUG: Record<string, string> = {
 
 export default function FactionSelectCard({ faction, ...rest }: FactionSelectCardProps) {
   const key = BY_FACTION[faction] ? faction : LEGACY_SLUG[faction] ?? faction;
-  const Card = BY_FACTION[key] ?? UASelectCard;
+  const Card = BY_FACTION[key] ?? UaSelectCard;
   return <Card {...rest} />;
 }

--- a/frontend/src/components/cards/SnideTaskCard.tsx
+++ b/frontend/src/components/cards/SnideTaskCard.tsx
@@ -98,7 +98,7 @@ function Ransom({ text, size = 22 }: { text: string; size?: number }) {
   );
 }
 
-export default function SNIDETaskCard({
+export default function SnideTaskCard({
   task,
   displayPoints,
   onSignup,

--- a/frontend/src/components/cards/UaCrest.tsx
+++ b/frontend/src/components/cards/UaCrest.tsx
@@ -5,7 +5,7 @@ import i18n from "../../i18n";
  * Shared UA (University of Asthmatics) heraldic atoms — the gilt-salon crest
  * and motto ribbon that are the faction's locked identity.
  *
- * Extracted from UAFactionHero so the crest is drawn once and dropped into
+ * Extracted from UaFactionHero so the crest is drawn once and dropped into
  * every UA surface that carries it (faction hero, task card, edit-praxis
  * masthead + commission slip) rather than re-drawn per file. All colors via
  * --ua-* tokens (never hardcode hex — CLAUDE.md); the salon is always-light,
@@ -14,7 +14,7 @@ import i18n from "../../i18n";
 
 
 /** Heraldic crest — a shield with a rising sun and crossed brushes. */
-export function UACrest({ width, height }: { width: number; height: number }) {
+export function UaCrest({ width, height }: { width: number; height: number }) {
   // Unique clip id per instance — the shield is rendered many times per page
   // (a card list, the hero, twice in edit-praxis); a shared literal id would
   // be invalid SVG and risk cross-instance clipping.

--- a/frontend/src/components/cards/UaFactionHero.tsx
+++ b/frontend/src/components/cards/UaFactionHero.tsx
@@ -1,6 +1,6 @@
 import type { FactionHeroProps } from "../../pages/FactionDetail";
 import i18n from "../../i18n";
-import { UACrest, MottoRibbon } from "./UACrest";
+import { UaCrest, MottoRibbon } from "./UaCrest";
 
 /**
  * UA (University of Asthmatics) faction-page hero — a gilt-salon frontispiece.
@@ -8,7 +8,7 @@ import { UACrest, MottoRibbon } from "./UACrest";
  * (--ua-gilt) around a parchment field, a heraldic crest, a regal serif
  * wordmark, a Latin motto cartouche, and the three counts engraved as salon
  * regalia (patrons / commissions / acquisitions). Ported from the UA design kit
- * (UATaskDetail hero / ua.css); conforms to {@link FactionHeroProps}.
+ * (UaTaskDetail hero / ua.css); conforms to {@link FactionHeroProps}.
  *
  * UA is ALWAYS LIGHT: its --faction-ua-* / --ua-* tokens are identical in both
  * themes, so the salon styles itself with them and never dims — it does not
@@ -38,7 +38,7 @@ const ENGRAVED = '"Marcellus", Georgia, serif';
 const ink = (pct: number): string =>
   `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
 
-export default function UAFactionHero({
+export default function UaFactionHero({
   name,
   description,
   members,
@@ -86,7 +86,7 @@ export default function UAFactionHero({
               alignItems: "center",
             }}
           >
-            <UACrest width={150} height={180} />
+            <UaCrest width={150} height={180} />
 
             <div style={{ flex: 1, minWidth: 260 }}>
               {/* engraved house line */}

--- a/frontend/src/components/cards/UaTaskCard.tsx
+++ b/frontend/src/components/cards/UaTaskCard.tsx
@@ -2,14 +2,14 @@ import { Link } from "react-router-dom";
 import type { TaskOut } from "../../api/tasks";
 import i18n from "../../i18n";
 import LevelPill from "../ui/LevelPill";
-import { UACrest, MottoRibbon } from "./UACrest";
+import { UaCrest, MottoRibbon } from "./UaCrest";
 
 /**
  * UA — Gilt salon crest placard (the University of Asthmatics archetype).
  * A gold-framed acquisition plate on the salon wall, center-composed around the
  * heraldic crest: masthead ("University of Asthmatics · EST · MMXX"), motto
  * ribbon, Playfair-italic title, and a "Matriculate" sign-up affordance. The
- * crest + motto are shared with UAFactionHero (see UACrest.tsx), not re-drawn.
+ * crest + motto are shared with UaFactionHero (see UaCrest.tsx), not re-drawn.
  * All colors via --ua-* tokens (never hardcode hex — CLAUDE.md); the salon is
  * always-light, so tokens read identically in both themes.
  */
@@ -24,7 +24,7 @@ interface Props {
   onSignup?: (id: number) => void;
 }
 
-export default function UATaskCard({ task, displayPoints, onSignup }: Props) {
+export default function UaTaskCard({ task, displayPoints, onSignup }: Props) {
   return (
     // Gilt frame: gold-leaf gradient border, then the parchment plate, hung with
     // a slight rotation like a plate on the salon wall.
@@ -56,7 +56,7 @@ export default function UATaskCard({ task, displayPoints, onSignup }: Props) {
         }}
       >
         {/* Crest */}
-        <UACrest width={72} height={86} />
+        <UaCrest width={72} height={86} />
 
         {/* Masthead */}
         <div

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -21,7 +21,7 @@ import {
   MentionText,
 } from './shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from './OwnerControls'
-import UAComment from './voices/UAComment'
+import UaComment from './voices/UaComment'
 import EverymenComment from './voices/EverymenComment'
 import WowComment from './voices/WowComment'
 import SnideComment from './voices/SnideComment'
@@ -88,7 +88,7 @@ export function DefaultComment(props: CommentProps) {
 /** Seven faction comment archetypes (ADR-0018). Albescent is explicit, so it
  *  beats the albescent→ua alias for comments while still aliasing elsewhere. */
 export const COMMENT_COMPONENTS: Record<string, CommentComponent> = {
-  ua: UAComment,
+  ua: UaComment,
   everymen: EverymenComment,
   wow: WowComment,
   snide: SnideComment,

--- a/frontend/src/components/comments/voices/UaComment.tsx
+++ b/frontend/src/components/comments/voices/UaComment.tsx
@@ -10,7 +10,7 @@ import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
  * UA — University of Asthmatics. The gilt salon (ADR-0026, superseding
  * ADR-0018's comment-scoped orange letterhead): a gold museum-frame around a
  * parchment plate, Marcellus small-caps house line, Playfair-italic body. Mirrors
- * UAFeedFrame / UAPraxisDetail; all colors via --ua-* tokens (no hex — CLAUDE.md).
+ * UaFeedFrame / UaPraxisDetail; all colors via --ua-* tokens (no hex — CLAUDE.md).
  * UA is always-light, so tokens read identically in both themes.
  */
 const GILT = 'var(--ua-gilt)'
@@ -51,7 +51,7 @@ function GiltFrame({ children, gap }: { children: ReactNode; gap: number }) {
   )
 }
 
-export default function UAComment(props: CommentProps) {
+export default function UaComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props

--- a/frontend/src/components/feed/AlbescentFeedFrame.tsx
+++ b/frontend/src/components/feed/AlbescentFeedFrame.tsx
@@ -14,7 +14,7 @@ import i18n from '../../i18n'
  *
  * Albescent is ALWAYS LIGHT: its --faction-albescent-* tokens are identical in
  * both themes, so the sheet reads as white paper regardless of the global theme
- * and never mutates data-theme (mirror of UAFeedFrame / SingularityFeedFrame).
+ * and never mutates data-theme (mirror of UaFeedFrame / SingularityFeedFrame).
  * It reads --faction-albescent-* directly rather than factionCssVar('albescent',
  * …), which still resolves the albescent→ua alias until the alias is dropped
  * (the final #232 step). An explicit `albescent` row in FACTION_FEED_FRAMES beats

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -19,7 +19,7 @@ import EphemeristsFeedFrame from './EphemeristsFeedFrame'
 import WowFeedFrame from './WowFeedFrame'
 import SnideFeedFrame from './SnideFeedFrame'
 import SingularityFeedFrame from './SingularityFeedFrame'
-import UAFeedFrame from './UAFeedFrame'
+import UaFeedFrame from './UaFeedFrame'
 import AlbescentFeedFrame from './AlbescentFeedFrame'
 
 type FrameProps = { children: ReactNode }
@@ -32,7 +32,7 @@ const FACTION_FEED_FRAMES: Record<string, ComponentType<FrameProps>> = {
   wow: WowFeedFrame,
   snide: SnideFeedFrame,
   singularity: SingularityFeedFrame,
-  ua: UAFeedFrame,
+  ua: UaFeedFrame,
   albescent: AlbescentFeedFrame,
 }
 

--- a/frontend/src/components/feed/UaFeedFrame.tsx
+++ b/frontend/src/components/feed/UaFeedFrame.tsx
@@ -31,7 +31,7 @@ const FONT_ENGRAVED = 'var(--font-faction-engraved)' // Cinzel
 const ink = (pct: number): string =>
   `color-mix(in srgb, ${INK} ${pct}%, transparent)`
 
-export default function UAFeedFrame({ children }: { children: ReactNode }) {
+export default function UaFeedFrame({ children }: { children: ReactNode }) {
   return (
     // Outer gilt border + soft brown drop-shadow & inset white hairline.
     <div

--- a/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { PraxisCardOut } from '../../../api/praxis'
 import { factionCssVar } from '../../../utils/factions'
-import { UACrest } from '../../cards/UACrest'
+import { UaCrest } from '../../cards/UaCrest'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
@@ -47,7 +47,7 @@ export default function UaMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }
             color: factionCssVar('ua', 'card-accent'),
           }}
         >
-          <UACrest width={16} height={19} />
+          <UaCrest width={16} height={19} />
           {t('card.masthead.ua')}
         </div>
         <MobilePraxisBody praxis={praxis} theme={theme} />

--- a/frontend/src/components/vote/UaVote.tsx
+++ b/frontend/src/components/vote/UaVote.tsx
@@ -20,7 +20,7 @@ const PLATE_FONT = 'var(--faction-ua-card-font)'
 
 const TIERS = VOTE_REFRAMES['ua'].tiers
 
-export default function UAVote({
+export default function UaVote({
   praxisId,
   currentValue,
   points,

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -6,7 +6,7 @@ import WowVote from './WowVote'
 import SnideVote from './SnideVote'
 import EphemeristsVote from './EphemeristsVote'
 import SingularityVote from './SingularityVote'
-import UAVote from './UAVote'
+import UaVote from './UaVote'
 import AlbescentVote from './AlbescentVote'
 
 /**
@@ -29,7 +29,7 @@ const FACTION_VOTE: Record<string, ComponentType<VoteUIProps>> = {
   snide: SnideVote,
   ephemerists: EphemeristsVote,
   singularity: SingularityVote,
-  ua: UAVote,
+  ua: UaVote,
   albescent: AlbescentVote,
 }
 

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -15,13 +15,13 @@ import {
   useEditPraxis,
   type EditPraxisState,
 } from "./editPraxis/useEditPraxis";
-import SNIDEEditPraxis from "./editPraxis/archetypes/SNIDEEditPraxis";
+import SnideEditPraxis from "./editPraxis/archetypes/SnideEditPraxis";
 import SingularityEditPraxis from "./editPraxis/archetypes/SingularityEditPraxis";
 import WowEditPraxis from "./editPraxis/archetypes/WowEditPraxis";
 import EphemeristsEditPraxis from "./editPraxis/archetypes/EphemeristsEditPraxis";
 import DefaultEditPraxis from "./editPraxis/archetypes/DefaultEditPraxis";
 import EverymenEditPraxis from "./editPraxis/archetypes/EverymenEditPraxis";
-import UAEditPraxis from "./editPraxis/archetypes/UAEditPraxis";
+import UaEditPraxis from "./editPraxis/archetypes/UaEditPraxis";
 import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
 import DefaultMobileEditPraxis from "./editPraxis/mobileArchetypes/DefaultEditPraxis";
 import WowMobileEditPraxis from "./editPraxis/mobileArchetypes/WowEditPraxis";
@@ -39,11 +39,11 @@ type Archetype = (props: { state: EditPraxisState }) => JSX.Element;
 // for `na` / unknown factions.
 const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
   everymen: EverymenEditPraxis,
-  snide: SNIDEEditPraxis,
+  snide: SnideEditPraxis,
   singularity: SingularityEditPraxis,
   wow: WowEditPraxis,
   ephemerists: EphemeristsEditPraxis,
-  ua: UAEditPraxis,
+  ua: UaEditPraxis,
   albescent: AlbescentEditPraxis,
 };
 

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -26,7 +26,7 @@ import EphemeristsFactionHero from "../components/cards/EphemeristsFactionHero";
 import SnideFactionHero from "../components/cards/SnideFactionHero";
 import SingularityFactionHero from "../components/cards/SingularityFactionHero";
 import EverymenFactionHero from "../components/cards/EverymenFactionHero";
-import UAFactionHero from "../components/cards/UAFactionHero";
+import UaFactionHero from "../components/cards/UaFactionHero";
 import WowFactionHero from "../components/cards/WowFactionHero";
 import AlbescentFactionHero from "../components/cards/AlbescentFactionHero";
 
@@ -58,7 +58,7 @@ const FACTION_HEROES: Record<string, ComponentType<FactionHeroProps>> = {
   snide: SnideFactionHero,
   singularity: SingularityFactionHero,
   everymen: EverymenFactionHero,
-  ua: UAFactionHero,
+  ua: UaFactionHero,
   wow: WowFactionHero,
   albescent: AlbescentFactionHero,
 };

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -28,7 +28,7 @@ import SnidePraxisDetail from './praxisDetail/archetypes/SnidePraxisDetail'
 import SingularityPraxisDetail from './praxisDetail/archetypes/SingularityPraxisDetail'
 import EverymenPraxisDetail from './praxisDetail/archetypes/EverymenPraxisDetail'
 import WowPraxisDetail from './praxisDetail/archetypes/WowPraxisDetail'
-import UAPraxisDetail from './praxisDetail/archetypes/UAPraxisDetail'
+import UaPraxisDetail from './praxisDetail/archetypes/UaPraxisDetail'
 import AlbescentPraxisDetail from './praxisDetail/archetypes/AlbescentPraxisDetail'
 import CommentThread from '../components/comments/CommentThread'
 import DuelCrossLink from './praxisDetail/DuelCrossLink'
@@ -43,7 +43,7 @@ export const ARCHETYPE_BY_SLUG: Record<string, ComponentType<{ state: PraxisDeta
   singularity: SingularityPraxisDetail,
   everymen: EverymenPraxisDetail,
   wow: WowPraxisDetail,
-  ua: UAPraxisDetail,
+  ua: UaPraxisDetail,
   // First-class read-surface identity (#231); explicit entry beats the
   // albescent→ua alias via pickVariant. Global alias stays until #232.
   albescent: AlbescentPraxisDetail,

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -22,12 +22,12 @@ import WowMobileTaskDetail from "./taskDetail/mobileArchetypes/WowTaskDetail";
 import EphemeristsMobileTaskDetail from "./taskDetail/mobileArchetypes/EphemeristsTaskDetail";
 import AlbescentMobileTaskDetail from "./taskDetail/mobileArchetypes/AlbescentTaskDetail";
 import SnideMobileTaskDetail from "./taskDetail/mobileArchetypes/SnideTaskDetail";
-import SNIDETaskDetail from "./taskDetail/archetypes/SNIDETaskDetail";
+import SnideTaskDetail from "./taskDetail/archetypes/SnideTaskDetail";
 import EverymenTaskDetail from "./taskDetail/archetypes/EverymenTaskDetail";
 import WowTaskDetail from "./taskDetail/archetypes/WowTaskDetail";
 import EphemeristsTaskDetail from "./taskDetail/archetypes/EphemeristsTaskDetail";
 import SingularityTaskDetail from "./taskDetail/archetypes/SingularityTaskDetail";
-import UATaskDetail from "./taskDetail/archetypes/UATaskDetail";
+import UaTaskDetail from "./taskDetail/archetypes/UaTaskDetail";
 import AlbescentTaskDetail from "./taskDetail/archetypes/AlbescentTaskDetail";
 import CommentThread from "../components/comments/CommentThread";
 
@@ -37,12 +37,12 @@ type Archetype = (props: { state: TaskDetailState }) => JSX.Element | null;
 // na) falls through to DefaultTaskDetail below. albescent is a FIRST-CLASS
 // identity (#232 slice 1) with its own entry.
 export const ARCHETYPE_BY_SLUG: Record<string, Archetype> = {
-  snide: SNIDETaskDetail,
+  snide: SnideTaskDetail,
   everymen: EverymenTaskDetail,
   wow: WowTaskDetail,
   ephemerists: EphemeristsTaskDetail,
   singularity: SingularityTaskDetail,
-  ua: UATaskDetail,
+  ua: UaTaskDetail,
   albescent: AlbescentTaskDetail,
 };
 

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -87,7 +87,7 @@ function RansomChar({ ch, index }: { ch: string; index: number }) {
   );
 }
 
-export default function SNIDEEditPraxis({ state }: Props) {
+export default function SnideEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
   const praxis = state.praxis!;
   const task = state.task;

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -1,7 +1,7 @@
 /**
  * The University of Asthmatics (UA) edit-praxis archetype — THE ATELIER.
  *
- * The gilt-salon counterpart to the read-page sheet (UAPraxisDetail) and UAVote:
+ * The gilt-salon counterpart to the read-page sheet (UaPraxisDetail) and UaVote:
  * a work-in-progress acquisition being prepared on the salon's workbench. Gilt
  * frames, parchment grounds, Playfair italic display, EB-Garamond serif body,
  * Marcellus small-caps regalia, burnt-amber accent. The salon never dims — UA
@@ -24,7 +24,7 @@ import {
   TitleCounter,
   formatAutosave,
 } from "./shared";
-import { UACrest } from "../../../components/cards/UACrest";
+import { UaCrest } from "../../../components/cards/UaCrest";
 import {
   BodyPreview,
   BodyTextarea,
@@ -78,7 +78,7 @@ function RegaliaLabel({ children }: { children: ReactNode }) {
   );
 }
 
-export default function UAEditPraxis({ state }: Props) {
+export default function UaEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
   const praxis = state.praxis!;
   const task = state.task;
@@ -126,7 +126,7 @@ export default function UAEditPraxis({ state }: Props) {
             }}
           >
             <span style={{ display: "inline-flex", alignItems: "center", gap: 10, minWidth: 0 }}>
-              <UACrest width={22} height={26} />
+              <UaCrest width={22} height={26} />
               <span style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: "0.14em", color: "var(--ua-paper-warm)" }}>
                 {t("editPraxis.ua.masthead", { number: praxis.id })}
               </span>
@@ -147,7 +147,7 @@ export default function UAEditPraxis({ state }: Props) {
             <div style={{ height: 0, borderTop: "1.5px dashed var(--ua-gold)", marginBottom: 18 }} />
             {/* commission reference slip — crest, task, points, era mark */}
             <div style={{ display: "flex", alignItems: "center", gap: 14, border: "1px solid var(--ua-line)", background: "var(--ua-paper-warm)", padding: "12px 16px" }}>
-              <UACrest width={50} height={60} />
+              <UaCrest width={50} height={60} />
               <div style={{ minWidth: 0 }}>
                 <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--ua-muted)", marginBottom: 4 }}>
                   {t("editPraxis.ua.commissionLabel")}

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -13,7 +13,7 @@ import type { FactionDetailState } from "../useFactionDetail";
 /**
  * UA (University of Asthmatics) faction-body — the gilt-salon skin of the
  * standardized six-section spine (② Prospectus, ③ The Registry, ④ Tasks,
- * ⑤ Praxis, ⑥ Members). Section ① (hero + side stats) is UAFactionHero above.
+ * ⑤ Praxis, ⑥ Members). Section ① (hero + side stats) is UaFactionHero above.
  *
  * Same shape as EverymenFactionBody — Tasks/Praxis reuse the app-wide per-faction
  * cards (TaskCard/PraxisCard already dispatch to the UA archetypes); this file

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -12,7 +12,7 @@ import type { FieldDeskHomeState } from '../useFieldDeskHome'
  * slots as the Default mobile home (character header, Points/Votes/Era stat
  * tiles, active-tasks list, primary actions) — only the dress changes. Grounds
  * on the `--faction-ua-*` / `--ua-*` tokens already in index.css (the set
- * UAFeedFrame / UaFactionBody use) and is always-light: UA never dims.
+ * UaFeedFrame / UaFactionBody use) and is always-light: UA never dims.
  * Presentation-only — all data arrives via {@link FieldDeskHomeState}.
  */
 

--- a/frontend/src/pages/praxisDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaDispatch.test.tsx
@@ -8,7 +8,7 @@ import { MOBILE_ARCHETYPE_BY_SLUG, ARCHETYPE_BY_SLUG } from '../../PraxisDetail'
 import { pickVariant } from '../../../utils/factionDispatch'
 import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
 import UAMobilePraxisDetail from '../mobileArchetypes/UaPraxisDetail'
-import UADesktopPraxisDetail from '../archetypes/UAPraxisDetail'
+import UADesktopPraxisDetail from '../archetypes/UaPraxisDetail'
 
 describe('mobile praxis-detail UA dispatch', () => {
   it('mobile + a UA praxis resolves to the bespoke UA mobile skin', () => {

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -169,7 +169,7 @@ function TheStanding({
   )
 }
 
-export default function UAPraxisDetail({ state }: { state: PraxisDetailState }) {
+export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
   const { praxis, votes, voters } = state
   if (!praxis) return null

--- a/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
@@ -11,7 +11,7 @@ import {
 import { pickVariant } from "../../../utils/factionDispatch";
 import DefaultMobileTaskDetail from "../mobileArchetypes/DefaultTaskDetail";
 import UAMobileTaskDetail from "../mobileArchetypes/UaTaskDetail";
-import UADesktopTaskDetail from "../archetypes/UATaskDetail";
+import UADesktopTaskDetail from "../archetypes/UaTaskDetail";
 
 describe("mobile task-detail UA dispatch", () => {
   it("mobile + a UA task resolves to the bespoke UA mobile skin", () => {

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -271,7 +271,7 @@ function AccompliceRow({
   );
 }
 
-export default function SNIDETaskDetail({
+export default function SnideTaskDetail({
   state,
 }: {
   state: TaskDetailState;

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -13,7 +13,7 @@ import type { TaskDetailState } from "../useTaskDetail";
  * (burnt amber / cream / gold / brown ink), a matriculation CTA, the commission
  * brief on parchment, the hands matriculated, "The Salon Wall" of filed praxis
  * (the finest hand wears a fleur-de-lis), and a read-only critique aggregate.
- * Ported from the UA design kit (UATaskDetail.tsx); wired to the real
+ * Ported from the UA design kit (UaTaskDetail.tsx); wired to the real
  * {@link TaskDetailState}.
  *
  * UA is ALWAYS-LIGHT — its --faction-ua-* / --ua-* tokens are identical in both
@@ -287,7 +287,7 @@ function StatPlate({
   );
 }
 
-export default function UATaskDetail({
+export default function UaTaskDetail({
   state,
 }: {
   state: TaskDetailState;


### PR DESCRIPTION
Implements #584. **Stacked on #587** (base `claude/desktop-praxis-parity-587`); auto-retargets to `main` as parents merge. (#583 escalated to `needs-design`, so this stacks on #587, not #583.)

## What
Pure mechanical rename standardizing the faction-slug component prefix on Title-case (`Ua`/`Snide`), matching every other faction. Per the issue's build-readiness report §4/§5:

- **14 `git mv` file renames** (all tracked as `R`): `UACrest→UaCrest`, `UAAvatar`, `UABackdrop`, `UAFeedFrame`, `UAVote`, `UAComment`, `UA+SNIDE TaskCard`, `UA+SNIDE EditPraxis`, `UA+SNIDE TaskDetail`, `UAPraxisDetail`, `UAFactionHero` — each with export + every importer + dispatch-registry key updated.
- **Private (non-exported) renames**: `FactionSelectCard` (`Ua/SnideSigil`, `Ua/SnideSelectCard`, `BY_FACTION` rows, fallback), `FactionCard` (`UaCard`), `PraxisCard` (`UaPraxisCard`).
- **`.eslint-legacy-raw-styles.txt`**: 11 renamed-file paths updated (incl. `UAFeedFrame`, which the report's §5 count flagged).
- Two dispatch-test **import paths** updated; test file names kept lowercase.
- Naming-convention note added to `WORLD_ZERO_STYLE.md`.

Caught beyond the report's inventory: a **5th `UACrest` consumer** — `components/praxisCard/mobile/UaMobilePraxisCard.tsx` (added by #573) — which would have broken Linux CI's case-sensitive resolution; updated it.

Deliberately untouched: lowercase slug literals, `--ua-*`/`--snide-*` CSS vars, i18n keys, `SNIDE_TORN_CLIP`, `_uaUid`/`"uasigil-"`, mobile `*Mobile*` local aliases.

## Verification
CI never runs tsc/vite build, so this was verified locally after the rename:
- `npx eslint src` — clean · **`npm run build`** — green (the key gate for case-only renames) · `npx vitest run` — **547 passed**
- `git grep` for every old identifier → **zero matches** · all 14 tracked as renames.

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
