### PR TITLE
feat(collab): per-faction voice, detail roster + success screen (#591)

### DIFF
--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -13,10 +13,14 @@
  * `action` is supplied only in the editable composer; the read-only detail view
  * omits it (the detail page owns its own reopen affordance). Spacing/type via
  * Tailwind utilities + --text-* tokens, not raw inline pixels (#588 lint guard).
+ *
+ * Every word resolves through `collabCopy(factionSlug, key)`, so each faction
+ * speaks the same states in its own voice and anything it hasn't overridden
+ * falls back to the shared `editPraxis.collab.*` block (#591).
  */
-import { useTranslation } from 'react-i18next'
 import type { PraxisMemberOut } from '../../api/praxis'
 import { factionCssVar } from '../../utils/factions'
+import { collabCopy } from './collabCopy'
 
 export type CollabState = 'writing' | 'waiting' | 'holdout' | 'published'
 
@@ -63,7 +67,6 @@ export function CollabRoster({
   taskPointValue?: number | null
   action?: CollabRosterAction
 }) {
-  const { t } = useTranslation('forms')
   const gate = deriveCollabGate(members, currentCharacterId)
   if (gate.memberCount < 2) return null // solo/duel render nothing
 
@@ -72,11 +75,11 @@ export function CollabRoster({
 
   const banner =
     gate.state === 'waiting'
-      ? { text: t('editPraxis.collab.bannerWaiting'), tone: accent, warn: false }
+      ? { text: collabCopy(factionSlug, 'bannerWaiting'), tone: accent, warn: false }
       : gate.state === 'holdout'
-        ? { text: t('editPraxis.collab.bannerHoldout'), tone: 'var(--color-warning)', warn: true }
+        ? { text: collabCopy(factionSlug, 'bannerHoldout'), tone: 'var(--color-warning)', warn: true }
         : gate.state === 'published'
-          ? { text: t('editPraxis.collab.bannerPublished'), tone: 'var(--color-success)', warn: false }
+          ? { text: collabCopy(factionSlug, 'bannerPublished'), tone: 'var(--color-success)', warn: false }
           : null
 
   return (
@@ -84,7 +87,7 @@ export function CollabRoster({
       {/* Header: label + cast progress chip */}
       <div className="flex items-center gap-2" style={{ justifyContent: 'space-between' }}>
         <span className="eyebrow text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
-          {t('editPraxis.collab.castStatus', { cast: gate.castCount, total: gate.memberCount })}
+          {collabCopy(factionSlug, 'castStatus', { cast: gate.castCount, total: gate.memberCount })}
         </span>
       </div>
 
@@ -94,7 +97,7 @@ export function CollabRoster({
         aria-valuenow={gate.castCount}
         aria-valuemin={0}
         aria-valuemax={gate.memberCount}
-        aria-label={t('editPraxis.collab.progressAria', { cast: gate.castCount, total: gate.memberCount })}
+        aria-label={collabCopy(factionSlug, 'progressAria', { cast: gate.castCount, total: gate.memberCount })}
         style={{ height: 4, borderRadius: 2, background: 'var(--color-border)', overflow: 'hidden' }}
       >
         <div style={{ width: `${pct}%`, height: '100%', background: accent, transition: 'width 200ms' }} />
@@ -118,14 +121,14 @@ export function CollabRoster({
               <span className="font-body text-[12px]" style={{ fontWeight: cast ? 700 : 400, flex: 1 }}>
                 {member.character_display_name}
                 {isMe && (
-                  <span style={{ color: 'var(--color-text-tertiary)' }}> · {t('editPraxis.collab.you')}</span>
+                  <span style={{ color: 'var(--color-text-tertiary)' }}> · {collabCopy(factionSlug, 'you')}</span>
                 )}
                 {gate.state === 'published' && taskPointValue != null && (
                   <span style={{ color: 'var(--color-success)', fontWeight: 700 }}> +{taskPointValue}</span>
                 )}
               </span>
               <span className="eyebrow text-[9px]" style={{ color: cast ? accent : 'var(--color-warning)' }}>
-                {cast ? `✓ ${t('editPraxis.collab.pillCast')}` : t('editPraxis.collab.pillWeaving')}
+                {cast ? `✓ ${collabCopy(factionSlug, 'pillCast')}` : collabCopy(factionSlug, 'pillWeaving')}
               </span>
             </div>
           )
@@ -157,10 +160,10 @@ export function CollabRoster({
           style={{ alignSelf: 'flex-start' }}
         >
           {gate.iCast
-            ? t('editPraxis.collab.pullBackAction')
+            ? collabCopy(factionSlug, 'pullBackAction')
             : gate.castCount === gate.memberCount - 1
-              ? t('editPraxis.collab.castFinalAction')
-              : t('editPraxis.collab.castAction')}
+              ? collabCopy(factionSlug, 'castFinalAction')
+              : collabCopy(factionSlug, 'castAction')}
         </button>
       )}
     </div>

--- a/frontend/src/components/collab/CollabSuccess.tsx
+++ b/frontend/src/components/collab/CollabSuccess.tsx
@@ -1,0 +1,140 @@
+/**
+ * Post-publish success screen for a collab (#591).
+ *
+ * Shown once, to the member whose own cast closed the consensus gate: the
+ * moment the last part lands, the composer stops being a composer and says so.
+ * Everyone else's cast leaves them in the composer's `waiting` state, so they
+ * never see this.
+ *
+ * Purely transient client state — derived from `praxis.members[]`, which the
+ * composer already refetches after a cast. No new API, no persistence: dismiss
+ * it and it's gone (this is a "your thing went live" beat, not a notification).
+ *
+ * Form factor (#494): mobile takes the whole screen, desktop is a centred panel
+ * over the composer. Continue is a manual action, never an auto-redirect timer —
+ * the player leaves when they've read it.
+ *
+ * Chrome mirrors LevelUpPopup / ImageEditModal: fixed dim overlay, role="dialog",
+ * the primary action autofocuses, no focus trap. Spacing/type via Tailwind
+ * utilities + --text-* tokens, not raw inline pixels (#588 lint guard).
+ */
+import type { PraxisMemberOut } from '../../api/praxis'
+import { useFormFactor } from '../../hooks/useFormFactor'
+import { factionCssVar } from '../../utils/factions'
+import { collabCopy } from './collabCopy'
+import { deriveCollabGate } from './CollabRoster'
+
+export function CollabSuccess({
+  members,
+  currentCharacterId,
+  factionSlug,
+  taskPointValue,
+  onContinue,
+}: {
+  members: readonly PraxisMemberOut[]
+  currentCharacterId: number | null | undefined
+  factionSlug: string | null | undefined
+  taskPointValue?: number | null
+  /** Manual continue → the praxis detail page. Never fired on a timer. */
+  onContinue: () => void
+}) {
+  const formFactor = useFormFactor()
+  const gate = deriveCollabGate(members, currentCharacterId)
+  const accent = factionCssVar(factionSlug, 'card-accent')
+  const isMobile = formFactor === 'mobile'
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={collabCopy(factionSlug, 'successHeading')}
+      className="fixed inset-0 z-50 flex items-center justify-center p-[16px]"
+      style={{
+        // Mobile fills the screen outright; desktop dims the composer behind.
+        background: isMobile
+          ? 'var(--color-bg-page)'
+          : 'radial-gradient(circle, rgba(0,0,0,0.55), rgba(0,0,0,0.75))',
+      }}
+    >
+      <div
+        className={`flex flex-col items-center gap-[14px] p-[24px] ${
+          isMobile ? 'w-full h-full justify-center' : 'w-full max-w-[420px]'
+        }`}
+        style={{
+          background: 'var(--color-bg-page)',
+          border: isMobile ? 'none' : `2px solid ${accent}`,
+          borderRadius: isMobile ? 0 : 8,
+        }}
+      >
+        <span className="eyebrow" style={{ color: accent }}>
+          {collabCopy(factionSlug, 'castStatus', {
+            cast: gate.castCount,
+            total: gate.memberCount,
+          })}
+        </span>
+
+        <h2
+          className="font-display text-center"
+          style={{ fontSize: 'var(--text-2xl)', color: 'var(--color-text-primary)' }}
+        >
+          {collabCopy(factionSlug, 'successHeading')}
+        </h2>
+
+        <p
+          className="font-body text-center"
+          style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)' }}
+        >
+          {collabCopy(factionSlug, 'successBody')}
+        </p>
+
+        {/* Everyone who was woven in, each credited with the full task value —
+            a collab pays every member in full (SPEC-game-rules). */}
+        <ul className="flex flex-col gap-[4px] w-full">
+          {members.map((member) => (
+            <li
+              key={member.id}
+              className="flex items-center justify-between gap-2 px-[10px] py-[5px]"
+              style={{
+                borderRadius: 4,
+                border: `1.5px solid ${accent}`,
+                background: factionCssVar(factionSlug, 'card-muted'),
+              }}
+            >
+              <span
+                className="font-body"
+                style={{
+                  fontSize: 'var(--text-xs)',
+                  fontWeight: member.character_id === currentCharacterId ? 700 : 400,
+                }}
+              >
+                {member.character_display_name}
+              </span>
+              {taskPointValue != null && (
+                <span
+                  className="font-body"
+                  style={{
+                    fontSize: 'var(--text-xs)',
+                    fontWeight: 700,
+                    color: 'var(--color-success)',
+                  }}
+                >
+                  +{taskPointValue}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        <button
+          type="button"
+          autoFocus
+          onClick={onContinue}
+          className="btn-primary px-[18px] py-[8px]"
+          style={{ fontSize: 'var(--text-sm)' }}
+        >
+          {collabCopy(factionSlug, 'successContinue')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
+++ b/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
@@ -34,13 +34,15 @@ describe('deriveCollabGate — the consensus state machine (#591)', () => {
 describe('CollabRoster render', () => {
   it('renders nothing for a solo/duel (fewer than two members)', () => {
     expect(renderToStaticMarkup(
-      <CollabRoster members={[member(1, false)]} currentCharacterId={1} factionSlug="wow" />,
+      <CollabRoster members={[member(1, false)]} currentCharacterId={1} factionSlug={null} />,
     )).toBe('')
   })
 
+  // A null slug takes the shared fallback voice — the faction-voiced wording is
+  // covered in collabCopy.test.ts (#591).
   it('shows a cast pill for cast members and a weaving pill otherwise', () => {
     const html = renderToStaticMarkup(
-      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug="wow" />,
+      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug={null} />,
     )
     expect(html).toContain('cast')
     expect(html).toContain('weaving')
@@ -50,13 +52,24 @@ describe('CollabRoster render', () => {
   it('offers pull-back when I have cast, cast when I have not', () => {
     const action = { onCast: () => {}, onPullBack: () => {}, submitting: false }
     const waiting = renderToStaticMarkup(
-      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug="wow" action={action} />,
+      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug={null} action={action} />,
     )
     expect(waiting).toContain('Pull my part back')
     const holdout = renderToStaticMarkup(
-      <CollabRoster members={[member(1, false), member(2, true)]} currentCharacterId={1} factionSlug="wow" action={action} />,
+      <CollabRoster members={[member(1, false), member(2, true)]} currentCharacterId={1} factionSlug={null} action={action} />,
     )
     // castCount === memberCount - 1 → the go-live wording.
     expect(holdout).toContain('send it live')
+  })
+
+  it('speaks the task faction voice when the faction overrides the copy', () => {
+    const action = { onCast: () => {}, onPullBack: () => {}, submitting: false }
+    const html = renderToStaticMarkup(
+      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug="everymen" action={action} />,
+    )
+    expect(html).toContain('signed off')
+    expect(html).toContain('still on the clock')
+    expect(html).toContain('Waiting on the rest of the crew.')
+    expect(html).not.toContain('weaving')
   })
 })

--- a/frontend/src/components/collab/__tests__/CollabSuccess.test.tsx
+++ b/frontend/src/components/collab/__tests__/CollabSuccess.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * #591 — the standalone post-publish success screen.
+ *
+ * Two things matter and are tested separately:
+ *   - `shouldShowCollabSuccess` — the gate the composer applies after a cast.
+ *     Only a multi-member collab whose gate my cast just closed qualifies; solo,
+ *     duel and still-waiting casts keep the plain redirect.
+ *   - the rendered screen — faction-voiced copy, every member credited, and a
+ *     manual continue action (never a timer).
+ *
+ * Rendered to static markup; the catalog is initialized so copy keys resolve.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { PraxisMemberOut } from '../../../api/praxis'
+import { CollabSuccess } from '../CollabSuccess'
+import { deriveCollabGate } from '../CollabRoster'
+
+function member(id: number, name: string, cast: boolean): PraxisMemberOut {
+  return {
+    id: id * 10,
+    praxis_id: 1,
+    character_id: id,
+    character_display_name: name,
+    has_submitted: cast,
+    joined_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+/**
+ * The composer's post-cast decision, mirrored from useEditPraxis.publish: show
+ * the beat only when my cast closed the gate on a multi-member collab.
+ */
+function shouldShowCollabSuccess(
+  members: readonly PraxisMemberOut[],
+  currentCharacterId: number | null,
+): boolean {
+  const gate = deriveCollabGate(members, currentCharacterId)
+  return gate.memberCount > 1 && gate.state === 'published'
+}
+
+describe('shouldShowCollabSuccess — when the beat fires', () => {
+  it('fires when my cast closed the gate', () => {
+    expect(
+      shouldShowCollabSuccess([member(1, 'Ada', true), member(2, 'Beth', true)], 1),
+    ).toBe(true)
+  })
+
+  it('does not fire while a co-author is still weaving', () => {
+    expect(
+      shouldShowCollabSuccess([member(1, 'Ada', true), member(2, 'Beth', false)], 1),
+    ).toBe(false)
+  })
+
+  it('does not fire on a solo/duel praxis (single member)', () => {
+    expect(shouldShowCollabSuccess([member(1, 'Ada', true)], 1)).toBe(false)
+  })
+})
+
+describe('CollabSuccess render', () => {
+  const MEMBERS = [member(1, 'Ada', true), member(2, 'Beth', true)]
+
+  it('credits every member with the full task value', () => {
+    const html = renderToStaticMarkup(
+      <CollabSuccess
+        members={MEMBERS}
+        currentCharacterId={1}
+        factionSlug={null}
+        taskPointValue={30}
+        onContinue={() => {}}
+      />,
+    )
+    expect(html).toContain('Ada')
+    expect(html).toContain('Beth')
+    // A collab pays every member in full — not a split.
+    expect(html.match(/\+30/g)).toHaveLength(2)
+    expect(html).toContain('The proof is woven')
+    expect(html).toContain('2 of 2 cast')
+  })
+
+  it('speaks the task faction voice', () => {
+    const html = renderToStaticMarkup(
+      <CollabSuccess
+        members={MEMBERS}
+        currentCharacterId={1}
+        factionSlug="ua"
+        taskPointValue={30}
+        onContinue={() => {}}
+      />,
+    )
+    expect(html).toContain('Hung in the Salon')
+    expect(html).toContain('Every hand has signed.')
+    expect(html).toContain('View the work')
+    expect(html).not.toContain('The proof is woven')
+  })
+
+  it('offers a manual continue action, not an auto-redirect', () => {
+    const onContinue = vi.fn()
+    const html = renderToStaticMarkup(
+      <CollabSuccess
+        members={MEMBERS}
+        currentCharacterId={1}
+        factionSlug={null}
+        taskPointValue={30}
+        onContinue={onContinue}
+      />,
+    )
+    expect(html).toContain('View the praxis')
+    // Nothing navigates on its own: the handler only runs when the player acts.
+    expect(onContinue).not.toHaveBeenCalled()
+  })
+
+  it('is a labelled modal dialog', () => {
+    const html = renderToStaticMarkup(
+      <CollabSuccess
+        members={MEMBERS}
+        currentCharacterId={1}
+        factionSlug={null}
+        onContinue={() => {}}
+      />,
+    )
+    expect(html).toContain('role="dialog"')
+    expect(html).toContain('aria-modal="true"')
+  })
+
+  it('omits the points column when the task value is unknown', () => {
+    const html = renderToStaticMarkup(
+      <CollabSuccess
+        members={MEMBERS}
+        currentCharacterId={1}
+        factionSlug={null}
+        taskPointValue={null}
+        onContinue={() => {}}
+      />,
+    )
+    expect(html).not.toContain('+')
+  })
+})

--- a/frontend/src/components/collab/__tests__/collabCopy.test.ts
+++ b/frontend/src/components/collab/__tests__/collabCopy.test.ts
@@ -1,0 +1,78 @@
+/**
+ * #591 — per-faction voice for the collab roster copy.
+ *
+ * Key names are verb-neutral and shared; the words are the faction's. A faction
+ * that overrides a key speaks its own line, anything it hasn't overridden falls
+ * back to the shared `editPraxis.collab.*` block, and an unaffiliated/unknown
+ * slug resolves straight to the shared wording.
+ */
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import { collabCopy } from '../collabCopy'
+import type { CollabCopyKey } from '../collabCopy'
+import forms from '../../../locales/en/forms.json'
+
+const FACTION_SLUGS = [
+  'na',
+  'ephemerists',
+  'everymen',
+  'snide',
+  'singularity',
+  'ua',
+  'wow',
+  'albescent',
+] as const
+
+const SHARED_KEYS = Object.keys(forms.editPraxis.collab) as CollabCopyKey[]
+
+describe('collabCopy — faction override resolution', () => {
+  it('resolves a faction override when one exists', () => {
+    // wow keeps the witch-walk diction; everymen files a work report.
+    expect(collabCopy('wow', 'pillWeaving')).toBe('still walking')
+    expect(collabCopy('everymen', 'pillWeaving')).toBe('still on the clock')
+    expect(collabCopy('singularity', 'pillWeaving')).toBe('pending')
+  })
+
+  it('falls back to the shared block for a null / blank slug', () => {
+    expect(collabCopy(null, 'pillWeaving')).toBe(forms.editPraxis.collab.pillWeaving)
+    expect(collabCopy(undefined, 'pillCast')).toBe(forms.editPraxis.collab.pillCast)
+    expect(collabCopy('', 'pillCast')).toBe(forms.editPraxis.collab.pillCast)
+  })
+
+  it('falls back to the shared block for an unknown slug', () => {
+    expect(collabCopy('not-a-faction', 'castAction')).toBe(
+      forms.editPraxis.collab.castAction,
+    )
+  })
+
+  it('interpolates counts in the faction voice', () => {
+    expect(collabCopy('singularity', 'castStatus', { cast: 1, total: 3 })).toBe(
+      '1/3 committed',
+    )
+    expect(collabCopy(null, 'castStatus', { cast: 1, total: 3 })).toBe('1 of 3 cast')
+  })
+})
+
+describe('collabCopy — catalog completeness', () => {
+  it.each(FACTION_SLUGS)('%s overrides every shared collab key', (slug) => {
+    const block = forms.editPraxis[slug].collab as Record<string, string>
+    expect(Object.keys(block).sort()).toEqual([...SHARED_KEYS].sort())
+  })
+
+  it.each(FACTION_SLUGS)('%s resolves every key to non-empty copy', (slug) => {
+    for (const key of SHARED_KEYS) {
+      expect(collabCopy(slug, key, { cast: 1, total: 2 }).trim()).not.toBe('')
+    }
+  })
+
+  // Each faction owns its own diction — two factions sharing a line means a
+  // copy-paste, not a voice. (This caught ephemerists/albescent both saying
+  // "Enter my account".)
+  it.each(['castAction', 'castFinalAction', 'pullBackAction'] as const)(
+    'gives each faction a distinct %s',
+    (key) => {
+      const lines = FACTION_SLUGS.map((slug) => collabCopy(slug, key))
+      expect(new Set(lines).size).toBe(FACTION_SLUGS.length)
+    },
+  )
+})

--- a/frontend/src/components/collab/collabCopy.ts
+++ b/frontend/src/components/collab/collabCopy.ts
@@ -1,0 +1,61 @@
+import i18n from '../../i18n'
+
+/**
+ * Per-faction voice for the collab roster copy (#591).
+ *
+ * The roster's key names are verb-neutral (`castAction`, `pillWeaving`, …);
+ * the *words* are the faction's. Each faction may override any key under
+ * `forms:editPraxis.<slug>.collab.<key>`; anything it doesn't override falls
+ * back to the shared `forms:editPraxis.collab.<key>` block. This mirrors the
+ * resolver shape already used for faction names/descriptions
+ * (`utils/factions.ts`) and taunts (`utils/taunts.ts`): probe with
+ * `i18n.exists()` first, because a bare `t()` on a missing key trips the
+ * dev/test missing-key throw before the result could be inspected. A faction
+ * with no entry for a key is a normal miss, not a defect.
+ *
+ * Keys are runtime-dynamic (the slug comes from the task), so they can't be the
+ * typed literals `t()` expects — resolve through a plain-string view of `t`, as
+ * the taunt resolver does. The catalog still owns every word; only the
+ * compile-time key check is relaxed.
+ */
+const tString = i18n.t as unknown as (
+  key: string,
+  options?: Record<string, string | number>,
+) => string
+
+/** The shared block every faction falls back to. */
+const SHARED_PREFIX = 'forms:editPraxis.collab'
+
+export type CollabCopyKey =
+  | 'castStatus'
+  | 'pillCast'
+  | 'pillWeaving'
+  | 'you'
+  | 'progressAria'
+  | 'bannerWaiting'
+  | 'bannerHoldout'
+  | 'bannerPublished'
+  | 'castAction'
+  | 'castFinalAction'
+  | 'pullBackAction'
+  | 'successHeading'
+  | 'successBody'
+  | 'successContinue'
+
+/**
+ * Resolve one collab copy key in the given faction's voice, falling back to the
+ * shared block. A null/blank slug (or an unaffiliated task) resolves straight to
+ * the shared wording.
+ */
+export function collabCopy(
+  factionSlug: string | null | undefined,
+  key: CollabCopyKey,
+  options?: Record<string, string | number>,
+): string {
+  const slug = factionSlug ?? ''
+  if (slug) {
+    const factionKey = `forms:editPraxis.${slug}.collab.${key}`
+    if (i18n.exists(factionKey)) return tString(factionKey, options)
+  }
+  return tString(`${SHARED_PREFIX}.${key}`, options)
+}

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -165,6 +165,22 @@
       "viewToggleAria": "Switch between write and preview"
     },
     "na": {
+      "collab": {
+        "castStatus": "{{cast}} of {{total}} in",
+        "pillCast": "in",
+        "pillWeaving": "still writing",
+        "you": "you",
+        "progressAria": "{{cast}} of {{total}} people have put their part in",
+        "bannerWaiting": "your part's in. waiting on the others now.",
+        "bannerHoldout": "everyone's waiting on you — put your part in.",
+        "bannerPublished": "all in. it's up on the board. everyone gets credit.",
+        "castAction": "put my part in",
+        "castFinalAction": "put mine in — that's everyone",
+        "pullBackAction": "take my part back out",
+        "successHeading": "it's up",
+        "successBody": "everyone's part is in. small thing, done together.",
+        "successContinue": "go look at it"
+      },
       "masthead": "casual proof board",
       "pageTitle": "edit praxis",
       "autosaveSaved": "saved {{ago}}!",
@@ -194,6 +210,22 @@
       "footer": "✦ small thing, badly. that's the whole point."
     },
     "ephemerists": {
+      "collab": {
+        "castStatus": "{{cast}} of {{total}} accounts entered",
+        "pillCast": "entered",
+        "pillWeaving": "still observing",
+        "you": "you",
+        "progressAria": "{{cast}} of {{total}} observers have entered their account",
+        "bannerWaiting": "Your account is entered. The others have yet to set theirs down.",
+        "bannerHoldout": "The concord waits on you — enter your account.",
+        "bannerPublished": "The accounts agree. Every observer is credited.",
+        "castAction": "Enter my account",
+        "castFinalAction": "Enter mine — seal the concord",
+        "pullBackAction": "Withdraw my account",
+        "successHeading": "The accounts agree",
+        "successBody": "Every observer has set it down. The concord is sealed.",
+        "successContinue": "Read the entry"
+      },
       "masthead": "The Ephemerists · ephemeris entry №{{number}}",
       "pageTitle": "EDIT <1>PRAXIS</1>",
       "tagline": "— set it down before it passes",
@@ -235,6 +267,22 @@
       "autosaveUnsaved": "↳ not yet sealed"
     },
     "everymen": {
+      "collab": {
+        "castStatus": "{{cast}} of {{total}} signed off",
+        "pillCast": "signed off",
+        "pillWeaving": "still on the clock",
+        "you": "you",
+        "progressAria": "{{cast}} of {{total}} of the crew have signed off on the report",
+        "bannerWaiting": "You signed off. Waiting on the rest of the crew.",
+        "bannerHoldout": "The crew is waiting on you — sign off on your part.",
+        "bannerPublished": "Signed off all round. Every hand on the report is credited.",
+        "castAction": "Sign off on my part",
+        "castFinalAction": "Sign off — file the report",
+        "pullBackAction": "Pull my sign-off",
+        "successHeading": "REPORT FILED",
+        "successBody": "Every hand signed off. The job's on the board.",
+        "successContinue": "See the filed report"
+      },
       "masthead": "THE EVERYMEN · WORK REPORT {{number}}",
       "pageTitle": "EDIT PRAXIS",
       "savingStatus": "filing carbon copy…",
@@ -274,6 +322,22 @@
       "dropLabel": "cancel"
     },
     "snide": {
+      "collab": {
+        "castStatus": "{{cast}} of {{total}} in on it",
+        "pillCast": "in",
+        "pillWeaving": "still scheming",
+        "you": "you",
+        "progressAria": "{{cast}} of {{total}} of the gang are in on it",
+        "bannerWaiting": "you're in. waiting on the rest of the gang.",
+        "bannerHoldout": "the gang's waiting on YOU · get in on it.",
+        "bannerPublished": "everyone's in. it's out there. no taking it back now.",
+        "castAction": "count me in",
+        "castFinalAction": "count me in · print it",
+        "pullBackAction": "back out",
+        "successHeading": "IT'S OUT THERE",
+        "successBody": "whole gang's in. it hit the street.",
+        "successContinue": "go see it"
+      },
       "masthead": "ZINE #47 ·· S.N.I.D.E. ·· FREE / STEAL ME",
       "pageTitle": "edit praxis",
       "taskRefLabel": "Re: completion of",
@@ -306,6 +370,22 @@
       "autosaveUnsaved": "↳ unsaved · staple it before it walks off"
     },
     "singularity": {
+      "collab": {
+        "castStatus": "{{cast}}/{{total}} committed",
+        "pillCast": "committed",
+        "pillWeaving": "pending",
+        "you": "self",
+        "progressAria": "{{cast}} of {{total}} nodes have committed their branch",
+        "bannerWaiting": "> branch committed. awaiting remaining nodes.",
+        "bannerHoldout": "> blocked: merge requires your commit.",
+        "bannerPublished": "> all branches merged. signal transmitted.",
+        "castAction": "$ commit --mine",
+        "castFinalAction": "$ commit --final && merge",
+        "pullBackAction": "$ revert --mine",
+        "successHeading": "> merge complete",
+        "successBody": "// all nodes committed · signal is live",
+        "successContinue": "$ open ./praxis"
+      },
       "terminal": {
         "sessionPath": "singularity://praxis/draft.md · session 0x{{session}}",
         "whoami": "$ wz auth --whoami",
@@ -363,6 +443,22 @@
       }
     },
     "ua": {
+      "collab": {
+        "castStatus": "{{cast}} of {{total}} hands have signed",
+        "pillCast": "signed",
+        "pillWeaving": "still at work",
+        "you": "you",
+        "progressAria": "{{cast}} of {{total}} hands have signed the work",
+        "bannerWaiting": "You have signed. The other hands have yet to.",
+        "bannerHoldout": "The atelier waits on you — sign the work.",
+        "bannerPublished": "Signed by every hand. The work hangs in the Salon.",
+        "castAction": "Sign the work",
+        "castFinalAction": "Sign — hang it in the Salon",
+        "pullBackAction": "Withdraw my signature",
+        "successHeading": "Hung in the Salon",
+        "successBody": "Every hand has signed. The work is on view.",
+        "successContinue": "View the work"
+      },
       "masthead": "University of Asthmatics · Salon Submission №{{number}}",
       "autosaveSaved": "sketched {{ago}}",
       "autosaveUnsaved": "unsaved",
@@ -394,6 +490,22 @@
       "dropLabel": "Withdraw Work"
     },
     "wow": {
+      "collab": {
+        "castStatus": "{{cast}} of {{total}} have cast",
+        "pillCast": "cast",
+        "pillWeaving": "still walking",
+        "you": "you",
+        "progressAria": "{{cast}} of {{total}} walkers have cast their part",
+        "bannerWaiting": "Cast. Waiting on the others to finish their walk.",
+        "bannerHoldout": "The circle is waiting on you — cast your part in.",
+        "bannerPublished": "The circle is closed. Every walker is credited.",
+        "castAction": "Cast my part",
+        "castFinalAction": "Cast — close the circle",
+        "pullBackAction": "Pull my part back",
+        "successHeading": "The circle is closed",
+        "successBody": "Every part is cast. It's out in the world now.",
+        "successContinue": "See where it landed"
+      },
       "windowTitle": "wow.exe — edit praxis",
       "pageTitle": "edit praxis",
       "taskRefLabel": "re: completion of",
@@ -422,6 +534,22 @@
       "dropLabel": "cancel"
     },
     "albescent": {
+      "collab": {
+        "castStatus": "{{cast}} of {{total}} hands have entered",
+        "pillCast": "entered",
+        "pillWeaving": "not yet entered",
+        "you": "you",
+        "progressAria": "{{cast}} of {{total}} hands have entered their account",
+        "bannerWaiting": "Your account is entered. The other hands have not yet.",
+        "bannerHoldout": "The Register waits on you — enter your account.",
+        "bannerPublished": "Entered by every hand. The Register keeps it.",
+        "castAction": "Set down my account",
+        "castFinalAction": "Set mine down — close the Register",
+        "pullBackAction": "Strike my account",
+        "successHeading": "Kept in the Register",
+        "successBody": "Every hand has entered. No more than was done.",
+        "successContinue": "Read the account"
+      },
       "masthead": "Albescent · Account № {{number}}",
       "autosaveSaved": "noted {{ago}}",
       "autosaveUnsaved": "unfiled draft",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -9,6 +9,7 @@ import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PageTitle from "../components/ui/PageTitle";
 import ImageEditModal from "../components/imageEdit/ImageEditModal";
+import { CollabSuccess } from "../components/collab/CollabSuccess";
 import { pickVariant } from "../utils/factionDispatch";
 import { useFormFactor } from "../hooks/useFormFactor";
 import {
@@ -110,6 +111,19 @@ export default function EditPraxis() {
         />
       )}
       <Archetype state={state} />
+      {/* The cast that closes a collab's consensus gate earns a standalone beat
+          rather than a silent redirect (#591). Rendered here, over whichever
+          archetype is mounted, so it's one shared screen for every faction and
+          both form factors. Only the member who cast last ever sees it. */}
+      {state.collabSuccess && (
+        <CollabSuccess
+          members={state.praxis.members}
+          currentCharacterId={state.currentCharacterId}
+          factionSlug={state.praxis.task_faction_slug}
+          taskPointValue={state.praxis.task_point_value}
+          onContinue={state.continueFromCollabSuccess}
+        />
+      )}
       {/* Praxis images crop/rotate in place before upload (#514), free-form so
           nothing is force-cropped. Sequential: keyed on identity so each queued
           image gets a fresh modal. */}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -105,6 +105,8 @@ function baseState(slug: string | null): EditPraxisState {
     submitting: false,
     publish: async () => {},
     pullBack: async () => {},
+    collabSuccess: false,
+    continueFromCollabSuccess: () => {},
     cancel: async () => {},
     autosaveAt: null,
     saveStatus: "idle",

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -106,6 +106,8 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
     submitting: false,
     publish,
     pullBack: async () => {},
+    collabSuccess: false,
+    continueFromCollabSuccess: () => {},
     cancel: async () => {},
     autosaveAt: null,
     saveStatus: "idle",

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -32,6 +32,7 @@ import {
   issueChallenge,
   type DuelDetailOut,
 } from "../../api/duel";
+import { deriveCollabGate } from "../../components/collab/CollabRoster";
 import { getGameConfig } from "../../api/gameConfig";
 import { listRelationships } from "../../api/relationships";
 import { getTask, type TaskOut } from "../../api/tasks";
@@ -109,6 +110,15 @@ export interface EditPraxisState {
   /** Pull my own cast back on a pending collab (#591). */
   pullBack: () => Promise<void>;
   cancel: () => Promise<void>;
+
+  /**
+   * My cast just closed the consensus gate on a multi-member collab, so the
+   * one-shot success screen is up (#591). Transient client state — never
+   * persisted, and only ever true for the member who cast last.
+   */
+  collabSuccess: boolean;
+  /** Manual continue from the success screen → the praxis detail page. */
+  continueFromCollabSuccess: () => void;
 
   // Autosave
   autosaveAt: Date | null;
@@ -204,6 +214,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const [inviting, setInviting] = useState(false);
 
   const [switchingMode, setSwitchingMode] = useState<PraxisType | null>(null);
+  // One-shot post-publish beat for the member whose cast closed the gate (#591).
+  const [collabSuccess, setCollabSuccess] = useState(false);
 
   // Duel challenge (#311)
   const [duelPaneOpen, setDuelPaneOpen] = useState(false);
@@ -480,10 +492,27 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       const praxisId = parseInt(idParam, 10);
       await persistEdits(praxisId);
       await submitPraxis(praxisId);
+      let refreshed: PraxisOut | null = null;
       try {
         await refetch();
+        // Reload the praxis too: `refetch` is the AUTH refetch (points/level),
+        // so it says nothing about who has now cast. The fresh member list is
+        // what decides between the success screen and the redirect below.
+        refreshed = await getPraxis(praxisId);
+        setPraxis(refreshed);
       } catch {
         // best-effort; praxis was submitted successfully
+      }
+      // If my cast is the one that closed the gate on a multi-member collab,
+      // hold the composer and show the success beat (#591). Every other case —
+      // solo, duel, or a cast that still leaves co-authors weaving — keeps the
+      // existing redirect.
+      if (refreshed) {
+        const gate = deriveCollabGate(refreshed.members, user?.character?.id);
+        if (gate.memberCount > 1 && gate.state === "published") {
+          setCollabSuccess(true);
+          return;
+        }
       }
       navigate(`/praxes/${idParam}`);
     } catch (err) {
@@ -491,7 +520,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     } finally {
       setSubmitting(false);
     }
-  }, [idParam, title, persistEdits, navigate, refetch]);
+  }, [idParam, title, persistEdits, navigate, refetch, user?.character?.id]);
 
   // Pull my own part back out of a pending collab (#591) — clears my cast so the
   // composer unlocks for editing. Backend re-opens only my membership (#590).
@@ -500,14 +529,25 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     setSubmitting(true);
     setError("");
     try {
-      await unsubmitPraxis(parseInt(idParam, 10));
+      const praxisId = parseInt(idParam, 10);
+      await unsubmitPraxis(praxisId);
       await refetch();
+      // `refetch` only refreshes auth — without reloading the praxis the roster
+      // would keep showing my part as cast right after I pulled it back.
+      setPraxis(await getPraxis(praxisId));
     } catch (err) {
       setError(extractError(err, i18n.t("forms:editPraxis.errors.publish")));
     } finally {
       setSubmitting(false);
     }
   }, [idParam, refetch]);
+
+  // The success screen's only exit: an explicit "it's on the public board" tap.
+  // Deliberately not a timer — the player leaves when they've read it (#591).
+  const continueFromCollabSuccess = useCallback(() => {
+    setCollabSuccess(false);
+    navigate(`/praxes/${idParam}`);
+  }, [idParam, navigate]);
 
   const cancel = useCallback(async () => {
     if (!praxis) return;
@@ -866,6 +906,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     publish,
     pullBack,
     cancel,
+    collabSuccess,
+    continueFromCollabSuccess,
 
     autosaveAt,
     saveStatus,

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -16,7 +16,11 @@ import { MemoryRouter } from "react-router-dom";
 import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
 import "../../../i18n";
-import { PraxisStatusBanners, PraxisOwnerActions } from "../shared";
+import {
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  CollabRosterBlock,
+} from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type {
   PraxisOut,
@@ -192,6 +196,75 @@ describe("PraxisStatusBanners pending-publish (#521)", () => {
     );
     expect(t).toContain("IN EDITING");
     expect(t).not.toContain("PENDING PUBLISH");
+  });
+});
+
+describe("CollabRosterBlock on the detail page (#591)", () => {
+  it("reports the cast state read-only for a still-resolving collab", () => {
+    const t = text(
+      <CollabRosterBlock
+        state={state({
+          user: user(2), // Beth — has not cast, so the circle waits on her
+          praxis: praxis([ADA(), BETH()], "pending", "2026-01-03T00:00:00Z"),
+        })}
+      />,
+    );
+    expect(t).toContain("Ada");
+    expect(t).toContain("Beth");
+    expect(t).toContain("1 of 2 cast");
+    // Read-only: the composer owns the cast / pull-back controls.
+    expect(t).not.toContain("Cast my part");
+    expect(t).not.toContain("Pull my part back");
+  });
+
+  it("renders the roster on an in_progress collab too", () => {
+    const t = text(
+      <CollabRosterBlock
+        state={state({
+          user: user(1),
+          praxis: praxis([ADA(), BETH()], "in_progress", null),
+        })}
+      />,
+    );
+    expect(t).toContain("1 of 2 cast");
+  });
+
+  it("hides once the praxis is live — the byline already credits everyone", () => {
+    const t = text(
+      <CollabRosterBlock
+        state={state({
+          user: user(1),
+          praxis: praxis([ADA(), member(2, "Beth", true)], "submitted", null),
+        })}
+      />,
+    );
+    expect(t).toBe("");
+  });
+
+  it("hides on a solo praxis (a single member is not a circle)", () => {
+    const t = text(
+      <CollabRosterBlock
+        state={state({
+          user: user(1),
+          praxis: praxis([ADA()], "in_progress", null),
+        })}
+      />,
+    );
+    expect(t).toBe("");
+  });
+
+  it("speaks the task faction's voice", () => {
+    const collab = praxis([ADA(), BETH()], "pending", "2026-01-03T00:00:00Z");
+    const t = text(
+      <CollabRosterBlock
+        state={{
+          ...state({ user: user(2) }),
+          praxis: { ...collab, task_faction_slug: "everymen" },
+        }}
+      />,
+    );
+    expect(t).toContain("1 of 2 signed off");
+    expect(t).toContain("still on the clock");
   });
 });
 

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { reframeLabel } from '../../components/vote/voteReframes'
 import { TaskCrown } from '../../components/cards/TaskCrown'
+import { CollabRoster } from '../../components/collab/CollabRoster'
 import type { PraxisDetailState } from './usePraxisDetail'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
 import { flagReasonOptions } from '../../utils/flagReasons'
@@ -192,6 +193,35 @@ export function PraxisAdminBar({ state }: { state: PraxisDetailState }) {
   )
 }
 
+// ── Collab cast-status roster (#591) ─────────────────────────────────────────
+
+/**
+ * The read-only twin of the composer's roster: the same shared `CollabRoster`
+ * component with no `action` prop, so it reports the ADR-0012 consensus state
+ * without offering a cast/pull-back control.
+ *
+ * Gated to a still-resolving collab (in_progress / pending), mirroring
+ * `MemberByline`'s `showSubmitState`: that is exactly when "who still owes their
+ * part" is a live question. Once the praxis is live the byline already credits
+ * every co-author and a cast roster would only restate it. The component
+ * self-hides on a solo/duel praxis (<2 members).
+ */
+export function CollabRosterBlock({ state }: { state: PraxisDetailState }) {
+  const { praxis, user } = state
+  if (!praxis) return null
+  if (praxis.status !== 'in_progress' && praxis.status !== 'pending') return null
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <CollabRoster
+        members={praxis.members}
+        currentCharacterId={user?.character?.id ?? null}
+        factionSlug={praxis.task_faction_slug}
+        taskPointValue={praxis.task_point_value}
+      />
+    </div>
+  )
+}
+
 // ── Status banners ────────────────────────────────────────────────────────────
 
 export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
@@ -201,6 +231,15 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
 
   return (
     <>
+      {/* Read-only cast-status roster (#591). The same shared component the
+          composer uses, minus the `action` prop — the detail page is a reading
+          surface, so it shows who has cast and who hasn't but offers no
+          cast/pull-back control (those live in the composer). It self-hides on
+          a solo/duel praxis (<2 members). Rendered here rather than in each
+          archetype because every archetype — desktop and mobile — already
+          renders PraxisStatusBanners, so both form factors pick it up from one
+          place and no faction skin has to re-implement it. */}
+      <CollabRosterBlock state={state} />
       {/* Task Crown hero (ADR-0028) — this praxis is the task's top submitted
           entry, computed live. Invariant chrome, so every archetype shows it. */}
       {praxis.is_top_for_task && (


### PR DESCRIPTION
Finishes the three sub-parts #591 deliberately kept open after PR #618 landed the roster core. Built on the current post-#618 shape on `main`, reusing the shared `CollabRoster` rather than adding a second implementation.

Closes #591

## 1. Per-faction copy overrides

The roster shipped with one shared `editPraxis.collab.*` block, so every faction said "cast"/"weaving" in the same words.

The brief pointed at `editPraxis.invite` as the per-faction pattern to mirror, but `invite` turned out to be **flat/shared** — faction voice reaches it by archetypes prop-drilling `skin.placeholder` from their own `editPraxis.<slug>.*` block. That mechanism doesn't fit here: `CollabRoster` is rendered once inside the shared `InviteSearch` and already receives `factionSlug`. So I used the repo's other established resolver — the `i18n.exists()` probe-then-fallback in `utils/factions.ts` (`factionName`) and `utils/taunts.ts`:

- `collabCopy(slug, key)` resolves `editPraxis.<slug>.collab.<key>`, falling back to the shared block.
- The `exists()` probe is load-bearing: a bare `t()` on a missing key trips the dev/test missing-key **throw** in `i18n.ts` before the result could be inspected.
- Key names stay verb-neutral; values carry each faction's voice, matched to the diction already in that faction's composer block (everymen sign off on a report, singularity commits a branch, ua signs the work, albescent sets an account down in the Register).

The catalog-completeness test caught `ephemerists` and `albescent` both saying "Enter my account" — albescent now speaks in its own Register voice.

## 2. Read-only roster on the praxis detail page

The same shared `CollabRoster`, minus the `action` prop — it reports the consensus state but offers no cast/pull-back (those stay in the composer).

Hung off `PraxisStatusBanners`, which **all 16 archetypes (8 desktop + 8 mobile) already render**, so both form factors pick it up from one place and no faction skin re-implements it — zero archetype edits.

Gated to a still-resolving collab (`in_progress` / `pending`), mirroring `MemberByline`'s existing `showSubmitState`: that's when "who still owes their part" is a live question. Once live, the byline already credits every co-author.

## 3. Standalone post-publish success screen

Shown once, only to the member whose cast closed the gate. Transient client state derived from `praxis.members[]` — no backend change, no new API, no persistence. Mobile takes the full screen, desktop is a centred panel (`useFormFactor`). Continue is a **manual** action, never an auto-redirect timer. Every other publish path (solo, duel, or a cast that still leaves co-authors weaving) keeps the existing redirect.

## Bug found and fixed along the way

`publish`/`pullBack` awaited `refetch()` — which is `useAuth().refetch` (points/level), **not** a praxis reload. Nothing refetched the praxis, so after pulling a part back the roster still showed it as cast. Both now reload the praxis, which is also what tells `publish` whether the gate just closed.

## Gates

Run from `frontend/`:

- `npm test` — **589 passed (89 files)**, +31 new
- `npx eslint src` — **0 problems** (the CI gate; new files use `var(--text-*)` + Tailwind, none added to the legacy raw-styles list)
- `npx tsc --noEmit` — **13 errors, all pre-existing on clean `main`** (12 in `AlbescentInvitation.tsx`, 1 in `factionMembershipRelocation.test.tsx`) in files this branch never touches. Verified by stashing to a clean tree: identical 13. This branch adds none — it did surface two new ones in composer test doubles when `EditPraxisState` gained fields, and those are fixed.

## Notes for review

- **Branch name:** the remote `claude/collab-roster-591` is the stale, already-squash-merged branch from #618; pushing there would have resurrected pre-squash commits. This PR uses `claude/collab-roster-591-followup` off current `main`.
- **Pre-existing defect, left alone (out of scope):** `forms.json` has a **duplicate `previewLabel` key** in the `ua` block (lines ~379 and ~387). `JSON.parse` silently keeps the last, so `"As it will hang"` is dead copy. Worth a separate issue — flagging rather than silently fixing.
- **Copy is mine to review:** I wrote 8 factions x 14 lines of voiced copy from each faction's existing diction. It passes lint/tests, but voice is a human call — worth a read-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
