### PR TITLE
fix(editPraxis): keep the markdown toolbar out of the tab order

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Markdown toolbar tab order (#693).
+ *
+ * `BodyTextarea` is the one shared control behind every faction editPraxis
+ * skin, and it renders its role="toolbar" formatting buttons *before* the
+ * <textarea>. Without an explicit tabIndex those buttons all sit in the
+ * natural tab order, so Tab from the title field stopped on eleven glyphs
+ * before ever reaching the body.
+ *
+ * This pins the fix: every toolbar button carries tabindex="-1", so Tab runs
+ * title → body. It also pins what the fix must NOT cost us — the buttons are
+ * still real <button>s (mouse-clickable) and the toolbar keeps its role and
+ * accessible name.
+ *
+ * renderToStaticMarkup needs no DOM, matching the rest of this suite.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import "../../../../i18n";
+import type { EditPraxisState } from "../../useEditPraxis";
+import { BodyTextarea } from "../controls";
+
+// BodyTextarea only reads `body` / `setBody` off the state.
+const state = {
+  body: "## What I did\n\nCaught the papers.",
+  setBody: () => {},
+} as unknown as EditPraxisState;
+
+function html(): string {
+  return renderToStaticMarkup(
+    <BodyTextarea state={state} skin={{ textareaStyle: {}, rows: 8 }} />,
+  );
+}
+
+describe("body markdown toolbar", () => {
+  it("keeps every toolbar button out of the tab order", () => {
+    const markup = html();
+    const buttons = markup.match(/<button[^>]*>/g) ?? [];
+
+    // Guard the guard: if the toolbar ever stops rendering buttons, an
+    // "every button is untabbable" assertion would vacuously pass.
+    expect(buttons.length, "toolbar renders formatting buttons").toBeGreaterThan(0);
+
+    const tabbable = buttons.filter((button) => !button.includes('tabindex="-1"'));
+    expect(tabbable, "toolbar buttons must not be tab stops").toEqual([]);
+  });
+
+  it("still renders the buttons as clickable buttons in a labelled toolbar", () => {
+    const markup = html();
+    // tabIndex={-1} removes the tab stop, not the control itself.
+    expect(markup).toContain('type="button"');
+    expect(markup).toContain('role="toolbar"');
+    expect(markup).toMatch(/role="toolbar"[^>]*aria-label="[^"]+"/);
+  });
+
+  it("leaves the textarea itself tabbable", () => {
+    const textarea = html().match(/<textarea[^>]*>/)?.[0] ?? "";
+    expect(textarea, "textarea renders").not.toEqual("");
+    expect(textarea, "body must remain the next tab stop").not.toContain("tabindex");
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -543,6 +543,12 @@ export function BodyTextarea({
           <button
             key={button.command}
             type="button"
+            // #693: keep the formatting buttons out of the natural tab order so
+            // Tab runs title → body instead of stopping on all eleven glyphs.
+            // Every command is also typeable as plain markdown, so keyboard
+            // users lose no capability. (Roving tabindex was considered and
+            // declined: it still leaves a tab stop between title and body.)
+            tabIndex={-1}
             onClick={() => runCommand(button.command)}
             aria-label={t(button.labelKey)}
             style={buttonStyle}


### PR DESCRIPTION
Closes #693

## The problem

`BodyTextarea` in `frontend/src/pages/editPraxis/archetypes/controls.tsx` is the one shared control behind **every** faction editPraxis skin. It renders a `role="toolbar"` div of formatting buttons *before* the `<textarea>`, and those buttons carried no `tabIndex` — so all eleven sat in the natural tab order between the title field and the body. Tabbing out of the title meant eleven stops on `B`, `I`, `S`, `H`, `•`, `1.`, `🔗`, `❝`, `</>`, `{ }`, `▦` before reaching the place you actually wanted to type.

## The fix

`tabIndex={-1}` on the toolbar `<button>`. One change at the shared control covers all archetypes (desktop and mobile). Tab now runs title → body.

Per the grill:
- Buttons stay mouse-clickable; every command is also typeable as plain markdown, so keyboard users lose no capability.
- `role="toolbar"` + `aria-label` kept as-is.
- Roving tabindex was considered and **declined** — it still leaves a tab stop between title and body, which is the thing being complained about. Not reintroduced.

## Sibling check

Grepped for the pattern: `BODY_TOOLBAR_BUTTONS` and `role="toolbar"` appear **only** in `controls.tsx`. Propose-task and the other composers don't reuse this toolbar, so scope stays editPraxis.

## Edit-character check (asked for in the issue)

Looked at `frontend/src/pages/EditCharacter.tsx`. Tab order is already sane and has the **same root cause absent** — no toolbar, no `tabIndex` overrides, focusables in DOM order: avatar file input → display name → bio → visibility → Save → Cancel. The `@handle` field is a read-only `<div>` (ADR-0019, auto-derived), so it correctly takes no tab stop rather than being a focusable dead end. **No change made** — per instructions, only a genuine same-root-cause defect would have warranted one.

## The runnable check

New `frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx`, following the existing convention in this suite (`renderToStaticMarkup`, node env — the repo has no jsdom/RTL setup, so no new frameworks were added). It pins three things: no toolbar button is a tab stop, the buttons are still real `<button>`s in a labelled toolbar, and the textarea itself stays tabbable. It also guards against a vacuous pass if the toolbar ever stops rendering buttons.

**Verified to actually fail on regression:** removing the `tabIndex={-1}` line and re-running gives `toolbar buttons must not be tab stops: expected [ …(11) ] to deeply equal []`.

## Verification

- `tsc --noEmit` — clean for this change. (Pre-existing `Cannot find module 'node:fs'/'node:url'` noise in two untouched test files is the known local junction artifact, not from this branch.)
- `vitest run` — 94 files, 822 tests, all passing.
- `vite build` — succeeds.
- `eslint` on both changed files — clean.

**Visual QA is outstanding** — I can't take screenshots, so the tab-through was verified by assertion on rendered markup rather than by driving a real browser.

## What to eyeball

- Tab from the praxis **title** field lands directly in the **body** textarea — check on a couple of different faction skins (e.g. WOW and Albescent), desktop and mobile.
- Toolbar buttons are still **mouse-clickable** and still apply their markdown correctly, with the caret/selection restored afterwards.
- Shift-Tab backwards out of the body goes to the title, not into the toolbar.
- **Edit-character** tab order still reads sensibly end to end (unchanged by this PR, but it's what prompted the ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
