### PR TITLE
docs(search): tell users the feed search matches players too

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -147,7 +147,10 @@ export async function listPraxes(filters?: {
   type?: PraxisType
   status?: PraxisStatus
   faction?: string
-  /** Free-text search over praxis title, praxis body, and task title (#644 §4). */
+  /**
+   * Free-text search over praxis title, praxis body, task title, and member
+   * name/handle (#644 §4; member axis added in #681).
+   */
   q?: string
   /**
    * Account-scoped vote filter (#644 §6). `no` = "needs my vote" (votable and

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -42,7 +42,10 @@ export interface TaskFilters {
   exclude_character_id?: number
   created_by?: number
   task_type?: TaskType
-  /** Free-text search over task title and task description (#661). */
+  /**
+   * Free-text search over task title, task description, and author name/handle
+   * (#661; author axis added in #681).
+   */
   q?: string
   /** 'newest' orders by creation time (newest first); default sorts by level/points. */
   sort?: string

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -14,7 +14,7 @@
     "filter": {
       "typeLabel": "type:",
       "showLabel": "show:",
-      "searchPlaceholder": "Search proof or task…",
+      "searchPlaceholder": "Search proof, task, or player…",
       "searchLabel": "Search praxes",
       "all": "All",
       "needsMyVote": "needs my vote",

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -4,7 +4,7 @@
     "empty": "No tasks match your filters.",
     "loadMore": "Load more",
     "filter": {
-      "searchPlaceholder": "Search tasks...",
+      "searchPlaceholder": "Search tasks or players...",
       "searchLabel": "Search tasks"
     }
   },


### PR DESCRIPTION
## Why

PR #711 (issue #681) widened feed search to also match author / player names —
task feed now matches title OR description OR author name/handle, praxis feed
matches its existing text axes OR member name/handle. The copy describing that
search stayed behind and now understates it. Copy-only follow-up; no behaviour
change.

## What changed

- `frontend/src/locales/en/praxis.json` — `listPage.filter.searchPlaceholder`:
  "Search proof or task…" → "Search proof, task, or player…"
- `frontend/src/locales/en/tasks.json` — `listPage.filter.searchPlaceholder`:
  "Search tasks..." → "Search tasks or players..."
- `frontend/src/api/tasks.ts` — `TaskFilters.q` doc comment now names the author
  name/handle axis alongside title and description.
- `frontend/src/api/praxis.ts` — `listPraxes` `q` doc comment now names the
  member name/handle axis (found by the sibling grep; it was stale the same way).

Both placeholders are single catalog keys shared by the desktop and mobile feed
surfaces (`Tasks.tsx` / `DefaultTasks.tsx`, `Praxes.tsx` / `MobilePraxisFeed.tsx`),
so each edit lands on both. No string is hardcoded in a component.

## Verification

`tsc --noEmit` clean for the touched files (the only errors printed are
pre-existing `Cannot find module 'node:fs'` in test files, unrelated and
untouched here), `vite build` green, `eslint` clean on both api clients, and the
locale catalog guard test passes (28/28) — no duplicate-key trip.

Visual QA is outstanding: I can't screenshot, so the rendered placeholder width
in the search boxes hasn't been eyeballed.

## Also noticed, not changed (out of scope)

`backend/tests/integration/test_tasks.py:1544` has a section header reading
"`q` ilikes over title AND description" — also stale post-#711, but it's a
backend test comment and outside this PR's frontend scope.

## What to eyeball

- Task feed search box placeholder: "Search tasks or players..."
- Praxis feed search box placeholder: "Search proof, task, or player…"
- Both on desktop and mobile, and that neither string truncates in the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
