### PR TITLE
fix(albescent): make the unlock account-collective per ADR-0021

### DIFF
--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -132,56 +132,47 @@ async def can_start_as_albescent(
     Albescent is joined in the field via defection (``defect_to_faction``) —
     it is never a starting faction and never a character-creation option.
 
-    Both conditions must hold on the *same* character:
-    (a) active and at level ``era.albescent_level_required`` or above, and
-    (b) has a submitted, non-hidden qualifying praxis for every non-sentinel
-        faction in the era (i.e. every faction except ``na`` and ``albescent``).
+    ADR-0021: the unlock is **account-collective**, and the two gates are
+    **independent** — they need not be satisfied by the same character:
+
+    (a) *Level* — **some** active character on the account is at level
+        ``era.albescent_level_required`` or above in the current era.
+    (b) *Coverage* — pooled across **all** the account's lives combined, there is
+        a submitted, non-hidden praxis for **every** non-sentinel faction in the
+        era (i.e. every faction except ``na`` and ``albescent``).
+
+    Coverage pools over the account roster (active + paused, banned excluded) —
+    the same "a player's own lives" set as :data:`_ROSTER_STATUSES`. A banned
+    life's work does not carry the account through the gate.
     """
+    if not await _account_has_character_at_level(
+        account_id, era.albescent_level_required, session
+    ):
+        return False
+
     required_faction_slugs = frozenset(
         slug for slug in era.factions if slug not in _ALBESCENT_SENTINEL_SLUGS
     )
-    era_row = await get_current_era_row(session)
-
-    level_result = await session.execute(
-        select(Character.id)
-        .join(
-            CharacterStats,
-            (CharacterStats.character_id == Character.id)
-            & (CharacterStats.era_id == era_row.id),
-        )
-        .where(
-            Character.account_id == account_id,
-            Character.status == CharacterStatus.active,
-            CharacterStats.level >= era.albescent_level_required,
-        )
-    )
-    qualifying_character_ids = [row[0] for row in level_result.all()]
-
-    if not qualifying_character_ids:
-        return False
-
     if not required_faction_slugs:
         return True
 
-    for character_id in qualifying_character_ids:
-        covered_result = await session.execute(
-            select(Task.primary_faction_slug)
-            .distinct()
-            .join(Praxis, Praxis.task_id == Task.id)
-            .where(
-                Praxis.created_by_id == character_id,
-                Praxis.status == PraxisStatus.submitted,
-                Praxis.moderation_status.in_(
-                    [ModerationStatus.visible, ModerationStatus.flagged]
-                ),
-                Task.primary_faction_slug.in_(list(required_faction_slugs)),
-            )
+    covered_result = await session.execute(
+        select(Task.primary_faction_slug)
+        .distinct()
+        .join(Praxis, Praxis.task_id == Task.id)
+        .join(Character, Character.id == Praxis.created_by_id)
+        .where(
+            Character.account_id == account_id,
+            Character.status.in_(list(_ROSTER_STATUSES)),
+            Praxis.status == PraxisStatus.submitted,
+            Praxis.moderation_status.in_(
+                [ModerationStatus.visible, ModerationStatus.flagged]
+            ),
+            Task.primary_faction_slug.in_(list(required_faction_slugs)),
         )
-        covered_slugs = frozenset(row[0] for row in covered_result.all())
-        if covered_slugs >= required_faction_slugs:
-            return True
-
-    return False
+    )
+    covered_slugs = frozenset(row[0] for row in covered_result.all())
+    return covered_slugs >= required_faction_slugs
 
 
 async def get_account_invited_faction_slugs(

--- a/backend/tests/integration/test_albescent_unlock.py
+++ b/backend/tests/integration/test_albescent_unlock.py
@@ -1,0 +1,408 @@
+"""ADR-0021: the Albescent unlock is account-collective, level and coverage decoupled.
+
+The gate is a *permissions* gate, so these tests pin the axes independently:
+
+* level satisfied / not satisfied, on any character of the account;
+* coverage pooled across the whole roster / partial;
+* and crucially the case #698 fixed — level on one character, coverage on a
+  *different* one. Under the old same-character coupling that account was
+  locked out.
+
+Threshold and faction list are read off ``EraConfig`` (never hardcoded); the
+tests also drive a ``replace()``-d era to prove the service honours the
+argument rather than the module singleton.
+"""
+from dataclasses import replace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA, EraConfig
+from models.account import Account
+from models.character import Character, CharacterStatus
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.praxis import ModerationStatus, Praxis, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from services.character import _ALBESCENT_SENTINEL_SLUGS, can_start_as_albescent
+
+
+def _required_faction_slugs(era: EraConfig = CURRENT_ERA) -> list[str]:
+    """Every faction the coverage gate demands, in a stable order."""
+    return [slug for slug in era.factions if slug not in _ALBESCENT_SENTINEL_SLUGS]
+
+
+async def _seed_faction(db_session: AsyncSession, slug: str) -> None:
+    existing = await db_session.scalar(select(Faction).where(Faction.slug == slug))
+    if existing is None:
+        db_session.add(Faction(slug=slug, status=FactionStatus.visible))
+        await db_session.flush()
+
+
+async def _make_character(
+    db_session: AsyncSession,
+    account: Account,
+    era_row: Era,
+    username: str,
+    level: int,
+    status: CharacterStatus = CharacterStatus.active,
+) -> Character:
+    """A second/third life on the *same* account, at a given level."""
+    character = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username.title(),
+        faction_slug="na",
+        status=status,
+    )
+    db_session.add(character)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=character.id,
+            era_id=era_row.id,
+            score=0,
+            all_time_score=0,
+            level=level,
+            votes_spent_this_era=0,
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(character)
+    return character
+
+
+async def _set_level(
+    db_session: AsyncSession, character: Character, era_row: Era, level: int
+) -> None:
+    stats = await db_session.scalar(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era_row.id,
+        )
+    )
+    stats.level = level
+    await db_session.commit()
+
+
+async def _complete_task_for(
+    db_session: AsyncSession,
+    character: Character,
+    faction_slug: str,
+    *,
+    status: PraxisStatus = PraxisStatus.submitted,
+    moderation_status: ModerationStatus = ModerationStatus.visible,
+) -> None:
+    """One submitted, non-hidden praxis on a task whose primary faction is ``faction_slug``."""
+    await _seed_faction(db_session, faction_slug)
+    task = Task(
+        title=f"Albescent coverage: {faction_slug}",
+        description="test",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug=faction_slug,
+    )
+    db_session.add(task)
+    await db_session.flush()
+    db_session.add(
+        Praxis(
+            task_id=task.id,
+            created_by_id=character.id,
+            type=PraxisType.solo,
+            title=f"Albescent coverage praxis: {faction_slug}",
+            body_text="proof",
+            status=status,
+            moderation_status=moderation_status,
+        )
+    )
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Single-character accounts — the classic path still behaves
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_character_with_level_and_full_coverage_unlocks(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """Account with a single life that is both high enough and has covered everything."""
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, character, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_one_character_below_level_stays_locked(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """Full coverage does not substitute for the level gate."""
+    await _set_level(
+        db_session, character, era, CURRENT_ERA.albescent_level_required - 1
+    )
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, character, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+@pytest.mark.asyncio
+async def test_one_character_missing_one_faction_stays_locked(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """Coverage is ALL non-sentinel factions — one short is still short."""
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    for slug in _required_faction_slugs()[:-1]:
+        await _complete_task_for(db_session, character, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+# ---------------------------------------------------------------------------
+# The #698 case: level and coverage on DIFFERENT characters of one account
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_level_and_coverage_on_different_characters_unlocks(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """ADR-0021's headline case, and the one the old same-character code failed.
+
+    The veteran is at the threshold but has completed nothing; the workhorse has
+    covered every faction but is level 0. Pooled across the account, both
+    conditions hold, so Albescent unlocks.
+    """
+    veteran = character
+    await _set_level(db_session, veteran, era, CURRENT_ERA.albescent_level_required)
+
+    workhorse = await _make_character(db_session, account, era, "workhorse", level=0)
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, workhorse, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_coverage_pools_across_several_characters(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """No single life covers everything; the account collectively does."""
+    slugs = _required_faction_slugs()
+    assert len(slugs) >= 2, "era must have >=2 non-sentinel factions for this test"
+
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    await _complete_task_for(db_session, character, slugs[0])
+
+    sibling = await _make_character(db_session, account, era, "sibling", level=0)
+    for slug in slugs[1:]:
+        await _complete_task_for(db_session, sibling, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_neither_gate_satisfied_stays_locked(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """Several lives, none at level, coverage incomplete even pooled."""
+    slugs = _required_faction_slugs()
+    await _set_level(
+        db_session, character, era, CURRENT_ERA.albescent_level_required - 1
+    )
+    await _complete_task_for(db_session, character, slugs[0])
+
+    sibling = await _make_character(db_session, account, era, "sibling", level=1)
+    if len(slugs) > 2:
+        await _complete_task_for(db_session, sibling, slugs[1])
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+@pytest.mark.asyncio
+async def test_pooled_coverage_without_the_level_stays_locked(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """The two gates are independent, not interchangeable: coverage alone is not enough."""
+    await _set_level(db_session, character, era, 0)
+    sibling = await _make_character(db_session, account, era, "sibling", level=1)
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, sibling, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+# ---------------------------------------------------------------------------
+# Scope guards: other accounts, non-roster lives, non-qualifying praxes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_another_accounts_coverage_does_not_count(
+    db_session: AsyncSession,
+    account: Account,
+    account2: Account,
+    character: Character,
+    character2: Character,
+    era: Era,
+):
+    """Pooling is per-account, not global."""
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, character2, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+@pytest.mark.asyncio
+async def test_paused_life_contributes_coverage(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """A paused life is still one of the player's own lives (``_ROSTER_STATUSES``)."""
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    paused = await _make_character(
+        db_session, account, era, "paused", level=0, status=CharacterStatus.paused
+    )
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, paused, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_banned_life_does_not_contribute_coverage(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """A banned life's work does not carry the account through the gate."""
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    banned = await _make_character(
+        db_session, account, era, "bannedlife", level=0, status=CharacterStatus.banned
+    )
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, banned, slug)
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+@pytest.mark.asyncio
+async def test_banned_life_does_not_satisfy_the_level_gate(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """The level gate reads active lives only."""
+    await _set_level(db_session, character, era, 0)
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, character, slug)
+    await _make_character(
+        db_session,
+        account,
+        era,
+        "bannedvet",
+        level=CURRENT_ERA.albescent_level_required,
+        status=CharacterStatus.banned,
+    )
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+@pytest.mark.asyncio
+async def test_unsubmitted_praxis_does_not_count_toward_coverage(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """Coverage is completed work: an in-progress praxis is not a completion."""
+    slugs = _required_faction_slugs()
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    for slug in slugs[:-1]:
+        await _complete_task_for(db_session, character, slug)
+    await _complete_task_for(
+        db_session, character, slugs[-1], status=PraxisStatus.in_progress
+    )
+
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+@pytest.mark.asyncio
+async def test_hidden_praxis_does_not_count_toward_coverage(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """Moderation-hidden work is not coverage; flagged-but-visible work is."""
+    slugs = _required_faction_slugs()
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    for slug in slugs[:-1]:
+        await _complete_task_for(db_session, character, slug)
+    await _complete_task_for(
+        db_session,
+        character,
+        slugs[-1],
+        moderation_status=ModerationStatus.hidden,
+    )
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+    # Same praxis, flagged rather than hidden -> counts, and the gate opens.
+    await _complete_task_for(
+        db_session,
+        character,
+        slugs[-1],
+        moderation_status=ModerationStatus.flagged,
+    )
+    assert await can_start_as_albescent(account.id, db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_account_with_no_characters_stays_locked(
+    db_session: AsyncSession, account: Account, era: Era
+):
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+
+# ---------------------------------------------------------------------------
+# The threshold comes from the era argument, not the module singleton
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_level_threshold_is_read_from_the_era_argument(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """A stricter EraConfig locks an account that CURRENT_ERA would unlock."""
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    for slug in _required_faction_slugs():
+        await _complete_task_for(db_session, character, slug)
+    assert await can_start_as_albescent(account.id, db_session) is True
+
+    strict_era = replace(
+        CURRENT_ERA,
+        albescent_level_required=CURRENT_ERA.albescent_level_required + 1,
+    )
+    assert await can_start_as_albescent(account.id, db_session, strict_era) is False
+
+
+@pytest.mark.asyncio
+async def test_coverage_faction_set_is_read_from_the_era_argument(
+    db_session: AsyncSession, account: Account, character: Character, era: Era
+):
+    """Coverage demands exactly the era's non-sentinel factions.
+
+    Narrow the era to a single faction and one completion is enough; the
+    sentinels (``na``, ``albescent``) are never demanded.
+    """
+    slugs = _required_faction_slugs()
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+    await _complete_task_for(db_session, character, slugs[0])
+    assert await can_start_as_albescent(account.id, db_session) is False
+
+    narrow_era = replace(
+        CURRENT_ERA,
+        factions={
+            faction_slug: faction_config
+            for faction_slug, faction_config in CURRENT_ERA.factions.items()
+            if faction_slug in _ALBESCENT_SENTINEL_SLUGS or faction_slug == slugs[0]
+        },
+    )
+    assert await can_start_as_albescent(account.id, db_session, narrow_era) is True

--- a/docs/adr/0021-albescent-unlock-is-account-collective.md
+++ b/docs/adr/0021-albescent-unlock-is-account-collective.md
@@ -1,10 +1,9 @@
 # Albescent unlock is account-collective, with level and coverage decoupled
 
-> **⚠ Status (2026-07-17 audit): CONTRADICTED BY CODE.** `services/character.py`
-> (`can_start_as_albescent`) currently requires level ≥ threshold **and** full
-> coverage on the *same* character — the option this ADR explicitly **rejected**.
-> Either the code is a standing bug or this decision was abandoned; tracked as a
-> code-cleanup follow-up, not resolved here.
+> **Status: in force (as of #698).** The 2026-07-17 audit found
+> `services/character.py` (`can_start_as_albescent`) implementing the
+> same-character option this ADR explicitly **rejected**. #698 resolved that in
+> this ADR's favour — the code is now two independent account-scoped gates.
 
 Albescent becomes a selectable starting/joining faction for an account when **two
 independent conditions** both hold across the account (not on a single character):


### PR DESCRIPTION
## What

`can_start_as_albescent` required level ≥ threshold **and** full faction coverage on the **same** character — the option ADR-0021 explicitly **rejected**. This makes the code conform to the ADR: the unlock is account-collective and the two gates are independent.

- **Level** — any *active* character on the account at level ≥ `era.albescent_level_required`. Reuses the existing `_account_has_character_at_level` helper (same one the second-character gate uses).
- **Coverage** — pooled across the account roster in **one** query, replacing the per-character loop (which ran N queries for N level-qualifying characters).
- The threshold and the faction list are read off the `era` argument; nothing is hardcoded.

ADR-0021's "CONTRADICTED BY CODE" banner is replaced with "in force (as of #698)".

**One judgement call worth a look:** coverage pools over `_ROSTER_STATUSES` (active + paused, **banned excluded**) rather than literally every row. ADR-0021 says "all the account's characters"; `_ROSTER_STATUSES` is the codebase's existing definition of "a player's own lives", and letting a banned life's work carry the account through a permissions gate seemed like the wrong default. Documented in the docstring and pinned by two tests. Easy to flip if you disagree.

## Behaviour change

This is strictly **more permissive** — every account that could unlock Albescent before still can. Accounts that newly qualify are those whose level and coverage live on different lives.

## Tests

New `backend/tests/integration/test_albescent_unlock.py`, 16 cases: single-character accounts (pass / below level / one faction short), level and coverage on **different** characters, coverage pooled across several lives, neither gate satisfied, pooled-coverage-without-the-level, cross-account isolation, paused vs banned lives, unsubmitted and moderation-hidden praxes, empty account, and two tests proving the threshold + faction set come from the `era` argument rather than `CURRENT_ERA`.

Checked against the pre-fix service: 3 of the 16 fail there and pass here, so the pooling behaviour is genuinely guarded rather than incidentally true.

```
TEST_DATABASE_URL=...wz698_test pytest --cov=. --cov-fail-under=80
625 passed in 57.91s — total coverage 88%
```

## Not addressed

ADR-0021 also calls Albescent a "selectable **starting**/joining faction", which contradicts `create_character`'s explicit 400 (`"Albescent is joined in the field, not chosen at creation."`) and ADR-0019/ADR-0027. That is a separate call from the one already made on this issue, so I left the wording alone and [flagged it on #698](https://github.com/pixieofhugs/WorldZeroPlayground/issues/698#issuecomment-5010275765) instead of guessing.

Backend + one ADR markdown file only — no migration, no schema change, no frontend change.

Closes #698

## What to eyeball

Verified by pytest only; **live verification is outstanding** (I can't screenshot).

- An account whose **level and coverage come from two different characters** should now see Albescent unlocked — this is the case that was broken. Note the surface is the **Field Desk** defection panel (`FieldDesk.tsx` gates on `user.can_start_as_albescent`), *not* character creation: `create_character` still rejects Albescent outright. If you were expecting it at character creation, that's the ADR-0021 wording discrepancy flagged above, not this change.
- An account with **one** character that is high-level but hasn't covered every faction should still see it locked.
- A **paused** sibling's completions count toward coverage; a **banned** sibling's do not.
- `/auth/me` still returns `can_start_as_albescent` for accounts with zero characters without erroring.
