### PR TITLE
Fix Everymen task card title unreadable in dark mode (wrong ink token)

### DIFF
--- a/frontend/src/components/cards/EverymenTaskCard.tsx
+++ b/frontend/src/components/cards/EverymenTaskCard.tsx
@@ -180,7 +180,7 @@ export default function EverymenTaskCard({ task, displayPoints, onSignup }: Prop
         maxWidth: 206,
         flex: "0 1 206px",
         background: "var(--everymen-paper)",
-        color: "var(--everymen-ink)",
+        color: "var(--faction-everymen-card-text)",
         border: "1.5px solid var(--everymen-ink)",
         boxShadow:
           "0 0 0 3px var(--everymen-paper), 0 0 0 4px var(--everymen-ink)",


### PR DESCRIPTION
## What

Fixes the Everymen task card title being unreadable in dark mode.

`frontend/src/components/cards/EverymenTaskCard.tsx` (card wrapper, ~line 183) set the text color from `var(--everymen-ink)`. The 32px task title inherits this color (`color: "inherit"`). `--everymen-ink` is an element-ink token that stays near-black in dark mode (`#0d0907`), so the title rendered near-black on the dark paper background (`--everymen-paper` = `#221a16`) at ~1.16:1 contrast — effectively invisible. In light mode the bug was hidden because `--everymen-ink` and `--everymen-paper-text` are byte-identical there.

## Fix

One-line change: the wrapper text color now uses `var(--faction-everymen-card-text)` (which resolves to `--everymen-paper-text`, flipping to cream `#f3e7ce` under `[data-theme="dark"]`), matching the convention every other faction's `*TaskCard.tsx` already follows.

## Scope notes

- Only the title-color usage (card wrapper `color`) was changed. The other `--everymen-ink` usages in this file are intentional element-ink and were left alone: the card border (~L184) and the outer box-shadow ring (~L186) are decorative frame ink meant to stay dark; the `Halftone` default `color` prop (L58) is a faint 0.07-opacity wash; the L302 usage is a decorative element background. None are a readability bug.

## Verification

- `tsc --noEmit`: my file is clean. Pre-existing (on base `652ec41`) type errors remain in `src/components/AlbescentInvitation.tsx` and `src/pages/__tests__/factionMembershipRelocation.test.tsx` — unrelated i18n key-type drift; a CSS-var string swap cannot introduce type errors, and confirmed present with my change stashed out.
- No dedicated `EverymenTaskCard` test file exists in the repo.

## Environment note (for the dispatcher)

The assigned worktree was NOT isolated during this task — HEAD flipped between multiple sibling branches (`contrast-policy-doc-578`, `moderation-type-filter-576`, `everymen-ink-token-595`) between git calls and the working tree carried unrelated uncommitted files from other concurrent tasks (index.css, AlbescentTaskCard, ImageEditModal, DesktopLayout, admin specs, etc.). I committed ONLY `EverymenTaskCard.tsx` by staging that single path, so this PR contains just the intended one-line change. Worth checking that concurrent sessions aren't sharing this worktree directory.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)
