### PR TITLE
Contrast foundation: mechanical AA sweep (token test + rendered spec + ratchet)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -103,13 +103,23 @@ async def dev_login(
     key: str = "1",
     name: Optional[str] = None,
     level: int = 0,
+    faction: Optional[str] = None,
 ):
     """Dev-only bot login (bypasses Google OAuth). Disabled in production.
 
     Optional query params turn it into a one-call e2e fixture:
-      key   — distinct dev account selector ("1" = the legacy dev account)
-      name  — if set, ensure the account carries a character with this display name
-      level — if >0, seed the carried character's current-era level (collab needs >=1)
+      key     — distinct dev account selector ("1" = the legacy dev account)
+      name    — if set, ensure the account carries a character with this display name
+      level   — if >0, seed the carried character's current-era level (collab needs >=1)
+      faction — if set, place the carried character in that faction directly
+
+    `faction` deliberately bypasses the join gate rather than replaying it.
+    Players start unaffiliated and most factions are invite-gated
+    (ADR-0030), so there is no real flow that puts a test character in all
+    seven — and the contrast sweep (#651) needs exactly that. This is the
+    same dev-only seam as `key`/`name`/`level`, behind the same production
+    guard; it is not a second enabler.
+
     Returns account_id + character_id so tests can invite/credit by id.
     """
     if settings.ENVIRONMENT == _ENV_PRODUCTION:
@@ -132,6 +142,19 @@ async def dev_login(
             account.id, CharacterCreate(display_name=name), session
         )
         character = result.character
+
+    if faction is not None:
+        if faction not in CURRENT_ERA.factions:
+            raise HTTPException(
+                status_code=400, detail=f"Unknown faction slug: {faction}"
+            )
+        if character is None:
+            raise HTTPException(
+                status_code=400,
+                detail="faction needs a character — pass name= on the first call.",
+            )
+        character.faction_slug = faction
+        await session.flush()
 
     if character is not None and level > 0:
         era_row = await get_current_era_row(session)
@@ -156,4 +179,5 @@ async def dev_login(
         "account_id": account.id,
         "character_id": character.id if character else None,
         "character_name": character.display_name if character else None,
+        "faction_slug": character.faction_slug if character else None,
     }

--- a/backend/tests/integration/test_dev_login.py
+++ b/backend/tests/integration/test_dev_login.py
@@ -1,0 +1,122 @@
+"""Integration tests for the dev-only bot-login seam (POST /auth/dev-login).
+
+Covers the `faction` param added for the contrast sweep (#651): it places a
+character in an arbitrary faction directly, bypassing the invite gate that
+would otherwise make 5 of the 7 factions unreachable from a test.
+
+The production guard is the load-bearing part — this endpoint hands out a
+session cookie with no credential, so a regression that let it answer in
+production would be a full auth bypass.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config import settings
+from models.character import Character
+from models.era import Era
+from models.faction import Faction, FactionStatus
+
+
+@pytest.fixture
+async def faction_ephemerists_row(db_session: AsyncSession) -> Faction:
+    """Seed a non-ua faction so the character.faction_slug FK can point at it."""
+    result = await db_session.execute(
+        select(Faction).where(Faction.slug == "ephemerists")
+    )
+    faction = result.scalar_one_or_none()
+    if faction is None:
+        faction = Faction(slug="ephemerists", status=FactionStatus.visible)
+        db_session.add(faction)
+        await db_session.flush()
+    return faction
+
+
+async def _character_faction(db_session: AsyncSession, character_id: int) -> str:
+    result = await db_session.execute(
+        select(Character.faction_slug).where(Character.id == character_id)
+    )
+    return result.scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_dev_login_faction_places_character(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    era: Era,
+    faction_ua: Faction,
+    faction_ephemerists_row: Faction,
+) -> None:
+    """?faction=<slug> puts the character straight into that faction."""
+    resp = await client.post(
+        "/auth/dev-login?key=contrast&name=Sweep%20Bot&faction=ephemerists"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["faction_slug"] == "ephemerists"
+    assert await _character_faction(db_session, body["character_id"]) == "ephemerists"
+
+
+@pytest.mark.asyncio
+async def test_dev_login_faction_is_idempotent_across_calls(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    era: Era,
+    faction_ua: Faction,
+    faction_ephemerists_row: Faction,
+) -> None:
+    """The sweep re-logs the same bot per faction — the last call wins."""
+    first = await client.post("/auth/dev-login?key=contrast&name=Sweep%20Bot&faction=ephemerists")
+    second = await client.post("/auth/dev-login?key=contrast&faction=ua")
+    assert second.status_code == 200
+    assert second.json()["character_id"] == first.json()["character_id"]
+    assert await _character_faction(db_session, second.json()["character_id"]) == "ua"
+
+
+@pytest.mark.asyncio
+async def test_dev_login_rejects_unknown_faction(
+    client: AsyncClient,
+    era: Era,
+    faction_ua: Faction,
+) -> None:
+    """A typo'd slug is a 400, not a silent no-op that skins the wrong faction."""
+    resp = await client.post("/auth/dev-login?key=contrast&name=Sweep%20Bot&faction=nosuch")
+    assert resp.status_code == 400
+    assert "nosuch" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_dev_login_faction_without_character_is_rejected(
+    client: AsyncClient,
+    era: Era,
+    faction_ua: Faction,
+) -> None:
+    """faction= with no character to place fails loudly rather than doing nothing."""
+    resp = await client.post("/auth/dev-login?key=contrast-nochar&faction=ua")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_dev_login_without_faction_leaves_membership_alone(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    era: Era,
+    faction_ua: Faction,
+    faction_ephemerists_row: Faction,
+) -> None:
+    """Omitting faction= must not reset an existing membership."""
+    first = await client.post("/auth/dev-login?key=contrast&name=Sweep%20Bot&faction=ephemerists")
+    await client.post("/auth/dev-login?key=contrast")
+    assert await _character_faction(db_session, first.json()["character_id"]) == "ephemerists"
+
+
+@pytest.mark.asyncio
+async def test_dev_login_404s_in_production(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard the whole seam rests on."""
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    resp = await client.post("/auth/dev-login?key=contrast&faction=ua")
+    assert resp.status_code == 404

--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
+import { appendFileSync } from 'node:fs'
 
-import { RENDERED_BASELINE, baselineKey, type BaselineEntry } from './contrastBaseline'
+import { RENDERED_BASELINE, baselineKey, unresolvedKey, type BaselineEntry } from './contrastBaseline'
 import { scanPageForContrast, type Finding } from './contrastScan'
 
 /**
@@ -20,9 +21,15 @@ import { scanPageForContrast, type Finding } from './contrastScan'
  *
  * Nightly, not per-PR: `.github/workflows/e2e.yml` already stands up Postgres
  * + backend + seed + Playwright. No new CI job.
+ *
+ * REGENERATING THE BASELINE. Set `CONTRAST_BASELINE_OUT=<path>` and run the
+ * suite; every failure is appended there as a ready-to-paste entry. The list
+ * is machine-produced on purpose — hand-typed ratios would be wrong within a
+ * week, which is the whole thesis of this issue.
  */
 
 const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
+const BASELINE_OUT = process.env.CONTRAST_BASELINE_OUT
 
 const FACTIONS = ['ua', 'everymen', 'wow', 'snide', 'ephemerists', 'singularity', 'albescent'] as const
 const THEMES = ['light', 'dark'] as const
@@ -63,44 +70,27 @@ async function useTheme(page: Page, theme: Theme): Promise<void> {
   }, theme)
 }
 
+function keyOf(theme: Theme, finding: Finding): string {
+  return finding.background === null
+    ? unresolvedKey(theme, finding.text, finding.backdropCss ?? 'unknown', finding.required)
+    : baselineKey(theme, finding.text, finding.background, finding.required)
+}
+
 function describeFinding(finding: Finding): string {
   const size = `${finding.fontSizePx}px/${finding.fontWeight}`
   if (finding.background === null) {
-    return `  UNRESOLVED BACKDROP — ${finding.where} (${size})\n    "${finding.sample}"\n    ${finding.unresolved}`
+    return `  UNRESOLVED BACKDROP (${finding.unresolvedKind}) — ${finding.where} (${size})\n    "${finding.sample}"\n    ${finding.unresolved}`
   }
   return `  ${finding.ratio.toFixed(2)}:1 (needs ${finding.required}:1) — ${finding.text} on ${finding.background}\n    ${finding.where} (${size}) "${finding.sample}"`
 }
 
-/** Everything the sweep saw, for the audit comment on #651. */
-const auditLog = new Map<string, { finding: Finding; seenAt: Set<string> }>()
-
-function record(theme: Theme, route: string, finding: Finding): string {
-  const key =
-    finding.background === null
-      ? `${theme} | UNRESOLVED | ${finding.where}`
-      : baselineKey(theme, finding.text, finding.background)
-  const existing = auditLog.get(key)
-  if (existing) existing.seenAt.add(route)
-  else auditLog.set(key, { finding, seenAt: new Set([route]) })
-  return key
+/** Emit a ready-to-paste BASELINE entry when regenerating (see header). */
+function emitBaseline(key: string, finding: Finding, faction: Faction, theme: Theme, viewport: ViewportName): void {
+  if (!BASELINE_OUT) return
+  const ratio = finding.background === null ? 'null' : finding.ratio.toFixed(2)
+  const where = `${faction}/${theme}/${viewport} ${finding.where}`.replace(/'/g, '')
+  appendFileSync(BASELINE_OUT, `  ${JSON.stringify(key)}: { ratio: ${ratio}, issue: 651, where: '${where}' },\n`)
 }
-
-test.afterAll(() => {
-  if (auditLog.size === 0) return
-  // Printed, not asserted: this is the audit list #651 asks to be posted as a
-  // comment so it can be triaged into children.
-  const kinds = new Map<string, number>()
-  for (const { finding } of auditLog.values()) {
-    const kind = finding.background === null ? `unresolved:${finding.unresolvedKind}` : 'measured-fail'
-    kinds.set(kind, (kinds.get(kind) ?? 0) + 1)
-  }
-  const breakdown = [...kinds].map(([kind, count]) => `${kind}: ${count}`).join('\n')
-  console.log(`\n===== #651 breakdown =====\n${breakdown}\n`)
-  const lines = [...auditLog.entries()]
-    .sort(([, a], [, b]) => a.finding.ratio - b.finding.ratio)
-    .map(([key, { finding, seenAt }]) => `${key}\n${describeFinding(finding)}\n    seen on: ${[...seenAt].join(', ')}`)
-  console.log(`\n===== #651 rendered contrast audit (${auditLog.size} distinct failing pairs) =====\n${lines.join('\n')}\n`)
-})
 
 for (const faction of FACTIONS) {
   for (const theme of THEMES) {
@@ -124,11 +114,11 @@ for (const faction of FACTIONS) {
 
           const findings = (await page.evaluate(scanPageForContrast)) as Finding[]
           for (const finding of findings) {
-            const resolved = finding.background !== null && finding.ratio >= finding.required
-            const key = resolved ? baselineKey(theme, finding.text, finding.background!) : record(theme, route, finding)
+            const ok = finding.background !== null && finding.ratio >= finding.required
+            const key = keyOf(theme, finding)
             const allowed: BaselineEntry | undefined = RENDERED_BASELINE[key]
 
-            if (resolved) {
+            if (ok) {
               // A pair that now passes but is still allowlisted is debt that
               // got fixed without the list being updated. Catch it: an
               // allowlist that outlives its bug stops being a ratchet.
@@ -136,15 +126,16 @@ for (const faction of FACTIONS) {
               continue
             }
             if (allowed) continue
+            emitBaseline(key, finding, faction, theme, viewport)
             failures.push(describeFinding(finding))
           }
         }
 
         expect(
-          failures,
-          `${faction}/${theme}/${viewport}: ${failures.length} text nodes below WCAG AA.\n` +
-            `An UNRESOLVED BACKDROP is a failure, not a skip — text over a gradient/image cannot be measured, ` +
-            `so it must be given a solid backdrop (or the gradient hoisted behind an opaque card).\n\n` +
+          [...new Set(failures)],
+          `${faction}/${theme}/${viewport}: text below WCAG AA.\n` +
+            `An UNRESOLVED BACKDROP is a failure, not a skip — text over an opaque-stop gradient or an image ` +
+            `cannot be measured, so it must be given a solid backdrop (or the fill hoisted behind an opaque card).\n\n` +
             [...new Set(failures)].join('\n\n'),
         ).toHaveLength(0)
 

--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect, type Page } from '@playwright/test'
+
+import { RENDERED_BASELINE, baselineKey, type BaselineEntry } from './contrastBaseline'
+import { scanPageForContrast, type Finding } from './contrastScan'
+
+/**
+ * Part B of the contrast foundation (#651) — the RENDERED contrast sweep.
+ *
+ * Part A (`src/utils/__tests__/factionContrast.test.ts`) measures token
+ * *values*. It cannot catch the other half of this bug family: a component
+ * reaching for the wrong token — `--everymen-ink` (structure: borders, rules,
+ * text on gold elements) used as body text on `--everymen-paper` (the surface
+ * that FLIPS in dark). That pairing is 1.16:1 in dark, and it only exists once
+ * rendered. #595 fixed one instance of it by hand; siblings survived. This
+ * walks all of them.
+ *
+ * Coverage: 7 factions x 2 themes x 2 viewports. Both viewports because the
+ * mobile archetypes are separate files and diverge (#565) — a desktop-only
+ * sweep would report green over half the app.
+ *
+ * Nightly, not per-PR: `.github/workflows/e2e.yml` already stands up Postgres
+ * + backend + seed + Playwright. No new CI job.
+ */
+
+const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
+
+const FACTIONS = ['ua', 'everymen', 'wow', 'snide', 'ephemerists', 'singularity', 'albescent'] as const
+const THEMES = ['light', 'dark'] as const
+const VIEWPORTS = {
+  // Matches useFormFactor's single 767px breakpoint (#494) — no tablet tier.
+  mobile: { width: 375, height: 812 },
+  desktop: { width: 1280, height: 800 },
+} as const
+
+type Theme = (typeof THEMES)[number]
+type Faction = (typeof FACTIONS)[number]
+type ViewportName = keyof typeof VIEWPORTS
+
+/**
+ * Routes whose chrome is skinned by the viewer's faction. `/factions/${slug}`
+ * is added per-faction — it is the faction's own bespoke surface.
+ */
+const SHARED_ROUTES = ['/', '/tasks', '/praxes', '/leaderboard', '/factions']
+
+// This spec opts out of the shared bot's saved cookie: it re-logs per faction
+// against its own dev account so it can't leave other specs' bot in Snide.
+test.use({ storageState: { cookies: [], origins: [] } })
+
+async function loginAs(page: Page, faction: Faction): Promise<void> {
+  const response = await page.request.post(
+    `${API}/auth/dev-login?key=contrast&name=Contrast%20Bot&faction=${faction}`,
+  )
+  expect(response.ok(), `dev-login?faction=${faction} failed — is the backend up on ${API}?`).toBeTruthy()
+  expect((await response.json()).faction_slug).toBe(faction)
+}
+
+async function useTheme(page: Page, theme: Theme): Promise<void> {
+  // The theme is bootstrapped from localStorage in index.html before React
+  // hydrates, so it must be seeded before the first navigation — not toggled
+  // after, which would measure a repaint rather than the real first paint.
+  await page.addInitScript((value) => {
+    window.localStorage.setItem('wz-theme', value as string)
+  }, theme)
+}
+
+function describeFinding(finding: Finding): string {
+  const size = `${finding.fontSizePx}px/${finding.fontWeight}`
+  if (finding.background === null) {
+    return `  UNRESOLVED BACKDROP — ${finding.where} (${size})\n    "${finding.sample}"\n    ${finding.unresolved}`
+  }
+  return `  ${finding.ratio.toFixed(2)}:1 (needs ${finding.required}:1) — ${finding.text} on ${finding.background}\n    ${finding.where} (${size}) "${finding.sample}"`
+}
+
+/** Everything the sweep saw, for the audit comment on #651. */
+const auditLog = new Map<string, { finding: Finding; seenAt: Set<string> }>()
+
+function record(theme: Theme, route: string, finding: Finding): string {
+  const key =
+    finding.background === null
+      ? `${theme} | UNRESOLVED | ${finding.where}`
+      : baselineKey(theme, finding.text, finding.background)
+  const existing = auditLog.get(key)
+  if (existing) existing.seenAt.add(route)
+  else auditLog.set(key, { finding, seenAt: new Set([route]) })
+  return key
+}
+
+test.afterAll(() => {
+  if (auditLog.size === 0) return
+  // Printed, not asserted: this is the audit list #651 asks to be posted as a
+  // comment so it can be triaged into children.
+  const kinds = new Map<string, number>()
+  for (const { finding } of auditLog.values()) {
+    const kind = finding.background === null ? `unresolved:${finding.unresolvedKind}` : 'measured-fail'
+    kinds.set(kind, (kinds.get(kind) ?? 0) + 1)
+  }
+  const breakdown = [...kinds].map(([kind, count]) => `${kind}: ${count}`).join('\n')
+  console.log(`\n===== #651 breakdown =====\n${breakdown}\n`)
+  const lines = [...auditLog.entries()]
+    .sort(([, a], [, b]) => a.finding.ratio - b.finding.ratio)
+    .map(([key, { finding, seenAt }]) => `${key}\n${describeFinding(finding)}\n    seen on: ${[...seenAt].join(', ')}`)
+  console.log(`\n===== #651 rendered contrast audit (${auditLog.size} distinct failing pairs) =====\n${lines.join('\n')}\n`)
+})
+
+for (const faction of FACTIONS) {
+  for (const theme of THEMES) {
+    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+      test(`${faction} · ${theme} · ${viewport} clears WCAG AA`, async ({ page }) => {
+        test.setTimeout(120_000)
+        await page.setViewportSize(VIEWPORTS[viewport])
+        await useTheme(page, theme)
+        await loginAs(page, faction)
+
+        const routes = [...SHARED_ROUTES, `/factions/${faction}`]
+        const failures: string[] = []
+        const passing: string[] = []
+
+        for (const route of routes) {
+          await page.goto(route)
+          // The skin depends on the viewer's faction, which arrives with
+          // /auth/me — measuring before it lands would measure the default.
+          await page.waitForLoadState('networkidle')
+          await expect(page.locator('html')).toHaveAttribute('data-theme', theme)
+
+          const findings = (await page.evaluate(scanPageForContrast)) as Finding[]
+          for (const finding of findings) {
+            const resolved = finding.background !== null && finding.ratio >= finding.required
+            const key = resolved ? baselineKey(theme, finding.text, finding.background!) : record(theme, route, finding)
+            const allowed: BaselineEntry | undefined = RENDERED_BASELINE[key]
+
+            if (resolved) {
+              // A pair that now passes but is still allowlisted is debt that
+              // got fixed without the list being updated. Catch it: an
+              // allowlist that outlives its bug stops being a ratchet.
+              if (allowed) passing.push(`${key} now measures ${finding.ratio.toFixed(2)}:1 (owned by #${allowed.issue})`)
+              continue
+            }
+            if (allowed) continue
+            failures.push(describeFinding(finding))
+          }
+        }
+
+        expect(
+          failures,
+          `${faction}/${theme}/${viewport}: ${failures.length} text nodes below WCAG AA.\n` +
+            `An UNRESOLVED BACKDROP is a failure, not a skip — text over a gradient/image cannot be measured, ` +
+            `so it must be given a solid backdrop (or the gradient hoisted behind an opaque card).\n\n` +
+            [...new Set(failures)].join('\n\n'),
+        ).toHaveLength(0)
+
+        expect(
+          [...new Set(passing)],
+          `These pairs are in RENDERED_BASELINE but now clear AA — delete their entries in contrastBaseline.ts. ` +
+            `The list only ever shrinks.`,
+        ).toHaveLength(0)
+      })
+    }
+  }
+}

--- a/frontend/e2e/contrastBaseline.ts
+++ b/frontend/e2e/contrastBaseline.ts
@@ -1,0 +1,37 @@
+/**
+ * Part C of the contrast foundation (#651) — the baseline allowlist for the
+ * RENDERED sweep. (The token-value sweep has its own list, in
+ * `src/utils/__tests__/factionContrast.test.ts`.)
+ *
+ * `contrast.spec.ts` was red on landing: this bug family is real, pre-dates
+ * the guard, and has already leaked past three hand audits. Blocking the guard
+ * on the fixes would have kept the leak open, so the known failures are
+ * enumerated here and the fixes land as children. Mirrors the repo's existing
+ * `no-raw-style-values` ratchet doctrine — new violations blocked, known debt
+ * tracked and visible.
+ *
+ * THE KEY IS THE COLOR PAIR, NOT THE DOM NODE. A rendered failure IS a
+ * (text, backdrop) pairing; which component happens to produce it is
+ * incidental, changes with every copy edit, and would make this list rot. So
+ * `theme | rgb(text) on rgb(backdrop)` is the identity, and `where` is only a
+ * breadcrumb for whoever picks up the fix.
+ *
+ * **This list only ever shrinks.** Fixing a pair means DELETING its entry, not
+ * editing the ratio — an allowlisted pair that starts passing fails the spec
+ * on purpose (see `contrast.spec.ts`). Never add an entry for new work.
+ */
+
+export type BaselineEntry = {
+  /** Measured ratio when this entry landed. */
+  ratio: number;
+  /** The issue that owns the fix. 651 = found by the sweep, awaiting a child. */
+  issue: number;
+  /** Where it was seen — a breadcrumb, not part of the identity. */
+  where: string;
+};
+
+export const RENDERED_BASELINE: Record<string, BaselineEntry> = {};
+
+export function baselineKey(theme: string, text: string, background: string): string {
+  return `${theme} | ${text} on ${background}`;
+}

--- a/frontend/e2e/contrastBaseline.ts
+++ b/frontend/e2e/contrastBaseline.ts
@@ -10,20 +10,21 @@
  * `no-raw-style-values` ratchet doctrine — new violations blocked, known debt
  * tracked and visible.
  *
- * THE KEY IS THE COLOR PAIR, NOT THE DOM NODE. A rendered failure IS a
+ * THE KEY IS THE COLOUR PAIR, NOT THE DOM NODE. A rendered failure IS a
  * (text, backdrop) pairing; which component happens to produce it is
  * incidental, changes with every copy edit, and would make this list rot. So
  * `theme | rgb(text) on rgb(backdrop)` is the identity, and `where` is only a
- * breadcrumb for whoever picks up the fix.
+ * breadcrumb for whoever picks up the fix. Unresolved findings are keyed the
+ * same way — on the CSS that defeated resolution, not on a DOM path.
  *
  * **This list only ever shrinks.** Fixing a pair means DELETING its entry, not
  * editing the ratio — an allowlisted pair that starts passing fails the spec
- * on purpose (see `contrast.spec.ts`). Never add an entry for new work.
+ * on purpose. Never add an entry for new work.
  */
 
 export type BaselineEntry = {
-  /** Measured ratio when this entry landed. */
-  ratio: number;
+  /** Measured ratio when this entry landed. `null` for an unresolved backdrop. */
+  ratio: number | null;
   /** The issue that owns the fix. 651 = found by the sweep, awaiting a child. */
   issue: number;
   /** Where it was seen — a breadcrumb, not part of the identity. */
@@ -31,31 +32,308 @@ export type BaselineEntry = {
 };
 
 /**
- * DELIBERATELY EMPTY — this spec does not go green until #651's open question
- * is answered. See the escalation comment on the issue.
+ * Identity of a measured failure.
  *
- * The sweep run produced two populations, and only one of them fits the entry
- * shape above:
- *
- *   - **149 distinct measured failures.** Real, keyed on their color pair,
- *     each carrying a ratio. These are the audit list, and they slot straight
- *     in. (They reproduce all four of #651's hand-measured failures exactly.)
- *
- *   - **134 "unresolved backdrop" findings**, overwhelmingly text sitting on a
- *     surface that paints a *translucent texture* over its own solid fill —
- *     the paper grain `radial-gradient(rgba(0,0,0,0.035) 1px, transparent 1px)`
- *     on `div.page` and on the faction cards. #651 calls failing loudly here
- *     non-negotiable, on the stated premise that "the gradient is only behind
- *     them". The sweep disproves that premise: the grain is painted ON the
- *     text-bearing surfaces. These findings have NO ratio (so they cannot
- *     carry one, as the entry shape requires) and no stable identity except a
- *     DOM path that rots on the next copy edit.
- *
- * Populating this list with 134 DOM-path keys would bury the 149 real findings
- * and rot immediately, so it is left empty rather than guessed at.
+ * `required` is part of the identity, not decoration: the same colour pair can
+ * legitimately pass as 24px display type (3:1) and fail as body copy (4.5:1).
+ * Without it, one node's large-text pass looks like the other node's entry
+ * going stale, and the ratchet fights itself.
  */
-export const RENDERED_BASELINE: Record<string, BaselineEntry> = {};
-
-export function baselineKey(theme: string, text: string, background: string): string {
-  return `${theme} | ${text} on ${background}`;
+export function baselineKey(theme: string, text: string, background: string, required: number): string {
+  return `${theme} | ${text} on ${background} @${required}`;
 }
+
+/**
+ * Identity of an unresolved backdrop — keyed on the CSS that defeated
+ * resolution (stable) rather than the DOM path (rots on the next copy edit).
+ */
+export function unresolvedKey(theme: string, text: string, backdropCss: string, required: number): string {
+  return `${theme} | ${text} over UNRESOLVED ${backdropCss} @${required}`;
+}
+
+/**
+ * THE LIST. 269 entries, machine-produced by the sweep itself
+ * (`CONTRAST_BASELINE_OUT=<path> bash frontend/e2e/run-e2e.sh contrast.spec.ts`),
+ * never hand-typed — 269 hand-copied ratios would be wrong within a week,
+ * which is this issue's whole thesis.
+ *
+ *   - 7 entries owned by #649 (white `--color-text-on-accent` on a faction
+ *     fill). That issue's acceptance, measured as rendered.
+ *   - 56 UNRESOLVED entries: text over a gradient with an OPAQUE stop — the
+ *     WOW `.exe` title bars, the Ephemerists' celestial radial fields, the gilt
+ *     wordmark. The colour genuinely varies under the text, so these stay loud
+ *     rather than being measured against a guess. (Before the texture/fill
+ *     split there were 134 of these, almost all paper grain.)
+ *   - the rest await triage into children off #651.
+ */
+export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
+  "dark | rgb(196, 100, 138) over UNRESOLVED linear-gradient(135deg, rgb(57, 21, 42), rgb(42, 13, 28)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
+  "dark | rgb(196, 100, 138) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 26px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > p' },
+  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
+  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > div > span' },
+  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > div' },
+  "dark | rgb(239, 227, 198) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
+  "dark | rgb(239, 227, 198) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > h1' },
+  "dark | rgb(240, 230, 208) over UNRESOLVED linear-gradient(rgb(19, 18, 26), rgb(19, 18, 26)), linear-gradient(90deg, rgb(79, 70, 229), rgb(190, 24, 93), rgb(249, 115, 22), rgb(22, 163, 74)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop nav.sticky.top-0 > div.max-w-5xl.mx-auto > a.shrink-0.leading-none > span.font-display.italic' },
+  "dark | rgb(244, 114, 182) over UNRESOLVED linear-gradient(135deg, rgb(57, 21, 42), rgb(42, 13, 28)) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > h1' },
+  "dark | rgb(244, 114, 182) over UNRESOLVED linear-gradient(160deg, rgb(94, 42, 70), rgb(196, 100, 138) 60%, rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile div.py-4 > section > div > p' },
+  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
+  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
+  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 26px) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
+  "dark | rgb(251, 207, 224) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
+  "dark | rgb(251, 214, 232) over UNRESOLVED linear-gradient(160deg, rgb(94, 42, 70), rgb(196, 100, 138) 60%, rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/mobile div.py-4 > section > div > h1' },
+  "dark | rgb(251, 214, 232) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
+  "dark | rgb(255, 255, 255) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "dark | rgb(255, 255, 255) over UNRESOLVED linear-gradient(rgb(244, 114, 182), rgb(196, 100, 138)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a' },
+  "dark | rgb(255, 255, 255) over UNRESOLVED radial-gradient(circle at 35% 28%, rgb(94, 42, 70), rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/mobile div > div.flex.items-center > div.shrink-0 > span.flex.w-full' },
+  "dark | rgb(57, 21, 42) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop a > div > div > span' },
+  "dark | rgb(57, 21, 42) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
+  "dark | rgb(79, 143, 176) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > h1 > span' },
+  "dark | rgba(239, 227, 198, 0.62) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > p > span' },
+  "dark | rgba(239, 227, 198, 0.7) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
+  "dark | rgba(239, 227, 198, 0.75) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > div > span' },
+  "dark | rgba(239, 227, 198, 0.92) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > p' },
+  "dark | rgba(251, 214, 232, 0.7) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
+  "dark | rgba(251, 214, 232, 0.75) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
+  "light | rgb(131, 24, 67) over UNRESOLVED linear-gradient(135deg, rgb(255, 253, 250), rgb(253, 238, 243)) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
+  "light | rgb(131, 24, 67) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 26px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > p' },
+  "light | rgb(142, 47, 92) over UNRESOLVED linear-gradient(160deg, rgb(251, 207, 226), rgb(131, 24, 67) 60%, rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/mobile div.py-4 > section > div > h1' },
+  "light | rgb(142, 47, 92) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
+  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > div > span' },
+  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > div' },
+  "light | rgb(236, 95, 153) over UNRESOLVED linear-gradient(135deg, rgb(255, 253, 250), rgb(253, 238, 243)) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > h1' },
+  "light | rgb(236, 95, 153) over UNRESOLVED linear-gradient(160deg, rgb(251, 207, 226), rgb(131, 24, 67) 60%, rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile div.py-4 > section > div > p' },
+  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
+  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
+  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 26px) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
+  "light | rgb(241, 232, 207) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
+  "light | rgb(241, 232, 207) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > h1' },
+  "light | rgb(255, 253, 250) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/desktop a > div > div > span' },
+  "light | rgb(255, 253, 250) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
+  "light | rgb(255, 255, 255) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "light | rgb(255, 255, 255) over UNRESOLVED linear-gradient(rgb(236, 95, 153), rgb(131, 24, 67)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a' },
+  "light | rgb(255, 255, 255) over UNRESOLVED radial-gradient(circle at 35% 28%, rgb(251, 207, 226), rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/mobile div > div.flex.items-center > div.shrink-0 > span.flex.w-full' },
+  "light | rgb(26, 18, 9) over UNRESOLVED linear-gradient(rgb(247, 244, 238), rgb(247, 244, 238)), linear-gradient(90deg, rgb(79, 70, 229), rgb(190, 24, 93), rgb(249, 115, 22), rgb(22, 163, 74)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop nav.sticky.top-0 > div.max-w-5xl.mx-auto > a.shrink-0.leading-none > span.font-display.italic' },
+  "light | rgb(29, 79, 110) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > h1 > span' },
+  "light | rgb(88, 28, 57) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
+  "light | rgba(142, 47, 92, 0.7) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgba(142, 47, 92, 0.75) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgba(241, 232, 207, 0.62) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > p > span' },
+  "light | rgba(241, 232, 207, 0.7) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
+  "light | rgba(241, 232, 207, 0.75) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > div > span' },
+  "light | rgba(241, 232, 207, 0.92) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > p' },
+  "dark | rgb(111, 174, 0) on rgb(244, 241, 232) @3": { ratio: 2.41, issue: 651, where: 'snide/dark/desktop div > div > div > div' },
+  "dark | rgb(111, 174, 0) on rgb(244, 241, 232) @4.5": { ratio: 2.41, issue: 651, where: 'snide/dark/desktop div > div > div > div' },
+  "dark | rgb(12, 10, 6) on rgb(19, 18, 26) @3": { ratio: 1.06, issue: 651, where: 'ephemerists/dark/desktop div.wz-faction-grid > div > div > h2' },
+  "dark | rgb(12, 10, 6) on rgb(33, 26, 16) @3": { ratio: 1.15, issue: 651, where: 'ephemerists/dark/desktop div > div > div > div' },
+  "dark | rgb(122, 112, 96) on rgb(19, 18, 26) @4.5": { ratio: 3.82, issue: 651, where: 'ua/dark/mobile div.min-h-screen.flex > header.sticky.top-0 > div.flex.items-center > a.eyebrow' },
+  "dark | rgb(122, 112, 96) on rgb(28, 27, 34) @4.5": { ratio: 3.51, issue: 651, where: 'ua/dark/desktop div.page > div > div > span' },
+  "dark | rgb(122, 112, 96) on rgb(28, 27, 35) @4.5": { ratio: 3.49, issue: 651, where: 'ua/dark/mobile div.py-4 > div.flex.items-center > div.flex.gap-2 > button' },
+  "dark | rgb(122, 112, 96) on rgb(38, 37, 44) @4.5": { ratio: 3.13, issue: 651, where: 'ua/dark/desktop section > div.grid.grid-cols-3 > div.text-center > div' },
+  "dark | rgb(13, 9, 7) on rgb(19, 18, 26) @3": { ratio: 1.07, issue: 651, where: 'everymen/dark/desktop div > div > div > h2' },
+  "dark | rgb(13, 9, 7) on rgb(23, 17, 13) @4.5": { ratio: 1.06, issue: 651, where: 'everymen/dark/mobile div > div.flex.gap-2 > div.text-center > div.truncate' },
+  "dark | rgb(13, 9, 7) on rgb(33, 25, 21) @3": { ratio: 1.15, issue: 651, where: 'everymen/dark/mobile div > div.flex.items-center > div.min-w-0.flex-1 > a.block.truncate' },
+  "dark | rgb(13, 9, 7) on rgb(33, 25, 21) @4.5": { ratio: 1.15, issue: 651, where: 'ua/dark/mobile div.mt-4 > div.flex.flex-col > a > h2' },
+  "dark | rgb(13, 9, 7) on rgb(34, 26, 22) @4.5": { ratio: 1.16, issue: 651, where: 'everymen/dark/mobile div.py-4 > section.mt-6 > div > span' },
+  "dark | rgb(143, 106, 58) on rgb(19, 18, 26) @4.5": { ratio: 3.80, issue: 651, where: 'ua/dark/desktop div.wz-faction-grid > div > div > p' },
+  "dark | rgb(143, 106, 58) on rgb(236, 228, 210) @4.5": { ratio: 3.87, issue: 651, where: 'ua/dark/mobile main.flex-1.relative > div.py-4 > section.mt-6 > p' },
+  "dark | rgb(143, 106, 58) on rgb(247, 240, 227) @4.5": { ratio: 4.32, issue: 651, where: 'ua/dark/mobile div > div.flex.items-center > div.min-w-0.flex-1 > div.truncate' },
+  "dark | rgb(156, 106, 26) on rgb(236, 228, 210) @4.5": { ratio: 3.70, issue: 651, where: 'ua/dark/mobile div.min-h-screen.flex > main.flex-1.relative > div.py-4 > p' },
+  "dark | rgb(156, 106, 26) on rgb(247, 240, 227) @4.5": { ratio: 4.12, issue: 651, where: 'ua/dark/desktop div > div > div > div' },
+  "dark | rgb(156, 106, 26) on rgb(253, 246, 234) @4.5": { ratio: 4.35, issue: 651, where: 'ua/dark/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "dark | rgb(156, 118, 38) on rgb(33, 26, 16) @4.5": { ratio: 4.13, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
+  "dark | rgb(168, 137, 90) on rgb(236, 228, 210) @4.5": { ratio: 2.60, issue: 651, where: 'ua/dark/mobile main.flex-1.relative > div.page > header > div' },
+  "dark | rgb(168, 137, 90) on rgb(247, 240, 227) @4.5": { ratio: 2.90, issue: 651, where: 'ua/dark/mobile div > div > div.flex.items-center > span' },
+  "dark | rgb(168, 137, 90) on rgb(253, 246, 234) @4.5": { ratio: 3.06, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
+  "dark | rgb(168, 137, 90) on rgb(254, 247, 234) @4.5": { ratio: 3.08, issue: 651, where: 'ua/dark/mobile div > div.flex.gap-2 > div.text-center > div' },
+  "dark | rgb(182, 160, 121) on rgb(243, 231, 206) @4.5": { ratio: 2.07, issue: 651, where: 'everymen/dark/desktop div > div > div > span' },
+  "dark | rgb(192, 83, 58) on rgb(24, 18, 8) @4.5": { ratio: 4.02, issue: 651, where: 'ephemerists/dark/mobile div.min-h-screen.flex > main.flex-1.relative > div.py-4 > p' },
+  "dark | rgb(192, 83, 58) on rgb(33, 26, 16) @4.5": { ratio: 3.72, issue: 651, where: 'ua/dark/desktop div > div > div > div' },
+  "dark | rgb(194, 84, 31) on rgb(247, 240, 227) @4.5": { ratio: 4.04, issue: 651, where: 'ua/dark/mobile div > div > div.flex.items-center > a' },
+  "dark | rgb(194, 84, 31) on rgb(253, 246, 234) @4.5": { ratio: 4.27, issue: 651, where: 'ua/dark/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "dark | rgb(194, 84, 31) on rgb(254, 247, 234) @4.5": { ratio: 4.30, issue: 651, where: 'ua/dark/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "dark | rgb(194, 84, 31) on rgb(28, 27, 35) @4.5": { ratio: 3.71, issue: 651, where: 'ua/dark/desktop div > div > div.sidebar-card > a.font-display.italic' },
+  "dark | rgb(196, 100, 138) on rgb(57, 21, 42) @4.5": { ratio: 4.21, issue: 651, where: 'ua/dark/mobile a > div > div > p' },
+  "dark | rgb(196, 100, 138) on rgb(74, 29, 53) @4.5": { ratio: 3.64, issue: 651, where: 'wow/dark/mobile main.flex-1.relative > div.page > header > div.eyebrow' },
+  "dark | rgb(226, 67, 63) on rgb(231, 185, 79) @4.5": { ratio: 2.24, issue: 651, where: 'everymen/dark/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "dark | rgb(226, 67, 63) on rgb(243, 231, 206) @4.5": { ratio: 3.35, issue: 651, where: 'everymen/dark/desktop div > div > div > b' },
+  "dark | rgb(226, 67, 63) on rgb(33, 25, 21) @4.5": { ratio: 4.21, issue: 651, where: 'everymen/dark/mobile div.page > div > div.flex.items-center > a' },
+  "dark | rgb(226, 67, 63) on rgb(34, 26, 22) @4.5": { ratio: 4.16, issue: 651, where: 'ua/dark/desktop div > div.card-footer > div > span' },
+  "dark | rgb(239, 227, 198) on rgb(192, 83, 58) @4.5": { ratio: 3.63, issue: 651, where: 'ephemerists/dark/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a.flex-1.flex' },
+  "dark | rgb(239, 227, 198) on rgb(79, 143, 176) @4.5": { ratio: 2.80, issue: 651, where: 'ephemerists/dark/desktop div.wz-faction-grid > div > div > div' },
+  "dark | rgb(240, 230, 208) on rgb(250, 249, 247) @4.5": { ratio: 1.18, issue: 651, where: 'albescent/dark/mobile div.flex.flex-col > a.sidebar-card > div > div.font-display.italic' },
+  "dark | rgb(243, 231, 206) on rgb(226, 67, 63) @4.5": { ratio: 3.35, issue: 651, where: 'ua/dark/desktop div > div > div.card-meta > span' },
+  "dark | rgb(244, 241, 232) on rgb(255, 45, 139) @4.5": { ratio: 3.10, issue: 651, where: 'snide/dark/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a.flex-1.flex' },
+  "dark | rgb(253, 246, 234) on rgb(194, 84, 31) @4.5": { ratio: 4.27, issue: 651, where: 'ua/dark/desktop button.fielddesk-life > div > div > span' },
+  "dark | rgb(254, 247, 234) on rgb(194, 84, 31) @4.5": { ratio: 4.30, issue: 651, where: 'ua/dark/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a.flex-1.flex' },
+  "dark | rgb(255, 255, 255) on rgb(136, 136, 136) @4.5": { ratio: 3.54, issue: 651, where: 'ua/dark/desktop div > div > div.sidebar-card > div' },
+  "dark | rgb(255, 255, 255) on rgb(182, 255, 46) @4.5": { ratio: 1.21, issue: 649, where: 'ua/dark/mobile div.py-4 > div > a > span.font-display.italic' },
+  "dark | rgb(255, 255, 255) on rgb(196, 154, 58) @4.5": { ratio: 2.62, issue: 651, where: 'ua/dark/desktop div > div > div.sidebar-card > div' },
+  "dark | rgb(255, 255, 255) on rgb(239, 83, 80) @4.5": { ratio: 3.49, issue: 649, where: 'ua/dark/mobile div.py-4 > div > a > span.font-display.italic' },
+  "dark | rgb(255, 255, 255) on rgb(240, 230, 208) @4.5": { ratio: 1.24, issue: 651, where: 'ua/dark/mobile div.py-4 > div.flex.items-center > div.flex.gap-2 > button' },
+  "dark | rgb(255, 255, 255) on rgb(244, 114, 182) @3": { ratio: 2.65, issue: 651, where: 'ua/dark/desktop div > div > div > button' },
+  "dark | rgb(255, 255, 255) on rgb(244, 114, 182) @4.5": { ratio: 2.65, issue: 649, where: 'ua/dark/mobile div.py-4 > div > a > span.font-display.italic' },
+  "dark | rgb(255, 255, 255) on rgb(245, 158, 11) @4.5": { ratio: 2.15, issue: 651, where: 'ua/dark/desktop div > div > div.sidebar-card > div' },
+  "dark | rgb(255, 255, 255) on rgb(255, 45, 139) @4.5": { ratio: 3.50, issue: 651, where: 'ua/dark/desktop a > div > span > span' },
+  "dark | rgb(255, 255, 255) on rgb(58, 160, 164) @4.5": { ratio: 3.11, issue: 649, where: 'ua/dark/mobile div.py-4 > div > a > span.font-display.italic' },
+  "dark | rgb(255, 255, 255) on rgb(96, 165, 250) @4.5": { ratio: 2.54, issue: 649, where: 'ua/dark/mobile div.py-4 > div > a > span.font-display.italic' },
+  "dark | rgb(28, 28, 26) on rgb(28, 27, 35) @3": { ratio: 1.00, issue: 651, where: 'albescent/dark/desktop div > div > div.sidebar-card > div.font-display.italic' },
+  "dark | rgb(28, 28, 26) on rgb(28, 27, 35) @4.5": { ratio: 1.00, issue: 651, where: 'albescent/dark/desktop div > div > div.sidebar-card > a.font-display.italic' },
+  "dark | rgb(33, 26, 16) on rgb(192, 83, 58) @4.5": { ratio: 3.72, issue: 651, where: 'ephemerists/dark/desktop button.fielddesk-life > div > div > span' },
+  "dark | rgb(34, 26, 22) on rgb(226, 67, 63) @4.5": { ratio: 4.16, issue: 651, where: 'ua/dark/desktop div > div.card-footer > div > span' },
+  "dark | rgb(61, 36, 16) on rgb(19, 18, 26) @3": { ratio: 1.29, issue: 651, where: 'ua/dark/desktop div > div > div > h2' },
+  "dark | rgb(74, 72, 96) on rgb(18, 17, 25) @4.5": { ratio: 2.13, issue: 651, where: 'ua/dark/desktop div.gap-4.items-start > main.min-w-0 > div.page > p' },
+  "dark | rgb(74, 72, 96) on rgb(19, 18, 26) @4.5": { ratio: 2.11, issue: 651, where: 'ua/dark/mobile div.min-h-screen.flex > main.flex-1.relative > div.py-4 > p.eyebrow.mb-3' },
+  "dark | rgb(74, 72, 96) on rgb(23, 32, 40) @4.5": { ratio: 1.87, issue: 651, where: 'ephemerists/dark/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "dark | rgb(74, 72, 96) on rgb(27, 33, 48) @4.5": { ratio: 1.83, issue: 651, where: 'singularity/dark/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "dark | rgb(74, 72, 96) on rgb(28, 27, 35) @4.5": { ratio: 1.93, issue: 651, where: 'ua/dark/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "dark | rgb(74, 72, 96) on rgb(32, 33, 53) @4.5": { ratio: 1.80, issue: 651, where: 'ua/dark/desktop div.py-8 > div > div.flex-1 > span.eyebrow' },
+  "dark | rgb(74, 72, 96) on rgb(33, 23, 26) @4.5": { ratio: 1.98, issue: 651, where: 'ua/dark/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "dark | rgb(74, 72, 96) on rgb(36, 20, 28) @4.5": { ratio: 2.00, issue: 651, where: 'everymen/dark/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "dark | rgb(74, 72, 96) on rgb(37, 26, 38) @4.5": { ratio: 1.91, issue: 651, where: 'wow/dark/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "dark | rgb(74, 72, 96) on rgb(39, 46, 28) @4.5": { ratio: 1.59, issue: 651, where: 'snide/dark/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "dark | rgba(122, 112, 96, 0.7) on rgb(33, 32, 39) @3": { ratio: 2.31, issue: 651, where: 'ua/dark/desktop div.page > div > div > div' },
+  "dark | rgba(122, 112, 96, 0.7) on rgb(33, 32, 39) @4.5": { ratio: 2.31, issue: 651, where: 'ua/dark/desktop div > div > div > b' },
+  "dark | rgba(136, 136, 136, 0.13) on rgb(28, 27, 35) @4.5": { ratio: 1.19, issue: 651, where: 'ua/dark/desktop div.py-8 > div > div > div' },
+  "dark | rgba(196, 154, 58, 0.13) on rgb(33, 29, 29) @3": { ratio: 1.24, issue: 651, where: 'ua/dark/desktop div.py-8 > div > div > div' },
+  "dark | rgba(226, 67, 63, 0.92) on rgb(34, 26, 22) @4.5": { ratio: 3.71, issue: 651, where: 'ua/dark/desktop div > div.card-footer > div > span' },
+  "dark | rgba(245, 158, 11, 0.13) on rgb(37, 29, 25) @3": { ratio: 1.28, issue: 651, where: 'ua/dark/desktop div.py-8 > div > div > div' },
+  "dark | rgba(255, 255, 255, 0.85) on rgb(182, 255, 46) @4.5": { ratio: 1.17, issue: 651, where: 'ua/dark/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "dark | rgba(255, 255, 255, 0.85) on rgb(194, 84, 31) @4.5": { ratio: 3.76, issue: 651, where: 'ua/dark/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "dark | rgba(255, 255, 255, 0.85) on rgb(239, 83, 80) @4.5": { ratio: 2.91, issue: 651, where: 'ua/dark/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "dark | rgba(255, 255, 255, 0.85) on rgb(244, 114, 182) @4.5": { ratio: 2.30, issue: 651, where: 'ua/dark/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "dark | rgba(255, 255, 255, 0.85) on rgb(58, 160, 164) @4.5": { ratio: 2.68, issue: 651, where: 'ua/dark/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "dark | rgba(255, 255, 255, 0.85) on rgb(96, 165, 250) @4.5": { ratio: 2.24, issue: 651, where: 'ua/dark/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "dark | rgba(28, 28, 26, 0.22) on rgb(255, 255, 255) @4.5": { ratio: 1.59, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
+  "dark | rgba(28, 28, 26, 0.24) on rgb(255, 255, 255) @4.5": { ratio: 1.66, issue: 651, where: 'ua/dark/mobile div.flex.flex-col > a > span > i' },
+  "dark | rgba(28, 28, 26, 0.3) on rgb(247, 244, 238) @4.5": { ratio: 1.90, issue: 651, where: 'albescent/dark/mobile div.page > header > div > div' },
+  "dark | rgba(28, 28, 26, 0.3) on rgb(255, 255, 255) @4.5": { ratio: 1.92, issue: 651, where: 'albescent/dark/mobile div.page > div > div.flex.items-center > span' },
+  "dark | rgba(28, 28, 26, 0.4) on rgb(255, 255, 255) @4.5": { ratio: 2.49, issue: 651, where: 'albescent/dark/mobile div.page > div > div.flex.items-center > span' },
+  "dark | rgba(28, 28, 26, 0.42) on rgb(255, 255, 255) @4.5": { ratio: 2.63, issue: 651, where: 'ua/dark/mobile div.mt-4 > div.flex.flex-col > a > p' },
+  "dark | rgba(28, 28, 26, 0.45) on rgb(255, 255, 255) @4.5": { ratio: 2.86, issue: 651, where: 'albescent/dark/mobile main.flex-1.relative > div.page > div > p' },
+  "dark | rgba(28, 28, 26, 0.5) on rgb(255, 255, 255) @4.5": { ratio: 3.30, issue: 651, where: 'albescent/dark/mobile div.page > div > div.flex.items-center > a' },
+  "dark | rgba(28, 28, 26, 0.52) on rgb(255, 255, 255) @4.5": { ratio: 3.50, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
+  "dark | rgba(28, 28, 26, 0.55) on rgb(246, 246, 246) @4.5": { ratio: 3.75, issue: 651, where: 'albescent/dark/mobile div > div.flex.items-center > div.shrink-0.flex > span' },
+  "dark | rgba(28, 28, 26, 0.55) on rgb(255, 255, 255) @4.5": { ratio: 3.84, issue: 651, where: 'ua/dark/mobile div.flex.flex-col > a > div.flex.items-center > span' },
+  "dark | rgba(74, 222, 128, 0.4) on rgb(19, 18, 26) @4.5": { ratio: 2.64, issue: 651, where: 'singularity/dark/desktop div.wz-faction-grid > div > div > div' },
+  "dark | rgba(74, 222, 128, 0.4) on rgb(5, 15, 8) @4.5": { ratio: 2.65, issue: 651, where: 'singularity/dark/desktop div > div > div > div' },
+  "dark | rgba(74, 222, 128, 0.45) on rgb(19, 18, 26) @4.5": { ratio: 3.03, issue: 651, where: 'singularity/dark/desktop div.wz-faction-grid > div > div > p' },
+  "dark | rgba(74, 222, 128, 0.45) on rgb(5, 15, 8) @4.5": { ratio: 3.06, issue: 651, where: 'singularity/dark/mobile div.page > div > div > p' },
+  "dark | rgba(74, 222, 128, 0.5) on rgb(5, 15, 8) @4.5": { ratio: 3.51, issue: 651, where: 'singularity/dark/mobile main.flex-1.relative > div.py-4 > section.mt-6 > p' },
+  "dark | rgba(74, 222, 128, 0.55) on rgb(5, 15, 8) @4.5": { ratio: 4.02, issue: 651, where: 'ua/dark/mobile div.mt-4 > div.flex.flex-col > a > p' },
+  "dark | rgba(74, 222, 128, 0.6) on rgb(96, 165, 250) @4.5": { ratio: 1.23, issue: 651, where: 'singularity/dark/desktop div > div > div > span' },
+  "dark | rgba(74, 72, 96, 0.7) on rgb(33, 32, 39) @4.5": { ratio: 1.51, issue: 651, where: 'ua/dark/desktop div.page > div > div > div' },
+  "dark | rgba(96, 165, 250, 0.5) on rgb(14, 30, 32) @4.5": { ratio: 2.67, issue: 651, where: 'singularity/dark/desktop div > div > div > span' },
+  "dark | rgba(96, 165, 250, 0.55) on rgb(14, 30, 32) @4.5": { ratio: 2.96, issue: 651, where: 'singularity/dark/desktop div > div > div > div' },
+  "dark | rgba(96, 165, 250, 0.55) on rgb(5, 15, 8) @4.5": { ratio: 3.04, issue: 651, where: 'singularity/dark/desktop div > div > div > div' },
+  "dark | rgba(96, 165, 250, 0.6) on rgb(12, 27, 27) @4.5": { ratio: 3.32, issue: 651, where: 'singularity/dark/mobile div > div.flex.gap-2 > div.text-center > div' },
+  "dark | rgba(96, 165, 250, 0.6) on rgb(5, 15, 8) @4.5": { ratio: 3.41, issue: 651, where: 'ua/dark/mobile div.flex.flex-col > a > div.flex.items-center > span' },
+  "dark | rgba(96, 165, 250, 0.7) on rgb(5, 15, 8) @4.5": { ratio: 4.24, issue: 651, where: 'singularity/dark/desktop header > div > div > div' },
+  "light | rgb(108, 90, 64) on rgb(221, 206, 172) @4.5": { ratio: 4.25, issue: 651, where: 'everymen/light/mobile div > div.flex.gap-2 > div.text-center > div' },
+  "light | rgb(111, 174, 0) on rgb(239, 236, 227) @4.5": { ratio: 2.30, issue: 651, where: 'snide/light/mobile div.min-h-screen.flex > main.flex-1.relative > div.py-4 > p' },
+  "light | rgb(111, 174, 0) on rgb(244, 241, 232) @3": { ratio: 2.41, issue: 651, where: 'snide/light/desktop div > div > div > div' },
+  "light | rgb(111, 174, 0) on rgb(244, 241, 232) @4.5": { ratio: 2.41, issue: 651, where: 'snide/light/desktop div > div > div > div' },
+  "light | rgb(111, 174, 0) on rgb(253, 252, 250) @3": { ratio: 2.65, issue: 651, where: 'snide/light/desktop div > div > div.sidebar-card > div.font-display.italic' },
+  "light | rgb(111, 174, 0) on rgb(253, 252, 250) @4.5": { ratio: 2.65, issue: 651, where: 'snide/light/desktop div > div > div.sidebar-card > a.font-display.italic' },
+  "light | rgb(111, 92, 62) on rgb(220, 203, 162) @4.5": { ratio: 4.00, issue: 651, where: 'ephemerists/light/mobile div.page > header > div > span' },
+  "light | rgb(124, 191, 153) on rgb(255, 253, 250) @3": { ratio: 2.12, issue: 651, where: 'wow/light/desktop div > div > div > span' },
+  "light | rgb(138, 102, 34) on rgb(233, 220, 191) @4.5": { ratio: 3.86, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgb(143, 106, 58) on rgb(236, 228, 210) @4.5": { ratio: 3.87, issue: 651, where: 'ua/light/mobile main.flex-1.relative > div.py-4 > section.mt-6 > p' },
+  "light | rgb(143, 106, 58) on rgb(247, 240, 227) @4.5": { ratio: 4.32, issue: 651, where: 'ua/light/mobile div > div.flex.items-center > div.min-w-0.flex-1 > div.truncate' },
+  "light | rgb(143, 106, 58) on rgb(247, 244, 238) @4.5": { ratio: 4.46, issue: 651, where: 'ua/light/desktop div.wz-faction-grid > div > div > p' },
+  "light | rgb(155, 142, 125) on rgb(225, 231, 226) @4.5": { ratio: 2.54, issue: 651, where: 'ephemerists/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(155, 142, 125) on rgb(226, 230, 238) @4.5": { ratio: 2.55, issue: 651, where: 'singularity/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(155, 142, 125) on rgb(234, 230, 237) @4.5": { ratio: 2.60, issue: 651, where: 'ua/light/desktop div.py-8 > div > div.flex-1 > span.eyebrow' },
+  "light | rgb(155, 142, 125) on rgb(237, 246, 207) @4.5": { ratio: 2.84, issue: 651, where: 'snide/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(155, 142, 125) on rgb(238, 235, 230) @4.5": { ratio: 2.70, issue: 651, where: 'ua/light/desktop div.gap-4.items-start > main.min-w-0 > div.page > p' },
+  "light | rgb(155, 142, 125) on rgb(242, 224, 219) @4.5": { ratio: 2.50, issue: 651, where: 'everymen/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(155, 142, 125) on rgb(243, 231, 221) @4.5": { ratio: 2.64, issue: 651, where: 'ua/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(155, 142, 125) on rgb(246, 229, 230) @4.5": { ratio: 2.63, issue: 651, where: 'wow/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(155, 142, 125) on rgb(247, 244, 238) @4.5": { ratio: 2.92, issue: 651, where: 'ua/light/mobile div.min-h-screen.flex > main.flex-1.relative > div.py-4 > p.eyebrow.mb-3' },
+  "light | rgb(155, 142, 125) on rgb(250, 249, 247) @4.5": { ratio: 3.04, issue: 651, where: 'albescent/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(155, 142, 125) on rgb(253, 252, 250) @4.5": { ratio: 3.12, issue: 651, where: 'ua/light/mobile div.mt-4 > div.flex.flex-col > a.sidebar-card > span.font-display.italic' },
+  "light | rgb(156, 106, 26) on rgb(236, 228, 210) @4.5": { ratio: 3.70, issue: 651, where: 'ua/light/mobile div.min-h-screen.flex > main.flex-1.relative > div.py-4 > p' },
+  "light | rgb(156, 106, 26) on rgb(247, 240, 227) @4.5": { ratio: 4.12, issue: 651, where: 'ua/light/desktop div > div > div > div' },
+  "light | rgb(156, 106, 26) on rgb(253, 246, 234) @4.5": { ratio: 4.35, issue: 651, where: 'ua/light/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "light | rgb(156, 54, 34) on rgb(220, 203, 162) @4.5": { ratio: 4.42, issue: 651, where: 'ephemerists/light/mobile div.min-h-screen.flex > main.flex-1.relative > div.py-4 > p' },
+  "light | rgb(168, 137, 90) on rgb(236, 228, 210) @4.5": { ratio: 2.60, issue: 651, where: 'ua/light/mobile main.flex-1.relative > div.page > header > div' },
+  "light | rgb(168, 137, 90) on rgb(247, 240, 227) @4.5": { ratio: 2.90, issue: 651, where: 'ua/light/mobile div > div > div.flex.items-center > span' },
+  "light | rgb(168, 137, 90) on rgb(247, 244, 238) @4.5": { ratio: 2.99, issue: 651, where: 'ua/light/desktop div > div > div > div' },
+  "light | rgb(168, 137, 90) on rgb(253, 246, 234) @4.5": { ratio: 3.06, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgb(168, 137, 90) on rgb(254, 247, 234) @4.5": { ratio: 3.08, issue: 651, where: 'ua/light/mobile div > div.flex.gap-2 > div.text-center > div' },
+  "light | rgb(168, 58, 110) on rgb(251, 207, 226) @4.5": { ratio: 4.33, issue: 651, where: 'ua/light/desktop div > div > div > div' },
+  "light | rgb(181, 88, 138) on rgb(255, 253, 250) @4.5": { ratio: 4.37, issue: 651, where: 'ua/light/desktop div > div > div > p' },
+  "light | rgb(182, 255, 46) on rgb(239, 236, 227) @4.5": { ratio: 1.03, issue: 651, where: 'snide/light/mobile div.py-4 > section.mt-6 > div > span' },
+  "light | rgb(182, 255, 46) on rgb(247, 244, 238) @3": { ratio: 1.10, issue: 651, where: 'snide/light/desktop div > div > div > span' },
+  "light | rgb(193, 39, 45) on rgb(217, 154, 43) @4.5": { ratio: 2.39, issue: 651, where: 'everymen/light/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "light | rgb(193, 39, 45) on rgb(224, 213, 187) @4.5": { ratio: 4.01, issue: 651, where: 'ua/light/mobile div.mt-4 > div.flex.flex-col > a > span' },
+  "light | rgb(193, 39, 45) on rgb(236, 225, 198) @4.5": { ratio: 4.49, issue: 651, where: 'ua/light/desktop div > div.card-footer > div > span' },
+  "light | rgb(194, 84, 31) on rgb(247, 240, 227) @4.5": { ratio: 4.04, issue: 651, where: 'ua/light/mobile div > div > div.flex.items-center > a' },
+  "light | rgb(194, 84, 31) on rgb(253, 246, 234) @4.5": { ratio: 4.27, issue: 651, where: 'ua/light/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "light | rgb(194, 84, 31) on rgb(253, 252, 250) @4.5": { ratio: 4.47, issue: 651, where: 'ua/light/desktop div > div > div.sidebar-card > a.font-display.italic' },
+  "light | rgb(194, 84, 31) on rgb(254, 247, 234) @4.5": { ratio: 4.30, issue: 651, where: 'ua/light/mobile section.mt-6 > div.flex.flex-col > a > span' },
+  "light | rgb(212, 171, 85) on rgb(233, 220, 191) @4.5": { ratio: 1.58, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgb(212, 171, 85) on rgb(29, 79, 110) @4.5": { ratio: 4.07, issue: 651, where: 'ua/light/desktop div > div > div > div' },
+  "light | rgb(216, 214, 200) on rgb(239, 236, 227) @4.5": { ratio: 1.24, issue: 651, where: 'snide/light/mobile main.flex-1.relative > div.page > header > div' },
+  "light | rgb(216, 214, 200) on rgb(247, 244, 238) @4.5": { ratio: 1.33, issue: 651, where: 'snide/light/desktop div.wz-faction-grid > div > div > p' },
+  "light | rgb(217, 154, 43) on rgb(193, 39, 45) @4.5": { ratio: 2.39, issue: 651, where: 'everymen/light/desktop div > div > div > div' },
+  "light | rgb(236, 225, 198) on rgb(193, 39, 45) @4.5": { ratio: 4.49, issue: 651, where: 'ua/light/desktop div > div.card-footer > div > span' },
+  "light | rgb(236, 95, 153) on rgb(245, 208, 227) @4.5": { ratio: 2.26, issue: 651, where: 'ua/light/desktop div > div > div.card-footer > span' },
+  "light | rgb(236, 95, 153) on rgb(253, 238, 243) @4.5": { ratio: 2.81, issue: 651, where: 'wow/light/desktop button.fielddesk-life > div > div > span' },
+  "light | rgb(236, 95, 153) on rgb(253, 238, 246) @4.5": { ratio: 2.81, issue: 651, where: 'ua/light/mobile div > div > div.flex.items-center > span' },
+  "light | rgb(236, 95, 153) on rgb(253, 252, 250) @4.5": { ratio: 3.07, issue: 651, where: 'wow/light/desktop div > div > div.sidebar-card > a.font-display.italic' },
+  "light | rgb(236, 95, 153) on rgb(255, 253, 250) @4.5": { ratio: 3.10, issue: 651, where: 'ua/light/mobile a > div > div > span' },
+  "light | rgb(244, 241, 232) on rgb(255, 45, 139) @4.5": { ratio: 3.10, issue: 651, where: 'snide/light/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a.flex-1.flex' },
+  "light | rgb(253, 238, 243) on rgb(236, 95, 153) @4.5": { ratio: 2.81, issue: 651, where: 'ua/light/desktop div > div > div.card-footer > span' },
+  "light | rgb(253, 246, 234) on rgb(194, 84, 31) @4.5": { ratio: 4.27, issue: 651, where: 'ua/light/desktop button.fielddesk-life > div > div > span' },
+  "light | rgb(254, 247, 234) on rgb(194, 84, 31) @4.5": { ratio: 4.30, issue: 651, where: 'ua/light/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a.flex-1.flex' },
+  "light | rgb(255, 255, 255) on rgb(111, 174, 0) @4.5": { ratio: 2.72, issue: 649, where: 'ua/light/mobile div.py-4 > div > a > span.font-display.italic' },
+  "light | rgb(255, 255, 255) on rgb(136, 136, 136) @4.5": { ratio: 3.54, issue: 651, where: 'ua/light/desktop div > div > div.sidebar-card > div' },
+  "light | rgb(255, 255, 255) on rgb(196, 154, 58) @4.5": { ratio: 2.62, issue: 651, where: 'ua/light/desktop div > div > div.sidebar-card > div' },
+  "light | rgb(255, 255, 255) on rgb(236, 95, 153) @4.5": { ratio: 3.15, issue: 649, where: 'ua/light/mobile div.py-4 > div > a > span.font-display.italic' },
+  "light | rgb(255, 255, 255) on rgb(245, 158, 11) @4.5": { ratio: 2.15, issue: 651, where: 'ua/light/desktop div > div > div.sidebar-card > div' },
+  "light | rgb(255, 255, 255) on rgb(255, 45, 139) @4.5": { ratio: 3.50, issue: 651, where: 'ua/light/desktop a > div > span > span' },
+  "light | rgb(255, 45, 139) on rgb(247, 244, 238) @4.5": { ratio: 3.19, issue: 651, where: 'snide/light/desktop div.wz-faction-grid > div > div > div' },
+  "light | rgb(29, 110, 114) on rgb(233, 220, 191) @4.5": { ratio: 4.38, issue: 651, where: 'ua/light/mobile div.mt-4 > div.flex.flex-col > a > span' },
+  "light | rgb(5, 15, 8) on rgb(37, 99, 235) @4.5": { ratio: 3.77, issue: 651, where: 'singularity/light/desktop div > div > div > span' },
+  "light | rgb(74, 222, 128) on rgb(247, 244, 238) @3": { ratio: 1.59, issue: 651, where: 'singularity/light/desktop div > div > div > h2' },
+  "light | rgba(107, 96, 80, 0.7) on rgb(240, 237, 230) @3": { ratio: 2.90, issue: 651, where: 'ua/light/desktop div.page > div > div > div' },
+  "light | rgba(107, 96, 80, 0.7) on rgb(240, 237, 230) @4.5": { ratio: 2.90, issue: 651, where: 'ua/light/desktop div > div > div > b' },
+  "light | rgba(111, 92, 62, 0.85) on rgb(233, 220, 191) @4.5": { ratio: 3.56, issue: 651, where: 'ua/light/desktop div > div > div > div' },
+  "light | rgba(136, 136, 136, 0.13) on rgb(238, 235, 230) @4.5": { ratio: 1.13, issue: 651, where: 'ua/light/desktop div.py-8 > div > div > div' },
+  "light | rgba(155, 142, 125, 0.7) on rgb(240, 237, 230) @4.5": { ratio: 1.95, issue: 651, where: 'ua/light/desktop div.page > div > div > div' },
+  "light | rgba(193, 39, 45, 0.92) on rgb(236, 225, 198) @4.5": { ratio: 4.10, issue: 651, where: 'ua/light/desktop div > div.card-footer > div > span' },
+  "light | rgba(196, 154, 58, 0.13) on rgb(243, 237, 224) @3": { ratio: 1.10, issue: 651, where: 'ua/light/desktop div.py-8 > div > div > div' },
+  "light | rgba(212, 171, 85, 0.7) on rgb(29, 79, 110) @4.5": { ratio: 2.73, issue: 651, where: 'ua/light/desktop div > div > div > div' },
+  "light | rgba(244, 236, 214, 0.9) on rgb(193, 39, 45) @4.5": { ratio: 4.26, issue: 651, where: 'ua/light/desktop div > div > div > div' },
+  "light | rgba(245, 158, 11, 0.13) on rgb(247, 237, 220) @3": { ratio: 1.09, issue: 651, where: 'ua/light/desktop div.py-8 > div > div > div' },
+  "light | rgba(255, 255, 255, 0.85) on rgb(111, 174, 0) @4.5": { ratio: 2.36, issue: 651, where: 'ua/light/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "light | rgba(255, 255, 255, 0.85) on rgb(194, 84, 31) @4.5": { ratio: 3.76, issue: 651, where: 'ua/light/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "light | rgba(255, 255, 255, 0.85) on rgb(236, 95, 153) @4.5": { ratio: 2.68, issue: 651, where: 'ua/light/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "light | rgba(255, 255, 255, 0.85) on rgb(37, 99, 235) @4.5": { ratio: 4.19, issue: 651, where: 'ua/light/desktop div.py-8 > div.flex.flex-col > div.flex.gap-1 > button.pennant-shape' },
+  "light | rgba(28, 28, 26, 0.22) on rgb(255, 255, 255) @4.5": { ratio: 1.59, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgba(28, 28, 26, 0.24) on rgb(255, 255, 255) @4.5": { ratio: 1.66, issue: 651, where: 'ua/light/mobile div.flex.flex-col > a > span > i' },
+  "light | rgba(28, 28, 26, 0.3) on rgb(247, 244, 238) @4.5": { ratio: 1.90, issue: 651, where: 'albescent/light/mobile div.page > header > div > div' },
+  "light | rgba(28, 28, 26, 0.3) on rgb(255, 255, 255) @4.5": { ratio: 1.92, issue: 651, where: 'albescent/light/mobile div.page > div > div.flex.items-center > span' },
+  "light | rgba(28, 28, 26, 0.4) on rgb(255, 255, 255) @4.5": { ratio: 2.49, issue: 651, where: 'albescent/light/mobile div.page > div > div.flex.items-center > span' },
+  "light | rgba(28, 28, 26, 0.42) on rgb(255, 255, 255) @4.5": { ratio: 2.63, issue: 651, where: 'ua/light/mobile div.mt-4 > div.flex.flex-col > a > p' },
+  "light | rgba(28, 28, 26, 0.45) on rgb(255, 255, 255) @4.5": { ratio: 2.86, issue: 651, where: 'albescent/light/mobile main.flex-1.relative > div.page > div > p' },
+  "light | rgba(28, 28, 26, 0.5) on rgb(255, 255, 255) @4.5": { ratio: 3.30, issue: 651, where: 'albescent/light/mobile div.page > div > div.flex.items-center > a' },
+  "light | rgba(28, 28, 26, 0.52) on rgb(255, 255, 255) @4.5": { ratio: 3.50, issue: 651, where: 'ua/light/desktop div > div > div > span' },
+  "light | rgba(28, 28, 26, 0.55) on rgb(246, 246, 246) @4.5": { ratio: 3.75, issue: 651, where: 'albescent/light/mobile div > div.flex.items-center > div.shrink-0.flex > span' },
+  "light | rgba(28, 28, 26, 0.55) on rgb(255, 255, 255) @4.5": { ratio: 3.84, issue: 651, where: 'ua/light/mobile div.flex.flex-col > a > div.flex.items-center > span' },
+  "light | rgba(74, 222, 128, 0.4) on rgb(247, 244, 238) @4.5": { ratio: 1.23, issue: 651, where: 'singularity/light/desktop div.wz-faction-grid > div > div > div' },
+  "light | rgba(74, 222, 128, 0.4) on rgb(5, 15, 8) @4.5": { ratio: 2.65, issue: 651, where: 'singularity/light/desktop div > div > div > div' },
+  "light | rgba(74, 222, 128, 0.45) on rgb(247, 244, 238) @4.5": { ratio: 1.26, issue: 651, where: 'singularity/light/desktop div.wz-faction-grid > div > div > p' },
+  "light | rgba(74, 222, 128, 0.45) on rgb(5, 15, 8) @4.5": { ratio: 3.06, issue: 651, where: 'singularity/light/mobile div.page > div > div > p' },
+  "light | rgba(74, 222, 128, 0.5) on rgb(5, 15, 8) @4.5": { ratio: 3.51, issue: 651, where: 'singularity/light/mobile main.flex-1.relative > div.py-4 > section.mt-6 > p' },
+  "light | rgba(74, 222, 128, 0.55) on rgb(5, 15, 8) @4.5": { ratio: 4.02, issue: 651, where: 'ua/light/mobile div.mt-4 > div.flex.flex-col > a > p' },
+  "light | rgba(74, 222, 128, 0.6) on rgb(37, 99, 235) @4.5": { ratio: 1.90, issue: 651, where: 'singularity/light/desktop div > div > div > span' },
+  "light | rgba(96, 165, 250, 0.5) on rgb(8, 23, 31) @4.5": { ratio: 2.71, issue: 651, where: 'singularity/light/desktop div > div > div > span' },
+  "light | rgba(96, 165, 250, 0.55) on rgb(5, 15, 8) @4.5": { ratio: 3.04, issue: 651, where: 'singularity/light/desktop div > div > div > div' },
+  "light | rgba(96, 165, 250, 0.55) on rgb(8, 23, 31) @4.5": { ratio: 3.02, issue: 651, where: 'singularity/light/desktop div > div > div > div' },
+  "light | rgba(96, 165, 250, 0.6) on rgb(12, 27, 27) @4.5": { ratio: 3.32, issue: 651, where: 'singularity/light/mobile div > div.flex.gap-2 > div.text-center > div' },
+  "light | rgba(96, 165, 250, 0.6) on rgb(5, 15, 8) @4.5": { ratio: 3.41, issue: 651, where: 'ua/light/mobile div.flex.flex-col > a > div.flex.items-center > span' },
+  "light | rgba(96, 165, 250, 0.7) on rgb(5, 15, 8) @4.5": { ratio: 4.24, issue: 651, where: 'singularity/light/desktop header > div > div > div' },
+};

--- a/frontend/e2e/contrastBaseline.ts
+++ b/frontend/e2e/contrastBaseline.ts
@@ -30,6 +30,30 @@ export type BaselineEntry = {
   where: string;
 };
 
+/**
+ * DELIBERATELY EMPTY — this spec does not go green until #651's open question
+ * is answered. See the escalation comment on the issue.
+ *
+ * The sweep run produced two populations, and only one of them fits the entry
+ * shape above:
+ *
+ *   - **149 distinct measured failures.** Real, keyed on their color pair,
+ *     each carrying a ratio. These are the audit list, and they slot straight
+ *     in. (They reproduce all four of #651's hand-measured failures exactly.)
+ *
+ *   - **134 "unresolved backdrop" findings**, overwhelmingly text sitting on a
+ *     surface that paints a *translucent texture* over its own solid fill —
+ *     the paper grain `radial-gradient(rgba(0,0,0,0.035) 1px, transparent 1px)`
+ *     on `div.page` and on the faction cards. #651 calls failing loudly here
+ *     non-negotiable, on the stated premise that "the gradient is only behind
+ *     them". The sweep disproves that premise: the grain is painted ON the
+ *     text-bearing surfaces. These findings have NO ratio (so they cannot
+ *     carry one, as the entry shape requires) and no stable identity except a
+ *     DOM path that rots on the next copy edit.
+ *
+ * Populating this list with 134 DOM-path keys would bury the 149 real findings
+ * and rot immediately, so it is left empty rather than guessed at.
+ */
 export const RENDERED_BASELINE: Record<string, BaselineEntry> = {};
 
 export function baselineKey(theme: string, text: string, background: string): string {

--- a/frontend/e2e/contrastScan.ts
+++ b/frontend/e2e/contrastScan.ts
@@ -1,0 +1,267 @@
+/**
+ * The in-page half of the rendered contrast sweep (#651).
+ *
+ * This module is serialized into the browser by `contrast.spec.ts` — it may
+ * not import anything (Playwright's `page.evaluate` ships the function source,
+ * not its module graph), so the small amount of WCAG math it needs is inlined
+ * inside `scanPageForContrast`. `src/utils/contrast.ts` remains the source of
+ * truth for the node-side math; the duplication here is a constraint of the
+ * evaluate boundary, not a second opinion.
+ */
+
+/** One measured text node. `background: null` means "could not resolve to a solid". */
+export type Finding = {
+  /** `rgb(r, g, b)` of the text, alpha already folded in from ancestor opacity. */
+  text: string;
+  /** The nearest resolved opaque backdrop, or null if it was a gradient/image. */
+  background: string | null;
+  /** Why it could not resolve — only set when `background` is null. */
+  unresolved: string | null;
+  /**
+   * What KIND of unresolvable backdrop this is (#651 audit):
+   *  - `texture`         — a gradient whose every color stop is translucent
+   *                        (paper grain, ruled lines). It sits ON a solid
+   *                        background-color and perturbs it by a few percent.
+   *  - `opaque-gradient` — a gradient with an opaque stop: a real fill whose
+   *                        color genuinely varies under the text.
+   *  - `other`           — an image, or a background-color we cannot parse.
+   */
+  unresolvedKind: 'texture' | 'opaque-gradient' | 'other' | null;
+  ratio: number;
+  required: number;
+  fontSizePx: number;
+  fontWeight: number;
+  /** A human-findable pointer: tag chain + a snippet of the offending text. */
+  where: string;
+  sample: string;
+};
+
+/**
+ * Walk every visible text node on the page, resolve the backdrop each one
+ * actually sits on, and measure the contrast.
+ *
+ * Two deliberate behaviours, both of them the reason this exists rather than
+ * an axe-core dependency:
+ *
+ *  1. **A gradient/image backdrop is a FAILURE, not a skip.** axe returns
+ *     "incomplete" there, which reads as green — and this app's flavor
+ *     surfaces (`.em-backdrop`, the S.N.I.D.E. flyposted wall, the
+ *     unaffiliated `repeating-conic-gradient`) are exactly that shape. Today
+ *     the broken text happens to sit on cards with solid fills and the
+ *     gradients are only *behind* those cards; that is luck, and the sweep
+ *     asserts it instead of assuming it.
+ *
+ *  2. **`aria-hidden="true"` text is ignored.** WCAG exempts incidental /
+ *     decorative content, and at least one such element (the Albescent mono
+ *     masthead, `AlbescentFeedFrame.tsx`) is intentionally ghosted — design
+ *     confirmed it stays.
+ */
+export function scanPageForContrast(): Finding[] {
+  type Rgba = { r: number; g: number; b: number; a: number };
+
+  function parse(input: string): Rgba | null {
+    const value = input.trim().toLowerCase();
+    if (value === "transparent") return { r: 0, g: 0, b: 0, a: 0 };
+
+    // Chromium serializes a resolved color-mix() as `color(srgb …)`, whose
+    // channels are 0–1 floats rather than 0–255.
+    const srgb = /^color\(\s*srgb\s+([^)]+)\)$/.exec(value);
+    if (srgb) {
+      const parts = srgb[1].replace(/\//g, " ").split(/[\s,]+/).filter(Boolean);
+      if (parts.length < 3) return null;
+      const [r, g, b] = parts.slice(0, 3).map((token) => Number.parseFloat(token) * 255);
+      const a = parts.length > 3 ? Number.parseFloat(parts[3]) : 1;
+      if ([r, g, b, a].some((channel) => Number.isNaN(channel))) return null;
+      return { r, g, b, a };
+    }
+
+    const match = /^rgba?\(([^)]+)\)$/.exec(value);
+    if (!match) return null;
+    const parts = match[1].replace(/\//g, " ").split(/[\s,]+/).filter(Boolean);
+    if (parts.length < 3) return null;
+    const [r, g, b] = parts.slice(0, 3).map((token) => Number.parseFloat(token));
+    const a = parts.length > 3 ? Number.parseFloat(parts[3]) : 1;
+    if ([r, g, b, a].some((channel) => Number.isNaN(channel))) return null;
+    return { r, g, b, a };
+  }
+
+  /**
+   * Classify a `background-image`. A gradient made only of translucent stops
+   * is a TEXTURE laid over the element's own background-color; a gradient with
+   * an opaque stop is a FILL that genuinely hides what's beneath it.
+   */
+  function classifyImage(image: string): 'texture' | 'opaque-gradient' | 'other' {
+    if (!/gradient\(/.test(image)) return 'other';
+    const stops = image.match(/(?:rgba?|color)\([^)]*\)/g);
+    if (!stops) return 'opaque-gradient';
+    const parsed = stops.map(parse);
+    if (parsed.some((stop) => stop === null)) return 'other';
+    return parsed.every((stop) => (stop as Rgba).a < 1) ? 'texture' : 'opaque-gradient';
+  }
+
+  function over(fore: Rgba, back: Rgba): Rgba {
+    return {
+      r: fore.r * fore.a + back.r * (1 - fore.a),
+      g: fore.g * fore.a + back.g * (1 - fore.a),
+      b: fore.b * fore.a + back.b * (1 - fore.a),
+      a: 1,
+    };
+  }
+
+  function luminance(color: Rgba): number {
+    const [r, g, b] = [color.r, color.g, color.b].map((channel) => {
+      const srgb = channel / 255;
+      return srgb <= 0.03928 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+
+  function ratioOf(text: Rgba, surface: Rgba): number {
+    const composited = over(text, surface);
+    const high = Math.max(luminance(composited), luminance(surface));
+    const low = Math.min(luminance(composited), luminance(surface));
+    return (high + 0.05) / (low + 0.05);
+  }
+
+  function show(color: Rgba): string {
+    const round = (channel: number) => Math.round(channel);
+    return `rgb(${round(color.r)}, ${round(color.g)}, ${round(color.b)})`;
+  }
+
+  function ariaHidden(element: Element): boolean {
+    let node: Element | null = element;
+    while (node) {
+      if (node.getAttribute("aria-hidden") === "true") return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+
+  function ownText(element: Element): string {
+    let text = "";
+    for (const child of Array.from(element.childNodes)) {
+      if (child.nodeType === Node.TEXT_NODE) text += child.textContent ?? "";
+    }
+    return text.trim();
+  }
+
+  function pathOf(element: Element): string {
+    const steps: string[] = [];
+    let node: Element | null = element;
+    for (let depth = 0; node && depth < 4; depth += 1) {
+      const classes = typeof node.className === "string" ? node.className.trim().split(/\s+/).slice(0, 2) : [];
+      steps.unshift(node.tagName.toLowerCase() + classes.map((name) => `.${name}`).join(""));
+      node = node.parentElement;
+    }
+    return steps.join(" > ");
+  }
+
+  /**
+   * Resolve the backdrop under `element`. Returns the solid color, or an
+   * explanation of why it isn't one. `backgroundImage` is checked BEFORE
+   * `backgroundColor` on purpose: `.em-backdrop` carries both, and its
+   * gradients paint over its solid fill, so the fill is not the answer.
+   */
+  function backdropOf(element: Element): {
+    color: Rgba | null;
+    why: string | null;
+    kind: Finding['unresolvedKind'];
+  } {
+    let stack: Rgba | null = null;
+    let node: Element | null = element;
+
+    while (node) {
+      const style = window.getComputedStyle(node);
+      if (style.backgroundImage && style.backgroundImage !== "none") {
+        return {
+          color: null,
+          why: `${pathOf(node)} paints ${style.backgroundImage.slice(0, 80)}`,
+          kind: classifyImage(style.backgroundImage),
+        };
+      }
+      const background = parse(style.backgroundColor);
+      if (background === null) {
+        return {
+          color: null,
+          why: `${pathOf(node)} background-color "${style.backgroundColor}" is not a solid color`,
+          kind: 'other',
+        };
+      }
+      if (background.a > 0) {
+        stack = stack === null ? background : over(stack, background);
+        if (stack.a >= 1) return { color: stack, why: null, kind: null };
+      }
+      node = node.parentElement;
+    }
+
+    // Nothing opaque all the way up: the canvas is the browser default white.
+    const canvas: Rgba = { r: 255, g: 255, b: 255, a: 1 };
+    return { color: stack === null ? canvas : over(stack, canvas), why: null, kind: null };
+  }
+
+  const findings: Finding[] = [];
+
+  for (const element of Array.from(document.body.querySelectorAll<HTMLElement>("*"))) {
+    const text = ownText(element);
+    if (!text) continue;
+    if (ariaHidden(element)) continue;
+
+    const box = element.getBoundingClientRect();
+    if (box.width < 1 || box.height < 1) continue;
+
+    const style = window.getComputedStyle(element);
+    if (style.visibility === "hidden" || style.display === "none") continue;
+
+    // Fold ancestor opacity into the text's alpha — a ghosted label is a
+    // contrast problem even though its declared `color` looks fine.
+    let opacity = Number.parseFloat(style.opacity);
+    let ancestor = element.parentElement;
+    while (ancestor) {
+      opacity *= Number.parseFloat(window.getComputedStyle(ancestor).opacity);
+      ancestor = ancestor.parentElement;
+    }
+    if (opacity <= 0.01) continue;
+
+    const foreground = parse(style.color);
+    if (foreground === null || foreground.a * opacity <= 0.01) continue;
+    const inked: Rgba = { ...foreground, a: Math.min(1, foreground.a * opacity) };
+
+    const backdrop = backdropOf(element);
+    const fontSizePx = Number.parseFloat(style.fontSize);
+    const fontWeight = Number.parseInt(style.fontWeight, 10) || 400;
+    const large = fontSizePx >= 24 || (fontSizePx >= 18.66 && fontWeight >= 700);
+    const required = large ? 3 : 4.5;
+    const sample = text.replace(/\s+/g, " ").slice(0, 40);
+
+    if (backdrop.color === null) {
+      findings.push({
+        text: show(inked),
+        background: null,
+        unresolved: backdrop.why,
+        unresolvedKind: backdrop.kind,
+        ratio: 0,
+        required,
+        fontSizePx,
+        fontWeight,
+        where: pathOf(element),
+        sample,
+      });
+      continue;
+    }
+
+    findings.push({
+      text: show(inked),
+      background: show(backdrop.color),
+      unresolved: null,
+      unresolvedKind: null,
+      ratio: ratioOf(inked, backdrop.color),
+      required,
+      fontSizePx,
+      fontWeight,
+      where: pathOf(element),
+      sample,
+    });
+  }
+
+  return findings;
+}

--- a/frontend/e2e/contrastScan.ts
+++ b/frontend/e2e/contrastScan.ts
@@ -3,30 +3,36 @@
  *
  * This module is serialized into the browser by `contrast.spec.ts` — it may
  * not import anything (Playwright's `page.evaluate` ships the function source,
- * not its module graph), so the small amount of WCAG math it needs is inlined
- * inside `scanPageForContrast`. `src/utils/contrast.ts` remains the source of
- * truth for the node-side math; the duplication here is a constraint of the
- * evaluate boundary, not a second opinion.
+ * not its module graph), so the WCAG math it needs is inlined inside
+ * `scanPageForContrast`. `src/utils/contrast.ts` remains the source of truth
+ * for the node-side math; the duplication here is a constraint of the evaluate
+ * boundary, not a second opinion.
  */
 
 /** One measured text node. `background: null` means "could not resolve to a solid". */
 export type Finding = {
   /** `rgb(r, g, b)` of the text, alpha already folded in from ancestor opacity. */
   text: string;
-  /** The nearest resolved opaque backdrop, or null if it was a gradient/image. */
+  /** The nearest resolved opaque backdrop, or null if it could not be resolved. */
   background: string | null;
   /** Why it could not resolve — only set when `background` is null. */
   unresolved: string | null;
   /**
-   * What KIND of unresolvable backdrop this is (#651 audit):
-   *  - `texture`         — a gradient whose every color stop is translucent
-   *                        (paper grain, ruled lines). It sits ON a solid
-   *                        background-color and perturbs it by a few percent.
+   * What KIND of unresolvable backdrop this is:
    *  - `opaque-gradient` — a gradient with an opaque stop: a real fill whose
-   *                        color genuinely varies under the text.
+   *                        colour genuinely varies under the text.
    *  - `other`           — an image, or a background-color we cannot parse.
+   * A gradient whose stops are ALL translucent is a texture, not a fill: it is
+   * composited and measured rather than reported here (see `textureOf`).
    */
-  unresolvedKind: 'texture' | 'opaque-gradient' | 'other' | null;
+  unresolvedKind: 'opaque-gradient' | 'other' | null;
+  /**
+   * The raw CSS that defeated resolution (the gradient / image / colour).
+   * This — not the DOM path — is what identifies an unresolved finding: the
+   * CSS is stable across copy edits and re-layouts, a `div > div > span` path
+   * is not.
+   */
+  backdropCss: string | null;
   ratio: number;
   required: number;
   fontSizePx: number;
@@ -43,13 +49,23 @@ export type Finding = {
  * Two deliberate behaviours, both of them the reason this exists rather than
  * an axe-core dependency:
  *
- *  1. **A gradient/image backdrop is a FAILURE, not a skip.** axe returns
+ *  1. **An unmeasurable backdrop is a FAILURE, not a skip.** axe returns
  *     "incomplete" there, which reads as green — and this app's flavor
- *     surfaces (`.em-backdrop`, the S.N.I.D.E. flyposted wall, the
- *     unaffiliated `repeating-conic-gradient`) are exactly that shape. Today
- *     the broken text happens to sit on cards with solid fills and the
- *     gradients are only *behind* those cards; that is luck, and the sweep
- *     asserts it instead of assuming it.
+ *     surfaces are exactly that shape.
+ *
+ *     "Unmeasurable" is narrower than "is a gradient", though. #651 originally
+ *     assumed gradients only ever sit *behind* opaque cards; the first sweep
+ *     disproved that — the text-bearing surfaces paint a translucent paper
+ *     grain (`radial-gradient(rgba(0,0,0,0.035) 1px, transparent 1px)`) over
+ *     their own solid fill, which made 134 perfectly legible nodes
+ *     "unresolvable". So we distinguish (Molly's call on #651):
+ *
+ *       - every stop translucent  → a TEXTURE over the element's own
+ *         background-color. Composite the most-opaque stop over that colour
+ *         and measure. Worst-case by construction; the accepted error is <2%.
+ *       - any stop opaque         → a FILL (gilt wordmark, WOW title bar, the
+ *         unaffiliated rainbow). It genuinely hides what is beneath it, so it
+ *         still fails loudly.
  *
  *  2. **`aria-hidden="true"` text is ignored.** WCAG exempts incidental /
  *     decorative content, and at least one such element (the Albescent mono
@@ -86,26 +102,17 @@ export function scanPageForContrast(): Finding[] {
   }
 
   /**
-   * Classify a `background-image`. A gradient made only of translucent stops
-   * is a TEXTURE laid over the element's own background-color; a gradient with
-   * an opaque stop is a FILL that genuinely hides what's beneath it.
+   * General source-over compositing — `back` may itself be translucent, and
+   * the result carries the combined alpha. (The simpler "assume the backdrop
+   * is opaque" shortcut silently resolves a translucent card against the first
+   * tinted panel it meets, which is wrong.)
    */
-  function classifyImage(image: string): 'texture' | 'opaque-gradient' | 'other' {
-    if (!/gradient\(/.test(image)) return 'other';
-    const stops = image.match(/(?:rgba?|color)\([^)]*\)/g);
-    if (!stops) return 'opaque-gradient';
-    const parsed = stops.map(parse);
-    if (parsed.some((stop) => stop === null)) return 'other';
-    return parsed.every((stop) => (stop as Rgba).a < 1) ? 'texture' : 'opaque-gradient';
-  }
-
-  function over(fore: Rgba, back: Rgba): Rgba {
-    return {
-      r: fore.r * fore.a + back.r * (1 - fore.a),
-      g: fore.g * fore.a + back.g * (1 - fore.a),
-      b: fore.b * fore.a + back.b * (1 - fore.a),
-      a: 1,
-    };
+  function srcOver(fore: Rgba, back: Rgba): Rgba {
+    const alpha = fore.a + back.a * (1 - fore.a);
+    if (alpha === 0) return { r: 0, g: 0, b: 0, a: 0 };
+    const mix = (front: number, behind: number) =>
+      (front * fore.a + behind * back.a * (1 - fore.a)) / alpha;
+    return { r: mix(fore.r, back.r), g: mix(fore.g, back.g), b: mix(fore.b, back.b), a: alpha };
   }
 
   function luminance(color: Rgba): number {
@@ -117,15 +124,44 @@ export function scanPageForContrast(): Finding[] {
   }
 
   function ratioOf(text: Rgba, surface: Rgba): number {
-    const composited = over(text, surface);
+    const composited = srcOver(text, surface);
     const high = Math.max(luminance(composited), luminance(surface));
     const low = Math.min(luminance(composited), luminance(surface));
     return (high + 0.05) / (low + 0.05);
   }
 
+  /**
+   * Serialize a colour for the baseline key. The alpha MUST survive: text at
+   * `rgba(28,28,26,1)` and the same ink ghosted to `rgba(28,28,26,0.22)` are
+   * different pairs (17.07:1 vs 1.66:1 on white), and printing both as
+   * `rgb(28, 28, 26)` collapses them into one entry that is simultaneously
+   * passing and failing.
+   */
   function show(color: Rgba): string {
-    const round = (channel: number) => Math.round(channel);
-    return `rgb(${round(color.r)}, ${round(color.g)}, ${round(color.b)})`;
+    const [r, g, b] = [color.r, color.g, color.b].map((channel) => Math.round(channel));
+    if (color.a >= 1) return `rgb(${r}, ${g}, ${b})`;
+    return `rgba(${r}, ${g}, ${b}, ${Number(color.a.toFixed(3))})`;
+  }
+
+  /**
+   * If `image` is a texture (a gradient whose every colour stop is
+   * translucent), return its most-opaque stop — the worst case it can
+   * contribute. Returns `undefined` for a fill, whose colour genuinely varies,
+   * and `null` when a stop can't be parsed (never guess).
+   */
+  function textureOf(image: string): Rgba | null | undefined {
+    if (!/gradient\(/.test(image)) return undefined;
+    const stops = image.match(/(?:rgba?|color)\([^)]*\)/g);
+    if (!stops) return undefined;
+    const parsed: Rgba[] = [];
+    for (const stop of stops) {
+      const color = parse(stop);
+      if (color === null) return null;
+      if (color.a >= 1) return undefined; // an opaque stop makes this a fill
+      parsed.push(color);
+    }
+    if (parsed.length === 0) return undefined;
+    return parsed.reduce((worst, stop) => (stop.a > worst.a ? stop : worst));
   }
 
   function ariaHidden(element: Element): boolean {
@@ -149,7 +185,10 @@ export function scanPageForContrast(): Finding[] {
     const steps: string[] = [];
     let node: Element | null = element;
     for (let depth = 0; node && depth < 4; depth += 1) {
-      const classes = typeof node.className === "string" ? node.className.trim().split(/\s+/).slice(0, 2) : [];
+      const classes =
+        typeof node.className === "string"
+          ? node.className.trim().split(/\s+/).slice(0, 2).filter(Boolean)
+          : [];
       steps.unshift(node.tagName.toLowerCase() + classes.map((name) => `.${name}`).join(""));
       node = node.parentElement;
     }
@@ -157,46 +196,56 @@ export function scanPageForContrast(): Finding[] {
   }
 
   /**
-   * Resolve the backdrop under `element`. Returns the solid color, or an
-   * explanation of why it isn't one. `backgroundImage` is checked BEFORE
-   * `backgroundColor` on purpose: `.em-backdrop` carries both, and its
-   * gradients paint over its solid fill, so the fill is not the answer.
+   * Resolve the backdrop under `element` by walking ancestors until the
+   * accumulated colour is opaque. At each node the paint order is
+   * background-color first, then background-image over it.
    */
   function backdropOf(element: Element): {
     color: Rgba | null;
     why: string | null;
-    kind: Finding['unresolvedKind'];
+    kind: Finding["unresolvedKind"];
+    css: string | null;
   } {
     let stack: Rgba | null = null;
     let node: Element | null = element;
 
     while (node) {
       const style = window.getComputedStyle(node);
-      if (style.backgroundImage && style.backgroundImage !== "none") {
-        return {
-          color: null,
-          why: `${pathOf(node)} paints ${style.backgroundImage.slice(0, 80)}`,
-          kind: classifyImage(style.backgroundImage),
-        };
-      }
-      const background = parse(style.backgroundColor);
-      if (background === null) {
+
+      let layer = parse(style.backgroundColor);
+      if (layer === null) {
         return {
           color: null,
           why: `${pathOf(node)} background-color "${style.backgroundColor}" is not a solid color`,
-          kind: 'other',
+          kind: "other",
+          css: style.backgroundColor,
         };
       }
-      if (background.a > 0) {
-        stack = stack === null ? background : over(stack, background);
-        if (stack.a >= 1) return { color: stack, why: null, kind: null };
+
+      if (style.backgroundImage && style.backgroundImage !== "none") {
+        const texture = textureOf(style.backgroundImage);
+        if (texture === undefined || texture === null) {
+          const isGradient = /gradient\(/.test(style.backgroundImage);
+          return {
+            color: null,
+            why: `${pathOf(node)} paints ${style.backgroundImage.slice(0, 80)}`,
+            kind: isGradient && texture === undefined ? "opaque-gradient" : "other",
+            css: style.backgroundImage,
+          };
+        }
+        layer = srcOver(texture, layer);
+      }
+
+      if (layer.a > 0) {
+        stack = stack === null ? layer : srcOver(stack, layer);
+        if (stack.a >= 0.999) return { color: { ...stack, a: 1 }, why: null, kind: null, css: null };
       }
       node = node.parentElement;
     }
 
     // Nothing opaque all the way up: the canvas is the browser default white.
     const canvas: Rgba = { r: 255, g: 255, b: 255, a: 1 };
-    return { color: stack === null ? canvas : over(stack, canvas), why: null, kind: null };
+    return { color: stack === null ? canvas : srcOver(stack, canvas), why: null, kind: null, css: null };
   }
 
   const findings: Finding[] = [];
@@ -233,28 +282,13 @@ export function scanPageForContrast(): Finding[] {
     const required = large ? 3 : 4.5;
     const sample = text.replace(/\s+/g, " ").slice(0, 40);
 
-    if (backdrop.color === null) {
-      findings.push({
-        text: show(inked),
-        background: null,
-        unresolved: backdrop.why,
-        unresolvedKind: backdrop.kind,
-        ratio: 0,
-        required,
-        fontSizePx,
-        fontWeight,
-        where: pathOf(element),
-        sample,
-      });
-      continue;
-    }
-
     findings.push({
       text: show(inked),
-      background: show(backdrop.color),
-      unresolved: null,
-      unresolvedKind: null,
-      ratio: ratioOf(inked, backdrop.color),
+      background: backdrop.color === null ? null : show(backdrop.color),
+      unresolved: backdrop.why,
+      unresolvedKind: backdrop.kind,
+      backdropCss: backdrop.css,
+      ratio: backdrop.color === null ? 0 : ratioOf(inked, backdrop.color),
       required,
       fontSizePx,
       fontWeight,

--- a/frontend/src/utils/__tests__/cssVars.ts
+++ b/frontend/src/utils/__tests__/cssVars.ts
@@ -1,0 +1,121 @@
+/**
+ * A tiny CSS custom-property resolver for the contrast test (#651).
+ *
+ * Not a general CSS parser and not shipped to the browser — it exists so a
+ * node-environment test can answer "what does `--everymen-paper` actually
+ * evaluate to under `[data-theme="dark"]`?" without booting a DOM.
+ *
+ * The one subtlety it must get right: a var can be declared once in `:root`
+ * and still differ per theme, because it POINTS at another var that the dark
+ * block rebinds — `--faction-ephemerists-card-bg: var(--eph-vellum)` is
+ * declared only in `:root`, yet flips in dark. So resolution is recursive and
+ * theme-scoped: every hop re-reads the dark map first, root second.
+ */
+
+/** A resolved theme: custom-property name (with `--`) → raw declared value. */
+export type VarMap = Map<string, string>;
+
+export type Theme = "light" | "dark";
+
+const COMMENT = /\/\*[\s\S]*?\*\//g;
+const CUSTOM_PROP = /(--[\w-]+)\s*:\s*([^;]+);/g;
+const VAR_REF = /var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)/;
+
+/** Strip comments so `/* … *​/` text can't be mistaken for a declaration. */
+function stripComments(css: string): string {
+  return css.replace(COMMENT, "");
+}
+
+/**
+ * Collect the bodies of every rule whose selector is exactly `selector`.
+ * index.css declares `:root` and `[data-theme="dark"]` in several passes
+ * (base, then the per-faction blocks), so all of them must merge — later
+ * declarations win, as the cascade does.
+ */
+function ruleBodies(css: string, selector: string): string[] {
+  const bodies: string[] = [];
+  let cursor = 0;
+  while (cursor < css.length) {
+    const start = css.indexOf(selector, cursor);
+    if (start === -1) break;
+    const open = css.indexOf("{", start);
+    if (open === -1) break;
+    // Reject `[data-theme="dark"] input` / `:root .foo` — selector must be
+    // the whole thing, not a prefix of a descendant selector.
+    const between = css.slice(start + selector.length, open).trim();
+    const before = start === 0 ? "\n" : css[start - 1];
+    if (between !== "" || !/[\s;{}]/.test(before)) {
+      cursor = start + selector.length;
+      continue;
+    }
+    let depth = 1;
+    let index = open + 1;
+    while (index < css.length && depth > 0) {
+      if (css[index] === "{") depth += 1;
+      else if (css[index] === "}") depth -= 1;
+      index += 1;
+    }
+    bodies.push(css.slice(open + 1, index - 1));
+    cursor = index;
+  }
+  return bodies;
+}
+
+function declarationsIn(bodies: string[]): VarMap {
+  const map: VarMap = new Map();
+  for (const body of bodies) {
+    for (const match of body.matchAll(CUSTOM_PROP)) {
+      map.set(match[1], match[2].trim());
+    }
+  }
+  return map;
+}
+
+/** Parse index.css into the light (`:root`) and dark (`[data-theme="dark"]`) var maps. */
+export function readThemes(css: string): Record<Theme, VarMap> {
+  const clean = stripComments(css);
+  return {
+    light: declarationsIn(ruleBodies(clean, ":root")),
+    dark: declarationsIn(ruleBodies(clean, '[data-theme="dark"]')),
+  };
+}
+
+/**
+ * Resolve a custom property to a literal value under `theme`, following
+ * `var()` hops. Returns null if the name is undeclared or the chain is
+ * circular — a caller that sees null has a broken token, not a passing one.
+ */
+export function resolveVar(
+  name: string,
+  theme: Theme,
+  themes: Record<Theme, VarMap>,
+  seen: Set<string> = new Set(),
+): string | null {
+  if (seen.has(name)) return null;
+  seen.add(name);
+
+  const declared = theme === "dark" ? themes.dark.get(name) ?? themes.light.get(name) : themes.light.get(name);
+  if (declared === undefined) return null;
+  return resolveValue(declared, theme, themes, seen);
+}
+
+/** Resolve every `var()` inside a declared value (may be plain text already). */
+function resolveValue(
+  value: string,
+  theme: Theme,
+  themes: Record<Theme, VarMap>,
+  seen: Set<string>,
+): string | null {
+  let current = value.trim();
+  let guard = 0;
+  let match = VAR_REF.exec(current);
+  while (match) {
+    if (guard++ > 32) return null;
+    const inner = resolveVar(match[1], theme, themes, new Set(seen));
+    const replacement = inner ?? (match[2] !== undefined ? match[2].trim() : null);
+    if (replacement === null) return null;
+    current = current.slice(0, match.index) + replacement + current.slice(match.index + match[0].length);
+    match = VAR_REF.exec(current);
+  }
+  return current;
+}

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Part A of the contrast foundation (#651) — the token-value test.
+ *
+ * WHY THIS EXISTS. The same contrast bug has been fixed three times, one
+ * instance at a time (#595, #594, #649), and each eyeball audit left siblings
+ * alive. 7 factions x 2 themes x ~6 surfaces is a few hundred pairings; no
+ * human and no file-reading agent covers that reliably. So the audit is
+ * mechanical — and once mechanical, the audit and the regression guard are the
+ * same artifact. SPEC-faction-ui-profile.md §4 item 15 already *requires* AA
+ * verification at faction registration; this is the test that bullet always
+ * should have been.
+ *
+ * WHAT IT CATCHES. The *value* shape of the bug: a token whose declared color
+ * simply doesn't clear AA against the surface it is documented to sit on, in
+ * either theme. It cannot catch the *pairing* shape (a component grabbing
+ * `--everymen-ink` for text on `--everymen-paper`) — pairings only exist once
+ * rendered, which is what `e2e/contrast.spec.ts` (Part B) is for.
+ *
+ * THE MANIFEST is the §3 token contract, not a guess: the standard
+ * `--faction-{key}-card-*` suffix set, the faction fills under
+ * `--color-text-on-accent`, and the archetype-private primitives whose roles
+ * index.css states verbatim ("text on gold/parchment elements", "bright text
+ * on dark elements", "primary text on vellum").
+ *
+ * ALPHA IS COMPOSITED. Several inks are rgba (`--faction-albescent-ink`), and
+ * measuring them un-composited is exactly what let #594's 2.78:1 muted ink
+ * ship green.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { AA_LARGE, AA_NORMAL, contrastRatio, formatRatio, parseColor } from "../contrast";
+import { readThemes, resolveVar, type Theme } from "./cssVars";
+
+const CSS_PATH = fileURLToPath(new URL("../../index.css", import.meta.url));
+const THEMES = readThemes(readFileSync(CSS_PATH, "utf8"));
+const BOTH_THEMES: Theme[] = ["light", "dark"];
+
+/** Every faction that supplies the standard `--faction-{key}-card-*` block (§3). */
+const CARD_KEYS = [
+  "ua",
+  "everymen",
+  "wow",
+  "snide",
+  "ephemerists",
+  "singularity",
+  "albescent",
+  "default",
+] as const;
+
+/**
+ * Factions whose primary is a solid fill that carries text. `default` (na) is
+ * absent on purpose: ADR-0039 says the unaffiliated fill is a *gradient*, not
+ * a hue, and its neutral `--faction-default` hex is canvas/SVG only — it is
+ * never a text backdrop. That is why #649 counts 14 pairs (7 x 2), not 16.
+ */
+const FILL_KEYS = CARD_KEYS.filter((key) => key !== "default");
+
+type Pair = {
+  /** Human label — this is what a failure message has to make actionable. */
+  what: string;
+  surface: string;
+  text: string;
+  /** AA floor. Defaults to 4.5; set AA_LARGE only where the role is large display type. */
+  floor?: number;
+};
+
+const CARD_PAIRS: Pair[] = CARD_KEYS.flatMap((key) => [
+  { what: `${key} card body text`, surface: `--faction-${key}-card-bg`, text: `--faction-${key}-card-text` },
+  { what: `${key} card muted text`, surface: `--faction-${key}-card-bg`, text: `--faction-${key}-card-muted` },
+  // "metadata / decorative accent" (§3) — metadata is text, so it owes 4.5:1.
+  { what: `${key} card accent`, surface: `--faction-${key}-card-bg`, text: `--faction-${key}-card-accent` },
+]);
+
+/** #649 — the global `--color-text-on-accent` pasted onto every faction fill. */
+const FILL_PAIRS: Pair[] = FILL_KEYS.map((key) => ({
+  what: `${key} fill, text-on-accent`,
+  surface: `--faction-${key}`,
+  text: "--color-text-on-accent",
+}));
+
+/**
+ * Archetype-private primitives. Each entry is a role index.css states in
+ * words; nothing here is inferred from how a component happens to use a token.
+ */
+const ARCHETYPE_PAIRS: Pair[] = [
+  // Everymen — "the paper surface + its text FLIP in dark"; ink is structure:
+  // "borders, rules, text on gold/parchment elements".
+  { what: "everymen paper", surface: "--everymen-paper", text: "--everymen-paper-text" },
+  { what: "everymen paper, muted", surface: "--everymen-paper", text: "--everymen-muted" },
+  { what: "everymen cream element, ink", surface: "--everymen-cream", text: "--everymen-ink" },
+  { what: "everymen gold element, ink", surface: "--everymen-gold", text: "--everymen-ink" },
+  { what: "everymen poster field, cream", surface: "--everymen-field", text: "--everymen-cream" },
+
+  // Ephemerists — "the VELLUM surface + its text FLIP in dark"; --eph-ink
+  // "stays dark in both themes"; --eph-parchment is "bright text on dark elements".
+  { what: "ephemerists vellum", surface: "--eph-vellum", text: "--eph-vellum-text" },
+  { what: "ephemerists vellum, muted", surface: "--eph-vellum", text: "--eph-muted" },
+  { what: "ephemerists vellum, rubric", surface: "--eph-vellum", text: "--eph-rubric" },
+  { what: "ephemerists gold element, ink", surface: "--eph-gold", text: "--eph-ink" },
+  { what: "ephemerists parchment element, ink", surface: "--eph-parchment", text: "--eph-ink" },
+  { what: "ephemerists lapis field, parchment", surface: "--eph-field", text: "--eph-parchment" },
+
+  // S.N.I.D.E. — the flyposted wall is the one SNIDE surface that flips.
+  { what: "snide flyposted wall", surface: "--faction-snide-wall", text: "--faction-snide-wall-text" },
+  { what: "snide deep wall", surface: "--faction-snide-wall-deep", text: "--faction-snide-wall-text" },
+  { what: "snide xerox paper, ink", surface: "--faction-snide-paper", text: "--faction-snide-ink" },
+
+  // UA — always-light gilt salon (#240); --ua-ink is "brown ink — all text".
+  { what: "ua sheet, ink", surface: "--ua-paper", text: "--ua-ink" },
+  { what: "ua sheet, secondary", surface: "--ua-paper", text: "--ua-sub" },
+  { what: "ua sheet, mono labels", surface: "--ua-paper", text: "--ua-muted" },
+  { what: "ua wall, ink", surface: "--ua-wall", text: "--ua-ink" },
+
+  // Albescent — always-light vellum register; the whole palette is one hue at
+  // varying alpha over the sheet, so compositing is the entire question.
+  { what: "albescent sheet, ink", surface: "--faction-albescent-surface", text: "--faction-albescent-ink" },
+  { what: "albescent sheet, faint", surface: "--faction-albescent-surface", text: "--faction-albescent-text-faint" },
+  { what: "albescent warm sheet, ink", surface: "--faction-albescent-surface-warm", text: "--faction-albescent-ink" },
+  {
+    what: "albescent warm sheet, faint",
+    surface: "--faction-albescent-surface-warm",
+    text: "--faction-albescent-text-faint",
+  },
+];
+
+const PAIRS: Pair[] = [...CARD_PAIRS, ...FILL_PAIRS, ...ARCHETYPE_PAIRS];
+
+/**
+ * Part C — the baseline allowlist (the ratchet).
+ *
+ * This spec was red on landing: the bug family is real and pre-dates the
+ * guard. Rather than block the guard on the fixes, known failures are
+ * enumerated here so the suite is green and NEW violations are blocked —
+ * mirroring the repo's `no-raw-style-values` ratchet doctrine.
+ *
+ * **This list only ever shrinks.** Fixing a token means DELETING its line, not
+ * editing the ratio: an allowlisted pair that starts passing fails this test
+ * on purpose. Never add a line for new work.
+ *
+ * `ratio` is the measured value at the time of landing; `issue` is the child
+ * that owns the fix. `651` means "found by the sweep, listed in #651's audit
+ * comment, awaiting triage into a child".
+ */
+const BASELINE: Record<string, { ratio: number; issue: number }> = {
+  // ── #649 — white on faction fills, 7 of 14 pairs ──
+  // NOTE: #649's table reads the dark everymen fill as `#e2433f` (4.11:1).
+  // That is `--everymen-red`; the fill token `--faction-everymen` is actually
+  // `#ef5350` in dark, which measures 3.49:1 — worse than #649 recorded. The
+  // hand-audit misread one token; this is the number.
+  "light | wow fill, text-on-accent": { ratio: 3.15, issue: 649 },
+  "light | snide fill, text-on-accent": { ratio: 2.72, issue: 649 },
+  "dark | everymen fill, text-on-accent": { ratio: 3.49, issue: 649 },
+  "dark | wow fill, text-on-accent": { ratio: 2.65, issue: 649 },
+  "dark | snide fill, text-on-accent": { ratio: 1.21, issue: 649 },
+  "dark | ephemerists fill, text-on-accent": { ratio: 3.11, issue: 649 },
+  "dark | singularity fill, text-on-accent": { ratio: 2.54, issue: 649 },
+
+  // ── Albescent faint ink — the sibling #594 left alive (named in #651) ──
+  "light | albescent sheet, faint": { ratio: 1.59, issue: 651 },
+  "light | albescent warm sheet, faint": { ratio: 1.58, issue: 651 },
+  "dark | albescent sheet, faint": { ratio: 1.59, issue: 651 },
+  "dark | albescent warm sheet, faint": { ratio: 1.58, issue: 651 },
+
+  // ── Found by this sweep — awaiting triage into children (#651 audit comment) ──
+  // Card accents used as metadata text (§3: "metadata / decorative accent").
+  "light | ua card accent": { ratio: 4.27, issue: 651 },
+  "light | everymen card accent": { ratio: 4.49, issue: 651 },
+  "light | wow card accent": { ratio: 2.81, issue: 651 },
+  "dark | ua card accent": { ratio: 4.27, issue: 651 },
+  "dark | everymen card accent": { ratio: 4.16, issue: 651 },
+  "dark | ephemerists card accent": { ratio: 3.72, issue: 651 },
+  // The same rubric vermilion, reached through its archetype-private primitive.
+  "dark | ephemerists vellum, rubric": { ratio: 3.72, issue: 651 },
+  // UA mono metadata labels on the gilt sheet, both themes (UA never dims).
+  "light | ua sheet, mono labels": { ratio: 3.06, issue: 651 },
+  "dark | ua sheet, mono labels": { ratio: 3.06, issue: 651 },
+};
+
+function key(theme: Theme, pair: Pair): string {
+  return `${theme} | ${pair.what}`;
+}
+
+function resolveColor(name: string, theme: Theme) {
+  const raw = resolveVar(name, theme, THEMES);
+  return { raw, color: raw === null ? null : parseColor(raw) };
+}
+
+describe("faction token contrast (WCAG AA)", () => {
+  for (const theme of BOTH_THEMES) {
+    describe(theme, () => {
+      for (const pair of PAIRS) {
+        it(`${pair.what} clears AA`, () => {
+          const surface = resolveColor(pair.surface, theme);
+          const text = resolveColor(pair.text, theme);
+
+          // Fail loudly, never skip: an unresolvable or non-solid token is a
+          // hole in the audit, and a silent hole is what makes axe useless here.
+          expect(surface.color, `${pair.surface} (${theme}) resolved to "${surface.raw}" — not a solid color`).not.toBeNull();
+          expect(text.color, `${pair.text} (${theme}) resolved to "${text.raw}" — not a solid color`).not.toBeNull();
+          expect(surface.color!.a, `${pair.surface} is a surface — it must be opaque`).toBe(1);
+
+          const floor = pair.floor ?? AA_NORMAL;
+          const ratio = contrastRatio(text.color!, surface.color!);
+          const allowed = BASELINE[key(theme, pair)];
+
+          if (allowed) {
+            expect(
+              ratio,
+              `${key(theme, pair)} now measures ${formatRatio(ratio)} and clears AA — delete its BASELINE entry (owned by #${allowed.issue}).`,
+            ).toBeLessThan(floor);
+            expect(
+              ratio,
+              `${key(theme, pair)} measures ${formatRatio(ratio)} but its BASELINE entry records ${allowed.ratio} — update the entry so the debt list stays honest.`,
+            ).toBeCloseTo(allowed.ratio, 1);
+            return;
+          }
+
+          expect(
+            ratio,
+            `${key(theme, pair)}: ${pair.text} (${text.raw}) on ${pair.surface} (${surface.raw}) = ${formatRatio(ratio)}, needs ${floor}:1.`,
+          ).toBeGreaterThanOrEqual(floor);
+        });
+      }
+    });
+  }
+
+  it("has no stale baseline entries", () => {
+    const live = new Set(BOTH_THEMES.flatMap((theme) => PAIRS.map((pair) => key(theme, pair))));
+    const stale = Object.keys(BASELINE).filter((entry) => !live.has(entry));
+    expect(stale, "BASELINE names a pair the manifest no longer measures").toEqual([]);
+  });
+
+  it("uses the WCAG large-text floor only where a role is large display type", () => {
+    // Guard against the floor becoming an escape hatch: 3:1 is a real WCAG
+    // allowance, not a way to launder a failing token.
+    const large = PAIRS.filter((pair) => pair.floor === AA_LARGE);
+    expect(large.every((pair) => pair.what.includes("display"))).toBe(true);
+  });
+});

--- a/frontend/src/utils/contrast.ts
+++ b/frontend/src/utils/contrast.ts
@@ -25,6 +25,9 @@ const HEX_SHORT = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
 const HEX_LONG = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
 const HEX_LONG_ALPHA = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
 const RGB_FUNC = /^rgba?\(([^)]+)\)$/i;
+// Chromium serializes a resolved `color-mix()` in the modern `color(srgb …)`
+// syntax, so computed styles hand us `color(srgb 0.129 0.102 0.063 / 0.82)`.
+const COLOR_SRGB = /^color\(\s*srgb\s+([^)]+)\)$/i;
 
 /**
  * Parse a solid CSS color into RGBA. Returns null for anything that is NOT a
@@ -58,6 +61,23 @@ export function parseColor(input: string): Rgba | null {
   if (long) {
     const [r, g, b] = long.slice(1, 4).map((pair) => parseInt(pair, 16));
     return { r, g, b, a: 1 };
+  }
+
+  const srgb = COLOR_SRGB.exec(value);
+  if (srgb) {
+    // `color(srgb …)` channels are 0–1 floats, not 0–255.
+    const parts = srgb[1].replace(/\//g, " ").split(/[\s,]+/).filter(Boolean);
+    if (parts.length < 3 || parts.length > 4) return null;
+    const channels = parts.slice(0, 3).map((token) => {
+      const numeric = Number.parseFloat(token);
+      if (Number.isNaN(numeric)) return null;
+      const unit = token.endsWith("%") ? numeric / 100 : numeric;
+      return clamp(unit * 255, 0, 255);
+    });
+    const alpha = parts.length === 4 ? readAlpha(parts[3]) : 1;
+    if (channels.some((channel) => channel === null) || alpha === null) return null;
+    const [r, g, b] = channels as number[];
+    return { r, g, b, a: alpha };
   }
 
   const func = RGB_FUNC.exec(value);

--- a/frontend/src/utils/contrast.ts
+++ b/frontend/src/utils/contrast.ts
@@ -1,0 +1,152 @@
+/**
+ * WCAG contrast math (#651).
+ *
+ * Hand-rolled on purpose. axe-core punts on gradient and image backgrounds —
+ * it returns "incomplete" rather than pass/fail — and this app's flavor
+ * surfaces (`.em-backdrop`, the S.N.I.D.E. flyposted wall, the unaffiliated
+ * `repeating-conic-gradient`) are exactly that shape. A dependency that
+ * reports green over the riskiest surfaces is worse than no dependency; the
+ * math below is ~40 lines and we control what happens over a gradient
+ * (`parseColor` returns null, and the callers must fail loudly).
+ *
+ * Two consumers:
+ *   - the token-value test (`__tests__/factionContrast.test.ts`) — resolves
+ *     index.css vars and measures the documented (surface, text) pairs.
+ *   - the rendered sweep (`e2e/contrast.spec.ts`) — measures computed styles.
+ */
+
+export type Rgba = { r: number; g: number; b: number; a: number };
+
+/** WCAG 1.4.3 AA thresholds. */
+export const AA_NORMAL = 4.5;
+export const AA_LARGE = 3;
+
+const HEX_SHORT = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
+const HEX_LONG = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
+const HEX_LONG_ALPHA = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
+const RGB_FUNC = /^rgba?\(([^)]+)\)$/i;
+
+/**
+ * Parse a solid CSS color into RGBA. Returns null for anything that is NOT a
+ * single solid color — gradients, `color-mix()`, `url()` images, keywords we
+ * don't model. Callers decide what null means; the sweep treats it as a
+ * failure, never a skip.
+ *
+ * `transparent` parses as a real value (alpha 0) because "see through to the
+ * ancestor" is a meaningful answer, not an unknown one.
+ */
+export function parseColor(input: string): Rgba | null {
+  const value = input.trim().toLowerCase();
+  if (!value) return null;
+  if (value === "transparent") return { r: 0, g: 0, b: 0, a: 0 };
+  if (value === "white") return { r: 255, g: 255, b: 255, a: 1 };
+  if (value === "black") return { r: 0, g: 0, b: 0, a: 1 };
+
+  const short = HEX_SHORT.exec(value);
+  if (short) {
+    const [r, g, b] = short.slice(1, 4).map((digit) => parseInt(digit + digit, 16));
+    return { r, g, b, a: 1 };
+  }
+
+  const longAlpha = HEX_LONG_ALPHA.exec(value);
+  if (longAlpha) {
+    const [r, g, b, a] = longAlpha.slice(1, 5).map((pair) => parseInt(pair, 16));
+    return { r, g, b, a: a / 255 };
+  }
+
+  const long = HEX_LONG.exec(value);
+  if (long) {
+    const [r, g, b] = long.slice(1, 4).map((pair) => parseInt(pair, 16));
+    return { r, g, b, a: 1 };
+  }
+
+  const func = RGB_FUNC.exec(value);
+  if (func) {
+    // Both legacy `rgb(1, 2, 3)` and modern `rgb(1 2 3 / 40%)` spellings.
+    const parts = func[1].replace(/\//g, " ").split(/[\s,]+/).filter(Boolean);
+    if (parts.length < 3 || parts.length > 4) return null;
+    const channels = parts.slice(0, 3).map(readChannel);
+    const alpha = parts.length === 4 ? readAlpha(parts[3]) : 1;
+    if (channels.some((channel) => channel === null) || alpha === null) return null;
+    const [r, g, b] = channels as number[];
+    return { r, g, b, a: alpha };
+  }
+
+  return null;
+}
+
+function readChannel(token: string): number | null {
+  const numeric = Number.parseFloat(token);
+  if (Number.isNaN(numeric)) return null;
+  const scaled = token.endsWith("%") ? (numeric / 100) * 255 : numeric;
+  return clamp(scaled, 0, 255);
+}
+
+function readAlpha(token: string): number | null {
+  const numeric = Number.parseFloat(token);
+  if (Number.isNaN(numeric)) return null;
+  const scaled = token.endsWith("%") ? numeric / 100 : numeric;
+  return clamp(scaled, 0, 1);
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+/**
+ * Composite a (possibly translucent) color over an opaque backdrop —
+ * standard source-over alpha blending.
+ *
+ * This is not a nicety: several faction inks ARE alpha
+ * (`--faction-albescent-ink: rgba(28, 28, 26, 0.72)`), and measuring them
+ * un-composited is what let #594's 2.78:1 muted ink ship.
+ */
+export function compositeOver(fore: Rgba, back: Rgba): Rgba {
+  return {
+    r: fore.r * fore.a + back.r * (1 - fore.a),
+    g: fore.g * fore.a + back.g * (1 - fore.a),
+    b: fore.b * fore.a + back.b * (1 - fore.a),
+    a: 1,
+  };
+}
+
+/** WCAG relative luminance of an opaque color. */
+export function relativeLuminance(color: Rgba): number {
+  const [r, g, b] = [color.r, color.g, color.b].map((channel) => {
+    const srgb = channel / 255;
+    return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Contrast ratio of `text` against `surface`. The text is composited over the
+ * surface first; the surface itself must already be opaque (resolve it against
+ * whatever is behind it before calling).
+ */
+export function contrastRatio(text: Rgba, surface: Rgba): number {
+  const composited = compositeOver(text, surface);
+  const lighter = Math.max(relativeLuminance(composited), relativeLuminance(surface));
+  const darker = Math.min(relativeLuminance(composited), relativeLuminance(surface));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * WCAG "large text": >= 24px, or >= 18.66px when bold (>= 700). Large text
+ * only owes 3:1. Several faction surfaces use big display type and would
+ * false-positive against the 4.5:1 floor.
+ */
+export function isLargeText(fontSizePx: number, fontWeight: number): boolean {
+  if (fontSizePx >= 24) return true;
+  return fontSizePx >= 18.66 && fontWeight >= 700;
+}
+
+/** The AA floor that applies to text of this size/weight. */
+export function requiredRatio(fontSizePx: number, fontWeight: number): number {
+  return isLargeText(fontSizePx, fontWeight) ? AA_LARGE : AA_NORMAL;
+}
+
+/** Round for stable, readable reporting (2dp — the precision issue #651 quotes). */
+export function formatRatio(ratio: number): string {
+  return `${ratio.toFixed(2)}:1`;
+}


### PR DESCRIPTION
Closes #651

Builds the mechanical contrast audit — and, because it's mechanical, the regression guard is the same artifact.

## Part A — token-value test (per-PR, no browser)

`src/utils/contrast.ts` (hand-rolled WCAG math) + `src/utils/__tests__/cssVars.ts` (a node-side CSS custom-property resolver) drive `factionContrast.test.ts`: every documented (surface, text) pair from the SPEC-faction-ui-profile §3 token contract, both themes, **alpha composited**. Turns §4 item 15's "verify contrast at faction registration" checklist bullet into the test it should always have been.

Resolution is theme-scoped and recursive — `--faction-ephemerists-card-bg: var(--eph-vellum)` is declared only in `:root` yet flips in dark, which a flat parse would miss.

No axe-core: it returns "incomplete" over gradient/image backgrounds, which reads as green precisely over this app's flavor surfaces.

## Part B — rendered sweep (nightly)

`e2e/contrast.spec.ts` walks 7 factions × 2 themes × 2 viewports (mobile included — the mobile archetypes are separate files and diverge, #565). For each visible text node it resolves the real backdrop, composites alpha and ancestor opacity, and measures against the WCAG floor for that node's computed size/weight. `aria-hidden` text is ignored.

**Enabler:** `dev-login` gains `?faction=<slug>`, extending the existing dev-only e2e seam (`key`/`name`/`level`) behind the same `ENVIRONMENT != production` guard. Players start unaffiliated and most factions are invite-gated (ADR-0030), so no real flow reaches all seven.

## Part C — the ratchet

269 entries, **machine-produced** by the sweep itself (`CONTRAST_BASELINE_OUT=<path>`), never hand-typed. Keyed on the colour pair — not the DOM node — so copy edits don't rot it. The list only ever shrinks.

## The texture/fill split

The issue called failing loudly on any gradient non-negotiable, on the premise that "the gradient is only behind" the cards. **The sweep disproved that** — the text-bearing surfaces paint translucent paper grain over their own fill, which made 134 legible nodes unmeasurable. Per Molly's call on the issue:

- every stop translucent → a **texture**; composite its most-opaque stop (worst case, <2% error) and measure.
- any stop opaque → a **fill** that genuinely hides what's beneath; still **fails loudly**.

Unmeasurable population: **134 → 56**, and every survivor is a real opaque-stop fill (WOW `.exe` title bars, Ephemerist celestial fields, the gilt wordmark).

## Reproduces every hand-measured failure

| #651 said | Measured |
|---|---|
| everymen ink on paper, dark — 1.16:1 | **1.16:1** |
| eph ink on vellum, dark — 1.15:1 | **1.15:1** |
| albescent text-faint — 1.59:1 | **1.59:1** |
| white on fills, 7 of 14 | all 7 |

**Corrects #649's table:** it reads the dark everymen fill as `#e2433f` (4.11:1) — that's `--everymen-red`. The fill token `--faction-everymen` is `#ef5350` in dark, measuring **3.49:1**. Worse than recorded.

**Two key-collision bugs** found while landing the baseline: `show()` dropped the text's alpha (so `rgba(28,28,26,1)` and `rgba(28,28,26,0.22)` shared one key measuring both 17.07:1 and 4.64:1), and the key ignored the WCAG floor (a large-text 3:1 pass looked like a body-copy entry going stale). Both are now part of the identity — the honest count is 269, not 202.

## Not in scope

No new CI jobs (`npm test` and the nightly e2e workflow already run these). The global-chrome AA failures the sweep found (`.nav-link` 3.82:1 dark, theme-toggle `.eyebrow` 2.11:1) are Molly's to file separately.

## Test results

- `pytest --cov=. --cov-fail-under=80` — **600 passed, 87.47%**
- `npm test` — **725 passed** (87 files)
- `bash frontend/e2e/run-e2e.sh contrast.spec.ts` — **29 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
