### PR TITLE
fix(flag): note available for every flag reason (#570)

### DIFF
--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -104,7 +104,7 @@
       "body": "If this content is inappropriate or violates the rules, flag it for admin review.",
       "flag": "Flag",
       "reasonGroupLabel": "Flag reason",
-      "notePlaceholder": "What's wrong? (optional note for the moderators)",
+      "notePlaceholder": "Add a note (optional)",
       "submit": "Submit flag",
       "submitting": "...",
       "cancel": "Cancel"

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -18,7 +18,7 @@ import { reframeLabel } from '../../components/vote/voteReframes'
 import { TaskCrown } from '../../components/cards/TaskCrown'
 import type { PraxisDetailState } from './usePraxisDetail'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
-import { flagReasonOptions, FLAG_REASON_OTHER } from '../../utils/flagReasons'
+import { flagReasonOptions } from '../../utils/flagReasons'
 
 // ── Egalitarian byline (#387) ────────────────────────────────────────────────
 //
@@ -385,7 +385,13 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
               </button>
             ))}
           </div>
-          {flagReason === FLAG_REASON_OTHER && (
+          {/* A note is available for every reason, not just "Other" (#570).
+              handleFlag forwards flagDetail regardless of reason. Note: the
+              backend only *persists* the note for the "other" reason (ADR-0037,
+              stored_flag_reason); for named reasons it is accepted but not
+              stored — persisting it for all reasons would need a reason_detail
+              column (follow-up, out of #570's scope). */}
+          {flagReason !== null && (
             <textarea
               className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink w-full resize-none"
               rows={2}


### PR DESCRIPTION
Closes #570

The flag-note textarea was gated to the "Other" reason only, so on both desktop and mobile you could not add a note when picking a named reason. Drop the gate so the note renders once any reason is selected, relabelled to the neutral "Add a note (optional)". `handleFlag` already forwards the note regardless of reason.

Backend note: `stored_flag_reason` (ADR-0037) only *persists* the note for the `other` reason; for named reasons the note is accepted (no rejection) but not stored — there is no `reason_detail` column. Persisting it for all reasons is a schema change, out of this frontend-scoped issue; flagging as a possible follow-up.
