### PR TITLE
feat: shared usePagedResource — paginate Tasks/Players/Leaderboard (#645)

### DIFF
--- a/frontend/src/hooks/__tests__/usePagedResource.test.ts
+++ b/frontend/src/hooks/__tests__/usePagedResource.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #645 — the growing-window paging math extracted from `usePagedResource`
+ * (mirrors the `runResource` precedent: hooks are tested via their pure core,
+ * the repo has no DOM/renderHook). Covers the two decisions the hook encodes:
+ * "load more iff the page came back full" and "one load-more grows by a page".
+ */
+import { describe, it, expect } from 'vitest'
+import { pageHasMore, growLimit, DEFAULT_PAGE_SIZE } from '../usePagedResource'
+
+describe('pageHasMore — load more iff the page came back full', () => {
+  it('is true when the page fills the window exactly', () => {
+    expect(pageHasMore(50, 50)).toBe(true)
+    expect(pageHasMore(100, 100)).toBe(true)
+  })
+
+  it('is false when a short page signals the end', () => {
+    expect(pageHasMore(37, 50)).toBe(false)
+    expect(pageHasMore(0, 50)).toBe(false)
+  })
+
+  it('is false before the first page settles (null / undefined length)', () => {
+    expect(pageHasMore(null, 50)).toBe(false)
+    expect(pageHasMore(undefined, 50)).toBe(false)
+  })
+})
+
+describe('growLimit — one load-more grows the window by a page', () => {
+  it('adds exactly one page step', () => {
+    expect(growLimit(50, 50)).toBe(100)
+    expect(growLimit(100, 50)).toBe(150)
+  })
+
+  it('walks a full sequence: full page → grow → still full → grow → short page ends', () => {
+    let limit = DEFAULT_PAGE_SIZE
+    // First page comes back full → hasMore, so grow.
+    expect(pageHasMore(limit, limit)).toBe(true)
+    limit = growLimit(limit, DEFAULT_PAGE_SIZE)
+    expect(limit).toBe(100)
+    // Second window still full → grow again.
+    expect(pageHasMore(limit, limit)).toBe(true)
+    limit = growLimit(limit, DEFAULT_PAGE_SIZE)
+    expect(limit).toBe(150)
+    // Third window short (only 128 rows exist) → end, no more growing.
+    expect(pageHasMore(128, limit)).toBe(false)
+  })
+})

--- a/frontend/src/hooks/usePagedResource.ts
+++ b/frontend/src/hooks/usePagedResource.ts
@@ -1,0 +1,71 @@
+import { useState, type DependencyList } from 'react'
+import { useResource } from './useResource'
+
+/** Default page size — one "load more" grows the window by this step. */
+export const DEFAULT_PAGE_SIZE = 50
+
+/**
+ * "Load more iff the page came back full." A full page (`length === limit`)
+ * implies the backend may be holding more rows behind the current window; a
+ * short page is the end. Needs no total count from the backend (the growing
+ * window's whole point — see {@link usePagedResource}). Pure, so the load-more
+ * contract is testable without a DOM (mirrors `runResource`).
+ */
+export function pageHasMore(pageLength: number | null | undefined, limit: number): boolean {
+  return pageLength === limit
+}
+
+/** Grow the window by one page. Pure, extracted alongside {@link pageHasMore}. */
+export function growLimit(current: number, pageSize: number): number {
+  return current + pageSize
+}
+
+export interface PagedResource<T> {
+  /** The current page's rows (null before the first settle). */
+  data: T[] | null
+  loading: boolean
+  error: Error | null
+  /** True when the page came back full — there may be more behind the window. */
+  hasMore: boolean
+  /** Grow the window by one page (refetches; does not append). */
+  loadMore: () => void
+  /** Collapse the window back to one page — call when a filter/sort changes so
+   *  "load more" can't strand a grown page against a freshly-narrowed result. */
+  resetWindow: () => void
+}
+
+/**
+ * Growing-window pagination over {@link useResource} (extracted from `usePraxes`,
+ * #644/#645). Owns a `limit` that starts at `pageSize` and grows by `pageSize`
+ * per "load more"; `limit` rides in the `useResource` dep key, so growing it
+ * refetches the wider window rather than appending. `hasMore` is true exactly
+ * when the last page came back full — no `COUNT(*)` needed.
+ *
+ * `fetchPage(limit)` receives the current window size; the caller closes its
+ * own filter/search state over it. `deps` is the caller's filter key (limit is
+ * appended automatically). Callers wrap their filter setters with
+ * `resetWindow()` so narrowing the feed collapses the window (see `usePraxes`).
+ *
+ * Deliberately a growing window, not offset accumulation: growing is what the
+ * praxis feed proved, needs no total count, and none of the current lists are
+ * large enough to feel the refetch. Offset accumulation is the named upgrade
+ * path if a real list outgrows that.
+ */
+export function usePagedResource<T>(
+  fetchPage: (limit: number) => Promise<T[]>,
+  deps: DependencyList,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): PagedResource<T> {
+  const [limit, setLimit] = useState(pageSize)
+
+  const { data, loading, error } = useResource(() => fetchPage(limit), [...deps, limit])
+
+  return {
+    data,
+    loading,
+    error,
+    hasMore: pageHasMore(data?.length, limit),
+    loadMore: () => setLimit((current) => growLimit(current, pageSize)),
+    resetWindow: () => setLimit(pageSize),
+  }
+}

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -1,7 +1,8 @@
 {
   "listPage": {
     "loading": "Loading tasks...",
-    "empty": "No tasks match your filters."
+    "empty": "No tasks match your filters.",
+    "loadMore": "Load more"
   },
   "mobile": {
     "count": "{{count}} shown",

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -39,6 +39,8 @@ function DesktopTasks({ state }: { state: TasksState }) {
     setFaction,
     level,
     setLevel,
+    hasMore,
+    loadMore,
     signupMsg,
     handleSignup,
     displayPointsFor,
@@ -71,17 +73,40 @@ function DesktopTasks({ state }: { state: TasksState }) {
       ) : tasks.length === 0 ? (
         <p className="font-body text-muted">{t('listPage.empty')}</p>
       ) : (
-        /* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
-          {tasks.map((task) => (
-            <TaskCard
-              key={task.id}
-              task={task}
-              displayPoints={displayPointsFor(task)}
-              onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
-            />
-          ))}
-        </div>
+        <>
+          {/* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
+            {tasks.map((task) => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                displayPoints={displayPointsFor(task)}
+                onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
+              />
+            ))}
+          </div>
+          {hasMore && (
+            <div className="flex justify-center mt-6">
+              <button
+                type="button"
+                onClick={loadMore}
+                className="font-body uppercase"
+                style={{
+                  fontSize: 'var(--text-sm)',
+                  letterSpacing: '0.1em',
+                  padding: 'var(--space-sm) var(--space-lg)',
+                  border: '1px solid var(--color-border-strong)',
+                  background: 'var(--color-bg-surface)',
+                  color: 'var(--color-text-primary)',
+                  borderRadius: 4,
+                  cursor: 'pointer',
+                }}
+              >
+                {t('listPage.loadMore')}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/pages/praxes/usePraxes.ts
+++ b/frontend/src/pages/praxes/usePraxes.ts
@@ -5,15 +5,16 @@
  * The old three-call (solo / collab / duel) fetch is collapsed into ONE
  * `listPraxes` call so filter/search/sort can sit on top of a single date-ordered
  * stream (§1). Filter state (type / faction / voted / sort / query) lives here
- * via `useState` and is keyed into `useResource`, so a chip tap rekeys the fetch
- * — mirroring `pages/tasks/useTasks.ts`. The growing window (§8) bumps `limit`,
- * another `useResource` dep. Filter values + setters ride on the returned state
- * so `MobilePraxisFeed` and the desktop page stay presentation-only.
+ * via `useState` and is keyed into the fetch, so a chip tap rekeys it — mirroring
+ * `pages/tasks/useTasks.ts`. The growing window (§8) lives in the shared
+ * `usePagedResource` hook (#645); filter setters call its `resetWindow`. Filter
+ * values + setters ride on the returned state so `MobilePraxisFeed` and the
+ * desktop page stay presentation-only.
  */
 import { useEffect, useState } from 'react'
 import { listPraxes, type PraxisCardOut, type PraxisType } from '../../api/praxis'
 import { getFactions, type FactionOut } from '../../api/factions'
-import { useResource } from '../../hooks/useResource'
+import { usePagedResource } from '../../hooks/usePagedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 
 /** How many rows a page fetches; "load more" grows the window by this step. */
@@ -62,7 +63,6 @@ export function usePraxes(): PraxesFeedState {
   const [voted, setVotedState] = useState<VotedFilter>('')
   const [sort, setSortState] = useState<SortOrder>('newest')
   const [query, setQueryState] = useState('')
-  const [limit, setLimit] = useState(PAGE_LIMIT)
 
   const debouncedQuery = useDebouncedValue(query, 200)
 
@@ -70,18 +70,9 @@ export function usePraxes(): PraxesFeedState {
     getFactions().then(setFactions).catch(() => {})
   }, [])
 
-  // Every filter/search change resets the window so "load more" can't strand a
-  // grown page against a freshly-narrowed result set.
-  const resetWindow = () => setLimit(PAGE_LIMIT)
-  const setType = (next: PraxisTypeFilter) => { setTypeState(next); resetWindow() }
-  const setFaction = (next: string) => { setFactionState(next); resetWindow() }
-  const setVoted = (next: VotedFilter) => { setVotedState(next); resetWindow() }
-  const setSort = (next: SortOrder) => { setSortState(next); resetWindow() }
-  const setQuery = (next: string) => { setQueryState(next); resetWindow() }
-
   const trimmedQuery = debouncedQuery.trim()
-  const { data, loading, error } = useResource(
-    () =>
+  const { data, loading, error, hasMore, loadMore, resetWindow } = usePagedResource(
+    (limit) =>
       listPraxes({
         status: 'submitted',
         type: type === 'all' ? undefined : type,
@@ -91,8 +82,17 @@ export function usePraxes(): PraxesFeedState {
         q: trimmedQuery || undefined,
         limit,
       }),
-    [type, faction, voted, sort, trimmedQuery, limit],
+    [type, faction, voted, sort, trimmedQuery],
+    PAGE_LIMIT,
   )
+
+  // Every filter/search change resets the window so "load more" can't strand a
+  // grown page against a freshly-narrowed result set.
+  const setType = (next: PraxisTypeFilter) => { setTypeState(next); resetWindow() }
+  const setFaction = (next: string) => { setFactionState(next); resetWindow() }
+  const setVoted = (next: VotedFilter) => { setVotedState(next); resetWindow() }
+  const setSort = (next: SortOrder) => { setSortState(next); resetWindow() }
+  const setQuery = (next: string) => { setQueryState(next); resetWindow() }
 
   const items = data ?? []
   const hasActiveFilters =
@@ -118,8 +118,8 @@ export function usePraxes(): PraxesFeedState {
     query,
     setQuery,
 
-    // A full page implies there may be more — reuses useResource untouched (§8).
-    hasMore: data?.length === limit,
-    loadMore: () => setLimit((current) => current + PAGE_LIMIT),
+    // A full page implies there may be more (§8) — via the shared usePagedResource.
+    hasMore,
+    loadMore,
   }
 }

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -35,6 +35,8 @@ const CANNED: TasksState = {
   setFaction: () => {},
   level: '',
   setLevel: () => {},
+  hasMore: false,
+  loadMore: () => {},
   signupMsg: null,
   handleSignup: async () => {},
   displayPointsFor: () => 0,

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -30,6 +30,8 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
     setFaction,
     level,
     setLevel,
+    hasMore,
+    loadMore,
     displayPointsFor,
   } = state
 
@@ -84,6 +86,25 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
             {tasks.map((task) => (
               <MobileTaskCard key={task.id} task={task} points={displayPointsFor(task)} />
             ))}
+            {hasMore && (
+              <button
+                type="button"
+                onClick={loadMore}
+                className="font-body uppercase w-full"
+                style={{
+                  fontSize: 'var(--text-md)',
+                  letterSpacing: '0.1em',
+                  padding: 'var(--space-md)',
+                  border: '1px solid var(--color-border-strong)',
+                  background: 'var(--color-bg-surface)',
+                  color: 'var(--color-text-primary)',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                }}
+              >
+                {t('listPage.loadMore')}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -3,11 +3,11 @@
  * the legacy Tasks.tsx so the desktop list and the mobile browse skin consume
  * one source of truth (mirrors useTaskDetail for the detail page).
  *
- * Behaviour preserved 1:1 from the original page: the factions/factionConfigs
- * fetch on mount, the status/faction/level filter state, the `useResource` task
- * read keyed on those filters + the viewer's character id, and the signup →
- * navigate-to-edit handler with its inline message. No behaviour change — the
- * desktop page renders identically off this hook.
+ * The factions/factionConfigs fetch on mount, the status/faction/level filter
+ * state, the task read keyed on those filters + the viewer's character id, and
+ * the signup → navigate-to-edit handler with its inline message. The read runs
+ * through the shared `usePagedResource` growing window (#645): filter setters
+ * reset the window and a full page exposes "load more".
  */
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -18,10 +18,13 @@ import { getGameConfig, type FactionConfigOut } from '../../api/gameConfig'
 import { extractError } from '../../utils/errors'
 import { useAuth } from '../../auth/AuthContext'
 import { computeDisplayPoints } from '../../utils/points'
-import { useResource } from '../../hooks/useResource'
+import { usePagedResource } from '../../hooks/usePagedResource'
 import type { CurrentUser } from '../../api/auth'
 
 export const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
+
+/** How many rows a page fetches; "load more" grows the window by this step. */
+const PAGE_LIMIT = 50
 
 export interface SignupMessage {
   id: number
@@ -44,13 +47,17 @@ export interface TasksState {
   levelFilters: number[]
   statusFilters: string[]
 
-  // Filter state
+  // Filter state (setters reset the growing window).
   status: string
   setStatus: (status: string) => void
   faction: string
   setFaction: (faction: string) => void
   level: number | ''
   setLevel: (level: number | '') => void
+
+  // Growing window (#645).
+  hasMore: boolean
+  loadMore: () => void
 
   // Signup
   signupMsg: SignupMessage | null
@@ -67,9 +74,9 @@ export function useTasks(): TasksState {
 
   const [factions, setFactions] = useState<FactionOut[]>([])
   const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
-  const [status, setStatus] = useState('All')
-  const [faction, setFaction] = useState('')
-  const [level, setLevel] = useState<number | ''>('')
+  const [status, setStatusState] = useState('All')
+  const [faction, setFactionState] = useState('')
+  const [level, setLevelState] = useState<number | ''>('')
   const [signupMsg, setSignupMsg] = useState<SignupMessage | null>(null)
 
   useEffect(() => {
@@ -79,17 +86,25 @@ export function useTasks(): TasksState {
       .catch(() => {})
   }, [])
 
-  const { data, loading, error } = useResource(
-    () =>
+  const { data, loading, error, hasMore, loadMore, resetWindow } = usePagedResource(
+    (limit) =>
       listTasks({
         status: status === 'All' ? undefined : status,
         faction: faction || undefined,
         level: level === '' ? undefined : level,
         exclude_character_id: characterId,
+        limit,
       }),
     [status, faction, level, characterId],
+    PAGE_LIMIT,
   )
   const tasks = data ?? []
+
+  // Every filter change resets the window so "load more" can't strand a grown
+  // page against a freshly-narrowed result set.
+  const setStatus = (next: string) => { setStatusState(next); resetWindow() }
+  const setFaction = (next: string) => { setFactionState(next); resetWindow() }
+  const setLevel = (next: number | '') => { setLevelState(next); resetWindow() }
 
   const handleSignup = async (id: number) => {
     setSignupMsg(null)
@@ -131,6 +146,9 @@ export function useTasks(): TasksState {
     setFaction,
     level,
     setLevel,
+
+    hasMore,
+    loadMore,
 
     signupMsg,
     handleSignup,


### PR DESCRIPTION
## What

Extracts the growing-window pagination proven in the praxis feed (#644) into a shared hook and applies it to the **Tasks** list. Reduced scope per the coordinator's scope correction on this issue — see the comment on #645.

Closes #645

## Scope correction (why not Players/Leaderboard)

The issue predates the Players Constellation redesign (#654–#657). Since then:

- **There is no separate Players surface** — `/characters` (`listCharacters`) no longer backs a Players directory; the Players page *is* the Leaderboard page (`pages/Leaderboard.tsx`, the only consumer of `pages/players/*`). App routing has only `/leaderboard`.
- **Leaderboard already paginates, correctly.** It fetches `getLeaderboard({ limit: 500 })` — not the default 50 — and computes global rank + search + faction filter + paging entirely client-side (desktop `RosterTable` numbered pages; mobile `DefaultPlayers` "load more"). A 50-at-a-time growing window would **regress** global rank, which must be computed over the whole field (the redesign explicitly fixed the old 50-row-slice rank that stranded anyone past rank 50). The issue itself flags this ("Leaderboard may want real pages... position is the point").

So Players/Leaderboard is **left untouched**. Its own in-code `ponytail:` note (`Leaderboard.tsx`) already documents the real upgrade path — move rank/count/search **server-side** — for when the roster outgrows a single 500-row fetch. That is a backend change, out of this frontend-gap issue's scope; deferred, not filed (coordinator is tracking).

That leaves **Tasks** as the one surface still silently truncating at the backend's default 50 (`useTasks` passed no limit and rendered no "load more"). Extraction is still earned: praxis + Tasks share the exact limit-dep + filter-reset + `hasMore` shape.

## Changes

**New shared hook** — `frontend/src/hooks/usePagedResource.ts`
- Growing window over `useResource`: owns `limit` (starts at `pageSize`, grows by `pageSize` per load-more), rides `limit` in the `useResource` dep key so growing refetches the wider window (no append, no `COUNT(*)`). `hasMore` is true exactly when the last page came back full. Exposes `resetWindow()` for callers to wire to their filter setters.
- Pure `pageHasMore` / `growLimit` helpers extracted for unit testing (the repo has no DOM/`renderHook`; it tests hooks via their pure core, mirroring `runResource`).

**Re-pointed praxis (no behavior change)** — `frontend/src/pages/praxes/usePraxes.ts`
- Drops its forked `limit`/`hasMore`/`loadMore` for the shared hook; filter setters now call the hook's `resetWindow`. The praxis instance no longer stays forked.

**Tasks (new pagination, desktop + mobile)**
- `frontend/src/pages/tasks/useTasks.ts` — reads through `usePagedResource`; status/faction/level setters reset the window; exposes `hasMore`/`loadMore`.
- `frontend/src/pages/Tasks.tsx` — desktop "load more" iff the page came back full (praxis desktop treatment).
- `frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx` — mobile "load more", following `MobilePraxisFeed`.
- `frontend/src/locales/en/tasks.json` — adds `listPage.loadMore`.
- `frontend/src/pages/tasks/__tests__/dispatch.test.tsx` — canned `TasksState` gains the two new fields.

## Notes / deferred

- **Pre-existing N+1** (`build_praxis_card_out` → `tally_votes` per card): unchanged. Praxis's growing window already exists (#644); this PR only re-points it at the shared hook (identical behavior), so it is not made worse. Tasks does not hit that path. Not fixed speculatively.
- No route `limit`/`offset` param changes — the backend already supports both; this was entirely a frontend gap.
- No total-count query added; counts shown are "N shown" via the existing eyebrow.

## Verification

- `tsc --noEmit`: clean (only the known `node:*`-builtin false alarm, PR #675).
- `vitest run`: **819 passed** (incl. 5 new `usePagedResource` paging tests).
- `eslint src`: clean (no-raw-style-values ratchet green; the one new file has no styles).
- `vite build`: succeeds (the >500 kB chunk warning is pre-existing and unrelated).
- **Visual QA is manual** — no dev stack and the in-app Browser can't screenshot. Load-more chrome reuses the exact praxis desktop/mobile button treatment, so it inherits the same styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
