### PR TITLE
feat: bind feed search to the URL for Tasks + Praxes (#660)

### DIFF
--- a/frontend/src/hooks/__tests__/useSearchQueryParam.test.ts
+++ b/frontend/src/hooks/__tests__/useSearchQueryParam.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #660 — the three decisions `useSearchQueryParam` encodes, tested through its
+ * pure core (the repo has no DOM/renderHook; same posture as
+ * `usePagedResource.test.ts`):
+ *
+ *   1. hydrate from the URL on mount,
+ *   2. non-default values only — clearing REMOVES `?q=`,
+ *   3. `replace`, never `push` — no history entry per keystroke.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  SEARCH_QUERY_PARAM,
+  SEARCH_QUERY_NAV_OPTIONS,
+  readSearchQuery,
+  nextSearchQueryParams,
+  writeSearchQuery,
+  type SearchParamsSetter,
+} from '../useSearchQueryParam'
+
+describe('readSearchQuery — a shared or refreshed link hydrates the box', () => {
+  it('restores the search from the URL', () => {
+    expect(readSearchQuery(new URLSearchParams('?q=compost'))).toBe('compost')
+  })
+
+  it('decodes a multi-word search', () => {
+    expect(readSearchQuery(new URLSearchParams('?q=river+clean+up'))).toBe('river clean up')
+  })
+
+  it('is an empty box, not null, when the param is absent', () => {
+    expect(readSearchQuery(new URLSearchParams(''))).toBe('')
+  })
+
+  it('treats an empty param as an empty box', () => {
+    expect(readSearchQuery(new URLSearchParams('?q='))).toBe('')
+  })
+
+  it('ignores params it does not own (only search rides in the URL)', () => {
+    expect(readSearchQuery(new URLSearchParams('?faction=everymen&level=3'))).toBe('')
+  })
+})
+
+describe('nextSearchQueryParams — non-default values only', () => {
+  it('writes a non-empty search', () => {
+    const next = nextSearchQueryParams(new URLSearchParams(''), 'compost')
+    expect(next.get(SEARCH_QUERY_PARAM)).toBe('compost')
+    expect(next.toString()).toBe('q=compost')
+  })
+
+  it('REMOVES the param when the search is cleared — no `?q=` noise', () => {
+    const next = nextSearchQueryParams(new URLSearchParams('?q=compost'), '')
+    expect(next.has(SEARCH_QUERY_PARAM)).toBe(false)
+    expect(next.toString()).toBe('')
+  })
+
+  it('leaves no param behind when a search is typed then cleared', () => {
+    let params = new URLSearchParams('')
+    params = nextSearchQueryParams(params, 'c')
+    params = nextSearchQueryParams(params, 'co')
+    params = nextSearchQueryParams(params, 'compost')
+    expect(params.toString()).toBe('q=compost')
+    params = nextSearchQueryParams(params, '')
+    expect(params.toString()).toBe('')
+  })
+
+  it('replaces rather than appends a second value for the same param', () => {
+    const next = nextSearchQueryParams(new URLSearchParams('?q=old'), 'new')
+    expect(next.getAll(SEARCH_QUERY_PARAM)).toEqual(['new'])
+  })
+
+  it('carries other params through untouched', () => {
+    const next = nextSearchQueryParams(new URLSearchParams('?tab=mine'), 'compost')
+    expect(next.get('tab')).toBe('mine')
+    expect(next.get(SEARCH_QUERY_PARAM)).toBe('compost')
+  })
+
+  it('does not mutate the previous params', () => {
+    const previous = new URLSearchParams('?q=compost')
+    nextSearchQueryParams(previous, 'river')
+    expect(previous.get(SEARCH_QUERY_PARAM)).toBe('compost')
+  })
+
+  it('round-trips through readSearchQuery', () => {
+    const next = nextSearchQueryParams(new URLSearchParams(''), 'river clean up')
+    expect(readSearchQuery(next)).toBe('river clean up')
+  })
+})
+
+describe('writeSearchQuery — replace, never push', () => {
+  it('always writes with replace semantics', () => {
+    const setSearchParams = vi.fn() as unknown as SearchParamsSetter
+    writeSearchQuery(setSearchParams, 'compost')
+    expect(setSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true })
+    expect(SEARCH_QUERY_NAV_OPTIONS.replace).toBe(true)
+  })
+
+  it('never writes a history entry per keystroke — 7 keystrokes, 0 pushes', () => {
+    const setSearchParams = vi.fn()
+    for (const value of ['c', 'co', 'com', 'comp', 'compo', 'compos', 'compost']) {
+      writeSearchQuery(setSearchParams as unknown as SearchParamsSetter, value)
+    }
+    expect(setSearchParams).toHaveBeenCalledTimes(7)
+    for (const call of setSearchParams.mock.calls) {
+      expect(call[1]).toEqual({ replace: true })
+    }
+  })
+
+  it('uses the functional updater form so concurrent params are not clobbered', () => {
+    const setSearchParams = vi.fn()
+    writeSearchQuery(setSearchParams as unknown as SearchParamsSetter, 'compost')
+    const updater = setSearchParams.mock.calls[0][0] as (p: URLSearchParams) => URLSearchParams
+    // The updater is applied to whatever the params are AT WRITE TIME, so a
+    // param set between renders survives.
+    expect(updater(new URLSearchParams('?tab=mine')).toString()).toBe('tab=mine&q=compost')
+  })
+
+  it('clearing the box removes the param through the same write path', () => {
+    const setSearchParams = vi.fn()
+    writeSearchQuery(setSearchParams as unknown as SearchParamsSetter, '')
+    const updater = setSearchParams.mock.calls[0][0] as (p: URLSearchParams) => URLSearchParams
+    expect(updater(new URLSearchParams('?q=compost')).toString()).toBe('')
+  })
+})

--- a/frontend/src/hooks/useSearchQueryParam.ts
+++ b/frontend/src/hooks/useSearchQueryParam.ts
@@ -1,0 +1,97 @@
+/**
+ * useSearchQueryParam — binds a feed's free-text search box to the `?q=` URL
+ * param (#660). Adopted by BOTH feed hooks in the same change (`usePraxes`,
+ * `useTasks`); a one-page-only adoption is the inconsistency #660 was filed to
+ * avoid.
+ *
+ * Deliberately narrow. Only the SEARCH query rides in the URL — faction, level,
+ * status, sort, type and voted stay component-local `useState`. Search is the
+ * one filter you'd paste to someone ("here's the praxis I mean"); there is no
+ * equivalent urge for "level 3+ tasks". Named for what it does rather than the
+ * issue's aspirational `useFilterParams`, and NOT generalised "for later" — it
+ * can grow a second axis when one is actually wanted.
+ *
+ * Three decisions baked in:
+ *
+ * 1. The URL is the single source of truth for the value, so a shared or
+ *    refreshed link hydrates the box on mount for free — no mirrored `useState`
+ *    to drift out of sync.
+ * 2. Non-default values only. `?q=` never appears empty; clearing the box
+ *    removes the param outright rather than leaving `?q=` noise behind.
+ * 3. `replace: true`, never a push. A debounced search field would otherwise
+ *    write one history entry per keystroke and the back button would need 40
+ *    presses to escape. Back should leave the feed, not walk the search letter
+ *    by letter.
+ *
+ * The debounce lives at the call site (`useDebouncedValue`, 200ms): this hook
+ * holds the raw box value, and the debounced copy keys the fetch as before.
+ *
+ * The two decisions worth pinning live in the pure {@link nextSearchQueryParams}
+ * and {@link writeSearchQuery} below, so they are testable without a DOM (the
+ * repo has no jsdom/renderHook — same posture as `usePagedResource`).
+ */
+import { useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+/** The URL param this hook owns. */
+export const SEARCH_QUERY_PARAM = 'q'
+
+/**
+ * Navigation options for every search write: replace, never push (decision 3).
+ * Exported so the "no history entry per keystroke" rule is assertable.
+ */
+export const SEARCH_QUERY_NAV_OPTIONS = { replace: true } as const
+
+/** The `setSearchParams` shape this hook depends on (the react-router setter). */
+export type SearchParamsSetter = (
+  updater: (previous: URLSearchParams) => URLSearchParams,
+  options: { replace: boolean },
+) => void
+
+/**
+ * Read the current search value out of the URL — the hydrate-on-mount path.
+ * A missing param is an empty box, never `null`.
+ */
+export function readSearchQuery(params: URLSearchParams): string {
+  return params.get(SEARCH_QUERY_PARAM) ?? ''
+}
+
+/**
+ * The next param set for a given search value (decision 2): a non-empty value
+ * is set, an empty one is REMOVED rather than left as `?q=` noise. Every other
+ * param is carried through untouched.
+ */
+export function nextSearchQueryParams(
+  previous: URLSearchParams,
+  next: string,
+): URLSearchParams {
+  const nextParams = new URLSearchParams(previous)
+  if (next) nextParams.set(SEARCH_QUERY_PARAM, next)
+  else nextParams.delete(SEARCH_QUERY_PARAM)
+  return nextParams
+}
+
+/**
+ * Perform the write. Uses the functional updater form so a fast typist can't
+ * clobber a param another surface set between renders, and always replaces.
+ */
+export function writeSearchQuery(setSearchParams: SearchParamsSetter, next: string): void {
+  setSearchParams(
+    (previous) => nextSearchQueryParams(previous, next),
+    SEARCH_QUERY_NAV_OPTIONS,
+  )
+}
+
+export type SearchQueryBinding = [query: string, setQuery: (next: string) => void]
+
+export function useSearchQueryParam(): SearchQueryBinding {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const query = readSearchQuery(searchParams)
+
+  const setQuery = useCallback(
+    (next: string) => writeSearchQuery(setSearchParams as SearchParamsSetter, next),
+    [setSearchParams],
+  )
+
+  return [query, setQuery]
+}

--- a/frontend/src/pages/praxes/usePraxes.ts
+++ b/frontend/src/pages/praxes/usePraxes.ts
@@ -4,9 +4,11 @@
  *
  * The old three-call (solo / collab / duel) fetch is collapsed into ONE
  * `listPraxes` call so filter/search/sort can sit on top of a single date-ordered
- * stream (§1). Filter state (type / faction / voted / sort / query) lives here
- * via `useState` and is keyed into the fetch, so a chip tap rekeys it — mirroring
- * `pages/tasks/useTasks.ts`. The growing window (§8) lives in the shared
+ * stream (§1). Filter state (type / faction / voted / sort) lives here via
+ * `useState` and is keyed into the fetch, so a chip tap rekeys it — mirroring
+ * `pages/tasks/useTasks.ts`. The search query is the one axis that rides in the
+ * URL instead (`?q=`, via `useSearchQueryParam`, #660), so a pasted or refreshed
+ * link restores it. The growing window (§8) lives in the shared
  * `usePagedResource` hook (#645); filter setters call its `resetWindow`. Filter
  * values + setters ride on the returned state so `MobilePraxisFeed` and the
  * desktop page stay presentation-only.
@@ -16,6 +18,7 @@ import { listPraxes, type PraxisCardOut, type PraxisType } from '../../api/praxi
 import { getFactions, type FactionOut } from '../../api/factions'
 import { usePagedResource } from '../../hooks/usePagedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
+import { useSearchQueryParam } from '../../hooks/useSearchQueryParam'
 
 /** How many rows a page fetches; "load more" grows the window by this step. */
 const PAGE_LIMIT = 50
@@ -62,7 +65,7 @@ export function usePraxes(): PraxesFeedState {
   const [faction, setFactionState] = useState('')
   const [voted, setVotedState] = useState<VotedFilter>('')
   const [sort, setSortState] = useState<SortOrder>('newest')
-  const [query, setQueryState] = useState('')
+  const [query, setQueryState] = useSearchQueryParam()
 
   const debouncedQuery = useDebouncedValue(query, 200)
 

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -7,7 +7,9 @@
  * state, the task read keyed on those filters + the viewer's character id, and
  * the signup → navigate-to-edit handler with its inline message. The free-text search (#661) rides
  * alongside them, debounced 200ms via `useDebouncedValue` — the idiom #644 set on
- * the praxis feed. The read runs through the shared `usePagedResource` growing
+ * the praxis feed — but its value lives in the URL (`?q=`, via
+ * `useSearchQueryParam`, #660) rather than local state, so a pasted or refreshed
+ * link restores it. The read runs through the shared `usePagedResource` growing
  * window (#645): filter setters (search included) reset the window and a full
  * page exposes "load more".
  */
@@ -22,6 +24,7 @@ import { useAuth } from '../../auth/AuthContext'
 import { computeDisplayPoints } from '../../utils/points'
 import { usePagedResource } from '../../hooks/usePagedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
+import { useSearchQueryParam } from '../../hooks/useSearchQueryParam'
 import type { CurrentUser } from '../../api/auth'
 
 export const LEVEL_FILTERS = [0, 1, 2, 3, 4, 5]
@@ -83,7 +86,7 @@ export function useTasks(): TasksState {
   const [status, setStatusState] = useState('All')
   const [faction, setFactionState] = useState('')
   const [level, setLevelState] = useState<number | ''>('')
-  const [query, setQueryState] = useState('')
+  const [query, setQueryState] = useSearchQueryParam()
   const [signupMsg, setSignupMsg] = useState<SignupMessage | null>(null)
 
   // Debounced so a refetch fires once the typing settles, not per keystroke —


### PR DESCRIPTION
Closes #660

Binds each feed's free-text search box to the URL `?q=` param, adopted by **both** feeds in the same change (a one-page-only adoption is the inconsistency #660 was filed to avoid).

## The three open questions, as decided
1. **Only the search rides in the URL.** Faction, level, status, sort, type and voted stay component-local `useState`. Search is the one filter you'd paste to someone ("here's the praxis I mean"); there's no equivalent urge for "level 3+ tasks".
2. **Non-default values only.** `?q=` never appears empty — clearing the box removes the param outright rather than leaving `?q=` noise behind.
3. **`replace`, never `push`.** A debounced search field would otherwise write one history entry per keystroke and the back button would need 40 presses to escape. Back should leave the feed, not walk the search letter by letter.

Hydrate-on-mount comes free: the URL is the single source of truth for the value, so there's no mirrored `useState` to drift out of sync — a shared or refreshed link just works.

## Shape
- `frontend/src/hooks/useSearchQueryParam.ts` — the hook, with the two load-bearing decisions extracted into pure `nextSearchQueryParams` / `writeSearchQuery` helpers so they're testable without a DOM (the repo has no jsdom/`renderHook` — same posture as `usePagedResource`).
- `usePraxes.ts` / `useTasks.ts` — swap the local search `useState` for the hook. Both keep their existing behavior: the **debounced** copy still keys the fetch (`useDebouncedValue`, 200ms), and `setQuery` still calls `resetWindow()` so the growing window can't strand a filtered result.

Named for what it does rather than the issue's aspirational `useFilterParams`, and deliberately **not** generalised "for later" — it can grow a second axis when one is actually wanted.

## Verification
`tsc --noEmit` clean · `vitest run` **835 passed** · `eslint src` clean · `vite build` ok.

## What to eyeball
- Type in the Tasks search, then the Praxes search — the URL should gain `?q=…` and results should filter as before.
- Clear the box — `?q=` should vanish from the URL entirely, not linger empty.
- Paste a `…/tasks?q=sourdough` link into a fresh tab (and refresh one) — the box should come up pre-filled and filtered.
- Press Back after typing — it should leave the feed, **not** step back through the search one letter at a time.
