### PR TITLE
fix(duel): branch DuelCrossLink explicitly on every DuelStatus

### DIFF
--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -417,6 +417,8 @@
     }
   },
   "duelCrossLink": {
+    "pending": "⚔ Challenge sent — waiting for {{name}} to accept.",
+    "declined": "⚔ {{name}} declined the challenge — this scores as an ordinary praxis.",
     "dueling": "⚔ Dueling {{name}}",
     "youForfeited": "You forfeited this duel.",
     "wonByDefault": "⚔ Won by default",

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -4,7 +4,11 @@
  * decision: a mechanism, not a per-faction identity statement). It inherits the
  * opponent's faction tokens so it reads native inside any archetype.
  *
- * Lifecycle states (ADR-0011, designs in #310):
+ * Lifecycle states (ADR-0011, designs in #310) — one branch per DuelStatus, no
+ * fallthrough (#717: pending/declined used to render a live settled tally):
+ *  - pending  (challenge sent, unanswered): "waiting to accept" — casting isn't
+ *              gated on accept, so a praxis can exist here. No tally.
+ *  - declined (opponent said no): scores as an ordinary praxis — no multiplier.
  *  - active   (accepted, pre-settle): a "⚔ Dueling [opponent]" marker only — no
  *              tally (voting isn't open; the opponent may be unsubmitted).
  *  - settled  (both submitted): live points-from-votes tally on both sides, who's
@@ -87,6 +91,26 @@ export default function DuelCrossLink({
 
   const forfeited = duel.forfeited_by_character_id != null;
 
+  // pending: the challenge is out but unanswered. Casting isn't gated on accept,
+  // so this praxis can exist before the opponent responds — no tally yet.
+  if (duel.status === "pending" && !forfeited) {
+    return (
+      <div style={wrapper}>
+        <span>{t("duelCrossLink.pending", { name: foe.display_name })}</span>
+      </div>
+    );
+  }
+
+  // declined: no duel happened. praxis_scoring only picks up active/settled
+  // duels, so this praxis takes no duel multiplier — say so plainly.
+  if (duel.status === "declined" && !forfeited) {
+    return (
+      <div style={wrapper}>
+        <span>{t("duelCrossLink.declined", { name: foe.display_name })}</span>
+      </div>
+    );
+  }
+
   // active: marker only.
   if (duel.status === "active" && !forfeited) {
     return (
@@ -125,7 +149,9 @@ export default function DuelCrossLink({
     );
   }
 
-  // settled: live tally + cross-link.
+  // settled: live tally + cross-link. ponytail: the other three DuelStatus arms
+  // returned above, so this is settled-only without a switch/exhaustiveness check.
+  // A fifth status would land here — #718 rewrites this component wholesale.
   const diff = me.points_from_votes - foe.points_from_votes;
   const standing =
     diff === 0

--- a/frontend/src/pages/praxisDetail/__tests__/DuelCrossLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/DuelCrossLink.test.tsx
@@ -1,6 +1,10 @@
 /**
  * DuelCrossLink lifecycle guard (#313): active shows a marker only; settled
  * shows the live tally + cross-link; forfeited shows won-by-default / you-forfeited.
+ *
+ * #717 regression: pending and declined used to fall through to the settled
+ * renderer, showing a live tally against someone who hadn't accepted or said no.
+ * One case per DuelStatus below — the tally must appear for settled only.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
@@ -55,7 +59,38 @@ function text(d: DuelDetailOut): string {
   return html.replace(/<[^>]*>/g, "");
 }
 
+// What the backend actually returns pre-accept (services/duel.py:107-118): the
+// opponent's identity is real, but they have no praxis and no points yet.
+const UNANSWERED_FOE: DuelSideOut = {
+  ...FOE,
+  praxis_id: null,
+  points_from_votes: 0,
+  is_submitted: false,
+};
+
 describe("DuelCrossLink", () => {
+  it("pending: says the challenge is unanswered, with no tally (#717)", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <DuelCrossLink
+          praxis={PRAXIS}
+          duel={duel({ status: "pending", opponent: UNANSWERED_FOE })}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).not.toMatch(/href="\/praxes\//); // nothing to cross-link to
+    const t = html.replace(/<[^>]*>/g, "");
+    expect(t).toMatch(/waiting for Bob to accept/i);
+    expect(t).not.toMatch(/ahead|behind|tied|live/i);
+  });
+
+  it("declined: says it scores as an ordinary praxis, with no tally (#717)", () => {
+    const t = text(duel({ status: "declined", opponent: UNANSWERED_FOE }));
+    expect(t).toMatch(/Bob declined/i);
+    expect(t).toMatch(/ordinary praxis/i);
+    expect(t).not.toMatch(/ahead|behind|tied|live/i);
+  });
+
   it("active: shows a marker only, no tally", () => {
     const t = text(duel({ status: "active" }));
     expect(t).toMatch(/Dueling Bob/);


### PR DESCRIPTION
A `pending` duel (challenge sent, not yet accepted) or a `declined` one rendered the **settled** UI — a live head-to-head vote tally against someone who hadn't accepted, or who said no.

`DuelCrossLink` branched on only two conditions (`status === "active" && !forfeited`, then `forfeited`) and let everything else fall through to the settled renderer. `DuelStatus` has four values, so two of them landed on the tally.

This is reachable today, not an edge case: `submit_praxis` has no duel gate and `maybe_settle_duel` no-ops on any status but `active`, so casting before the opponent responds is normal.

## What changed

- `frontend/src/pages/praxisDetail/DuelCrossLink.tsx` — explicit branch per `DuelStatus`, no fallthrough. `active` and `settled` are byte-for-byte unchanged in behaviour; the `forfeited` check keeps its existing precedence.
  - `pending` — challenge sent, waiting on the opponent to accept. No tally.
  - `declined` — the opponent declined; this scores as an ordinary praxis. That claim is true: `praxis_scoring.py:89` only picks up duels in `active`/`settled`, so a declined duel's praxis takes no duel multiplier.
- `frontend/src/locales/en/praxis.json` — two faction-neutral keys in the existing `duelCrossLink.*` block. No dynamic key resolver.
- `frontend/src/pages/praxisDetail/__tests__/DuelCrossLink.test.tsx` — one case per status. The new cases model what the backend actually returns pre-accept (`services/duel.py:107-118`): real opponent identity, `praxis_id: null`, zero points, `is_submitted: false`.

Frontend only — no backend changes.

## Verification

- `vitest` DuelCrossLink: 6/6 pass. Reverting the component to `origin/main` fails **exactly** the 2 new cases and no others, so the regression test genuinely bites.
- `vitest` locale catalog: 28/28 pass.
- `tsc --noEmit`: no errors in the touched files. (The 8 `Cannot find module 'node:fs'/'node:url'` hits are the known stale-junction false alarm from PR #675, in files this branch doesn't touch.)
- `vite build`: clean. `eslint` on both touched files: clean.
- **Visual QA is outstanding** — I can't screenshot and there's no dev stack here.

## Notes

- Marked one deliberate simplification with a `ponytail:` comment: the three early returns leave `settled` as the final arm rather than a `switch` with an exhaustiveness check. A hypothetical fifth status would land there.
- #718 rewrites this component wholesale; a trivial conflict is expected and fine.

## What to eyeball

- **The reproduction path**: challenge someone, cast your praxis before they respond, land on the praxis detail page. Should now read "Challenge sent — waiting for Bob to accept." instead of a `0 — 0 · live, tied` tally.
- Have the opponent **decline**, then reload that praxis detail page — should say it scores as an ordinary praxis.
- Confirm `active` (marker) and `settled` (tally + cross-link) look exactly as they did before.
- The copy itself — it's minimum-viable and faction-neutral; swap the wording if you want more voice.

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
