### PR TITLE
feat(collab): pending consensus status + unify withdraw/unsubmit (#590)

### DIFF
--- a/backend/alembic/versions/0001_squashed.py
+++ b/backend/alembic/versions/0001_squashed.py
@@ -37,7 +37,7 @@ ENUMS: list[tuple[str, list[str]]] = [
     ("taskstatus", ["pending", "active", "retired"]),
     ("tasktype", ["standard", "metatask"]),
     ("praxistype", ["solo", "collab", "duel"]),
-    ("praxisstatus", ["in_progress", "submitted"]),
+    ("praxisstatus", ["in_progress", "pending", "submitted"]),
     ("praxisinvitestatus", ["pending", "accepted", "declined"]),
     ("mediatype", ["image", "video", "audio"]),
     ("moderationstatus", ["visible", "flagged", "hidden", "failed", "deleted"]),

--- a/backend/models/praxis.py
+++ b/backend/models/praxis.py
@@ -38,6 +38,10 @@ class PraxisType(enum.Enum):
 
 class PraxisStatus(enum.Enum):
     in_progress = "in_progress"
+    # A collab mid-consensus (#590): at least one member submitted but not all.
+    # Open, member-only and unscored like in_progress, but distinct so the UI/feed
+    # can surface the pending-publish state. Solo/duel never enter it.
+    pending = "pending"
     submitted = "submitted"
 
 

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -62,7 +62,7 @@ from services.praxis import (
     respond_to_invite,
     submit_praxis,
     update_praxis,
-    withdraw_praxis,
+    unsubmit_praxis,
 )
 from services.media import process_and_save_media
 from services.vote import cast_vote_on_praxis
@@ -221,13 +221,13 @@ async def delete_praxis_route(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{praxis_id}/withdraw", response_model=PraxisOut)
-async def withdraw_praxis_route(
+@router.post("/{praxis_id}/unsubmit", response_model=PraxisOut)
+async def unsubmit_praxis_route(
     praxis_id: int,
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    praxis = await withdraw_praxis(
+    praxis = await unsubmit_praxis(
         praxis_id=praxis_id,
         character_id=character.id,
         session=session,

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -163,7 +163,7 @@ async def _get_my_task_ids(
         .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
         .where(
             PraxisMember.character_id == character_id,
-            Praxis.status == PraxisStatus.in_progress,
+            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.pending]),
         )
     )
     return list(result.scalars().all())

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -548,7 +548,9 @@ async def list_characters_for_viewer(
             .join(Praxis, PraxisMember.praxis_id == Praxis.id)
             .where(
                 Praxis.task_id == exclude_active_task_id,
-                Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.submitted]),
+                Praxis.status.in_(
+                    [PraxisStatus.in_progress, PraxisStatus.pending, PraxisStatus.submitted]
+                ),
             )
         )
         query = query.where(

--- a/backend/services/collab_consensus.py
+++ b/backend/services/collab_consensus.py
@@ -60,7 +60,7 @@ async def settle_if_window_lapsed(
     """
     if (
         praxis.type != PraxisType.collab
-        or praxis.status != PraxisStatus.in_progress
+        or praxis.status not in (PraxisStatus.in_progress, PraxisStatus.pending)
         or praxis.submit_proposed_at is None
     ):
         return
@@ -119,9 +119,13 @@ async def on_submit(
         _apply_seal(praxis)
         await session.flush()
         return True
-    if praxis.type == PraxisType.collab and praxis.submit_proposed_at is None:
-        # First member to submit opens the silence-is-consent countdown.
-        praxis.submit_proposed_at = datetime.now(timezone.utc)
+    if praxis.type == PraxisType.collab:
+        # A partial collab submit is a first-class "pending" state (#590): some
+        # members are in, not all. The first submit also opens the
+        # silence-is-consent countdown.
+        praxis.status = PraxisStatus.pending
+        if praxis.submit_proposed_at is None:
+            praxis.submit_proposed_at = datetime.now(timezone.utc)
         await session.flush()
     return False
 
@@ -148,4 +152,26 @@ async def on_member_kicked(praxis: Praxis, session: AsyncSession) -> None:
         member.has_submitted = False
     praxis.status = PraxisStatus.in_progress
     praxis.submit_proposed_at = None
+    await session.flush()
+
+
+async def on_member_unsubmit(
+    praxis: Praxis, character_id: int, session: AsyncSession, era: EraConfig = CURRENT_ERA
+) -> None:
+    """Pull back a single member's submission from a pending collab (#590).
+
+    Only the caller's ``has_submitted`` clears. If anyone else is still in, the
+    collab stays ``pending``; if the caller was the last hold-out it returns to
+    ``in_progress`` and the silence-is-consent window closes. Pending collabs are
+    unscored, so no stat recalc is needed. Solo/duel never reach ``pending``.
+    """
+    for member in praxis.members:
+        if member.character_id == character_id:
+            member.has_submitted = False
+            break
+    if any(m.has_submitted for m in praxis.members):
+        praxis.status = PraxisStatus.pending
+    else:
+        praxis.status = PraxisStatus.in_progress
+        praxis.submit_proposed_at = None
     await session.flush()

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -109,7 +109,9 @@ async def _count_in_progress_praxes(character_id: int, session: AsyncSession) ->
         .join(Praxis, PraxisMember.praxis_id == Praxis.id)
         .where(
             PraxisMember.character_id == character_id,
-            Praxis.status == PraxisStatus.in_progress,
+            # pending = a collab mid-consensus; still an open, slot-consuming
+            # membership for bank-cap purposes (#590).
+            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.pending]),
         )
     )
     return result.scalar_one()
@@ -125,7 +127,7 @@ async def recalculate_members_stats(
     """Recalculate stats for every member of ``praxis``, then flush (#492).
 
     Lifts the per-member recalc loop copy-pasted across ``submit_praxis``,
-    ``withdraw_praxis``, ``apply_metatask``, and ``remove_metatask``. Callers
+    ``unsubmit_praxis``, ``apply_metatask``, and ``remove_metatask``. Callers
     that already hold an ``era_row`` (e.g. a duel-forfeit recalc that reuses it)
     pass it in to avoid a re-fetch. ``leave_praxis`` deliberately does NOT use
     this — it recalcs only the single leaver, not all members.
@@ -637,25 +639,41 @@ async def update_praxis(
     return await get_praxis(praxis_id, session)
 
 
-async def withdraw_praxis(
+async def unsubmit_praxis(
     praxis_id: int,
     character_id: int,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> Praxis:
-    """Move praxis back to editing (in_progress). Any member may reopen (ADR-0013).
+    """Unsubmit a praxis back to editing. Any member may act (ADR-0013). #590.
 
-    Votes are preserved but stop contributing to score until resubmitted via
-    ``submit_praxis``. For collabs/duels, member submission flags are reset so
-    the full group must re-submit.
-
-    Unsubmitting a *settled* duel side forfeits the contest (ADR-0011 §Forfeit):
-    the opponent wins by default, the duel stays ``settled``, and the forfeit is
-    permanent — resubmitting does not restore it.
+    Three cases by status:
+    - ``submitted``: the whole group reopens. Votes are preserved but stop scoring
+      until resubmitted; every member's ``has_submitted`` clears. Unsubmitting a
+      *settled* duel side forfeits the contest permanently (ADR-0011 §Forfeit):
+      the opponent wins by default and the duel stays ``settled``.
+    - ``pending`` (a collab mid-consensus) where the caller has already submitted:
+      only the caller's part is pulled back (``on_member_unsubmit``); other members'
+      submissions stand. Pending praxes are unscored — no stat recalc.
+    - anything else (a fresh ``in_progress`` praxis, or ``pending`` where the caller
+      has not submitted): 422 — nothing of theirs to pull back.
     """
     praxis = await get_praxis(praxis_id, session)
     _require_member(praxis, character_id, "reopen")
-    if praxis.status == PraxisStatus.in_progress:
+
+    # Pending collab: pull back only the caller's own submission.
+    if praxis.status == PraxisStatus.pending:
+        caller = next(
+            (m for m in praxis.members if m.character_id == character_id), None
+        )
+        if caller is None or not caller.has_submitted:
+            raise HTTPException(
+                status_code=422, detail="Praxis is already in editing mode."
+            )
+        await collab_consensus.on_member_unsubmit(praxis, character_id, session, era)
+        return await get_praxis(praxis_id, session)
+
+    if praxis.status != PraxisStatus.submitted:
         raise HTTPException(status_code=422, detail="Praxis is already in editing mode.")
 
     # ADR-0011 §Forfeit (#307): unsubmitting a *settled* duel side forfeits the
@@ -725,7 +743,7 @@ async def change_praxis_type(
 
     praxis = await get_praxis(praxis_id, session)
     _require_member(praxis, character_id, "change the mode of")
-    if praxis.status != PraxisStatus.in_progress:
+    if praxis.status not in (PraxisStatus.in_progress, PraxisStatus.pending):
         raise HTTPException(
             status_code=422, detail="Can only change mode while the praxis is in editing."
         )
@@ -875,7 +893,9 @@ def active_member_task_ids_subquery(character_id: int):
         .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
         .where(
             PraxisMember.character_id == character_id,
-            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.submitted]),
+            Praxis.status.in_(
+                [PraxisStatus.in_progress, PraxisStatus.pending, PraxisStatus.submitted]
+            ),
         )
     )
 
@@ -897,7 +917,9 @@ async def is_active_member_of_task(
         .where(
             PraxisMember.character_id == character.id,
             Praxis.task_id == task.id,
-            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.submitted]),
+            Praxis.status.in_(
+                [PraxisStatus.in_progress, PraxisStatus.pending, PraxisStatus.submitted]
+            ),
         )
     )
     return result.scalar_one_or_none() is not None
@@ -1452,5 +1474,5 @@ __all__ = [
     "SignupEligibility",
     "submit_praxis",
     "update_praxis",
-    "withdraw_praxis",
+    "unsubmit_praxis",
 ]

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -177,7 +177,7 @@ async def list_signups_for_task(
         .join(Character, PraxisMember.character_id == Character.id)
         .where(
             Praxis.task_id == task_id,
-            Praxis.status == PraxisStatus.in_progress,
+            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.pending]),
         )
         .order_by(PraxisMember.joined_at.asc())
     )

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -278,7 +278,7 @@ async def test_withdraw_praxis(
     # Must be submitted before withdrawing back to editing
     await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
 
-    withdraw_resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    withdraw_resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)
     assert withdraw_resp.status_code == 200
     data = withdraw_resp.json()
     assert data["status"] == "in_progress"
@@ -314,7 +314,7 @@ async def test_withdraw_updates_score(
     await db_session.refresh(stats)
     score_after_submit = stats.score
 
-    withdraw_resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    withdraw_resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)
     assert withdraw_resp.status_code == 200
 
     await db_session.refresh(stats)
@@ -342,7 +342,7 @@ async def test_submit_editing_withdraw_submit_roundtrip(
     assert submit_resp.status_code == 200
     assert submit_resp.json()["status"] == "submitted"
 
-    withdraw_resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    withdraw_resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)
     assert withdraw_resp.status_code == 200
     assert withdraw_resp.json()["status"] == "in_progress"
 
@@ -368,7 +368,7 @@ async def test_withdraw_already_in_progress_returns_422(
     praxis_id = create_resp.json()["id"]
 
     # Praxis starts in_progress — withdrawing immediately returns 422
-    resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)
     assert resp.status_code == 422
 
 
@@ -390,7 +390,7 @@ async def test_withdraw_wrong_owner_returns_403(
     assert create_resp.status_code == 201
     praxis_id = create_resp.json()["id"]
 
-    resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers2)
+    resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers2)
     assert resp.status_code == 403
 
 
@@ -849,7 +849,7 @@ async def test_collab_all_submit_transitions_to_submitted(
     submit1 = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
     assert submit1.status_code == 200
     # Not yet submitted (character still needs to submit)
-    assert submit1.json()["status"] == "in_progress"
+    assert submit1.json()["status"] == "pending"
 
     # character submits
     submit2 = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
@@ -990,7 +990,7 @@ async def test_collab_non_creator_can_reopen(
     submit2 = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
     assert submit2.json()["status"] == "submitted"
 
-    resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)
     assert resp.status_code == 200
     assert resp.json()["status"] == "in_progress"
 
@@ -1039,7 +1039,7 @@ async def test_collab_partial_submit_opens_pending_window(
     resp = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
     assert resp.status_code == 200
     data = resp.json()
-    assert data["status"] == "in_progress"          # not Live yet
+    assert data["status"] == "pending"          # not Live yet
     assert data["submit_proposed_at"] is not None   # countdown opened
 
 
@@ -2245,3 +2245,137 @@ async def test_change_type_takeover_clears_pending_publish_window(
     assert body["status"] == "in_progress"
     assert body["submit_proposed_at"] is None
     assert all(not m["has_submitted"] for m in body["members"])
+
+
+# ---------------------------------------------------------------------------
+# Pending consensus state + per-member unsubmit (#590)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_collab_counts_against_bank_cap(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """A pending (mid-consensus) collab is still an open, slot-consuming membership."""
+    from services.praxis import _count_in_progress_praxes
+
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    resp = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+    assert resp.json()["status"] == "pending"
+    assert await _count_in_progress_praxes(character2.id, db_session) == 1
+    assert await _count_in_progress_praxes(character.id, db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_collab_appears_in_active_tasks(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """A pending collab's task still counts as one its members are working on."""
+    from services.activity_feed import _get_my_task_ids
+
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+    assert active_task.id in await _get_my_task_ids(character2.id, db_session)
+    assert active_task.id in await _get_my_task_ids(character.id, db_session)
+
+
+@pytest.mark.asyncio
+async def test_unsubmit_pending_clears_only_caller(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    auth_headers3: dict,
+):
+    """In a pending collab with two members submitted, one member's unsubmit clears
+    only their own part; the collab stays pending while the other remains in (#590)."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Trio"},
+        headers=auth_headers2,
+    )
+    praxis_id = create.json()["id"]
+    for invitee_id, invitee_headers in (
+        (character.id, auth_headers),
+        (character3.id, auth_headers3),
+    ):
+        inv = await client.post(
+            f"/praxes/{praxis_id}/invite",
+            json={"invitee_id": invitee_id},
+            headers=auth_headers2,
+        )
+        await client.post(
+            f"/praxes/{praxis_id}/invite/{inv.json()['id']}/respond",
+            json={"accept": True},
+            headers=invitee_headers,
+        )
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+    resp = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers3)
+    assert resp.json()["status"] == "pending"
+
+    unsub = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers2)
+    assert unsub.status_code == 200
+    data = unsub.json()
+    assert data["status"] == "pending"
+    submitted = {m["character_id"]: m["has_submitted"] for m in data["members"]}
+    assert submitted[character2.id] is False
+    assert submitted[character3.id] is True
+
+
+@pytest.mark.asyncio
+async def test_unsubmit_last_pending_member_returns_to_in_progress(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """The last submitted member unsubmitting a pending collab reopens it fully (#590)."""
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+    resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers2)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "in_progress"
+    assert data["submit_proposed_at"] is None
+    assert all(not m["has_submitted"] for m in data["members"])
+
+
+@pytest.mark.asyncio
+async def test_unsubmit_fresh_in_progress_returns_422(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """Unsubmitting a praxis that was never submitted is a 422 — nothing to pull back."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Fresh"},
+        headers=auth_headers,
+    )
+    praxis_id = create.json()["id"]
+    resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)
+    assert resp.status_code == 422

--- a/backend/tests/integration/test_praxis_visibility.py
+++ b/backend/tests/integration/test_praxis_visibility.py
@@ -154,7 +154,7 @@ async def test_resubmit_preserves_vote_tally(
     before = await client.get(f"/praxes/{praxis_id}/votes")
     assert before.json()["total_votes"] == 1
 
-    assert (await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)).status_code == 200
+    assert (await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)).status_code == 200
     assert (await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)).status_code == 200
 
     after = await client.get(f"/praxes/{praxis_id}/votes")
@@ -201,7 +201,7 @@ async def test_withdraw_collab_recalculates_every_member(
     assert coauthor_before > 0
 
     # character (a member, but NOT the co-author) reopens the collab.
-    withdraw = await client.post(f"/praxes/{praxis.id}/withdraw", headers=auth_headers)
+    withdraw = await client.post(f"/praxes/{praxis.id}/unsubmit", headers=auth_headers)
     assert withdraw.status_code == 200
 
     coauthor_after = (await client.get(f"/characters/{character2.id}")).json()["score"]
@@ -237,7 +237,7 @@ async def test_withdraw_settled_duel_side_forfeits(
     db_session.add(duel)
     await db_session.commit()
 
-    resp = await client.post(f"/praxes/{praxis_id}/withdraw", headers=auth_headers)
+    resp = await client.post(f"/praxes/{praxis_id}/unsubmit", headers=auth_headers)
     assert resp.status_code == 200
 
     await db_session.refresh(duel)

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -814,7 +814,7 @@ async def test_forfeit_by_unsubmit_gives_opponent_win_regardless_of_votes(
     resubmitting does not restore the contest (ADR-0011 §Forfeit)."""
     from game_config import CURRENT_ERA
     from models.duel import Duel, DuelStatus
-    from services.praxis import get_praxis, withdraw_praxis
+    from services.praxis import get_praxis, unsubmit_praxis
     from services.praxis_scoring import compute_contributions
 
     challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
@@ -833,7 +833,7 @@ async def test_forfeit_by_unsubmit_gives_opponent_win_regardless_of_votes(
 
     # No votes cast on either side → without forfeit this is a 1.0x tie for both.
     # character2 forfeits by unsubmitting their side.
-    await withdraw_praxis(opponent_pid, character2.id, db_session)
+    await unsubmit_praxis(opponent_pid, character2.id, db_session)
 
     challenger_praxis = await get_praxis(challenger_pid, db_session)
     contribs = await compute_contributions(
@@ -1042,7 +1042,7 @@ async def test_duel_detail_marks_forfeited_side(
 ):
     """A forfeited duel: winner renders fully, thrown side marked unsubmitted, no body leak."""
     from models.duel import Duel, DuelStatus
-    from services.praxis import withdraw_praxis
+    from services.praxis import unsubmit_praxis
 
     challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
     opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
@@ -1057,7 +1057,7 @@ async def test_duel_detail_marks_forfeited_side(
     await db_session.commit()
 
     # character2 forfeits by unsubmitting their side; commit so the API view sees it.
-    await withdraw_praxis(opponent_pid, character2.id, db_session)
+    await unsubmit_praxis(opponent_pid, character2.id, db_session)
     await db_session.commit()
 
     resp = await client.get(f"/duels/{duel.id}/detail")

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -171,8 +171,11 @@ export async function changePraxisType(id: number, type: PraxisType): Promise<Pr
 // Lifecycle transitions
 // ---------------------------------------------------------------------------
 
-export async function withdrawPraxis(id: number): Promise<PraxisOut> {
-  const { data } = await api.post<PraxisOut>(`/praxes/${id}/withdraw`)
+// Unsubmit a praxis back to editing (#590 renamed withdraw → unsubmit). For a
+// sealed solo/collab this reopens the whole group; for a pending collab where
+// the caller has submitted, it clears only the caller's part.
+export async function unsubmitPraxis(id: number): Promise<PraxisOut> {
+  const { data } = await api.post<PraxisOut>(`/praxes/${id}/unsubmit`)
   return data
 }
 

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -84,7 +84,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
   // Drop the chosen in-progress praxis to free a slot, then retry the accept.
   //   authored solo  → deletePraxis  (removes the praxis)
   //   joined collab  → leavePraxis   (drops your membership)
-  // NEVER withdrawPraxis — it keeps the membership and does not free a slot.
+  // NEVER unsubmitPraxis — it keeps the membership and does not free a slot.
   const dropAndRetry = async (praxis: {
     id: number;
     created_by_id: number;

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -13,7 +13,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   getPraxis,
-  withdrawPraxis,
+  unsubmitPraxis,
   submitPraxis,
   flagPraxis,
   applyMetatask,
@@ -236,7 +236,7 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     setWithdrawing(true);
     setWithdrawError(null);
     try {
-      const updated = await withdrawPraxis(praxis.id);
+      const updated = await unsubmitPraxis(praxis.id);
       setPraxis(updated);
       setShowWithdrawConfirm(false);
       void refetch();


### PR DESCRIPTION
Closes #590

Promotes the collab mid-consensus state to a first-class `PraxisStatus.pending` and unifies withdraw/unsubmit.

- **pending status**: a partial collab submit (some members in, not all) now sets `status=pending` instead of leaving `in_progress`. Solo/duel never enter it. Strategy A — no migration; the enum value is added to the model and the dev/test DB enum type.
- **per-member unsubmit**: new `collab_consensus.on_member_unsubmit` pulls back only the caller's submission — stays `pending` if another member remains submitted, else returns to `in_progress` and closes the silence-is-consent window.
- **widened "still open" checks** so a pending collab keeps behaving like an active hold: bank-cap count, active-tasks query, task-member list, change-type guard, active-membership subqueries, invite-search exclusion, and the auto-publish timeout guard (which would otherwise never fire for a pending collab — a bug the new state introduced). Visibility is deliberately NOT widened (a pending collab stays member-only, like in_progress).
- **rename** `withdraw_praxis` → `unsubmit_praxis`; route `POST /praxes/{id}/withdraw` → `/unsubmit`; the frontend caller was updated in an earlier commit on this branch. `unsubmit` now branches three ways: `submitted` → group-wide reopen (unchanged, incl. settled-duel forfeit); `pending` + caller submitted → per-member pull-back; anything else → 422.

Gate: `pytest --cov=. --cov-fail-under=80` → **573 passed, 86.91%**. Stacked on #575 (base `claude/flag-comment-frontend-575`).
