### PR TITLE
feat(feed): collaborator-submitted notification (#571)

### DIFF
--- a/backend/models/praxis.py
+++ b/backend/models/praxis.py
@@ -155,6 +155,11 @@ class PraxisMember(Base):
     has_submitted: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
     )
+    # When has_submitted last flipped True (#571). The collaborator-submitted feed
+    # sorts strictly by this, not joined_at. NULL = never submitted / pulled back.
+    submitted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     joined_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -79,6 +79,7 @@ FEED_ITEM_TYPE_INVITATION_LETTER = "invitation_letter"
 FEED_ITEM_TYPE_FRIEND_DEFECTION = "friend_defection"
 FEED_ITEM_TYPE_FOE_COMPLETION = "foe_completion"
 FEED_ITEM_TYPE_COMMENT_MENTION = "comment_mention"
+FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED = "collaborator_submitted"
 
 # --- Filter tabs ------------------------------------------------------------
 FILTER_ALL = "all"
@@ -627,6 +628,65 @@ def _comment_mention_item(row: Any) -> ActivityFeedItemDC:
     )
 
 
+def _collaborator_submitted_query(ctx: FeedContext) -> Select:
+    """A collaborator submitted their part of a collab the viewer is also in (#571).
+
+    PraxisMember rows with has_submitted=True on collab praxes the viewer is also
+    a member of, excluding the viewer's own membership. Ordered by submitted_at —
+    the moment their part landed, not when they joined.
+    """
+    viewer_praxis_ids = (
+        select(PraxisMember.praxis_id)
+        .where(PraxisMember.character_id == ctx.character_id)
+        .scalar_subquery()
+    )
+    query = (
+        select(
+            PraxisMember.id,
+            PraxisMember.submitted_at,
+            PraxisMember.praxis_id,
+            Character.id.label("character_id"),
+            Character.display_name,
+            Character.faction_slug,
+            Character.avatar_url,
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+        )
+        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+        .join(Character, PraxisMember.character_id == Character.id)
+        .join(Task, Praxis.task_id == Task.id)
+        .where(
+            PraxisMember.has_submitted.is_(True),
+            PraxisMember.submitted_at.is_not(None),
+            PraxisMember.character_id != ctx.character_id,
+            Praxis.type == PraxisType.collab,
+            PraxisMember.praxis_id.in_(viewer_praxis_ids),
+        )
+    )
+    if ctx.before is not None:
+        query = query.where(PraxisMember.submitted_at < ctx.before)
+    return query.order_by(PraxisMember.submitted_at.desc()).limit(SUB_QUERY_LIMIT)
+
+
+def _collaborator_submitted_item(row: Any) -> ActivityFeedItemDC:
+    return ActivityFeedItemDC(
+        type=FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED,
+        timestamp=row.submitted_at,
+        actor_display_name=row.display_name,
+        actor_faction_slug=row.faction_slug,
+        actor_avatar_url=row.avatar_url,
+        payload={
+            "praxis_member_id": row.id,
+            "character_id": row.character_id,
+            "praxis_id": row.praxis_id,
+            "task_title": row.task_title,
+            "task_point_value": row.task_point_value,
+            "task_faction_slug": row.task_faction_slug,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # The registry — one entry per feed type. Adding a type is one line here.
 # ---------------------------------------------------------------------------
@@ -687,6 +747,13 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset({NEEDS_FRIEND_IDS, NEEDS_MY_TASK_IDS}),
         query=_friend_signups_query,
         to_item=_friend_signup_item,
+    ),
+    FeedSource(
+        item_type=FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED,
+        filters=frozenset({FILTER_ALL, FILTER_YOUR_STUFF}),
+        needs=frozenset(),
+        query=_collaborator_submitted_query,
+        to_item=_collaborator_submitted_item,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_INVITATION_LETTER,

--- a/backend/services/collab_consensus.py
+++ b/backend/services/collab_consensus.py
@@ -27,9 +27,12 @@ def _apply_seal(praxis: Praxis) -> None:
     """Pure state mutation for going Live: mark the whole group submitted and clear
     the window. Caller flushes and recalculates member stats."""
     praxis.status = PraxisStatus.submitted
-    praxis.submitted_at = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc)
+    praxis.submitted_at = now
     praxis.submit_proposed_at = None
     for member in praxis.members:
+        if not member.has_submitted:
+            member.submitted_at = now
         member.has_submitted = True
 
 
@@ -88,6 +91,7 @@ async def on_member_edit(
     praxis.status = PraxisStatus.in_progress
     for member in praxis.members:
         member.has_submitted = False
+        member.submitted_at = None
     await session.flush()
     if was_live:
         # Leaving Live changes scoring — recompute every member's stats.
@@ -111,6 +115,7 @@ async def on_submit(
     for member in praxis.members:
         if member.character_id == character_id:
             member.has_submitted = True
+            member.submitted_at = datetime.now(timezone.utc)
             break
     await session.flush()
     await session.refresh(praxis)
@@ -150,6 +155,7 @@ async def on_member_kicked(praxis: Praxis, session: AsyncSession) -> None:
     Call after removing the kicked member."""
     for member in praxis.members:
         member.has_submitted = False
+        member.submitted_at = None
     praxis.status = PraxisStatus.in_progress
     praxis.submit_proposed_at = None
     await session.flush()
@@ -168,6 +174,7 @@ async def on_member_unsubmit(
     for member in praxis.members:
         if member.character_id == character_id:
             member.has_submitted = False
+            member.submitted_at = None
             break
     if any(m.has_submitted for m in praxis.members):
         praxis.status = PraxisStatus.pending

--- a/backend/tests/integration/test_activity_feed.py
+++ b/backend/tests/integration/test_activity_feed.py
@@ -242,3 +242,53 @@ async def test_badge_count_equals_windowed_fetch_length_per_tab(
     ).json()
     assert any(i["type"] == "duel_challenge" for i in requests["items"])
     assert requests["counts"]["requests"] == 2  # pending collab invite + pending duel
+
+
+@pytest.mark.asyncio
+async def test_activity_feed_shows_collaborator_submitted(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A co-member submitting their part of a collab the viewer is in surfaces a
+    collaborator_submitted entry in the viewer's feed (#571)."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Team"},
+        headers=auth_headers2,
+    )
+    praxis_id = create.json()["id"]
+    inv = await client.post(
+        f"/praxes/{praxis_id}/invite",
+        json={"invitee_id": character.id},
+        headers=auth_headers2,
+    )
+    await client.post(
+        f"/praxes/{praxis_id}/invite/{inv.json()['id']}/respond",
+        json={"accept": True},
+        headers=auth_headers,
+    )
+    # character2 submits their part -> pending; character (a co-member) should see it.
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+
+    feed = await client.get(
+        "/activity-feed", params={"filter": "your_stuff"}, headers=auth_headers
+    )
+    assert feed.status_code == 200
+    items = [i for i in feed.json()["items"] if i["type"] == "collaborator_submitted"]
+    assert len(items) == 1, feed.json()["items"]
+    entry = items[0]
+    assert entry["payload"]["praxis_id"] == praxis_id
+    assert entry["payload"]["character_id"] == character2.id
+    assert entry["actor_display_name"] == character2.display_name
+
+    # The submitter does not get a notification about their own submission.
+    own = await client.get(
+        "/activity-feed", params={"filter": "your_stuff"}, headers=auth_headers2
+    )
+    assert not [
+        i for i in own.json()["items"] if i["type"] == "collaborator_submitted"
+    ]

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -36,6 +36,24 @@ describe('normalizeFeedItem', () => {
     expect(row.badge?.label).toBe('Friend')
   })
 
+  it('maps a collaborator submission to the your-stuff row (#571)', () => {
+    const row = normalizeFeedItem(
+      item('collaborator_submitted', {
+        character_id: 8,
+        praxis_id: 12,
+        task_title: 'Plant a tree',
+        task_point_value: 25,
+      }),
+    )!
+    expect(row.actor).toBe('Ada')
+    expect(row.action).toBe('submitted their part of')
+    expect(row.actorHref).toBe('/characters/8')
+    expect(row.headline).toBe('Plant a tree')
+    expect(row.headlineHref).toBe('/praxes/12')
+    expect(row.points).toBe('25 pts')
+    expect(row.badge?.label).toBe('Your Stuff')
+  })
+
   it('resolves a taunt from the catalog, quotes it, and drops points', () => {
     // ADR-0031: payload is a structured reference; the catalog owns the words.
     // wow/score_overtake has 2 variants; taunt_id 9 -> 9 % 2 = 1 -> the second.

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -28,6 +28,7 @@ export const FACTION_ROW_TYPES = new Set([
   'friend_signup',
   'friend_defection',
   'global_task',
+  'collaborator_submitted',
 ])
 
 export interface FeedRow {
@@ -94,6 +95,25 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
+        time,
+      }
+    case 'collaborator_submitted':
+      // A co-member submitted their part of a collab you're in (#571). Reuses the
+      // friend-signup row shape; framed in the submitter's faction voice.
+      return {
+        slug,
+        actor,
+        actorHref: p.character_id != null ? `/characters/${p.character_id}` : null,
+        action: i18n.t('feed:row.action.collaboratorSubmitted'),
+        badge: { type: 'your_stuff', label: i18n.t('feed:badge.yourStuff') },
+        headline: p.task_title ?? null,
+        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}` : null,
+        headlineQuoted: false,
+        points:
+          p.task_point_value != null
+            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            : null,
+        level: null,
         time,
       }
     case 'vote_on_mine':

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -32,6 +32,7 @@
     "action": {
       "completedTask": "completed a task",
       "signedUpSharedTask": "signed up for a task you're doing",
+      "collaboratorSubmitted": "submitted their part of",
       "votedOnYourPraxis": "voted on your praxis",
       "tauntsYou": "taunts you",
       "defected": "defected from {{oldFaction}} to {{newFaction}}",


### PR DESCRIPTION
Closes #571

You now get an Updates entry when a co-member submits their part of a collab you're in.

**Backend**
- `PraxisMember.submitted_at` — stamped at every `has_submitted` → True flip (`on_submit`, `_apply_seal`), nulled when cleared. The feed sorts by this, not `joined_at` (the wrong time). No migration (Strategy A; dev DB column added, test DB rebuilt by `create_all`).
- New `collaborator_submitted` `FeedSource`: `PraxisMember` rows with `has_submitted` on collab praxes where the viewer is also a member, excluding the viewer's own membership, ordered by `submitted_at`. It lands in `all` + `your_stuff`. `context_faction_slug` resolves to the submitter's faction automatically (`actor_faction_slug`), so it's framed in their voice — no schema change.

**Frontend**
- Adds `collaborator_submitted` to `normalizeFeedItem` (the #376 faction-owned-row path, which is where friend-signup/completion actually live now — not a bespoke `FeedCardRouter` card). Reuses the friend-signup row shape with a your-stuff badge. Shared by desktop + mobile Updates via `useUpdates`.

Tests: feed integration test (co-member submit surfaces the entry; submitter doesn't self-notify) + `normalizeFeedItem` row test. Gate: **574 passed, 86.95%**. Stacked on #590 (base `claude/collab-pending-status-590`).
