### PR TITLE
docs(context): pin "seal date" — submitted_at vs created_at

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -375,6 +375,16 @@ A **sealed, public** praxis. Its votes count toward score; it appears on every p
 surface (lists, detail, task/faction pages, activity feed). The only publicly visible
 praxis state. _Avoid_: "published"/"Live" as distinct states — they are this one.
 
+**Seal date** *(`submitted_at`)*:
+When a praxis entered the public register — set once on `in_progress → submitted`. For
+solo/duel, the author's submit; for collab, the lazy-consensus seal (everyone submitted
+**or** the window lapsed — ADR-0012). This is the date a praxis card shows and the date the
+**Praxis Index** sorts by. Distinct from `created_at`, which is the **draft-open** timestamp
+(row insert, when the first member opens the draft) — private, often days earlier, and never
+displayed.
+_Avoid_: "created"/"creation date" for the seal (`created_at` is a different, earlier event);
+"when the last one submits" (the timeout seals without them).
+
 **In editing** *(`status = in_progress`)*:
 A praxis being worked on — a never-submitted **draft** *or* one that was **unsubmitted**.
 The two are indistinguishable by design (ADR-0007): no "was previously submitted" flag.


### PR DESCRIPTION
Adds one glossary entry. Docs only — no code changes.

## Why

Grilling for #644 (praxis filtering/search/sort) hit a vocabulary collision worth pinning before anyone builds against it.

"Created" means two different things here:

- **`created_at`** — `server_default=func.now()` on row insert (`backend/models/mixins.py:8`); the row is inserted at `backend/services/praxis.py:605` with `status=in_progress`. It is **the moment the first person opens a draft** — private, often days early on a collab, never displayed on desktop.
- **`submitted_at`** — set in `_apply_seal` (`backend/services/collab_consensus.py:31`) when the praxis **seals to Live**. This is when it entered the public register, and it is what the desktop card already shows.

The Praxis Index lists only sealed praxes, so it sorts by the seal date. An agent reading "sort by when the praxis was created" in an issue would reach for `Praxis.created_at` and be confidently wrong — the sort would silently disagree with the date printed on the card.

The entry also nails down the seal rule itself: it is **not** "when the last member submits". ADR-0012 lazy consensus means `settle_if_window_lapsed` seals a collab when the `collab_auto_submit_days` window lapses, even if the last member never submits.

## Note on existing drift

This entry documents a disagreement the code already has, which #644 fixes rather than this PR:

- Desktop shows `submitted_at` — `frontend/src/components/praxisCard/shared.tsx:218`
- Mobile shows `created_at` — `frontend/src/components/praxisCard/mobile/shared.tsx:122`

So mobile currently ages a praxis from its draft-open: a collab drafted three weeks ago and sealed yesterday reads "3 weeks ago" on its first day live. The glossary now states which one is canonical; #644 points mobile at it.

Related: #644, #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)
