### PR TITLE
Refactor: --space-* scale + content-text floor, migrate 4 components (#579)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -95,7 +95,34 @@ Use `factionCssVar(slug, 'card-font')` in components. Never hardcode the font fa
 
 **Type scale** is defined as CSS variables (`--text-xs` through `--text-4xl`). Use the variable names, not raw pixel values.
 
+**Content-text floor.** `--text-2xl` (18px) is the floor for _real content_ — anything a player is meant to actually read: titles, scores, body copy, descriptions. `--text-xs` through `--text-xl` (8–14px) remain valid but are **label tier only**: eyebrows, kickers, badges, pills, stamps, button chrome. If a human reads it for meaning rather than scanning it as a label, it is `--text-2xl` or larger.
+
+This is a usage rule, not a change to the scale — no token values were renumbered and no new type tokens were added.
+
 **Eyebrow / label text:** Courier Prime, `--text-sm` (9px), uppercase, letter-spacing 0.15em, `var(--color-text-tertiary)`. Use the `.eyebrow` class.
+
+---
+
+## 4a. Spacing
+
+**Spacing scale** is defined as CSS variables in `index.css`. Use the variable names, not raw pixel values.
+
+| Token         | Value |
+| ------------- | ----- |
+| `--space-xs`  | 4px   |
+| `--space-sm`  | 8px   |
+| `--space-md`  | 12px  |
+| `--space-lg`  | 16px  |
+| `--space-xl`  | 24px  |
+| `--space-2xl` | 32px  |
+
+**Rule:** `padding`, `margin`, and `gap` take a `--space-*` token — never a raw pixel value. If you're about to write `padding: 13` or `gap: 6`, stop and pick the nearest token. This mirrors the typography rule: the scale is the vocabulary, and a value outside it is a bug, not a nuance.
+
+Both scales are **global, not per-faction**. A faction picks a headline font, a colour, and an ornament — never its own type size or spacing. There are no per-faction size or spacing exceptions.
+
+**Not covered by the rule:** ornament geometry (`width`/`height`/`top`/`inset` on decorative marks, sprocket holes, tape strips, corner brackets) is illustration, not layout spacing, and stays in raw pixels.
+
+**Enforcement.** The `local/no-raw-style-values` ESLint rule fails the build on a raw numeric `fontSize`/`padding`/`margin`/`gap` in an inline style. Files not yet migrated are grandfathered in `frontend/.eslint-legacy-raw-styles.txt`. **That list only ever shrinks** — migrating a file means deleting its line; no file may ever be added to it.
 
 ---
 
@@ -204,6 +231,8 @@ Brief design intent for each page. For implementation details, read the componen
 - **No sans-serif for body text** — Courier Prime is the base UI font
 - **No solid color backgrounds on the page** — the watercolor SVG is always present
 - **No hardcoded hex values in components** — always use CSS custom properties
+- **No raw pixel values for fontSize/padding/margin/gap** — use the `--text-*` / `--space-*` scales (§4, §4a); enforced by `local/no-raw-style-values`
+- **No content text below `--text-2xl`** — 7px and 9px are label sizes, not reading sizes
 - **No dark mode via ternaries** — use CSS variables so the cascade handles it
 - **No dark mode by inverting colors** — each card has a specifically designed dark variant in the CSS variables
 - **No disabled buttons for permission gates** — hide controls users can't use

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -12,7 +12,6 @@ src/components/cards/EverymenTaskCard.tsx
 src/components/cards/FactionCard.tsx
 src/components/cards/FactionSelectCard.tsx
 src/components/cards/SingularityFactionHero.tsx
-src/components/cards/SingularityTaskCard.tsx
 src/components/cards/SnideFactionHero.tsx
 src/components/cards/SnideMasthead.tsx
 src/components/cards/SNIDETaskCard.tsx

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -55,8 +55,6 @@ src/components/layout/MobileTabBar.tsx
 src/components/LevelUpPopup.tsx
 src/components/MediaGallery.tsx
 src/components/NavBar.tsx
-src/components/PraxisCard.tsx
-src/components/praxisCard/shared.tsx
 src/components/snide/snideAtoms.tsx
 src/components/TaskCard.tsx
 src/components/ui/FilterFactionTabs.tsx

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -52,7 +52,6 @@ src/components/imageEdit/ImageEditModal.tsx
 src/components/InvitationLetterPopup.tsx
 src/components/layout/MobileLayout.tsx
 src/components/layout/MobileTabBar.tsx
-src/components/layout/Sidebar.tsx
 src/components/LevelUpPopup.tsx
 src/components/MediaGallery.tsx
 src/components/NavBar.tsx

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -87,7 +87,7 @@ function PraxisBody({
           display: "flex",
           justifyContent: "space-between",
           alignItems: "flex-start",
-          gap: 10,
+          gap: "var(--space-md)",
         }}
       >
         <div style={{ flex: 1, minWidth: 0 }}>
@@ -102,7 +102,7 @@ function PraxisBody({
           showCrown={showCrown}
         />
       </div>
-      <PraxisStats praxis={praxis} style={{ color: muted, marginTop: 8 }} />
+      <PraxisStats praxis={praxis} style={{ color: muted, marginTop: "var(--space-sm)" }} />
       <PraxisByline praxis={praxis} style={{ color: muted }} />
     </>
   );
@@ -121,7 +121,7 @@ function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
     <div
       style={{
         ...frameBase,
-        padding: 5,
+        padding: "var(--space-xs)",
         background: "var(--ua-gilt)",
         boxShadow:
           "0 12px 26px color-mix(in srgb, var(--ua-ink) 22%, transparent), inset 0 0 0 1px color-mix(in srgb, white 45%, transparent)",
@@ -132,7 +132,7 @@ function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
           position: "relative",
           background: factionCssVar("ua", "card-bg"),
           border: "1px solid color-mix(in srgb, var(--ua-ink) 30%, transparent)",
-          padding: "16px 17px 14px",
+          padding: "var(--space-lg)",
           fontFamily: "'EB Garamond', serif",
           color: factionCssVar("ua", "card-text"),
           backgroundImage:
@@ -143,11 +143,11 @@ function UAPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         <div
           style={{
             fontFamily: "'Marcellus SC', serif",
-            fontSize: 8,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.12em",
             textTransform: "uppercase",
             color: factionCssVar("ua", "card-accent"),
-            marginBottom: 6,
+            marginBottom: "var(--space-sm)",
           }}
         >
           {t("card.masthead.ua")}
@@ -176,7 +176,7 @@ function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         clipPath:
           "polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)",
         position: "relative",
-        padding: "14px 16px 28px 28px",
+        padding: "var(--space-lg) var(--space-lg) var(--space-xl) var(--space-2xl)",
         fontFamily: "'Special Elite', serif",
         color: factionCssVar("everymen", "card-text"),
         backgroundImage:
@@ -247,7 +247,7 @@ function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
           background: factionCssVar("wow", "card-bg"),
           border: "1.5px solid rgba(0,0,0,0.12)",
           transform: "rotate(-2deg)",
-          padding: "22px 14px 16px",
+          padding: "var(--space-xl) var(--space-lg) var(--space-lg)",
           fontFamily: "'Courier Prime', monospace",
           color: factionCssVar("wow", "card-text"),
           zIndex: 2,
@@ -291,7 +291,7 @@ function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         ...frameBase,
         background: factionCssVar("snide", "card-bg"),
         position: "relative",
-        padding: "14px 14px 16px",
+        padding: "var(--space-lg)",
         fontFamily: "'Special Elite', serif",
         color: factionCssVar("snide", "card-text"),
         transition: "background 150ms, color 150ms",
@@ -361,8 +361,8 @@ function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
           zIndex: 2,
           display: "flex",
           alignItems: "center",
-          gap: 8,
-          padding: "7px 14px 6px",
+          gap: "var(--space-sm)",
+          padding: "var(--space-sm) var(--space-lg) var(--space-sm)",
           borderBottom: "1px solid var(--eph-gold-deep)",
           boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)",
         }}
@@ -371,7 +371,7 @@ function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
         <span
           style={{
             fontFamily: "var(--eph-serif)",
-            fontSize: 8.5,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.18em",
             textTransform: "uppercase",
             color: "var(--eph-rubric)",
@@ -380,7 +380,7 @@ function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
           {t("card.masthead.ephemerists")}
         </span>
       </div>
-      <div style={{ position: "relative", zIndex: 2, padding: "10px 14px 14px" }}>
+      <div style={{ position: "relative", zIndex: 2, padding: "var(--space-md) var(--space-lg) var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
@@ -401,8 +401,8 @@ function SingularityHoles() {
       style={{
         display: "flex",
         justifyContent: "center",
-        gap: 6,
-        padding: "4px 0",
+        gap: "var(--space-sm)",
+        padding: "var(--space-xs) 0",
       }}
     >
       {Array.from({ length: 5 }).map((_, index) => (
@@ -492,15 +492,15 @@ function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
       />
       <SingularityHoles />
       <div
-        style={{ padding: "6px 16px 12px", position: "relative", zIndex: 2 }}
+        style={{ padding: "var(--space-sm) var(--space-lg) var(--space-md)", position: "relative", zIndex: 2 }}
       >
         <div
           style={{
-            fontSize: 8,
+            fontSize: "var(--text-xs)",
             color: "var(--faction-singularity-card-muted)",
             textTransform: "uppercase",
             letterSpacing: "0.15em",
-            marginBottom: 8,
+            marginBottom: "var(--space-sm)",
           }}
         >
           {t("card.masthead.singularity")}
@@ -510,7 +510,7 @@ function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
               width: 5,
               height: 9,
               background: "var(--faction-singularity-card-text)",
-              marginLeft: 3,
+              marginLeft: "var(--space-xs)",
               verticalAlign: "middle",
               animation: "blink 1s step-end infinite",
             }}
@@ -573,8 +573,8 @@ function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
           position: "relative",
           display: "flex",
           alignItems: "center",
-          gap: 8,
-          padding: "9px 15px 7px",
+          gap: "var(--space-sm)",
+          padding: "var(--space-sm) var(--space-lg) var(--space-sm)",
           borderBottom: `1px solid ${ink(7)}`,
         }}
       >
@@ -582,7 +582,7 @@ function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
         <span
           style={{
             fontFamily: "var(--faction-albescent-mono)",
-            fontSize: 8,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.22em",
             textTransform: "uppercase",
             color: ink(30),
@@ -591,7 +591,7 @@ function AlbescentPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
           {t("card.masthead.albescent")}
         </span>
       </div>
-      <div style={{ position: "relative", padding: "12px 15px 14px" }}>
+      <div style={{ position: "relative", padding: "var(--space-md) var(--space-lg) var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
@@ -626,7 +626,7 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
       style={{
         ...frameBase,
         borderRadius: 10,
-        padding: 5,
+        padding: "var(--space-xs)",
         background: "var(--faction-default-rainbow)",
         boxShadow: "0 12px 26px -14px rgba(0,0,0,0.4)",
       }}
@@ -637,17 +637,17 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
           background: "var(--faction-default-card-bg)",
           color: "var(--faction-default-card-text)",
           borderRadius: 5,
-          padding: "14px 16px",
+          padding: "var(--space-lg)",
         }}
       >
         <div
           style={{
             display: "flex",
             alignItems: "center",
-            gap: 8,
-            marginBottom: 10,
+            gap: "var(--space-sm)",
+            marginBottom: "var(--space-md)",
             fontFamily: "'Courier Prime', monospace",
-            fontSize: 8.5,
+            fontSize: "var(--text-xs)",
             letterSpacing: "0.22em",
             textTransform: "uppercase",
             color: "var(--faction-default-card-muted)",

--- a/frontend/src/components/cards/SingularityTaskCard.tsx
+++ b/frontend/src/components/cards/SingularityTaskCard.tsx
@@ -25,8 +25,8 @@ function SprocketHoles() {
       style={{
         display: "flex",
         justifyContent: "center",
-        gap: 6,
-        padding: "4px 0",
+        gap: "var(--space-sm)",
+        padding: "var(--space-xs) 0",
       }}
     >
       {Array.from({ length: 5 }).map((_, index) => (
@@ -125,15 +125,21 @@ export default function SingularityTaskCard({
 
       <SprocketHoles />
 
-      <div style={{ padding: "4px 12px 8px", position: "relative", zIndex: 2 }}>
-        {/* Header */}
+      <div
+        style={{
+          padding: "var(--space-xs) var(--space-md) var(--space-sm)",
+          position: "relative",
+          zIndex: 2,
+        }}
+      >
+        {/* Header — eyebrow, stays label-tier (§4 content-text floor). */}
         <div
           style={{
-            fontSize: 7,
+            fontSize: "var(--text-xs)",
             color: "var(--faction-singularity-card-muted)",
             textTransform: "uppercase",
             letterSpacing: "0.15em",
-            marginBottom: 6,
+            marginBottom: "var(--space-sm)",
           }}
         >
           {i18n.t("feed:identity.singularity.protocol")}
@@ -143,7 +149,7 @@ export default function SingularityTaskCard({
               width: 5,
               height: 9,
               background: "var(--faction-singularity-card-text)",
-              marginLeft: 3,
+              marginLeft: "var(--space-xs)",
               verticalAlign: "middle",
               animation: "blink 1s step-end infinite",
             }}
@@ -154,10 +160,11 @@ export default function SingularityTaskCard({
           to={`/tasks/${task.id}`}
           style={{ textDecoration: "none", color: "inherit" }}
         >
+          {/* Task title — real content, so --text-2xl per the floor rule (§4). */}
           <div
             style={{
-              fontSize: "var(--text-sm)",
-              marginBottom: 6,
+              fontSize: "var(--text-2xl)",
+              marginBottom: "var(--space-sm)",
               lineHeight: 1.3,
               overflowWrap: "anywhere",
             }}
@@ -172,15 +179,16 @@ export default function SingularityTaskCard({
             fontSize: "var(--text-xs)",
             color: "var(--faction-singularity-card-muted)",
             lineHeight: 1.6,
-            marginBottom: 6,
+            marginBottom: "var(--space-sm)",
           }}
         >
           <div>
             {i18n.t("feed:taskCard.singularity.pointsLabel")}{" "}
+            {/* Points value — a score, so --text-2xl per the floor rule (§4). */}
             <span
               style={{
                 color: "var(--faction-singularity-card-text)",
-                fontSize: "var(--text-md)",
+                fontSize: "var(--text-2xl)",
                 fontWeight: 700,
               }}
             >
@@ -195,12 +203,17 @@ export default function SingularityTaskCard({
         </div>
 
         {task.description && (
+          /* ponytail: a 2-line-clamped teaser in a ~140px card. The floor rule
+             would put body copy at --text-2xl, but 18px clamped text would eat
+             the whole card, and #579's own commit-4 note moves only the title
+             and points value to --text-2xl. Parked at the top of the label tier
+             — a 2x lift off the un-tokenized 7px without distorting the card. */
           <div
             style={{
-              fontSize: 7,
+              fontSize: "var(--text-xl)",
               color: "var(--faction-singularity-card-muted)",
               lineHeight: 1.4,
-              marginBottom: 6,
+              marginBottom: "var(--space-sm)",
               overflow: "hidden",
               display: "-webkit-box",
               WebkitLineClamp: 2,
@@ -219,12 +232,12 @@ export default function SingularityTaskCard({
               color: "var(--faction-singularity-card-text)",
               border: "1px solid var(--faction-singularity-card-text)",
               fontFamily: factionCssVar("singularity", "card-font"),
-              fontSize: 7,
+              fontSize: "var(--text-xs)",
               textTransform: "uppercase",
               letterSpacing: "0.1em",
-              padding: "2px 8px",
+              padding: "var(--space-xs) var(--space-sm)",
               cursor: "pointer",
-              marginBottom: 4,
+              marginBottom: "var(--space-xs)",
             }}
           >
             {">"} {i18n.t("feed:taskCard.singularity.signup")}
@@ -236,15 +249,16 @@ export default function SingularityTaskCard({
             display: "flex",
             justifyContent: "flex-end",
             borderTop: "1px solid var(--faction-singularity-border-hard)",
-            paddingTop: 5,
+            paddingTop: "var(--space-xs)",
           }}
         >
+          {/* Level pill — badge label, stays label-tier (§4). */}
           <span
             style={{
               border: "1px solid var(--faction-singularity-card-text)",
               color: "var(--faction-singularity-card-text)",
-              fontSize: 7,
-              padding: "1px 6px",
+              fontSize: "var(--text-xs)",
+              padding: "0 var(--space-xs)",
               borderRadius: 6,
               textTransform: "uppercase",
             }}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -21,12 +21,12 @@ const panelStyle: CSSProperties = {
   background: 'var(--color-bg-surface)',
   border: '1px solid var(--color-border)',
   borderRadius: 'var(--radius-xl)',
-  padding: 18,
+  padding: 'var(--space-lg)',
 }
 
 const sectionLabel: CSSProperties = {
   fontFamily: 'var(--font-body)',
-  fontSize: 10,
+  fontSize: 'var(--text-base)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: 'var(--color-text-secondary)',
@@ -100,18 +100,20 @@ export default function Sidebar() {
           />
           <div className="flex items-center justify-between mb-4">
             <span style={sectionLabel}>{t('sidebar.characterCard.eyebrow')}</span>
+            {/* ponytail: dropped a 1px paddingBottom rather than round it up to
+                --space-xs — 4px would visibly detach the underline; 0 is the
+                nearest honest value and the smallest delta off 1px. */}
             <Link
               to={`/characters/${character.id}/edit`}
               className="hover:opacity-80"
               style={{
                 fontFamily: 'var(--font-body)',
-                fontSize: 10,
+                fontSize: 'var(--text-base)',
                 letterSpacing: '0.16em',
                 textTransform: 'uppercase',
                 color: 'var(--faction-default-card-muted)',
                 textDecoration: 'none',
                 borderBottom: '1px solid var(--color-border-strong)',
-                paddingBottom: 1,
               }}
             >
               {t('sidebar.characterCard.edit')}
@@ -122,7 +124,7 @@ export default function Sidebar() {
             {/* avatar in a rainbow ring (unaffiliated / all-paths mark) */}
             <div
               className="shrink-0 rounded-full"
-              style={{ width: 58, height: 58, padding: 3, background: 'var(--faction-default-ring)' }}
+              style={{ width: 58, height: 58, padding: 'var(--space-xs)', background: 'var(--faction-default-ring)' }}
             >
               {character.avatar_url ? (
                 <img
@@ -144,16 +146,16 @@ export default function Sidebar() {
               <Link
                 to={`/characters/${character.id}`}
                 className="font-display italic block truncate"
-                style={{ fontSize: 24, lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                style={{ fontSize: 'var(--text-3xl)', lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
               >
                 {character.display_name}
               </Link>
               <div
                 className="truncate"
                 style={{
-                  marginTop: 5,
+                  marginTop: 'var(--space-xs)',
                   fontFamily: 'var(--font-body)',
-                  fontSize: 10,
+                  fontSize: 'var(--text-base)',
                   letterSpacing: '0.16em',
                   textTransform: 'uppercase',
                   color: 'var(--color-text-secondary)',
@@ -180,17 +182,17 @@ export default function Sidebar() {
                   background: 'var(--color-bg-surface)',
                   border: '1px solid var(--color-border)',
                   borderRadius: 9,
-                  padding: '11px 8px',
+                  padding: 'var(--space-md) var(--space-sm)',
                 }}
               >
-                <div className="font-display" style={{ fontSize: 22, lineHeight: 1, color: 'var(--color-text-primary)' }}>
+                <div className="font-display" style={{ fontSize: 'var(--text-2xl)', lineHeight: 1, color: 'var(--color-text-primary)' }}>
                   {stat.value}
                 </div>
                 <div
                   style={{
-                    marginTop: 6,
+                    marginTop: 'var(--space-sm)',
                     fontFamily: 'var(--font-body)',
-                    fontSize: 8,
+                    fontSize: 'var(--text-xs)',
                     letterSpacing: '0.2em',
                     textTransform: 'uppercase',
                     color: 'var(--color-text-secondary)',
@@ -245,7 +247,7 @@ export default function Sidebar() {
                 <Link
                   to={`/praxes/${praxis.id}/edit`}
                   className="font-display min-w-0"
-                  style={{ fontSize: 17, lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                  style={{ fontSize: 'var(--text-2xl)', lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
                 >
                   {praxis.task_title}
                 </Link>
@@ -253,11 +255,11 @@ export default function Sidebar() {
                   className="shrink-0"
                   style={{
                     fontFamily: 'var(--font-body)',
-                    fontSize: 9,
+                    fontSize: 'var(--text-sm)',
                     letterSpacing: '0.16em',
                     textTransform: 'uppercase',
                     color: 'var(--faction-default-card-muted)',
-                    padding: '4px 9px',
+                    padding: 'var(--space-xs) var(--space-sm)',
                     border: '1px solid var(--color-border-strong)',
                     borderRadius: 999,
                   }}
@@ -286,7 +288,7 @@ export default function Sidebar() {
           </div>
           <p
             className="font-body text-right"
-            style={{ fontSize: 10, letterSpacing: '0.08em', color: 'var(--color-text-secondary)', marginTop: 8 }}
+            style={{ fontSize: 'var(--text-base)', letterSpacing: '0.08em', color: 'var(--color-text-secondary)', marginTop: 'var(--space-sm)' }}
           >
             {t('sidebar.activeTasks.slots', { count: slotCount, max: maxTaskSlots })}
           </p>
@@ -319,7 +321,7 @@ export default function Sidebar() {
                   ? t('sidebar.globalActivity.kickerNewTask')
                   : item.actor_display_name
               const titleStyle: CSSProperties = {
-                fontSize: 14,
+                fontSize: 'var(--text-2xl)',
                 lineHeight: 1.3,
                 color: 'var(--color-text-primary)',
                 textDecoration: 'none',
@@ -329,7 +331,7 @@ export default function Sidebar() {
                   key={`${item.type}-${index}`}
                   className="flex gap-3"
                   style={{
-                    padding: '13px 0',
+                    padding: 'var(--space-md) 0',
                     borderBottom: isLast ? undefined : '1px solid var(--color-border)',
                   }}
                 >
@@ -339,7 +341,7 @@ export default function Sidebar() {
                     style={{
                       width: 6,
                       height: 6,
-                      marginTop: 5,
+                      marginTop: 'var(--space-xs)',
                       borderRadius: 2,
                       background: 'var(--faction-default-rainbow)',
                       backgroundSize: '600% 100%',
@@ -350,11 +352,11 @@ export default function Sidebar() {
                     <div
                       style={{
                         fontFamily: 'var(--font-body)',
-                        fontSize: 9,
+                        fontSize: 'var(--text-sm)',
                         letterSpacing: '0.18em',
                         textTransform: 'uppercase',
                         color: 'var(--color-text-secondary)',
-                        marginBottom: 3,
+                        marginBottom: 'var(--space-xs)',
                       }}
                     >
                       {kicker}
@@ -368,7 +370,7 @@ export default function Sidebar() {
                         {title}
                       </div>
                     )}
-                    <div className="font-body" style={{ marginTop: 3, fontSize: 10, color: 'var(--color-text-tertiary)' }}>
+                    <div className="font-body" style={{ marginTop: 'var(--space-xs)', fontSize: 'var(--text-base)', color: 'var(--color-text-tertiary)' }}>
                       {relativeTime(item.timestamp)}
                     </div>
                   </div>
@@ -385,9 +387,9 @@ export default function Sidebar() {
         className="font-display w-full flex items-center justify-center gap-2.5 hover:opacity-90"
         style={{
           boxSizing: 'border-box',
-          padding: 14,
+          padding: 'var(--space-lg)',
           borderRadius: 11,
-          fontSize: 14,
+          fontSize: 'var(--text-xl)',
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           color: 'var(--color-bg-page)',
@@ -396,7 +398,7 @@ export default function Sidebar() {
           textDecoration: 'none',
         }}
       >
-        <span style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+        <span style={{ fontSize: 'var(--text-xl)', lineHeight: 1 }}>+</span>
         <span>{t('actions.proposeTask')}</span>
       </Link>
     </aside>
@@ -405,11 +407,11 @@ export default function Sidebar() {
 
 const REQUEST_BUTTON_BASE: CSSProperties = {
   fontFamily: "'Courier Prime', monospace",
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   fontWeight: 700,
   textTransform: 'uppercase',
   letterSpacing: '0.08em',
-  padding: '3px 8px',
+  padding: 'var(--space-xs) var(--space-sm)',
 }
 
 /**
@@ -458,7 +460,10 @@ function PendingRequestRow({
           <Link
             to={`/characters/${actorId}`}
             className="font-body block truncate"
-            style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+            /* ponytail: an actor byline in a dense 24px-avatar notification
+               row — scanned, not read, so it stays label-tier rather than
+               taking the --text-2xl content floor, which would break the row. */
+            style={{ fontSize: 'var(--text-xl)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
           >
             {item.actor_display_name}
           </Link>
@@ -471,7 +476,7 @@ function PendingRequestRow({
           </Link>
         </div>
       </div>
-      <div className="flex items-center gap-1.5" style={{ marginTop: 4, marginLeft: 32 }}>
+      <div className="flex items-center gap-1.5" style={{ marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}>
         <button
           onClick={() => respond(accept)}
           disabled={loading}
@@ -502,7 +507,7 @@ function PendingRequestRow({
       {error && (
         <span
           className="eyebrow block"
-          style={{ color: 'var(--color-danger)', marginTop: 3, marginLeft: 32 }}
+          style={{ color: 'var(--color-danger)', marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}
         >
           {error}
         </span>

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -28,7 +28,7 @@ export function PraxisTitle({
     <Link to={`/praxes/${praxis.id}`}>
       <h3
         className="font-display font-semibold leading-tight hover:underline"
-        style={{ fontSize: "var(--text-lg)", marginBottom: 6, ...style }}
+        style={{ fontSize: "var(--text-2xl)", marginBottom: "var(--space-sm)", ...style }}
       >
         {praxis.title}
       </h3>
@@ -68,8 +68,8 @@ export function PraxisByline({
       className="flex justify-between items-center font-body"
       style={{
         fontSize: "var(--text-xs)",
-        marginTop: 8,
-        paddingTop: 6,
+        marginTop: "var(--space-sm)",
+        paddingTop: "var(--space-sm)",
         borderTop: "1px dashed rgba(128,128,128,0.3)",
         ...style,
       }}
@@ -83,7 +83,7 @@ export function PraxisByline({
       {praxis.score !== null && (
         <span
           className="font-display font-bold"
-          style={{ fontSize: "var(--text-sm)", color: "inherit" }}
+          style={{ fontSize: "var(--text-2xl)", color: "inherit" }}
         >
           {praxis.score.toFixed(1)}
         </span>
@@ -130,7 +130,7 @@ export function PraxisScoreHero({
         justifyContent: "center",
         flexShrink: 0,
         minWidth: 54,
-        padding: "6px 10px",
+        padding: "var(--space-sm) var(--space-md)",
         border: `2px solid ${border ?? "currentColor"}`,
         borderRadius: 4,
         transform: "rotate(-3deg)",
@@ -149,17 +149,18 @@ export function PraxisScoreHero({
           style={{ position: "absolute", top: -13, right: -12, zIndex: 3 }}
         />
       )}
-      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-lg)", whiteSpace: "nowrap" }}>
+      {/* The earned-points readout — a score, so --text-2xl per the floor (§4). */}
+      <span className="font-display" style={{ fontWeight: 800, fontSize: "var(--text-2xl)", whiteSpace: "nowrap" }}>
         {base}
-        <span style={{ opacity: 0.55, margin: "0 2px" }}>+</span>
+        <span style={{ opacity: 0.55, margin: "0 var(--space-xs)" }}>+</span>
         {votePoints}
       </span>
       <span
         style={{
-          fontSize: 7,
+          fontSize: "var(--text-xs)",
           letterSpacing: "0.16em",
           textTransform: "uppercase",
-          marginTop: 3,
+          marginTop: "var(--space-xs)",
           opacity: 0.8,
         }}
       >
@@ -234,8 +235,8 @@ export function AdminOverlay({
             position: "absolute",
             top: 8,
             right: 8,
-            fontSize: 7,
-            padding: "1px 5px",
+            fontSize: "var(--text-xs)",
+            padding: "0 var(--space-xs)",
             border: "1px solid rgba(220,38,38,0.4)",
             color: "var(--color-danger)",
             background: "rgba(220,38,38,0.05)",
@@ -251,8 +252,8 @@ export function AdminOverlay({
             position: "absolute",
             top: 8,
             right: 8,
-            fontSize: 7,
-            padding: "1px 5px",
+            fontSize: "var(--text-xs)",
+            padding: "0 var(--space-xs)",
             border: "1px solid rgba(245,158,11,0.4)",
             color: "var(--color-warning)",
             background: "rgba(245,158,11,0.05)",
@@ -268,8 +269,8 @@ export function AdminOverlay({
             position: "absolute",
             top: 8,
             right: 8,
-            fontSize: 7,
-            padding: "1px 5px",
+            fontSize: "var(--text-xs)",
+            padding: "0 var(--space-xs)",
             border: "1px solid rgba(107,114,128,0.4)",
             color: "var(--color-text-secondary)",
             background: "rgba(107,114,128,0.05)",
@@ -284,7 +285,7 @@ export function AdminOverlay({
           style={{
             fontSize: "var(--text-xs)",
             color: "var(--color-danger)",
-            marginBottom: 4,
+            marginBottom: "var(--space-xs)",
           }}
         >
           {moderateError}
@@ -297,15 +298,15 @@ export function AdminOverlay({
             top: 8,
             right: 8,
             display: "flex",
-            gap: 4,
+            gap: "var(--space-xs)",
           }}
         >
           <button
             onClick={onHide}
             className="eyebrow"
             style={{
-              fontSize: 7,
-              padding: "1px 5px",
+              fontSize: "var(--text-xs)",
+              padding: "0 var(--space-xs)",
               border: "1px solid rgba(220,38,38,0.3)",
               color: "var(--color-danger)",
               background: "rgba(220,38,38,0.05)",
@@ -318,8 +319,8 @@ export function AdminOverlay({
             onClick={onFail}
             className="eyebrow"
             style={{
-              fontSize: 7,
-              padding: "1px 5px",
+              fontSize: "var(--text-xs)",
+              padding: "0 var(--space-xs)",
               border: "1px solid rgba(245,158,11,0.3)",
               color: "var(--color-warning)",
               background: "rgba(245,158,11,0.05)",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -281,6 +281,20 @@
   --radius-lg: 12px;
   --radius-xl: 14px;
 
+  /* ── Spacing scale (issue #579) ──
+     The only legal values for padding / margin / gap. Like --radius-* and
+     --text-*, this scale is theme-invariant and global: it lives in :root
+     ONLY and is deliberately NOT repeated under [data-theme="dark"] — a
+     duplicate would be two places to drift, for zero benefit. A faction
+     expresses identity through font, colour and ornament, never through its
+     own spacing or type scale. */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+  --space-2xl: 32px;
+
   /* ── Filter stamp dashed-border (inverts with active state bg) ── */
   --stamp-active-dashed: rgba(255, 255, 255, 0.2);
   --stamp-inactive-dashed: rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
Closes #579

Establishes the `--space-*` scale + the content-text floor, and proves the pattern on the named components.

## Note on the plan

The issue specifies **7 commits**. **Commit 3 (the ESLint rule + the grandfathered ratchet) was already on `main`** — `frontend/eslint.config.js` already defines `local/no-raw-style-values` and reads the ratchet from `frontend/.eslint-legacy-raw-styles.txt`. It was not rebuilt. Commit 7 is explicitly "no further commits pre-planned". So this PR is commits **1, 2, 4, 5, 6**.

| Commit | What |
| --- | --- |
| 1 | `--space-xs`…`--space-2xl` (4/8/12/16/24/32px) in `index.css` |
| 2 | `WORLD_ZERO_STYLE.md`: content-text floor (§4) + new Spacing section (§4a) |
| 4 | `SingularityTaskCard.tsx` migrated, off the ratchet |
| 5 | `Sidebar.tsx` migrated, off the ratchet |
| 6 | `PraxisCard.tsx` + `praxisCard/shared.tsx` migrated, off the ratchet |

Ratchet: **199 → 195 files**, deletions only, zero additions.

## Decisions worth a reviewer's eye

**1. `--space-*` lives in `:root` only, not duplicated under `[data-theme="dark"]`.** The issue asks for "both the light and dark variable blocks", but the two scales it names as the precedent — `--radius-*` and `--text-*` — are both `:root`-only, because they're theme-invariant. Spacing is too. A dark-mode duplicate of identical values would only be a second place to drift. Flagging explicitly since it's a deliberate deviation from the issue text; **Settled: repo owner confirmed `:root`-only is correct — the issue text is the slip, not the code. Please don't revert this.**

**2. `badgeArt.tsx` has nothing to migrate.** It was named in commit 6, but it contains **zero** raw `fontSize`/`padding`/`margin`/`gap` values and is not on the ratchet. Skipped rather than inventing work.

**3. Two deliberate sub-floor retentions** (both marked `/* ponytail: */` in place):
- **Singularity task-card description** → `--text-xl`, not the `--text-2xl` floor. It's a 2-line-clamped teaser in a ~140px-wide card; 18px clamped body copy would eat the card. The issue's own commit-4 note moves only *the title and the points value* to `--text-2xl` and doesn't place the description. Still a 2x lift off the un-tokenized 7px.
- **Sidebar pending-request actor byline** → `--text-xl`. A name in a dense 24px-avatar notification row: scanned, not read. The floor would break the row.

Everything that is the *primary content* of its surface does meet the floor: Singularity title + points, Sidebar character name / stat values / task titles / activity titles, PraxisTitle, PraxisScoreHero, byline score.

**4. Rounding calls where a token didn't land exactly:**
- Everymen ruled page: 28px left pad rounds **up** to `--space-2xl` (an exact 4px tie between 24 and 32) to keep text clear of the red margin rule at `left: 22`.
- UA plate: `16px 17px 14px` collapses to a single `--space-lg` — the 1–3px asymmetry isn't load-bearing.
- Sidebar edit link: dropped a 1px `paddingBottom` rather than round it up to 4px, which would visibly detach the underline.
- Ornament geometry (`width`/`height`/`top`/`inset` on sprocket holes, tape, corner brackets) stays raw — it's illustration, not layout spacing. Documented as a carve-out in §4a. Where the rule *does* reach an ornament (`marginLeft: 3` on the blinking cursor, `padding: 3` on the avatar ring), it's tokenized to `--space-xs`; sub-pixel-scale visual delta.

## Gates

| Gate | Result |
| --- | --- |
| `npx eslint src` | **PASS** (exit 0) — the primary gate: all 4 files are off the ratchet, so the rule now fires on them |
| `npm test` | **PASS** — 87 files, 552 tests |
| `npx tsc --noEmit` | **FAILS — pre-existing, not from this PR** |

`tsc` reports 13 errors in `AlbescentInvitation.tsx` (i18n key typing) and `factionMembershipRelocation.test.tsx`. I verified the **identical 13 errors on untouched base `f958ffd`** by checking out the base and re-running. No file in this PR is implicated and the error set is byte-identical before/after. Consistent with `tsc` not being wired into frontend CI. Not fixed here — out of scope for a token migration; worth its own issue.

## Not verified

No visual spot-check — the issue notes nothing in the suite exercises visual styling, and no dev server was run. The size changes on Sidebar activity titles (14→18px) and the praxis score/title slots are real and intentional per the floor rule, but they'd benefit from a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

