### PR TITLE
Guard against duplicate keys in locale catalogs (#670)

### DIFF
--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -1,8 +1,12 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, relative } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import i18n from '../../i18n'
 import forms from '../en/forms.json'
 import praxis from '../en/praxis.json'
 import votes from '../en/votes.json'
+import { findDuplicateJsonKeys } from './findDuplicateJsonKeys'
 
 // Factions with a vote voice (per-faction tier labels). Kept as an explicit
 // list, mirroring the seed catalog this test was ported from. Albescent joined
@@ -48,6 +52,61 @@ describe('en copy catalog shape', () => {
 
   it('has the praxis charLimit.terminal key referenced by ADR-0010/ADR-0032', () => {
     expect(praxis.charLimit).toHaveProperty('terminal')
+  })
+})
+
+describe('no duplicate keys in any locale catalog', () => {
+  // JSON is last-wins: a key repeated inside the same object silently drops the
+  // earlier block at parse time, so the copy vanishes with no error (this is
+  // what happened to factions.json `albescent.invitation`, #634). `JSON.parse`
+  // cannot catch it — we scan the raw file text instead. Guard for #670.
+  const localesDir = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+  const jsonFiles = readdirSync(localesDir, { recursive: true })
+    .map((entry) => String(entry))
+    .filter((entry) => entry.endsWith('.json'))
+    .map((entry) => join(localesDir, entry))
+
+  it('finds catalog files to scan', () => {
+    // Fails loudly if the glob ever silently matches nothing (moved dir, etc.).
+    expect(jsonFiles.length).toBeGreaterThan(0)
+  })
+
+  for (const filePath of jsonFiles) {
+    const label = relative(localesDir, filePath).replace(/\\/g, '/')
+    it(`${label} has no duplicate keys`, () => {
+      const duplicates = findDuplicateJsonKeys(readFileSync(filePath, 'utf8'))
+      expect(
+        duplicates,
+        `duplicate keys in ${label}: ${duplicates.map((d) => d.path).join(', ')}`,
+      ).toEqual([])
+    })
+  }
+})
+
+describe('findDuplicateJsonKeys scanner', () => {
+  it('passes clean nested JSON', () => {
+    const text = JSON.stringify({ a: { b: 1, c: 2 }, d: [{ e: 3 }, { e: 4 }] })
+    expect(findDuplicateJsonKeys(text)).toEqual([])
+  })
+
+  it('flags a duplicate key nested in an object', () => {
+    // Hand-written (not JSON.stringify, which would collapse the dup) so both
+    // blocks survive into the raw text the scanner reads.
+    const text = '{ "faction": { "invitation": "first", "invitation": "second" } }'
+    expect(findDuplicateJsonKeys(text)).toEqual([
+      { path: 'faction.invitation', key: 'invitation' },
+    ])
+  })
+
+  it('does not confuse a value equal to a sibling key', () => {
+    const text = '{ "a": "b", "c": "a" }'
+    expect(findDuplicateJsonKeys(text)).toEqual([])
+  })
+
+  it('does not treat a colon inside a string value as a key separator', () => {
+    const text = '{ "a": "x: y", "b": "z" }'
+    expect(findDuplicateJsonKeys(text)).toEqual([])
   })
 })
 

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -63,9 +63,9 @@ describe('no duplicate keys in any locale catalog', () => {
   const localesDir = join(dirname(fileURLToPath(import.meta.url)), '..')
 
   const jsonFiles = readdirSync(localesDir, { recursive: true })
-    .map((entry) => String(entry))
-    .filter((entry) => entry.endsWith('.json'))
-    .map((entry) => join(localesDir, entry))
+    .map((entry: string) => String(entry))
+    .filter((entry: string) => entry.endsWith('.json'))
+    .map((entry: string) => join(localesDir, entry))
 
   it('finds catalog files to scan', () => {
     // Fails loudly if the glob ever silently matches nothing (moved dir, etc.).

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -62,10 +62,10 @@ describe('no duplicate keys in any locale catalog', () => {
   // cannot catch it — we scan the raw file text instead. Guard for #670.
   const localesDir = join(dirname(fileURLToPath(import.meta.url)), '..')
 
-  const jsonFiles = readdirSync(localesDir, { recursive: true })
-    .map((entry: string) => String(entry))
-    .filter((entry: string) => entry.endsWith('.json'))
-    .map((entry: string) => join(localesDir, entry))
+  // recursive + no withFileTypes → path strings; the cast drops the string|Buffer union.
+  const jsonFiles = (readdirSync(localesDir, { recursive: true }) as string[])
+    .filter((entry) => entry.endsWith('.json'))
+    .map((entry) => join(localesDir, entry))
 
   it('finds catalog files to scan', () => {
     // Fails loudly if the glob ever silently matches nothing (moved dir, etc.).

--- a/frontend/src/locales/__tests__/findDuplicateJsonKeys.ts
+++ b/frontend/src/locales/__tests__/findDuplicateJsonKeys.ts
@@ -1,0 +1,117 @@
+// Reports keys that appear twice within the SAME JSON object, at any nesting
+// depth. `JSON.parse` cannot do this: it silently keeps the last value and
+// drops the earlier block (JSON is last-wins), so a duplicated catalog key
+// erases its own copy with no error. See issue #670 / the #634 factions.json
+// `albescent.invitation` incident.
+//
+// This is a raw token scanner rather than a JSON.parse reviver, because the
+// reviver only ever sees the survivor — duplicates are already collapsed by
+// the time it runs.
+//
+// ponytail: the scanner assumes WELL-FORMED JSON (it is only ever run on
+// catalogs that also go through `import ... from '*.json'`, which would fail
+// the build first on malformed input). It does not validate syntax; it only
+// finds duplicate object keys. Array indices are not reflected in the reported
+// path — a duplicate inside `[{...}, {...}]` reports the enclosing key path.
+
+export interface DuplicateKey {
+  /** Dotted path to the object that holds the duplicate, plus the key itself. */
+  path: string
+  key: string
+}
+
+interface Frame {
+  kind: 'object' | 'array'
+  keys: Set<string>
+  /** Dotted path from the document root to this container. */
+  path: string
+}
+
+export function findDuplicateJsonKeys(text: string): DuplicateKey[] {
+  const duplicates: DuplicateKey[] = []
+  const stack: Frame[] = []
+  // The key most recently read in the innermost object, so a nested container
+  // opened as that key's value can build its own path.
+  let pendingKey: string | null = null
+  let index = 0
+
+  const readString = (): string => {
+    // Assumes text[index] === '"'. Returns the decoded-enough key text
+    // (escape sequences are kept verbatim; duplicate detection only needs
+    // byte-equal keys, which raw text preserves).
+    let result = ''
+    index++ // skip opening quote
+    while (index < text.length) {
+      const char = text[index]
+      if (char === '\\') {
+        result += text[index] + (text[index + 1] ?? '')
+        index += 2
+        continue
+      }
+      if (char === '"') {
+        index++ // skip closing quote
+        return result
+      }
+      result += char
+      index++
+    }
+    return result
+  }
+
+  const peekNextNonWhitespace = (): string => {
+    let scan = index
+    while (scan < text.length && /\s/.test(text[scan])) scan++
+    return text[scan] ?? ''
+  }
+
+  while (index < text.length) {
+    const char = text[index]
+
+    if (char === '{' || char === '[') {
+      const parent = stack[stack.length - 1]
+      const parentPath = parent ? parent.path : ''
+      const path =
+        pendingKey != null
+          ? parentPath
+            ? `${parentPath}.${pendingKey}`
+            : pendingKey
+          : parentPath
+      stack.push({
+        kind: char === '{' ? 'object' : 'array',
+        keys: new Set<string>(),
+        path,
+      })
+      pendingKey = null
+      index++
+      continue
+    }
+
+    if (char === '}' || char === ']') {
+      stack.pop()
+      index++
+      continue
+    }
+
+    if (char === '"') {
+      const value = readString()
+      const isKey = peekNextNonWhitespace() === ':'
+      const frame = stack[stack.length - 1]
+      if (isKey && frame && frame.kind === 'object') {
+        if (frame.keys.has(value)) {
+          duplicates.push({
+            path: frame.path ? `${frame.path}.${value}` : value,
+            key: value,
+          })
+        } else {
+          frame.keys.add(value)
+        }
+        pendingKey = value
+      }
+      continue
+    }
+
+    index++
+  }
+
+  return duplicates
+}

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -472,7 +472,6 @@
         "duel": { "label": "Salon Duel", "desc": "a contested acquisition" }
       },
       "taskRefLabel": "Re: the commission",
-      "previewLabel": "As it will hang",
       "inviteLabel": "The other hands",
       "inviteLabelDuel": "The challenger",
       "invitePlaceholder": "name or @handle",


### PR DESCRIPTION
## What

Adds a test that fails when any locale catalog under `frontend/src/locales/**/*.json` contains the same key twice within one object, at any nesting depth.

JSON is last-wins: a key repeated inside the same object silently drops the earlier block at parse time, so its copy vanishes with no error. This already bit us once — `factions.json` had two `albescent.invitation` blocks (#634, since fixed). `JSON.parse` can't catch it: the reviver only ever sees the survivor.

## How

- **Hand-rolled raw-token JSON scanner** (`findDuplicateJsonKeys.ts`), ~90 lines. No installed dependency reports duplicate JSON keys (no `jsonc-parser`, no JSON eslint plugin), and a new dep isn't warranted for what a small tokenizer does. The scanner tracks object/array scopes and reports any key seen twice in the same object, plus a dotted path. Its assumptions are marked with a `// ponytail:` comment (well-formed input only; array indices not reflected in the path).
- **`catalog.test.ts`**: a per-file vitest case that scans every `*.json` under `src/locales` (auto-discovered via `readdirSync(..., { recursive: true })`, following the existing `factionContrast.test.ts` node:fs pattern), plus 4 scanner unit tests (clean pass, dup-flag, value-equal-to-key, colon-inside-string-value).

## Real bug caught

The new guard immediately found a **second, previously-unknown duplicate**: `editPraxis.ua.previewLabel` was defined twice in `forms.json` ("As it will hang" at one line, "As it will read" at another). JSON last-wins meant only "As it will read" ever rendered; "As it will hang" was dead. Both consumers (`UaEditPraxis`, mobile `UaComposer`) reference the key exactly once and already showed the surviving value, so removing the dead earlier copy leaves rendered output identical.

## Verification

- New test **passes** on the current real catalogs (766/766 vitest green overall).
- **Fail-proof done**: temporarily injected a duplicate `"brand"` into `common.json` → the `en/common.json` case failed with the exact key reported → reverted.
- `eslint` clean on both new files.
- `tsc --noEmit`: clean apart from the known `node:fs`/`node:url`/`node:path` stale-junction false alarm (PR #675), which the pre-existing `factionContrast.test.ts` throws identically; CI's `npm ci` resolves it.

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)
