### PR TITLE
FactionSigil dispatcher + FactionSigilRow; swap mobile Tasks faction chips for sigils

### DIFF
--- a/frontend/src/components/avatar/SnideAvatar.tsx
+++ b/frontend/src/components/avatar/SnideAvatar.tsx
@@ -1,20 +1,5 @@
 import { BadgedAvatar, type FactionAvatarProps } from './FactionAvatar'
-
-/** Circled-A anarchy sigil. */
-function CircledAGlyph({ size, color }: { size: number; color: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 48 48" fill="none" aria-hidden="true">
-      <circle cx="24" cy="24" r="19" stroke={color} strokeWidth="3.5" />
-      <path
-        d="M14 34 L24 12 L34 34 M18 27 H30"
-        stroke={color}
-        strokeWidth="3.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
+import { SnideSigil } from '../cards/SnideSigil'
 
 /**
  * S.N.I.D.E. avatar — the standard circle on photocopier ink with an acid
@@ -33,7 +18,7 @@ export default function SnideAvatar({ character, size }: FactionAvatarProps) {
       }}
       badgeBg="var(--faction-snide-ink)"
       badgeRing="var(--faction-snide-acid)"
-      glyph={(s, color) => <CircledAGlyph size={s} color={color} />}
+      glyph={(s, color) => <SnideSigil size={s} color={color} />}
     />
   )
 }

--- a/frontend/src/components/cards/FactionSigil.tsx
+++ b/frontend/src/components/cards/FactionSigil.tsx
@@ -1,0 +1,65 @@
+import type { ComponentType } from "react";
+import { pickVariant } from "../../utils/factionDispatch";
+import { factionCssVar } from "../../utils/factions";
+import { EverymenSigil } from "./EverymenSigil";
+import { WowSigil } from "./WowSigil";
+import { SnideSigil } from "./SnideSigil";
+import { EphemeristsSigil } from "./ephemeristsAtoms";
+import { SingularitySigil } from "./SingularitySigil";
+import { UaSigil } from "./UaSigil";
+import AlbescentSigil from "./AlbescentSigil";
+import DefaultSigil from "./DefaultSigil";
+
+/**
+ * FactionSigil — the dispatcher that makes the seven faction sigils (each
+ * previously its own inline/scattered component with its own prop shape)
+ * reachable as one `{ slug, size, color }` component (ADR-0040, #659). Falls
+ * back to the unaffiliated seven-segment `DefaultSigil` ring for an
+ * unknown/null slug, mirroring `FactionAvatar`'s dispatch pattern.
+ */
+export interface FactionSigilProps {
+  slug: string | null | undefined;
+  size?: number;
+  color?: string;
+}
+
+type SigilVariantProps = { size?: number; color?: string };
+
+function UaSigilAdapter({ size }: SigilVariantProps) {
+  const dim = size ?? 22;
+  // UA draws its own --ua-* tokens internally; it has no color prop.
+  return <UaSigil width={dim} height={dim} />;
+}
+
+function SingularitySigilAdapter({ size, color }: SigilVariantProps) {
+  return (
+    <SingularitySigil
+      size={size ?? 22}
+      color={color ?? factionCssVar("singularity")}
+    />
+  );
+}
+
+function AlbescentSigilAdapter({ size, color }: SigilVariantProps) {
+  return <AlbescentSigil size={size} color={color} />;
+}
+
+function DefaultSigilAdapter({ size }: SigilVariantProps) {
+  // The default ring has no color prop — it draws --faction-default-ring.
+  return <DefaultSigil size={size} />;
+}
+
+const FACTION_SIGILS: Record<string, ComponentType<SigilVariantProps>> = {
+  everymen: EverymenSigil,
+  wow: WowSigil,
+  snide: SnideSigil,
+  ephemerists: EphemeristsSigil,
+  singularity: SingularitySigilAdapter,
+  ua: UaSigilAdapter,
+  albescent: AlbescentSigilAdapter,
+};
+
+export default function FactionSigil({ slug, size, color }: FactionSigilProps) {
+  const Variant = pickVariant(FACTION_SIGILS, slug, DefaultSigilAdapter);
+  return <Variant size={size} color={color} />;
+}

--- a/frontend/src/components/cards/SnideSigil.tsx
+++ b/frontend/src/components/cards/SnideSigil.tsx
@@ -1,0 +1,28 @@
+/**
+ * SnideSigil — the S.N.I.D.E. circled-A anarchy mark, the faction's only sigil.
+ *
+ * Extracted from the inline `CircledAGlyph` in SnideAvatar (#659) so it's
+ * reachable as a standalone component like the other six faction sigils.
+ * Colors come from the --faction-snide-acid token by default — never hardcode
+ * hex.
+ */
+export function SnideSigil({
+  size = 22,
+  color = "var(--faction-snide-acid)",
+}: {
+  size?: number;
+  color?: string;
+}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 48 48" fill="none" aria-hidden="true">
+      <circle cx="24" cy="24" r="19" stroke={color} strokeWidth="3.5" />
+      <path
+        d="M14 34 L24 12 L34 34 M18 27 H30"
+        stroke={color}
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/cards/__tests__/factionSigil.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionSigil.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * FactionSigil dispatcher (#659, ADR-0040). Confirms the map resolves the
+ * bespoke sigil per faction slug and falls back to the unaffiliated
+ * seven-segment `DefaultSigil` ring for an unknown/null slug — the same
+ * fallback contract as `FactionAvatar` (see factionAvatar.test.tsx).
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import "../../../i18n";
+import FactionSigil from "../FactionSigil";
+
+describe("FactionSigil dispatcher (#659)", () => {
+  it("renders the UA heraldic shield for the ua slug", () => {
+    const html = renderToStaticMarkup(<FactionSigil slug="ua" />);
+    // UaSigil's shield markup marker — a viewBox unique to that sigil.
+    expect(html).toContain('viewBox="0 0 100 120"');
+    expect(html).toContain("var(--ua-gold)");
+  });
+
+  it("renders the S.N.I.D.E. circled-A for the snide slug", () => {
+    const html = renderToStaticMarkup(<FactionSigil slug="snide" />);
+    expect(html).toContain('viewBox="0 0 48 48"');
+    expect(html).toContain("var(--faction-snide-acid)");
+  });
+
+  it("renders the Everymen union cog for the everymen slug", () => {
+    const html = renderToStaticMarkup(<FactionSigil slug="everymen" />);
+    expect(html).toContain("var(--everymen-red)");
+    expect(html).toContain("var(--everymen-cream)");
+  });
+
+  it("falls back to the unaffiliated ring for an unknown slug", () => {
+    const html = renderToStaticMarkup(<FactionSigil slug="totally-unknown" />);
+    expect(html).toContain("var(--faction-default-ring)");
+    expect(html).not.toContain("var(--faction-snide-acid)");
+    expect(html).not.toContain("var(--ua-gold)");
+    expect(html).not.toContain("var(--everymen-red)");
+  });
+
+  it("falls back to the unaffiliated ring for a null slug", () => {
+    const html = renderToStaticMarkup(<FactionSigil slug={null} />);
+    expect(html).toContain("var(--faction-default-ring)");
+  });
+});

--- a/frontend/src/components/ui/FactionSigilRow.tsx
+++ b/frontend/src/components/ui/FactionSigilRow.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from "react-i18next";
+import type { FactionOut } from "../../api/factions";
+import {
+  factionCssVar,
+  factionName,
+  sortFactionsByRainbowOrder,
+} from "../../utils/factions";
+import FactionSigil from "../cards/FactionSigil";
+
+/**
+ * Faction filter — mobile sigil row (ADR-0040 §3, #659). The touch-native
+ * sibling of `FilterFactionTabs`: same `{factions, value, onChange}` shape,
+ * so it's a drop-in swap for a chip row. Renders one round sigil button per
+ * faction from the `factions` prop (never a hardcoded list — ADR-0027) plus
+ * an "all factions" circle using the shared spectrum-ring token. The row
+ * itself is neutral chrome; only the sigils/rings render faction color as
+ * data.
+ */
+interface Props {
+  factions: FactionOut[];
+  value: string;
+  onChange: (slug: string) => void;
+}
+
+const CIRCLE_DIAMETER = 36;
+const SIGIL_SIZE = 20;
+
+/**
+ * The toggle-off decision a faction circle's click makes: tapping the
+ * already-active faction clears the filter, otherwise selects it. Exported
+ * so the interaction can be unit-tested without a DOM (mirrors
+ * `FilterFactionTabs`'s inline `value === faction.slug ? "" : faction.slug`).
+ */
+export function nextFactionValue(current: string, slug: string): string {
+  return current === slug ? "" : slug;
+}
+
+export default function FactionSigilRow({ factions, value, onChange }: Props) {
+  const { t } = useTranslation("common");
+  const { t: tt } = useTranslation("tasks");
+  const allActive = value === "";
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="eyebrow flex-none">{t("filters.faction")}</span>
+      <div
+        className="flex gap-2"
+        style={{ overflowX: "auto", paddingBottom: 2, scrollbarWidth: "none" }}
+      >
+        <button
+          type="button"
+          aria-label={tt("mobile.allFactions")}
+          onClick={() => onChange("")}
+          className="rounded-full flex-none"
+          style={{
+            width: CIRCLE_DIAMETER,
+            height: CIRCLE_DIAMETER,
+            background: "var(--faction-default-rainbow)",
+            boxShadow: allActive
+              ? "0 0 0 2px var(--color-text-primary)"
+              : "0 0 0 1px var(--color-border-strong)",
+            opacity: allActive ? 1 : 0.85,
+            cursor: "pointer",
+          }}
+        />
+        {sortFactionsByRainbowOrder(factions).map((faction) => {
+          const active = value === faction.slug;
+          return (
+            <button
+              key={faction.slug}
+              type="button"
+              aria-label={factionName(faction.slug)}
+              onClick={() => onChange(nextFactionValue(value, faction.slug))}
+              className="rounded-full flex-none flex items-center justify-center"
+              style={{
+                width: CIRCLE_DIAMETER,
+                height: CIRCLE_DIAMETER,
+                background: "var(--color-bg-surface)",
+                boxShadow: active
+                  ? `0 0 0 2px ${factionCssVar(faction.slug)}`
+                  : "0 0 0 1px var(--color-border-strong)",
+                opacity: active ? 1 : 0.85,
+                cursor: "pointer",
+              }}
+            >
+              <FactionSigil slug={faction.slug} size={SIGIL_SIZE} />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/FactionSigilRow.tsx
+++ b/frontend/src/components/ui/FactionSigilRow.tsx
@@ -44,8 +44,8 @@ export default function FactionSigilRow({ factions, value, onChange }: Props) {
     <div className="flex items-center gap-2">
       <span className="eyebrow flex-none">{t("filters.faction")}</span>
       <div
-        className="flex gap-2"
-        style={{ overflowX: "auto", paddingBottom: 2, scrollbarWidth: "none" }}
+        className="flex gap-2 pb-0.5"
+        style={{ overflowX: "auto", scrollbarWidth: "none" }}
       >
         <button
           type="button"

--- a/frontend/src/components/ui/__tests__/factionSigilRow.test.tsx
+++ b/frontend/src/components/ui/__tests__/factionSigilRow.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * FactionSigilRow — mobile faction filter (#659, ADR-0040 §3).
+ *
+ * The check this issue calls out: the row must render exactly the factions it
+ * is given (never a hardcoded literal list), so a `getFactions()`-shaped
+ * response that omits `albescent` (pre-reveal, ADR-0027/#390) never leaks an
+ * Albescent circle. Also confirms the toggle-off click wiring calls `onChange`
+ * with the right slug, using the same element-tree-walk technique as
+ * mobileArchetypeDispatch.test.tsx (no DOM in this test env).
+ */
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect, vi } from "vitest";
+
+// Stub the i18n hook to a plain t so the component can be invoked as a plain
+// function (no hook dispatcher) when we walk its element tree below. The rest
+// of react-i18next (initReactI18next, used by ../../../i18n) is real.
+vi.mock("react-i18next", async (importActual) => {
+  const actual = await importActual<typeof import("react-i18next")>();
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) };
+});
+// factionName/factionCssVar read the raw i18n instance, not the hook.
+import "../../../i18n";
+
+import FactionSigilRow, { nextFactionValue } from "../FactionSigilRow";
+import type { FactionOut } from "../../../api/factions";
+
+const FACTIONS_WITHOUT_ALBESCENT: FactionOut[] = [
+  { slug: "everymen" },
+  { slug: "ua" },
+  { slug: "snide" },
+  { slug: "ephemerists" },
+  { slug: "singularity" },
+  { slug: "wow" },
+];
+
+describe("FactionSigilRow — secrecy guard (ADR-0027/#390)", () => {
+  it("renders no Albescent circle when the factions prop omits it", () => {
+    const html = renderToStaticMarkup(
+      <FactionSigilRow
+        factions={FACTIONS_WITHOUT_ALBESCENT}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    expect(html).not.toContain("/Albescent");
+    expect(html).not.toContain("var(--faction-albescent)");
+  });
+
+  it("renders an Albescent circle once it is present in the factions prop", () => {
+    const html = renderToStaticMarkup(
+      <FactionSigilRow
+        factions={[...FACTIONS_WITHOUT_ALBESCENT, { slug: "albescent" }]}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    expect(html).toContain("/Albescent");
+  });
+});
+
+describe("nextFactionValue — toggle-off decision (#659)", () => {
+  it("selects the tapped slug when a different faction is active", () => {
+    expect(nextFactionValue("everymen", "ua")).toBe("ua");
+  });
+  it("clears the filter when the already-active faction is tapped again", () => {
+    expect(nextFactionValue("ua", "ua")).toBe("");
+  });
+});
+
+// Depth-first search for the button element whose accessible name matches.
+function findButtonByLabel(node: unknown, label: string): ReactElement | null {
+  if (!node || typeof node !== "object") return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = findButtonByLabel(child, label);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  const element = node as ReactElement;
+  const props = element.props as
+    | { "aria-label"?: string; children?: unknown }
+    | undefined;
+  if (props?.["aria-label"] === label) return element;
+  return props ? findButtonByLabel(props.children, label) : null;
+}
+
+describe("FactionSigilRow — click wiring calls onChange", () => {
+  it("tapping a faction circle calls onChange with that faction's slug", () => {
+    const onChange = vi.fn();
+    const tree = FactionSigilRow({
+      factions: FACTIONS_WITHOUT_ALBESCENT,
+      value: "",
+      onChange,
+    });
+    // useTranslation is stubbed to `t = (key) => key`, so factionName's
+    // catalog lookup below the hook doesn't apply here — aria-label comes
+    // from factionName() directly (not the stubbed hook), so it's still the
+    // real English name.
+    const button = findButtonByLabel(tree, "UA");
+    expect(button, "UA sigil button found").not.toBeNull();
+    (button?.props as { onClick: () => void }).onClick();
+    expect(onChange).toHaveBeenCalledWith("ua");
+  });
+
+  it("tapping the already-active faction circle clears the filter", () => {
+    const onChange = vi.fn();
+    const tree = FactionSigilRow({
+      factions: FACTIONS_WITHOUT_ALBESCENT,
+      value: "ua",
+      onChange,
+    });
+    const button = findButtonByLabel(tree, "UA");
+    (button?.props as { onClick: () => void }).onClick();
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it('tapping the "all factions" circle calls onChange with an empty slug', () => {
+    const onChange = vi.fn();
+    const tree = FactionSigilRow({
+      factions: FACTIONS_WITHOUT_ALBESCENT,
+      value: "ua",
+      onChange,
+    });
+    // useTranslation is stubbed to `t = (key) => key` in this file, so the
+    // "all factions" button's aria-label (sourced from the hook, unlike
+    // factionName) is the raw catalog key here, not the resolved "All" copy.
+    const button = findButtonByLabel(tree, "mobile.allFactions");
+    expect(button, "all-factions button found").not.toBeNull();
+    (button?.props as { onClick: () => void }).onClick();
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+});

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
-import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
 import type { TasksState } from '../useTasks'
 import MobileTaskCard from './mobileTaskCard'
+import FactionSigilRow from '../../../components/ui/FactionSigilRow'
 
 /**
  * Default MOBILE task-browse skin — a scannable single-column card list with
@@ -51,22 +51,10 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
         ))}
       </ChipRow>
 
-      {/* Faction chips */}
-      <ChipRow label={tc('filters.faction')}>
-        <Chip on={faction === ''} onClick={() => setFaction('')}>
-          {t('mobile.allFactions')}
-        </Chip>
-        {sortFactionsByRainbowOrder(factions).map((f) => (
-          <Chip
-            key={f.slug}
-            on={faction === f.slug}
-            onClick={() => setFaction(faction === f.slug ? '' : f.slug)}
-            tint={factionCssVar(f.slug)}
-          >
-            {factionName(f.slug)}
-          </Chip>
-        ))}
-      </ChipRow>
+      {/* Faction sigils */}
+      <div className="mb-2">
+        <FactionSigilRow factions={factions} value={faction} onChange={setFaction} />
+      </div>
 
       {/* Level chips */}
       <ChipRow label={tc('filters.level')}>


### PR DESCRIPTION
Closes #659

## What changed

- **`SnideSigil`** (`components/cards/SnideSigil.tsx`) — extracted the circled-A anarchy glyph out of `SnideAvatar.tsx`'s private inline `CircledAGlyph`, so it's reachable as a standalone component like the other six faction sigils. Pixel-identical markup; `SnideAvatar.tsx` now imports it.
- **`FactionSigil`** (`components/cards/FactionSigil.tsx`) — the dispatcher named in the issue. Normalizes all seven faction sigils' differing prop shapes (`UaSigil`'s `width`/`height`, `SingularitySigil`'s required-no-defaults `size`/`color`, `DefaultSigil`'s no-color ring, etc.) behind one `{ slug, size, color }` interface via `pickVariant`, mirroring `FactionAvatar`'s dispatch pattern. Falls back to the unaffiliated `DefaultSigil` ring for an unknown/null slug.
- **`FactionSigilRow`** (`components/ui/FactionSigilRow.tsx`) — the shared mobile faction filter (ADR-0040 §3), desktop's `FilterFactionTabs` sibling. Same `{factions, value, onChange}` prop shape. Renders one round sigil button per faction from the `factions` prop (never a hardcoded list — the ADR-0027 Albescent-secrecy guard) plus an "all factions" circle using the existing `var(--faction-default-rainbow)` token (no hand-rolled `conic-gradient`).
- **Mobile Tasks swap** (`pages/tasks/mobileArchetypes/DefaultTasks.tsx`) — replaced the faction `ChipRow`/`Chip` block with `<FactionSigilRow />`. Status and level chip rows are untouched, per the issue.

Out of scope, untouched: desktop faction filtering, the other six avatar variants' inline glyph callbacks, mobile Tasks search.

## Tests

- `factionSigil.test.tsx` — dispatch spot-checks per slug + fallback to `DefaultSigil` for unknown/null.
- `factionSigilRow.test.tsx` — includes the explicit regression guard: **no Albescent circle renders when `factions` omits it** (the secrecy-leak check the issue calls out). Also covers the toggle-off click behavior via an exported pure helper (`nextFactionValue`), following this repo's no-jsdom interaction-test convention.
- `npm test`: **89 files / 737 tests passing**, no regressions (including `SnideAvatar`'s existing coverage).
- `eslint`: clean on all touched/new files — including a fix for a raw-pixel `paddingBottom` the initial pass introduced (new files aren't grandfathered into `.eslint-legacy-raw-styles.txt`), swapped for the Tailwind `pb-0.5` utility.
- `tsc --noEmit`: zero errors attributable to this change (2 pre-existing, unrelated errors in untouched files remain).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ju7H82B5fnbmp1Gc4MmGvB)_