### PR TITLE
feat(collab): cast-status roster for the composer (part of #591)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -7,7 +7,7 @@ import type { FlagReason } from '../utils/flagReasons'
 // ---------------------------------------------------------------------------
 
 export type PraxisType = 'solo' | 'collab' | 'duel'
-export type PraxisStatus = 'in_progress' | 'submitted'
+export type PraxisStatus = 'in_progress' | 'pending' | 'submitted'
 export type PraxisInviteStatus = 'pending' | 'accepted' | 'declined'
 export type ModerationStatus = 'visible' | 'flagged' | 'hidden' | 'failed'
 export type MediaType = 'image' | 'video' | 'audio'

--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -11,7 +11,8 @@
  *   cast_count === member_count         → published (S4) every part woven
  *
  * `action` is supplied only in the editable composer; the read-only detail view
- * omits it (the detail page owns its own reopen affordance).
+ * omits it (the detail page owns its own reopen affordance). Spacing/type via
+ * Tailwind utilities + --text-* tokens, not raw inline pixels (#588 lint guard).
  */
 import { useTranslation } from 'react-i18next'
 import type { PraxisMemberOut } from '../../api/praxis'
@@ -79,10 +80,10 @@ export function CollabRoster({
           : null
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+    <div className="flex flex-col gap-[8px]">
       {/* Header: label + cast progress chip */}
       <div className="flex items-center gap-2" style={{ justifyContent: 'space-between' }}>
-        <span className="eyebrow" style={{ fontSize: 10, color: 'var(--color-text-secondary)' }}>
+        <span className="eyebrow text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
           {t('editPraxis.collab.castStatus', { cast: gate.castCount, total: gate.memberCount })}
         </span>
       </div>
@@ -100,22 +101,21 @@ export function CollabRoster({
       </div>
 
       {/* Roster rows */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <div className="flex flex-col gap-[4px]">
         {members.map((member) => {
           const isMe = member.character_id === currentCharacterId
           const cast = member.has_submitted
           return (
             <div
               key={member.id}
-              className="flex items-center gap-2"
+              className="flex items-center gap-2 px-[10px] py-[5px]"
               style={{
-                padding: '5px 10px',
                 borderRadius: 4,
                 border: cast ? `1.5px solid ${accent}` : '1.5px dashed var(--color-border)',
                 background: cast ? factionCssVar(factionSlug, 'card-muted') : 'transparent',
               }}
             >
-              <span className="font-body" style={{ fontSize: 12, fontWeight: cast ? 700 : 400, flex: 1 }}>
+              <span className="font-body text-[12px]" style={{ fontWeight: cast ? 700 : 400, flex: 1 }}>
                 {member.character_display_name}
                 {isMe && (
                   <span style={{ color: 'var(--color-text-tertiary)' }}> · {t('editPraxis.collab.you')}</span>
@@ -124,13 +124,7 @@ export function CollabRoster({
                   <span style={{ color: 'var(--color-success)', fontWeight: 700 }}> +{taskPointValue}</span>
                 )}
               </span>
-              <span
-                className="eyebrow"
-                style={{
-                  fontSize: 9,
-                  color: cast ? accent : 'var(--color-warning)',
-                }}
-              >
+              <span className="eyebrow text-[9px]" style={{ color: cast ? accent : 'var(--color-warning)' }}>
                 {cast ? `✓ ${t('editPraxis.collab.pillCast')}` : t('editPraxis.collab.pillWeaving')}
               </span>
             </div>
@@ -141,10 +135,8 @@ export function CollabRoster({
       {/* Per-state banner */}
       {banner && (
         <p
-          className="font-body"
+          className="font-body text-[11px] px-[10px] py-[6px]"
           style={{
-            fontSize: 11,
-            padding: '6px 10px',
             borderRadius: 4,
             color: banner.tone,
             border: `1px solid ${banner.tone}`,
@@ -161,8 +153,8 @@ export function CollabRoster({
           type="button"
           onClick={() => (gate.iCast ? action.onPullBack() : action.onCast())}
           disabled={action.submitting}
-          className={gate.iCast ? 'btn-outline' : 'btn-primary'}
-          style={{ fontSize: 11, padding: '6px 14px', alignSelf: 'flex-start' }}
+          className={`${gate.iCast ? 'btn-outline' : 'btn-primary'} text-[11px] px-[14px] py-[6px]`}
+          style={{ alignSelf: 'flex-start' }}
         >
           {gate.iCast
             ? t('editPraxis.collab.pullBackAction')

--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -1,0 +1,176 @@
+/**
+ * Collab submission roster (#591). One shared, faction-token-themed block that
+ * replaces the flat member-pill list in the composer and the plain member byline
+ * on the praxis detail page. It renders the ADR-0012 lazy-consensus state live:
+ * who has cast, who is still weaving, and the gate progress.
+ *
+ * State machine (derived from `members[]` — see docs/design/collab-submission):
+ *   cast_count === 0                    → writing   (S1) nobody cast yet
+ *   0 < cast_count < member_count, I cast → waiting  (S2) my part is in, others aren't
+ *   0 < cast_count < member_count, I didn't → holdout (S3) the circle waits on me
+ *   cast_count === member_count         → published (S4) every part woven
+ *
+ * `action` is supplied only in the editable composer; the read-only detail view
+ * omits it (the detail page owns its own reopen affordance).
+ */
+import { useTranslation } from 'react-i18next'
+import type { PraxisMemberOut } from '../../api/praxis'
+import { factionCssVar } from '../../utils/factions'
+
+export type CollabState = 'writing' | 'waiting' | 'holdout' | 'published'
+
+export interface CollabGate {
+  memberCount: number
+  castCount: number
+  iCast: boolean
+  state: CollabState
+}
+
+/** Pure derivation of the consensus gate from the member list. */
+export function deriveCollabGate(
+  members: readonly PraxisMemberOut[],
+  currentCharacterId: number | null | undefined,
+): CollabGate {
+  const memberCount = members.length
+  const castCount = members.filter((m) => m.has_submitted).length
+  const iCast = members.some(
+    (m) => m.character_id === currentCharacterId && m.has_submitted,
+  )
+  let state: CollabState
+  if (castCount === 0) state = 'writing'
+  else if (castCount >= memberCount) state = 'published'
+  else state = iCast ? 'waiting' : 'holdout'
+  return { memberCount, castCount, iCast, state }
+}
+
+export interface CollabRosterAction {
+  onCast: () => void
+  onPullBack: () => void
+  submitting: boolean
+}
+
+export function CollabRoster({
+  members,
+  currentCharacterId,
+  factionSlug,
+  taskPointValue,
+  action,
+}: {
+  members: readonly PraxisMemberOut[]
+  currentCharacterId: number | null | undefined
+  factionSlug: string | null | undefined
+  taskPointValue?: number | null
+  action?: CollabRosterAction
+}) {
+  const { t } = useTranslation('forms')
+  const gate = deriveCollabGate(members, currentCharacterId)
+  if (gate.memberCount < 2) return null // solo/duel render nothing
+
+  const accent = factionCssVar(factionSlug, 'card-accent')
+  const pct = Math.round((gate.castCount / gate.memberCount) * 100)
+
+  const banner =
+    gate.state === 'waiting'
+      ? { text: t('editPraxis.collab.bannerWaiting'), tone: accent, warn: false }
+      : gate.state === 'holdout'
+        ? { text: t('editPraxis.collab.bannerHoldout'), tone: 'var(--color-warning)', warn: true }
+        : gate.state === 'published'
+          ? { text: t('editPraxis.collab.bannerPublished'), tone: 'var(--color-success)', warn: false }
+          : null
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {/* Header: label + cast progress chip */}
+      <div className="flex items-center gap-2" style={{ justifyContent: 'space-between' }}>
+        <span className="eyebrow" style={{ fontSize: 10, color: 'var(--color-text-secondary)' }}>
+          {t('editPraxis.collab.castStatus', { cast: gate.castCount, total: gate.memberCount })}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div
+        role="progressbar"
+        aria-valuenow={gate.castCount}
+        aria-valuemin={0}
+        aria-valuemax={gate.memberCount}
+        aria-label={t('editPraxis.collab.progressAria', { cast: gate.castCount, total: gate.memberCount })}
+        style={{ height: 4, borderRadius: 2, background: 'var(--color-border)', overflow: 'hidden' }}
+      >
+        <div style={{ width: `${pct}%`, height: '100%', background: accent, transition: 'width 200ms' }} />
+      </div>
+
+      {/* Roster rows */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {members.map((member) => {
+          const isMe = member.character_id === currentCharacterId
+          const cast = member.has_submitted
+          return (
+            <div
+              key={member.id}
+              className="flex items-center gap-2"
+              style={{
+                padding: '5px 10px',
+                borderRadius: 4,
+                border: cast ? `1.5px solid ${accent}` : '1.5px dashed var(--color-border)',
+                background: cast ? factionCssVar(factionSlug, 'card-muted') : 'transparent',
+              }}
+            >
+              <span className="font-body" style={{ fontSize: 12, fontWeight: cast ? 700 : 400, flex: 1 }}>
+                {member.character_display_name}
+                {isMe && (
+                  <span style={{ color: 'var(--color-text-tertiary)' }}> · {t('editPraxis.collab.you')}</span>
+                )}
+                {gate.state === 'published' && taskPointValue != null && (
+                  <span style={{ color: 'var(--color-success)', fontWeight: 700 }}> +{taskPointValue}</span>
+                )}
+              </span>
+              <span
+                className="eyebrow"
+                style={{
+                  fontSize: 9,
+                  color: cast ? accent : 'var(--color-warning)',
+                }}
+              >
+                {cast ? `✓ ${t('editPraxis.collab.pillCast')}` : t('editPraxis.collab.pillWeaving')}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Per-state banner */}
+      {banner && (
+        <p
+          className="font-body"
+          style={{
+            fontSize: 11,
+            padding: '6px 10px',
+            borderRadius: 4,
+            color: banner.tone,
+            border: `1px solid ${banner.tone}`,
+            background: banner.warn ? 'rgba(234,179,8,0.08)' : 'transparent',
+          }}
+        >
+          {banner.text}
+        </p>
+      )}
+
+      {/* Composer-only primary action (cast / pull-back). */}
+      {action && gate.state !== 'published' && (
+        <button
+          type="button"
+          onClick={() => (gate.iCast ? action.onPullBack() : action.onCast())}
+          disabled={action.submitting}
+          className={gate.iCast ? 'btn-outline' : 'btn-primary'}
+          style={{ fontSize: 11, padding: '6px 14px', alignSelf: 'flex-start' }}
+        >
+          {gate.iCast
+            ? t('editPraxis.collab.pullBackAction')
+            : gate.castCount === gate.memberCount - 1
+              ? t('editPraxis.collab.castFinalAction')
+              : t('editPraxis.collab.castAction')}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
+++ b/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
@@ -1,0 +1,62 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import type { PraxisMemberOut } from '../../../api/praxis'
+import { CollabRoster, deriveCollabGate } from '../CollabRoster'
+
+function member(id: number, cast: boolean): PraxisMemberOut {
+  return {
+    id,
+    praxis_id: 1,
+    character_id: id,
+    character_display_name: `M${id}`,
+    has_submitted: cast,
+    joined_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('deriveCollabGate — the consensus state machine (#591)', () => {
+  it('nobody cast → writing', () => {
+    const g = deriveCollabGate([member(1, false), member(2, false)], 1)
+    expect(g).toMatchObject({ castCount: 0, memberCount: 2, iCast: false, state: 'writing' })
+  })
+  it('I cast, another has not → waiting', () => {
+    expect(deriveCollabGate([member(1, true), member(2, false)], 1).state).toBe('waiting')
+  })
+  it('another cast, I have not → holdout', () => {
+    expect(deriveCollabGate([member(1, false), member(2, true)], 1).state).toBe('holdout')
+  })
+  it('everyone cast → published', () => {
+    expect(deriveCollabGate([member(1, true), member(2, true)], 1).state).toBe('published')
+  })
+})
+
+describe('CollabRoster render', () => {
+  it('renders nothing for a solo/duel (fewer than two members)', () => {
+    expect(renderToStaticMarkup(
+      <CollabRoster members={[member(1, false)]} currentCharacterId={1} factionSlug="wow" />,
+    )).toBe('')
+  })
+
+  it('shows a cast pill for cast members and a weaving pill otherwise', () => {
+    const html = renderToStaticMarkup(
+      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug="wow" />,
+    )
+    expect(html).toContain('cast')
+    expect(html).toContain('weaving')
+    expect(html).toContain('1 of 2 cast')
+  })
+
+  it('offers pull-back when I have cast, cast when I have not', () => {
+    const action = { onCast: () => {}, onPullBack: () => {}, submitting: false }
+    const waiting = renderToStaticMarkup(
+      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug="wow" action={action} />,
+    )
+    expect(waiting).toContain('Pull my part back')
+    const holdout = renderToStaticMarkup(
+      <CollabRoster members={[member(1, false), member(2, true)]} currentCharacterId={1} factionSlug="wow" action={action} />,
+    )
+    // castCount === memberCount - 1 → the go-live wording.
+    expect(holdout).toContain('send it live')
+  })
+})

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -128,6 +128,22 @@
       "cancelChallengeAria": "cancel challenge",
       "rescindInviteAria": "rescind invite to {{name}}"
     },
+    "collab": {
+      "castStatus": "{{cast}} of {{total}} cast",
+      "pillCast": "cast",
+      "pillWeaving": "weaving",
+      "you": "you",
+      "progressAria": "{{cast}} of {{total}} members have cast their part",
+      "bannerWaiting": "Cast. Waiting on the others to weave their parts.",
+      "bannerHoldout": "The circle is waiting on you — cast your part to weave it in.",
+      "bannerPublished": "Woven and live. Every member is credited.",
+      "castAction": "Cast my part",
+      "castFinalAction": "Cast — send it live",
+      "pullBackAction": "Pull my part back",
+      "successHeading": "The proof is woven",
+      "successBody": "Every part is cast — your collab is live.",
+      "successContinue": "View the praxis"
+    },
     "toolbar": {
       "label": "formatting",
       "bold": "bold",

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -14,6 +14,7 @@ import MarkdownPreview from "../blocks/MarkdownPreview";
 import { applyMarkdown } from "../blocks/markdownToolbar";
 import type { MarkdownCommand } from "../blocks/markdownToolbar";
 import type { EditPraxisState } from "../useEditPraxis";
+import { CollabRoster } from "../../../components/collab/CollabRoster";
 
 export interface InviteSearchSkin {
   inputBg?: string;
@@ -46,6 +47,8 @@ export function InviteSearch({
   const duelMode = state.duelMode;
   const challengeAttached = duelMode && praxis.duel_id != null;
   const onPick = duelMode ? state.sendChallenge : state.sendInvite;
+  // Cast progress drives the roster + hides "invite another" once weaving starts (#591).
+  const castCount = praxis.members.filter((m) => m.has_submitted).length;
   return (
     <div>
       <div
@@ -98,28 +101,20 @@ export function InviteSearch({
               </span>
             )
           : [
-              ...praxis.members
-                .filter(
-                  (member) => member.character_id !== state.currentCharacterId,
-                )
-                .map((member) => (
-                  <span
-                    key={`m-${member.id}`}
-                    style={{
-                      fontFamily: skin.fontFamily,
-                      fontSize: 11,
-                      padding: "4px 10px",
-                      background: skin.acceptedBg ?? "var(--color-success)",
-                      color: skin.acceptedColor ?? "var(--color-text-on-accent)",
-                    }}
-                  >
-                    {member.character_display_name}
-                    {/* Collab submit indicator (#521): who has already submitted. */}
-                    {member.has_submitted && (
-                      <em> · ✓ {t("editPraxis.invite.statusSubmitted")}</em>
-                    )}
-                  </span>
-                )),
+              // Live cast-status roster replaces the flat member pills (#591).
+              <div key="roster" style={{ flex: "1 1 100%" }}>
+                <CollabRoster
+                  members={praxis.members}
+                  currentCharacterId={state.currentCharacterId}
+                  factionSlug={praxis.task_faction_slug}
+                  taskPointValue={praxis.task_point_value}
+                  action={{
+                    onCast: state.publish,
+                    onPullBack: state.pullBack,
+                    submitting: state.submitting,
+                  }}
+                />
+              </div>,
               ...praxis.invites
                 .filter((invite) => invite.status === "pending")
                 .map((invite) => (
@@ -160,7 +155,7 @@ export function InviteSearch({
                 )),
             ]}
       </div>
-      {!challengeAttached && (
+      {!challengeAttached && (duelMode || castCount === 0) && (
       <div style={{ position: "relative" }}>
         <input
           type="text"
@@ -688,6 +683,8 @@ export function PublishButton({
   skin: PublishButtonSkin;
 }) {
   if (state.isPublished) return null;
+  // Multi-member collabs cast through the CollabRoster action, not this button (#591).
+  if (state.praxis?.type === "collab" && state.praxis.members.length > 1) return null;
   return (
     <button
       type="button"

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -104,6 +104,7 @@ function baseState(slug: string | null): EditPraxisState {
     toggleMetatask: async () => {},
     submitting: false,
     publish: async () => {},
+    pullBack: async () => {},
     cancel: async () => {},
     autosaveAt: null,
     saveStatus: "idle",

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -105,6 +105,7 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
     toggleMetatask: async () => {},
     submitting: false,
     publish,
+    pullBack: async () => {},
     cancel: async () => {},
     autosaveAt: null,
     saveStatus: "idle",

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -19,6 +19,7 @@ import {
   inviteToPraxis,
   removeMetatask,
   submitPraxis,
+  unsubmitPraxis,
   updatePraxis,
   uploadPraxisMedia,
   type MediaItemOut,
@@ -105,6 +106,8 @@ export interface EditPraxisState {
   // Save / publish / drop
   submitting: boolean;
   publish: () => Promise<void>;
+  /** Pull my own cast back on a pending collab (#591). */
+  pullBack: () => Promise<void>;
   cancel: () => Promise<void>;
 
   // Autosave
@@ -490,6 +493,22 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     }
   }, [idParam, title, persistEdits, navigate, refetch]);
 
+  // Pull my own part back out of a pending collab (#591) — clears my cast so the
+  // composer unlocks for editing. Backend re-opens only my membership (#590).
+  const pullBack = useCallback(async () => {
+    if (!idParam) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      await unsubmitPraxis(parseInt(idParam, 10));
+      await refetch();
+    } catch (err) {
+      setError(extractError(err, i18n.t("forms:editPraxis.errors.publish")));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [idParam, refetch]);
+
   const cancel = useCallback(async () => {
     if (!praxis) return;
     const confirmed = window.confirm(
@@ -845,6 +864,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
 
     submitting,
     publish,
+    pullBack,
     cancel,
 
     autosaveAt,

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -66,7 +66,11 @@ export function MemberByline({
   const sepStyle = separatorStyle ?? linkStyle
   // Per-member submit state only reads meaningfully mid-lifecycle on a collab
   // (>1 member, still in editing). A solo/duel praxis or a live one stays clean.
-  const showSubmitState = members.length > 1 && praxis.status === 'in_progress'
+  // `pending` is the mid-consensus state (#590/#591) — exactly when cast status
+  // matters most — so it counts as "still open" alongside in_progress.
+  const showSubmitState =
+    members.length > 1 &&
+    (praxis.status === 'in_progress' || praxis.status === 'pending')
 
   return (
     <span


### PR DESCRIPTION
**Part of #591** (roster core — see the follow-ups below before closing the issue).

Adds the collab-submission cast-status roster and wires it into the composer, plus the state machine that drives every state.

**Delivered**
- **`CollabRoster`** (`components/collab/CollabRoster.tsx`): a pure `deriveCollabGate` state machine (writing / waiting / holdout / published per the design's S1–S4) + a live roster (cast vs weaving pills), progress bar, per-state banner, and published credit chips. One faction-token-themed component (no per-faction files), standalone with unit tests.
- **Composer wiring**: replaces the flat member-pill list in the shared `InviteSearch` (all 8 desktop archetypes + mobile). Cast → `publish`; pull-back → #590's new `unsubmit` via a new `useEditPraxis.pullBack`. `PublishButton` yields to the roster for multi-member collabs; the "invite another" field hides once weaving starts (`cast_count === 0` gate).
- **Detail correctness**: `MemberByline` cast status now shows through the new `pending` status — it was gated to `in_progress` only, which #590 would have silently broken.
- Adds `pending` to the frontend `PraxisStatus` type + a shared `editPraxis.collab.*` i18n block.

**Follow-ups (deliberately not in this PR)** — so the issue stays open until they land:
- Full read-only roster block on the praxis **detail page** body (currently the detail page keeps its existing per-member status byline, now correct for `pending`).
- Per-faction copy overrides for the collab wording (this uses one shared copy block, mirroring how `editPraxis.invite` is shared).
- A standalone post-publish success screen (the roster's published state shows credit chips; `publish` still navigates to the detail page as before).

Tests: `CollabRoster` unit tests (state machine + render); full FE suite green (**542 passed**), tsc clean. Stacked on #571 (base `claude/collab-submit-notification-571`).
