### PR TITLE
fix(characters): faction_slug default 'ua' -> 'na' (ADR-0019)

### DIFF
--- a/backend/alembic/versions/0004_character_faction_default_na.py
+++ b/backend/alembic/versions/0004_character_faction_default_na.py
@@ -1,0 +1,36 @@
+"""Carry #697 (character.faction_slug default 'ua' -> 'na') to deployed DBs.
+
+0001_squashed builds the schema from the live ORM models, so a *fresh* DB (CI,
+local reset) picks up the model's new ``server_default`` with no help. An
+already-deployed DB is stamped past 0001_squashed and never re-runs it, so the
+stale ``DEFAULT 'ua'`` would linger there — contradicting ADR-0019 (characters
+are born Unaffiliated; factions are invite-gated).
+
+The default is dormant in practice: services.character.create_character always
+sets faction_slug explicitly. This aligns the backstop with the rule so a direct
+insert can't silently mint a UA character.
+
+Idempotent: SET DEFAULT is a no-op on any DB already built from the current
+models, so it is safe on fresh and drifted DBs alike. No row data is touched —
+existing characters keep whatever faction they hold.
+
+Revision ID: 0004_character_faction_default_na
+Revises: 0003_backfill_praxis_seal_time
+Create Date: 2026-07-17
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0004_character_faction_default_na"
+down_revision: Union[str, None] = "0003_backfill_praxis_seal_time"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE character ALTER COLUMN faction_slug SET DEFAULT 'na'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE character ALTER COLUMN faction_slug SET DEFAULT 'ua'")

--- a/backend/alembic/versions/0004_character_faction_na.py
+++ b/backend/alembic/versions/0004_character_faction_na.py
@@ -14,7 +14,7 @@ Idempotent: SET DEFAULT is a no-op on any DB already built from the current
 models, so it is safe on fresh and drifted DBs alike. No row data is touched —
 existing characters keep whatever faction they hold.
 
-Revision ID: 0004_character_faction_default_na
+Revision ID: 0004_character_faction_na
 Revises: 0003_backfill_praxis_seal_time
 Create Date: 2026-07-17
 """
@@ -22,7 +22,7 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "0004_character_faction_default_na"
+revision: str = "0004_character_faction_na"
 down_revision: Union[str, None] = "0003_backfill_praxis_seal_time"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/models/character.py
+++ b/backend/models/character.py
@@ -28,9 +28,11 @@ class Character(TimestampMixin, Base):
     bio: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     avatar_url: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     location: Mapped[str] = mapped_column(String, nullable=False, server_default="")
-    # faction_slug defaults to "ua" — the starting faction for all new characters
+    # ADR-0019: characters are born Unaffiliated ("na"); factions are invite-gated.
+    # services.character.create_character always sets this explicitly — the default
+    # is only a backstop for direct inserts, and must not contradict ADR-0019.
     faction_slug: Mapped[str] = mapped_column(
-        ForeignKey("faction.slug"), nullable=False, server_default="ua"
+        ForeignKey("faction.slug"), nullable=False, server_default="na"
     )
     status: Mapped[CharacterStatus] = mapped_column(
         Enum(CharacterStatus, create_type=False), nullable=False, default=CharacterStatus.active

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -754,3 +754,25 @@ async def test_votes_received_with_votes(
     data = resp.json()
     assert data["character_id"] == character.id
     assert data["votes_received"] == 1
+
+
+@pytest.mark.asyncio
+async def test_faction_slug_db_default_is_unaffiliated(
+    db_session: AsyncSession, account: Account, era: Era, faction_ua: Faction
+):
+    """A direct insert that omits faction_slug falls back to 'na', not 'ua' (#697).
+
+    ADR-0019: characters are born Unaffiliated. create_character always sets the
+    slug explicitly, so this guards the column default itself against drifting
+    back to a real faction.
+    """
+    bare = Character(
+        account_id=account.id,
+        username="defaultfaction",
+        display_name="Default Faction",
+    )
+    db_session.add(bare)
+    await db_session.commit()
+    await db_session.refresh(bare)
+
+    assert bare.faction_slug == "na"


### PR DESCRIPTION
## What

`Character.faction_slug` declared `server_default="ua"` while `services/character.py`
always sets `"na"` on creation (ADR-0019: characters are born Unaffiliated, factions
are invite-gated). The default was dormant but actively misleading — and it *is* a
live backstop for any direct insert.

- `backend/models/character.py` — `server_default` `"ua"` -> `"na"`, comment rewritten
  to cite ADR-0019 and say plainly that the service sets this explicitly.
- `backend/alembic/versions/0004_character_faction_na.py` — new revision
  (`ALTER COLUMN faction_slug SET DEFAULT 'na'`), idempotent, touches no row data.
- `backend/tests/integration/test_characters.py` — regression test: an insert that
  omits `faction_slug` lands `"na"`.

## Changed the default rather than dropping it

Dropping it entirely is the smaller diff on paper, but it makes the column a
`NOT NULL` with no fallback, so any future direct insert that forgets the slug
becomes a runtime error instead of a correct Unaffiliated character. Keeping a
default that *agrees with the rule* is the honest version: the backstop now says
the same thing ADR-0019 and the service say.

## Migration + the squashed-baseline hazard

`0001_squashed` builds tables from `Base.metadata`, so a fresh DB inherits the model's
new default with no migration edit needed (unlike enum values, which `0001` owns
explicitly and which *do* need editing there). But a deployed DB is stamped past
`0001` and would keep the stale `DEFAULT 'ua'` — so `0004` follows the convention set
by `0002_praxis_pending_submitted`: leave the baseline alone, add an idempotent
forward revision for drifted DBs.

Verified on a scratch DB:
- fresh `alembic upgrade head` -> `column_default = 'na'::character varying`
- `downgrade -1` -> `'ua'` -> `upgrade head` -> `'na'` (proves the deployed-DB repair path)
- `alembic check` -> "No new upgrade operations detected."

Note: revision ids are capped at 32 chars by `alembic_version.version_num`; the first
id I used blew that cap and failed mid-upgrade. Shortened to `0004_character_faction_na`.

## Grep for reliance on the old default

Nothing reads the DB default. One adjacent thing worth a look but deliberately left
alone: `backend/schemas/admin.py:124` has `faction_slug: str = Field(default="ua")` on
the admin character-create schema, asserted by `test_admin.py:801`. That's an explicit
app-level admin default, not the DB one, and changing it would change admin behaviour
outside this issue's scope. Flagging it in case it's also unintended.

## Tests

`TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz697_test pytest --cov=. --cov-fail-under=80`
-> **610 passed**, coverage 87.71%.

Backend-only; no frontend surface touched. Visual QA is N/A (no rendered change) — I
cannot screenshot in any case.

Closes #697

## What to eyeball

- Create a brand-new character through the normal flow and confirm it lands
  **Unaffiliated** (`na`), not UA — profile and Players grid.
- On a fresh `alembic upgrade head` DB:
  `SELECT column_default FROM information_schema.columns WHERE table_name='character' AND column_name='faction_slug';`
  should read `'na'::character varying`.
- Existing characters' factions are untouched (no data migration) — spot-check that
  anyone already in UA is still in UA.
