### PR TITLE
fix(vote): praxis card tally reacts to your own cast (#626)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import { clearVoteOverrides } from '../components/vote/voteOverrides'
 import type { TaskOut } from './tasks'
 import type { FlagReason } from '../utils/flagReasons'
 
@@ -147,11 +148,14 @@ export async function listPraxes(filters?: {
   offset?: number
 }): Promise<PraxisCardOut[]> {
   const { data } = await api.get<PraxisCardOut[]>('/praxes', { params: filters })
+  // Server truth — retire any local vote overrides so they can't double-count (#626).
+  clearVoteOverrides(data.map((praxis) => praxis.id))
   return data
 }
 
 export async function getPraxis(id: number): Promise<PraxisOut> {
   const { data } = await api.get<PraxisOut>(`/praxes/${id}`)
+  clearVoteOverrides([id])
   return data
 }
 

--- a/frontend/src/api/votes.ts
+++ b/frontend/src/api/votes.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import { clearVoteOverrides } from '../components/vote/voteOverrides'
 
 export interface VoteOut {
   id: number
@@ -31,6 +32,8 @@ export async function castVote(praxisId: number, value: number): Promise<VoteOut
 
 export async function getVotes(praxisId: number): Promise<VoteSummary> {
   const { data } = await api.get<VoteSummary>(`/praxes/${praxisId}/votes`)
+  // Server truth — retire any local override so it can't double-count (#626).
+  clearVoteOverrides([praxisId])
   return data
 }
 

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { PraxisCardOut } from "../api/praxis";
 import { factionCssVar } from "../utils/factions";
 import { pickVariant } from "../utils/factionDispatch";
+import { useVotedPraxis } from "./vote/useVotedPraxis";
 import SnideMasthead from "./cards/SnideMasthead";
 import AlbescentSigil from "./cards/AlbescentSigil";
 import DefaultSigil from "./cards/DefaultSigil";
@@ -693,10 +694,13 @@ export const PRAXIS_CARD_BY_SLUG: Record<string, ComponentType<ArchetypeProps>> 
 
 export default function PraxisCard({ praxis, onModerated, showCrown = true }: Props) {
   const { localPraxis, adminProps } = usePraxisCard(praxis, onModerated);
+  // Merge the viewer's own just-cast vote (#626) before the skin sees it, so the
+  // score hero, footer meta and vote tally all move together on one object.
+  const voted = useVotedPraxis(localPraxis);
   const Card = pickVariant(
     PRAXIS_CARD_BY_SLUG,
-    localPraxis.task_faction_slug,
+    voted.task_faction_slug,
     DefaultPraxisCard,
   );
-  return <Card praxis={localPraxis} adminProps={adminProps} showCrown={showCrown} />;
+  return <Card praxis={voted} adminProps={adminProps} showCrown={showCrown} />;
 }

--- a/frontend/src/components/praxisCard/mobile/MobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/MobilePraxisCard.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react'
 import type { PraxisCardOut } from '../../../api/praxis'
 import { pickVariant } from '../../../utils/factionDispatch'
+import { useVotedPraxis } from '../../vote/useVotedPraxis'
 import UaMobilePraxisCard from './UaMobilePraxisCard'
 import WowMobilePraxisCard from './WowMobilePraxisCard'
 import SnideMobilePraxisCard from './SnideMobilePraxisCard'
@@ -34,6 +35,9 @@ export const MOBILE_PRAXIS_CARD_BY_SLUG: Record<string, ComponentType<MobilePrax
 }
 
 export default function MobilePraxisCard({ praxis }: MobilePraxisCardProps) {
-  const Card = pickVariant(MOBILE_PRAXIS_CARD_BY_SLUG, praxis.task_faction_slug, DefaultMobilePraxisCard)
-  return <Card praxis={praxis} />
+  // Merge the viewer's own just-cast vote (#626) before the skin sees it, so the
+  // score and the vote tally move together on one object.
+  const voted = useVotedPraxis(praxis)
+  const Card = pickVariant(MOBILE_PRAXIS_CARD_BY_SLUG, voted.task_faction_slug, DefaultMobilePraxisCard)
+  return <Card praxis={voted} />
 }

--- a/frontend/src/components/ui/VoteStamps.tsx
+++ b/frontend/src/components/ui/VoteStamps.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { castVote } from '../../api/votes'
-import { useAuth } from '../../auth/AuthContext'
-import { extractError } from '../../utils/errors'
+import { useVote } from '../vote/useVote'
+import type { VoteUIProps } from '../vote/VoteUI'
 
 /**
  * Stamp-style vote buttons replacing star rating (Style Guide §13.1).
  * Five rectangular stamps numbered 1–5 with word labels and value-specific colors.
+ *
+ * The fallback every unregistered / `na`-faction praxis renders, so it drives
+ * from the shared {@link useVote} hook exactly like the seven faction variants
+ * do — cast, error handling and the tally override (#626) stay in one place.
+ * It keeps its own summary markup because its copy is the common:voteStamps
+ * catalog branch rather than votes:chrome.
  */
 
 interface StampConfig {
@@ -15,20 +19,9 @@ interface StampConfig {
   color: string
 }
 
-interface Props {
-  praxisId: number
-  currentValue?: number
-  points?: number | null
-  totalVotes?: number
-  mode?: 'caster' | 'summary'
-}
-
-export default function VoteStamps({ praxisId, currentValue, points, totalVotes }: Props) {
+export default function VoteStamps({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('common')
-  const { user, refetch } = useAuth()
-  const [selected, setSelected] = useState(currentValue ?? 0)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState('')
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 
   const stamps: StampConfig[] = [
     { value: 1, label: t('voteStamps.a-start'), color: 'var(--vote-1)' },
@@ -37,21 +30,6 @@ export default function VoteStamps({ praxisId, currentValue, points, totalVotes 
     { value: 4, label: t('voteStamps.excellent'), color: 'var(--vote-4)' },
     { value: 5, label: t('voteStamps.legendary'), color: 'var(--vote-5)' },
   ]
-
-  const handleVote = async (stars: number) => {
-    setSaving(true)
-    setError('')
-    try {
-      await castVote(praxisId, stars)
-      setSelected(stars)
-      // Refresh sidebar character stats (score/level may have changed)
-      void refetch()
-    } catch (err) {
-      setError(extractError(err, t('voteStamps.saveError')))
-    } finally {
-      setSaving(false)
-    }
-  }
 
   return (
     <div>
@@ -66,7 +44,7 @@ export default function VoteStamps({ praxisId, currentValue, points, totalVotes 
               <div key={stamp.value} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
                 <button
                   disabled={saving}
-                  onClick={() => void handleVote(stamp.value)}
+                  onClick={() => void vote(stamp.value)}
                   className={active ? 'vote-stamp vote-stamp-active' : 'vote-stamp'}
                   style={{ '--stamp-color': stamp.color } as React.CSSProperties}
                   aria-label={t('voteStamps.rateAria', { value: stamp.value, label: stamp.label })}

--- a/frontend/src/components/vote/__tests__/voteOverrides.test.ts
+++ b/frontend/src/components/vote/__tests__/voteOverrides.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  __resetVoteOverrides,
+  clearVoteOverrides,
+  recordVote,
+  seedViewerVote,
+  tallyDelta,
+  viewerVote,
+} from '../voteOverrides'
+
+const PRAXIS = 42
+
+describe('voteOverrides', () => {
+  beforeEach(() => {
+    __resetVoteOverrides()
+  })
+
+  it('reports no delta for a praxis nobody voted on', () => {
+    expect(tallyDelta(PRAXIS)).toBeNull()
+    expect(viewerVote(PRAXIS)).toBeNull()
+  })
+
+  it('counts a first cast as +stars and +1 voter', () => {
+    recordVote(PRAXIS, 4, null)
+    expect(tallyDelta(PRAXIS)).toEqual({ score: 4, voters: 1 })
+    expect(viewerVote(PRAXIS)).toBe(4)
+  })
+
+  it('counts a re-vote as the difference, with no new voter', () => {
+    recordVote(PRAXIS, 5, 3)
+    expect(tallyDelta(PRAXIS)).toEqual({ score: 2, voters: 0 })
+  })
+
+  it('measures a second cast from server truth, not from my own last cast', () => {
+    // Vote 4, then change my mind to 2 before any refetch lands. The tally must
+    // move by 2 total (0 -> 2), not 4 then -2 compounding off my own guess.
+    recordVote(PRAXIS, 4, null)
+    recordVote(PRAXIS, 2, null)
+    expect(tallyDelta(PRAXIS)).toEqual({ score: 2, voters: 1 })
+  })
+
+  it('retires the override once the server has caught up', () => {
+    recordVote(PRAXIS, 4, null)
+    clearVoteOverrides([PRAXIS])
+    // Without this the refetched score — which already includes the vote —
+    // would get the delta added on top of it a second time.
+    expect(tallyDelta(PRAXIS)).toBeNull()
+  })
+
+  it('leaves other praxes alone when clearing', () => {
+    recordVote(PRAXIS, 4, null)
+    recordVote(99, 5, null)
+    clearVoteOverrides([PRAXIS])
+    expect(tallyDelta(PRAXIS)).toBeNull()
+    expect(tallyDelta(99)).toEqual({ score: 5, voters: 1 })
+  })
+
+  it('seeds the viewer vote without moving the tally', () => {
+    seedViewerVote(PRAXIS, 3)
+    expect(viewerVote(PRAXIS)).toBe(3)
+    expect(tallyDelta(PRAXIS)).toBeNull()
+  })
+
+  it('treats a cast after a seed as a re-vote off the seeded value', () => {
+    // The praxis-detail path: no viewer_vote prop, prior comes from the seed.
+    seedViewerVote(PRAXIS, 3)
+    recordVote(PRAXIS, 5, null)
+    expect(tallyDelta(PRAXIS)).toEqual({ score: 2, voters: 0 })
+  })
+
+  it('does not let a later seed clobber a cast', () => {
+    recordVote(PRAXIS, 5, null)
+    seedViewerVote(PRAXIS, 5)
+    expect(tallyDelta(PRAXIS)).toEqual({ score: 5, voters: 1 })
+  })
+})

--- a/frontend/src/components/vote/useVote.ts
+++ b/frontend/src/components/vote/useVote.ts
@@ -3,16 +3,25 @@ import { useTranslation } from 'react-i18next'
 import { castVote } from '../../api/votes'
 import { useAuth } from '../../auth/AuthContext'
 import { extractError } from '../../utils/errors'
+import { recordVote, viewerVote } from './voteOverrides'
 
 /**
  * Shared vote interaction for all per-faction vote UIs. Faction variants render
  * the 1-5 control however they like (stamps, hearts, …) and drive it from this
  * hook so the cast/refetch logic lives in exactly one place.
+ *
+ * A cast also publishes a tally override (#626): the card's score hero and
+ * footer read the praxis object, which this hook cannot reach, so local state
+ * alone would leave those numbers stale until a reload. This is the override
+ * store's ONLY writer.
  */
 export function useVote(praxisId: number, currentValue?: number) {
   const { t } = useTranslation('votes')
   const { user, refetch } = useAuth()
-  const [selected, setSelected] = useState(currentValue ?? 0)
+  // Praxis detail pages don't pass currentValue (PraxisOut carries no
+  // viewer_vote), so fall back to what the store knows — seeded there from the
+  // voters list, which does carry it.
+  const [selected, setSelected] = useState(currentValue ?? viewerVote(praxisId) ?? 0)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
@@ -21,6 +30,7 @@ export function useVote(praxisId: number, currentValue?: number) {
     setError('')
     try {
       await castVote(praxisId, stars)
+      recordVote(praxisId, stars, currentValue ?? viewerVote(praxisId) ?? null)
       setSelected(stars)
       // Refresh sidebar character stats (score/level may have changed)
       void refetch()

--- a/frontend/src/components/vote/useVotedPraxis.ts
+++ b/frontend/src/components/vote/useVotedPraxis.ts
@@ -1,0 +1,26 @@
+import type { PraxisCardOut } from '../../api/praxis'
+import { useVoteOverride } from './voteOverrides'
+
+/**
+ * Merge the viewer's own just-cast vote into a praxis (#626).
+ *
+ * Both card dispatchers (desktop PraxisCard, mobile MobilePraxisCard) call this
+ * before picking a faction skin, so every slot below them — PraxisScoreHero's
+ * `{base} + {votes}`, PraxisFooterMeta's score, and the VoteUI tally — reads one
+ * already-correct object instead of each learning about the cast separately.
+ *
+ * Returns the praxis unchanged when there's no override, so the common case
+ * keeps its identity and skins don't re-render for nothing.
+ *
+ * Kept out of voteOverrides.ts so the store stays free of api types: the api
+ * layer imports the store to clear it, and a type-only cycle back is a trap.
+ */
+export function useVotedPraxis(praxis: PraxisCardOut): PraxisCardOut {
+  const delta = useVoteOverride(praxis.id)
+  if (!delta) return praxis
+  return {
+    ...praxis,
+    score: praxis.score + delta.score,
+    voter_count: praxis.voter_count + delta.voters,
+  }
+}

--- a/frontend/src/components/vote/voteOverrides.ts
+++ b/frontend/src/components/vote/voteOverrides.ts
@@ -1,0 +1,131 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Client-side vote overrides (#626) — "the tally moved because I just voted".
+ *
+ * A card renders its tally in three sibling components (VoteSummary,
+ * PraxisScoreHero, PraxisFooterMeta) that all read the praxis object, which
+ * useVote has no way to reach. Rather than drill an onVoted callback through
+ * eight faction variants that only draw stamps and hearts, a cast publishes
+ * here and the two card dispatchers + usePraxisDetail merge it back in.
+ *
+ * One writer (useVote), three read points. Keep it that way.
+ *
+ * An override lives only until the server catches up: every fetch that returns
+ * fresh truth for a praxis clears it (see clearVoteOverrides' callers in the
+ * api layer). That's the honest retire signal — it makes double-counting on
+ * refetch impossible, and stops an override masking another player's vote for
+ * longer than it takes the next fetch to land. Deliberately NOT inferred by
+ * comparing scores: cards count base+votes and detail pages count votes-only,
+ * so there is no one baseline to compare against.
+ *
+ * ponytail: deliberately not a general optimistic-overlay layer. Flagging and
+ * friends have a different shape (a boolean on the control you're already
+ * looking at) and no sibling fan-out. Generalize when a second real case shows
+ * up, not before.
+ */
+
+export interface VoteOverride {
+  /** The viewer's vote as the server knew it before the cast; null if unvoted. */
+  prior: number | null
+  /** The viewer's own current value (1-5). */
+  mine: number
+}
+
+/** The adjustment a reader adds to the server's own numbers. */
+export interface VoteDelta {
+  score: number
+  voters: number
+}
+
+const overrides = new Map<number, VoteOverride>()
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Record a cast. `prior` is the viewer's vote as the server last reported it
+ * (praxis.viewer_vote on a card), used to tell a first vote from a re-vote. A
+ * re-vote before the server catches up keeps the original prior — the delta is
+ * always measured from server truth, never from my own last guess.
+ */
+export function recordVote(praxisId: number, stars: number, prior: number | null): void {
+  const existing = overrides.get(praxisId)
+  overrides.set(praxisId, {
+    prior: existing ? existing.prior : prior,
+    mine: stars,
+  })
+  emit()
+}
+
+/**
+ * Seed the viewer's existing vote. Praxis detail pages have no `viewer_vote` on
+ * PraxisOut, but they already fetch the voters list, which carries it — so this
+ * is how useVote learns to pre-highlight there, and how a later cast on that
+ * page knows it's a re-vote rather than a first vote.
+ *
+ * Inert by construction: prior === mine, so the delta is 0 points and 0 voters
+ * until an actual cast moves `mine`.
+ */
+export function seedViewerVote(praxisId: number, value: number): void {
+  // Any existing entry is either a live cast (which must win — it's newer than
+  // whatever the voters list said) or an identical seed (a no-op). Fetches
+  // clear first, so a genuinely new seed always finds the slot empty.
+  if (overrides.has(praxisId)) return
+  overrides.set(praxisId, { prior: value, mine: value })
+  emit()
+}
+
+/** Drop overrides for praxes the server has just told us the truth about. */
+export function clearVoteOverrides(praxisIds: Iterable<number>): void {
+  let dropped = false
+  for (const praxisId of praxisIds) {
+    if (overrides.delete(praxisId)) dropped = true
+  }
+  if (dropped) emit()
+}
+
+/** The viewer's own vote if the client knows it — seeded or cast. */
+export function viewerVote(praxisId: number): number | null {
+  return overrides.get(praxisId)?.mine ?? null
+}
+
+function deltaFrom(entry: VoteOverride): VoteDelta | null {
+  const score = entry.mine - (entry.prior ?? 0)
+  const voters = entry.prior === null ? 1 : 0
+  // A seeded entry (prior === mine) moves nothing. Report it as no delta so
+  // readers hand back their input untouched instead of cloning it every render.
+  if (score === 0 && voters === 0) return null
+  return { score, voters }
+}
+
+/** Pure read — the delta to add to the server's numbers, or null for none. */
+export function tallyDelta(praxisId: number): VoteDelta | null {
+  const entry = overrides.get(praxisId)
+  return entry ? deltaFrom(entry) : null
+}
+
+/** Subscribing read for the three merge points. */
+export function useVoteOverride(praxisId: number): VoteDelta | null {
+  const read = () => overrides.get(praxisId) ?? null
+  // Third arg is the server snapshot: praxis cards render through
+  // renderToString in the archetype tests, and useSyncExternalStore throws
+  // without it. Nobody has voted during an SSR pass, so it's always null.
+  const entry = useSyncExternalStore(subscribe, read, () => null)
+  return entry ? deltaFrom(entry) : null
+}
+
+/** Test seam only. */
+export function __resetVoteOverrides(): void {
+  overrides.clear()
+  emit()
+}

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -26,6 +26,7 @@ import { useAuth } from "../../auth/AuthContext";
 import { useAdminMode } from "../../auth/AdminModeContext";
 import { moderatePraxis } from "../../api/admin";
 import { extractError } from "../../utils/errors";
+import { seedViewerVote, useVoteOverride } from "../../components/vote/voteOverrides";
 import type { CurrentUser } from "../../api/auth";
 import { listTasks, type TaskOut } from "../../api/tasks";
 import { FLAG_REASON_OTHER, type FlagReason } from "../../utils/flagReasons";
@@ -285,6 +286,30 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     }
   };
 
+  const viewerCharacterId = user?.character?.id ?? null;
+
+  // PraxisOut carries no viewer_vote, but the voters list does — seed it so
+  // VoteUI pre-highlights the viewer's existing cast, and so a re-vote here
+  // counts as a re-vote rather than a first vote (#626). Its own effect because
+  // auth can resolve after the fetch does.
+  useEffect(() => {
+    if (viewerCharacterId == null || praxis == null) return;
+    const own = voters.find((voter) => voter.character_id === viewerCharacterId);
+    if (own) seedViewerVote(praxis.id, own.value);
+  }, [voters, viewerCharacterId, praxis?.id]);
+
+  // Merge the viewer's own just-cast vote into the tally the archetypes render
+  // (#626) — every bespoke "standing" panel reads this, not just the vote line.
+  const voteDelta = useVoteOverride(praxis?.id ?? -1);
+  const displayVotes =
+    votes && voteDelta
+      ? {
+          ...votes,
+          total_score: votes.total_score + voteDelta.score,
+          total_votes: votes.total_votes + voteDelta.voters,
+        }
+      : votes;
+
   const isOwner = isViewerMember(praxis, user?.character?.id);
 
   return {
@@ -292,7 +317,7 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     praxis,
     fetchError,
 
-    votes,
+    votes: displayVotes,
     voters,
     duel,
 


### PR DESCRIPTION
Closes #626

Casting a vote from a praxis card highlighted your chosen rung but left every number at its pre-vote value until a reload.

## Root cause

`useVote` updated only its local `selected`. The totals are **props owned by parents** that never refetch after a cast, and `POST /vote` returns `VoteOut` — which carries no tally, so the response gives the client nothing to update from either. The `refetch()` already in `useVote` is `useAuth().refetch`: sidebar character stats, not the praxis.

The tally is rendered by **three siblings per card**, not one — `VoteSummary`, `PraxisScoreHero` (`{base} + {votes}`), and `PraxisFooterMeta` — all reading the praxis object, which `useVote` cannot reach. So local state in the hook could never have fixed this.

## Approach

Client-side delta published to a small module-level store (`voteOverrides.ts`), merged back in at the two card dispatchers and `usePraxisDetail`. **Frontend-only, no new dependency** (`useSyncExternalStore`; React 18.3 is already here).

The alternative was drilling an `onVoted` callback through eight faction variants whose entire job is drawing stamps and hearts, plus 16 detail archetypes — ~35 files. This is 10.

**An override retires when a fetch returns fresh truth for that praxis** (`clearVoteOverrides`, called from `listPraxes` / `getPraxis` / `getVotes`). That makes double-counting on refetch impossible, and stops an override masking another player's vote for longer than it takes the next fetch to land. It's deliberately not inferred by comparing scores — cards count base+votes and detail pages count votes-only, so there is no single baseline to compare against.

## Two bugs fixed along the way

- **`VoteStamps`** — the fallback every `na`/unregistered-faction praxis renders — hand-rolled its own copy of the cast logic instead of calling `useVote`. Refactored onto the hook, so there's genuinely one writer. Its only importer is `VoteUI`, verified. Side effect: its error copy is now `votes:chrome.saveError` instead of `common:voteStamps.saveError`.
- **Praxis detail pages never passed `currentValue`** (`PraxisOut` has no `viewer_vote`), so a re-vote there would have counted as a first vote and over-counted by 1. The voters list already carries it and is already fetched, so it's derived client-side — no backend widen. This independently fixes detail pages never pre-highlighting the vote you'd already cast.

## Test

`voteOverrides.test.ts` — 9 tests against the store as a pure module: first cast vs re-vote arithmetic, a second cast measuring from server truth rather than compounding off my own guess, retire-on-fetch, seeding, and seed-never-clobbers-a-cast.

## Verification

- `vitest`: 617/617 pass (86 files)
- `eslint src`: clean
- `tsc --noEmit`: 50 lines, **identical to baseline on a clean tree** — all pre-existing i18n-key errors in `AlbescentInvitation.tsx`, none in touched files

Not verified in a browser — flagged for @pixieofhugs, who said she'd test on site.

## Deliberately out of scope

Spun off rather than folded in: #637 (shadowed vote route — also missing the live route's hidden-praxis guard), #638, #639, #640, #641.

No general optimistic-overlay layer. Flagging has a different shape (a boolean on the control you're already looking at, with existing local state) and none of the sibling fan-out that motivates this store. Worth factoring when a second real case exists, not against a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
