### PR TITLE
Add pre-paint theme bootstrap to kill mobile dark-mode revert (#566)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,27 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>World Zero</title>
+    <script>
+      // Pre-paint theme bootstrap (mirrors useTheme's getInitialTheme).
+      // Applies the persisted [data-theme] before first paint so a mobile
+      // refresh (MobileLayout never mounts useTheme) doesn't revert to light,
+      // and desktop doesn't flash light before React hydrates. Keep this in
+      // sync with THEME_STORAGE_KEY ('wz-theme') in src/hooks/useTheme.ts.
+      (function () {
+        try {
+          var stored = localStorage.getItem('wz-theme')
+          var theme =
+            stored === 'light' || stored === 'dark'
+              ? stored
+              : window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light'
+          document.documentElement.setAttribute('data-theme', theme)
+        } catch (error) {
+          /* localStorage/matchMedia can throw; fall back to CSS default. */
+        }
+      })()
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## What

Adds a tiny dependency-free pre-paint theme bootstrap `<script>` to the `<head>` of `frontend/index.html` (above the app module script) so the persisted theme is applied to `<html>` before first paint.

## Why

`MobileLayout` never calls `useTheme` — only the desktop `NavBar` and the Settings page do. So on a **mobile refresh** nothing re-applied the persisted `[data-theme]`, and the page reverted to light mode (the bug in #566). Desktop also had a flash-of-light before React mounted and `useTheme`'s effect ran.

## How

The inline script mirrors `useTheme`'s `getInitialTheme` (`src/hooks/useTheme.ts`):

- Reads `localStorage['wz-theme']` (the exact `THEME_STORAGE_KEY`).
- If it's `'dark'` or `'light'`, sets `document.documentElement.dataset.theme` to it.
- If absent, replicates `useTheme`'s default: `window.matchMedia('(prefers-color-scheme: dark)')` so there's no flash.
- Wrapped in `try/catch` since `localStorage`/`matchMedia` can throw (falls back to the CSS default).

`useTheme`'s toggle/persist logic is **unchanged** — this only handles the pre-mount initial paint. The script sits in `<head>` above `<script type="module" src="/src/main.tsx">`, so `data-theme` is set before the app bundle loads. This fixes both the mobile-refresh revert and the desktop flash-of-light.

## Testing

- `tsc --noEmit`: no new errors (this is a static HTML change; the only pre-existing errors are in `AlbescentInvitation.tsx` and `factionMembershipRelocation.test.tsx`, untouched here).
- `vitest run src/hooks src/pages/settings/__tests__/defaultSettings.test.tsx`: 19/19 pass.
- No new unit test — this is static HTML; verified the script is syntactically valid JS and set before the app bundle loads.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
