### PR TITLE
Promote useTheme to a shared ThemeProvider

### DIFF
--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
 
 export type Theme = 'light' | 'dark'
 
@@ -21,11 +21,20 @@ export function applyTheme(theme: Theme): void {
   document.documentElement.setAttribute('data-theme', theme)
 }
 
+interface ThemeState {
+  theme: Theme
+  toggle: () => void
+}
+
+const ThemeContext = createContext<ThemeState | null>(null)
+
 /**
- * Theme hook (Style Guide §8).
+ * Single shared source of the current theme (Style Guide §8). Mount once at
+ * the app root — every `useTheme()` call reads the same state, so toggling
+ * anywhere updates all consumers without a remount.
  * Persists to localStorage key 'wz-theme', defaults to system preference.
  */
-export function useTheme() {
+export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(getInitialTheme)
 
   useEffect(() => {
@@ -40,5 +49,13 @@ export function useTheme() {
     })
   }, [])
 
-  return { theme, toggle } as const
+  return <ThemeContext.Provider value={{ theme, toggle }}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme(): ThemeState {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider } from 'react-i18next'
 import App from './App'
 import { AuthProvider } from './auth/AuthContext'
 import { AdminModeProvider } from './auth/AdminModeContext'
+import { ThemeProvider } from './hooks/useTheme'
 import i18n from './i18n'
 import './index.css'
 
@@ -12,11 +13,13 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <I18nextProvider i18n={i18n}>
       <BrowserRouter>
-        <AuthProvider>
-          <AdminModeProvider>
-            <App />
-          </AdminModeProvider>
-        </AuthProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            <AdminModeProvider>
+              <App />
+            </AdminModeProvider>
+          </AuthProvider>
+        </ThemeProvider>
       </BrowserRouter>
     </I18nextProvider>
   </React.StrictMode>,


### PR DESCRIPTION
Closes #701

## What changed

`useTheme` held its state in a per-component `useState`, so `NavBar` and `Settings` (and mobile `DefaultSettings` via its props) each kept a private copy of the current theme — toggling in one place flipped `[data-theme]` + localStorage but didn't reactively update any other `useTheme()` instance.

- Added a `ThemeProvider` (`frontend/src/hooks/useTheme.tsx`, renamed from `.ts` since it now returns JSX) holding the single `theme` state + `toggle`, mounted once at the app root in `main.tsx`.
- `useTheme()` now reads from context instead of its own `useState`, and throws if called outside a `ThemeProvider`.
- `getInitialTheme()` (localStorage `wz-theme` → system preference), `applyTheme()`, `nextTheme()`, and localStorage persistence on toggle are all preserved exactly — `applyTheme`/`nextTheme` stay exported for the existing behaviour tests.
- No changes needed in `NavBar.tsx`, `Settings.tsx`, or `DefaultSettings.tsx` — they already call `useTheme()`/receive its values as props, so only the hook's internals changed.

This unblocks #684 (light-theme "Meadow" players viz), which needs a reactive, shared theme value to dispatch the on-screen visualization live on toggle.

## Test plan

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 870 tests passed (97 files), including the existing `nextTheme`/`applyTheme` behaviour tests in `defaultSettings.test.tsx`


---
_Generated by [Claude Code](https://claude.ai/code/session_013yFXrvxLFx5WiyK6QmYWgS)_