### PR TITLE
Players redesign (backend): stable ordering + batched badges on the list serializer

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -23,6 +23,7 @@ from services.badge import list_badges_for_character
 from services.character import (
     CharacterCreationResult,
     build_character_out,
+    build_character_outs,
     create_character,
     list_characters_for_viewer,
     soft_delete_character,
@@ -58,7 +59,9 @@ async def list_characters(
         limit=limit,
         offset=offset,
     )
-    return [build_character_out(character, stats) for character, stats in rows]
+    # Badges ride along, batched (#655) — the invite search shares this path and
+    # gets them too, which is harmless: /characters/{id} is already public.
+    return await build_character_outs(rows, session)
 
 
 @router.get("/{character_id}", response_model=CharacterOut)

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
 from schemas.character import CharacterOut
-from services.character import build_character_out, list_characters_for_viewer
+from services.character import build_character_outs, list_characters_for_viewer
 
 router = APIRouter()
 
@@ -21,4 +21,4 @@ async def get_leaderboard(
     rows = await list_characters_for_viewer(
         session, faction_slug=faction, limit=limit, offset=offset
     )
-    return [build_character_out(character, stats) for character, stats in rows]
+    return await build_character_outs(rows, session)

--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -18,9 +18,11 @@ class CharacterOut(BaseModel):
     (see services.scoring.compute_votes_available); it reflects score growth
     and spent votes without a stored counter.
 
-    badges is evaluated on read (ADR-0033) and populated ONLY by the
-    single-character GET /characters/{id} — list serializers leave it empty
-    to avoid N+1 sibling queries. account_id / email never leave the backend.
+    badges is evaluated on read (ADR-0033) — never stored. List serializers may
+    populate it, but only via services.badge.build_badge_contexts, which resolves
+    a whole page in one GROUP BY account_id query; the rule is "never
+    per-character on a list path", not "never on a list path" (#655).
+    account_id / email never leave the backend.
     """
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/services/badge.py
+++ b/backend/services/badge.py
@@ -2,10 +2,17 @@
 
 Evaluates the code-defined :data:`badges.ALL_BADGES` registry against a
 per-character :class:`badges.BadgeContext` built from explicit queries.
-Only the single-character read path calls this — list serializers skip
-badges entirely to avoid N+1 sibling queries.
+
+Every fact a badge condition consults is a **per-account aggregate**, so list
+paths do not need one query per character: :func:`build_badge_contexts` folds
+the whole page into a single ``GROUP BY account_id`` query and builds each
+context in memory (#655). The rule is "never *per-character* on list paths",
+not "never on list paths".
 """
-from sqlalchemy import select
+from typing import Iterable
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import aggregate_order_by, array_agg
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from badges import ALL_BADGES, BadgeContext
@@ -13,27 +20,66 @@ from models.character import Character
 from schemas.character import BadgeOut
 
 
+async def build_badge_contexts(
+    characters: Iterable[Character],
+    session: AsyncSession,
+) -> dict[int, BadgeContext]:
+    """Assemble each character's :class:`BadgeContext` in ONE query, keyed by id.
+
+    ``Character.account`` is ``lazy="raise"`` — siblings are queried explicitly
+    by ``account_id``. One ``GROUP BY account_id`` row per distinct account
+    carries both facts a condition can consult: how many characters the account
+    owns, and which of them is "earliest" — first by ``(created_at, id)``, id
+    breaking same-instant creation ties.
+
+    The sibling count is deliberately unfiltered by status: a puppet is a puppet
+    whether or not the list path would surface it.
+    """
+    characters = list(characters)
+    account_ids = {character.account_id for character in characters}
+    if not account_ids:
+        return {}
+
+    result = await session.execute(
+        select(
+            Character.account_id,
+            func.count(Character.id).label("character_count"),
+            # Postgres arrays are 1-indexed: [1] is the earliest by (created_at, id).
+            array_agg(
+                aggregate_order_by(
+                    Character.id,
+                    Character.created_at.asc(),
+                    Character.id.asc(),
+                )
+            )[1].label("earliest_id"),
+        )
+        .where(Character.account_id.in_(account_ids))
+        .group_by(Character.account_id)
+    )
+    by_account = {
+        account_id: (character_count, earliest_id)
+        for account_id, character_count, earliest_id in result.all()
+    }
+
+    contexts: dict[int, BadgeContext] = {}
+    for character in characters:
+        character_count, earliest_id = by_account.get(
+            character.account_id, (1, character.id)
+        )
+        contexts[character.id] = BadgeContext(
+            account_character_count=character_count,
+            is_earliest_on_account=character.id == earliest_id,
+        )
+    return contexts
+
+
 async def build_badge_context(
     character: Character,
     session: AsyncSession,
 ) -> BadgeContext:
-    """Assemble the facts badge conditions consult for one character.
-
-    ``Character.account`` is ``lazy="raise"`` — sibling characters are queried
-    explicitly by ``account_id``. The account's "earliest" character is the
-    first by ``(created_at, id)`` (id breaks same-instant creation ties).
-    """
-    result = await session.execute(
-        select(Character.id)
-        .where(Character.account_id == character.account_id)
-        .order_by(Character.created_at.asc(), Character.id.asc())
-    )
-    sibling_ids = [row[0] for row in result.all()]
-    earliest_id = sibling_ids[0] if sibling_ids else character.id
-    return BadgeContext(
-        account_character_count=len(sibling_ids),
-        is_earliest_on_account=character.id == earliest_id,
-    )
+    """Single-character :func:`build_badge_contexts` — the same one query."""
+    contexts = await build_badge_contexts([character], session)
+    return contexts[character.id]
 
 
 def evaluate_badges(context: BadgeContext) -> list[BadgeOut]:

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -35,8 +35,9 @@ def build_character_out(
     """Flatten a Character row plus its (optional) CharacterStats into CharacterOut.
 
     votes_available is computed on read from stats.score and votes_spent_this_era.
-    badges (ADR-0033) is supplied only by the single-character read path; list
-    serializers omit it and the field defaults to empty.
+    badges (ADR-0033) is supplied by the caller and defaults to empty; list
+    callers should go through :func:`build_character_outs` so every context is
+    resolved in one batched query rather than one per character (#655).
     invitations (#243) is supplied only by the /auth/me active-character path so
     the frontend can detect newly-earned invitation letters; it defaults to empty
     everywhere else.
@@ -564,11 +565,35 @@ async def list_characters_for_viewer(
                 Character.id.notin_(active_member_ids),
             )
         )
+    # id ASC is the tiebreak, not decoration: most of the roster is tied at zero,
+    # and score alone leaves Postgres free to reshuffle equal-score rows between
+    # requests — which flickers the sky's top-N membership and its crown, and
+    # makes limit/offset paging silently duplicate and drop rows (#655).
     query = (
-        query.order_by(CharacterStats.score.desc().nulls_last())
+        query.order_by(CharacterStats.score.desc().nulls_last(), Character.id.asc())
         .limit(limit)
         .offset(offset)
     )
 
     result = await session.execute(query)
     return list(result.all())
+
+
+async def build_character_outs(
+    rows: list[tuple[Character, CharacterStats | None]],
+    session: AsyncSession,
+) -> list[CharacterOut]:
+    """Serialize a list page, badges included, in one extra query total (#655).
+
+    Both facts a badge condition consults are per-account aggregates, so the
+    whole page resolves through a single ``GROUP BY account_id`` — the N+1 that
+    kept badges off list paths (ADR-0033) is avoidable, not inherent. The query
+    count does not scale with ``len(rows)``.
+    """
+    from services.badge import build_badge_contexts, evaluate_badges
+
+    contexts = await build_badge_contexts([character for character, _ in rows], session)
+    return [
+        build_character_out(character, stats, badges=evaluate_badges(contexts[character.id]))
+        for character, stats in rows
+    ]

--- a/backend/tests/integration/test_badges.py
+++ b/backend/tests/integration/test_badges.py
@@ -1,14 +1,17 @@
-"""Integration tests for on-read badges on GET /characters/{id} (ADR-0033, #459).
+"""Integration tests for on-read badges (ADR-0033, #459; batched list path #655).
 
 The seed pair keys off one account owning multiple characters, ordered by
-created_at (earliest = sock_puppeteer, later = sock_puppet). Badges are
-populated only by the single-character read — the list endpoint leaves the
-field empty.
+created_at (earliest = sock_puppeteer, later = sock_puppet). Both the
+single-character read and the list serializer populate badges; the list path
+resolves the whole page in one GROUP BY account_id query, so its query count
+does not scale with the number of characters returned.
 """
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.account import Account
@@ -16,6 +19,55 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction
+
+
+@contextmanager
+def _count_selects(db_connection):
+    """Collect every SELECT issued on the test connection while the block runs."""
+    selects: list[str] = []
+    sync_connection = db_connection.sync_connection
+
+    def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            selects.append(statement)
+
+    event.listen(sync_connection, "before_cursor_execute", before_cursor_execute)
+    try:
+        yield selects
+    finally:
+        event.remove(sync_connection, "before_cursor_execute", before_cursor_execute)
+
+
+async def _add_character_on_new_account(
+    db_session: AsyncSession,
+    era: Era,
+    index: int,
+) -> Character:
+    """One solo character on its own fresh account — pads out a list page."""
+    account = Account(email=f"filler{index}@example.com")
+    db_session.add(account)
+    await db_session.flush()
+    character = Character(
+        account_id=account.id,
+        username=f"filler{index}",
+        display_name=f"Filler {index}",
+        faction_slug="na",
+    )
+    db_session.add(character)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=character.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=0,
+            votes_spent_this_era=0,
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(character)
+    return character
 
 
 async def _add_second_character(
@@ -99,7 +151,7 @@ async def test_other_accounts_do_not_cross_pollinate(
 
 
 @pytest.mark.asyncio
-async def test_list_endpoint_does_not_evaluate_badges(
+async def test_list_endpoint_populates_badges(
     client: AsyncClient,
     db_session: AsyncSession,
     account: Account,
@@ -107,8 +159,8 @@ async def test_list_endpoint_does_not_evaluate_badges(
     character: Character,
     faction_ua: Faction,
 ):
-    """Badges appear empty in the list serializer even when they'd be earned."""
-    await _add_second_character(
+    """The list serializer resolves badges too (#655 amends ADR-0033)."""
+    second = await _add_second_character(
         db_session,
         account,
         era,
@@ -116,9 +168,77 @@ async def test_list_endpoint_does_not_evaluate_badges(
     )
     resp = await client.get("/characters")
     assert resp.status_code == 200
-    rows = resp.json()
-    assert rows, "expected at least the fixture characters"
-    assert all(row["badges"] == [] for row in rows)
+    badges_by_id = {row["id"]: row["badges"] for row in resp.json()}
+    assert badges_by_id[character.id] == [
+        {"key": "sock_puppeteer", "name": "Sock Puppeteer"}
+    ]
+    assert badges_by_id[second.id] == [{"key": "sock_puppet", "name": "Sock Puppet"}]
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_populates_badges(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    """/leaderboard shares the batched serializer, so it carries badges too."""
+    await _add_second_character(
+        db_session,
+        account,
+        era,
+        created_at=character.created_at + timedelta(seconds=1),
+    )
+    resp = await client.get("/leaderboard")
+    assert resp.status_code == 200
+    badges_by_id = {row["id"]: row["badges"] for row in resp.json()}
+    assert badges_by_id[character.id] == [
+        {"key": "sock_puppeteer", "name": "Sock Puppeteer"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_solo_character_has_no_badges_on_list_path(
+    client: AsyncClient, character: Character, character2: Character
+):
+    """Two solo characters on different accounts earn nothing on the list path."""
+    resp = await client.get("/characters")
+    assert resp.status_code == 200
+    assert all(row["badges"] == [] for row in resp.json())
+
+
+@pytest.mark.asyncio
+async def test_list_badge_query_count_does_not_scale_with_page_size(
+    client: AsyncClient,
+    db_connection,
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    """The badge join is batched: 2 characters and 10 cost the same queries (#655).
+
+    This is the whole reason ADR-0033's "no badges on list paths" rule could be
+    amended — so it is the assertion that has to hold, not the badge payload.
+    """
+    await _add_character_on_new_account(db_session, era, index=1)
+
+    with _count_selects(db_connection) as small_page:
+        small_resp = await client.get("/characters")
+    assert small_resp.status_code == 200
+    assert len(small_resp.json()) == 2
+    small_count = len(small_page)
+
+    for index in range(2, 10):
+        await _add_character_on_new_account(db_session, era, index=index)
+
+    with _count_selects(db_connection) as large_page:
+        large_resp = await client.get("/characters")
+    assert large_resp.status_code == 200
+    assert len(large_resp.json()) == 10
+    assert len(large_page) == small_count
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_leaderboard.py
+++ b/backend/tests/integration/test_leaderboard.py
@@ -120,3 +120,88 @@ async def test_leaderboard_response_structure(
         # account_id must never be exposed
         assert "account_id" not in char
         assert "email" not in char
+
+
+# ---------------------------------------------------------------------------
+# Stable ordering (#655) — score alone is not a total order
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tied_characters(db_session, era: Era, count: int) -> list[int]:
+    """``count`` characters, all on score 0 — the shape most of the roster has."""
+    from models.account import Account
+    from models.character import Character
+    from models.character_stats import CharacterStats
+
+    ids: list[int] = []
+    for index in range(count):
+        account = Account(email=f"tied{index}@example.com")
+        db_session.add(account)
+        await db_session.flush()
+        character = Character(
+            account_id=account.id,
+            username=f"tied{index}",
+            display_name=f"Tied {index}",
+            faction_slug="na",
+        )
+        db_session.add(character)
+        await db_session.flush()
+        db_session.add(
+            CharacterStats(
+                character_id=character.id,
+                era_id=era.id,
+                score=0,
+                all_time_score=0,
+                level=0,
+                votes_spent_this_era=0,
+            )
+        )
+        ids.append(character.id)
+    await db_session.commit()
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_tied_scores_order_identically_across_calls(
+    client: AsyncClient,
+    db_session,
+    era: Era,
+    faction_ua: Faction,
+):
+    """Characters tied at zero come back in the same order every request.
+
+    Without the id tiebreak Postgres is free to reshuffle equal-score rows, which
+    flickers the sky's top-N membership and its crown.
+    """
+    await _seed_tied_characters(db_session, era, count=5)
+
+    orders = []
+    for _ in range(3):
+        resp = await client.get("/leaderboard")
+        assert resp.status_code == 200
+        orders.append([row["id"] for row in resp.json()])
+
+    assert orders[0] == orders[1] == orders[2]
+    assert orders[0] == sorted(orders[0]), "tied rows sort by id ascending"
+
+
+@pytest.mark.asyncio
+async def test_paging_tied_scores_partitions_without_overlap_or_gaps(
+    client: AsyncClient,
+    db_session,
+    era: Era,
+    faction_ua: Faction,
+):
+    """limit/offset over a tied set slices it cleanly — no duplicates, no drops."""
+    seeded_ids = await _seed_tied_characters(db_session, era, count=6)
+
+    paged: list[int] = []
+    for offset in (0, 2, 4):
+        resp = await client.get(f"/leaderboard?limit=2&offset={offset}")
+        assert resp.status_code == 200
+        page = [row["id"] for row in resp.json()]
+        assert len(page) == 2
+        paged.extend(page)
+
+    assert len(set(paged)) == len(paged), "no character appears on two pages"
+    assert set(paged) == set(seeded_ids), "every character appears on exactly one page"

--- a/docs/adr/0033-player-profile-contract-and-badge-registry.md
+++ b/docs/adr/0033-player-profile-contract-and-badge-registry.md
@@ -37,9 +37,8 @@ bool]`. They are **evaluated on read** in `services/badge.py` — no table, no
 A badge either holds right now or it doesn't; a new badge is one registry
 entry.
 
-- The payload is `{ key, name }[]` on `CharacterOut.badges`, populated
-  **only** by the single-character `GET /characters/{id}` — list serializers
-  leave it empty (no N+1 sibling queries).
+- The payload is `{ key, name }[]` on `CharacterOut.badges`. List serializers
+  may populate it — see the amendment below.
 - The **image is not in the payload**: the frontend maps `key` to a bundled
   SVG (`frontend/src/components/badges/badgeArt.tsx`), exactly like faction
   sigils.
@@ -50,6 +49,29 @@ entry.
 Seed pair (both key off one account owning multiple characters, ordered by
 `(created_at, id)`): `sock_puppeteer` on the account's earliest character,
 `sock_puppet` on every later one. A solo-account character has neither.
+
+### Amendment (#655) — list paths may serve badges, batched
+
+The original rule was **"badges never appear on a list path"**. That was the
+N+1 wearing the mask of a contract: the ban was a defence against one sibling
+query per character, and it outlived its reason. The Players redesign (The
+Constellation) puts a Badges column on the roster, and every fact a condition
+can consult — `account_character_count`, `is_earliest_on_account` — is a
+**per-account aggregate**, so a whole page resolves in one
+`GROUP BY account_id`.
+
+The replacement rule: **badges are never evaluated *per character* on a list
+path.** A list serializer populates them only through
+`services.badge.build_badge_contexts`, which takes the page's characters and
+returns every `BadgeContext` from a single query — one extra query total,
+regardless of page length. `build_character_outs` is that seam; a list caller
+that reaches for `build_badge_context` (singular) in a loop is the thing being
+banned, and it is the thing to keep banning.
+
+`GET /characters` (invite search) shares the serializer and therefore also
+serves badges. Accepted rather than papered over with an opt-in flag for one
+caller: `/characters/{id}` is already a public, unprotected route that renders
+the same badges, so this exposes nothing new.
 
 ## Rejected
 


### PR DESCRIPTION
Closes #655

Backend prep for the Players redesign (The Constellation). No migration, no new endpoint, no new query param.

### 1. Stable ordering

`list_characters_for_viewer` ordered by `score DESC NULLS LAST` alone. Most of the roster is tied at zero, so rank was whatever Postgres felt like that request — the sky's top-N membership and its crown flicker, and `limit`/`offset` silently duplicates and drops rows across pages. Added `Character.id ASC` as the tiebreak. Both `GET /leaderboard` and `GET /characters` route through this function, so both get it.

### 2. Badges on the list serializer, batched

Both facts `build_badge_context` consults (`account_character_count`, `is_earliest_on_account`) are per-account aggregates, so the N+1 that kept badges off list paths was avoidable, not inherent.

- `services/badge.py` gains `build_badge_contexts(characters, session)` — one `GROUP BY account_id` query (count + earliest id via `array_agg(... ORDER BY created_at, id)[1]`), every context built in memory. The singular `build_badge_context` now delegates to it, so there is one code path.
- `services/character.py` gains `build_character_outs(rows, session)`, the batched list seam. `/characters` and `/leaderboard` use it. **One extra query total, regardless of page length.**
- `GET /characters` (invite search) shares the serializer and so also starts returning badges. Accepted per the issue rather than adding an opt-in flag for one caller — `/characters/{id}` is already public and renders the same badges.

The sibling count stays unfiltered by status, matching the single-character path.

### 3. ADR-0033 amendment

Amended ADR-0033 and the `CharacterOut` / `build_character_out` docstrings that stated the old rule verbatim. Old rule: badges never on list paths. New rule: badges are never evaluated **per character** on a list path — list serializers go through `build_badge_contexts` or not at all.

### Tests

- `test_leaderboard.py`: 5 characters tied at zero return a byte-identical order across 3 calls; `limit=2` over `offset` 0/2/4 partitions a 6-character tied set with no overlap and no gaps.
- `test_badges.py`: badges are populated on `/characters` and `/leaderboard`; the query count does not scale with page size (2 characters and 10 cost the same number of SELECTs). Verified this assertion bites — reverting to a per-character loop fails it (12 SELECTs vs 4).
- `test_list_endpoint_does_not_evaluate_badges` asserted the rule this issue replaces; it is now `test_list_endpoint_populates_badges`.

**Test results:** `pytest --cov=. --cov-fail-under=80` — 586 passed, 87.24% coverage. Backend-only diff; no frontend files touched.
