### PR TITLE
feat(praxes): sort by submitted_at + free-text search on the praxis feed (#658)

### DIFF
--- a/backend/alembic/versions/0003_backfill_praxis_seal_time.py
+++ b/backend/alembic/versions/0003_backfill_praxis_seal_time.py
@@ -1,0 +1,53 @@
+"""Backfill praxis.submitted_at on legacy submitted rows (#658).
+
+The invariant ``status == submitted ⟹ submitted_at IS NOT NULL`` holds in code
+— ``services.collab_consensus._apply_seal`` is the only writer of
+``submitted_at`` and sits on the only path to ``status=submitted`` — but it was
+never true of the *data*. ``submitted_at`` predates the squash; 0001_squashed
+builds from ``Base.metadata.create_all`` so fresh DBs are fine, but nothing ever
+backfilled rows written before the column existed. (The tell is 0002, which
+backfills ``praxis_member.submitted_at`` as
+``COALESCE(praxis.submitted_at, praxis_member.joined_at)`` — you don't write a
+backstop unless the real thing can be null.)
+
+The #658 praxis feed sorts on ``submitted_at``, so any such row would sort as a
+NULL. ``created_at`` is the best available approximation of the seal time for a
+row that never recorded one: it is the only timestamp those rows carry, and it
+at least preserves their relative order.
+
+After this runs, the invariant is true in the data, which is what lets
+``list_praxes`` sort with a plain ``ORDER BY`` and lets its
+``submitted_at IS NOT NULL`` guard only ever catch a genuine future bug.
+
+Idempotent: a no-op on any DB where the invariant already holds.
+
+Revision ID: 0003_backfill_praxis_seal_time  (<=32 chars: alembic_version.version_num is varchar(32))
+Revises: 0002_praxis_pending_submitted
+Create Date: 2026-07-16
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0003_backfill_praxis_seal_time"
+down_revision: Union[str, None] = "0002_praxis_pending_submitted"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE praxis
+           SET submitted_at = created_at
+         WHERE status = 'submitted'
+           AND submitted_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    # ponytail: no rollback. The backfilled value is indistinguishable from a
+    # genuinely-sealed one, so there is nothing to un-set without also
+    # destroying real seal times.
+    pass

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -58,6 +58,7 @@ from services.praxis import (
     kick_member,
     leave_praxis,
     list_praxes,
+    PraxisSort,
     remove_metatask,
     respond_to_invite,
     submit_praxis,
@@ -87,11 +88,20 @@ async def list_praxes_route(
     status: Optional[str] = None,
     moderation_status: Optional[str] = None,
     faction: Optional[str] = None,
+    q: Optional[str] = None,
+    sort: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_db),
     viewer: Optional[Character] = Depends(get_current_character_optional),
 ):
+    praxis_sort: Optional[PraxisSort] = None
+    if sort is not None:
+        try:
+            praxis_sort = PraxisSort(sort)
+        except ValueError:
+            raise HTTPException(status_code=422, detail=f"Invalid praxis sort: {sort}")
+
     praxis_type: Optional[PraxisType] = None
     if type is not None:
         try:
@@ -116,6 +126,8 @@ async def list_praxes_route(
         status=praxis_status,
         moderation_status=moderation_status,
         faction=faction,
+        search=q,
+        sort=praxis_sort,
         viewer_id=viewer.id if viewer else None,
         limit=limit,
         offset=offset,

--- a/backend/services/collab_consensus.py
+++ b/backend/services/collab_consensus.py
@@ -25,7 +25,17 @@ from services.era import get_current_era_row
 
 def _apply_seal(praxis: Praxis) -> None:
     """Pure state mutation for going Live: mark the whole group submitted and clear
-    the window. Caller flushes and recalculates member stats."""
+    the window. Caller flushes and recalculates member stats.
+
+    **Establishes the invariant** ``status == submitted ⟹ submitted_at IS NOT NULL``.
+    This is the only writer of ``praxis.submitted_at``, and every route to
+    ``status=submitted`` runs through it: solo and duel seal on the first submit
+    (one member, so ``all(has_submitted)`` holds immediately), collab seals via
+    :func:`seal_to_live`. Set both fields together, always. The reader that
+    depends on it — and drops any row that violates it — is the
+    ``status == submitted`` branch of ``services.praxis.list_praxes``, whose
+    feed sort orders on ``submitted_at`` (#658).
+    """
     praxis.status = PraxisStatus.submitted
     now = datetime.now(timezone.utc)
     praxis.submitted_at = now

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -358,6 +358,19 @@ def praxis_visibility_condition(viewer_id: Optional[int]):
     return visible
 
 
+class PraxisSort(str, Enum):
+    """Feed orderings for the ``status=submitted`` praxis feed (#658).
+
+    Both sort on ``Praxis.submitted_at`` — when the praxis was *filed* — not
+    ``created_at``, which is merely when the draft was started (i.e. when the
+    author signed up for the task). A praxis begun three weeks ago and filed
+    this morning is news, and belongs at the top of ``newest``.
+    """
+
+    newest = "newest"
+    oldest = "oldest"
+
+
 async def list_praxes(
     session: AsyncSession,
     *,
@@ -368,6 +381,8 @@ async def list_praxes(
     status: Optional[PraxisStatus] = None,
     moderation_status: Optional[str] = None,
     faction: Optional[str] = None,
+    search: Optional[str] = None,
+    sort: Optional[PraxisSort] = None,
     viewer_id: Optional[int] = None,
     limit: int = 50,
     offset: int = 0,
@@ -382,14 +397,35 @@ async def list_praxes(
     filters by *membership* (``PraxisMember``), mirroring
     :func:`_count_in_progress_praxes` so a membership-based list (the sidebar's
     in-progress tasks) can never disagree with the slot count.
+
+    ``search`` is a free-text ``ilike`` over the praxis title, its body, and the
+    linked task's title. Author is deliberately excluded: ``faction`` already
+    answers "show me the Ephemerists", and finding a *person* is what the
+    character search is for.
+
+    ``sort`` only applies to the ``status=submitted`` feed and is ignored
+    otherwise; every caller that passes no ``sort`` keeps ``created_at DESC``.
     """
     query = select(Praxis).where(praxis_visibility_condition(viewer_id))
 
+    # Unconditional: both the faction filter and the ``search`` task-title match
+    # need it, and joining once keeps ``?faction=x&q=y`` from double-joining.
+    query = query.join(Task, Praxis.task_id == Task.id)
+
     if faction is not None:
         # Praxis has no faction of its own; it inherits the linked task's faction.
-        query = query.join(Task, Praxis.task_id == Task.id).where(
-            Task.primary_faction_slug == faction
-        )
+        query = query.where(Task.primary_faction_slug == faction)
+
+    if search:
+        term = search.strip()
+        if term:
+            query = query.where(
+                or_(
+                    Praxis.title.ilike(f"%{term}%"),
+                    Praxis.body_text.ilike(f"%{term}%"),
+                    Task.title.ilike(f"%{term}%"),
+                )
+            )
 
     if praxis_type is not None:
         query = query.where(Praxis.type == praxis_type)
@@ -436,8 +472,27 @@ async def list_praxes(
     if status is not None:
         query = query.where(Praxis.status == status)
 
+    if status == PraxisStatus.submitted:
+        # Invariant, established by collab_consensus._apply_seal — the single
+        # writer of submitted_at, on the only path to status=submitted:
+        # status == submitted ⟹ submitted_at IS NOT NULL. A submitted praxis
+        # with no seal time is corrupt, so it is not shown. Scoped to this
+        # branch on purpose: in-progress praxes have a NULL submitted_at *by
+        # definition*, and a blanket filter would empty the sidebar.
+        query = query.where(Praxis.submitted_at.isnot(None))
+        # That invariant is also what lets the sort below be a plain ORDER BY
+        # with no coalesce and no NULLS-FIRST-on-DESC trap.
+
     query = query.options(selectinload(Praxis.media_items))
-    query = query.order_by(Praxis.created_at.desc()).limit(limit).offset(offset)
+    if sort is not None and status == PraxisStatus.submitted:
+        order = (
+            Praxis.submitted_at.asc()
+            if sort == PraxisSort.oldest
+            else Praxis.submitted_at.desc()
+        )
+    else:
+        order = Praxis.created_at.desc()
+    query = query.order_by(order).limit(limit).offset(offset)
     result = await session.execute(query)
     praxes = list(result.scalars().all())
     for praxis in praxes:
@@ -1479,6 +1534,7 @@ __all__ = [
     "leave_praxis",
     "list_praxes",
     "praxis_visibility_condition",
+    "PraxisSort",
     "moderate_praxis",
     "remove_metatask",
     "respond_to_invite",

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -8,6 +8,7 @@ creating a praxis.  create_praxis() checks level and bank cap only.
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 import pytest
 from httpx import AsyncClient
@@ -202,6 +203,330 @@ async def test_list_praxes_filter_by_faction(
     wow_ids = {item["id"] for item in wow_list.json()}
     assert wow_praxis_id in wow_ids
     assert ua_praxis_id not in wow_ids
+
+
+# ---------------------------------------------------------------------------
+# Feed: sort + free-text search (#658)
+# ---------------------------------------------------------------------------
+
+
+async def _submitted_praxis(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    headers: dict,
+    *,
+    task_title: str,
+    praxis_title: str,
+    body_text: str = "",
+    submitted_at: datetime,
+    created_at: Optional[datetime] = None,
+) -> int:
+    """Create a task + a solo praxis on it, submit it, then pin its timestamps.
+
+    Both timestamps are pinned explicitly, and the ordering tests set them in
+    *opposite* orders, so a sort that silently fell back to the wrong column
+    fails instead of passing by coincidence.
+
+    ``created_at`` must be pinned for any test that asserts on creation order:
+    its ``server_default`` is ``now()``, which in Postgres is *transaction*-start
+    time, and the fixture session runs the whole test in one transaction — so
+    rows created in a single test all tie, and the tiebreak is arbitrary.
+    """
+    task = Task(
+        title=task_title,
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(task)
+    await db_session.commit()
+    await db_session.refresh(task)
+
+    create_resp = await client.post(
+        "/praxes",
+        json={
+            "task_id": task.id,
+            "type": "solo",
+            "title": praxis_title,
+            "body_text": body_text,
+        },
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    submit_resp = await client.post(f"/praxes/{praxis_id}/submit", headers=headers)
+    assert submit_resp.status_code == 200
+
+    praxis = await db_session.get(Praxis, praxis_id)
+    praxis.submitted_at = submitted_at
+    if created_at is not None:
+        praxis.created_at = created_at
+    await db_session.commit()
+    return praxis_id
+
+
+@pytest.mark.asyncio
+async def test_feed_sort_orders_by_submitted_at_not_created_at(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """?sort=newest|oldest orders on submitted_at, and oldest reverses newest.
+
+    The three praxes are created oldest-first but sealed newest-first, so any
+    implementation that ordered on ``created_at`` would return them backwards.
+    """
+    now = datetime.now(timezone.utc)
+    ids = []
+    for index in range(3):
+        ids.append(
+            await _submitted_praxis(
+                client,
+                db_session,
+                character,
+                auth_headers,
+                task_title=f"Sort Task {index}",
+                praxis_title=f"Sort Praxis {index}",
+                # Inverted on purpose: praxis 0 was started first but filed
+                # last, so created_at DESC and submitted_at DESC disagree.
+                submitted_at=now - timedelta(days=index),
+                created_at=now - timedelta(days=10 - index),
+            )
+        )
+
+    newest = await client.get(
+        "/praxes", params={"status": "submitted", "sort": "newest"}
+    )
+    assert newest.status_code == 200
+    newest_ids = [item["id"] for item in newest.json() if item["id"] in ids]
+    assert newest_ids == ids  # praxis 0 sealed most recently
+
+    oldest = await client.get(
+        "/praxes", params={"status": "submitted", "sort": "oldest"}
+    )
+    assert oldest.status_code == 200
+    oldest_ids = [item["id"] for item in oldest.json() if item["id"] in ids]
+    assert oldest_ids == list(reversed(ids))
+
+
+@pytest.mark.asyncio
+async def test_list_praxes_without_sort_keeps_created_at_desc(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A caller that passes no ``sort`` still gets created_at DESC.
+
+    ``list_praxes`` is shared — the sidebar, task detail and profile lists all
+    call it. This is the regression guard on that blast radius: the seal times
+    below invert the creation order, so a sort that leaked into the default
+    would flip this list.
+    """
+    now = datetime.now(timezone.utc)
+    ids = []
+    for index in range(3):
+        ids.append(
+            await _submitted_praxis(
+                client,
+                db_session,
+                character,
+                auth_headers,
+                task_title=f"Default Task {index}",
+                praxis_title=f"Default Praxis {index}",
+                submitted_at=now - timedelta(days=index),
+                created_at=now - timedelta(days=10 - index),
+            )
+        )
+
+    resp = await client.get("/praxes", params={"status": "submitted"})
+    assert resp.status_code == 200
+    got = [item["id"] for item in resp.json() if item["id"] in ids]
+    # created_at DESC — last created first, i.e. the reverse of `ids`.
+    assert got == list(reversed(ids))
+
+
+@pytest.mark.asyncio
+async def test_feed_search_matches_task_title(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """?q= matches the linked task's title, not just the praxis's own fields."""
+    now = datetime.now(timezone.utc)
+    match_id = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Sweep the Aqueduct",
+        praxis_title="Untitled findings",
+        submitted_at=now,
+    )
+    other_id = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Catalogue the Reliquary",
+        praxis_title="Untitled findings",
+        submitted_at=now,
+    )
+
+    resp = await client.get(
+        "/praxes", params={"status": "submitted", "q": "aqueduct"}
+    )
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()}
+    assert match_id in ids
+    assert other_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_feed_search_matches_praxis_title_and_body(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """?q= also matches the praxis's own title and body_text."""
+    now = datetime.now(timezone.utc)
+    by_title = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Generic Task A",
+        praxis_title="The Lantern Report",
+        submitted_at=now,
+    )
+    by_body = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Generic Task B",
+        praxis_title="Untitled",
+        body_text="Found a lantern under the bridge.",
+        submitted_at=now,
+    )
+    neither = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Generic Task C",
+        praxis_title="Untitled",
+        body_text="Nothing to report.",
+        submitted_at=now,
+    )
+
+    resp = await client.get("/praxes", params={"status": "submitted", "q": "lantern"})
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()}
+    assert by_title in ids
+    assert by_body in ids
+    assert neither not in ids
+
+
+@pytest.mark.asyncio
+async def test_faction_and_search_combine(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """?faction=x&q=y works — the Task join is unconditional, never doubled."""
+    now = datetime.now(timezone.utc)
+    match_id = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Beacon Duty",
+        praxis_title="Report",
+        submitted_at=now,
+    )
+
+    resp = await client.get(
+        "/praxes",
+        params={"status": "submitted", "faction": "ua", "q": "beacon", "sort": "newest"},
+    )
+    assert resp.status_code == 200
+    assert match_id in {item["id"] for item in resp.json()}
+
+
+@pytest.mark.asyncio
+async def test_invalid_sort_returns_422(client: AsyncClient):
+    """An unknown ?sort= is rejected, not silently ignored."""
+    resp = await client.get("/praxes", params={"sort": "sideways"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_in_progress_still_returns_null_submitted_at(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """The submitted_at guard is scoped to status=submitted only.
+
+    In-progress praxes have a NULL submitted_at *by definition* — a blanket
+    ``submitted_at IS NOT NULL`` would empty the sidebar's in-progress list.
+    """
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Still Drafting"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    resp = await client.get(
+        "/praxes", params={"status": "in_progress"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    assert praxis_id in {item["id"] for item in resp.json()}
+
+
+@pytest.mark.asyncio
+async def test_submitted_praxis_with_null_seal_time_is_hidden(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A submitted praxis with no submitted_at is corrupt, and is not shown.
+
+    _apply_seal makes this unreachable and the #658 backfill cleared the legacy
+    rows, so this can only ever fire on a genuine future bug — which is exactly
+    what it is here for.
+    """
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Corrupt Seal"},
+        headers=auth_headers,
+    )
+    praxis_id = create_resp.json()["id"]
+    submit_resp = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+    assert submit_resp.status_code == 200
+
+    praxis = await db_session.get(Praxis, praxis_id)
+    praxis.submitted_at = None
+    await db_session.commit()
+
+    resp = await client.get("/praxes", params={"status": "submitted"})
+    assert resp.status_code == 200
+    assert praxis_id not in {item["id"] for item in resp.json()}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #658

Backend half of #642 — adds `sort` and `q` to `GET /praxes`, and settles the `submitted_at` invariant the sort depends on. No frontend work; #642 consumes this. Faction filtering already existed and needed zero lines, as the brief predicted.

## `sort=newest|oldest`

Orders on `Praxis.submitted_at` — when the praxis was *filed* — not `created_at`, which is only when the draft was started. A praxis begun three weeks ago and filed this morning now sits at the top of newest-first instead of buried.

Scoped to the `status=submitted` branch. `list_praxes` is shared (sidebar, task detail, profile lists), so every caller that passes no `sort` keeps `created_at DESC` and sees **zero** change — there's a dedicated regression test for that blast radius.

## `submitted_at` backfill + guard

The invariant `status == submitted ⟹ submitted_at IS NOT NULL` held in code — `_apply_seal` is the only writer, on the only path to submitted — but never in the data, since nothing backfilled rows written before the column existed.

Migration `0003` backfills `submitted_at = created_at` on legacy submitted rows. With the data true, the sort is a plain `ORDER BY` (no coalesce, no NULLS-FIRST-on-DESC trap) and the new `submitted_at IS NOT NULL` guard can only ever catch a genuine future bug. The guard is scoped to `status=submitted` — a blanket filter would empty the in-progress sidebar, which is also covered by a test.

The invariant is documented at both ends: `_apply_seal` establishes it, the `list_praxes` guard names `_apply_seal` as the establishing writer. Not an ADR, per the no-state-mirrors doctrine.

## `q=` free-text search

`ilike` over `Praxis.title`, `Praxis.body_text`, and `Task.title`, following the `services/character.py` precedent. Author deliberately excluded. The `Task` join is now **unconditional** so `?faction=x&q=y` can't double-join — safe because `Praxis.task_id` is `nullable=False` with an FK, so the inner join can neither drop nor duplicate rows.

## Verification

- **Backend: 589 passed, 87.27% coverage** (`--cov-fail-under=80`).
- Migration chain `alembic upgrade head` applies clean from scratch; the backfill was exercised against hand-built legacy rows — the null-seal row got `created_at`, a real seal time was left untouched, an `in_progress` row kept its null — and re-running is a no-op.
- Frontend untouched (zero frontend files in the diff), so `npm test` was not run.

## Two findings worth noting

- **Fixed a bug CI would have caught:** the first revision id was 33 chars and `alembic_version.version_num` is `varchar(32)`. Renamed to `0003_backfill_praxis_seal_time` and noted the limit in the docstring.
- **The default-order test needed `created_at` pinned explicitly.** Its `server_default` is `now()`, which in Postgres is *transaction*-start time, and the fixture session runs each test in one transaction — so rows created in a single test all tie and the tiebreak is arbitrary. Both ordering tests now pin `created_at` and `submitted_at` in *opposite* orders, so a sort on the wrong column fails rather than passing by coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
