### PR TITLE
Six-issue batch: dead-code cleanup (#668/#638/#639) + AA contrast fixes (#653/#652/#649)

### DIFF
--- a/backend/schemas/vote.py
+++ b/backend/schemas/vote.py
@@ -1,11 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
-
-
-class VoteIn(BaseModel):
-    value: int = Field(..., ge=1, le=5)
+from pydantic import BaseModel, ConfigDict
 
 
 class VoteOut(BaseModel):

--- a/docs/spec/SPEC-faction-ui-profile.md
+++ b/docs/spec/SPEC-faction-ui-profile.md
@@ -91,6 +91,7 @@ Required suffixes (consumed by the dispatchers / `factionCssVar`):
 | `--faction-{key}-card-accent` | metadata / decorative accent |
 | `--faction-{key}-card-muted` | secondary text |
 | `--faction-{key}-card-font` | headline font (points at a `--font-*` face) |
+| `--faction-{key}-on-fill` | AA-legible text ink for the faction's **solid fill** — white or ink per faction × theme, so `factionCssVar(slug, 'on-fill')` never paints white on a fill that fails AA (#649). Not for `na`, whose fill is a gradient, not a text backdrop. Guarded by `factionContrast.test.ts`. |
 
 Plus any **archetype-private primitives** (e.g. Everymen's `--everymen-cream/-gold/-ink/-paper/-field`, Gestalt's window-chrome tokens, S.N.I.D.E.'s punk pigments `--faction-snide-acid/-ink/-paper/-pink/-tape` + flyposted-wall `--faction-snide-wall*` + the `--faction-snide-font-*` set). These are referenced only inside that faction's own components, not through `factionCssVar`, and are ported verbatim from the design kit. S.N.I.D.E. namespaces them under `--faction-snide-*` (rather than bare `--acid` etc.) so they stay within the single-source-of-truth scheme; note that this flips `--faction-snide-card-bg` to ink — SNIDE is an always-dark card like Singularity.
 

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -129,10 +129,6 @@ export interface PraxisUpdate {
   body_text?: string
 }
 
-export interface PraxisVoteIn {
-  value: number
-}
-
 // ---------------------------------------------------------------------------
 // List / detail
 // ---------------------------------------------------------------------------
@@ -269,14 +265,6 @@ export async function applyMetatask(praxisId: number, taskId: number): Promise<P
 
 export async function removeMetatask(praxisId: number, taskId: number): Promise<void> {
   await api.delete(`/praxes/${praxisId}/metatasks/${taskId}`)
-}
-
-// ---------------------------------------------------------------------------
-// Voting
-// ---------------------------------------------------------------------------
-
-export async function votePraxis(id: number, data: PraxisVoteIn): Promise<void> {
-  await api.post(`/praxes/${id}/vote`, data)
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -69,7 +69,7 @@ export default function TaskCard({ task, displayPoints, onSignup }: CardProps) {
           <span
             style={{
               background: factionCssVar(task.metatask_faction_slug),
-              color: 'var(--color-text-on-accent)',
+              color: factionCssVar(task.metatask_faction_slug, 'on-fill'),
               fontFamily: "'Courier Prime', monospace",
               fontSize: 8,
               fontWeight: 700,

--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -49,7 +49,10 @@ export default function AlbescentVote({
           fontSize: 7,
           letterSpacing: '0.26em',
           textTransform: 'uppercase',
-          color: 'var(--faction-albescent-text-faint)',
+          // card-muted (4.65:1, #594), not -text-faint: this prompt is
+          // functional text and owes AA. -text-faint is decorative-only —
+          // it drives the deliberately-ghosted AlbescentFeedFrame masthead.
+          color: 'var(--faction-albescent-card-muted)',
           marginBottom: 10,
         }}
       >

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -20,7 +20,6 @@ export interface VoteUIProps {
   currentValue?: number
   points?: number | null
   totalVotes?: number
-  mode?: 'caster' | 'summary'
 }
 
 const FACTION_VOTE: Record<string, ComponentType<VoteUIProps>> = {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,6 +47,21 @@
   --faction-ephemerists: #1d6e72; /* lapis-verdigris — Ephemerists reskin of the teal slot */
   --faction-singularity: #2563eb; /* blue */
 
+  /* ── Text on faction fills (#649) ── The AA-legible ink for text painted on a
+     --faction-{key} SOLID fill. "Is white legible on this fill?" is a per-faction,
+     per-theme question; a global #ffffff answered it wrong 7 of 14 times. White
+     where it clears AA (>=4.5:1); near-black #14110b where white fails. Read via
+     factionCssVar(slug, 'on-fill'); guarded by factionContrast.test.ts. Dark
+     overrides (for fills that brighten in dark) live in the dark block; tokens
+     omitted there inherit these :root values through the cascade. */
+  --faction-ua-on-fill: #ffffff; /* #c2541f — 4.58:1 */
+  --faction-everymen-on-fill: #ffffff; /* #c1272d — 5.84:1 */
+  --faction-wow-on-fill: #14110b; /* #ec5f99 — white only 3.15:1; ink 5.98:1 */
+  --faction-snide-on-fill: #14110b; /* #6fae00 — white only 2.72:1; ink 6.93:1 */
+  --faction-ephemerists-on-fill: #ffffff; /* #1d6e72 — 5.96:1 */
+  --faction-singularity-on-fill: #ffffff; /* #2563eb — 5.17:1 */
+  --faction-albescent-on-fill: #ffffff; /* #1c1c1a — 17.07:1 */
+
   /* ── Faction tints (backgrounds, highlights) ── */
   --faction-ua-light: rgba(194, 84, 31, 0.08);
   --faction-wow-light: rgba(236, 95, 153, 0.1);
@@ -370,6 +385,14 @@
   --faction-snide: #b6ff2e; /* acid green (bright — pops on dark) */
   --faction-ephemerists: #3aa0a4; /* lapis-verdigris lifted for dark — Ephemerists */
   --faction-singularity: #60a5fa; /* blue */
+
+  /* ── Text on faction fills (dark, #649) ── The dark primaries brighten to pop
+     against the dark page, which makes white-on-fill worse. These three flip to
+     ink; ua/albescent (white) and wow/snide (ink) are theme-invariant and inherit
+     their :root on-fill value. */
+  --faction-everymen-on-fill: #14110b; /* #ef5350 — white only 3.49:1; ink 5.45:1 */
+  --faction-ephemerists-on-fill: #14110b; /* #3aa0a4 — white only 3.11:1; ink 6.05:1 */
+  --faction-singularity-on-fill: #14110b; /* #60a5fa — white only 2.54:1; ink 7.41:1 */
 
   /* ── Faction tints (dark) ── */
   --faction-ua-light: rgba(194, 84, 31, 0.08);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -247,6 +247,9 @@
   --faction-albescent-surface: #ffffff; /* the sheet */
   --faction-albescent-surface-warm: #faf9f7;
   --faction-albescent-ink: rgba(28, 28, 26, 0.72);
+  /* Decorative-only (1.59:1 on the white sheet — below AA on purpose). Drives
+     the deliberately-ghosted AlbescentFeedFrame masthead. Functional text uses
+     -card-muted; do not repoint functional text here. #653. */
   --faction-albescent-text-faint: rgba(28, 28, 26, 0.22);
   --faction-albescent-border-faint: rgba(0, 0, 0, 0.055);
   --faction-albescent-border-rule: rgba(0, 0, 0, 0.07);
@@ -438,6 +441,9 @@
   --faction-albescent-surface: #ffffff;
   --faction-albescent-surface-warm: #faf9f7;
   --faction-albescent-ink: rgba(28, 28, 26, 0.72);
+  /* Decorative-only (1.59:1 on the white sheet — below AA on purpose). Drives
+     the deliberately-ghosted AlbescentFeedFrame masthead. Functional text uses
+     -card-muted; do not repoint functional text here. #653. */
   --faction-albescent-text-faint: rgba(28, 28, 26, 0.22);
   --faction-albescent-border-faint: rgba(0, 0, 0, 0.055);
   --faction-albescent-border-rule: rgba(0, 0, 0, 0.07);

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -282,7 +282,7 @@ export default function CharacterProfile() {
               disabled={relationshipLoading}
               style={{
                 background: factionCssVar(character.faction_slug),
-                color: "var(--color-text-on-accent)",
+                color: factionCssVar(character.faction_slug, "on-fill"),
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 8,
                 textTransform: "uppercase",

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -130,7 +130,7 @@ function DesktopLeaderboard({
                       className="pennant-shape"
                       style={{
                         display: 'inline-block',
-                        background: factionCssVar(player.faction_slug), color: 'var(--color-text-on-accent)',
+                        background: factionCssVar(player.faction_slug), color: factionCssVar(player.faction_slug, 'on-fill'),
                         fontFamily: "'Courier Prime', monospace",
                         fontSize: 7, fontWeight: 700, textTransform: 'uppercase',
                         letterSpacing: '0.07em', padding: '2px 10px',
@@ -220,7 +220,7 @@ function DesktopLeaderboard({
                         className="pennant-shape"
                         style={{
                           display: 'inline-block',
-                          background: factionCssVar(player.faction_slug), color: 'var(--color-text-on-accent)',
+                          background: factionCssVar(player.faction_slug), color: factionCssVar(player.faction_slug, 'on-fill'),
                           fontFamily: "'Courier Prime', monospace",
                           fontSize: 7, fontWeight: 700, textTransform: 'uppercase',
                           letterSpacing: '0.07em', padding: '2px 10px',
@@ -319,7 +319,7 @@ function DesktopLeaderboard({
                         className="pennant-shape"
                         style={{
                           display: 'inline-block',
-                          background: factionCssVar(player.faction_slug), color: 'var(--color-text-on-accent)',
+                          background: factionCssVar(player.faction_slug), color: factionCssVar(player.faction_slug, 'on-fill'),
                           fontFamily: "'Courier Prime', monospace",
                           fontSize: 7, fontWeight: 700, textTransform: 'uppercase',
                           letterSpacing: '0.07em', padding: '2px 10px',

--- a/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
@@ -14,7 +14,8 @@ import type { ReactNode } from 'react'
 import type { ProfileBodyProps } from '../FactionProfileBody'
 import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
 
-const INK = 'var(--eph-ink)'
+const INK = 'var(--eph-ink)' // structure / kit spine (stays dark in both themes)
+const VELLUM_TEXT = 'var(--eph-vellum-text)' // text on the vellum surface (flips in dark)
 const MUTED = 'var(--eph-muted)'
 const GOLD = 'var(--eph-gold-light)'
 const GOLD_DEEP = 'var(--eph-gold)'
@@ -65,7 +66,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           fontFamily: DISPLAY,
           fontSize: 26,
           letterSpacing: '0.06em',
-          color: INK,
+          color: VELLUM_TEXT,
           margin: 0,
         }}
       >
@@ -167,7 +168,7 @@ const kit: ProfileKit = {
       badge={badge}
       last={last}
       dividerColor="rgba(176,134,58,0.28)"
-      nameStyle={{ fontFamily: DISPLAY, fontSize: 14, color: INK, lineHeight: 1.2, letterSpacing: '0.03em' }}
+      nameStyle={{ fontFamily: DISPLAY, fontSize: 14, color: VELLUM_TEXT, lineHeight: 1.2, letterSpacing: '0.03em' }}
       medallion={(glyph) => (
         <span
           style={{

--- a/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
@@ -14,7 +14,8 @@ import type { ReactNode } from 'react'
 import type { ProfileBodyProps } from '../FactionProfileBody'
 import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
 
-const INK = 'var(--everymen-ink)'
+const INK = 'var(--everymen-ink)' // structure + text on the stable cream board (near-black both themes)
+const PAPER_TEXT = 'var(--everymen-paper-text)' // text on the paper page (flips in dark)
 const MUTED = 'var(--everymen-muted)'
 const RED = 'var(--everymen-red)'
 const GOLD = 'var(--everymen-gold)'
@@ -46,7 +47,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           fontFamily: BEBAS,
           fontSize: 34,
           letterSpacing: '0.03em',
-          color: INK,
+          color: PAPER_TEXT,
           margin: 0,
           textShadow: '2px 2px 0 rgba(0,0,0,0.12)',
         }}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
@@ -29,7 +29,8 @@ import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
  * submit logic lives here.
  */
 
-const INK = 'var(--everymen-ink)'
+const INK = 'var(--everymen-ink)' // structure only: borders/rules + text on gold (stays near-black in dark)
+const PAPER_TEXT = 'var(--everymen-paper-text)' // text on the paper surface (flips in dark)
 const CREAM = 'var(--everymen-cream)'
 const RED = 'var(--everymen-red)'
 const GOLD = 'var(--everymen-gold)'
@@ -67,10 +68,10 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
   const task = state.task
 
   return (
-    <div data-skin="everymen" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: INK, background: PAPER }}>
+    <div data-skin="everymen" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: PAPER_TEXT, background: PAPER }}>
       <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-          <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 30, lineHeight: 0.95, letterSpacing: '0.02em', color: INK, margin: 0 }}>
+          <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 30, lineHeight: 0.95, letterSpacing: '0.02em', color: PAPER_TEXT, margin: 0 }}>
             {t('editPraxis.everymen.pageTitle')}
           </h1>
           <span style={{ ...kicker, marginLeft: 'auto' }}>
@@ -101,7 +102,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
       {/* For-task reference */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: PAPER_DEEP, border: `1.5px solid ${INK}` }}>
         <span style={kicker}>{t('editPraxis.everymen.taskRefLabel')}</span>
-        <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.02em', color: INK, textAlign: 'right', flex: 1, lineHeight: 1 }}>
+        <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.02em', color: PAPER_TEXT, textAlign: 'right', flex: 1, lineHeight: 1 }}>
           {praxis.task_title}
         </span>
       </div>
@@ -122,7 +123,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
                   fontFamily: ACCENT_FONT,
                   fontSize: 24,
                   letterSpacing: '0.01em',
-                  color: INK,
+                  color: PAPER_TEXT,
                   background: 'transparent',
                   border: 'none',
                   outline: 'none',
@@ -144,7 +145,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
                   fontFamily: BODY_FONT,
                   fontSize: 14,
                   lineHeight: 1.6,
-                  color: INK,
+                  color: PAPER_TEXT,
                   background: PAPER_DEEP,
                   border: `1.5px solid ${INK}`,
                   padding: '13px 15px',
@@ -163,7 +164,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
                 skin={{
                   fontFamily: BODY_FONT,
                   inputBg: PAPER_DEEP,
-                  inputColor: INK,
+                  inputColor: PAPER_TEXT,
                   inputBorder: `1.5px solid ${INK}`,
                   acceptedBg: RED,
                   acceptedColor: CREAM,
@@ -188,7 +189,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
                     background: selected ? PAPER_DEEP : 'transparent',
                     border: `1.5px solid ${selected ? RED : 'color-mix(in srgb, var(--everymen-ink) 30%, transparent)'}`,
                   }),
-                  titleColor: INK,
+                  titleColor: PAPER_TEXT,
                   descColor: MUTED,
                   pointsActiveColor: RED,
                   pointsIdleColor: MUTED,
@@ -199,7 +200,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
         </>
       ) : (
         <Plate title={t('editPraxis.everymen.previewLabel')}>
-          <div style={{ fontFamily: ACCENT_FONT, fontSize: 24, letterSpacing: '0.01em', color: INK, marginBottom: 10 }}>
+          <div style={{ fontFamily: ACCENT_FONT, fontSize: 24, letterSpacing: '0.01em', color: PAPER_TEXT, marginBottom: 10 }}>
             {state.title || t('editPraxis.everymen.titlePlaceholder')}
           </div>
           {state.media.length > 0 && (
@@ -210,7 +211,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
           <BodyPreview
             state={state}
             skin={{
-              markdownStyle: { fontFamily: BODY_FONT, fontSize: 14, lineHeight: 1.6, color: INK },
+              markdownStyle: { fontFamily: BODY_FONT, fontSize: 14, lineHeight: 1.6, color: PAPER_TEXT },
             }}
           />
         </Plate>

--- a/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
@@ -223,7 +223,6 @@ export default function AlbescentPraxisDetail({ state }: { state: PraxisDetailSt
           praxisId={praxis.id}
           points={votes?.total_score}
           totalVotes={votes?.total_votes}
-          mode="caster"
         />
 
         {/* ── Flag block ── */}

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -124,7 +124,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
             fontSize: 26,
             fontWeight: 700,
             lineHeight: 1.15,
-            color: 'var(--eph-ink)',
+            color: 'var(--eph-vellum-text)',
             marginBottom: 4,
             letterSpacing: '0.01em',
           }}
@@ -195,7 +195,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
               style={{
                 fontFamily: 'var(--eph-display)',
                 fontSize: 18,
-                color: 'var(--eph-ink)',
+                color: 'var(--eph-vellum-text)',
                 lineHeight: 1,
               }}
             >
@@ -332,7 +332,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
                   style={{
                     fontFamily: 'var(--eph-display)',
                     fontSize: 18,
-                    color: 'var(--eph-ink)',
+                    color: 'var(--eph-vellum-text)',
                     lineHeight: 1,
                   }}
                 >

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -356,7 +356,6 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
             praxisId={praxis.id}
             points={votes?.total_score}
             totalVotes={votes?.total_votes}
-            mode="caster"
           />
         </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -253,7 +253,6 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
             praxisId={praxis.id}
             points={votes?.total_score}
             totalVotes={votes?.total_votes}
-            mode="caster"
           />
         </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -427,7 +427,6 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
               praxisId={praxis.id}
               points={votes?.total_score}
               totalVotes={votes?.total_votes}
-              mode="caster"
             />
           </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -415,7 +415,6 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
             praxisId={praxis.id}
             points={votes?.total_score}
             totalVotes={votes?.total_votes}
-            mode="caster"
           />
         </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -427,7 +427,6 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
             praxisId={praxis.id}
             points={votes?.total_score}
             totalVotes={votes?.total_votes}
-            mode="caster"
           />
         </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -430,7 +430,6 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
               praxisId={praxis.id}
               points={votes?.total_score}
               totalVotes={votes?.total_votes}
-              mode="caster"
             />
           </div>
         </div>

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
@@ -24,7 +24,8 @@ import { MobileStarVote } from './shared'
  * `--everymen-*` tokens; flips with `[data-theme]`.
  */
 
-const INK = 'var(--everymen-ink)'
+const INK = 'var(--everymen-ink)' // structure only: borders/rules (stays near-black in dark)
+const PAPER_TEXT = 'var(--everymen-paper-text)' // text on the paper surface (flips in dark)
 const RED = 'var(--everymen-red)'
 const GOLD = 'var(--everymen-gold)'
 const MUTED = 'var(--everymen-muted)'
@@ -61,7 +62,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
   const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
 
   return (
-    <div data-skin="everymen" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: INK, background: PAPER }}>
+    <div data-skin="everymen" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: PAPER_TEXT, background: PAPER }}>
       {/* Behavior slots (invariant) */}
       <PraxisStatusBanners state={state} />
       <PraxisAdminBar state={state} />
@@ -80,7 +81,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
         <div className="min-w-0 flex-1">
           <MemberByline
             praxis={praxis}
-            linkStyle={{ fontFamily: ACCENT_FONT, fontSize: 20, letterSpacing: '0.02em', color: INK, lineHeight: 1, textDecoration: 'none' }}
+            linkStyle={{ fontFamily: ACCENT_FONT, fontSize: 20, letterSpacing: '0.02em', color: PAPER_TEXT, lineHeight: 1, textDecoration: 'none' }}
           />
           <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
             {t('detail.everymen.mobile.filed')} · {formatTimestamp(sealedDate)}
@@ -98,7 +99,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
       {/* Finding headline */}
       <div>
         <div style={{ ...kicker, marginBottom: 4, color: RED }}>{t('detail.everymen.theWork')}</div>
-        <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 34, lineHeight: 0.95, letterSpacing: '0.01em', margin: 0, color: INK, overflowWrap: 'anywhere' }}>
+        <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 34, lineHeight: 0.95, letterSpacing: '0.01em', margin: 0, color: PAPER_TEXT, overflowWrap: 'anywhere' }}>
           {praxis.title ?? t('detail.everymen.untitled')}
         </h1>
       </div>
@@ -119,13 +120,13 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
         <MarkdownPreview
           source={praxis.body_text}
           className="markdown-preview"
-          style={{ fontFamily: BODY_FONT, fontSize: 14, lineHeight: 1.75, color: INK }}
+          style={{ fontFamily: BODY_FONT, fontSize: 14, lineHeight: 1.75, color: PAPER_TEXT }}
         />
       )}
 
       {/* The crew's marks — vote caster */}
       <Plate title={t('detail.everymen.crewsMarks')}>
-        <div className="flex items-center justify-center" style={{ marginBottom: 12, fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.04em', color: INK }}>
+        <div className="flex items-center justify-center" style={{ marginBottom: 12, fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.04em', color: PAPER_TEXT }}>
           {t('detail.everymen.mobile.appraise')}
         </div>
         <MobileStarVote

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -142,7 +142,7 @@ export default function DefaultTaskDetail({
                     padding: "2px 8px",
                     borderRadius: 4,
                     background: factionCssVar(task.metatask_faction_slug),
-                    color: "var(--color-text-on-accent)",
+                    color: factionCssVar(task.metatask_faction_slug, "on-fill"),
                     fontWeight: 700,
                     textShadow: "0 1px 2px rgba(0,0,0,0.3)",
                   }}

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -74,11 +74,15 @@ const CARD_PAIRS: Pair[] = CARD_KEYS.flatMap((key) => [
   { what: `${key} card accent`, surface: `--faction-${key}-card-bg`, text: `--faction-${key}-card-accent` },
 ]);
 
-/** #649 — the global `--color-text-on-accent` pasted onto every faction fill. */
+/**
+ * #649 — text on each faction's solid fill. The global `--color-text-on-accent`
+ * (#ffffff) failed AA on 7 of these 14 pairs, so each faction now owns a
+ * per-theme `--faction-{key}-on-fill` (white or ink); this measures that token.
+ */
 const FILL_PAIRS: Pair[] = FILL_KEYS.map((key) => ({
-  what: `${key} fill, text-on-accent`,
+  what: `${key} fill, on-fill`,
   surface: `--faction-${key}`,
-  text: "--color-text-on-accent",
+  text: `--faction-${key}-on-fill`,
 }));
 
 /**
@@ -145,18 +149,8 @@ const PAIRS: Pair[] = [...CARD_PAIRS, ...FILL_PAIRS, ...ARCHETYPE_PAIRS];
  * comment, awaiting triage into a child".
  */
 const BASELINE: Record<string, { ratio: number; issue: number }> = {
-  // ── #649 — white on faction fills, 7 of 14 pairs ──
-  // NOTE: #649's table reads the dark everymen fill as `#e2433f` (4.11:1).
-  // That is `--everymen-red`; the fill token `--faction-everymen` is actually
-  // `#ef5350` in dark, which measures 3.49:1 — worse than #649 recorded. The
-  // hand-audit misread one token; this is the number.
-  "light | wow fill, text-on-accent": { ratio: 3.15, issue: 649 },
-  "light | snide fill, text-on-accent": { ratio: 2.72, issue: 649 },
-  "dark | everymen fill, text-on-accent": { ratio: 3.49, issue: 649 },
-  "dark | wow fill, text-on-accent": { ratio: 2.65, issue: 649 },
-  "dark | snide fill, text-on-accent": { ratio: 1.21, issue: 649 },
-  "dark | ephemerists fill, text-on-accent": { ratio: 3.11, issue: 649 },
-  "dark | singularity fill, text-on-accent": { ratio: 2.54, issue: 649 },
+  // ── #649 fixed: `--faction-{key}-on-fill` now carries AA-legible text on every
+  //    faction fill in both themes, so the 7 failing white-on-fill pairs are gone. ──
 
   // ── Albescent faint ink — the sibling #594 left alive (named in #651) ──
   "light | albescent sheet, faint": { ratio: 1.59, issue: 651 },


### PR DESCRIPTION
Implements six well-specified, self-contained issues as one commit each. Three are dead-code removals; three are WCAG AA contrast fixes that build on the #672 contrast foundation.

Green locally: **frontend `npm run lint` clean, `npm test` 725 passing** (incl. 108 token-contrast assertions), no new `tsc` errors vs. main. Backend `#668` is a dead-class removal verified by grep + `py_compile`; full pytest runs in CI (needs the postgres service).

## Cleanups

**#668 — Remove dead `VoteIn` schema** (`backend/schemas/vote.py`)
Orphaned when #637 deleted the shadowed `POST /praxes/{id}/vote` route. Zero callers across backend + frontend. `VoteOut` kept (still used by the guarded route in `routers/praxes.py`); drops the now-unused `Field` import.

**#638 — Delete dead `votePraxis` / `PraxisVoteIn`** (`frontend/src/api/praxis.ts`)
Zero callers; the live vote path is `castVote` in `api/votes.ts`.

**#639 — Drop dead `mode` prop from `VoteUIProps`**
No variant (nor `VoteStamps`) ever read `mode?: 'caster' | 'summary'`. Removed the prop and all call sites that passed it (7 praxis-detail archetypes — the issue estimated 6; there were 7).

## Contrast fixes (siblings of the #651 sweep; parent #672 already landed)

**#653 — Albescent vote prompt** (`AlbescentVote.tsx`)
The vote prompt painted functional text in `--faction-albescent-text-faint` (~1.59:1). Repointed to `--faction-albescent-card-muted` (4.65:1, #594). Token value unchanged — `-text-faint` stays decorative-only and keeps the `AlbescentFeedFrame` masthead ghosted; added a note at the token so the distinction isn't lost again.

**#652 — Everymen / Ephemerists dark-mode ink**
Text on the flipping paper/vellum surfaces used the *structural* ink token (stays near-black in dark) → ~1.15:1. Swapped `--everymen-ink → --everymen-paper-text` and `--eph-ink → --eph-vellum-text` at text-on-flipping-surface sites only; kept `-ink` for borders/rules/shadows and text on stable elements (gold/cream/parchment).

**#649 — `--faction-{key}-on-fill` AA tokens**
`--color-text-on-accent` (global `#ffffff`) failed AA on 7 of 14 fill×theme pairs (S.N.I.D.E. dark = 1.21:1). Added a per-faction/per-theme `-on-fill` token (white or ink) to the §3 contract, swapped the 6 call sites, repointed the contrast test's `FILL_PAIRS`, and deleted the 7 baselined entries — every fill/on-fill pair now clears 4.5:1.

## Deviations from the issue text (called out for review)

- **#652 / `EverymenProfileBody.tsx:150`** — the issue lists the badge `nameStyle` as a swap site, but it sits on the **CREAM** board, which stays light in both themes; `--everymen-paper-text` flips to that *same* cream (`#f3e7ce`) in dark, so swapping would paint invisible light-on-light. Kept as `-ink`, per the issue's own "check each site's real surface" rule. (Ephemerists' badge board is *vellum*, which flips, so that one **is** swapped.)
- **#652 residual** — shared `ProfileSkin` plumbing (`kit.ink` drives the badge-section title and empty-state text) is a cross-faction concern left to the #651 sweep, not touched here.
- **#653 out-of-scope observation** — `AlbescentFactionBody.tsx:59` also uses `-text-faint` as a text `color`; the issue scoped #653 to exactly two sites, so it's left for a separate finding rather than expanded here.

Closes #668, #638, #639, #653, #652, #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017VuBQ9c24QQBmQZ52je79t)_