### PR TITLE
fix(mobile): stop flattening animated GIFs on upload (#569)

### DIFF
--- a/frontend/src/components/imageEdit/ImageEditModal.tsx
+++ b/frontend/src/components/imageEdit/ImageEditModal.tsx
@@ -151,6 +151,12 @@ export default function ImageEditModal({
     setRotation((previous) => (previous + delta + 360) % 360)
 
   const handleApply = async () => {
+    // Belt-and-suspenders for #569: a GIF should never be canvas-encoded (that
+    // flattens it to its first frame), so short-circuit to the untouched file.
+    if (file.type === 'image/gif') {
+      onConfirm(originalUpload(file))
+      return
+    }
     const area = croppedAreaRef.current
     if (!objectUrl || !area) {
       // Nothing to slice yet — fall back to the untouched file.

--- a/frontend/src/components/imageEdit/__tests__/imageEditHelpers.test.ts
+++ b/frontend/src/components/imageEdit/__tests__/imageEditHelpers.test.ts
@@ -9,6 +9,7 @@ import {
   blobToFile,
   cropOutputSize,
   effectiveAspect,
+  isCropEditableImage,
   isImageFile,
   originalUpload,
   partitionByEditability,
@@ -90,6 +91,20 @@ describe('isImageFile / partitionByEditability — which files open the modal', 
     const { toEdit, toUploadDirect } = partitionByEditability([image, video])
     expect(toEdit).toEqual([image])
     expect(toUploadDirect).toEqual([video])
+  })
+
+  it('a GIF is still an image but is not crop-editable (#569)', () => {
+    expect(isImageFile({ type: 'image/gif' })).toBe(true)
+    expect(isCropEditableImage({ type: 'image/gif' })).toBe(false)
+    expect(isCropEditableImage({ type: 'image/png' })).toBe(true)
+  })
+
+  it('a GIF uploads directly (untouched), never entering the crop queue (#569)', () => {
+    const gif = { type: 'image/gif', name: 'party.gif' }
+    const png = { type: 'image/png', name: 'shot.png' }
+    const { toEdit, toUploadDirect } = partitionByEditability([png, gif])
+    expect(toEdit).toEqual([png])
+    expect(toUploadDirect).toEqual([gif])
   })
 })
 

--- a/frontend/src/components/imageEdit/imageEditHelpers.ts
+++ b/frontend/src/components/imageEdit/imageEditHelpers.ts
@@ -63,9 +63,20 @@ export function isImageFile(file: { type: string }): boolean {
 }
 
 /**
- * Split picked files into the ones that open the edit modal (images) and the
- * ones that upload straight through (video/audio). Keeps original order within
- * each bucket so the sequential image queue stays predictable.
+ * True when an image can safely go through the crop/rotate stage. Animated GIFs
+ * are excluded (#569): the edit modal canvas-encodes on "Apply", which only ever
+ * captures the first frame, so a cropped GIF loses its animation. GIFs upload
+ * straight through untouched instead.
+ */
+export function isCropEditableImage(file: { type: string }): boolean {
+  return isImageFile(file) && file.type !== 'image/gif'
+}
+
+/**
+ * Split picked files into the ones that open the edit modal (crop-editable
+ * images) and the ones that upload straight through (video/audio, and animated
+ * GIFs — see #569). Keeps original order within each bucket so the sequential
+ * image queue stays predictable.
  */
 export function partitionByEditability<T extends { type: string }>(
   files: readonly T[],
@@ -73,7 +84,7 @@ export function partitionByEditability<T extends { type: string }>(
   const toEdit: T[] = []
   const toUploadDirect: T[] = []
   for (const file of files) {
-    if (isImageFile(file)) toEdit.push(file)
+    if (isCropEditableImage(file)) toEdit.push(file)
     else toUploadDirect.push(file)
   }
   return { toEdit, toUploadDirect }


### PR DESCRIPTION
Closes #569

Animated GIFs were flattened to their first frame because the crop modal canvas-encodes on Apply. Route `image/gif` to the direct-upload path via a new `isCropEditableImage` predicate, plus a belt-and-suspenders short-circuit in ImageEditModal. Helper test asserts a GIF lands in the direct-upload bucket.
