### PR TITLE
fix(db): carry pending enum + member submitted_at to deployed DBs

### DIFF
--- a/backend/alembic/versions/0002_praxis_pending_submitted.py
+++ b/backend/alembic/versions/0002_praxis_pending_submitted.py
@@ -1,0 +1,62 @@
+"""Carry #590 (praxisstatus.pending) and #571 (praxis_member.submitted_at) to deployed DBs.
+
+0001_squashed builds the schema from the live ORM models, so a *fresh* DB (CI,
+local reset) always lands on the current shape. An already-deployed DB is
+stamped at 0001_squashed and never re-runs it — so #590 and #571, which edited
+the baseline/models in place rather than adding a revision, never reached prod.
+Prod's DB predates both (squash 2026-07-14; both landed 2026-07-16), which is
+why every praxis-touching query 500s with:
+
+    invalid input value for enum praxisstatus: "pending"
+
+Idempotent by design: a no-op on any DB already built from the current models,
+so it is safe on fresh and drifted DBs alike.
+
+Revision ID: 0002_praxis_pending_submitted
+Revises: 0001_squashed
+Create Date: 2026-07-16
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0002_praxis_pending_submitted"
+down_revision: Union[str, None] = "0001_squashed"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ADD VALUE can't be followed by a *use* of the new value in the same
+    # transaction; autocommit_block keeps it out of the migration's txn so the
+    # backfill below can never trip that rule. BEFORE 'submitted' matches the
+    # member order in models/praxis.py (enum sort order follows declaration).
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE praxisstatus ADD VALUE IF NOT EXISTS 'pending' BEFORE 'submitted'"
+        )
+
+    op.execute(
+        "ALTER TABLE praxis_member ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ"
+    )
+
+    # Backfill (#571): members sealed before this migration would otherwise read
+    # as never-submitted and sort wrong in the collaborator-submitted feed.
+    # praxis.submitted_at is the real seal time; joined_at is the backstop.
+    op.execute(
+        """
+        UPDATE praxis_member
+           SET submitted_at = COALESCE(praxis.submitted_at, praxis_member.joined_at)
+          FROM praxis
+         WHERE praxis.id = praxis_member.praxis_id
+           AND praxis_member.has_submitted
+           AND praxis_member.submitted_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE praxis_member DROP COLUMN IF EXISTS submitted_at")
+    # ponytail: no enum rollback — Postgres can't DROP a value from a type, and
+    # undoing it means recreating praxisstatus + rewriting every dependent
+    # column. Rows written as 'pending' would have nowhere to land anyway.


### PR DESCRIPTION
## The bug

Prod's backend is up, but **Tasks and faction detail pages don't load**. Every praxis-touching query 500s:

```
sqlalchemy.exc.DBAPIError: asyncpg.exceptions.InvalidTextRepresentationError:
invalid input value for enum praxisstatus: "pending"
```

## Root cause — schema drift on the deployed DB

`0001_squashed` builds the schema from the live ORM models via `Base.metadata.create_all()`, so a **fresh** DB (CI, local reset) always lands on the current shape. An **already-deployed** DB is stamped at `0001_squashed` and never re-runs it — so two changes that edited the baseline/models in place instead of adding a revision never reached prod:

| Change | What it added | How |
|---|---|---|
| #590 (`c3295f8`) | `pending` on `praxisstatus` | edited `0001_squashed.py` in place |
| #571 (`37dd7fa`) | `PraxisMember.submitted_at` | model-only |

Prod's DB was built from the squash on **2026-07-14**; both landed **2026-07-16**. `alembic upgrade head` is a no-op, so neither arrived.

**CI stayed green for exactly the reason prod broke** — CI builds the DB from scratch every run, so it only ever exercises the fresh-DB path.

## Why those two pages

| Endpoint | Result |
|---|---|
| `/tasks` | 200 |
| `/tasks?exclude_character_id=1` | **500** |
| `/praxes` | **500** |

- **Tasks** only 500s **when logged in** — that's when it passes `exclude_character_id`, whose subquery filters `praxis.status IN ('in_progress','pending','submitted')`. Anonymous browsing works, so it looked intermittent.
- **Faction detail** dies because `useFactionDetail.ts:116` wraps `listPraxes` in a `Promise.all` — one 500 rejects the batch and the page never renders, despite `/factions` returning 200.

## The fix

A forward migration (`0002`) carrying both changes to deployed DBs. Non-destructive rather than the `reset_db.sh` wipe that `db-migrations.md` Strategy A prescribes — this keeps prod data and repairs any drifted DB. (Strategy A remains valid; data is disposable pre-launch. This just costs less.)

Idempotent by design (`ADD VALUE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS`), so it's a no-op on fresh DBs — CI and local resets are unaffected.

## Verification

Reproduced the exact prod error against a hand-drifted PG15 DB, then confirmed after applying:

- the failing query recovers
- enum order matches the model — `in_progress,pending,submitted` (`BEFORE 'submitted'`)
- backfill correct: sealed member → `praxis.submitted_at`; sealed with NULL → `joined_at` backstop; never-submitted → stays NULL
- re-run is a clean no-op (`UPDATE 0`, both `skipping` notices)

## Deploy note

`render.yaml` has `autoDeploy: true` on `main` — merging deploys and runs this migration against prod.

## Follow-up (not in this PR)

Nothing stops the next PR from editing `0001_squashed.py` in place and silently breaking prod again while CI stays green. Worth a CI guard that fails if that file is touched. `db-migrations.md` covers squash-stamp recovery but not this failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
