### PR TITLE
feat(search): match author/member names in the task and praxis feed search (#681)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -422,10 +422,15 @@ async def list_praxes(
     :func:`_count_in_progress_praxes` so a membership-based list (the sidebar's
     in-progress tasks) can never disagree with the slot count.
 
-    ``search`` is a free-text ``ilike`` over the praxis title, its body, and the
-    linked task's title. Author is deliberately excluded: ``faction`` already
-    answers "show me the Ephemerists", and finding a *person* is what the
-    character search is for.
+    ``search`` is a free-text ``ilike`` over the praxis title, its body, the
+    linked task's title, and **any member's** handle / display name. The player
+    axis (#681) reverses #658's deliberate exclusion of the author: the
+    maintainer chose one box that finds content OR a person, accepting that a
+    common word can surface every praxis by anyone whose name contains it.
+    It matches *members* rather than the author so a collab surfaces for each
+    participant; a duel is two praxis rows of one member each, so each side
+    already surfaces for its own duelist. A leading ``@`` is a sigil and is
+    dropped for the player axis only, matching the character search (#624).
 
     ``sort`` only applies to the ``status=submitted`` feed and is ignored
     otherwise; every caller that passes no ``sort`` keeps ``created_at DESC``.
@@ -448,13 +453,31 @@ async def list_praxes(
     if search:
         term = search.strip()
         if term:
-            query = query.where(
-                or_(
-                    Praxis.title.ilike(f"%{term}%"),
-                    Praxis.body_text.ilike(f"%{term}%"),
-                    Task.title.ilike(f"%{term}%"),
+            conditions = [
+                Praxis.title.ilike(f"%{term}%"),
+                Praxis.body_text.ilike(f"%{term}%"),
+                Task.title.ilike(f"%{term}%"),
+            ]
+            # Player axis (#681): match ANY member, not just the author. Every
+            # praxis has PraxisMember rows (solo/duel exactly one — the creator,
+            # per _require_member), so one condition covers all three types.
+            # `IN (subquery)` rather than a join: a collab with two matching
+            # members must still yield exactly one feed row.
+            player_term = term.lstrip("@")
+            if player_term:
+                conditions.append(
+                    Praxis.id.in_(
+                        select(PraxisMember.praxis_id)
+                        .join(Character, Character.id == PraxisMember.character_id)
+                        .where(
+                            or_(
+                                Character.username.ilike(f"%{player_term}%"),
+                                Character.display_name.ilike(f"%{player_term}%"),
+                            )
+                        )
+                    )
                 )
-            )
+            query = query.where(or_(*conditions))
 
     if praxis_type is not None:
         query = query.where(Praxis.type == praxis_type)

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -218,8 +218,11 @@ async def list_tasks(
     spec's "below level 6 cannot see the metatask list". ``skip_level_check``
     is the admin escape hatch, mirroring :func:`propose_task`.
 
-    ``q`` is a free-text ``ilike`` over the task title AND its description
-    (#661), mirroring the praxis-feed search in :func:`services.praxis.list_praxes`.
+    ``q`` is a free-text ``ilike`` over the task title, its description (#661),
+    AND the proposing character's handle / display name (#681), mirroring the
+    praxis-feed search in :func:`services.praxis.list_praxes`. A leading ``@``
+    is treated as a sigil and dropped for the player axis only (``@mol`` finds
+    ``@mollusk``), matching :func:`services.character.list_characters`.
     Metatasks are deliberately NOT excluded: whatever the type filter and the
     ``level_to_see_metatasks`` gate already let this viewer see stays
     searchable. It composes with every other filter as one more AND clause —
@@ -290,12 +293,26 @@ async def list_tasks(
             # ever grows to where this bites, the upgrade path is Postgres
             # full-text (`to_tsvector`/`plainto_tsquery` + a GIN index) — noted,
             # not built.
-            query = query.where(
-                or_(
-                    Task.title.ilike(f"%{term}%"),
-                    Task.description.ilike(f"%{term}%"),
+            conditions = [
+                Task.title.ilike(f"%{term}%"),
+                Task.description.ilike(f"%{term}%"),
+            ]
+            # Author axis (#681): the same box also matches the proposer's
+            # handle or display name. `IN (subquery)` rather than a join so a
+            # matching author can never multiply the task's feed row.
+            author_term = term.lstrip("@")
+            if author_term:
+                conditions.append(
+                    Task.created_by.in_(
+                        select(Character.id).where(
+                            or_(
+                                Character.username.ilike(f"%{author_term}%"),
+                                Character.display_name.ilike(f"%{author_term}%"),
+                            )
+                        )
+                    )
                 )
-            )
+            query = query.where(or_(*conditions))
 
     # Exclude tasks from hidden/deprecated factions
     if hidden_slugs:

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -464,6 +464,132 @@ async def test_faction_and_search_combine(
 
 
 @pytest.mark.asyncio
+async def test_feed_search_matches_member_name(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """?q= also matches a member's handle and display name (#681).
+
+    Reverses #658's deliberate exclusion of the author: one box now finds
+    content OR a person.
+    """
+    now = datetime.now(timezone.utc)
+    theirs = await _submitted_praxis(
+        client,
+        db_session,
+        character2,
+        auth_headers2,
+        task_title="Generic Task A",
+        praxis_title="Untitled",
+        submitted_at=now,
+    )
+    mine = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Generic Task B",
+        praxis_title="Untitled",
+        submitted_at=now,
+    )
+
+    # By handle, with the '@' sigil the player typed (#624).
+    resp = await client.get(
+        "/praxes", params={"status": "submitted", "q": "@othercharacter"}
+    )
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()}
+    assert theirs in ids
+    assert mine not in ids
+
+    # By display name ("Other Character") — case-insensitive, partial.
+    resp = await client.get("/praxes", params={"status": "submitted", "q": "oTHer ch"})
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()}
+    assert theirs in ids
+    assert mine not in ids
+
+
+@pytest.mark.asyncio
+async def test_feed_search_by_member_does_not_duplicate_rows(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A praxis with TWO matching members still yields exactly one feed row.
+
+    This is why the player axis is an ``IN (subquery)`` and not a join: a
+    multi-member collab would otherwise be multiplied once per matching member.
+    """
+    now = datetime.now(timezone.utc)
+    praxis_id = await _submitted_praxis(
+        client,
+        db_session,
+        character,
+        auth_headers,
+        task_title="Generic Task C",
+        praxis_title="Untitled",
+        submitted_at=now,
+    )
+    # Second member, so the term below matches two rows of the same praxis.
+    db_session.add(PraxisMember(praxis_id=praxis_id, character_id=character2.id))
+    await db_session.commit()
+
+    # "character" is a substring of BOTH usernames (testcharacter/othercharacter).
+    resp = await client.get("/praxes", params={"status": "submitted", "q": "character"})
+    assert resp.status_code == 200
+    returned = [item["id"] for item in resp.json()]
+    assert returned.count(praxis_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_feed_search_by_member_ands_with_other_filters(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """The player axis is an OR *within* ?q=, still a plain AND with filters.
+
+    ``?faction=wow`` excludes a praxis whose member matches the term, proving
+    the name match cannot smuggle a row past another active filter.
+    """
+    now = datetime.now(timezone.utc)
+    theirs = await _submitted_praxis(
+        client,
+        db_session,
+        character2,
+        auth_headers2,
+        task_title="Generic Task D",
+        praxis_title="Untitled",
+        submitted_at=now,
+    )
+
+    # Same term, matching faction: present.
+    resp = await client.get(
+        "/praxes",
+        params={"status": "submitted", "q": "othercharacter", "faction": "ua"},
+    )
+    assert resp.status_code == 200
+    assert theirs in {item["id"] for item in resp.json()}
+
+    # Same term, non-matching faction: gone.
+    resp = await client.get(
+        "/praxes",
+        params={"status": "submitted", "q": "othercharacter", "faction": "wow"},
+    )
+    assert resp.status_code == 200
+    assert theirs not in {item["id"] for item in resp.json()}
+
+
+@pytest.mark.asyncio
 async def test_invalid_sort_returns_422(client: AsyncClient):
     """An unknown ?sort= is rejected, not silently ignored."""
     resp = await client.get("/praxes", params={"sort": "sideways"})

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -1630,6 +1630,105 @@ async def test_list_tasks_search_composes_with_existing_filter(
 
 
 @pytest.mark.asyncio
+async def test_list_tasks_search_matches_proposer_name(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+):
+    """`q` also matches the proposing character's handle / display name (#681).
+
+    Overrides #644 §4's rejection of author search: the maintainer accepted
+    that a common word can surface every task by anyone whose name contains it.
+    """
+    mine = Task(
+        title="Ordinary title one",
+        description="No distinguishing token.",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    theirs = Task(
+        title="Ordinary title two",
+        description="No distinguishing token.",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character2.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add_all([mine, theirs])
+    await db_session.commit()
+    await db_session.refresh(mine)
+    await db_session.refresh(theirs)
+
+    # By handle, with the '@' sigil the player typed (#624).
+    resp = await client.get("/tasks", params={"q": "@othercharacter"})
+    assert resp.status_code == 200
+    ids = [task["id"] for task in resp.json()]
+    assert theirs.id in ids
+    assert mine.id not in ids
+    # One matching proposer must not multiply the task's feed row.
+    assert ids.count(theirs.id) == 1
+
+    # By display name ("Other Character") — case-insensitive, partial.
+    resp = await client.get("/tasks", params={"q": "oTHer ch"})
+    assert resp.status_code == 200
+    ids = [task["id"] for task in resp.json()]
+    assert theirs.id in ids
+    assert mine.id not in ids
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_proposer_search_ands_with_other_filters(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character2: Character,
+):
+    """The proposer axis ORs *within* `q`, and still ANDs with other filters."""
+    cheap = Task(
+        title="Ordinary title three",
+        description="No distinguishing token.",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character2.id,
+        primary_faction_slug="ua",
+    )
+    pricey = Task(
+        title="Ordinary title four",
+        description="No distinguishing token.",
+        point_value=50,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character2.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add_all([cheap, pricey])
+    await db_session.commit()
+    await db_session.refresh(cheap)
+    await db_session.refresh(pricey)
+
+    # The name alone hits both of their tasks.
+    both = await client.get("/tasks", params={"q": "othercharacter"})
+    assert both.status_code == 200
+    both_ids = [task["id"] for task in both.json()]
+    assert cheap.id in both_ids
+    assert pricey.id in both_ids
+
+    # min_points narrows that same set — the name match can't smuggle a row past it.
+    narrowed = await client.get(
+        "/tasks", params={"q": "othercharacter", "min_points": 50}
+    )
+    assert narrowed.status_code == 200
+    narrowed_ids = [task["id"] for task in narrowed.json()]
+    assert pricey.id in narrowed_ids
+    assert cheap.id not in narrowed_ids
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_absent_or_blank_q_is_no_filter(
     client: AsyncClient, db_session: AsyncSession, character: Character
 ):


### PR DESCRIPTION
Adds a **player axis** to the existing free-text search box on both feeds. Backend-only.

Closes #681

## Decision on the record: this overrides #644 §4

#644 §4's last wave explicitly **rejected** author-name search, on the grounds that `?character_id=` already filters by author and that matching display names means a common word surfaces every praxis by anyone whose name contains it. **The maintainer has overridden that decision**, and the noise trade-off is accepted knowingly: searching `an` will match every player whose name contains `an`, alongside the content hits. That is the intended behaviour, not a bug to file later.

The same reversal applies to the docstring in `services/praxis.py`, which documented author as *deliberately* excluded ("finding a person is what the character search is for"). That paragraph is rewritten to record the override rather than deleted, so the next reader sees the decision, not a silent flip.

## What changed

One `or_(...)` widened per feed — the existing search plumbing, no parallel mechanism, no second input, no new query param.

**Task feed** (`services/task.py`) — `q` now also matches the **proposer**: `Task.created_by IN (select Character.id where username ILIKE … OR display_name ILIKE …)`.

**Praxis feed** (`services/praxis.py`) — `q` now also matches **any member**, not just the author: `Praxis.id IN (select PraxisMember.praxis_id join Character where …)`. Members rather than the author because every praxis has `PraxisMember` rows (solo/duel exactly one — the creator, per `_require_member`), so one condition covers all three types uniformly and a collab surfaces for each participant. A duel is two praxis rows of one member each, so each side already surfaces for its own duelist — no `Duel` join needed.

Both use the **`IN (subquery)`** form rather than a join, specifically so a multi-member collab (or any matching author) cannot multiply feed rows. There is a test for exactly this.

Semantics are inherited, not invented: same `ILIKE '%term%'` case-insensitive partial match as the existing content search, same `.strip()`, and the player axis is an **OR within the search term** that still composes as a plain **AND** against every other filter. A leading `@` is dropped for the player axis only, reusing the sigil convention from the character search (#624), so `@mol` finds `@mollusk`.

## No frontend change needed

The search box already passes its term through untouched (`listTasks` spreads `TaskFilters` straight into axios `params`), so the feature works as soon as the backend widens. Nothing new is added to any response schema — this searches **character display names / handles**, never `account_id` or `email`.

## Tests

`pytest -q` (backend, `TEST_DATABASE_URL` → `wz681_test`): **614 passed**.

Five new integration tests, two on the task feed and three on the praxis feed. Each was verified to **fail** against the pre-#681 service before being kept, so none pass vacuously:

- match by handle (with the `@` sigil) and by display name, case-insensitive and partial, on each feed
- ANDs correctly with an existing filter on each feed (`min_points` on tasks, `faction` on praxes — including the negative case, proving a name match can't smuggle a row past another active filter)
- a praxis with **two** matching members still returns exactly one feed row

## Known gaps / follow-ups (not in this PR)

- **Visual QA outstanding** — I can't screenshot; everything above is verified by pytest only.
- Two copy nits now slightly understate the box, both frontend-only and outside this PR's scope: `frontend/src/locales/en/praxis.json` placeholder still reads "Search proof or task…" (no mention of a player), and the `TaskFilters.q` doc comment in `frontend/src/api/tasks.ts` still says "title and description". Worth a small copy pass once #660 lands.

## What to eyeball

- Search a player's name on the **task feed** — their proposed tasks should appear alongside any content matches.
- Search a player's name on the **praxis feed** — their praxes should appear, including collabs they're a member of but didn't author.
- Search a **common substring** (e.g. `an`, or `character` on seed data) — confirm the expected noise looks acceptable in practice, since that's the trade-off being accepted.
- Combine search with **another active filter** (faction on praxes, min points / task type on tasks) — the result set should narrow, never widen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
