### PR TITLE
Route all 8 praxis-detail archetypes through VoteUI (#640)

### DIFF
--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
-import EphemeristsVote from '../../../components/vote/EphemeristsVote'
+import VoteUI from '../../../components/vote/VoteUI'
 import { EphemeristsSigil, EphEyebrow, Foxing, LapisLastWord, toRoman } from '../../../components/cards/ephemeristsAtoms'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
@@ -351,7 +351,8 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
               </div>
             )}
           </div>
-          <EphemeristsVote
+          <VoteUI
+            factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
             points={votes?.total_score}
             totalVotes={votes?.total_votes}

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
-import EverymenVote from '../../../components/vote/EverymenVote'
+import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
@@ -248,7 +248,8 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
           )}
         </div>
         <div style={{ marginBottom: 20 }}>
-          <EverymenVote
+          <VoteUI
+            factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
             points={votes?.total_score}
             totalVotes={votes?.total_votes}

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
-import SingularityVote from '../../../components/vote/SingularityVote'
+import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
@@ -422,7 +422,8 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
                 </span>
               </div>
             )}
-            <SingularityVote
+            <VoteUI
+              factionSlug={praxis.task_faction_slug}
               praxisId={praxis.id}
               points={votes?.total_score}
               totalVotes={votes?.total_votes}

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
-import SnideVote from '../../../components/vote/SnideVote'
+import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
@@ -410,7 +410,8 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
               </div>
             )}
           </div>
-          <SnideVote
+          <VoteUI
+            factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
             points={votes?.total_score}
             totalVotes={votes?.total_votes}

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import MediaGallery from '../../../components/MediaGallery'
-import WowVote from '../../../components/vote/WowVote'
+import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, MemberByline } from '../shared'
@@ -426,7 +426,8 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
                 </div>
               )}
             </div>
-            <WowVote
+            <VoteUI
+              factionSlug={praxis.task_faction_slug}
               praxisId={praxis.id}
               points={votes?.total_score}
               totalVotes={votes?.total_votes}


### PR DESCRIPTION
Route all 8 praxis-detail archetypes through the shared `VoteUI` dispatcher.

## Problem
Three praxis-detail archetypes already rendered `<VoteUI factionSlug=…>` and let the dispatcher pick the variant (Ua, Default, Albescent). The other five imported their concrete vote variant directly, bypassing `VoteUI`:

- `WowPraxisDetail.tsx`
- `SnidePraxisDetail.tsx`
- `EverymenPraxisDetail.tsx`
- `SingularityPraxisDetail.tsx`
- `EphemeristsPraxisDetail.tsx`

It worked because each archetype is faction-specific, so the dispatch was a no-op — but it meant changes to `VoteUI` (props, gating, dispatch rules) silently skipped five files, the class of drift that makes "one shared surface" untrue in practice.

## Change
Swap the direct-variant import for `VoteUI` and render `<VoteUI factionSlug={praxis.task_faction_slug} … />` in all five, matching the pattern Ua/Default/Albescent already use. The other props (`praxisId`, `points`, `totalVotes`) were already identical to `VoteUIProps`, so no prop shape changed.

**No vote tally semantics changed** — this is import/dispatch wiring only. Tally work is #641, which builds on this routing.

## Verification
- `npx tsc --noEmit`: clean for all touched files (2 pre-existing, unrelated `node:fs`/`node:url` errors in `factionContrast.test.ts`, masked on main by its incremental cache).
- vitest: dispatch + slot + vote-override suites pass (38 tests across 7 files).

Closes #640
