### PR TITLE
fix(characters): treat a leading @ as a sigil in player search (#624)

### DIFF
--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -531,13 +531,18 @@ async def list_characters_for_viewer(
     era_id = era_row.id if era_row else None
 
     query = _character_stats_era_join(era_id)
-    if search:
+    # Callers pass the handle as the player typed it, sigil and all ("@mol") —
+    # the invite search even prompts for "@handle". Neither a username nor a
+    # display name can contain '@', so a leading one is a sigil to drop, not a
+    # character to match (#624).
+    term = search.lstrip("@") if search else None
+    if term:
         # Match on handle OR display name so "@Mol" surfaces "Molly" (@mollusk).
         # The inserted mention is still @username; display_name only *matches*.
         query = query.where(
             or_(
-                Character.username.ilike(f"%{search}%"),
-                Character.display_name.ilike(f"%{search}%"),
+                Character.username.ilike(f"%{term}%"),
+                Character.display_name.ilike(f"%{term}%"),
             )
         )
     if faction_slug:

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -142,6 +142,23 @@ async def test_list_characters_search_by_display_name(
 
 
 @pytest.mark.asyncio
+async def test_list_characters_search_ignores_handle_sigil(
+    client: AsyncClient, character: Character, character2: Character
+):
+    """A leading '@' is a sigil, not a search character (#624).
+
+    The collab/duel invite search prompts for "@handle" and sends the query as
+    typed. No username contains '@', so without stripping it the ILIKE matched
+    nothing and the dropdown never opened.
+    """
+    resp = await client.get("/characters", params={"search": "@testcharacter"})
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert character.id in ids
+    assert character2.id not in ids
+
+
+@pytest.mark.asyncio
 async def test_list_characters_filter_by_faction(
     client: AsyncClient, character: Character, character2: Character
 ):


### PR DESCRIPTION
Fixes the edit-praxis half of #624: typing `@handle` into the collab/duel invite search found nobody, so you could not invite or challenge a real player.

## Root cause

The invite search sends the query exactly as typed — `search: inviteQuery` (`useEditPraxis.ts:672`) — and the UI *asks* for the sigil: the placeholder is `search player name or @handle`, and SNIDE's skin says `@ who else?`. So the `@` reached the backend and became `username ILIKE '%@sol%'`. Neither a username nor a display name can contain an `@`, so it matched nothing, `setInviteOpen(false)` ran, and the dropdown never appeared. Collab and duel share one input, so both were dead.

Verified against the live app:

| Typed | Before | After |
|---|---|---|
| `@sol` | nothing | Sol Brennan · Everymen |
| `sol` | Sol Brennan | Sol Brennan (unchanged) |

End-to-end after the fix: type `@sol` → pick the result → `GET /praxes/1` returns `invites: [{to: "Sol Brennan", status: "pending"}]`.

## Why the fix is in the backend

Three callers reach this search: the comment mention hook (strips the `@` itself, so it was never affected), faction detail (no search term), and the invite search (broken). The service is the one place they all converge, so a guard there fixes the reported surface and any future one by default — a smaller diff than patching each caller.

It also honors a promise the code already made. The comment on that exact branch read `Match on handle OR display name so "@Mol" surfaces "Molly" (@mollusk)` — the behavior was documented but never implemented.

Stripping is strictly more permissive: display-name matching is a substring `ILIKE`, so a name that genuinely starts with `@` still matches on the remainder. A bare `@` now returns unfiltered results instead of an empty list; no caller sends one (the invite search guards on `length < 2`, and the mention hook strips the sigil and requires ≥1 char).

## Not in scope

The comment `@mention` typeahead is **not** broken — I drove the real composer and `@sol` opens the dropdown with "Sol Brennan @demo_sol". The only failing case was `@mol`, where the sole match is the viewer's own character, which the hook deliberately filters out as self. Left as-is.

`comment_mention` is already a live feed type (`activity_feed.py:81`), so mentions already reach Updates. No change needed.

## Tests

Adds `test_list_characters_search_ignores_handle_sigil`, which asserts `search=@testcharacter` finds the character. Confirmed it fails without the fix (reverted the one line to check) rather than passing vacuously. Full backend suite: 581 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
