### PR TITLE
docs: point CLAUDE.md at the /wz-next-batch sibling skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,8 @@ For file-editing work, dispatch to a specialist that loads only its own context:
 
 `/wz-next-issue` picks up where `/triage` stops: it selects the best unblocked `ready-for-agent` issue (dependency-aware), builds it in a worktree, and opens a draft PR — commenting on the issue and stopping if it needs a human.
 
+`/wz-next-batch` is the multi-issue sibling: it shapes a whole batch (dependency-aware, grouped by **file footprint** so only disjoint work runs in parallel), grills anything ungrilled, dispatches each issue to a scoped subagent in its own worktree, then waits for CI and **merges** each PR. Use it for a wave/batch; use `/wz-next-issue` for a single issue.
+
 ### Issue tracker
 Work lives in **GitHub Issues** on `pixieofhugs/WorldZeroPlayground`, managed via the `gh` CLI. External PRs are **not** a triage surface. See `docs/agents/issue-tracker.md`.
 


### PR DESCRIPTION
Adds a one-line pointer to the new `/wz-next-batch` skill, the multi-issue sibling of `/wz-next-issue`.

`/wz-next-issue` builds **one** issue itself and deliberately stops at a draft PR. `/wz-next-batch` shapes a whole batch — dependency-aware, then grouped by **file footprint** so only verified-disjoint work runs in parallel — grills anything ungrilled, dispatches each issue to a scoped subagent in its own worktree, and then waits for CI and **merges** each PR.

The skill file itself is not in this diff: `.gitignore` excludes `/.claude/*`, so skills (including the existing `wz-next-issue`) are machine-local and don't travel with the repo. Only the CLAUDE.md pointer is trackable, which matches how `/wz-next-issue` is already documented here.

## What to eyeball
Nothing visual — docs only. Worth a read of the two-line skills section in `CLAUDE.md` to check the framing is how you'd describe the split.
