### PR TITLE
#646 Collab cast button back in footer; [Cancel] … [Submit] everywhere

### DIFF
--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -10,9 +10,10 @@
  *   0 < cast_count < member_count, I didn't → holdout (S3) the circle waits on me
  *   cast_count === member_count         → published (S4) every part woven
  *
- * `action` is supplied only in the editable composer; the read-only detail view
- * omits it (the detail page owns its own reopen affordance). Spacing/type via
- * Tailwind utilities + --text-* tokens, not raw inline pixels (#588 lint guard).
+ * Pure display everywhere (#646): the cast / pull-back action lives in the
+ * composer footer's PublishButton, not the roster, so both the composer and the
+ * read-only detail view consume this the same way. Spacing/type via Tailwind
+ * utilities + --text-* tokens, not raw inline pixels (#588 lint guard).
  *
  * Every word resolves through `collabCopy(factionSlug, key)`, so each faction
  * speaks the same states in its own voice and anything it hasn't overridden
@@ -48,24 +49,16 @@ export function deriveCollabGate(
   return { memberCount, castCount, iCast, state }
 }
 
-export interface CollabRosterAction {
-  onCast: () => void
-  onPullBack: () => void
-  submitting: boolean
-}
-
 export function CollabRoster({
   members,
   currentCharacterId,
   factionSlug,
   taskPointValue,
-  action,
 }: {
   members: readonly PraxisMemberOut[]
   currentCharacterId: number | null | undefined
   factionSlug: string | null | undefined
   taskPointValue?: number | null
-  action?: CollabRosterAction
 }) {
   const gate = deriveCollabGate(members, currentCharacterId)
   if (gate.memberCount < 2) return null // solo/duel render nothing
@@ -148,23 +141,6 @@ export function CollabRoster({
         >
           {banner.text}
         </p>
-      )}
-
-      {/* Composer-only primary action (cast / pull-back). */}
-      {action && gate.state !== 'published' && (
-        <button
-          type="button"
-          onClick={() => (gate.iCast ? action.onPullBack() : action.onCast())}
-          disabled={action.submitting}
-          className={`${gate.iCast ? 'btn-outline' : 'btn-primary'} text-[11px] px-[14px] py-[6px]`}
-          style={{ alignSelf: 'flex-start' }}
-        >
-          {gate.iCast
-            ? collabCopy(factionSlug, 'pullBackAction')
-            : gate.castCount === gate.memberCount - 1
-              ? collabCopy(factionSlug, 'castFinalAction')
-              : collabCopy(factionSlug, 'castAction')}
-        </button>
       )}
     </div>
   )

--- a/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
+++ b/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
@@ -49,23 +49,12 @@ describe('CollabRoster render', () => {
     expect(html).toContain('1 of 2 cast')
   })
 
-  it('offers pull-back when I have cast, cast when I have not', () => {
-    const action = { onCast: () => {}, onPullBack: () => {}, submitting: false }
-    const waiting = renderToStaticMarkup(
-      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug={null} action={action} />,
-    )
-    expect(waiting).toContain('Pull my part back')
-    const holdout = renderToStaticMarkup(
-      <CollabRoster members={[member(1, false), member(2, true)]} currentCharacterId={1} factionSlug={null} action={action} />,
-    )
-    // castCount === memberCount - 1 → the go-live wording.
-    expect(holdout).toContain('send it live')
-  })
-
-  it('speaks the task faction voice when the faction overrides the copy', () => {
-    const action = { onCast: () => {}, onPullBack: () => {}, submitting: false }
+  // The cast / pull-back action moved to the footer's PublishButton (#646); the
+  // roster is pure display. Its faction-voiced button copy is now covered by
+  // PublishButton.test.tsx (and collabCopy.test.ts for the words themselves).
+  it('speaks the task faction voice for its display copy', () => {
     const html = renderToStaticMarkup(
-      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug="everymen" action={action} />,
+      <CollabRoster members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug="everymen" />,
     )
     expect(html).toContain('signed off')
     expect(html).toContain('still on the clock')

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -319,7 +319,7 @@
       "metatasksPoints": "+{{points}} PTS",
       "publishIdle": "★ STAMP & FILE ★",
       "publishBusy": "✓ FILING…",
-      "dropLabel": "cancel"
+      "dropLabel": "VOID THE REPORT"
     },
     "snide": {
       "collab": {
@@ -365,7 +365,7 @@
       "metatasksLabel": "★ optional bonus",
       "publishIdle": "FILE IT & RUN",
       "publishBusy": "running...",
-      "dropLabel": "cancel",
+      "dropLabel": "burn it",
       "autosaveSaved": "↳ photocopied & filed {{ago}}",
       "autosaveUnsaved": "↳ unsaved · staple it before it walks off"
     },
@@ -531,7 +531,7 @@
       "metatasksLabel": "★ optional bonus",
       "publishIdle": "cast it into the world",
       "publishBusy": "casting...",
-      "dropLabel": "cancel"
+      "dropLabel": "let it go"
     },
     "albescent": {
       "collab": {

--- a/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
@@ -498,6 +498,23 @@ export default function AlbescentEditPraxis({ state }: Props) {
               flexWrap: "wrap",
             }}
           >
+            <DropButton
+              state={state}
+              skin={{
+                label: t("editPraxis.albescent.dropLabel"),
+                style: {
+                  cursor: "pointer",
+                  border: `1px solid ${ink(12)}`,
+                  background: "transparent",
+                  color: ink(50),
+                  fontFamily: MONO,
+                  fontSize: "var(--text-sm)",
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  padding: "14px 18px",
+                },
+              }}
+            />
             <PublishButton
               state={state}
               skin={{
@@ -515,23 +532,6 @@ export default function AlbescentEditPraxis({ state }: Props) {
                   letterSpacing: "0.02em",
                   padding: "12px 30px",
                   whiteSpace: "nowrap",
-                },
-              }}
-            />
-            <DropButton
-              state={state}
-              skin={{
-                label: t("editPraxis.albescent.dropLabel"),
-                style: {
-                  cursor: "pointer",
-                  border: `1px solid ${ink(12)}`,
-                  background: "transparent",
-                  color: ink(50),
-                  fontFamily: MONO,
-                  fontSize: "var(--text-sm)",
-                  letterSpacing: "0.12em",
-                  textTransform: "uppercase",
-                  padding: "14px 18px",
                 },
               }}
             />

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -581,6 +581,21 @@ export default function DefaultEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.na.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: SLATE_DEEP,
+                fontFamily: "'Caveat', cursive",
+                fontSize: "var(--text-xl)",
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
           <PublishButton
             state={state}
             skin={{
@@ -610,21 +625,6 @@ export default function DefaultEditPraxis({ state }: Props) {
                 transform: "rotate(-2deg)",
                 boxShadow: "4px 5px 8px rgba(0,0,0,.3)",
                 position: "relative",
-              },
-            }}
-          />
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.na.dropLabel"),
-              style: {
-                background: "transparent",
-                border: "none",
-                color: SLATE_DEEP,
-                fontFamily: "'Caveat', cursive",
-                fontSize: "var(--text-xl)",
-                textDecoration: "underline",
-                cursor: "pointer",
               },
             }}
           />

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -455,6 +455,23 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.ephemerists.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: MUTED,
+                fontFamily: "var(--eph-serif)",
+                fontSize: "var(--text-md)",
+                fontStyle: "italic",
+                letterSpacing: "0.06em",
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
           <PublishButton
             state={state}
             skin={{
@@ -473,23 +490,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 whiteSpace: "nowrap",
                 boxShadow:
                   "inset 0 2px 4px rgba(255,255,255,0.16), inset 0 -4px 7px rgba(0,0,0,0.38), 0 2px 5px rgba(0,0,0,0.25)",
-              },
-            }}
-          />
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.ephemerists.dropLabel"),
-              style: {
-                background: "transparent",
-                border: "none",
-                color: MUTED,
-                fontFamily: "var(--eph-serif)",
-                fontSize: "var(--text-md)",
-                fontStyle: "italic",
-                letterSpacing: "0.06em",
-                textDecoration: "underline",
-                cursor: "pointer",
               },
             }}
           />

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -552,12 +552,29 @@ export default function EverymenEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.everymen.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: MUTED,
+                fontFamily: BODY_FONT,
+                fontSize: "var(--text-md)",
+                fontStyle: "italic",
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
           <PublishButton
             state={state}
             skin={{
               idleLabel: t("editPraxis.everymen.publishIdle"),
               busyLabel: t("editPraxis.everymen.publishBusy"),
               style: {
+                marginLeft: "auto",
                 cursor: state.submitting ? "wait" : "pointer",
                 border: `2px solid ${INK}`,
                 background: state.submitting ? OLIVE : RED,
@@ -569,23 +586,6 @@ export default function EverymenEditPraxis({ state }: Props) {
                 whiteSpace: "nowrap",
                 boxShadow: `5px 5px 0 ${INK}`,
                 transition: "background 150ms",
-              },
-            }}
-          />
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.everymen.dropLabel"),
-              style: {
-                marginLeft: "auto",
-                background: "transparent",
-                border: "none",
-                color: MUTED,
-                fontFamily: BODY_FONT,
-                fontSize: "var(--text-md)",
-                fontStyle: "italic",
-                textDecoration: "underline",
-                cursor: "pointer",
               },
             }}
           />

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -630,6 +630,22 @@ export default function SingularityEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.singularity.dropLabel"),
+              style: {
+                background: "transparent",
+                color: dim,
+                fontFamily: "'Share Tech Mono', monospace",
+                fontSize: "var(--text-sm)",
+                border: "none",
+                cursor: "pointer",
+                textDecoration: "underline",
+              },
+            }}
+          />
+          <div style={{ flex: 1 }} />
           <PublishButton
             state={state}
             skin={{
@@ -658,22 +674,6 @@ export default function SingularityEditPraxis({ state }: Props) {
                 cursor: state.submitting ? "wait" : "pointer",
                 textTransform: "uppercase",
                 position: "relative",
-              },
-            }}
-          />
-          <div style={{ flex: 1 }} />
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.singularity.dropLabel"),
-              style: {
-                background: "transparent",
-                color: dim,
-                fontFamily: "'Share Tech Mono', monospace",
-                fontSize: "var(--text-sm)",
-                border: "none",
-                cursor: "pointer",
-                textDecoration: "underline",
               },
             }}
           />

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -599,6 +599,22 @@ export default function SnideEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.snide.dropLabel"),
+              style: {
+                background: "transparent",
+                color: muted,
+                fontFamily: "'Special Elite', serif",
+                fontSize: "var(--text-md)",
+                border: "none",
+                cursor: "pointer",
+                textDecoration: "underline",
+              },
+            }}
+          />
+          <div style={{ flex: 1 }} />
           <PublishButton
             state={state}
             skin={{
@@ -627,22 +643,6 @@ export default function SnideEditPraxis({ state }: Props) {
                 position: "relative",
                 transform: "rotate(-1.8deg)",
                 boxShadow: `4px 4px 0 ${ink}`,
-              },
-            }}
-          />
-          <div style={{ flex: 1 }} />
-          <DropButton
-            state={state}
-            skin={{
-              label: "cancel",
-              style: {
-                background: "transparent",
-                color: muted,
-                fontFamily: "'Special Elite', serif",
-                fontSize: "var(--text-md)",
-                border: "none",
-                cursor: "pointer",
-                textDecoration: "underline",
               },
             }}
           />

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -376,6 +376,22 @@ export default function UaEditPraxis({ state }: Props) {
 
         {/* CTAs */}
         <div style={{ display: "flex", gap: 18, alignItems: "center", marginTop: 26, flexWrap: "wrap" }}>
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.ua.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: "var(--ua-muted)",
+                fontFamily: SERIF,
+                fontStyle: "italic",
+                fontSize: "var(--text-xl)",
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
           <PublishButton
             state={state}
             skin={{
@@ -392,22 +408,6 @@ export default function UaEditPraxis({ state }: Props) {
                 borderRadius: 0,
                 cursor: state.submitting ? "wait" : "pointer",
                 boxShadow: "0 4px 10px color-mix(in srgb, var(--ua-ink) 22%, transparent)",
-              },
-            }}
-          />
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.ua.dropLabel"),
-              style: {
-                background: "transparent",
-                border: "none",
-                color: "var(--ua-muted)",
-                fontFamily: SERIF,
-                fontStyle: "italic",
-                fontSize: "var(--text-xl)",
-                textDecoration: "underline",
-                cursor: "pointer",
               },
             }}
           />

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -703,6 +703,22 @@ export default function WowEditPraxis({ state }: Props) {
                 flexWrap: "wrap",
               }}
             >
+              <DropButton
+                state={state}
+                skin={{
+                  label: t("editPraxis.wow.dropLabel"),
+                  style: {
+                    background: "transparent",
+                    color: muted,
+                    fontFamily: cardFont,
+                    fontSize: "var(--text-content)",
+                    fontWeight: 700,
+                    border: "none",
+                    cursor: "pointer",
+                  },
+                }}
+              />
+              <div style={{ flex: 1 }} />
               <PublishButton
                 state={state}
                 skin={{
@@ -727,22 +743,6 @@ export default function WowEditPraxis({ state }: Props) {
                     borderRadius: 9,
                     cursor: state.submitting ? "wait" : "pointer",
                     boxShadow: "0 4px 12px rgba(236,95,153,.32)",
-                  },
-                }}
-              />
-              <div style={{ flex: 1 }} />
-              <DropButton
-                state={state}
-                skin={{
-                  label: t("editPraxis.wow.dropLabel"),
-                  style: {
-                    background: "transparent",
-                    color: muted,
-                    fontFamily: cardFont,
-                    fontSize: "var(--text-content)",
-                    fontWeight: 700,
-                    border: "none",
-                    cursor: "pointer",
                   },
                 }}
               />

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * PublishButton collab gate (#646). Multi-member collabs cast and pull back
+ * through the footer's PublishButton (the roster is pure display); this proves
+ * the gate picks the right action + faction-voiced label. PublishButton uses no
+ * hooks, so it's invoked directly: we read the returned <button>'s onClick to
+ * fire the action headlessly and renderToStaticMarkup for the visible label.
+ */
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import type { PraxisMemberOut, PraxisOut } from "../../../../api/praxis";
+import type { EditPraxisState } from "../../useEditPraxis";
+import { collabCopy } from "../../../../components/collab/collabCopy";
+import { PublishButton, type PublishButtonSkin } from "../controls";
+
+function member(id: number, cast: boolean): PraxisMemberOut {
+  return {
+    id,
+    praxis_id: 1,
+    character_id: id,
+    character_display_name: `M${id}`,
+    has_submitted: cast,
+    joined_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const SKIN: PublishButtonSkin = {
+  style: {},
+  idleLabel: "SOLO_IDLE",
+  busyLabel: "SOLO_BUSY",
+};
+
+function collabState(
+  members: PraxisMemberOut[],
+  overrides: {
+    currentCharacterId?: number;
+    factionSlug?: string | null;
+    publish?: () => Promise<void>;
+    pullBack?: () => Promise<void>;
+  } = {},
+): EditPraxisState {
+  const praxis = {
+    id: 1,
+    type: "collab",
+    members,
+    task_faction_slug: overrides.factionSlug ?? null,
+    task_point_value: 20,
+  } as unknown as PraxisOut;
+  return {
+    praxis,
+    submitting: false,
+    switchingMode: null,
+    isPublished: false,
+    currentCharacterId: overrides.currentCharacterId ?? 1,
+    publish: overrides.publish ?? (async () => {}),
+    pullBack: overrides.pullBack ?? (async () => {}),
+  } as unknown as EditPraxisState;
+}
+
+/** Invoke the (hookless) component directly to inspect its rendered button. */
+function renderButton(state: EditPraxisState): ReactElement<{
+  onClick: () => void;
+}> {
+  return PublishButton({ state, skin: SKIN }) as ReactElement<{
+    onClick: () => void;
+  }>;
+}
+
+describe("PublishButton — collab cast/pull-back gate (#646)", () => {
+  it("a multi-member collab I have not cast shows the cast label and calls publish", () => {
+    const publish = vi.fn(async () => {});
+    const pullBack = vi.fn(async () => {});
+    const state = collabState([member(1, false), member(2, false)], {
+      publish,
+      pullBack,
+    });
+    const el = renderButton(state);
+
+    expect(renderToStaticMarkup(el)).toContain(collabCopy(null, "castAction"));
+    el.props.onClick();
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(pullBack).not.toHaveBeenCalled();
+  });
+
+  it("once I have cast it shows the pull-back label and calls pullBack", () => {
+    const publish = vi.fn(async () => {});
+    const pullBack = vi.fn(async () => {});
+    const state = collabState([member(1, true), member(2, false)], {
+      publish,
+      pullBack,
+    });
+    const el = renderButton(state);
+
+    expect(renderToStaticMarkup(el)).toContain(
+      collabCopy(null, "pullBackAction"),
+    );
+    el.props.onClick();
+    expect(pullBack).toHaveBeenCalledTimes(1);
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("resolves the idle label through collabCopy in the task faction's voice", () => {
+    const state = collabState([member(1, false), member(2, false)], {
+      factionSlug: "everymen",
+    });
+    const html = renderToStaticMarkup(renderButton(state));
+
+    // Everymen overrides castAction; the button speaks its voice, not the shared one.
+    expect(html).toContain(collabCopy("everymen", "castAction"));
+    expect(html).not.toContain(collabCopy(null, "castAction"));
+  });
+
+  it("keeps the archetype's own idle label for a solo praxis", () => {
+    const state = {
+      praxis: { id: 1, type: "solo", members: [] },
+      submitting: false,
+      switchingMode: null,
+      isPublished: false,
+      currentCharacterId: 1,
+      publish: async () => {},
+      pullBack: async () => {},
+    } as unknown as EditPraxisState;
+    expect(renderToStaticMarkup(renderButton(state))).toContain("SOLO_IDLE");
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -14,7 +14,8 @@ import MarkdownPreview from "../blocks/MarkdownPreview";
 import { applyMarkdown } from "../blocks/markdownToolbar";
 import type { MarkdownCommand } from "../blocks/markdownToolbar";
 import type { EditPraxisState } from "../useEditPraxis";
-import { CollabRoster } from "../../../components/collab/CollabRoster";
+import { CollabRoster, deriveCollabGate } from "../../../components/collab/CollabRoster";
+import { collabCopy } from "../../../components/collab/collabCopy";
 
 export interface InviteSearchSkin {
   inputBg?: string;
@@ -108,11 +109,6 @@ export function InviteSearch({
                   currentCharacterId={state.currentCharacterId}
                   factionSlug={praxis.task_faction_slug}
                   taskPointValue={praxis.task_point_value}
-                  action={{
-                    onCast: state.publish,
-                    onPullBack: state.pullBack,
-                    submitting: state.submitting,
-                  }}
                 />
               </div>,
               ...praxis.invites
@@ -693,17 +689,35 @@ export function PublishButton({
   skin: PublishButtonSkin;
 }) {
   if (state.isPublished) return null;
-  // Multi-member collabs cast through the CollabRoster action, not this button (#591).
-  if (state.praxis?.type === "collab" && state.praxis.members.length > 1) return null;
+  // Multi-member collabs cast (and pull back) through this same footer button
+  // (#646). The consensus gate decides the action and the faction-voiced idle
+  // label; the busy label stays the archetype's mode-agnostic present participle.
+  const praxis = state.praxis;
+  const collab =
+    praxis?.type === "collab" && praxis.members.length > 1
+      ? deriveCollabGate(praxis.members, state.currentCharacterId)
+      : null;
+  const idleLabel =
+    collab && praxis
+      ? collabCopy(
+          praxis.task_faction_slug,
+          collab.iCast
+            ? "pullBackAction"
+            : collab.castCount === collab.memberCount - 1
+              ? "castFinalAction"
+              : "castAction",
+        )
+      : skin.idleLabel;
+  const onClick = collab?.iCast ? state.pullBack : state.publish;
   return (
     <button
       type="button"
-      onClick={() => void state.publish()}
+      onClick={() => void onClick()}
       disabled={state.submitting || state.switchingMode !== null}
       style={skin.style}
     >
       {skin.ornament}
-      {state.submitting ? skin.busyLabel : skin.idleLabel}
+      {state.submitting ? skin.busyLabel : idleLabel}
     </button>
   );
 }

--- a/frontend/src/pages/editPraxis/mobileArchetypes/AlbescentComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/AlbescentComposer.tsx
@@ -230,6 +230,23 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
           borderTop: `1px solid ${ink(14)}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.albescent.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: ink(40),
+                fontFamily: FONT,
+                fontStyle: 'italic',
+                fontSize: "var(--text-xl)",
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -249,23 +266,6 @@ export default function AlbescentComposer({ state }: { state: EditPraxisState })
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t('editPraxis.albescent.dropLabel'),
-              style: {
-                background: 'transparent',
-                border: 'none',
-                color: ink(40),
-                fontFamily: FONT,
-                fontStyle: 'italic',
-                fontSize: "var(--text-xl)",
-                cursor: 'pointer',
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   )

--- a/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
@@ -283,6 +283,23 @@ export default function DefaultEditPraxis({
           borderTop: `1px solid ${BORDER}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.na.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: FAINT,
+                fontFamily: "var(--font-body)",
+                fontSize: "var(--text-md)",
+                textDecoration: "underline",
+                cursor: "pointer",
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -304,23 +321,6 @@ export default function DefaultEditPraxis({
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.na.dropLabel"),
-              style: {
-                background: "transparent",
-                border: "none",
-                color: FAINT,
-                fontFamily: "var(--font-body)",
-                fontSize: "var(--text-md)",
-                textDecoration: "underline",
-                cursor: "pointer",
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   );

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
@@ -239,6 +239,24 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
           borderTop: `1px solid ${GOLD}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.ephemerists.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: MUTED,
+                fontFamily: SCRIPT,
+                fontStyle: 'italic',
+                fontSize: "var(--text-xl)",
+                textDecoration: 'underline',
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -258,24 +276,6 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t('editPraxis.ephemerists.dropLabel'),
-              style: {
-                background: 'transparent',
-                border: 'none',
-                color: MUTED,
-                fontFamily: SCRIPT,
-                fontStyle: 'italic',
-                fontSize: "var(--text-xl)",
-                textDecoration: 'underline',
-                cursor: 'pointer',
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   )

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
@@ -228,6 +228,23 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
           borderTop: `2px solid ${INK}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.everymen.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: MUTED,
+                fontFamily: BODY_FONT,
+                fontSize: "var(--text-lg)",
+                textDecoration: 'underline',
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -246,23 +263,6 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t('editPraxis.everymen.dropLabel'),
-              style: {
-                background: 'transparent',
-                border: 'none',
-                color: MUTED,
-                fontFamily: BODY_FONT,
-                fontSize: "var(--text-lg)",
-                textDecoration: 'underline',
-                cursor: 'pointer',
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   )

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
@@ -229,6 +229,22 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
           borderTop: `1px solid ${BORDER_HARD}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.singularity.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: signal(60),
+                fontFamily: FONT,
+                fontSize: "var(--text-lg)",
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -249,22 +265,6 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t('editPraxis.singularity.dropLabel'),
-              style: {
-                background: 'transparent',
-                border: 'none',
-                color: signal(60),
-                fontFamily: FONT,
-                fontSize: "var(--text-lg)",
-                cursor: 'pointer',
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   )

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
@@ -235,6 +235,24 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
           borderTop: `1px solid ${ACID}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.snide.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: MUTED,
+                fontFamily: TYPE,
+                fontSize: "var(--text-lg)",
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -255,24 +273,6 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t('editPraxis.snide.dropLabel'),
-              style: {
-                background: 'transparent',
-                border: 'none',
-                color: MUTED,
-                fontFamily: TYPE,
-                fontSize: "var(--text-lg)",
-                textTransform: 'uppercase',
-                letterSpacing: '0.06em',
-                cursor: 'pointer',
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   )

--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -239,6 +239,23 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
           borderTop: `1px solid ${GOLD}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t('editPraxis.ua.dropLabel'),
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: MUTED,
+                fontFamily: DISPLAY,
+                fontStyle: 'italic',
+                fontSize: "var(--text-xl)",
+                cursor: 'pointer',
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -258,23 +275,6 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t('editPraxis.ua.dropLabel'),
-              style: {
-                background: 'transparent',
-                border: 'none',
-                color: MUTED,
-                fontFamily: DISPLAY,
-                fontStyle: 'italic',
-                fontSize: "var(--text-xl)",
-                cursor: 'pointer',
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   )

--- a/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
@@ -394,6 +394,23 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
           borderTop: `1.5px solid ${WIN_BORDER}`,
         }}
       >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.wow.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: CARD_MUTED,
+                fontFamily: SCRIPT,
+                fontSize: "var(--text-content)",
+                fontWeight: 700,
+                cursor: "pointer",
+              },
+            }}
+          />
+        )}
         <PublishButton
           state={state}
           skin={{
@@ -420,23 +437,6 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
             },
           }}
         />
-        {!state.isPublished && (
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.wow.dropLabel"),
-              style: {
-                background: "transparent",
-                border: "none",
-                color: CARD_MUTED,
-                fontFamily: SCRIPT,
-                fontSize: "var(--text-content)",
-                fontWeight: 700,
-                cursor: "pointer",
-              },
-            }}
-          />
-        )}
       </MobileStickyBar>
     </div>
   );


### PR DESCRIPTION
## What

Fixes the collab composer footer: the "Cast my part" button no longer renders mid-form beside the collaborator selector, and every composer's footer now reads `[Cancel] … [Submit]`. Also voices the three remaining "cancel" labels and localizes Snide's desktop cancel.

Closes #646

## How (per the grilled spec)

**1. Cast action returns to the footer (net deletion).**
- `PublishButton` (`archetypes/controls.tsx`): deleted the `return null` for multi-member collabs. It now derives the gate via `deriveCollabGate(praxis.members, currentCharacterId)` and, for a multi-member collab, uses `onClick = iCast ? pullBack : publish` with the faction-voiced idle label (`pullBackAction` / `castFinalAction` / `castAction`, same precedence the roster used). Busy label stays `skin.busyLabel`; solo/duel keep `skin.idleLabel`.
- `CollabRoster` is now pure display everywhere: removed `CollabRosterAction`, the `action` prop, and the cast/pull-back button. `InviteSearch` stops passing `action`. Fixes all 16 archetypes at once.

**2. Footer order → `[Cancel] … [Submit]`** in all 8 desktop archetypes and all 8 mobile composers (DropButton now precedes PublishButton). Mobile Submit keeps `flex: 1`. Everymen desktop carried its gap via `marginLeft: auto` on the Drop button, so that auto-margin moved onto Publish to keep Cancel anchored left / Submit anchored right (same spacing, mirrored — no redesign).

**3. Cancel copy (addendum).** `forms.json`: `wow` → "let it go", `everymen` → "VOID THE REPORT", `snide` → "burn it" (the other five voiced labels untouched). `SnideEditPraxis.tsx` desktop routed its hardcoded `label: "cancel"` through `t("editPraxis.snide.dropLabel")`.

**Tests.** Moved the two `action` cases off `CollabRoster.test.tsx` onto a new `PublishButton.test.tsx` (multi-member collab renders the cast label + calls `publish`; after casting renders the pull-back label + calls `pullBack`; idle label resolves through `collabCopy` in the task faction's voice; solo keeps `skin.idleLabel`). `deriveCollabGate` tests kept; the roster keeps a faction-voice *display* assertion (pills/banner) without `action`.

## Files

- `archetypes/controls.tsx`, `components/collab/CollabRoster.tsx`
- 8 desktop `archetypes/*EditPraxis.tsx`
- 8 mobile `mobileArchetypes/*.tsx`
- `locales/en/forms.json`
- `archetypes/__tests__/PublishButton.test.tsx` (new), `collab/__tests__/CollabRoster.test.tsx`

## Verification

- `vitest run`: **753 passed** (90 files).
- `eslint` on all touched files: **clean** (no `i18next/no-literal-string` or `no-raw-style-values`).
- `tsc --noEmit`: clean apart from the known `node:fs` / `node:url` false alarms from the stale node_modules junction (PR #675), which are unrelated to this change.

## Manual QA still pending (could not run here)

The in-app Browser renderer can't screenshot and the full dev stack (Postgres + seed + backend + frontend) isn't set up in this environment, so the acceptance screenshots are a manual step: **WOW mobile** (reported case), **WOW desktop** (spacer swap), **Default mobile** (shared path + fallback skin). The other 13 are the same two mechanical edits on different skins and are covered by vitest + eslint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
