### PR TITLE
refactor(tasks): bespoke-frame + shared-slots for the mobile task cards (#589)

### DIFF
--- a/frontend/src/pages/tasks/mobileArchetypes/__tests__/mobileTaskCardSlots.test.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/__tests__/mobileTaskCardSlots.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Mobile task-card content-slot invariant (#589).
+ *
+ * The sibling `mobileTaskCardDispatch` test only proves each slug resolves to
+ * the right component — it never renders one, so it could not catch a broken
+ * shared slot. This renders every bespoke mobile task card plus the Default
+ * fallback and asserts each still emits its content (title, description,
+ * points, level) and that the description carries the two-line clamp mechanics
+ * now owned by `cards/shared.tsx`.
+ *
+ * That clamp assertion is the regression guard: if the shared
+ * MobileTaskDescription slot stops applying `-webkit-line-clamp`, or a faction
+ * card stops passing its own typography through `style`, these fail.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ComponentType } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the points/level keys resolve to English text.
+import '../../../../i18n'
+import type { TaskOut } from '../../../../api/tasks'
+import { MOBILE_TASK_CARD_BY_SLUG } from '../mobileTaskCard'
+import DefaultMobileTaskCard from '../cards/DefaultMobileTaskCard'
+
+type MobileTaskCardProps = { task: TaskOut; points: number }
+
+function task(overrides: Partial<TaskOut> = {}): TaskOut {
+  return {
+    id: 11,
+    title: 'Plant a tree',
+    description: 'Dig a hole, put a sapling in it, and water the thing.',
+    point_value: 20,
+    level_required: 3,
+    status: 'open',
+    task_type: 'standard',
+    created_by: 7,
+    primary_faction_slug: 'everymen',
+    metatask_faction_slug: null,
+    is_task_vision_eligible: true,
+    created_at: '2026-01-01T00:00:00Z',
+    can_submit_praxis: true,
+    allowed_modes: ['solo'],
+    eligible_for_current_user: true,
+    ...overrides,
+  }
+}
+
+function render(Card: ComponentType<MobileTaskCardProps>, item: TaskOut) {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <Card task={item} points={item.point_value} />
+    </MemoryRouter>,
+  )
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+const cards: Record<string, ComponentType<MobileTaskCardProps>> = {
+  ...MOBILE_TASK_CARD_BY_SLUG,
+  __default__: DefaultMobileTaskCard,
+}
+
+describe('mobile task-card content-slot invariant', () => {
+  for (const [slug, Card] of Object.entries(cards)) {
+    it(`${slug} renders title, description, points and level`, () => {
+      const { text } = render(Card, task())
+      expect(text, 'title').toContain('Plant a tree')
+      expect(text, 'description').toContain('Dig a hole')
+      expect(text, 'points').toContain('20')
+      expect(text, 'level').toContain('3')
+    })
+
+    it(`${slug} clamps its description to two lines`, () => {
+      const { html } = render(Card, task())
+      expect(html).toContain('-webkit-line-clamp:2')
+      expect(html).toContain('-webkit-box')
+    })
+
+    it(`${slug} omits the description block entirely when there is none`, () => {
+      const { html, text } = render(Card, task({ description: null }))
+      expect(text, 'title still renders').toContain('Plant a tree')
+      expect(html, 'no empty clamped paragraph').not.toContain('-webkit-line-clamp')
+    })
+  }
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/AlbescentMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/AlbescentMobileTaskCard.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionName } from '../../../../utils/factions'
 import AlbescentSigil from '../../../../components/cards/AlbescentSigil'
+import { MobileTaskDescription } from './shared'
 
 /**
  * Albescent MOBILE task card (#528/#565) — a quiet cotton Ledger entry: the
@@ -54,23 +55,10 @@ export default function AlbescentMobileTaskCard({ task, points }: { task: TaskOu
         {task.title}
       </h2>
 
-      {task.description && (
-        <p
-          style={{
-            fontFamily: MONO,
-            fontSize: 10,
-            lineHeight: 1.6,
-            color: ink(42),
-            margin: 0,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {task.description}
-        </p>
-      )}
+      <MobileTaskDescription
+        text={task.description}
+        style={{ fontFamily: MONO, fontSize: 10, lineHeight: 1.6, color: ink(42), margin: 0 }}
+      />
 
       <div className="flex items-center justify-between" style={{ marginTop: 2, borderTop: `1px solid ${ink(7)}`, paddingTop: 10 }}>
         <span style={{ ...kicker, letterSpacing: '0.2em', color: ink(24) }}>{t('mobile.level', { level: task.level_required })}</span>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/DefaultMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/DefaultMobileTaskCard.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionCssVar, factionName } from '../../../../utils/factions'
+import { MobileTaskDescription } from './shared'
 
 /**
  * Default MOBILE task card — the scannable single-column proof card each task
@@ -43,22 +44,11 @@ export default function DefaultMobileTaskCard({ task, points }: { task: TaskOut;
       </h2>
 
       {/* Description — clamp to two lines */}
-      {task.description && (
-        <p
-          className="font-body"
-          style={{
-            fontSize: 13,
-            lineHeight: 1.5,
-            color: 'var(--color-text-secondary)',
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {task.description}
-        </p>
-      )}
+      <MobileTaskDescription
+        text={task.description}
+        className="font-body"
+        style={{ fontSize: 13, lineHeight: 1.5, color: 'var(--color-text-secondary)' }}
+      />
 
       {/* Footer — points + level */}
       <div className="flex items-center gap-3" style={{ marginTop: 2 }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/EphemeristsMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/EphemeristsMobileTaskCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionCssVar, factionName } from '../../../../utils/factions'
+import { MobileTaskDescription } from './shared'
 
 /**
  * The Ephemerists MOBILE task card (#527/#565) — a ledger-ruled commission leaf
@@ -53,24 +54,10 @@ export default function EphemeristsMobileTaskCard({ task, points }: { task: Task
         {task.title}
       </h2>
 
-      {task.description && (
-        <p
-          style={{
-            fontFamily: SCRIPT,
-            fontStyle: 'italic',
-            fontSize: 14,
-            lineHeight: 1.5,
-            color: MUTED,
-            margin: 0,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {task.description}
-        </p>
-      )}
+      <MobileTaskDescription
+        text={task.description}
+        style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, lineHeight: 1.5, color: MUTED, margin: 0 }}
+      />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
         <span style={{ fontFamily: DISPLAY, fontSize: 12, letterSpacing: '0.04em', color: TEXT, background: VELLUM_DEEP, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/EverymenMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/EverymenMobileTaskCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionCssVar, factionName } from '../../../../utils/factions'
+import { MobileTaskDescription } from './shared'
 
 /**
  * Everymen MOBILE task card (#529/#565) — a posted work order on cream
@@ -54,23 +55,10 @@ export default function EverymenMobileTaskCard({ task, points }: { task: TaskOut
         {task.title}
       </h2>
 
-      {task.description && (
-        <p
-          style={{
-            fontFamily: BODY_FONT,
-            fontSize: 13,
-            lineHeight: 1.5,
-            color: MUTED,
-            margin: 0,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {task.description}
-        </p>
-      )}
+      <MobileTaskDescription
+        text={task.description}
+        style={{ fontFamily: BODY_FONT, fontSize: 13, lineHeight: 1.5, color: MUTED, margin: 0 }}
+      />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
         <span style={{ fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.04em', color: INK, background: GOLD, padding: '3px 10px' }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/SingularityMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/SingularityMobileTaskCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionCssVar, factionName } from '../../../../utils/factions'
+import { MobileTaskDescription } from './shared'
 
 /**
  * Singularity MOBILE task card (#526/#565) — a bracketed readout card on a void
@@ -56,23 +57,10 @@ export default function SingularityMobileTaskCard({ task, points }: { task: Task
         {task.title}
       </h2>
 
-      {task.description && (
-        <p
-          style={{
-            fontFamily: FONT,
-            fontSize: 11,
-            lineHeight: 1.5,
-            color: phosphor(55),
-            margin: 0,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {task.description}
-        </p>
-      )}
+      <MobileTaskDescription
+        text={task.description}
+        style={{ fontFamily: FONT, fontSize: 11, lineHeight: 1.5, color: phosphor(55), margin: 0 }}
+      />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2, borderTop: `1px solid ${signal(20)}`, paddingTop: 8 }}>
         <span style={{ fontFamily: FONT, fontSize: 12, letterSpacing: '0.04em', color: PHOSPHOR, border: `1px solid ${signal(38)}`, padding: '3px 9px' }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/SnideMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/SnideMobileTaskCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionCssVar, factionName } from '../../../../utils/factions'
+import { MobileTaskDescription } from './shared'
 
 /**
  * S.N.I.D.E. MOBILE task card (#530/#565) — a dark job file taped to the wall:
@@ -64,24 +65,10 @@ export default function SnideMobileTaskCard({ task, points }: { task: TaskOut; p
         {task.title}
       </h2>
 
-      {task.description && (
-        <p
-          style={{
-            position: 'relative',
-            fontFamily: TYPE,
-            fontSize: 12.5,
-            lineHeight: 1.5,
-            color: MUTED,
-            margin: 0,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {task.description}
-        </p>
-      )}
+      <MobileTaskDescription
+        text={task.description}
+        style={{ position: 'relative', fontFamily: TYPE, fontSize: 12.5, lineHeight: 1.5, color: MUTED, margin: 0 }}
+      />
 
       <div className="flex items-center gap-3" style={{ position: 'relative', marginTop: 2 }}>
         <span style={{ fontFamily: IMPACT, fontSize: 13, letterSpacing: '0.02em', color: INK, background: ACID, padding: '3px 9px' }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionCssVar, factionName } from '../../../../utils/factions'
+import { MobileTaskDescription } from './shared'
 
 /**
  * University of Asthmatics MOBILE task card (#525/#565) — a parchment commission
@@ -58,24 +59,10 @@ export default function UaMobileTaskCard({ task, points }: { task: TaskOut; poin
         {task.title}
       </h2>
 
-      {task.description && (
-        <p
-          style={{
-            fontFamily: DISPLAY,
-            fontStyle: 'italic',
-            fontSize: 13,
-            lineHeight: 1.5,
-            color: SUB,
-            margin: 0,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {task.description}
-        </p>
-      )}
+      <MobileTaskDescription
+        text={task.description}
+        style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 13, lineHeight: 1.5, color: SUB, margin: 0 }}
+      />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
         <span style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.04em', color: INK, background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/WowMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/WowMobileTaskCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
 import { factionCssVar, factionName } from '../../../../utils/factions'
+import { MobileTaskDescription } from './shared'
 
 /**
  * Warriors of Whimsy MOBILE task card (#531/#565) — a pink scrapbook "quest"
@@ -69,23 +70,10 @@ export default function WowMobileTaskCard({ task, points }: { task: TaskOut; poi
             {task.title}
           </h2>
 
-          {task.description && (
-            <p
-              style={{
-                fontFamily: BODY,
-                fontSize: 12,
-                lineHeight: 1.5,
-                color: CARD_MUTED,
-                margin: 0,
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-              }}
-            >
-              {task.description}
-            </p>
-          )}
+          <MobileTaskDescription
+            text={task.description}
+            style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.5, color: CARD_MUTED, margin: 0 }}
+          />
 
           <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
             <span style={{ fontFamily: BODY, fontSize: 12, fontWeight: 700, color: PINK_DEEP, background: BODY_BG, border: `1px solid ${NOTEPAD_BORDER}`, borderRadius: 999, padding: '3px 11px' }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/shared.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/shared.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Shared MOBILE task-card slots (#589).
+ *
+ * Mirrors the split the mobile praxis cards established in #573
+ * (`components/praxisCard/mobile/shared.tsx`): each faction's mobile task card
+ * owns a bespoke FRAME — chrome, fonts, fills, dot geometry, footer anatomy —
+ * and composes the genuinely-repeated STRUCTURAL pieces from here.
+ *
+ * Only one piece earned extraction. The description excerpt repeats its clamp
+ * mechanics identically in all 8 cards; it lives here. The faction tag row (6
+ * of 8) and the points/level footer (7 of 8 share only the wrapper) did NOT:
+ * their dot geometry, typography and footer order differ per faction, so every
+ * meaningful value would become a prop and the "shared" component would cost
+ * more lines than the call sites it replaced. Those stay bespoke on purpose —
+ * each faction keeps its own card archetype.
+ *
+ * This file is NOT on the `.eslint-legacy-raw-styles` allowlist (new files may
+ * never be added to it), so it carries no raw fontSize/padding/margin/gap
+ * numbers. Every faction-specific value — including the `margin` and font size
+ * the originals set inline — arrives through `style` from the calling card,
+ * which keeps the rendered output byte-for-byte what it was.
+ */
+
+/**
+ * Slot: the task description excerpt, clamped to two lines.
+ *
+ * Holds only the clamp mechanics that all 8 cards repeat verbatim
+ * (`-webkit-box` + `WebkitLineClamp: 2` + `WebkitBoxOrient` + `overflow`) and
+ * the "render nothing without a description" guard. Typography, colour and
+ * margin stay with the faction card and come in through `className` / `style`,
+ * which is spread last so a card can still override anything it needs.
+ */
+export function MobileTaskDescription({
+  text,
+  className,
+  style,
+}: {
+  text: string | null | undefined
+  className?: string
+  style?: CSSProperties
+}) {
+  if (!text) return null
+  return (
+    <p
+      className={className}
+      style={{
+        display: '-webkit-box',
+        WebkitLineClamp: 2,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+        ...style,
+      }}
+    >
+      {text}
+    </p>
+  )
+}


### PR DESCRIPTION
Retrofits the 8 mobile task cards onto the **bespoke-frame + shared-slots** pattern that the mobile praxis cards established in #573.

Pure internal restructuring — **no intended visual change**.

## Note on the issue's prose

The issue text predates #565: it describes the extraction of the mobile task cards into per-file components as upcoming work. That already landed — the cards live at `pages/tasks/mobileArchetypes/cards/*MobileTaskCard.tsx` with a dispatcher at `mobileTaskCard.tsx`. Verified on `origin/main` before planning. Only the slot-extraction half of the issue was outstanding. Not a spec contradiction, just stale sequencing.

## What was extracted, with duplicate counts

I counted the real copies across the 8 card files before extracting anything.

| Candidate slot | Copies | Extracted? |
|---|---|---|
| Description excerpt clamp | **8 / 8** | **Yes** |
| Faction tag row (dot + faction name) | 6 / 8 | No |
| Points + level footer | 7 / 8 (wrapper only) | No |

### Extracted: `MobileTaskDescription` (8/8)

All 8 cards repeat the identical clamp mechanics — `-webkit-box` + `WebkitLineClamp: 2` + `WebkitBoxOrient` + `overflow: hidden` — plus the same "render nothing without a description" guard. That's the only piece where the *structure* is genuinely shared and only the dress differs. Typography, colour and margin stay with the faction card and arrive through `className` / `style`, spread last, so the rendered output is unchanged.

### Not extracted, deliberately

- **Faction tag row (6/8).** WOW and Albescent already opt out with bespoke glyphs (`Sparkle`, `AlbescentSigil`) and different label text. Across the remaining 6, the dot size, dot border-radius, gap and full typography all differ — every meaningful value would become a prop, leaving a component thinner than its own prop list. Measured at roughly **+7 lines**. Didn't pay for itself, so it stays bespoke.
- **Points + level footer (7/8).** Only the wrapper `div` is common; the points and level spans are fully bespoke per faction (different fonts, fills, borders), and Albescent reverses the order and uses `justify-between`. Extracting a bare wrapper saves **0 lines**.
- **The per-faction `kicker` style const (6/8).** Every field value differs, and hoisting its `fontSize: 8` into a new file would need a `--text-*` token whose value may not be exactly 8px — a visual-change risk for no real gain.

Each faction keeps its own card archetype; nothing was unified away.

## Net effect: a deletion

```
9 files changed, 100 insertions(+), 138 deletions(-)   → net -38
```

## Lint ratchet

`no-raw-style-values` states new files may never join `.eslint-legacy-raw-styles.txt`. The new `cards/shared.tsx` is therefore **not** on that list and carries no raw `fontSize`/`padding`/`margin`/`gap` numbers — it holds only clamp mechanics, and every faction-specific value (including `margin`) is passed in from the calling card, which is already grandfathered. **No line was removed from the legacy list.**

## Verification

- `tsc --noEmit` — clean (only the known stale-junction `node:fs`/`node:url` false alarms).
- `eslint src` — clean, exit 0.
- `vitest run` — **94/94 test files pass**.
- `vite build` — succeeds.
- New `mobileTaskCardSlots.test.tsx`: the existing dispatch test only asserts slug→component resolution and never renders, so it could **not** catch a broken slot. The new test renders all 8 skins + Default and asserts title/description/points/level plus the clamp. **Mutation-checked:** deleting `WebkitLineClamp` from the shared slot fails all 8 faction tests.

## Visual QA is outstanding

I cannot screenshot, and "zero visual change" is the acceptance criterion here — so it is verified by construction (styles pass through untouched) and by tests, **not** by eye. This needs a human look before merge.

### What to eyeball

The mobile Tasks feed, one card per faction skin — checking the description excerpt still clamps at two lines and keeps its own font/colour/margin:

- [ ] Default (unregistered / `na` task)
- [ ] UA — parchment plate
- [ ] WOW — scrapbook sticker (description sits inside the inner notepad)
- [ ] S.N.I.D.E. — dark job file (description carries `position: relative` over the dot texture)
- [ ] Everymen — cream work order
- [ ] Singularity — void readout
- [ ] Ephemerists — vellum leaf (italic script excerpt)
- [ ] Albescent — cotton ledger (mono excerpt, reversed footer)
- [ ] A task with **no** description — no empty gap in any skin

Closes #589
