### PR TITLE
Bring the Constellation to mobile Players (#657)

### DIFF
--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -133,7 +133,6 @@ src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
 src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
 src/pages/Home.tsx
 src/pages/Leaderboard.tsx
-src/pages/players/mobileArchetypes/DefaultPlayers.tsx
 src/pages/praxes/MobilePraxisFeed.tsx
 src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
 src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -88,7 +88,9 @@
       "factionLevel": "{{faction}} · Lv {{level}}",
       "points": "pts",
       "empty": "No players match this filter.",
-      "loadError": "Couldn't load the leaderboard."
+      "loadError": "Couldn't load the leaderboard.",
+      "loadMore": "Load more players",
+      "showing": "Showing {{shown}} of {{total}}"
     }
   },
   "collaborationCard": {

--- a/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
+++ b/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
@@ -1,19 +1,33 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { CharacterOut } from '../../../api/auth'
-import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import { useAuth } from '../../../auth/AuthContext'
+import {
+  FACTION_RAINBOW_ORDER,
+  factionCssVar,
+  factionName,
+  sortFactionsByRainbowOrder,
+} from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { badgeArtFor } from '../../../components/badges/badgeArt'
+import LevelPill from '../../../components/ui/LevelPill'
+import Constellation, { type RankedPlayer } from '../Constellation'
 
 export interface PlayersDirectoryProps {
   characters: CharacterOut[]
   loading: boolean
   error: Error | null
-  /** The viewer's own character id, highlighted in the list. */
+  /** The viewer's own character id, pinned in the sky and highlighted in the roster. */
   myCharId: number | null
 }
 
 type ScoreMode = 'era' | 'alltime'
+
+/** The sky shows the top few; mobile fits fewer labelled orbs than desktop's 12. */
+const SKY_POPULATION = 6
+/** "Load more players" reveals one more page of this many roster rows. */
+const PAGE_STEP = 8
 
 /** Unaffiliated players carry a null faction_slug; normalise to a stable chip
  *  key so the "All / <faction>" filter can include them. factionName(null)
@@ -22,37 +36,72 @@ const UNAFFILIATED = 'na'
 const slugKey = (slug: string | null): string => slug ?? UNAFFILIATED
 
 /**
- * Default MOBILE players-directory skin (#517) — a scannable single-column
- * ranking (rank · avatar · faction tint · level · points) with phone-native
- * filter chips (sort by era/all-time score, filter by faction), NOT the desktop
- * podium + table. A row taps through to the public profile. Mirrors the
- * DefaultTasks mobile browse idiom; consumes the same leaderboard read the
- * desktop board uses (presentation-only, no backend change).
+ * Default MOBILE players-directory skin (#657) — the desktop Constellation
+ * (#656) brought to the phone. The sky is the *reused* `Constellation`
+ * component at a smaller population (top 6 + you, pinned); the roster below is
+ * a single-column stack of everyone with a "Load more players" pager instead
+ * of desktop's numbered pages. The Era / All-Time toggle drives the whole page
+ * — sky and roster share one `scoreMode` — mirroring desktop (epic #654 §6).
+ *
+ * Copy is shared with the desktop board: the sky's eyebrow/title/tagline/legend
+ * reuse the `leaderboard.desktop.*` catalog keys (the reused Constellation
+ * already pulls its own copy from there), so there is one voice, not two.
  */
 export default function DefaultPlayers({ characters, loading, error, myCharId }: PlayersDirectoryProps) {
   const { t } = useTranslation('common')
+  const { user } = useAuth()
   const [scoreMode, setScoreMode] = useState<ScoreMode>('era')
-  const [faction, setFaction] = useState<string>('')
 
-  const scoreOf = (c: CharacterOut) => (scoreMode === 'era' ? c.score : c.all_time_score)
-  const sorted = [...characters].sort((a, b) => scoreOf(b) - scoreOf(a))
-  const shown = faction === '' ? sorted : sorted.filter((c) => slugKey(c.faction_slug) === faction)
+  const pointsOf = (character: CharacterOut) =>
+    scoreMode === 'era' ? character.score : character.all_time_score
 
-  // Distinct factions present, in canonical rainbow order, for the filter row.
-  const presentSlugs = Array.from(new Set(characters.map((c) => slugKey(c.faction_slug))))
-  const factionChips = sortFactionsByRainbowOrder(presentSlugs.map((slug) => ({ slug })))
+  // Rank is the true global standing over everyone in the field (server already
+  // returns score DESC, id ASC, so ties stay deterministic across renders).
+  const ranked: RankedPlayer[] = useMemo(
+    () =>
+      [...characters]
+        .sort((a, b) => pointsOf(b) - pointsOf(a))
+        .map((character, index) => ({ character, rank: index + 1, points: pointsOf(character) })),
+    [characters, scoreMode],
+  )
+
+  const maxScore = ranked.length > 0 ? ranked[0].points : 0
+  const factionCount = new Set(
+    characters.map((c) => c.faction_slug).filter((slug): slug is string => slug != null),
+  ).size
+
+  const eyebrow =
+    scoreMode === 'era'
+      ? t('leaderboard.desktop.eyebrowEra', { era: user?.era_name ?? '' })
+      : t('leaderboard.desktop.eyebrowAllTime')
+  const tagline =
+    scoreMode === 'era'
+      ? t('leaderboard.desktop.taglineEra')
+      : t('leaderboard.desktop.taglineAllTime')
+  const legend =
+    scoreMode === 'era'
+      ? t('leaderboard.desktop.legendEra')
+      : t('leaderboard.desktop.legendAllTime')
 
   return (
     <div className="py-4" data-testid="mobile-players-directory">
-      <h1
-        className="font-display italic font-medium mb-1"
-        style={{ fontSize: 26, color: 'var(--color-text-primary)', lineHeight: 1.1 }}
-      >
-        {t('nav.players')}
-      </h1>
-      <p className="eyebrow mb-3">{t('leaderboard.mobile.count', { count: characters.length })}</p>
+      {/* ── Sky header ── */}
+      <p className="eyebrow mb-1">{eyebrow}</p>
 
-      {/* Sort chips — era vs all-time score */}
+      <h1
+        className="font-display italic font-medium leading-tight mb-1"
+        style={{ fontSize: 'var(--text-heading)', color: 'var(--color-text-primary)' }}
+      >
+        {t('leaderboard.desktop.title')}
+      </h1>
+
+      <p className="eyebrow mb-2">
+        {t('leaderboard.desktop.playersCount', { count: characters.length })}
+        {' · '}
+        {t('leaderboard.desktop.factionsCount', { count: factionCount })}
+      </p>
+
+      {/* Era / All-Time toggle — drives the sky and the roster together. */}
       <ChipRow label={t('filters.sort')}>
         <Chip on={scoreMode === 'era'} onClick={() => setScoreMode('era')}>
           {t('leaderboard.mobile.sortEra')}
@@ -62,16 +111,173 @@ export default function DefaultPlayers({ characters, loading, error, myCharId }:
         </Chip>
       </ChipRow>
 
-      {/* Faction chips */}
+      {/* Rainbow rule — the faction spectrum, in canonical order. */}
+      <div
+        aria-hidden
+        className="mt-3 mb-3"
+        style={{
+          height: 3,
+          borderRadius: 2,
+          background: `linear-gradient(90deg, ${FACTION_RAINBOW_ORDER.map((slug) =>
+            factionCssVar(slug),
+          ).join(', ')})`,
+        }}
+      />
+
+      {loading ? (
+        <p className="font-body content-text text-muted">{t('leaderboard.loading')}</p>
+      ) : error ? (
+        <p className="font-body content-text text-red-600 border-2 border-red-300 px-3 py-2">
+          {t('leaderboard.mobile.loadError')}
+        </p>
+      ) : characters.length === 0 ? (
+        <p className="font-body content-text text-muted">{t('leaderboard.mobile.empty')}</p>
+      ) : (
+        <>
+          <p
+            className="mb-3"
+            style={{
+              fontFamily: 'var(--font-faction-script)',
+              fontSize: 'var(--text-title)',
+              color: 'var(--color-text-secondary)',
+              lineHeight: 1.2,
+            }}
+          >
+            {tagline}
+          </p>
+
+          <SkyCanvas players={ranked} maxScore={maxScore} myCharId={myCharId} />
+
+          <p className="content-text mt-3" style={{ color: 'var(--color-text-secondary)' }}>
+            {legend}
+          </p>
+
+          {/* ── Full roster ── */}
+          <Roster players={ranked} myCharId={myCharId} />
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Measures its own width so the Constellation's spiral radius is derived from
+ * the real phone-column width rather than a magic constant — 6 labelled orbs on
+ * a ~360px canvas is tight, so equal offsets must be equal px (epic #654 §1).
+ * The stage is drawn slightly taller than wide so `min(w, h)` — the radius
+ * basis inside Constellation — tracks the measured width.
+ */
+function SkyCanvas({
+  players,
+  maxScore,
+  myCharId,
+}: {
+  players: RankedPlayer[]
+  maxScore: number
+  myCharId: number | null
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+    const measure = () => setWidth(element.clientWidth)
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref} style={{ minHeight: 320 }}>
+      {width > 0 && (
+        <Constellation
+          players={players}
+          maxScore={maxScore}
+          myCharId={myCharId}
+          population={SKY_POPULATION}
+          stageWidth={width}
+          stageHeight={Math.round(width * 1.08)}
+        />
+      )}
+    </div>
+  )
+}
+
+function Roster({ players, myCharId }: { players: RankedPlayer[]; myCharId: number | null }) {
+  const { t } = useTranslation('common')
+  const [query, setQuery] = useState('')
+  const [faction, setFaction] = useState('')
+  const [visible, setVisible] = useState(PAGE_STEP)
+
+  // Distinct factions present, in canonical rainbow order, for the chip row.
+  const factionChips = useMemo(() => {
+    const present = Array.from(new Set(players.map((p) => slugKey(p.character.faction_slug))))
+    return sortFactionsByRainbowOrder(present.map((slug) => ({ slug })))
+  }, [players])
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return players.filter((p) => {
+      if (faction && slugKey(p.character.faction_slug) !== faction) return false
+      if (!needle) return true
+      return p.character.display_name.toLowerCase().includes(needle)
+    })
+  }, [players, query, faction])
+
+  const shownRows = filtered.slice(0, visible)
+  const hasMore = visible < filtered.length
+
+  const resetPaging = () => setVisible(PAGE_STEP)
+
+  return (
+    <section className="mt-8">
+      <h2
+        className="font-display italic content-title mb-3"
+        style={{ color: 'var(--color-text-primary)' }}
+      >
+        {t('leaderboard.desktop.roster.heading')}
+      </h2>
+
+      <input
+        type="text"
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value)
+          resetPaging()
+        }}
+        placeholder={t('leaderboard.desktop.roster.searchPlaceholder')}
+        className="font-body w-full mb-3"
+        style={{
+          fontSize: 'var(--text-md)',
+          padding: 'var(--space-sm) var(--space-md)',
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border-strong)',
+          color: 'var(--color-text-primary)',
+          borderRadius: 6,
+        }}
+      />
+
       <ChipRow label={t('filters.faction')}>
-        <Chip on={faction === ''} onClick={() => setFaction('')}>
+        <Chip
+          on={faction === ''}
+          onClick={() => {
+            setFaction('')
+            resetPaging()
+          }}
+        >
           {t('leaderboard.mobile.allFactions')}
         </Chip>
         {factionChips.map(({ slug }) => (
           <Chip
             key={slug}
             on={faction === slug}
-            onClick={() => setFaction(faction === slug ? '' : slug)}
+            onClick={() => {
+              setFaction(faction === slug ? '' : slug)
+              resetPaging()
+            }}
             tint={factionCssVar(slug === UNAFFILIATED ? null : slug)}
           >
             {factionName(slug === UNAFFILIATED ? null : slug)}
@@ -79,56 +285,59 @@ export default function DefaultPlayers({ characters, loading, error, myCharId }:
         ))}
       </ChipRow>
 
-      {/* Results */}
-      <div className="mt-4">
-        {loading ? (
-          <p className="font-body text-muted">{t('leaderboard.loading')}</p>
-        ) : error ? (
-          <p className="font-body text-sm text-red-600 border-2 border-red-300 px-3 py-2">
-            {t('leaderboard.mobile.loadError')}
-          </p>
-        ) : shown.length === 0 ? (
-          <p className="font-body text-muted">{t('leaderboard.mobile.empty')}</p>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {shown.map((character, index) => (
-              <PlayerRow
-                key={character.id}
-                character={character}
-                rank={index + 1}
-                points={scoreOf(character)}
-                isMe={character.id === myCharId}
-              />
+      {filtered.length === 0 ? (
+        <p className="font-body content-text text-muted mt-4">{t('leaderboard.mobile.empty')}</p>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2 mt-4">
+            {shownRows.map((row) => (
+              <PlayerRow key={row.character.id} row={row} isMe={row.character.id === myCharId} />
             ))}
           </div>
-        )}
-      </div>
-    </div>
+
+          <div className="flex flex-col items-center gap-3 mt-4">
+            <span className="eyebrow">
+              {t('leaderboard.mobile.showing', { shown: shownRows.length, total: filtered.length })}
+            </span>
+            {hasMore && (
+              <button
+                type="button"
+                onClick={() => setVisible((current) => current + PAGE_STEP)}
+                className="font-body uppercase w-full"
+                style={{
+                  fontSize: 'var(--text-base)',
+                  letterSpacing: '0.1em',
+                  padding: 'var(--space-md)',
+                  border: '1px solid var(--color-border-strong)',
+                  background: 'var(--color-bg-surface)',
+                  color: 'var(--color-text-primary)',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                }}
+              >
+                {t('leaderboard.mobile.loadMore')}
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </section>
   )
 }
 
-function PlayerRow({
-  character,
-  rank,
-  points,
-  isMe,
-}: {
-  character: CharacterOut
-  rank: number
-  points: number
-  isMe: boolean
-}) {
+function PlayerRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
   const { t } = useTranslation('common')
+  const { character, rank, points } = row
   const color = factionCssVar(character.faction_slug)
+  const badges = character.badges ?? []
+
   return (
     <Link
       to={`/characters/${character.id}`}
-      className="sidebar-card"
+      className="sidebar-card flex items-center"
       style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: '10px 14px 10px 16px',
+        gap: 'var(--space-md)',
+        padding: 'var(--space-sm) var(--space-md)',
         borderLeft: `4px solid ${color}`,
         textDecoration: 'none',
         background: isMe ? factionCssVar(character.faction_slug, 'light') : undefined,
@@ -141,9 +350,9 @@ function PlayerRow({
           flex: 'none',
           minWidth: 22,
           textAlign: 'center',
-          fontSize: 16,
+          fontSize: 'var(--text-content)',
           fontWeight: 700,
-          color: 'var(--color-text-tertiary)',
+          color: isMe ? color : 'var(--color-text-tertiary)',
         }}
       >
         {rank}
@@ -153,7 +362,7 @@ function PlayerRow({
       {character.avatar_url ? (
         <img
           src={mediaUrl(character.avatar_url)}
-          alt={character.display_name}
+          alt=""
           style={{ width: 40, height: 40, borderRadius: '50%', objectFit: 'cover', flex: 'none' }}
         />
       ) : (
@@ -169,22 +378,32 @@ function PlayerRow({
         />
       )}
 
-      {/* Name + faction · level */}
+      {/* Name + faction · level · badges */}
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           className="font-display italic truncate"
-          style={{ fontSize: 16, color: 'var(--color-text-primary)', lineHeight: 1.15 }}
+          style={{
+            fontSize: 'var(--text-content)',
+            color: isMe ? color : 'var(--color-text-primary)',
+            lineHeight: 1.15,
+          }}
         >
           {character.display_name}
         </div>
-        <div
-          className="eyebrow"
-          style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}
-        >
-          <i style={{ width: 8, height: 8, borderRadius: 2, background: color, flex: 'none' }} />
-          {t('leaderboard.mobile.factionLevel', {
-            faction: factionName(character.faction_slug),
-            level: character.level,
+        <div className="flex items-center flex-wrap mt-1" style={{ gap: 'var(--space-xs)' }}>
+          <span className="eyebrow">{factionName(character.faction_slug)}</span>
+          <LevelPill level={character.level} factionSlug={character.faction_slug} />
+          {badges.map((badge) => {
+            const Art = badgeArtFor(badge.key)
+            return (
+              <span
+                key={badge.key}
+                title={badge.name}
+                style={{ display: 'inline-flex', color: 'var(--color-text-secondary)' }}
+              >
+                <Art size={16} />
+              </span>
+            )
           })}
         </div>
       </div>
@@ -193,7 +412,7 @@ function PlayerRow({
       <div style={{ flex: 'none', textAlign: 'right' }}>
         <div
           className="font-body"
-          style={{ fontSize: 16, fontWeight: 700, color: 'var(--color-text-primary)' }}
+          style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: 'var(--color-text-primary)' }}
         >
           {points}
         </div>
@@ -212,8 +431,8 @@ function ChipRow({ label, children }: { label: string; children: React.ReactNode
         {label}
       </span>
       <div
-        className="flex gap-2"
-        style={{ overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}
+        className="flex gap-2 pb-0.5"
+        style={{ overflowX: 'auto', scrollbarWidth: 'none' }}
       >
         {children}
       </div>
@@ -236,21 +455,20 @@ function Chip({
     <button
       type="button"
       onClick={onClick}
+      className="font-body uppercase"
       style={{
         flex: 'none',
         display: 'inline-flex',
         alignItems: 'center',
-        gap: 6,
-        fontFamily: "'Courier Prime', monospace",
-        fontSize: 11,
+        gap: 'var(--space-xs)',
+        fontSize: 'var(--text-md)',
         fontWeight: on ? 700 : 400,
         letterSpacing: '0.05em',
-        textTransform: 'uppercase',
         color: on ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
         background: on ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
         border: `1px solid ${on ? 'transparent' : 'var(--color-border-strong)'}`,
         borderRadius: 999,
-        padding: '8px 14px',
+        padding: 'var(--space-sm) var(--space-md)',
         minHeight: 36,
         whiteSpace: 'nowrap',
         cursor: 'pointer',


### PR DESCRIPTION
Brings **The Constellation** to the phone. Rewrites `frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx` around the **reused** desktop `Constellation` component — no fork.

Closes #657

## What changed

- **Sky = reused `Constellation` at `population={6}`** (top 6 + you, pinned on a dashed tether). Everything else — Vogel spiral, crown, zero state, theme-invariant `--sky-*`, `/characters/:id` node links — comes for free from the shared component.
- **Measured radius, not a constant.** A small `SkyCanvas` wrapper measures its own width via `ResizeObserver` and passes `stageWidth`/`stageHeight` (drawn slightly taller than wide so `min(w,h)` tracks the phone-column width). 6 labelled orbs on a ~360px canvas fit without a magic number (epic §1).
- **Era / All-Time toggle drives the whole page.** The old roster-only sort chips (`:37-43`) are kept as the affordance but widened: one `scoreMode` feeds `ranked`, which feeds both the sky and the roster. Eyebrow/title/tagline/legend swap with it.
- **Load-more roster.** Single-column stacked rows (rank · avatar · name · faction · `LevelPill` · `badgeArtFor` glyphs · pts), search box + labelled faction chips (kept the local `ChipRow`/`Chip` helpers per #644), a `Showing N of M` range label, and a **"Load more players"** button that reveals +8 (hidden once everything shows).

## Copy / i18n

- Sky copy reuses the shared `leaderboard.desktop.*` keys (the reused `Constellation` already pulls its own copy from there — one voice, not two).
- Faction/sort labels use the existing `filters.sort` / `filters.faction` (`sort:` / `faction:`), so the directory test's assertions hold.
- Two new keys: `leaderboard.mobile.loadMore`, `leaderboard.mobile.showing`.

## Contract

`PlayersDirectoryProps` and the `Leaderboard.tsx` dispatch (`MOBILE_ARCHETYPE_BY_SLUG` empty, hardcoded `pickVariant(..., null, DefaultPlayers)`) are untouched — the directory is faction-neutral.

## Notes / deferrals

- The design's "glyph chips" for the faction filter were **not** adopted: the issue explicitly says to keep the local `ChipRow`/`Chip` helpers (they don't list `FactionSigilRow` in the reuse set), and labelled chips keep the directory test's `Unaffiliated` assertion green. A later swap to `FactionSigilRow` would need a visible active-label to preserve that. Flagging for `frontend-style` if the glyph treatment is wanted.

## Verification

- `eslint src` clean (migrated the file fully onto `--text-*`/`--space-*` tokens and removed it from `.eslint-legacy-raw-styles.txt`).
- `tsc --noEmit`: zero errors in changed files (only the known stale-junction `node:fs`/`node:url` artifact in an unrelated test file).
- `vitest playersDirectory.test.tsx`: 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
