### PR TITLE
fix(mobile): back affordance for mobile edit-praxis (#567)

### DIFF
--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -23,6 +23,7 @@ import DefaultEditPraxis from "./editPraxis/archetypes/DefaultEditPraxis";
 import EverymenEditPraxis from "./editPraxis/archetypes/EverymenEditPraxis";
 import UAEditPraxis from "./editPraxis/archetypes/UAEditPraxis";
 import AlbescentEditPraxis from "./editPraxis/archetypes/AlbescentEditPraxis";
+import { Breadcrumb } from "./editPraxis/archetypes/shared";
 import DefaultMobileEditPraxis from "./editPraxis/mobileArchetypes/DefaultEditPraxis";
 import WowMobileEditPraxis from "./editPraxis/mobileArchetypes/WowEditPraxis";
 import UAMobileEditPraxis from "./editPraxis/mobileArchetypes/UaComposer";
@@ -96,6 +97,18 @@ export default function EditPraxis() {
   return (
     <>
       <PageTitle title="Edit Praxis" />
+      {/* Mobile skins paint no breadcrumb of their own, so after publish the
+          phone composer is a dead end (#567). Render the shared desktop
+          breadcrumb once here for the mobile path — present for every skin and
+          every state, including the published state. Desktop archetypes render
+          their own breadcrumb, so gate this to mobile to avoid doubling up. */}
+      {formFactor === "mobile" && (
+        <Breadcrumb
+          praxisId={state.praxis.id}
+          taskId={state.praxis.task_id}
+          taskTitle={state.praxis.task_title}
+        />
+      )}
       <Archetype state={state} />
       {/* Praxis images crop/rotate in place before upload (#514), free-form so
           nothing is force-cropped. Sequential: keyed on identity so each queued

--- a/frontend/src/pages/__tests__/EditPraxisMobileBack.test.tsx
+++ b/frontend/src/pages/__tests__/EditPraxisMobileBack.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Mobile edit-praxis back affordance (#567). The phone composer skins paint no
+ * breadcrumb, so after publish there was no way back — a dead end. EditPraxis
+ * now renders the shared breadcrumb once on the mobile path, present for every
+ * skin and every state (including published). Desktop archetypes render their
+ * own breadcrumb, so the wrapper must NOT add one on desktop (no doubling).
+ *
+ * Runs headless (node env): renderToStaticMarkup, skins mocked to null so the
+ * test isolates the wrapper's own breadcrumb.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../i18n";
+import type { EditPraxisState } from "../editPraxis/useEditPraxis";
+
+const formFactor = vi.hoisted(() => ({ value: "mobile" as "mobile" | "desktop" }));
+const editState = vi.hoisted(() => ({ current: null as EditPraxisState | null }));
+
+vi.mock("../../hooks/useFormFactor", () => ({
+  useFormFactor: () => formFactor.value,
+}));
+vi.mock("../editPraxis/useEditPraxis", () => ({
+  useEditPraxis: () => editState.current,
+}));
+// Skins render null so only the wrapper's breadcrumb can appear in the output.
+vi.mock("../editPraxis/mobileArchetypes/DefaultEditPraxis", () => ({
+  default: () => null,
+}));
+vi.mock("../editPraxis/archetypes/DefaultEditPraxis", () => ({
+  default: () => null,
+}));
+
+import EditPraxis from "../EditPraxis";
+
+// Sparse published state — EditPraxis reads only these fields; the skin (which
+// reads the rest) is mocked to null. slug 'na' falls through to the Default skin.
+const publishedState = {
+  loading: false,
+  isPublished: true,
+  pendingImage: null,
+  error: "",
+  praxis: { id: 55, task_id: 7, task_title: "A Very Human Thing" },
+  task: { primary_faction_slug: "na" },
+} as unknown as EditPraxisState;
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EditPraxis />
+    </MemoryRouter>,
+  );
+}
+
+describe("EditPraxis mobile back affordance (#567)", () => {
+  it("renders a breadcrumb back to the praxis on mobile, even when published", () => {
+    formFactor.value = "mobile";
+    editState.current = publishedState;
+    expect(render()).toContain('href="/praxes/55"');
+  });
+
+  it("does not add its own breadcrumb on desktop (archetypes own it there)", () => {
+    formFactor.value = "desktop";
+    editState.current = publishedState;
+    expect(render()).not.toContain('href="/praxes/55"');
+  });
+});


### PR DESCRIPTION
Closes #567

Mobile edit-praxis skins paint no breadcrumb, so after publish the phone composer was a dead end with no way back. Render the shared desktop `Breadcrumb` once in the EditPraxis wrapper on the mobile path — present for every skin and every state (incl. published). Gated to mobile so desktop archetypes (which own their breadcrumb) do not double up. Test renders the wrapper headless and asserts the back link appears on mobile and is absent on desktop.
