### PR TITLE
feat(mobile): Updates bell entry point in mobile header (#572)

### DIFF
--- a/frontend/src/components/layout/MobileLayout.tsx
+++ b/frontend/src/components/layout/MobileLayout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../../auth/AuthContext'
+import { usePendingRequests } from '../../hooks/usePendingRequests'
 import MobileTabBar from './MobileTabBar'
 
 /**
@@ -14,6 +15,10 @@ import MobileTabBar from './MobileTabBar'
 export default function MobileLayout({ children }: { children: ReactNode }) {
   const { t } = useTranslation('common')
   const { user } = useAuth()
+  // Same pending-request count the desktop sidebar surfaces; drives the bell
+  // badge so the Updates page is reachable from the phone header (#572).
+  const { pendingRequests } = usePendingRequests()
+  const pendingCount = pendingRequests.length
 
   return (
     <>
@@ -29,22 +34,69 @@ export default function MobileLayout({ children }: { children: ReactNode }) {
         <Link to="/" className="font-display italic" style={{ fontSize: 18, color: 'var(--color-text-primary)', textDecoration: 'none' }}>
           {t('brand')}
         </Link>
-        {/* Settings / More affordance — the phone path to theme + sign out +
-            character management (#520). Only meaningful when signed in. */}
+        {/* Right-side header controls — only meaningful when signed in. */}
         {user && (
-          <Link
-            to="/settings"
-            aria-label={t('settings.title')}
-            className="eyebrow"
-            style={{
-              fontSize: 10,
-              color: 'var(--color-text-secondary)',
-              textDecoration: 'none',
-              padding: '4px 2px',
-            }}
-          >
-            {t('settings.open')}
-          </Link>
+          <div className="flex items-center gap-3">
+            {/* Bell → Updates. The only phone entry point to the Updates page
+                (#572); carries the same pending-request badge as the sidebar. */}
+            <Link
+              to="/updates"
+              aria-label={t('nav.updates')}
+              className="relative flex items-center"
+              style={{ color: 'var(--color-text-secondary)', textDecoration: 'none', padding: '4px 2px' }}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+                <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+              </svg>
+              {pendingCount > 0 && (
+                <span
+                  aria-hidden="true"
+                  className="absolute flex items-center justify-center font-body"
+                  style={{
+                    top: -2,
+                    right: -4,
+                    minWidth: 15,
+                    height: 15,
+                    padding: '0 3px',
+                    borderRadius: 999,
+                    fontSize: 9,
+                    fontWeight: 700,
+                    lineHeight: 1,
+                    color: 'var(--color-text-on-accent)',
+                    background: 'var(--badge-collab)',
+                  }}
+                >
+                  {pendingCount}
+                </span>
+              )}
+            </Link>
+            {/* Settings / More affordance — the phone path to theme + sign out +
+                character management (#520). */}
+            <Link
+              to="/settings"
+              aria-label={t('settings.title')}
+              className="eyebrow"
+              style={{
+                fontSize: 10,
+                color: 'var(--color-text-secondary)',
+                textDecoration: 'none',
+                padding: '4px 2px',
+              }}
+            >
+              {t('settings.open')}
+            </Link>
+          </div>
         )}
       </header>
 

--- a/frontend/src/components/layout/__tests__/MobileLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileLayout.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+// Initialize the i18n catalog so nav/settings copy keys resolve to English text.
+import '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+import type { ActivityFeedItem } from '../../../api/activityFeed'
+
+// useAuth reads from context whose value is populated by an async effect that
+// never runs under renderToStaticMarkup — mock it to control signed-in state.
+const authMock = vi.fn()
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => authMock(),
+}))
+
+// usePendingRequests fetches over the network; mock it to control the badge.
+const pendingMock = vi.fn()
+vi.mock('../../../hooks/usePendingRequests', () => ({
+  usePendingRequests: () => pendingMock(),
+}))
+
+import MobileLayout from '../MobileLayout'
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={['/']}>
+      <MobileLayout>
+        <div>content</div>
+      </MobileLayout>
+    </MemoryRouter>,
+  )
+}
+
+const signedIn = { user: { character: null } as unknown as CurrentUser }
+const signedOut = { user: null }
+
+beforeEach(() => {
+  pendingMock.mockReturnValue({ pendingRequests: [], refetch: vi.fn(), loading: false })
+})
+
+describe('MobileLayout header bell', () => {
+  it('links the bell to /updates when signed in', () => {
+    authMock.mockReturnValue(signedIn)
+    const html = render()
+    expect(html).toContain('href="/updates"')
+  })
+
+  it('omits the bell when signed out', () => {
+    authMock.mockReturnValue(signedOut)
+    const html = render()
+    expect(html).not.toContain('href="/updates"')
+  })
+
+  it('shows the pending-request badge only when there are requests', () => {
+    authMock.mockReturnValue(signedIn)
+    // No requests → no badge.
+    expect(render()).not.toContain('>3<')
+
+    // Three pending requests → badge count is rendered.
+    pendingMock.mockReturnValue({
+      pendingRequests: [{}, {}, {}] as ActivityFeedItem[],
+      refetch: vi.fn(),
+      loading: false,
+    })
+    expect(render()).toContain('>3<')
+  })
+})


### PR DESCRIPTION
Closes #572

The mobile Updates page had no entry point. Add a bell to the mobile header (signed-in only) linking to /updates, carrying the same pending-request badge (`usePendingRequests().pendingRequests.length`) the desktop sidebar uses. Render test covers the link, sign-out hiding, and the badge.
