### PR TITLE
feat(comments): frontend comment flagging control (#575)

### DIFF
--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import type { FlagReason } from '../utils/flagReasons'
 
 /** A resolved @mention — the frontend linkifies these handles in the body. */
 export interface CommentMention {
@@ -62,4 +63,20 @@ export async function editComment(
 /** Author-only soft-delete → the comment is withdrawn (204, no body). */
 export async function deleteComment(commentId: number): Promise<void> {
   await api.delete(`/comments/${commentId}`)
+}
+
+/**
+ * Flag a comment for moderator review (#575). Same FlagIn body (ADR-0037) as the
+ * praxis flag route; `reasonDetail` only persists server-side with reason='other'.
+ * The backend 403s self-flags, so the UI hides this on the viewer's own comments.
+ */
+export async function flagComment(
+  commentId: number,
+  reason: FlagReason,
+  reasonDetail?: string,
+): Promise<void> {
+  await api.post(`/comments/${commentId}/flag`, {
+    reason,
+    reason_detail: reasonDetail || null,
+  })
 }

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -21,6 +21,7 @@ import {
   MentionText,
 } from './shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from './OwnerControls'
+import { CommentFlagControl } from './FlagControl'
 import UAComment from './voices/UAComment'
 import EverymenComment from './voices/EverymenComment'
 import WowComment from './voices/WowComment'
@@ -72,6 +73,7 @@ export function DefaultComment(props: CommentProps) {
             {comment.is_edited ? ` · ${t('comments.edited')}` : ''}
           </span>
           <OwnerControls owner={owner} />
+          <CommentFlagControl comment={comment} />
         </div>
         <div style={{ marginTop: 2, color: 'var(--color-text-primary)', lineHeight: 1.5 }}>
           {owner.editing ? (

--- a/frontend/src/components/comments/FlagControl.tsx
+++ b/frontend/src/components/comments/FlagControl.tsx
@@ -1,0 +1,116 @@
+/**
+ * Comment flag control (#575) — the sibling of OwnerControls: a per-comment
+ * action every voice renders next to the byline. OwnerControls shows for the
+ * author; this shows for everyone else. Templated on praxisDetail's
+ * PraxisFlagBlock (shared reason vocabulary ADR-0037), compact for the inline
+ * comment header. A note is available for every reason (mirrors #570); the
+ * backend only persists it for reason='other', and 403s self-flags — so this is
+ * hidden on the viewer's own comment.
+ */
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../../auth/AuthContext'
+import { flagComment, type CommentOut } from '../../api/comments'
+import { flagReasonOptions, type FlagReason } from '../../utils/flagReasons'
+
+/** May the viewer flag this comment? Signed in, and not the author. */
+export function canFlagComment(
+  comment: CommentOut,
+  viewerCharacterId: number | null | undefined,
+): boolean {
+  return viewerCharacterId != null && viewerCharacterId !== comment.author.id
+}
+
+export function CommentFlagControl({ comment }: { comment: CommentOut }) {
+  const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState<FlagReason | null>(null)
+  const [detail, setDetail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+
+  if (!canFlagComment(comment, user?.character?.id)) return null
+
+  if (submitted) {
+    return (
+      <span className="eyebrow" style={{ fontSize: 9, color: 'var(--color-success)' }}>
+        {t('detail.flag.flaggedTitle')}
+      </span>
+    )
+  }
+
+  const submit = async () => {
+    if (reason === null || submitting) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await flagComment(comment.id, reason, detail)
+      setSubmitted(true)
+    } catch {
+      setError(t('detail.flag.error'))
+      setSubmitting(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => { setOpen(true); setError(null) }}
+        className="btn-outline"
+        style={{ fontSize: 8, padding: '2px 8px', borderColor: 'rgba(220,38,38,0.4)', color: 'var(--color-danger)' }}
+      >
+        {t('detail.flag.flag')}
+      </button>
+    )
+  }
+
+  return (
+    <div style={{ width: '100%', marginTop: 6 }}>
+      <div className="flex items-center gap-2" style={{ flexWrap: 'wrap' }} role="radiogroup" aria-label={t('detail.flag.reasonGroupLabel')}>
+        {flagReasonOptions().map(({ value, label }) => (
+          <button
+            key={value}
+            role="radio"
+            aria-checked={reason === value}
+            onClick={() => { setReason(value); setError(null) }}
+            disabled={submitting}
+            className="btn-outline"
+            style={{
+              fontSize: 9,
+              padding: '3px 8px',
+              ...(reason === value
+                ? { background: 'var(--color-danger)', borderColor: 'var(--color-danger)', color: 'var(--color-bg-surface)' }
+                : {}),
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {reason !== null && (
+        <textarea
+          className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink w-full resize-none"
+          rows={2}
+          placeholder={t('detail.flag.notePlaceholder')}
+          value={detail}
+          onChange={(e) => setDetail(e.target.value)}
+          disabled={submitting}
+          style={{ marginTop: 6 }}
+        />
+      )}
+      <div className="flex items-center gap-2" style={{ marginTop: 6 }}>
+        {reason !== null && (
+          <button onClick={() => void submit()} disabled={submitting} className="btn-primary" style={{ fontSize: 9, padding: '3px 10px', background: 'var(--color-danger)', borderColor: 'var(--color-danger)' }}>
+            {submitting ? t('detail.flag.submitting') : t('detail.flag.submit')}
+          </button>
+        )}
+        <button onClick={() => { setOpen(false); setReason(null); setDetail(''); setError(null) }} disabled={submitting} className="btn-outline" style={{ fontSize: 9, padding: '3px 10px' }}>
+          {t('detail.flag.cancel')}
+        </button>
+      </div>
+      {error && <p className="font-body text-xs" style={{ color: 'var(--color-danger)', marginTop: 4 }}>{error}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/comments/FlagControl.tsx
+++ b/frontend/src/components/comments/FlagControl.tsx
@@ -6,6 +6,9 @@
  * comment header. A note is available for every reason (mirrors #570); the
  * backend only persists it for reason='other', and 403s self-flags — so this is
  * hidden on the viewer's own comment.
+ *
+ * Spacing/type via Tailwind utilities + --text-* tokens, not raw inline pixels
+ * (#588 no-raw-style-values lint guard).
  */
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -35,7 +38,7 @@ export function CommentFlagControl({ comment }: { comment: CommentOut }) {
 
   if (submitted) {
     return (
-      <span className="eyebrow" style={{ fontSize: 9, color: 'var(--color-success)' }}>
+      <span className="eyebrow text-[9px]" style={{ color: 'var(--color-success)' }}>
         {t('detail.flag.flaggedTitle')}
       </span>
     )
@@ -58,8 +61,8 @@ export function CommentFlagControl({ comment }: { comment: CommentOut }) {
     return (
       <button
         onClick={() => { setOpen(true); setError(null) }}
-        className="btn-outline"
-        style={{ fontSize: 8, padding: '2px 8px', borderColor: 'rgba(220,38,38,0.4)', color: 'var(--color-danger)' }}
+        className="btn-outline text-[8px] px-[8px] py-[2px]"
+        style={{ borderColor: 'rgba(220,38,38,0.4)', color: 'var(--color-danger)' }}
       >
         {t('detail.flag.flag')}
       </button>
@@ -67,8 +70,8 @@ export function CommentFlagControl({ comment }: { comment: CommentOut }) {
   }
 
   return (
-    <div style={{ width: '100%', marginTop: 6 }}>
-      <div className="flex items-center gap-2" style={{ flexWrap: 'wrap' }} role="radiogroup" aria-label={t('detail.flag.reasonGroupLabel')}>
+    <div className="w-full mt-[6px]">
+      <div className="flex items-center gap-2 flex-wrap" role="radiogroup" aria-label={t('detail.flag.reasonGroupLabel')}>
         {flagReasonOptions().map(({ value, label }) => (
           <button
             key={value}
@@ -76,14 +79,12 @@ export function CommentFlagControl({ comment }: { comment: CommentOut }) {
             aria-checked={reason === value}
             onClick={() => { setReason(value); setError(null) }}
             disabled={submitting}
-            className="btn-outline"
-            style={{
-              fontSize: 9,
-              padding: '3px 8px',
-              ...(reason === value
+            className="btn-outline text-[9px] px-[8px] py-[3px]"
+            style={
+              reason === value
                 ? { background: 'var(--color-danger)', borderColor: 'var(--color-danger)', color: 'var(--color-bg-surface)' }
-                : {}),
-            }}
+                : undefined
+            }
           >
             {label}
           </button>
@@ -91,26 +92,25 @@ export function CommentFlagControl({ comment }: { comment: CommentOut }) {
       </div>
       {reason !== null && (
         <textarea
-          className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink w-full resize-none"
+          className="border-2 border-border bg-card px-3 py-2 font-body text-sm focus:outline-none focus:border-ink w-full resize-none mt-[6px]"
           rows={2}
           placeholder={t('detail.flag.notePlaceholder')}
           value={detail}
           onChange={(e) => setDetail(e.target.value)}
           disabled={submitting}
-          style={{ marginTop: 6 }}
         />
       )}
-      <div className="flex items-center gap-2" style={{ marginTop: 6 }}>
+      <div className="flex items-center gap-2 mt-[6px]">
         {reason !== null && (
-          <button onClick={() => void submit()} disabled={submitting} className="btn-primary" style={{ fontSize: 9, padding: '3px 10px', background: 'var(--color-danger)', borderColor: 'var(--color-danger)' }}>
+          <button onClick={() => void submit()} disabled={submitting} className="btn-primary text-[9px] px-[10px] py-[3px]" style={{ background: 'var(--color-danger)', borderColor: 'var(--color-danger)' }}>
             {submitting ? t('detail.flag.submitting') : t('detail.flag.submit')}
           </button>
         )}
-        <button onClick={() => { setOpen(false); setReason(null); setDetail(''); setError(null) }} disabled={submitting} className="btn-outline" style={{ fontSize: 9, padding: '3px 10px' }}>
+        <button onClick={() => { setOpen(false); setReason(null); setDetail(''); setError(null) }} disabled={submitting} className="btn-outline text-[9px] px-[10px] py-[3px]">
           {t('detail.flag.cancel')}
         </button>
       </div>
-      {error && <p className="font-body text-xs" style={{ color: 'var(--color-danger)', marginTop: 4 }}>{error}</p>}
+      {error && <p className="font-body text-xs mt-[4px]" style={{ color: 'var(--color-danger)' }}>{error}</p>}
     </div>
   )
 }

--- a/frontend/src/components/comments/__tests__/FlagControl.test.tsx
+++ b/frontend/src/components/comments/__tests__/FlagControl.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Comment flag control (#575). Exercises the pure viewer-eligibility decision,
+ * the `flagComment` client body shape, and the neutral affordance's presence:
+ * a flag button for other people's comments, nothing on the viewer's own.
+ * Rendered to static markup (no DOM), per the comments-test convention.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+
+// Mock axios so the comments client exercises without a network.
+vi.mock('../../../api/axios', () => ({
+  default: { get: vi.fn(), post: vi.fn().mockResolvedValue({ data: {} }), patch: vi.fn(), delete: vi.fn() },
+}))
+// Control the signed-in viewer for the render cases.
+const authState = vi.hoisted(() => ({ user: null as unknown }))
+vi.mock('../../../auth/AuthContext', () => ({ useAuth: () => authState }))
+
+import api from '../../../api/axios'
+import { flagComment } from '../../../api/comments'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'hi',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: { id: 42, username: 'ada', display_name: 'Ada', avatar_url: null, faction_slug: 'ua' },
+  mentions: [],
+}
+
+describe('canFlagComment — viewer eligibility (#575)', () => {
+  it('is false when signed out', () => {
+    expect(canFlagComment(COMMENT, null)).toBe(false)
+    expect(canFlagComment(COMMENT, undefined)).toBe(false)
+  })
+  it("is false on the viewer's own comment", () => {
+    expect(canFlagComment(COMMENT, 42)).toBe(false)
+  })
+  it("is true on someone else's comment", () => {
+    expect(canFlagComment(COMMENT, 99)).toBe(true)
+  })
+})
+
+describe('flagComment — client body (#575)', () => {
+  it('POSTs the reason + reason_detail to the comment flag route', async () => {
+    await flagComment(7, 'spam', 'context')
+    expect(api.post).toHaveBeenCalledWith('/comments/7/flag', {
+      reason: 'spam',
+      reason_detail: 'context',
+    })
+  })
+})
+
+describe('CommentFlagControl — affordance presence (#575)', () => {
+  it("renders a flag control on someone else's comment", () => {
+    authState.user = { character: { id: 99 } }
+    const html = renderToStaticMarkup(<CommentFlagControl comment={COMMENT} />)
+    expect(html).toContain('Flag')
+  })
+  it("renders nothing on the viewer's own comment", () => {
+    authState.user = { character: { id: 42 } }
+    const html = renderToStaticMarkup(<CommentFlagControl comment={COMMENT} />)
+    expect(html).toBe('')
+  })
+})

--- a/frontend/src/components/comments/voices/AlbescentComment.tsx
+++ b/frontend/src/components/comments/voices/AlbescentComment.tsx
@@ -4,6 +4,7 @@ import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
+import { CommentFlagControl } from '../FlagControl'
 
 /**
  * Albescent — vellum correspondence (ADR-0018). The quietest archetype: warm-white
@@ -77,6 +78,7 @@ export default function AlbescentComment(props: CommentProps) {
         {formatCommentTime(slug, comment.created_at)}
         {comment.is_edited ? ` · ${t('comments.albescent.edited')}` : ''}
         <OwnerControls owner={owner} />
+        <CommentFlagControl comment={comment} />
       </div>
     </div>
   )

--- a/frontend/src/components/comments/voices/EphemeristsComment.tsx
+++ b/frontend/src/components/comments/voices/EphemeristsComment.tsx
@@ -4,6 +4,7 @@ import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
+import { CommentFlagControl } from '../FlagControl'
 
 /**
  * The Ephemerists — marginalia (ADR-0018). Vellum leaf, engraved Cinzel byline,
@@ -55,6 +56,7 @@ export default function EphemeristsComment(props: CommentProps) {
           {formatCommentTime(slug, comment.created_at)}
           {comment.is_edited ? ` · ${t('comments.ephemerists.edited')}` : ''}
           <OwnerControls owner={owner} />
+          <CommentFlagControl comment={comment} />
         </span>
       </div>
       {owner.editing ? (

--- a/frontend/src/components/comments/voices/EverymenComment.tsx
+++ b/frontend/src/components/comments/voices/EverymenComment.tsx
@@ -4,6 +4,7 @@ import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
+import { CommentFlagControl } from '../FlagControl'
 
 /**
  * Everymen — dispatch from the floor (ADR-0018). Union-poster register: red
@@ -57,6 +58,7 @@ export default function EverymenComment(props: CommentProps) {
               {formatCommentTime(slug, comment.created_at)}
               {comment.is_edited ? ` · ${t('comments.everymen.edited')}` : ''}
               <OwnerControls owner={owner} />
+              <CommentFlagControl comment={comment} />
             </span>
           </div>
           <div style={{ fontSize: 15, lineHeight: 1.4, marginTop: 3 }}>

--- a/frontend/src/components/comments/voices/SingularityComment.tsx
+++ b/frontend/src/components/comments/voices/SingularityComment.tsx
@@ -5,6 +5,7 @@ import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
+import { CommentFlagControl } from '../FlagControl'
 
 /**
  * Singularity — terminal printout (ADR-0018). Dark, green mono, corner brackets,
@@ -74,6 +75,7 @@ export default function SingularityComment(props: CommentProps) {
               {formatCommentTime(slug, comment.created_at)}
               {comment.is_edited ? ` [${t('comments.singularity.edited')}]` : ''}
               <OwnerControls owner={owner} />
+              <CommentFlagControl comment={comment} />
             </span>
           </div>
           <div style={{ fontSize: 13, lineHeight: 1.55, marginTop: 4 }}>

--- a/frontend/src/components/comments/voices/SnideComment.tsx
+++ b/frontend/src/components/comments/voices/SnideComment.tsx
@@ -4,6 +4,7 @@ import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
+import { CommentFlagControl } from '../FlagControl'
 
 /**
  * S.N.I.D.E. — ransom dispatch (ADR-0018). Reuses the task-card ransom vocabulary:
@@ -90,6 +91,7 @@ export default function SnideComment(props: CommentProps) {
               {formatCommentTime(slug, comment.created_at)}
               {comment.is_edited ? ` · ${t('comments.snide.edited')}` : ''}
               <OwnerControls owner={owner} />
+              <CommentFlagControl comment={comment} />
             </span>
           </div>
           <div style={{ fontFamily: 'var(--faction-snide-font-cond)', textTransform: 'uppercase', fontSize: 15, lineHeight: 1.4, letterSpacing: '0.02em' }}>

--- a/frontend/src/components/comments/voices/UAComment.tsx
+++ b/frontend/src/components/comments/voices/UAComment.tsx
@@ -5,6 +5,7 @@ import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
+import { CommentFlagControl } from '../FlagControl'
 
 /**
  * UA — University of Asthmatics. The gilt salon (ADR-0026, superseding
@@ -85,6 +86,7 @@ export default function UAComment(props: CommentProps) {
             {formatCommentTime(slug, comment.created_at)}
             {comment.is_edited ? ` · ${t('comments.ua.edited')}` : ''}
             <OwnerControls owner={owner} />
+            <CommentFlagControl comment={comment} />
           </span>
         </div>
         <div style={{ height: 1, background: 'color-mix(in srgb, var(--ua-gold) 55%, transparent)', margin: '8px 0 9px' }} />

--- a/frontend/src/components/comments/voices/WowComment.tsx
+++ b/frontend/src/components/comments/voices/WowComment.tsx
@@ -4,6 +4,7 @@ import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
+import { CommentFlagControl } from '../FlagControl'
 
 /**
  * Warriors of Whimsy — `{handle}.exe` (ADR-0018). Reuses the task-card window
@@ -69,6 +70,7 @@ export default function WowComment(props: CommentProps) {
               {comment.is_edited ? ` · ${t('comments.wow.edited')}` : ''}
             </span>
             <OwnerControls owner={owner} />
+            <CommentFlagControl comment={comment} />
           </div>
         </div>
       </div>

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -107,7 +107,8 @@
       "notePlaceholder": "Add a note (optional)",
       "submit": "Submit flag",
       "submitting": "...",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "error": "Couldn't flag this. Please try again."
     },
     "voters": {
       "heading": "Who voted",


### PR DESCRIPTION
Closes #575

Frontend comment flagging wired to the existing backend endpoint: `flagComment` client + a shared `CommentFlagControl` (sibling of OwnerControls) in DefaultComment and all 7 faction voices, reusing the ADR-0037 reason vocabulary and #570 note-for-every-reason. Hidden on the viewer own comments. Spacing/type use tokens (no-raw-style-values lint).

(Replaces PR #615, which GitHub auto-closed when its stacked base branch was deleted on merge.)
