### PR TITLE
Unaffiliated fill is the rainbow, not UA orange (#636)

### DIFF
--- a/docs/spec/SPEC-faction-ui-profile.md
+++ b/docs/spec/SPEC-faction-ui-profile.md
@@ -77,7 +77,7 @@ A per-faction surface needs to know *which* faction to render as. Use these rule
 
 ## 3. The token contract a new faction must satisfy
 
-Every faction supplies one CSS-variable block in `frontend/src/index.css`, defined in **both** `:root` (light) and `[data-theme="dark"]`. Naming is `--faction-{cssKey}-{suffix}`. `factionCssVar(slug, suffix)` reads these; a missing `CSS_KEY` entry silently falls back to the `ua` theme.
+Every faction supplies one CSS-variable block in `frontend/src/index.css`, defined in **both** `:root` (light) and `[data-theme="dark"]`. Naming is `--faction-{cssKey}-{suffix}`. `factionCssVar(slug, suffix)` reads these; a missing `CSS_KEY` entry falls back to the `default` theme (neutral grey / rainbow — the `na` set, ADR-0039), not `ua`. Fills that render a dynamic slug use `factionFill(slug, shape)` instead, which turns `na`'s scalar grey into its spectrum by surface shape.
 
 Required suffixes (consumed by the dispatchers / `factionCssVar`):
 
@@ -177,7 +177,7 @@ Hand this to whoever wires the faction after design is delivered. (Designer only
 
 ### B. Token / tint surfaces — every faction has these by construction
 
-Not bespoke components; driven by the CSS-var block (§3) + registry (`utils/factions.ts`). A faction can't be "missing" one — a blank token silently falls back to the `ua` theme. So they're **not** a design-commission gap, only a "did you fill in the tokens" check.
+Not bespoke components; driven by the CSS-var block (§3) + registry (`utils/factions.ts`). A faction can't be "missing" one — a blank token falls back to the `default` (neutral grey / `na`) theme, not `ua` (ADR-0039). So they're **not** a design-commission gap, only a "did you fill in the tokens" check.
 
 | Surface (§1 #) | How it varies | Mechanism |
 |---|---|---|

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -10,7 +10,7 @@ import SingularityTaskCard from './cards/SingularityTaskCard'
 import EverymenTaskCard from './cards/EverymenTaskCard'
 import AlbescentTaskCard from './cards/AlbescentTaskCard'
 import DefaultTaskCard from './cards/DefaultTaskCard'
-import { factionCssVar, factionName } from '../utils/factions'
+import { factionCssVar, factionFill, factionName } from '../utils/factions'
 import { pickVariant } from '../utils/factionDispatch'
 import type { ComponentType } from 'react'
 
@@ -68,8 +68,6 @@ export default function TaskCard({ task, displayPoints, onSignup }: CardProps) {
         >
           <span
             style={{
-              background: factionCssVar(task.metatask_faction_slug),
-              color: factionCssVar(task.metatask_faction_slug, 'on-fill'),
               fontFamily: "'Courier Prime', monospace",
               fontSize: 8,
               fontWeight: 700,
@@ -78,6 +76,9 @@ export default function TaskCard({ task, displayPoints, onSignup }: CardProps) {
               padding: '2px 8px',
               border: `1.5px solid ${factionCssVar(task.metatask_faction_slug, 'border')}`,
               textShadow: '0 1px 2px rgba(0,0,0,0.3)',
+              // na → rainbow frame (overrides the faction border below); real
+              // faction → solid hue + on-fill ink, keeping its 1.5px border.
+              ...factionFill(task.metatask_faction_slug, 'pill'),
             }}
           >
             META

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -28,7 +28,7 @@ import { useGameConfig } from "../hooks/useGameConfig";
 import { useFormFactor } from "../hooks/useFormFactor";
 import { pickVariant } from "../utils/factionDispatch";
 import { extractError } from "../utils/errors";
-import { factionCssVar } from "../utils/factions";
+import { factionFill } from "../utils/factions";
 import { useFactionBackdrop } from "../components/backdrop/BackdropContext";
 import FactionProfileBody, {
   type ProfileBodyProps,
@@ -281,8 +281,6 @@ export default function CharacterProfile() {
               onClick={() => handleAddRelationship("friend")}
               disabled={relationshipLoading}
               style={{
-                background: factionCssVar(character.faction_slug),
-                color: factionCssVar(character.faction_slug, "on-fill"),
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: 8,
                 textTransform: "uppercase",
@@ -292,6 +290,8 @@ export default function CharacterProfile() {
                 cursor: "pointer",
                 borderRadius: 2,
                 opacity: relationshipLoading ? 0.5 : 1,
+                // na → rainbow frame; real faction → solid hue + on-fill ink
+                ...factionFill(character.faction_slug, "pill"),
               }}
             >
               {t("relationships.addFriend")}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { factionCssVar, factionName } from '../../../utils/factions'
+import { factionCssVar, factionFill, factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
@@ -248,7 +248,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
               >
                 <span
                   className="shrink-0"
-                  style={{ width: 10, height: 10, borderRadius: 3, background: factionCssVar(praxis.task_faction_slug) }}
+                  style={{ width: 10, height: 10, borderRadius: 3, ...factionFill(praxis.task_faction_slug, 'dot') }}
                 />
                 <div className="min-w-0 flex-1">
                   <div className="font-display truncate" style={{ fontSize: 17, lineHeight: 1.2, color: 'var(--color-text-primary)' }}>

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -4,7 +4,7 @@ import PraxisCard from "../../../components/PraxisCard";
 import LevelPill from "../../../components/ui/LevelPill";
 import FeedBadge from "../../../components/feed/FeedBadge";
 import DefaultSigil from "../../../components/cards/DefaultSigil";
-import { factionCssVar, factionName } from "../../../utils/factions";
+import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { TaskDetailState } from "../useTaskDetail";
 
@@ -141,10 +141,10 @@ export default function DefaultTaskDetail({
                     letterSpacing: "0.15em",
                     padding: "2px 8px",
                     borderRadius: 4,
-                    background: factionCssVar(task.metatask_faction_slug),
-                    color: factionCssVar(task.metatask_faction_slug, "on-fill"),
                     fontWeight: 700,
                     textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+                    // na → rainbow frame; real faction → solid hue + on-fill ink
+                    ...factionFill(task.metatask_faction_slug, "pill"),
                   }}
                 >
                   {t("default.meta")}

--- a/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
+++ b/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   FACTION_RAINBOW_ORDER,
+  factionCssVar,
+  factionFill,
   sortFactionsByRainbowOrder,
 } from "../factions";
 
@@ -39,5 +41,72 @@ describe("sortFactionsByRainbowOrder", () => {
     const factions = [{ slug: "wow" }, { slug: "everymen" }];
     sortFactionsByRainbowOrder(factions);
     expect(factions.map((f) => f.slug)).toEqual(["wow", "everymen"]);
+  });
+});
+
+describe("factionCssVar unaffiliated fallback (#636 / ADR-0039)", () => {
+  it("resolves na to the default (neutral grey) theme, not ua", () => {
+    expect(factionCssVar("na")).toBe("var(--faction-default)");
+    expect(factionCssVar("na", "border")).toBe("var(--faction-default-border)");
+  });
+
+  it("degrades unregistered slugs to default, never impersonating ua", () => {
+    expect(factionCssVar("not_a_faction")).toBe("var(--faction-default)");
+    expect(factionCssVar(null)).toBe("var(--faction-default)");
+    expect(factionCssVar(undefined)).toBe("var(--faction-default)");
+  });
+
+  it("still resolves real factions to their own theme", () => {
+    expect(factionCssVar("ua")).toBe("var(--faction-ua)");
+    expect(factionCssVar("everymen", "card-bg")).toBe(
+      "var(--faction-everymen-card-bg)",
+    );
+  });
+});
+
+describe("factionFill (#636 / ADR-0039)", () => {
+  it("gives na the linear rainbow for a bar", () => {
+    expect(factionFill("na", "bar")).toEqual({
+      background: "var(--faction-default-rainbow)",
+    });
+  });
+
+  it("gives na the conic rainbow for a dot (linear reads as mud at 10-12px)", () => {
+    expect(factionFill("na", "dot")).toEqual({
+      background: "var(--faction-default-ring)",
+    });
+  });
+
+  it("frames na's rainbow around a paper interior for a pill", () => {
+    const fill = factionFill("na", "pill");
+    expect(fill.border).toBe("2px solid transparent");
+    expect(fill.color).toBe("var(--faction-default-card-text)");
+    expect(fill.background).toContain("border-box");
+    expect(fill.background).toContain("--faction-default-rainbow");
+  });
+
+  it("unregistered / null slugs fill like na (default), not ua", () => {
+    expect(factionFill("not_a_faction", "bar")).toEqual({
+      background: "var(--faction-default-rainbow)",
+    });
+    expect(factionFill(null, "dot")).toEqual({
+      background: "var(--faction-default-ring)",
+    });
+  });
+
+  it("returns a real faction's solid hue for every shape", () => {
+    expect(factionFill("everymen", "bar")).toEqual({
+      background: "var(--faction-everymen)",
+    });
+    expect(factionFill("everymen", "dot")).toEqual({
+      background: "var(--faction-everymen)",
+    });
+  });
+
+  it("pairs a real faction fill with its on-fill AA ink for a pill (#649)", () => {
+    expect(factionFill("wow", "pill")).toEqual({
+      background: "var(--faction-wow)",
+      color: "var(--faction-wow-on-fill)",
+    });
   });
 });

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -15,6 +15,7 @@
  * slug (ADR-0031, same split as taunts/ranks), and are resolved via
  * factionName() / factionDescription().
  */
+import type { CSSProperties } from "react";
 import i18n from "../i18n";
 
 // Faction slugs are runtime-dynamic, so the catalog keys (`factions:names.<slug>`
@@ -71,7 +72,20 @@ const CSS_KEY: Record<string, string> = {
   ephemerists: "ephemerists",
   singularity: "singularity",
   albescent: "albescent", // first-class (#232) — its own --faction-albescent-* set
+  // `na` (unaffiliated) is a state, not a faction: it reads the neutral/rainbow
+  // --faction-default-* set (#418). Scalars resolve to grey here; the spectrum
+  // reaches fills only through factionFill() (ADR-0039).
+  na: "default",
 };
+
+/**
+ * Resolve a slug (through aliases) to its CSS-variable key. Unknown/unregistered
+ * slugs degrade to `default` (neutral grey / rainbow), never impersonate `ua`.
+ */
+function resolveCssKey(slug: string | null | undefined): string {
+  const resolved = FACTION_ALIASES[slug ?? ""] ?? slug ?? "";
+  return CSS_KEY[resolved] ?? "default";
+}
 
 /**
  * Get a CSS variable reference for a faction property.
@@ -90,10 +104,69 @@ export function factionCssVar(
   slug: string | null | undefined,
   suffix?: string,
 ): string {
-  const resolved = FACTION_ALIASES[slug ?? ""] ?? slug ?? "";
-  const key = CSS_KEY[resolved] ?? "ua";
+  const key = resolveCssKey(slug);
   const prop = suffix ? `--faction-${key}-${suffix}` : `--faction-${key}`;
   return `var(${prop})`;
+}
+
+/**
+ * Surface geometry a faction FILL can occupy. Determines how `na`'s spectrum is
+ * rendered — the wrong shape compiles fine but looks bad (a 7-stop linear on a
+ * 10px dot reads as mud), so the call site picks it. See ADR-0039.
+ */
+export type FactionFillShape = "bar" | "dot" | "pill";
+
+/**
+ * A faction FILL as a style object to spread onto the filled element.
+ *
+ * Every real faction returns its solid hue for every shape (with the paired
+ * `--faction-{key}-on-fill` AA ink for `"pill"`, #649). Only `na`/unregistered
+ * slugs are shape-dependent, because their identity is a gradient, not a hue
+ * (ADR-0039):
+ *   - `"bar"`  → the linear rainbow (`--faction-default-rainbow`)
+ *   - `"dot"`  → the conic rainbow (`--faction-default-ring`; a 7-stop linear is
+ *                mud at 10–12px)
+ *   - `"pill"` → the rainbow as a *frame* (border-box) around a neutral paper
+ *                interior with ink text — no single ink is legible across the
+ *                spectrum, so the label never sits on it.
+ *
+ * Prefer this over `factionCssVar(slug)` for any `background:` that renders a
+ * dynamic slug (one that can be `na` at runtime). Scalar contexts (`color:`,
+ * borders) keep using `factionCssVar` and stay neutral grey for `na`.
+ */
+export function factionFill(
+  slug: string | null | undefined,
+  shape: FactionFillShape,
+): CSSProperties {
+  const key = resolveCssKey(slug);
+  const isDefault = key === "default";
+
+  if (shape === "pill") {
+    if (isDefault) {
+      // Paper interior on padding-box, spectrum on border-box, ink on paper.
+      return {
+        background:
+          "linear-gradient(var(--faction-default-card-bg), var(--faction-default-card-bg)) padding-box, var(--faction-default-rainbow) border-box",
+        border: "2px solid transparent",
+        color: "var(--faction-default-card-text)",
+        boxSizing: "border-box",
+      };
+    }
+    return {
+      background: `var(--faction-${key})`,
+      color: `var(--faction-${key}-on-fill)`,
+    };
+  }
+
+  if (isDefault) {
+    return {
+      background:
+        shape === "dot"
+          ? "var(--faction-default-ring)"
+          : "var(--faction-default-rainbow)",
+    };
+  }
+  return { background: `var(--faction-${key})` };
 }
 
 /** Get faction color by slug, with fallback (raw hex — light mode only) */


### PR DESCRIPTION
Closes #636

Unaffiliated (`na`) rendered as UA burnt-amber wherever a slug asked for its color, because `CSS_KEY` had no `na` entry and `factionCssVar` ended `?? "ua"`. This reaches `na`'s existing rainbow identity (`--faction-default-*`, #418) by slug, and gives fills a shape-aware helper. Full decision record: **ADR-0039**.

## Core change (`frontend/src/utils/factions.ts`)

- `CSS_KEY` gains `na: "default"`; `factionCssVar`'s terminal fallback is now `?? "default"` (via a shared `resolveCssKey`), so **scalars** (`color:`, borders) for `na`/unregistered slugs degrade to neutral grey instead of impersonating UA.
- New **`factionFill(slug, shape)`** returns a `CSSProperties` object to spread onto a filled element. Real factions return their solid hue for every shape (pill also pairs the `--faction-{key}-on-fill` AA ink, #649). Only `na`/unregistered slugs are shape-dependent:
  - `"bar"` → `--faction-default-rainbow` (linear)
  - `"dot"` → `--faction-default-ring` (conic — a 7-stop linear reads as mud at 10–12px)
  - `"pill"` → rainbow *frame* (`border-box`) around a paper interior in ink text (no single ink is legible across the spectrum)
- `na` stays **out** of `FACTION_FALLBACKS` (it's a state, not a faction — keeps it out of `getAllFactions()`/the propose-task picker).

## Docs

- `SPEC-faction-ui-profile.md` §3 and §7B: the "falls back to the `ua` theme" claims are now false — corrected to `default`, with a pointer to `factionFill`.

## Fill call-site classification

The issue's "12 fill sites" is approximate. Only fills that render a **dynamic** slug that can be `na`/unregistered at runtime need routing. I classified every candidate:

**Routed (4):**
- `pages/CharacterProfile.tsx` — add-friend pill (`character.faction_slug`) → `pill`
- `components/TaskCard.tsx` — META badge (`task.metatask_faction_slug`) → `pill`
- `pages/taskDetail/archetypes/DefaultTaskDetail.tsx` — META badge → `pill`
- `pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx` — 10px praxis dot (`praxis.task_faction_slug`) → `dot`

The three `pill` sites spread `factionFill` **last** so `na`'s rainbow border wins, while real factions keep their existing border and geometry unchanged.

**Deliberately skipped:**
- **Faction pickers / directories** (`CreateCharacter`, `DefaultCreateCharacter`, `DefaultProposeTask`, `DefaultFactionsDirectory`, `FilterFactionTabs`) — iterate `getAllFactions()` / an API faction list, which **excludes `na`**. The slug is never `na`, so `factionFill` would only ever return the solid hue. No churn.
- **`Leaderboard.tsx` rainbow rule** — a linear gradient over the fixed 7-faction `FACTION_RAINBOW_ORDER`, not a single dynamic slug.
- **Composite avatar gradients** (`Sidebar`, `DefaultProfile`, `RosterTable`, `Constellation`, `CharacterSwitcherSheet`, `DefaultFieldDesk:110`, `DefaultSettings`, `DefaultTaskDetail:548`) — `linear-gradient(135deg, {slug}-light, {slug})`, i.e. two **scalars**. Per ADR-0039 decision #2, scalar contexts stay neutral grey; the `CSS_KEY` fix alone turns these from orange to grey for `na`, which is the accepted placeholder. Not one of the three fill shapes, so no `factionFill`.
- **Players files** (`pages/players/**`) untouched — a concurrent agent (#657) owns `DefaultPlayers.tsx`.

## Tests

`frontend/src/utils/__tests__/factionRainbowOrder.test.ts` extended (12 tests total): `na`/unregistered/`null`/`undefined` resolve to `default` not `ua`; each `factionFill` shape returns its expected treatment; real factions return their solid hue + on-fill ink.

Verified: `tsc --noEmit` clean on all touched files (only the pre-existing `node:fs` errors in `factionContrast.test.ts` from the missing `@types/node` remain); `factionRainbowOrder` (12), `factionContrast` (108), `factionAlbescentFirstClass` (3) all green.

## Unblocks

#648 (drop `WORLD_ZERO_STYLE.md` §6's stale hex column; adds the `na` row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
