### PR TITLE
docs(adr): ADR-0040 — feed controls are neutral chrome (#642)

### DIFF
--- a/docs/adr/0040-feed-controls-are-neutral-chrome.md
+++ b/docs/adr/0040-feed-controls-are-neutral-chrome.md
@@ -1,0 +1,99 @@
+# ADR-0040: Feed controls are neutral chrome; faction skinning stops at the card boundary
+
+Status: Accepted (2026-07-16)
+
+## Context
+
+This repo's default reflex is per-faction divergence. CLAUDE.md says it outright — *"Each
+faction has its own card archetype; don't unify"* — and ADR-0016 makes the surface seam
+law: every page dispatches through `ARCHETYPE_BY_SLUG` / `pickVariant`, and #494 (ADR-0035)
+added a parallel `MOBILE_ARCHETYPE_BY_SLUG` on the same axis. Seven factions, seven skins,
+per surface.
+
+#642 adds a **control surface** to the praxis feed (faction filter, date sort, free-text
+search). The praxis feed is a *mixed* feed — #565/#573 settled that each card picks its own
+skin from its own item's faction slug, so the page shows every faction's archetype at once
+rather than theming the whole page to the viewer's faction. That leaves an unanswered
+question the surface seam doesn't cover: **what faction is a filter bar?**
+
+There is no good answer. It can't be the viewer's faction (the feed isn't the viewer's), it
+can't be the filtered faction (it exists to change that), and it can't be the page's faction
+(a mixed feed has none). The question is malformed — which is the signal that controls sit
+on the other side of a boundary the seam never named.
+
+The Tasks page already answered this by construction and nobody wrote it down: `Tasks.tsx`
+renders `FilterStamps` / `FilterFactionTabs` / `FilterLevelNodes` as a bare neutral stack
+above a grid of faction-skinned `TaskCard`s. The design pass for #642 independently reached
+the same shape, calling the control bar "shared neutral chrome (like `PageTitle`)".
+
+Without this written down, the next control added to a faction surface gets "correctly"
+faction-skinned to match its page, and the two feeds drift apart.
+
+## Decision
+
+**Faction skinning stops at the card boundary. Controls, filters, and page chrome are shared
+neutral components; only the items a feed renders carry faction identity.**
+
+1. **Controls do not dispatch.** A filter, sort, search box, or page header has no
+   `ARCHETYPE_BY_SLUG` / `MOBILE_ARCHETYPE_BY_SLUG` entry and no `pickVariant` call. One
+   component serves every faction and every viewer. (This is the boundary ADR-0016 implies
+   but never states: the seam governs *surfaces that represent a faction's things*, not the
+   apparatus for finding them.)
+
+2. **Depicting a faction is not being skinned by one.** A control may render faction colour,
+   name, pennant, or sigil as *data* — that is what a faction filter is for. The distinction
+   is authorship: `FilterFactionTabs` draws seven pennants from one neutral component; it is
+   not seven components. Same for the mobile faction sigil row.
+
+3. **Feeds sharing an axis share the component.** Two feeds filtering by faction use one
+   faction-filter component per form factor — desktop `FilterFactionTabs`, mobile
+   `FactionSigilRow`. A second idiom for the same axis is a defect, not a skin.
+
+4. **Faction lists come from `getFactions()`, never a literal.** A hardcoded faction array in
+   a control is a bug with two heads: it hardcodes hex (forbidden — colour lives in
+   `index.css`, ADR-0003), and it defeats the Albescent secrecy filter (ADR-0027/#390), which
+   is enforced *server-side* by `GET /factions` omitting Albescent for unrevealed accounts. A
+   literal list puts an Albescent pennant in front of every player.
+
+5. **Feed-scoped filtering is not global search.** ADR-0035's mobile drop-list parks
+   `search`; `docs/design/mobile/README.md` shows what that entry means — **"Global search
+   (moments) | Not built | Parked."** That is a cross-entity search *screen*, parked because
+   no backend existed for it. A filter scoped to one feed's own list endpoint is a different
+   thing, and #642 commissions the very backend whose absence was the reason for parking.
+   ADR-0035 §4 ("mobile surfaces render only real domain fields") still binds: feed search
+   ships only once `GET /praxes` really accepts the param.
+
+### Enforcement
+
+- A control that dispatches on faction slug, or hardcodes a faction list/hex, is rejected in
+  review.
+- A second faction-filter idiom for an existing axis is rejected; extend the shared one.
+- Citing ADR-0035's parked `search` against a feed-scoped filter is answered by §5 above.
+
+## Consequences
+
+- #642's desktop build is almost entirely wiring: `FilterStamps` (sort) + `FilterFactionTabs`
+  (faction) already exist and are reused verbatim. The only new desktop code is a search
+  input.
+- Mobile needs a `FactionSigil` dispatcher — the one genuinely new component. All seven
+  glyphs already exist but are unreachable, locked inside the avatar variants as inline
+  `glyph={(size, color) => …}` callbacks (`components/avatar/*Avatar.tsx`). Extracting them
+  behind a `pickVariant` map mirrors `FACTION_AVATARS`.
+- `FactionSigilRow` lands in mobile Tasks *and* mobile Praxes by §3 — mobile Tasks' faction
+  `ChipRow` is replaced rather than left as a second idiom.
+- Restyling the filter row restyles both feeds. That is the point.
+
+## Alternatives considered
+
+- **Per-faction control skins (the seam's default reflex).** Rejected: the "what faction is a
+  filter bar?" question has no answer on a mixed feed, and seven filter bars is seven times
+  the surface for zero identity gain.
+- **Skin the control bar to the viewer's faction.** Rejected: #565/#573 already settled that
+  a mixed feed is not themed to the viewer. A viewer-tinted bar over a mixed grid asserts an
+  ownership the page doesn't have.
+- **Bespoke control bar for Praxes only (as drawn).** The design's bordered bar is nicer than
+  the Tasks stack. Rejected as-drawn because it makes Tasks look unfinished and forks the
+  idiom by §3. If the box wins, it wins as the shared component and Tasks is retrofitted in
+  the same change.
+- **Let each feed hardcode its own faction list.** Rejected by §4 — it is how the Albescent
+  leak happens.


### PR DESCRIPTION
Docs-only. Adds **ADR-0040**, the design decision that came out of the #642 grill (2026-07-16). No code.

## What it decides

**Faction skinning stops at the card boundary.** Controls, filters and page chrome are shared neutral components; only the items a feed renders carry faction identity.

## Why it's worth an ADR

It's the *opposite* of this repo's dominant reflex. CLAUDE.md says *"Each faction has its own card archetype; don't unify"*, and ADR-0016/ADR-0035 make the per-faction surface seam law. So when #642 adds a control surface to a mixed feed, the reflex answer is "give it seven skins".

The question that breaks that: **what faction is a filter bar?** It can't be the viewer's (the feed isn't theirs), can't be the filtered faction (it exists to change that), can't be the page's (a mixed feed has none — #565/#573 settled that each card skins itself). The question is malformed, which is the signal that controls sit outside the seam.

`Tasks.tsx` already answered this by construction — neutral filter stack over faction-skinned cards — and nobody wrote it down. The #642 design pass independently reached the same shape ("shared neutral chrome, like `PageTitle`"). Two independent arrivals at the same boundary, zero documentation of it.

## The two traps it defuses

Both are things a build agent would otherwise hit:

1. **§2 — depicting a faction is not being skinned by one.** A faction filter renders pennants/sigils as *data*. `FilterFactionTabs` draws seven pennants from one component; it is not seven components. Without this, "don't unify" reads as a prohibition on the shared filter.

2. **§5 — ADR-0035's parked `search` is the *global/moments* search screen.** Its Consequences line compresses it to the bare word `search`, but the drop table it summarises (`docs/design/mobile/README.md:46`) says *"**Global search** (moments) | Not built | Parked"* — parked because no backend existed. #642 is a feed-scoped filter and commissions that very backend. An agent grepping the ADRs would reasonably conclude it's been told not to build this.

Per the no-state-mirrors doctrine, §5 lives here rather than as a rider patch to ADR-0035 — that ADR stays a true record of what was decided in July; this one carries the distinction it didn't need to draw at the time.

## Numbering

**0040, not 0039.** `0039-unaffiliated-fill-is-a-gradient-not-a-hue.md` (from the #636 grill) exists on another branch but isn't on `main` yet.

## Related

- Consumed by #642, #658, #659 (all three cite it)
- The `submitted_at` invariant from the same grill is deliberately **not** an ADR — it goes in `_apply_seal`'s docstring per the no-state-mirrors doctrine. Spec'd in #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
