### PR TITLE
fix(votes): delete shadowed POST /praxes/{id}/vote route

### DIFF
--- a/backend/routers/votes.py
+++ b/backend/routers/votes.py
@@ -3,29 +3,17 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import get_current_character
 from models.character import Character
 from models.praxis import Praxis
 from models.vote import Vote
-from schemas.vote import VoterDetail, VoteIn, VoteOut, VoteSummary
-from services.vote import cast_or_update_vote
+from schemas.vote import VoterDetail, VoteSummary
 from services.vote_tally import tally_votes
 
+# Read-only vote surfaces. The write surface (POST /praxes/{id}/vote) lives in
+# ``routers/praxes.py`` -- it enforces the hidden-praxis 404 guard. A duplicate
+# POST route here was shadowed by include order in ``main.py`` and lacked that
+# guard; it was deleted in #637. Do not re-add a vote write route to this module.
 router = APIRouter()
-
-
-@router.post("/praxes/{praxis_id}/vote", response_model=VoteOut)
-async def cast_vote(
-    praxis_id: int,
-    data: VoteIn,
-    voter: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    praxis = await session.get(Praxis, praxis_id)
-    if praxis is None:
-        raise HTTPException(status_code=404, detail="Praxis not found.")
-    vote = await cast_or_update_vote(voter, praxis, data.value, session)
-    return VoteOut.model_validate(vote)
 
 
 @router.get("/praxes/{praxis_id}/votes", response_model=VoteSummary)


### PR DESCRIPTION
Closes #637

`backend/routers/votes.py` declared `POST /praxes/{praxis_id}/vote`, and so does
`backend/routers/praxes.py`. `main.py` includes `praxes.router` before
`votes.router` and FastAPI matches first-registered, so the `votes.py` handler
was dead code.

**Why it mattered:** the dead handler lacked the hidden-praxis 404 guard the live
one has. Unreachable today, but a change to include order in `main.py` would have
silently swapped in a handler that permits votes on moderated-hidden praxes.

## What changed

- Deleted the shadowed `POST` route from `routers/votes.py`, plus the imports it
  orphaned (`get_current_character`, `VoteIn`, `VoteOut`, `cast_or_update_vote`).
- Added a comment on `router` recording why the write surface lives in `praxes.py`,
  so the route doesn't get re-added.
- The `GET` routes (`/praxes/{id}/votes`, `/praxes/{id}/voters`) are live and untouched.

Net: **5 insertions, 17 deletions**, one file. No stub left behind.

## Caller audit

Every caller of the path resolves to the surviving `praxes.py` route, so nothing
changes at runtime:

- `frontend/src/api/votes.ts` — hits `POST /praxes/{id}/vote`, still served.
- `backend/tests/integration/test_activity_feed.py:38` — same path, still served.
- No test imports `routers.votes` or targets the deleted handler directly.
- `services/vote.py::cast_or_update_vote` is **not** dead — `cast_vote_on_praxis`
  (the live path) calls it at `services/vote.py:29`, and two tests call it
  directly. The service stays.

## Verification

Asserted against the built app's route table that exactly one `POST` vote handler
survives and it is the guarded one:

```
('/praxes/{praxis_id}/vote',  ['POST'], 'cast_vote_route',    'routers.praxes')
('/praxes/{praxis_id}/votes', ['GET'],  'get_vote_summary',   'routers.votes')
('/praxes/{praxis_id}/voters',['GET'],  'list_voters',        'routers.votes')
```

Test results: `pytest --cov=. --cov-fail-under=80` — **581 passed**, coverage
**87.14%** (gate 80%). `test_votes.py` at 100%.

Frontend `npm test` not run: the diff is backend-only and touches no frontend
file. CI covers it.

## Left out of scope

`schemas/vote.py::VoteIn` is now unused — it had no caller but the deleted route.
`schemas/` is outside this issue's file scope, so I left it rather than folding
the removal in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
