### PR TITLE
Content-floor sweep: edit-praxis composer (301 sizes + skin seam) (#632)

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
@@ -63,7 +63,7 @@ function MannerLabel({ label, gloss }: { label: string; gloss?: string }) {
       <span
         style={{
           fontFamily: MONO,
-          fontSize: 8,
+          fontSize: "var(--text-xs)",
           letterSpacing: "0.26em",
           textTransform: "uppercase",
           color: ink(30),
@@ -73,7 +73,7 @@ function MannerLabel({ label, gloss }: { label: string; gloss?: string }) {
         {label}
       </span>
       {gloss && (
-        <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 13, color: ink(40), whiteSpace: "nowrap" }}>
+        <span style={{ fontFamily: FONT, fontStyle: "italic", fontSize: "var(--text-lg)", color: ink(40), whiteSpace: "nowrap" }}>
           {gloss}
         </span>
       )}
@@ -146,7 +146,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                 alignItems: "center",
                 gap: 9,
                 fontFamily: MONO,
-                fontSize: 8.5,
+                fontSize: "var(--text-xs)",
                 letterSpacing: "0.24em",
                 textTransform: "uppercase",
                 color: ink(30),
@@ -158,7 +158,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
             <span
               style={{
                 fontFamily: MONO,
-                fontSize: 7.5,
+                fontSize: "var(--text-xs)",
                 letterSpacing: "0.16em",
                 textTransform: "uppercase",
                 color: ink(26),
@@ -181,7 +181,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
               fontFamily: FONT,
               fontStyle: "italic",
               fontWeight: 300,
-              fontSize: 56,
+              fontSize: "var(--text-display)",
               lineHeight: 1.0,
               color: INK,
               margin: "26px 0 8px",
@@ -195,7 +195,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
               fontFamily: FONT,
               fontStyle: "italic",
               fontWeight: 300,
-              fontSize: 16,
+              fontSize: "var(--text-xl)",
               lineHeight: 1.5,
               color: ink(50),
               maxWidth: 480,
@@ -223,7 +223,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
               <div
                 style={{
                   fontFamily: MONO,
-                  fontSize: 7.5,
+                  fontSize: "var(--text-xs)",
                   letterSpacing: "0.2em",
                   textTransform: "uppercase",
                   color: ink(30),
@@ -238,7 +238,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                 style={{
                   fontFamily: FONT,
                   fontStyle: "italic",
-                  fontSize: 24,
+                  fontSize: "var(--text-title)",
                   lineHeight: 1.05,
                   color: INK,
                   marginBottom: 7,
@@ -248,11 +248,11 @@ export default function AlbescentEditPraxis({ state }: Props) {
                 {praxis.task_title}
               </div>
               {task?.description && (
-                <div style={{ fontFamily: MONO, fontSize: 9, lineHeight: 1.5, color: ink(40), marginBottom: 6, overflowWrap: "anywhere" }}>
+                <div style={{ fontFamily: MONO, fontSize: "var(--text-content)", lineHeight: 1.5, color: ink(40), marginBottom: 6, overflowWrap: "anywhere" }}>
                   {task.description}
                 </div>
               )}
-              <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.08em", color: ink(40) }}>
+              <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.08em", color: ink(40) }}>
                 {t("editPraxis.albescent.pointsLabel", {
                   points: praxis.task_point_value,
                 })}
@@ -291,10 +291,10 @@ export default function AlbescentEditPraxis({ state }: Props) {
                         transition: "all 160ms",
                       }}
                     >
-                      <div style={{ fontFamily: FONT, fontStyle: "italic", fontWeight: 400, fontSize: 22, lineHeight: 1 }}>
+                      <div style={{ fontFamily: FONT, fontStyle: "italic", fontWeight: 400, fontSize: "var(--text-title)", lineHeight: 1 }}>
                         {opt.label}
                       </div>
-                      <div style={{ fontFamily: MONO, fontSize: 7.5, letterSpacing: "0.06em", marginTop: 6, opacity: 0.7 }}>
+                      <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.06em", marginTop: 6, opacity: 0.7 }}>
                         {opt.desc}
                       </div>
                     </button>
@@ -349,7 +349,6 @@ export default function AlbescentEditPraxis({ state }: Props) {
                   fontFamily: FONT,
                   fontStyle: "italic",
                   fontWeight: 400,
-                  fontSize: 26,
                   color: INK,
                   padding: "4px 2px 10px",
                   outline: "none",
@@ -380,7 +379,6 @@ export default function AlbescentEditPraxis({ state }: Props) {
                   border: `1px solid ${ink(10)}`,
                   background: WARM,
                   fontFamily: FONT,
-                  fontSize: 18,
                   lineHeight: 1.75,
                   color: INK,
                   padding: "16px 18px",
@@ -397,7 +395,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                   <div
                     style={{
                       fontFamily: MONO,
-                      fontSize: 8,
+                      fontSize: "var(--text-xs)",
                       letterSpacing: "0.2em",
                       textTransform: "uppercase",
                       color: ink(30),
@@ -407,7 +405,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                     {t("editPraxis.albescent.previewLabel")}
                   </div>
                 ),
-                markdownStyle: { fontFamily: FONT, fontStyle: "italic", fontSize: 15, lineHeight: 1.75, color: ink(62) },
+                markdownStyle: { fontFamily: FONT, fontStyle: "italic", lineHeight: 1.75, color: ink(62) },
               }}
             />
           </div>
@@ -444,7 +442,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                     border: `1px dashed ${ink(16)}`,
                     cursor: "pointer",
                     fontFamily: MONO,
-                    fontSize: 9,
+                    fontSize: "var(--text-sm)",
                     letterSpacing: "0.14em",
                     textTransform: "uppercase",
                     color: ink(40),
@@ -457,7 +455,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                   buttonLabel: t("editPraxis.albescent.fileButton"),
                   errorColor: "var(--color-danger)",
                   helperText: t("editPraxis.albescent.fileHelper"),
-                  helperStyle: { fontFamily: MONO, fontSize: 8, letterSpacing: "0.08em", color: ink(30), marginTop: 8 },
+                  helperStyle: { fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.08em", color: ink(30), marginTop: 8 },
                 }}
               />
             </div>
@@ -513,7 +511,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                   fontFamily: FONT,
                   fontStyle: "italic",
                   fontWeight: 500,
-                  fontSize: 20,
+                  fontSize: "var(--text-content)",
                   letterSpacing: "0.02em",
                   padding: "12px 30px",
                   whiteSpace: "nowrap",
@@ -530,7 +528,7 @@ export default function AlbescentEditPraxis({ state }: Props) {
                   background: "transparent",
                   color: ink(50),
                   fontFamily: MONO,
-                  fontSize: 9,
+                  fontSize: "var(--text-sm)",
                   letterSpacing: "0.12em",
                   textTransform: "uppercase",
                   padding: "14px 18px",
@@ -569,7 +567,7 @@ function PlateFrame({
       <div
         style={{
           fontFamily: MONO,
-          fontSize: 8,
+          fontSize: "var(--text-xs)",
           letterSpacing: "0.04em",
           color: ink(40),
           textAlign: "center",
@@ -596,7 +594,7 @@ function PlateFrame({
           background: SHEET,
           border: `1.5px solid ${INK}`,
           color: INK,
-          fontSize: 12,
+          fontSize: "var(--text-lg)",
           fontWeight: 700,
           cursor: "pointer",
           lineHeight: 1,

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -116,7 +116,7 @@ export default function DefaultEditPraxis({ state }: Props) {
             style={{
               marginTop: 6,
               fontFamily: "'Permanent Marker', cursive",
-              fontSize: 14,
+              fontSize: "var(--text-xl)",
               color: SLATE_DEEP,
               letterSpacing: "0.05em",
             }}
@@ -143,7 +143,7 @@ export default function DefaultEditPraxis({ state }: Props) {
               position: "absolute",
               top: 6,
               right: 14,
-              fontSize: 12,
+              fontSize: "var(--text-lg)",
               color: SLATE,
               fontFamily: "'Caveat', cursive",
               fontStyle: "italic",
@@ -164,7 +164,7 @@ export default function DefaultEditPraxis({ state }: Props) {
           </div>
           <div
             style={{
-              fontSize: 22,
+              fontSize: "var(--text-title)",
               color: SLATE_DEEP,
               lineHeight: 1.25,
               marginTop: 8,
@@ -174,7 +174,7 @@ export default function DefaultEditPraxis({ state }: Props) {
             <span
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 9,
+                fontSize: "var(--text-sm)",
                 textTransform: "uppercase",
                 letterSpacing: "0.15em",
                 color: SLATE,
@@ -186,7 +186,7 @@ export default function DefaultEditPraxis({ state }: Props) {
             {praxis.task_title}
           </div>
           {task?.description && (
-            <div style={{ fontSize: 12, lineHeight: 1.5, color: SLATE, marginTop: 8 }}>
+            <div style={{ fontSize: "var(--text-content)", lineHeight: 1.5, color: SLATE, marginTop: 8 }}>
               {task.description}
             </div>
           )}
@@ -209,7 +209,7 @@ export default function DefaultEditPraxis({ state }: Props) {
             <div
               style={{
                 fontFamily: "'Permanent Marker', cursive",
-                fontSize: 16,
+                fontSize: "var(--text-xl)",
                 color: "#fef3c7",
                 alignSelf: "center",
                 transform: "rotate(-2deg)",
@@ -249,7 +249,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                     <div
                       style={{
                         fontFamily: "'Permanent Marker', cursive",
-                        fontSize: 22,
+                        fontSize: "var(--text-title)",
                         color: SLATE_DEEP,
                         lineHeight: 1,
                         marginBottom: 4,
@@ -257,7 +257,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                     >
                       {opt.label}
                     </div>
-                    <div style={{ fontSize: 13, color: SLATE }}>{opt.desc}</div>
+                    <div style={{ fontSize: "var(--text-content)", color: SLATE }}>{opt.desc}</div>
                     {active && (
                       <span
                         style={{
@@ -265,7 +265,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                           top: -8,
                           right: -8,
                           fontFamily: "'Permanent Marker', cursive",
-                          fontSize: 16,
+                          fontSize: "var(--text-xl)",
                           color: "#dc2626",
                           transform: "rotate(20deg)",
                         }}
@@ -294,7 +294,7 @@ export default function DefaultEditPraxis({ state }: Props) {
               <div
                 style={{
                   fontFamily: "'Permanent Marker', cursive",
-                  fontSize: 13,
+                  fontSize: "var(--text-lg)",
                   color: SLATE,
                   marginBottom: 6,
                 }}
@@ -331,7 +331,7 @@ export default function DefaultEditPraxis({ state }: Props) {
           <div
             style={{
               fontFamily: "'Permanent Marker', cursive",
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               color: SLATE,
               marginBottom: 6,
               letterSpacing: "0.05em",
@@ -346,7 +346,6 @@ export default function DefaultEditPraxis({ state }: Props) {
               inputStyle: {
                 width: "100%",
                 fontFamily: "'Caveat', cursive",
-                fontSize: 30,
                 color: SLATE_DEEP,
                 fontWeight: 700,
                 background: "transparent",
@@ -392,7 +391,7 @@ export default function DefaultEditPraxis({ state }: Props) {
           <div
             style={{
               fontFamily: "'Permanent Marker', cursive",
-              fontSize: 12,
+              fontSize: "var(--text-lg)",
               color: SLATE,
               marginBottom: 10,
             }}
@@ -407,7 +406,6 @@ export default function DefaultEditPraxis({ state }: Props) {
               textareaStyle: {
                 width: "100%",
                 fontFamily: "'Caveat', cursive",
-                fontSize: 18,
                 lineHeight: 1.5,
                 color: SLATE_DEEP,
                 background: "transparent",
@@ -430,7 +428,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                 <div
                   style={{
                     fontFamily: "'Permanent Marker', cursive",
-                    fontSize: 11,
+                    fontSize: "var(--text-md)",
                     color: SLATE,
                     marginBottom: 6,
                   }}
@@ -440,7 +438,6 @@ export default function DefaultEditPraxis({ state }: Props) {
               ),
               markdownStyle: {
                 fontFamily: "'Caveat', cursive",
-                fontSize: 18,
                 lineHeight: 1.5,
                 color: SLATE_DEEP,
               },
@@ -461,7 +458,7 @@ export default function DefaultEditPraxis({ state }: Props) {
           <div
             style={{
               fontFamily: "'Permanent Marker', cursive",
-              fontSize: 14,
+              fontSize: "var(--text-xl)",
               color: "#fef3c7",
               alignSelf: "center",
               transform: "rotate(-3deg)",
@@ -507,7 +504,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                 border: `2.5px dashed ${SLATE_DEEP}`,
                 cursor: "pointer",
                 fontFamily: "'Permanent Marker', cursive",
-                fontSize: 16,
+                fontSize: "var(--text-xl)",
                 color: SLATE_DEEP,
                 display: "flex",
                 alignItems: "center",
@@ -520,7 +517,7 @@ export default function DefaultEditPraxis({ state }: Props) {
               errorColor: "#dc2626",
               helperText: t("editPraxis.na.fileHelper"),
               helperStyle: {
-                fontSize: 12,
+                fontSize: "var(--text-lg)",
                 color: "#fef3c7",
                 marginTop: 6,
                 fontStyle: "italic",
@@ -544,7 +541,7 @@ export default function DefaultEditPraxis({ state }: Props) {
             <div
               style={{
                 fontFamily: "'Permanent Marker', cursive",
-                fontSize: 13,
+                fontSize: "var(--text-lg)",
                 color: SLATE,
                 marginBottom: 8,
               }}
@@ -604,7 +601,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                 background: "#dc2626",
                 color: STICKY_PAPER,
                 fontFamily: "'Permanent Marker', cursive",
-                fontSize: 22,
+                fontSize: "var(--text-title)",
                 padding: "14px 28px",
                 border: "none",
                 borderRadius: 0,
@@ -625,7 +622,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                 border: "none",
                 color: SLATE_DEEP,
                 fontFamily: "'Caveat', cursive",
-                fontSize: 16,
+                fontSize: "var(--text-xl)",
                 textDecoration: "underline",
                 cursor: "pointer",
               },
@@ -635,7 +632,7 @@ export default function DefaultEditPraxis({ state }: Props) {
           <span
             style={{
               fontFamily: "'Caveat', cursive",
-              fontSize: 16,
+              fontSize: "var(--text-xl)",
               color: "#fef3c7",
               fontStyle: "italic",
               maxWidth: 220,
@@ -696,7 +693,7 @@ function PolaroidStickie({
       </div>
       <div
         style={{
-          fontSize: 12,
+          fontSize: "var(--text-lg)",
           fontFamily: "'Caveat', cursive",
           color: SLATE_DEEP,
           textAlign: "center",
@@ -719,7 +716,7 @@ function PolaroidStickie({
           background: "#fef3c7",
           border: `1.5px solid ${SLATE_DEEP}`,
           color: SLATE_DEEP,
-          fontSize: 11,
+          fontSize: "var(--text-md)",
           fontWeight: 700,
           cursor: "pointer",
           lineHeight: 1,

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -48,7 +48,7 @@ function FieldLabel({ children, meta }: { children: ReactNode; meta?: ReactNode 
         style={{
           fontFamily: "var(--eph-display)",
           fontWeight: 700,
-          fontSize: 14,
+          fontSize: "var(--text-xl)",
           letterSpacing: "0.16em",
           color: RUBRIC,
           whiteSpace: "nowrap",
@@ -57,7 +57,7 @@ function FieldLabel({ children, meta }: { children: ReactNode; meta?: ReactNode 
         {children}
       </span>
       {meta && (
-        <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9.5, fontStyle: "italic", letterSpacing: "0.06em", color: MUTED, whiteSpace: "nowrap" }}>
+        <span style={{ fontFamily: "var(--eph-serif)", fontSize: "var(--text-sm)", fontStyle: "italic", letterSpacing: "0.06em", color: MUTED, whiteSpace: "nowrap" }}>
           {meta}
         </span>
       )}
@@ -120,7 +120,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
           }}
         >
           <EphemeristsSigil size={15} color="var(--eph-lapis)" />
-          <span style={{ fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: 14, letterSpacing: "0.18em", textTransform: "uppercase", whiteSpace: "nowrap" }}>
+          <span style={{ fontFamily: "var(--eph-display)", fontWeight: 600, fontSize: "var(--text-xl)", letterSpacing: "0.18em", textTransform: "uppercase", whiteSpace: "nowrap" }}>
             {t("editPraxis.ephemerists.masthead", {
               number: praxis.id.toString().padStart(4, "0"),
             })}
@@ -129,7 +129,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
 
         {/* title */}
         <div style={{ display: "flex", alignItems: "baseline", gap: 14, margin: "18px 0 4px", flexWrap: "wrap" }}>
-          <div style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: 54, lineHeight: 0.9, letterSpacing: "0.02em", color: TEXT, whiteSpace: "nowrap" }}>
+          <div style={{ fontFamily: "var(--eph-display)", fontWeight: 800, fontSize: "var(--text-display)", lineHeight: 0.9, letterSpacing: "0.02em", color: TEXT, whiteSpace: "nowrap" }}>
             <Trans
               ns="forms"
               i18nKey="editPraxis.ephemerists.pageTitle"
@@ -139,7 +139,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               ]}
             />
           </div>
-          <span style={{ fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: 14, color: MUTED }}>
+          <span style={{ fontFamily: "var(--eph-script)", fontStyle: "italic", fontSize: "var(--text-xl)", color: MUTED }}>
             {t("editPraxis.ephemerists.tagline")}
           </span>
         </div>
@@ -173,32 +173,32 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)",
             }}
           >
-            <span style={{ fontSize: 8.5, letterSpacing: "0.18em", textTransform: "uppercase", color: RUBRIC }}>
+            <span style={{ fontSize: "var(--text-xs)", letterSpacing: "0.18em", textTransform: "uppercase", color: RUBRIC }}>
               {t("editPraxis.ephemerists.slipRunningHead")}
             </span>
-            <span style={{ fontSize: 8.5, letterSpacing: "0.06em", color: MUTED, whiteSpace: "nowrap" }}>
+            <span style={{ fontSize: "var(--text-xs)", letterSpacing: "0.06em", color: MUTED, whiteSpace: "nowrap" }}>
               {t("editPraxis.ephemerists.slipGrade", { grade: toRoman(grade) })}
             </span>
           </div>
           {/* body */}
           <div style={{ position: "relative", zIndex: 2, padding: "13px 16px 14px" }}>
-            <div style={{ fontSize: 9, fontStyle: "italic", letterSpacing: "0.14em", textTransform: "uppercase", color: MUTED, marginBottom: 4 }}>
+            <div style={{ fontSize: "var(--text-sm)", fontStyle: "italic", letterSpacing: "0.14em", textTransform: "uppercase", color: MUTED, marginBottom: 4 }}>
               {t("editPraxis.ephemerists.taskRefLabel")}
             </div>
-            <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 30, lineHeight: 0.96, color: TEXT }}>
+            <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: "var(--text-heading)", lineHeight: 0.96, color: TEXT }}>
               <LapisLastWord text={praxis.task_title} />
             </div>
             {task?.description && (
-              <div style={{ fontSize: 11, fontStyle: "italic", lineHeight: 1.5, color: MUTED, marginTop: 8 }}>
+              <div style={{ fontSize: "var(--text-content)", fontStyle: "italic", lineHeight: 1.5, color: MUTED, marginTop: 8 }}>
                 {task.description}
               </div>
             )}
             <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 8, flexWrap: "wrap" }}>
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 9.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--eph-lapis)", fontWeight: 600 }}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: "var(--text-sm)", letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--eph-lapis)", fontWeight: 600 }}>
                 <EphemeristsSigil size={12} color="var(--eph-lapis)" />{" "}
                 {t("editPraxis.ephemerists.factionTag")}
               </span>
-              <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 15, color: RUBRIC }}>
+              <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: "var(--text-xl)", color: RUBRIC }}>
                 {t("editPraxis.ephemerists.pointsLabel", {
                   points: praxis.task_point_value,
                 })}
@@ -241,8 +241,8 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                       transition: "all 120ms",
                     }}
                   >
-                    <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 21, lineHeight: 1, letterSpacing: "0.03em" }}>{opt.label}</div>
-                    <div style={{ fontStyle: "italic", fontSize: 10, letterSpacing: "0.02em", marginTop: 4, opacity: on ? 0.9 : 0.7 }}>{opt.sub}</div>
+                    <div style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: "var(--text-title)", lineHeight: 1, letterSpacing: "0.03em" }}>{opt.label}</div>
+                    <div style={{ fontStyle: "italic", fontSize: "var(--text-base)", letterSpacing: "0.02em", marginTop: 4, opacity: on ? 0.9 : 0.7 }}>{opt.sub}</div>
                     {on && (
                       <div style={{ position: "absolute", top: 8, right: 9, width: 9, height: 9, borderRadius: "50%", background: "var(--eph-gold-light)", boxShadow: `0 0 0 2px ${INK}` }} />
                     )}
@@ -302,7 +302,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 background: "transparent",
                 fontFamily: "var(--eph-display)",
                 fontWeight: 700,
-                fontSize: 24,
                 letterSpacing: "0.01em",
                 color: TEXT,
                 padding: "4px 2px 8px",
@@ -332,7 +331,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 border: `1.5px solid ${INK}`,
                 background: "var(--eph-vellum)",
                 fontFamily: "var(--eph-serif)",
-                fontSize: 14,
                 lineHeight: 1.65,
                 color: TEXT,
                 padding: "13px 15px",
@@ -340,7 +338,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               },
             }}
           />
-          <div style={{ fontSize: 9.5, fontStyle: "italic", color: MUTED, marginTop: 7 }}>
+          <div style={{ fontSize: "var(--text-sm)", fontStyle: "italic", color: MUTED, marginTop: 7 }}>
             <Trans
               ns="forms"
               i18nKey="editPraxis.ephemerists.bodyFootnote"
@@ -359,7 +357,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                   {t("editPraxis.ephemerists.previewLabel")}
                 </FieldLabel>
               ),
-              markdownStyle: { fontFamily: "var(--eph-serif)", fontSize: 14, lineHeight: 1.65, color: TEXT },
+              markdownStyle: { fontFamily: "var(--eph-serif)", lineHeight: 1.65, color: TEXT },
             }}
           />
         </div>
@@ -407,7 +405,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 background: "transparent",
                 color: TEXT,
                 fontFamily: "var(--eph-serif)",
-                fontSize: 11.5,
+                fontSize: "var(--text-md)",
                 fontWeight: 600,
                 letterSpacing: "0.1em",
                 textTransform: "uppercase",
@@ -415,7 +413,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               },
               buttonLabel: t("editPraxis.ephemerists.fileButton"),
               helperText: t("editPraxis.ephemerists.fileHelper"),
-              helperStyle: { fontSize: 10, fontStyle: "italic", color: MUTED, marginTop: 9 },
+              helperStyle: { fontSize: "var(--text-base)", fontStyle: "italic", color: MUTED, marginTop: 9 },
             }}
           />
         </div>
@@ -469,7 +467,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 color: "var(--eph-parchment)",
                 fontFamily: "var(--eph-display)",
                 fontWeight: 700,
-                fontSize: 22,
+                fontSize: "var(--text-title)",
                 letterSpacing: "0.08em",
                 padding: "12px 28px",
                 whiteSpace: "nowrap",
@@ -487,7 +485,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 border: "none",
                 color: MUTED,
                 fontFamily: "var(--eph-serif)",
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 fontStyle: "italic",
                 letterSpacing: "0.06em",
                 textDecoration: "underline",
@@ -495,7 +493,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               },
             }}
           />
-          <span style={{ fontSize: 11, fontStyle: "italic", color: MUTED, marginLeft: "auto" }}>
+          <span style={{ fontSize: "var(--text-md)", fontStyle: "italic", color: MUTED, marginLeft: "auto" }}>
             {state.autosaveAt
               ? t("editPraxis.ephemerists.autosaveSaved", {
                   ago: formatAutosave(state.autosaveAt),
@@ -529,7 +527,7 @@ function Specimen({ children, caption, rotation, onRemove }: SpecimenProps) {
       }}
     >
       <div style={{ width: 140, height: 100, overflow: "hidden" }}>{children}</div>
-      <div style={{ fontSize: 9, marginTop: 4, fontFamily: "var(--eph-serif)", fontStyle: "italic", color: GOLD, textAlign: "center" }}>
+      <div style={{ fontSize: "var(--text-sm)", marginTop: 4, fontFamily: "var(--eph-serif)", fontStyle: "italic", color: GOLD, textAlign: "center" }}>
         {caption}
       </div>
       <button
@@ -546,7 +544,7 @@ function Specimen({ children, caption, rotation, onRemove }: SpecimenProps) {
           background: "var(--eph-vellum)",
           border: `1.5px solid ${GOLD}`,
           color: GOLD,
-          fontSize: 11,
+          fontSize: "var(--text-md)",
           fontWeight: 700,
           cursor: "pointer",
           lineHeight: 1,

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -69,7 +69,7 @@ function FieldLabel({
       <span
         style={{
           fontFamily: ACCENT_FONT,
-          fontSize: 16,
+          fontSize: "var(--text-xl)",
           letterSpacing: "0.12em",
           color: RED,
           whiteSpace: "nowrap",
@@ -81,7 +81,7 @@ function FieldLabel({
         <span
           style={{
             fontFamily: BODY_FONT,
-            fontSize: 9,
+            fontSize: "var(--text-sm)",
             letterSpacing: "0.14em",
             textTransform: "uppercase",
             color: MUTED,
@@ -160,7 +160,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           <span
             style={{
               fontFamily: ACCENT_FONT,
-              fontSize: 18,
+              fontSize: "var(--text-content)",
               letterSpacing: "0.16em",
               whiteSpace: "nowrap",
             }}
@@ -182,7 +182,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           <div
             style={{
               fontFamily: ACCENT_FONT,
-              fontSize: 58,
+              fontSize: "var(--text-display)",
               lineHeight: 0.9,
               letterSpacing: "0.02em",
               color: PAPER_TEXT,
@@ -194,7 +194,7 @@ export default function EverymenEditPraxis({ state }: Props) {
             style={{
               textAlign: "right",
               fontFamily: BODY_FONT,
-              fontSize: 9,
+              fontSize: "var(--text-sm)",
               letterSpacing: "0.12em",
               textTransform: "uppercase",
               color: MUTED,
@@ -249,7 +249,7 @@ export default function EverymenEditPraxis({ state }: Props) {
             <div
               style={{
                 fontFamily: BODY_FONT,
-                fontSize: 8.5,
+                fontSize: "var(--text-xs)",
                 letterSpacing: "0.2em",
                 textTransform: "uppercase",
                 color: MUTED,
@@ -261,7 +261,7 @@ export default function EverymenEditPraxis({ state }: Props) {
             <div
               style={{
                 fontFamily: ACCENT_FONT,
-                fontSize: 30,
+                fontSize: "var(--text-heading)",
                 lineHeight: 0.96,
                 color: PAPER_TEXT,
                 marginBottom: 8,
@@ -270,7 +270,7 @@ export default function EverymenEditPraxis({ state }: Props) {
               {praxis.task_title}
             </div>
             {task?.description && (
-              <div style={{ fontFamily: ACCENT_FONT, fontSize: 13, lineHeight: 1.5, color: MUTED, marginBottom: 8 }}>
+              <div style={{ fontFamily: ACCENT_FONT, fontSize: "var(--text-content)", lineHeight: 1.5, color: MUTED, marginBottom: 8 }}>
                 {task.description}
               </div>
             )}
@@ -316,7 +316,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                     <div
                       style={{
                         fontFamily: ACCENT_FONT,
-                        fontSize: 24,
+                        fontSize: "var(--text-title)",
                         lineHeight: 1,
                         letterSpacing: "0.04em",
                       }}
@@ -325,7 +325,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                     </div>
                     <div
                       style={{
-                        fontSize: 9.5,
+                        fontSize: "var(--text-sm)",
                         letterSpacing: "0.04em",
                         marginTop: 3,
                         opacity: active ? 0.9 : 0.7,
@@ -377,7 +377,6 @@ export default function EverymenEditPraxis({ state }: Props) {
                 borderBottom: `2px solid ${INK}`,
                 background: "transparent",
                 fontFamily: ACCENT_FONT,
-                fontSize: 26,
                 letterSpacing: "0.01em",
                 color: PAPER_TEXT,
                 padding: "4px 2px 8px",
@@ -388,7 +387,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           <div
             style={{
               fontFamily: BODY_FONT,
-              fontSize: 9,
+              fontSize: "var(--text-sm)",
               letterSpacing: "0.12em",
               textTransform: "uppercase",
               color: MUTED,
@@ -423,7 +422,6 @@ export default function EverymenEditPraxis({ state }: Props) {
                 border: `1.5px solid ${INK}`,
                 background: PAPER,
                 fontFamily: BODY_FONT,
-                fontSize: 13,
                 lineHeight: 1.6,
                 color: PAPER_TEXT,
                 padding: "13px 15px",
@@ -444,7 +442,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                 <div
                   style={{
                     fontFamily: BODY_FONT,
-                    fontSize: 9,
+                    fontSize: "var(--text-sm)",
                     letterSpacing: "0.2em",
                     textTransform: "uppercase",
                     color: MUTED,
@@ -456,7 +454,6 @@ export default function EverymenEditPraxis({ state }: Props) {
               ),
               markdownStyle: {
                 fontFamily: BODY_FONT,
-                fontSize: 13,
                 lineHeight: 1.6,
                 color: PAPER_TEXT,
               },
@@ -496,7 +493,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                 background: "transparent",
                 color: PAPER_TEXT,
                 fontFamily: BODY_FONT,
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 fontWeight: 700,
                 letterSpacing: "0.12em",
                 textTransform: "uppercase",
@@ -506,7 +503,7 @@ export default function EverymenEditPraxis({ state }: Props) {
               <span
                 style={{
                   fontFamily: ACCENT_FONT,
-                  fontSize: 18,
+                  fontSize: "var(--text-content)",
                   color: RED,
                   lineHeight: 0.6,
                 }}
@@ -527,7 +524,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           {state.fileError && (
             <p
               style={{
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 color: "var(--color-danger)",
                 marginTop: 9,
               }}
@@ -566,7 +563,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                 background: state.submitting ? OLIVE : RED,
                 color: CREAM,
                 fontFamily: ACCENT_FONT,
-                fontSize: 26,
+                fontSize: "var(--text-title)",
                 letterSpacing: "0.1em",
                 padding: "12px 30px",
                 whiteSpace: "nowrap",
@@ -585,7 +582,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                 border: "none",
                 color: MUTED,
                 fontFamily: BODY_FONT,
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 fontStyle: "italic",
                 textDecoration: "underline",
                 cursor: "pointer",
@@ -624,7 +621,7 @@ function ProofSlip({ children, caption, onRemove }: ProofSlipProps) {
       <div
         style={{
           fontFamily: BODY_FONT,
-          fontSize: 9,
+          fontSize: "var(--text-sm)",
           letterSpacing: "0.04em",
           color: PAPER_TEXT,
           marginTop: 6,
@@ -648,7 +645,7 @@ function ProofSlip({ children, caption, onRemove }: ProofSlipProps) {
           background: RED,
           border: `2px solid ${INK}`,
           color: CREAM,
-          fontSize: 12,
+          fontSize: "var(--text-lg)",
           fontWeight: 700,
           cursor: "pointer",
           lineHeight: 1,
@@ -800,14 +797,14 @@ function MetatasksBlock({ state }: { state: EditPraxisState }) {
             </span>
             <div style={{ flex: 1 }}>
               <div
-                style={{ fontSize: 14, color: PAPER_TEXT, fontWeight: 700 }}
+                style={{ fontSize: "var(--text-xl)", color: PAPER_TEXT, fontWeight: 700 }}
               >
                 {mt.title}
               </div>
               {mt.description && (
                 <div
                   style={{
-                    fontSize: 11,
+                    fontSize: "var(--text-md)",
                     color: MUTED,
                     fontStyle: "italic",
                   }}
@@ -819,7 +816,7 @@ function MetatasksBlock({ state }: { state: EditPraxisState }) {
             <span
               style={{
                 fontFamily: ACCENT_FONT,
-                fontSize: 15,
+                fontSize: "var(--text-xl)",
                 color: selected ? OLIVE : RED,
                 whiteSpace: "nowrap",
               }}

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -105,7 +105,7 @@ export default function SingularityEditPraxis({ state }: Props) {
           ))}
           <span
             style={{
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               color: dim,
               marginLeft: 12,
               letterSpacing: "0.15em",
@@ -115,7 +115,7 @@ export default function SingularityEditPraxis({ state }: Props) {
             {t("editPraxis.singularity.terminal.sessionPath", { session: praxis.id.toString(16) })}
           </span>
         </div>
-        <div style={{ display: "flex", gap: 12, fontSize: 10, color: dim }}>
+        <div style={{ display: "flex", gap: 12, fontSize: "var(--text-base)", color: dim }}>
           <span style={{ color: term }}>{cursorOn ? "●" : "○"} REC</span>
         </div>
       </div>
@@ -137,7 +137,7 @@ export default function SingularityEditPraxis({ state }: Props) {
         />
 
         {/* Boot lines */}
-        <div style={{ marginBottom: 16, fontSize: 11, lineHeight: 1.7 }}>
+        <div style={{ marginBottom: 16, fontSize: "var(--text-md)", lineHeight: 1.7 }}>
           <div style={{ color: dim }}>{t("editPraxis.singularity.terminal.whoami")}</div>
           <div style={{ color: term }}>
             {t("editPraxis.singularity.terminal.whoamiResult", { name: praxis.created_by_display_name })}
@@ -156,7 +156,7 @@ export default function SingularityEditPraxis({ state }: Props) {
               left: 12,
               background: bg,
               padding: "0 8px",
-              fontSize: 9,
+              fontSize: "var(--text-sm)",
               color: accent,
               letterSpacing: "0.15em",
               textTransform: "uppercase",
@@ -171,12 +171,12 @@ export default function SingularityEditPraxis({ state }: Props) {
               background: "rgba(37,99,235,.05)",
             }}
           >
-            <div style={{ fontSize: 13, color: term, lineHeight: 1.4 }}>
+            <div style={{ fontSize: "var(--text-content)", color: term, lineHeight: 1.4 }}>
               <span style={{ color: dim }}>&gt; </span>
               {praxis.task_title}
             </div>
             {task?.description && (
-              <div style={{ fontSize: 12, color: dim, lineHeight: 1.5, marginTop: 6, whiteSpace: "pre-wrap" }}>
+              <div style={{ fontSize: "var(--text-content)", color: dim, lineHeight: 1.5, marginTop: 6, whiteSpace: "pre-wrap" }}>
                 <span style={{ color: accent }}># </span>
                 {task.description}
               </div>
@@ -186,7 +186,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                 display: "flex",
                 gap: 14,
                 marginTop: 10,
-                fontSize: 10,
+                fontSize: "var(--text-base)",
                 color: dim,
                 flexWrap: "wrap",
               }}
@@ -215,7 +215,7 @@ export default function SingularityEditPraxis({ state }: Props) {
         {/* Mode selector */}
         {!state.controlsLocked && (
           <div style={{ marginBottom: 22 }}>
-            <div style={{ fontSize: 10, color: dim, marginBottom: 10 }}>
+            <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: 10 }}>
               <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.setModeCommand")}
             </div>
             <ModePicker
@@ -245,7 +245,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                   >
                     <div
                       style={{
-                        fontSize: 12,
+                        fontSize: "var(--text-lg)",
                         fontWeight: 700,
                         marginBottom: 2,
                       }}
@@ -254,7 +254,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                       {opt.flag}
                       {active && "]"}
                     </div>
-                    <div style={{ fontSize: 9, opacity: active ? 0.85 : 0.6 }}>
+                    <div style={{ fontSize: "var(--text-sm)", opacity: active ? 0.85 : 0.6 }}>
                       {opt.desc}
                     </div>
                   </button>
@@ -267,7 +267,7 @@ export default function SingularityEditPraxis({ state }: Props) {
         {/* Invite */}
         {state.showInviteBox && (
             <div style={{ marginBottom: 22 }}>
-              <div style={{ fontSize: 10, color: dim, marginBottom: 8 }}>
+              <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: 8 }}>
                 <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.inviteCommand")}
               </div>
               <div
@@ -299,7 +299,7 @@ export default function SingularityEditPraxis({ state }: Props) {
 
         {/* Title */}
         <div style={{ marginBottom: 22 }}>
-          <div style={{ fontSize: 10, color: dim, marginBottom: 6 }}>
+          <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: 6 }}>
             <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.titleCommand")}{" "}
             <TitleCounter length={state.title.length} color={dim} />
           </div>
@@ -316,7 +316,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                 left: 0,
                 top: 4,
                 color: dim,
-                fontSize: 18,
+                fontSize: "var(--text-content)",
               }}
             >
               #{" "}
@@ -330,7 +330,6 @@ export default function SingularityEditPraxis({ state }: Props) {
                   paddingLeft: 22,
                   fontFamily: "'Lora', serif",
                   fontStyle: "italic",
-                  fontSize: 26,
                   color: term,
                   background: "transparent",
                   border: "none",
@@ -351,7 +350,7 @@ export default function SingularityEditPraxis({ state }: Props) {
               marginBottom: 6,
             }}
           >
-            <div style={{ fontSize: 10, color: dim }}>
+            <div style={{ fontSize: "var(--text-base)", color: dim }}>
               <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.bodyCommand")}{" "}
               <span style={{ color: dim }}>
                 {t("editPraxis.singularity.bodyMeta", {
@@ -376,7 +375,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                 background: "rgba(37,99,235,.08)",
                 padding: "12px 8px",
                 borderRight: `1px solid ${accent}`,
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 color: dim,
                 lineHeight: 1.7,
                 textAlign: "right",
@@ -401,7 +400,6 @@ export default function SingularityEditPraxis({ state }: Props) {
                     height: "100%",
                     minHeight: 220,
                     fontFamily: "'Share Tech Mono', monospace",
-                    fontSize: 12,
                     lineHeight: 1.7,
                     color: term,
                     background: "transparent",
@@ -418,7 +416,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                     position: "absolute",
                     bottom: 16,
                     left: 14,
-                    fontSize: 12,
+                    fontSize: "var(--text-lg)",
                     color: dim,
                     fontStyle: "italic",
                     pointerEvents: "none",
@@ -438,7 +436,7 @@ export default function SingularityEditPraxis({ state }: Props) {
               background: accent,
               color: bg,
               padding: "3px 12px",
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               fontWeight: 700,
               letterSpacing: "0.05em",
             }}
@@ -467,13 +465,12 @@ export default function SingularityEditPraxis({ state }: Props) {
                 background: "rgba(0,0,0,.5)",
               },
               label: (
-                <div style={{ fontSize: 9, color: dim, marginBottom: 8 }}>
+                <div style={{ fontSize: "var(--text-sm)", color: dim, marginBottom: 8 }}>
                   <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.renderCommand")}
                 </div>
               ),
               markdownStyle: {
                 fontFamily: "'Share Tech Mono', monospace",
-                fontSize: 12,
                 lineHeight: 1.7,
                 color: term,
               },
@@ -483,7 +480,7 @@ export default function SingularityEditPraxis({ state }: Props) {
 
         {/* Media */}
         <div style={{ marginBottom: 22 }}>
-          <div style={{ fontSize: 10, color: dim, marginBottom: 8 }}>
+          <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: 8 }}>
             <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.attachCommand")}
           </div>
           <div
@@ -496,7 +493,7 @@ export default function SingularityEditPraxis({ state }: Props) {
             {state.media.length === 0 ? (
               <div
                 style={{
-                  fontSize: 11,
+                  fontSize: "var(--text-md)",
                   color: dim,
                   fontStyle: "italic",
                   marginBottom: 12,
@@ -504,7 +501,7 @@ export default function SingularityEditPraxis({ state }: Props) {
               >
                 {t("editPraxis.singularity.mediaEmpty")}
                 <br />
-                <span style={{ fontSize: 9 }}>
+                <span style={{ fontSize: "var(--text-sm)" }}>
                   {t("editPraxis.singularity.mediaHelper")}
                 </span>
               </div>
@@ -531,7 +528,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                         padding: "6px 10px",
                         background: "rgba(74,222,128,.06)",
                         border: `1px solid ${accent}`,
-                        fontSize: 11,
+                        fontSize: "var(--text-md)",
                         color: term,
                       }}
                     >
@@ -553,7 +550,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                           border: "none",
                           cursor: "pointer",
                           fontFamily: "inherit",
-                          fontSize: 10,
+                          fontSize: "var(--text-base)",
                         }}
                       >
                         {t("editPraxis.singularity.removeButton")}
@@ -571,7 +568,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                   color: term,
                   border: `1px solid ${term}`,
                   fontFamily: "'Share Tech Mono', monospace",
-                  fontSize: 10,
+                  fontSize: "var(--text-base)",
                   padding: "6px 14px",
                   cursor: "pointer",
                   textTransform: "uppercase",
@@ -587,7 +584,7 @@ export default function SingularityEditPraxis({ state }: Props) {
         {/* Metatasks */}
         {state.showMetatasks && (
           <div style={{ marginBottom: 22 }}>
-            <div style={{ fontSize: 10, color: dim, marginBottom: 8 }}>
+            <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: 8 }}>
               <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.metataskCommand")}
             </div>
             <div
@@ -653,7 +650,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                 background: term,
                 color: bg,
                 fontFamily: "'Share Tech Mono', monospace",
-                fontSize: 13,
+                fontSize: "var(--text-lg)",
                 fontWeight: 700,
                 letterSpacing: "0.1em",
                 padding: "12px 22px",
@@ -673,7 +670,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                 background: "transparent",
                 color: dim,
                 fontFamily: "'Share Tech Mono', monospace",
-                fontSize: 9,
+                fontSize: "var(--text-sm)",
                 border: "none",
                 cursor: "pointer",
                 textDecoration: "underline",

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -144,7 +144,7 @@ export default function SnideEditPraxis({ state }: Props) {
               transform: "rotate(-1.2deg)",
               fontFamily: "'Bebas Neue', sans-serif",
               letterSpacing: "0.2em",
-              fontSize: 18,
+              fontSize: "var(--text-content)",
               display: "inline-block",
               boxShadow: `3px 3px 0 ${hot}`,
             }}
@@ -181,11 +181,11 @@ export default function SnideEditPraxis({ state }: Props) {
           >
             {t("editPraxis.snide.taskRefLabel")}
           </span>
-          <div style={{ fontSize: 18, lineHeight: 1.25, marginTop: 6 }}>
+          <div style={{ fontSize: "var(--text-content)", lineHeight: 1.25, marginTop: 6 }}>
             {praxis.task_title}
           </div>
           {task?.description && (
-            <div style={{ fontSize: 12, lineHeight: 1.45, color: muted, marginTop: 6 }}>
+            <div style={{ fontSize: "var(--text-content)", lineHeight: 1.45, color: muted, marginTop: 6 }}>
               {task.description}
             </div>
           )}
@@ -207,7 +207,7 @@ export default function SnideEditPraxis({ state }: Props) {
                 background: lightBg,
                 color: ink,
                 fontFamily: "'Permanent Marker', cursive",
-                fontSize: 13,
+                fontSize: "var(--text-lg)",
                 padding: "3px 12px",
                 marginBottom: 10,
                 transform: "rotate(-1.5deg)",
@@ -252,13 +252,13 @@ export default function SnideEditPraxis({ state }: Props) {
                       }}
                     >
                       <div
-                        style={{ fontSize: 22, lineHeight: 1, marginBottom: 4 }}
+                        style={{ fontSize: "var(--text-title)", lineHeight: 1, marginBottom: 4 }}
                       >
                         {opt.label}
                       </div>
                       <div
                         style={{
-                          fontSize: 10,
+                          fontSize: "var(--text-base)",
                           fontFamily: "'Courier Prime', monospace",
                           opacity: 0.85,
                         }}
@@ -335,7 +335,7 @@ export default function SnideEditPraxis({ state }: Props) {
               <RansomChar key={index} ch={ch} index={index} />
             ))}
             {!state.title && (
-              <span style={{ color: muted, fontStyle: "italic", fontSize: 14 }}>
+              <span style={{ color: muted, fontStyle: "italic", fontSize: "var(--text-xl)" }}>
                 {t("editPraxis.snide.titleEmptyHint")}
               </span>
             )}
@@ -347,7 +347,6 @@ export default function SnideEditPraxis({ state }: Props) {
               inputStyle: {
                 width: "100%",
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 13,
                 padding: "6px 10px",
                 background: surface,
                 color: ink,
@@ -376,7 +375,6 @@ export default function SnideEditPraxis({ state }: Props) {
                 textareaStyle: {
                   width: "100%",
                   fontFamily: "'Special Elite', serif",
-                  fontSize: 13,
                   lineHeight: 1.7,
                   color: ink,
                   background: surface,
@@ -413,7 +411,6 @@ export default function SnideEditPraxis({ state }: Props) {
               ),
               markdownStyle: {
                 fontFamily: "'Special Elite', serif",
-                fontSize: 12,
                 lineHeight: 1.6,
                 color: ink,
               },
@@ -480,7 +477,7 @@ export default function SnideEditPraxis({ state }: Props) {
                     </div>
                     <div
                       style={{
-                        fontSize: 9,
+                        fontSize: "var(--text-sm)",
                         marginTop: 4,
                         fontStyle: "italic",
                         fontFamily: "'Special Elite', serif",
@@ -502,7 +499,7 @@ export default function SnideEditPraxis({ state }: Props) {
                         background: lightBg,
                         border: `2px solid ${ink}`,
                         color: ink,
-                        fontSize: 12,
+                        fontSize: "var(--text-lg)",
                         fontWeight: 700,
                         cursor: "pointer",
                         lineHeight: 1,
@@ -534,7 +531,7 @@ export default function SnideEditPraxis({ state }: Props) {
                 background: accentDeep,
                 color: "var(--color-text-on-accent)",
                 fontFamily: "'Permanent Marker', cursive",
-                fontSize: 14,
+                fontSize: "var(--text-xl)",
                 padding: "8px 18px",
                 border: `2px solid ${accentDeep}`,
                 cursor: "pointer",
@@ -543,7 +540,7 @@ export default function SnideEditPraxis({ state }: Props) {
               buttonLabel: "+ paste it in",
               helperText: "images · video · audio · max 50mb each",
               helperStyle: {
-                fontSize: 9,
+                fontSize: "var(--text-sm)",
                 color: muted,
                 marginTop: 6,
                 fontStyle: "italic",
@@ -622,7 +619,7 @@ export default function SnideEditPraxis({ state }: Props) {
                 background: accent,
                 color: "var(--color-text-on-accent)",
                 fontFamily: "'Permanent Marker', cursive",
-                fontSize: 22,
+                fontSize: "var(--text-title)",
                 padding: "14px 28px",
                 border: `3px solid ${accentDeep}`,
                 borderRadius: 0,
@@ -642,7 +639,7 @@ export default function SnideEditPraxis({ state }: Props) {
                 background: "transparent",
                 color: muted,
                 fontFamily: "'Special Elite', serif",
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 border: "none",
                 cursor: "pointer",
                 textDecoration: "underline",
@@ -654,7 +651,7 @@ export default function SnideEditPraxis({ state }: Props) {
         <div
           style={{
             marginTop: 14,
-            fontSize: 10,
+            fontSize: "var(--text-base)",
             color: muted,
             fontFamily: "'Special Elite', serif",
             fontStyle: "italic",

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -70,7 +70,7 @@ function Plate({ children, style }: { children: ReactNode; style?: CSSProperties
 function RegaliaLabel({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: REGALIA, fontSize: 9, letterSpacing: "0.2em", color: "var(--ua-gold)", whiteSpace: "nowrap" }}>
+      <span style={{ fontFamily: REGALIA, fontSize: "var(--text-sm)", letterSpacing: "0.2em", color: "var(--ua-gold)", whiteSpace: "nowrap" }}>
         {children}
       </span>
       <div style={{ height: 1, flex: 1, background: "var(--ua-line-soft)" }} />
@@ -127,11 +127,11 @@ export default function UaEditPraxis({ state }: Props) {
           >
             <span style={{ display: "inline-flex", alignItems: "center", gap: 10, minWidth: 0 }}>
               <UaSigil width={22} height={26} />
-              <span style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: "0.14em", color: "var(--ua-paper-warm)" }}>
+              <span style={{ fontFamily: REGALIA, fontSize: "var(--text-base)", letterSpacing: "0.14em", color: "var(--ua-paper-warm)" }}>
                 {t("editPraxis.ua.masthead", { number: praxis.id })}
               </span>
             </span>
-            <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ua-paper-warm)", fontStyle: "italic", whiteSpace: "nowrap" }}>
+            <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ua-paper-warm)", fontStyle: "italic", whiteSpace: "nowrap" }}>
               {state.autosaveAt
                 ? t("editPraxis.ua.autosaveSaved", {
                     ago: formatAutosave(state.autosaveAt),
@@ -140,7 +140,7 @@ export default function UaEditPraxis({ state }: Props) {
             </span>
           </div>
           <div style={{ padding: "22px 24px 22px" }}>
-            <h1 style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 600, fontSize: 50, lineHeight: 1.04, color: "var(--ua-ink)", margin: "0 0 14px" }}>
+            <h1 style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 600, fontSize: "var(--text-display)", lineHeight: 1.04, color: "var(--ua-ink)", margin: "0 0 14px" }}>
               {t("editPraxis.ua.pageTitle")}
             </h1>
             {/* red/gold dashed rule */}
@@ -149,18 +149,18 @@ export default function UaEditPraxis({ state }: Props) {
             <div style={{ display: "flex", alignItems: "center", gap: 14, border: "1px solid var(--ua-line)", background: "var(--ua-paper-warm)", padding: "12px 16px" }}>
               <UaSigil width={50} height={60} />
               <div style={{ minWidth: 0 }}>
-                <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--ua-muted)", marginBottom: 4 }}>
+                <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--ua-muted)", marginBottom: 4 }}>
                   {t("editPraxis.ua.commissionLabel")}
                 </div>
-                <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 20, color: "var(--ua-ink)", lineHeight: 1.15, overflowWrap: "anywhere" }}>
+                <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: "var(--text-content)", color: "var(--ua-ink)", lineHeight: 1.15, overflowWrap: "anywhere" }}>
                   {praxis.task_title}
                 </div>
                 {task?.description && (
-                  <div style={{ fontFamily: MONO, fontSize: 10, lineHeight: 1.45, color: "var(--ua-muted)", marginTop: 6, overflowWrap: "anywhere" }}>
+                  <div style={{ fontFamily: MONO, fontSize: "var(--text-content)", lineHeight: 1.45, color: "var(--ua-muted)", marginTop: 6, overflowWrap: "anywhere" }}>
                     {task.description}
                   </div>
                 )}
-                <div style={{ fontFamily: REGALIA, fontSize: 10, letterSpacing: "0.12em", color: "var(--ua-gold)", marginTop: 4 }}>
+                <div style={{ fontFamily: REGALIA, fontSize: "var(--text-base)", letterSpacing: "0.12em", color: "var(--ua-gold)", marginTop: 4 }}>
                   {t("editPraxis.ua.pointsLabel", {
                     points: praxis.task_point_value,
                   })}
@@ -199,10 +199,10 @@ export default function UaEditPraxis({ state }: Props) {
                         : "none",
                     }}
                   >
-                    <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 18, color: active ? "var(--ua-paper)" : "var(--ua-ink)", lineHeight: 1 }}>
+                    <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: "var(--text-content)", color: active ? "var(--ua-paper)" : "var(--ua-ink)", lineHeight: 1 }}>
                       {opt.label}
                     </div>
-                    <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.06em", textTransform: "uppercase", color: active ? "var(--ua-paper)" : "var(--ua-muted)", marginTop: 5 }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.06em", textTransform: "uppercase", color: active ? "var(--ua-paper)" : "var(--ua-muted)", marginTop: 5 }}>
                       {opt.desc}
                     </div>
                   </button>
@@ -248,7 +248,6 @@ export default function UaEditPraxis({ state }: Props) {
                 width: "100%",
                 fontFamily: DISPLAY,
                 fontStyle: "italic",
-                fontSize: 30,
                 fontWeight: 600,
                 color: "var(--ua-ink)",
                 background: "transparent",
@@ -277,7 +276,6 @@ export default function UaEditPraxis({ state }: Props) {
               textareaStyle: {
                 width: "100%",
                 fontFamily: SERIF,
-                fontSize: 15,
                 lineHeight: 1.75,
                 color: "var(--ua-sub)",
                 background: "var(--ua-paper-warm)",
@@ -294,11 +292,11 @@ export default function UaEditPraxis({ state }: Props) {
             skin={{
               wrapperStyle: { borderTop: "1px solid var(--ua-line-soft)", marginTop: 14, paddingTop: 12 },
               label: (
-                <div style={{ fontFamily: REGALIA, fontSize: 9, letterSpacing: "0.2em", color: "var(--ua-gold)", marginBottom: 8 }}>
+                <div style={{ fontFamily: REGALIA, fontSize: "var(--text-sm)", letterSpacing: "0.2em", color: "var(--ua-gold)", marginBottom: 8 }}>
                   {t("editPraxis.ua.previewLabel")}
                 </div>
               ),
-              markdownStyle: { fontFamily: SERIF, fontSize: 14, lineHeight: 1.85, color: "var(--ua-sub)" },
+              markdownStyle: { fontFamily: SERIF, lineHeight: 1.85, color: "var(--ua-sub)" },
             }}
           />
         </Plate>
@@ -332,7 +330,7 @@ export default function UaEditPraxis({ state }: Props) {
                   border: "2px dashed var(--ua-line)",
                   cursor: "pointer",
                   fontFamily: REGALIA,
-                  fontSize: 11,
+                  fontSize: "var(--text-md)",
                   letterSpacing: "0.14em",
                   textTransform: "uppercase",
                   color: "var(--ua-gold)",
@@ -345,7 +343,7 @@ export default function UaEditPraxis({ state }: Props) {
                 buttonLabel: t("editPraxis.ua.fileButton"),
                 errorColor: "var(--ua-orange-deep)",
                 helperText: t("editPraxis.ua.fileHelper"),
-                helperStyle: { fontFamily: MONO, fontSize: 8, letterSpacing: "0.08em", color: "var(--ua-muted)", marginTop: 8, fontStyle: "italic" },
+                helperStyle: { fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.08em", color: "var(--ua-muted)", marginTop: 8, fontStyle: "italic" },
               }}
             />
           </div>
@@ -387,7 +385,7 @@ export default function UaEditPraxis({ state }: Props) {
                 background: "var(--ua-orange)",
                 color: "var(--ua-paper)",
                 fontFamily: REGALIA,
-                fontSize: 13,
+                fontSize: "var(--text-lg)",
                 letterSpacing: "0.1em",
                 padding: "12px 24px",
                 border: "none",
@@ -407,7 +405,7 @@ export default function UaEditPraxis({ state }: Props) {
                 color: "var(--ua-muted)",
                 fontFamily: SERIF,
                 fontStyle: "italic",
-                fontSize: 14,
+                fontSize: "var(--text-xl)",
                 textDecoration: "underline",
                 cursor: "pointer",
               },
@@ -434,7 +432,7 @@ function GiltPlate({
     <div style={{ position: "relative", background: "var(--ua-gilt)", padding: 5, boxShadow: "0 8px 18px color-mix(in srgb, var(--ua-ink) 20%, transparent)" }}>
       <div style={{ background: "var(--ua-paper)", padding: 4 }}>
         <div style={{ width: 140, height: 100, overflow: "hidden" }}>{children}</div>
-        <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.04em", color: "var(--ua-muted)", textAlign: "center", marginTop: 4, maxWidth: 140, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.04em", color: "var(--ua-muted)", textAlign: "center", marginTop: 4, maxWidth: 140, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {caption}
         </div>
       </div>
@@ -452,7 +450,7 @@ function GiltPlate({
           background: "var(--ua-paper)",
           border: "1.5px solid var(--ua-orange)",
           color: "var(--ua-orange)",
-          fontSize: 12,
+          fontSize: "var(--text-lg)",
           fontWeight: 700,
           cursor: "pointer",
           lineHeight: 1,

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -221,7 +221,7 @@ export default function WowEditPraxis({ state }: Props) {
   const eyebrowStyle: React.CSSProperties = {
     display: "block",
     fontFamily: "var(--font-body)",
-    fontSize: 9,
+    fontSize: "var(--text-sm)",
     textTransform: "uppercase",
     letterSpacing: "0.18em",
     color: pinkDeep,
@@ -323,7 +323,7 @@ export default function WowEditPraxis({ state }: Props) {
             </div>
             <span
               style={{
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 color: titleText,
                 letterSpacing: "0.03em",
                 display: "flex",
@@ -337,7 +337,7 @@ export default function WowEditPraxis({ state }: Props) {
             <span
               style={{
                 marginLeft: "auto",
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 color: titleText,
                 opacity: 0.75,
                 letterSpacing: "1.5px",
@@ -361,7 +361,7 @@ export default function WowEditPraxis({ state }: Props) {
             <div
               style={{
                 fontFamily: cardFont,
-                fontSize: 40,
+                fontSize: "var(--text-display)",
                 fontWeight: 700,
                 lineHeight: 1,
                 color: ink,
@@ -383,7 +383,7 @@ export default function WowEditPraxis({ state }: Props) {
               <div
                 style={{
                   fontFamily: cardFont,
-                  fontSize: 24,
+                  fontSize: "var(--text-title)",
                   fontWeight: 700,
                   lineHeight: 1.1,
                   color: ink,
@@ -394,7 +394,7 @@ export default function WowEditPraxis({ state }: Props) {
                 {praxis.task_title}
               </div>
               {task?.description && (
-                <div style={{ fontFamily: cardFont, fontSize: 13, lineHeight: 1.5, color: muted, marginBottom: 8 }}>
+                <div style={{ fontFamily: cardFont, fontSize: "var(--text-content)", lineHeight: 1.5, color: muted, marginBottom: 8 }}>
                   {task.description}
                 </div>
               )}
@@ -440,14 +440,14 @@ export default function WowEditPraxis({ state }: Props) {
                         <div
                           style={{
                             fontFamily: cardFont,
-                            fontSize: 22,
+                            fontSize: "var(--text-title)",
                             fontWeight: 700,
                             marginBottom: 2,
                           }}
                         >
                           {opt.label}
                         </div>
-                        <div style={{ fontSize: 10, opacity: 0.85 }}>
+                        <div style={{ fontSize: "var(--text-base)", opacity: 0.85 }}>
                           {opt.desc}
                         </div>
                       </button>
@@ -499,7 +499,6 @@ export default function WowEditPraxis({ state }: Props) {
                   inputStyle: {
                     width: "100%",
                     fontFamily: cardFont,
-                    fontSize: 28,
                     fontWeight: 700,
                     color: ink,
                     background: "transparent",
@@ -518,7 +517,7 @@ export default function WowEditPraxis({ state }: Props) {
                 }}
               >
                 <TitleCounter length={state.title.length} color={muted} />
-                <span style={{ ...eyebrowStyle, color: muted, fontSize: 8 }}>
+                <span style={{ ...eyebrowStyle, color: muted, fontSize: "var(--text-xs)" }}>
                   {state.autosaveAt
                     ? t("editPraxis.wow.autosaveSaved", {
                         ago: formatAutosave(state.autosaveAt),
@@ -541,7 +540,6 @@ export default function WowEditPraxis({ state }: Props) {
                   textareaStyle: {
                     width: "100%",
                     fontFamily: "var(--font-body)",
-                    fontSize: 14,
                     lineHeight: "24px",
                     color: ink,
                     background: bodyBg,
@@ -571,7 +569,6 @@ export default function WowEditPraxis({ state }: Props) {
                   ),
                   markdownStyle: {
                     fontFamily: "var(--font-body)",
-                    fontSize: 15,
                     lineHeight: 1.65,
                     color: ink,
                   },
@@ -638,7 +635,7 @@ export default function WowEditPraxis({ state }: Props) {
                       borderRadius: 9,
                       cursor: "pointer",
                       fontFamily: cardFont,
-                      fontSize: 18,
+                      fontSize: "var(--text-content)",
                       fontWeight: 700,
                       color: pink,
                       display: "flex",
@@ -650,7 +647,7 @@ export default function WowEditPraxis({ state }: Props) {
                     buttonLabel: t("editPraxis.wow.fileButton"),
                     helperText: t("editPraxis.wow.fileHelper"),
                     helperStyle: {
-                      fontSize: 9,
+                      fontSize: "var(--text-sm)",
                       color: muted,
                       marginTop: 6,
                     },
@@ -721,7 +718,7 @@ export default function WowEditPraxis({ state }: Props) {
                     background: `linear-gradient(180deg, ${pink}, ${pinkDeep})`,
                     color: "var(--color-text-on-accent)",
                     fontFamily: "var(--font-body)",
-                    fontSize: 12,
+                    fontSize: "var(--text-lg)",
                     fontWeight: 600,
                     textTransform: "uppercase",
                     letterSpacing: "0.1em",
@@ -742,7 +739,7 @@ export default function WowEditPraxis({ state }: Props) {
                     background: "transparent",
                     color: muted,
                     fontFamily: cardFont,
-                    fontSize: 18,
+                    fontSize: "var(--text-content)",
                     fontWeight: 700,
                     border: "none",
                     cursor: "pointer",
@@ -832,7 +829,7 @@ function MediaTile({
           bottom: 4,
           left: 8,
           right: 8,
-          fontSize: 10,
+          fontSize: "var(--text-base)",
           fontFamily: "var(--font-body)",
           color: borderColor,
           textAlign: "center",
@@ -857,7 +854,7 @@ function MediaTile({
           background: tileBg,
           border: `1.5px solid ${removeColor}`,
           color: removeColor,
-          fontSize: 11,
+          fontSize: "var(--text-md)",
           fontWeight: 700,
           cursor: "pointer",
           lineHeight: 1,

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -62,7 +62,7 @@ export function InviteSearch({
                   alignItems: "center",
                   gap: 6,
                   fontFamily: skin.fontFamily,
-                  fontSize: 11,
+                  fontSize: "var(--text-md)",
                   padding: "4px 10px",
                   background: skin.pendingBg ?? "transparent",
                   color: skin.pendingColor ?? "inherit",
@@ -90,7 +90,7 @@ export function InviteSearch({
                       border: "none",
                       color: "inherit",
                       cursor: "pointer",
-                      fontSize: 14,
+                      fontSize: "var(--text-xl)",
                       lineHeight: 1,
                       padding: 0,
                     }}
@@ -122,7 +122,7 @@ export function InviteSearch({
                     key={`i-${invite.id}`}
                     style={{
                       fontFamily: skin.fontFamily,
-                      fontSize: 11,
+                      fontSize: "var(--text-md)",
                       padding: "4px 10px",
                       background: skin.pendingBg ?? "transparent",
                       color: skin.pendingColor ?? "inherit",
@@ -143,7 +143,7 @@ export function InviteSearch({
                         border: "none",
                         color: "inherit",
                         cursor: "pointer",
-                        fontSize: 14,
+                        fontSize: "var(--text-xl)",
                         lineHeight: 1,
                         padding: 0,
                         marginLeft: 6,
@@ -175,7 +175,7 @@ export function InviteSearch({
           style={{
             width: "100%",
             fontFamily: skin.fontFamily,
-            fontSize: 13,
+            fontSize: "var(--text-lg)",
             padding: "8px 12px",
             background: skin.inputBg ?? "transparent",
             color: skin.inputColor ?? "inherit",
@@ -220,7 +220,7 @@ export function InviteSearch({
                   cursor: state.inviting ? "wait" : "pointer",
                   textAlign: "left",
                   fontFamily: skin.fontFamily,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   color: skin.inputColor ?? "inherit",
                 }}
               >
@@ -237,7 +237,7 @@ export function InviteSearch({
                 <span style={{ fontWeight: 700 }}>
                   {character.display_name}
                 </span>
-                <span style={{ marginLeft: "auto", fontSize: 9, opacity: 0.7 }}>
+                <span style={{ marginLeft: "auto", fontSize: "var(--text-sm)", opacity: 0.7 }}>
                   {factionName(character.faction_slug)}
                 </span>
               </button>
@@ -287,7 +287,7 @@ export function FilePicker({
       {state.fileError && (
         <p
           style={{
-            fontSize: 11,
+            fontSize: "var(--text-md)",
             color: skin.errorColor ?? "var(--color-danger)",
             marginTop: 8,
           }}
@@ -375,18 +375,18 @@ export function MetatasksList({
               aria-hidden
             />
             <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 13, color: skin.titleColor }}>
+              <div style={{ fontSize: "var(--text-lg)", color: skin.titleColor }}>
                 {mt.title}
               </div>
               {mt.description && (
-                <div style={{ fontSize: 10, color: skin.descColor }}>
+                <div style={{ fontSize: "var(--text-base)", color: skin.descColor }}>
                   {mt.description}
                 </div>
               )}
             </div>
             <span
               style={{
-                fontSize: 12,
+                fontSize: "var(--text-lg)",
                 fontWeight: 700,
                 color: selected
                   ? (skin.pointsActiveColor ?? "var(--color-success)")
@@ -423,9 +423,13 @@ export function TitleField({
   skin: TitleFieldSkin;
 }) {
   return (
+    // The role class owns the type size; the skin keeps font/colour/ornament
+    // only (§4a). Inline style wins over class, so the size lands as soon as the
+    // skin stops setting fontSize.
     <input
       type="text"
       maxLength={200}
+      className="content-text"
       value={state.title}
       onChange={(event) => state.setTitle(event.target.value)}
       placeholder={skin.placeholder}
@@ -516,7 +520,7 @@ export function BodyTextarea({
   const buttonStyle: CSSProperties = {
     minWidth: 26,
     padding: "3px 7px",
-    fontSize: 12,
+    fontSize: "var(--text-lg)",
     fontWeight: 700,
     lineHeight: 1.2,
     background: "var(--color-bg-surface)",
@@ -551,8 +555,10 @@ export function BodyTextarea({
           </button>
         ))}
       </div>
+      {/* Role class owns the size; the skin gives up only fontSize (§4a). */}
       <textarea
         ref={textareaRef}
+        className="content-text"
         value={state.body}
         onChange={(event) => state.setBody(event.target.value)}
         rows={skin.rows}
@@ -587,9 +593,13 @@ export function BodyPreview({
   return (
     <div style={skin.wrapperStyle}>
       {skin.label}
+      {/* content-text owns the body's type size (the largest player-written
+          prose on the site); the skin's markdownStyle keeps only font/colour.
+          The literal class lives on TitleField/BodyTextarea so Tailwind emits
+          it even though this one is assembled. */}
       <MarkdownPreview
         source={state.body}
-        className={skin.markdownClassName ?? "markdown-preview"}
+        className={`content-text ${skin.markdownClassName ?? "markdown-preview"}`}
         style={skin.markdownStyle}
       />
     </div>

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -93,7 +93,7 @@ export function Breadcrumb({
     <nav
       className="font-body"
       style={{
-        fontSize: 9,
+        fontSize: "var(--text-sm)",
         letterSpacing: "0.1em",
         color: tone,
         marginBottom: 12,
@@ -152,7 +152,7 @@ export function TaskMetaInline({
         alignItems: "center",
         flexWrap: "wrap",
         fontFamily: "'Courier Prime', monospace",
-        fontSize: 9,
+        fontSize: "var(--text-sm)",
         textTransform: "uppercase",
         letterSpacing: "0.12em",
         color: textColor ?? factionCssVar(slug),
@@ -224,7 +224,7 @@ export function ErrorBanner({ message }: ErrorBannerProps) {
     <div
       className="font-body"
       style={{
-        fontSize: 11,
+        fontSize: "var(--text-md)",
         color: "var(--color-danger)",
         marginTop: 8,
         padding: "8px 12px",

--- a/frontend/src/pages/editPraxis/mobileArchetypes/AlbescentComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/AlbescentComposer.tsx
@@ -41,7 +41,7 @@ const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
 const kicker: CSSProperties = {
   display: 'block',
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: "var(--text-xs)",
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: ink(30),
@@ -51,7 +51,7 @@ const kicker: CSSProperties = {
 function Sheet({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: 14 }}>
-      <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.22em', textTransform: 'uppercase', color: ink(40), marginBottom: 10 }}>
+      <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: '0.22em', textTransform: 'uppercase', color: ink(40), marginBottom: 10 }}>
         {title}
       </div>
       {children}
@@ -70,7 +70,7 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
       <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <AlbescentSigil size={22} />
-          <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 27, lineHeight: 1, color: INK, margin: 0 }}>
+          <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: "var(--text-title)", lineHeight: 1, color: INK, margin: 0 }}>
             {t('editPraxis.albescent.pageTitle')}
           </h1>
           <span style={{ ...kicker, marginLeft: 'auto' }}>
@@ -89,7 +89,7 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
               padding: '9px 10px',
               border: 'none',
               fontFamily: MONO,
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: '0.12em',
               textTransform: 'uppercase',
               background: active ? INK : 'transparent',
@@ -102,7 +102,7 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
       {/* In-answer-to reference */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: SHEET, border: `1px solid ${ink(10)}` }}>
         <span style={kicker}>{t('editPraxis.albescent.taskRefLabel')}</span>
-        <span style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 16, color: INK, textAlign: 'right', flex: 1, lineHeight: 1.15 }}>
+        <span style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: "var(--text-content)", color: INK, textAlign: 'right', flex: 1, lineHeight: 1.15 }}>
           {praxis.task_title}
         </span>
       </div>
@@ -122,7 +122,6 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
                   width: '100%',
                   fontFamily: FONT,
                   fontStyle: 'italic',
-                  fontSize: 22,
                   fontWeight: 300,
                   color: INK,
                   background: 'transparent',
@@ -145,7 +144,6 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
                   width: '100%',
                   fontFamily: FONT,
                   fontStyle: 'italic',
-                  fontSize: 15,
                   lineHeight: 1.65,
                   color: INK,
                   background: ink(2),
@@ -202,7 +200,7 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
         </>
       ) : (
         <Sheet title={t('editPraxis.albescent.previewLabel')}>
-          <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 22, color: INK, marginBottom: 10 }}>
+          <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: "var(--text-title)", color: INK, marginBottom: 10 }}>
             {state.title || t('editPraxis.albescent.titlePlaceholder')}
           </div>
           {state.media.length > 0 && (
@@ -213,7 +211,7 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
           <BodyPreview
             state={state}
             skin={{
-              markdownStyle: { fontFamily: FONT, fontStyle: 'italic', fontSize: 15, lineHeight: 1.65, color: ink(72) },
+              markdownStyle: { fontFamily: FONT, fontStyle: 'italic', lineHeight: 1.65, color: ink(72) },
             }}
           />
         </Sheet>
@@ -242,7 +240,7 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
               background: INK,
               color: PAGE,
               fontFamily: MONO,
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: '0.16em',
               textTransform: 'uppercase',
               padding: '13px 18px',
@@ -262,7 +260,7 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
                 color: ink(40),
                 fontFamily: FONT,
                 fontStyle: 'italic',
-                fontSize: 14,
+                fontSize: "var(--text-xl)",
                 cursor: 'pointer',
               },
             }}
@@ -305,7 +303,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
                   background: SHEET,
                   border: `1px solid ${ink(20)}`,
                   color: ink(55),
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: 'pointer',
@@ -334,7 +332,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
               justifyContent: 'center',
               gap: 4,
               fontFamily: MONO,
-              fontSize: 9,
+              fontSize: "var(--text-sm)",
               letterSpacing: '0.1em',
               textTransform: 'uppercase',
               color: ink(50),

--- a/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
@@ -36,7 +36,7 @@ const FAINT = "var(--color-text-tertiary)";
 
 const eyebrow: React.CSSProperties = {
   fontFamily: "var(--font-body)",
-  fontSize: 9,
+  fontSize: "var(--text-sm)",
   letterSpacing: "0.16em",
   textTransform: "uppercase",
   color: FAINT,
@@ -68,7 +68,7 @@ export default function DefaultEditPraxis({
         <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
           <h1
             className="font-display italic"
-            style={{ fontSize: 26, lineHeight: 1, color: INK, margin: 0 }}
+            style={{ fontSize: "var(--text-title)", lineHeight: 1, color: INK, margin: 0 }}
           >
             {t("editPraxis.na.pageTitle")}
           </h1>
@@ -97,7 +97,7 @@ export default function DefaultEditPraxis({
               borderRadius: 999,
               border: "none",
               fontFamily: "var(--font-body)",
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: "0.1em",
               textTransform: "uppercase",
               fontWeight: active ? 700 : 400,
@@ -124,7 +124,7 @@ export default function DefaultEditPraxis({
         <span style={eyebrow}>{t("editPraxis.na.taskRefLabel")}</span>
         <span
           className="font-display italic"
-          style={{ fontSize: 15, color: INK, textAlign: "right", flex: 1 }}
+          style={{ fontSize: "var(--text-content)", color: INK, textAlign: "right", flex: 1 }}
         >
           {praxis.task_title}
         </span>
@@ -146,7 +146,6 @@ export default function DefaultEditPraxis({
                 inputStyle: {
                   width: "100%",
                   fontFamily: "var(--font-body)",
-                  fontSize: 16,
                   color: INK,
                   background: SURFACE,
                   border: `1px solid ${BORDER}`,
@@ -171,7 +170,6 @@ export default function DefaultEditPraxis({
                 textareaStyle: {
                   width: "100%",
                   fontFamily: "var(--font-body)",
-                  fontSize: 15,
                   lineHeight: 1.55,
                   color: INK,
                   background: SURFACE,
@@ -247,7 +245,7 @@ export default function DefaultEditPraxis({
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           <div
             className="font-display italic"
-            style={{ fontSize: 20, color: INK }}
+            style={{ fontSize: "var(--text-content)", color: INK }}
           >
             {state.title || t("editPraxis.na.titlePlaceholder")}
           </div>
@@ -263,7 +261,6 @@ export default function DefaultEditPraxis({
               },
               markdownStyle: {
                 fontFamily: "var(--font-body)",
-                fontSize: 15,
                 lineHeight: 1.6,
                 color: INK,
               },
@@ -296,7 +293,7 @@ export default function DefaultEditPraxis({
               background: ACCENT,
               color: "var(--color-text-on-accent)",
               fontFamily: "var(--font-body)",
-              fontSize: 13,
+              fontSize: "var(--text-lg)",
               fontWeight: 700,
               letterSpacing: "0.1em",
               textTransform: "uppercase",
@@ -317,7 +314,7 @@ export default function DefaultEditPraxis({
                 border: "none",
                 color: FAINT,
                 fontFamily: "var(--font-body)",
-                fontSize: 11,
+                fontSize: "var(--text-md)",
                 textDecoration: "underline",
                 cursor: "pointer",
               },
@@ -394,7 +391,7 @@ function MediaGrid({
                   background: "var(--color-bg-page)",
                   border: `1px solid ${BORDER}`,
                   color: INK,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: "pointer",
@@ -424,7 +421,7 @@ function MediaGrid({
               justifyContent: "center",
               gap: 4,
               fontFamily: "var(--font-body)",
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: "0.1em",
               textTransform: "uppercase",
               color: MUTED,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
@@ -46,7 +46,7 @@ const SCRIPT = 'var(--eph-script)'
 const kicker: CSSProperties = {
   display: 'block',
   fontFamily: DISPLAY,
-  fontSize: 8,
+  fontSize: "var(--text-xs)",
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -56,7 +56,7 @@ const kicker: CSSProperties = {
 function Leaf({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: 14 }}>
-      <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 12, letterSpacing: '0.14em', textTransform: 'uppercase', color: RUBRIC, marginBottom: 10 }}>
+      <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: "var(--text-lg)", letterSpacing: '0.14em', textTransform: 'uppercase', color: RUBRIC, marginBottom: 10 }}>
         {title}
       </div>
       {children}
@@ -74,7 +74,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
     <div data-skin="ephemerists" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }}>
       <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-          <h1 style={{ fontFamily: DISPLAY, fontWeight: 800, fontSize: 28, lineHeight: 1, color: TEXT, margin: 0 }}>
+          <h1 style={{ fontFamily: DISPLAY, fontWeight: 800, fontSize: "var(--text-title)", lineHeight: 1, color: TEXT, margin: 0 }}>
             <Trans
               ns="forms"
               i18nKey="editPraxis.ephemerists.pageTitle"
@@ -97,7 +97,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
               padding: '9px 10px',
               border: 'none',
               fontFamily: DISPLAY,
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: '0.1em',
               textTransform: 'uppercase',
               background: active ? INK : 'transparent',
@@ -110,7 +110,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
       {/* Observed-task reference */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: VELLUM, border: `1px solid ${GOLD_DEEP}` }}>
         <span style={kicker}>{t('editPraxis.ephemerists.taskRefLabel')}</span>
-        <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 16, color: TEXT, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
+        <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: "var(--text-content)", color: TEXT, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
           {praxis.task_title}
         </span>
       </div>
@@ -129,7 +129,6 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
                 inputStyle: {
                   width: '100%',
                   fontFamily: DISPLAY,
-                  fontSize: 22,
                   fontWeight: 700,
                   color: TEXT,
                   background: 'transparent',
@@ -151,7 +150,6 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
                 textareaStyle: {
                   width: '100%',
                   fontFamily: SERIF,
-                  fontSize: 15,
                   lineHeight: 1.65,
                   color: TEXT,
                   background: VELLUM_DEEP,
@@ -211,7 +209,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
         </>
       ) : (
         <Leaf title={t('editPraxis.ephemerists.previewLabel')}>
-          <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 22, color: TEXT, marginBottom: 10 }}>
+          <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: "var(--text-title)", color: TEXT, marginBottom: 10 }}>
             {state.title || t('editPraxis.ephemerists.titlePlaceholder')}
           </div>
           {state.media.length > 0 && (
@@ -222,7 +220,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
           <BodyPreview
             state={state}
             skin={{
-              markdownStyle: { fontFamily: SERIF, fontSize: 15, lineHeight: 1.65, color: TEXT },
+              markdownStyle: { fontFamily: SERIF, lineHeight: 1.65, color: TEXT },
             }}
           />
         </Leaf>
@@ -252,7 +250,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
               color: PARCHMENT,
               fontFamily: DISPLAY,
               fontWeight: 700,
-              fontSize: 14,
+              fontSize: "var(--text-xl)",
               letterSpacing: '0.08em',
               padding: '13px 18px',
               border: `1px solid ${GOLD}`,
@@ -271,7 +269,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
                 color: MUTED,
                 fontFamily: SCRIPT,
                 fontStyle: 'italic',
-                fontSize: 14,
+                fontSize: "var(--text-xl)",
                 textDecoration: 'underline',
                 cursor: 'pointer',
               },
@@ -315,7 +313,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
                   background: VELLUM,
                   border: `1.5px solid ${GOLD}`,
                   color: GOLD,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: 'pointer',
@@ -344,7 +342,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
               justifyContent: 'center',
               gap: 4,
               fontFamily: DISPLAY,
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: '0.08em',
               textTransform: 'uppercase',
               color: RUBRIC,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
@@ -43,7 +43,7 @@ const BODY_FONT = 'var(--font-body)'
 const kicker: CSSProperties = {
   display: 'block',
   fontFamily: BODY_FONT,
-  fontSize: 8,
+  fontSize: "var(--text-xs)",
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -53,7 +53,7 @@ const kicker: CSSProperties = {
 function Plate({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section style={{ background: PAPER, border: `2px solid ${INK}`, padding: 14 }}>
-      <div style={{ fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.06em', color: RED, marginBottom: 10 }}>
+      <div style={{ fontFamily: ACCENT_FONT, fontSize: "var(--text-xl)", letterSpacing: '0.06em', color: RED, marginBottom: 10 }}>
         {title}
       </div>
       {children}
@@ -71,7 +71,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
     <div data-skin="everymen" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: PAPER_TEXT, background: PAPER }}>
       <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-          <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 30, lineHeight: 0.95, letterSpacing: '0.02em', color: PAPER_TEXT, margin: 0 }}>
+          <h1 style={{ fontFamily: ACCENT_FONT, fontSize: "var(--text-heading)", lineHeight: 0.95, letterSpacing: '0.02em', color: PAPER_TEXT, margin: 0 }}>
             {t('editPraxis.everymen.pageTitle')}
           </h1>
           <span style={{ ...kicker, marginLeft: 'auto' }}>
@@ -90,7 +90,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
               padding: '9px 10px',
               border: 'none',
               fontFamily: ACCENT_FONT,
-              fontSize: 14,
+              fontSize: "var(--text-xl)",
               letterSpacing: '0.08em',
               background: active ? INK : 'transparent',
               color: active ? CREAM : MUTED,
@@ -102,7 +102,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
       {/* For-task reference */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: PAPER_DEEP, border: `1.5px solid ${INK}` }}>
         <span style={kicker}>{t('editPraxis.everymen.taskRefLabel')}</span>
-        <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.02em', color: PAPER_TEXT, textAlign: 'right', flex: 1, lineHeight: 1 }}>
+        <span style={{ fontFamily: ACCENT_FONT, fontSize: "var(--text-content)", letterSpacing: '0.02em', color: PAPER_TEXT, textAlign: 'right', flex: 1, lineHeight: 1 }}>
           {praxis.task_title}
         </span>
       </div>
@@ -121,7 +121,6 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
                 inputStyle: {
                   width: '100%',
                   fontFamily: ACCENT_FONT,
-                  fontSize: 24,
                   letterSpacing: '0.01em',
                   color: PAPER_TEXT,
                   background: 'transparent',
@@ -143,7 +142,6 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
                 textareaStyle: {
                   width: '100%',
                   fontFamily: BODY_FONT,
-                  fontSize: 14,
                   lineHeight: 1.6,
                   color: PAPER_TEXT,
                   background: PAPER_DEEP,
@@ -200,7 +198,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
         </>
       ) : (
         <Plate title={t('editPraxis.everymen.previewLabel')}>
-          <div style={{ fontFamily: ACCENT_FONT, fontSize: 24, letterSpacing: '0.01em', color: PAPER_TEXT, marginBottom: 10 }}>
+          <div style={{ fontFamily: ACCENT_FONT, fontSize: "var(--text-title)", letterSpacing: '0.01em', color: PAPER_TEXT, marginBottom: 10 }}>
             {state.title || t('editPraxis.everymen.titlePlaceholder')}
           </div>
           {state.media.length > 0 && (
@@ -211,7 +209,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
           <BodyPreview
             state={state}
             skin={{
-              markdownStyle: { fontFamily: BODY_FONT, fontSize: 14, lineHeight: 1.6, color: PAPER_TEXT },
+              markdownStyle: { fontFamily: BODY_FONT, lineHeight: 1.6, color: PAPER_TEXT },
             }}
           />
         </Plate>
@@ -240,7 +238,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
               background: RED,
               color: CREAM,
               fontFamily: ACCENT_FONT,
-              fontSize: 16,
+              fontSize: "var(--text-xl)",
               letterSpacing: '0.08em',
               padding: '13px 18px',
               border: `2px solid ${INK}`,
@@ -258,7 +256,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
                 border: 'none',
                 color: MUTED,
                 fontFamily: BODY_FONT,
-                fontSize: 12,
+                fontSize: "var(--text-lg)",
                 textDecoration: 'underline',
                 cursor: 'pointer',
               },
@@ -301,7 +299,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
                   background: GOLD,
                   border: `1.5px solid ${INK}`,
                   color: INK,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: 'pointer',
@@ -330,7 +328,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
               justifyContent: 'center',
               gap: 4,
               fontFamily: ACCENT_FONT,
-              fontSize: 13,
+              fontSize: "var(--text-lg)",
               letterSpacing: '0.06em',
               color: RED,
             },

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
@@ -43,7 +43,7 @@ const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, t
 const kicker: CSSProperties = {
   display: 'block',
   fontFamily: FONT,
-  fontSize: 8,
+  fontSize: "var(--text-xs)",
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: signal(60),
@@ -53,7 +53,7 @@ const kicker: CSSProperties = {
 function Panel({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: 14 }}>
-      <div style={{ fontFamily: FONT, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: PHOSPHOR, marginBottom: 10 }}>
+      <div style={{ fontFamily: FONT, fontSize: "var(--text-sm)", letterSpacing: '0.13em', textTransform: 'uppercase', color: PHOSPHOR, marginBottom: 10 }}>
         {title}
       </div>
       {children}
@@ -71,7 +71,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
     <div data-skin="singularity" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: FONT, color: PHOSPHOR, background: VOID }}>
       <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-          <h1 style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.03em', margin: 0 }}>
+          <h1 style={{ fontFamily: FONT, fontSize: "var(--text-title)", lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.03em', margin: 0 }}>
             {t('editPraxis.singularity.mobile.pageTitle')}
           </h1>
           <span style={{ ...kicker, marginLeft: 'auto' }}>
@@ -90,7 +90,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
               padding: '9px 10px',
               border: 'none',
               fontFamily: FONT,
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: '0.1em',
               textTransform: 'uppercase',
               background: active ? PHOSPHOR : 'transparent',
@@ -103,7 +103,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
       {/* For-function reference */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: VOID, border: `1px solid ${signal(38)}` }}>
         <span style={kicker}>{t('editPraxis.singularity.mobile.taskRefLabel')}</span>
-        <span style={{ fontFamily: FONT, fontSize: 14, color: PHOSPHOR, textAlign: 'right', flex: 1, lineHeight: 1.2 }}>
+        <span style={{ fontFamily: FONT, fontSize: "var(--text-content)", color: PHOSPHOR, textAlign: 'right', flex: 1, lineHeight: 1.2 }}>
           {praxis.task_title}
         </span>
       </div>
@@ -122,7 +122,6 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
                 inputStyle: {
                   width: '100%',
                   fontFamily: FONT,
-                  fontSize: 18,
                   color: PHOSPHOR,
                   background: 'transparent',
                   border: 'none',
@@ -143,7 +142,6 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
                 textareaStyle: {
                   width: '100%',
                   fontFamily: FONT,
-                  fontSize: 13,
                   lineHeight: 1.6,
                   color: PHOSPHOR,
                   background: signal(6),
@@ -200,7 +198,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
         </>
       ) : (
         <Panel title={t('editPraxis.singularity.mobile.previewLabel')}>
-          <div style={{ fontFamily: FONT, fontSize: 18, color: PHOSPHOR, marginBottom: 10 }}>
+          <div style={{ fontFamily: FONT, fontSize: "var(--text-content)", color: PHOSPHOR, marginBottom: 10 }}>
             {'> '}
             {state.title || t('editPraxis.singularity.titlePlaceholder')}
           </div>
@@ -212,7 +210,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
           <BodyPreview
             state={state}
             skin={{
-              markdownStyle: { fontFamily: FONT, fontSize: 13, lineHeight: 1.6, color: phosphor(80) },
+              markdownStyle: { fontFamily: FONT, lineHeight: 1.6, color: phosphor(80) },
             }}
           />
         </Panel>
@@ -241,7 +239,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
               background: PHOSPHOR,
               color: VOID,
               fontFamily: FONT,
-              fontSize: 12,
+              fontSize: "var(--text-lg)",
               letterSpacing: '0.12em',
               textTransform: 'uppercase',
               padding: '13px 18px',
@@ -261,7 +259,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
                 border: 'none',
                 color: signal(60),
                 fontFamily: FONT,
-                fontSize: 13,
+                fontSize: "var(--text-lg)",
                 cursor: 'pointer',
               },
             }}
@@ -303,7 +301,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
                   background: VOID,
                   border: `1px solid ${PHOSPHOR}`,
                   color: PHOSPHOR,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   lineHeight: 1,
                   cursor: 'pointer',
                   padding: 0,
@@ -331,7 +329,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
               justifyContent: 'center',
               gap: 4,
               fontFamily: FONT,
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: '0.08em',
               textTransform: 'uppercase',
               color: PHOSPHOR,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
@@ -48,7 +48,7 @@ const CARD_SHADOW = '5px 6px 0 rgba(0,0,0,.5)'
 const kicker: CSSProperties = {
   display: 'block',
   fontFamily: TYPE,
-  fontSize: 8,
+  fontSize: "var(--text-xs)",
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -59,7 +59,7 @@ function Plate({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section style={{ position: 'relative', background: INK, color: TEXT, border: `1px solid ${LINE}`, boxShadow: CARD_SHADOW, padding: 14, overflow: 'hidden' }}>
       <span aria-hidden style={{ position: 'absolute', top: -10, left: 18, width: 56, height: 22, background: TAPE, transform: 'rotate(-4deg)', opacity: 0.92 }} />
-      <div style={{ fontFamily: COND, fontSize: 13, letterSpacing: '0.08em', textTransform: 'uppercase', color: ACID, marginBottom: 10 }}>
+      <div style={{ fontFamily: COND, fontSize: "var(--text-lg)", letterSpacing: '0.08em', textTransform: 'uppercase', color: ACID, marginBottom: 10 }}>
         {title}
       </div>
       {children}
@@ -77,7 +77,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
     <div data-skin="snide" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: TYPE, color: WALL_TEXT, background: WALL }}>
       <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-          <h1 style={{ fontFamily: COND, fontSize: 30, letterSpacing: '0.03em', lineHeight: 1, color: WALL_TEXT, margin: 0, textTransform: 'uppercase' }}>
+          <h1 style={{ fontFamily: COND, fontSize: "var(--text-heading)", letterSpacing: '0.03em', lineHeight: 1, color: WALL_TEXT, margin: 0, textTransform: 'uppercase' }}>
             {t('editPraxis.snide.pageTitle')}
           </h1>
           <span style={{ ...kicker, marginLeft: 'auto' }}>
@@ -96,7 +96,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
               padding: '9px 10px',
               border: 'none',
               fontFamily: BLACK,
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: '0.06em',
               textTransform: 'uppercase',
               background: active ? ACID : 'transparent',
@@ -109,7 +109,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
       {/* For-completion reference */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: INK, color: TEXT, border: `1px solid ${LINE}` }}>
         <span style={kicker}>{t('editPraxis.snide.taskRefLabel')}</span>
-        <span style={{ fontFamily: COND, fontSize: 17, letterSpacing: '0.03em', color: TEXT, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
+        <span style={{ fontFamily: COND, fontSize: "var(--text-content)", letterSpacing: '0.03em', color: TEXT, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
           {praxis.task_title}
         </span>
       </div>
@@ -128,7 +128,6 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
                 inputStyle: {
                   width: '100%',
                   fontFamily: COND,
-                  fontSize: 24,
                   letterSpacing: '0.02em',
                   color: TEXT,
                   background: 'transparent',
@@ -150,7 +149,6 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
                 textareaStyle: {
                   width: '100%',
                   fontFamily: TYPE,
-                  fontSize: 15,
                   lineHeight: 1.6,
                   color: TEXT,
                   background: 'rgba(255,255,255,0.04)',
@@ -207,7 +205,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
         </>
       ) : (
         <Plate title={t('editPraxis.snide.previewLabel')}>
-          <div style={{ fontFamily: COND, fontSize: 24, letterSpacing: '0.02em', color: TEXT, marginBottom: 10 }}>
+          <div style={{ fontFamily: COND, fontSize: "var(--text-title)", letterSpacing: '0.02em', color: TEXT, marginBottom: 10 }}>
             {state.title || t('editPraxis.snide.titlePlaceholder')}
           </div>
           {state.media.length > 0 && (
@@ -218,7 +216,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
           <BodyPreview
             state={state}
             skin={{
-              markdownStyle: { fontFamily: TYPE, fontSize: 15, lineHeight: 1.6, color: TEXT },
+              markdownStyle: { fontFamily: TYPE, lineHeight: 1.6, color: TEXT },
             }}
           />
         </Plate>
@@ -247,7 +245,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
               background: PINK,
               color: PAPER,
               fontFamily: BLACK,
-              fontSize: 12,
+              fontSize: "var(--text-lg)",
               letterSpacing: '0.06em',
               textTransform: 'uppercase',
               padding: '13px 18px',
@@ -267,7 +265,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
                 border: 'none',
                 color: MUTED,
                 fontFamily: TYPE,
-                fontSize: 13,
+                fontSize: "var(--text-lg)",
                 textTransform: 'uppercase',
                 letterSpacing: '0.06em',
                 cursor: 'pointer',
@@ -311,7 +309,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
                   background: INK,
                   border: `1px solid ${ACID}`,
                   color: ACID,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: 'pointer',
@@ -340,7 +338,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
               justifyContent: 'center',
               gap: 4,
               fontFamily: TYPE,
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: '0.06em',
               textTransform: 'uppercase',
               color: ACID,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -47,7 +47,7 @@ const MONO = 'var(--font-body)'
 const kicker: CSSProperties = {
   display: 'block',
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: "var(--text-xs)",
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -59,7 +59,7 @@ function Plate({ title, children }: { title: string; children: ReactNode }) {
     <section style={{ padding: 7, background: GILT, boxShadow: '0 8px 20px rgba(60,40,10,.16), inset 0 0 0 1px rgba(255,255,255,0.45)' }}>
       <div style={{ padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
         <div style={{ background: PAPER, border: `1px solid ${LINE}`, padding: 14 }}>
-          <div style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.13em', textTransform: 'uppercase', color: ACCENT, marginBottom: 10 }}>
+          <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-sm)", letterSpacing: '0.13em', textTransform: 'uppercase', color: ACCENT, marginBottom: 10 }}>
             {title}
           </div>
           {children}
@@ -79,7 +79,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
     <div data-skin="ua" style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: WALL }}>
       <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-          <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 28, lineHeight: 1, color: INK, margin: 0 }}>
+          <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: "var(--text-title)", lineHeight: 1, color: INK, margin: 0 }}>
             {t('editPraxis.ua.pageTitle')}
           </h1>
           <span style={{ ...kicker, marginLeft: 'auto' }}>
@@ -99,7 +99,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
               borderRadius: 999,
               border: 'none',
               fontFamily: ENGRAVED,
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: '0.1em',
               textTransform: 'uppercase',
               background: active ? ACCENT : 'transparent',
@@ -112,7 +112,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
       {/* For-commission reference */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '11px 14px', background: PAPER, border: `1px solid ${LINE}` }}>
         <span style={kicker}>{t('editPraxis.ua.taskRefLabel')}</span>
-        <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 16, color: INK, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
+        <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: "var(--text-content)", color: INK, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
           {praxis.task_title}
         </span>
       </div>
@@ -132,7 +132,6 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
                   width: '100%',
                   fontFamily: DISPLAY,
                   fontStyle: 'italic',
-                  fontSize: 22,
                   fontWeight: 700,
                   color: INK,
                   background: 'transparent',
@@ -154,7 +153,6 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
                 textareaStyle: {
                   width: '100%',
                   fontFamily: DISPLAY,
-                  fontSize: 15,
                   lineHeight: 1.6,
                   color: INK,
                   background: PAPER_WARM,
@@ -211,7 +209,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
         </>
       ) : (
         <Plate title={t('editPraxis.ua.previewLabel')}>
-          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 22, color: INK, marginBottom: 10 }}>
+          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: "var(--text-title)", color: INK, marginBottom: 10 }}>
             {state.title || t('editPraxis.ua.titlePlaceholder')}
           </div>
           {state.media.length > 0 && (
@@ -222,7 +220,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
           <BodyPreview
             state={state}
             skin={{
-              markdownStyle: { fontFamily: DISPLAY, fontSize: 15, lineHeight: 1.6, color: INK },
+              markdownStyle: { fontFamily: DISPLAY, lineHeight: 1.6, color: INK },
             }}
           />
         </Plate>
@@ -251,7 +249,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
               background: ACCENT,
               color: PAPER_WARM,
               fontFamily: ENGRAVED,
-              fontSize: 12,
+              fontSize: "var(--text-lg)",
               letterSpacing: '0.12em',
               textTransform: 'uppercase',
               padding: '13px 18px',
@@ -271,7 +269,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
                 color: MUTED,
                 fontFamily: DISPLAY,
                 fontStyle: 'italic',
-                fontSize: 14,
+                fontSize: "var(--text-xl)",
                 cursor: 'pointer',
               },
             }}
@@ -314,7 +312,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
                   background: PAPER,
                   border: `1px solid ${ACCENT}`,
                   color: ACCENT,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: 'pointer',
@@ -343,7 +341,7 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
               justifyContent: 'center',
               gap: 4,
               fontFamily: ENGRAVED,
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: '0.08em',
               textTransform: 'uppercase',
               color: ACCENT,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
@@ -65,7 +65,7 @@ function Sparkle({
 const eyebrow: CSSProperties = {
   display: "block",
   fontFamily: BODY,
-  fontSize: 9,
+  fontSize: "var(--text-sm)",
   letterSpacing: "0.18em",
   textTransform: "uppercase",
   color: PINK_DEEP,
@@ -116,7 +116,7 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
             alignItems: "center",
             gap: 5,
             fontFamily: SCRIPT,
-            fontSize: 18,
+            fontSize: "var(--text-content)",
             color: TITLE_TEXT,
           }}
         >
@@ -172,7 +172,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
           <h1
             style={{
               fontFamily: SCRIPT,
-              fontSize: 34,
+              fontSize: "var(--text-heading)",
               lineHeight: 0.9,
               color: TITLE_TEXT,
               margin: 0,
@@ -209,7 +209,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
               borderRadius: 999,
               border: active ? `1.5px solid ${PINK_DEEP}` : "1.5px solid transparent",
               fontFamily: BODY,
-              fontSize: 11,
+              fontSize: "var(--text-md)",
               letterSpacing: "0.1em",
               textTransform: "uppercase",
               fontWeight: 700,
@@ -239,7 +239,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
         <span
           style={{
             fontFamily: SCRIPT,
-            fontSize: 20,
+            fontSize: "var(--text-content)",
             color: TITLE_TEXT,
             textAlign: "right",
             flex: 1,
@@ -264,7 +264,6 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
                 inputStyle: {
                   width: "100%",
                   fontFamily: SCRIPT,
-                  fontSize: 24,
                   fontWeight: 700,
                   color: TITLE_TEXT,
                   background: "transparent",
@@ -286,7 +285,6 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
                 textareaStyle: {
                   width: "100%",
                   fontFamily: BODY,
-                  fontSize: 15,
                   lineHeight: 1.55,
                   color: CARD_TEXT,
                   background: BODY_BG,
@@ -358,7 +356,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
           <div
             style={{
               fontFamily: SCRIPT,
-              fontSize: 22,
+              fontSize: "var(--text-title)",
               color: TITLE_TEXT,
               marginBottom: 10,
             }}
@@ -375,7 +373,6 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
             skin={{
               markdownStyle: {
                 fontFamily: BODY,
-                fontSize: 15,
                 lineHeight: 1.6,
                 color: CARD_TEXT,
               },
@@ -412,7 +409,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
               background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`,
               color: ON_ACCENT,
               fontFamily: BODY,
-              fontSize: 12,
+              fontSize: "var(--text-lg)",
               fontWeight: 700,
               letterSpacing: "0.12em",
               textTransform: "uppercase",
@@ -433,7 +430,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
                 border: "none",
                 color: CARD_MUTED,
                 fontFamily: SCRIPT,
-                fontSize: 18,
+                fontSize: "var(--text-content)",
                 fontWeight: 700,
                 cursor: "pointer",
               },
@@ -510,7 +507,7 @@ function MediaGrid({
                   background: NOTEPAD_BG,
                   border: `1.5px solid ${PINK}`,
                   color: PINK,
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: "pointer",
@@ -540,7 +537,7 @@ function MediaGrid({
               justifyContent: "center",
               gap: 4,
               fontFamily: SCRIPT,
-              fontSize: 16,
+              fontSize: "var(--text-xl)",
               fontWeight: 700,
               color: PINK,
             },


### PR DESCRIPTION
Closes #632

Content-floor sweep of the **edit-praxis composer** (all 301 raw `fontSize` values) + the skin seam. fontSize floor only — spacing (§4a/#579) is untouched, so legacy lines stay.

## The seam (`archetypes/controls.tsx`)
The three shared controls now own the content-tier size via a role class; the archetype skin objects give up exactly one property (`fontSize`), keeping font/style/colour/lineHeight:
- `TitleField` `<input>` and `BodyTextarea` `<textarea>` → literal `className="content-text"`.
- `BodyPreview` → `className={`content-text …`}` on the markdown container (the largest player-written prose on the site). The literal lives on the two controls above so Tailwind still emits the class.
- Every `inputStyle` / `textareaStyle` / `markdownStyle` in all **8 desktop archetypes + 8 mobile composers** dropped `fontSize`. Inline style beats class, so the class wins the moment the skin stops setting the size. Verified: no seam-fed skin object sets `fontSize` anywhere.

## Convention (identical to #631/#633)
- **Content role → the floor.** Title `<input>`, body `<textarea>`, all 9 `markdownStyle` previews → `.content-text`. The proven **task-title reference** and re-rendered **`task.description`** → `--text-content` — this bumps the below-floor readable text the issue called out (e.g. Singularity/mobile textarea were **13/14px**; task refs were **12–13px**).
- **Everything else → nearest ramp token** by value (tie rounds down, matching #631's `12.5→lg`): `13→--text-lg`, `15/16→--text-xl`, `8→--text-xs`, hero `40–58→--text-display`, etc. Ornament/terminal chrome is tokenized to its nearest small token rather than left raw.

## Calls made (issue asked)
- **ModePicker flag vs description.** The option **name** (flag) snaps by nearest token — large display names land in the content/title tier, so size is preserved. The option **description/sub** I kept as a **label** (nearest small token, *not* bumped to the floor): they're terse per-mode subtitles scanned once during a one-time mode choice, and bumping them to 18px would blow out every faction's compact mode-picker button. This is the deferred "arguably content" call.
- **`RainbowTitle`** (shared.tsx) uses a dynamic `size` prop (an identifier, not a raw literal, already above the floor) — left as-is rather than pinned to `.content-title` (24px), which would shrink the composer hero.
- **`ErrorBanner`** compact error strip → `--text-md` (label treatment).

## Legacy list — all 20 lines KEPT
Every touched file still has raw **spacing** (`padding`/`margin`/`gap`), so deleting its `.eslint-legacy-raw-styles.txt` line would redden CI. Kept per the fontSize-only scope; this is the §4a/#579 spacing pass. Raw-spacing violations that block deletion, per file:

| File | raw spacing |
|---|---|
| archetypes: Snide 52 · Singularity 49 · Wow 47 · Everymen 46 · Default 43 · Ephemerists 43 · Albescent 42 · UA 39 | |
| archetypes/controls.tsx 17 · shared.tsx 7 | |
| mobile: Wow 26 · Default 25 · UA 23 · Ephemerists 22 · Albescent 20 · Everymen/Singularity/Snide 21 each · shared 1 | |

Surface total ≈ 565 raw-spacing values remaining (out of scope here).

## Verify
- `npx eslint src/pages/editPraxis/{archetypes,mobileArchetypes}` → **0 errors** (files stay grandfathered for spacing; CI = eslint stays green).
- `tsc` clean on all editPraxis files (the only error is `node:fs` in an unrelated test — stale junction, not this change).
- No raw `fontSize` remains anywhere under `pages/editPraxis/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
