### PR TITLE
fix(i18n): un-shadow the Albescent letter's copy (#634)

### DIFF
--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -45,7 +45,7 @@ const HAIRLINE = 'rgba(0,0,0,0.10)'
 const HAIRLINE_FAINT = 'rgba(0,0,0,0.055)'
 const RULE = 'rgba(0,0,0,0.07)'
 
-// i18n key stems under factions:albescent.invitation — resolved at render.
+// i18n key stems under factions:albescent.letter — resolved at render.
 const TERM_KEYS: ReadonlyArray<{ label: string; value: string }> = [
   { label: 'terms.tollLabel', value: 'terms.tollValue' },
   { label: 'terms.skillsLabel', value: 'terms.skillsValue' },
@@ -94,14 +94,14 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
       setJoined(true)
       await onJoined()
     } catch (err) {
-      setError(extractError(err, t('albescent.invitation.declineError')))
+      setError(extractError(err, t('albescent.letter.declineError')))
     } finally {
       setSubmitting(false)
     }
   }
 
   return (
-    <section style={letter} aria-label={t('albescent.invitation.aria')}>
+    <section style={letter} aria-label={t('albescent.letter.aria')}>
       <div style={innerFrame} />
 
       {/* letterhead */}
@@ -109,30 +109,30 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
         <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 18 }}>
           <AlbescentSigil size={44} />
         </div>
-        <div style={{ ...monoCaps, fontSize: 9, letterSpacing: '0.34em', color: ACCENT, marginBottom: 6 }}>{t('albescent.invitation.wordmark')}</div>
-        <div style={{ ...monoCaps, fontSize: 8, letterSpacing: '0.28em', marginBottom: 22 }}>{t('albescent.invitation.letterhead')}</div>
+        <div style={{ ...monoCaps, fontSize: 9, letterSpacing: '0.34em', color: ACCENT, marginBottom: 6 }}>{t('albescent.letter.wordmark')}</div>
+        <div style={{ ...monoCaps, fontSize: 8, letterSpacing: '0.28em', marginBottom: 22 }}>{t('albescent.letter.letterhead')}</div>
         <div style={{ width: 54, height: 1, background: HAIRLINE, margin: '0 auto 22px' }} />
-        <div style={{ ...monoCaps, fontSize: 8, letterSpacing: '0.2em', marginBottom: 10 }}>{t('albescent.invitation.handExtended')}</div>
-        <h2 style={headline}>{t('albescent.invitation.headline')}</h2>
+        <div style={{ ...monoCaps, fontSize: 8, letterSpacing: '0.2em', marginBottom: 10 }}>{t('albescent.letter.handExtended')}</div>
+        <h2 style={headline}>{t('albescent.letter.headline')}</h2>
         <p style={pitch}>
-          {t('albescent.invitation.pitch')}
+          {t('albescent.letter.pitch')}
         </p>
       </div>
 
       {/* terms slip */}
       <div style={{ position: 'relative', margin: '0 42px', borderTop: `1px solid ${RULE}`, padding: '20px 0 4px', textAlign: 'left' }}>
-        <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.22em', marginBottom: 12 }}>{t('albescent.invitation.termsHeading')}</div>
+        <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.22em', marginBottom: 12 }}>{t('albescent.letter.termsHeading')}</div>
         <div style={termsGrid}>
           {TERM_KEYS.map((term) => (
             <div key={term.label} style={{ borderBottom: `1px solid ${HAIRLINE_FAINT}`, padding: '8px 0' }}>
-              <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.14em' }}>{tDynamic(`albescent.invitation.${term.label}`)}</div>
-              <div style={{ ...serifItalic, fontSize: 18, color: INK, marginTop: 2 }}>{tDynamic(`albescent.invitation.${term.value}`)}</div>
+              <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.14em' }}>{tDynamic(`albescent.letter.${term.label}`)}</div>
+              <div style={{ ...serifItalic, fontSize: 18, color: INK, marginTop: 2 }}>{tDynamic(`albescent.letter.${term.value}`)}</div>
             </div>
           ))}
         </div>
         <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: '4px 16px' }}>
           {PERK_KEYS.map((perk) => (
-            <div key={perk} style={{ ...serifItalic, fontSize: 14, color: ACCENT }}>— {tDynamic(`albescent.invitation.${perk}`)}</div>
+            <div key={perk} style={{ ...serifItalic, fontSize: 14, color: ACCENT }}>— {tDynamic(`albescent.letter.${perk}`)}</div>
           ))}
         </div>
       </div>
@@ -140,10 +140,10 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
       {/* answer */}
       <div style={{ position: 'relative', padding: '24px 42px 36px' }}>
         {joined ? (
-          <div style={{ ...serifItalic, fontSize: 22, color: INK, textAlign: 'center' }}>{t('albescent.invitation.joined')}</div>
+          <div style={{ ...serifItalic, fontSize: 22, color: INK, textAlign: 'center' }}>{t('albescent.letter.joined')}</div>
         ) : (
           <>
-            <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.22em', marginBottom: 10 }}>{t('albescent.invitation.whoHeading')}</div>
+            <div style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.22em', marginBottom: 10 }}>{t('albescent.letter.whoHeading')}</div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 20 }}>
               {choices.map((life) => {
                 const selected = life.id === selectedId
@@ -157,7 +157,7 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
                   >
                     <span style={{ ...serifItalic, fontSize: 16, color: INK, lineHeight: 1.1 }}>{life.display_name}</span>
                     <span style={{ ...monoCaps, fontSize: 7, letterSpacing: '0.08em', marginTop: 3 }}>
-                      {t('albescent.invitation.lifeMeta', { username: life.username, faction: factionName(life.faction_slug) })}
+                      {t('albescent.letter.lifeMeta', { username: life.username, faction: factionName(life.faction_slug) })}
                     </span>
                     <span style={{ marginLeft: 'auto', fontSize: 12, color: MUTED, position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)' }}>
                       {selected ? '•' : '→'}
@@ -168,9 +168,9 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap', justifyContent: 'center' }}>
               <button type="button" onClick={() => void handleAccept()} disabled={submitting} style={acceptButton}>
-                {submitting ? t('albescent.invitation.acceptBusy') : t('albescent.invitation.acceptIdle')}
+                {submitting ? t('albescent.letter.acceptBusy') : t('albescent.letter.acceptIdle')}
               </button>
-              <span style={{ ...serifItalic, fontSize: 15, color: ACCENT }}>{t('albescent.invitation.reassurance')}</span>
+              <span style={{ ...serifItalic, fontSize: 15, color: ACCENT }}>{t('albescent.letter.reassurance')}</span>
             </div>
             {error && (
               <p style={{ ...serifItalic, fontSize: 14, color: INK, textAlign: 'center', marginTop: 14, marginBottom: 0 }}>{error}</p>

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -59,7 +59,7 @@
       "eyebrow": "— no such account —",
       "line": "You know not what you seek."
     },
-    "invitation": {
+    "letter": {
       "aria": "A correspondence",
       "wordmark": "Albescent",
       "letterhead": "Faction no. 7 · enlistment · in confidence",


### PR DESCRIPTION
## What

`albescent` in `factions.json` carried **two `"invitation"` keys**. JSON is last-wins, so the letter's 22-key block (line 62, from #485) was silently shadowed by the popup's 6-key block (line 108, added by #486 for all seven factions). The letter's copy has been sitting in the file, unreachable, ever since.

This moves the letter to `albescent.letter.*` and repoints `AlbescentInvitation.tsx`'s key stem. **All 22 keys are restored verbatim** — no copy invented, none re-voiced.

## Why not merge the two blocks

They collide on `headline`, `pitch`, `terms` and `perks`, and `terms`/`perks` disagree in *shape* (object vs array). `<slug>.invitation.*` is `InvitationLetterPopup`'s convention across all seven factions, so the letter — the odd one out, and Albescent-only — is the one that moves.

## Two prod-visible defects fixed

1. **23 of the letter's 25 keys resolved to nothing.** The accept button rendered the literal string `albescent.invitation.acceptIdle`. `saveMissing` is off in prod so the throwing `missingKeyHandler` never fired; in dev it would throw, but no test renders the letter.
2. **`headline` and `pitch` were worse than missing — they resolved to the *popup's* copy.** The letter quietly rendered "Keep the quiet work" where it should read "Take up the work". No throw, no visible key, just wrong copy. This one wasn't in the issue.

## Note on the issue's diagnosis

#634 attributed this to #485 forgetting four keys, and proposed pointing `acceptIdle` at `cta.join` on the theory that the catalog had been deliberately re-voiced. `git log -S'"wordmark"'` returns only 377cdb2 (#485, adding them) — nothing ever removed them. There was no re-voicing: `cta.join = "Attend the Record"` is the *popup's* copy for the Albescent prospectus, a different component. Adopting it would have imported the popup's voice into the letter — the inversion of the issue's stated intent. Full trace in the [escalation comment](https://github.com/pixieofhugs/WorldZeroPlayground/issues/634#issuecomment-4997305209); Molly chose Option A.

## Gates

- `tsc --noEmit`: **13 → 1 error**. The 12 that cleared are exactly this bug; the 1 remaining is a pre-existing unrelated failure in `factionMembershipRelocation.test.tsx`, which the issue already accounted for ("12 of the 13 error lines").
- `npm test`: **617 passed** (86 files).
- `npm run lint`: **0 errors**.
- Verified programmatically: no duplicate keys remain, all 25 letter keys resolve, and all seven popup blocks are intact.

Frontend-only — backend untouched, so no pytest run.

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
