### PR TITLE
fix(layout): responsive desktop sidebar column (#585)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -106,7 +106,7 @@ Every logged-in page follows this shell:
 ```
 Nav (sticky, frosted glass)
 Watercolor Background (absolute, behind content)
-Body: Main Content (flex: 1) + Sidebar (256px)
+Body: Main Content (flex: 1) + Sidebar (minmax 280–340px)
 ```
 
 The sidebar contains: character card, active tasks panel, recent activity panel, propose-a-task button. Some pages add contextual panels (e.g., faction standings on Players, pending requests on Updates).

--- a/frontend/src/components/layout/DesktopLayout.tsx
+++ b/frontend/src/components/layout/DesktopLayout.tsx
@@ -23,7 +23,7 @@ export default function DesktopLayout({ children }: { children: ReactNode }) {
         className="flex-1 relative max-w-[min(92vw,1600px)] mx-auto w-full px-4 sm:px-6 py-5"
         style={{ zIndex: 5 }}
       >
-        <div className={`gap-4 items-start ${user ? 'lg:grid lg:grid-cols-[1fr_340px]' : ''}`}>
+        <div className={`gap-4 items-start ${user ? 'lg:grid lg:grid-cols-[1fr_minmax(280px,340px)]' : ''}`}>
           <main className="min-w-0">{children}</main>
           {user && (
             <div className="hidden lg:block">


### PR DESCRIPTION
Closes #585

Desktop sidebar grid column was a flat `340px`; make it `minmax(280px,340px)` so it can shrink on narrower large screens. Reconciled the (already-stale) ASCII layout diagram in WORLD_ZERO_STYLE.md to match.
