### PR TITLE
Wow duel skins: seal-confirm + rail, desktop and mobile

### DIFF
--- a/frontend/src/components/duel/DuelSealConfirm.tsx
+++ b/frontend/src/components/duel/DuelSealConfirm.tsx
@@ -30,6 +30,8 @@ import { useFormFactor } from '../../hooks/useFormFactor'
 import { factionCssVar } from '../../utils/factions'
 import { pickVariant } from '../../utils/factionDispatch'
 import { duelSides, RaceRoster, SealActions, StakesTiles, type DuelSlotTheme } from './shared'
+import WowDuelSealConfirm from './WowDuelSealConfirm'
+import WowMobileDuelSealConfirm from './WowMobileDuelSealConfirm'
 
 export interface DuelSealConfirmProps {
   duel: DuelDetailOut
@@ -127,14 +129,18 @@ export function DefaultDuelSealConfirm({
 }
 
 /**
- * Per-faction seal dialogs. Empty for now by design — every faction gets the
- * Default skin the moment #718 lands, and each bespoke skin is a purely visual
- * follow-up that can never be urgent.
+ * Per-faction seal dialogs. Every unregistered faction gets the Default skin;
+ * each bespoke skin is a purely visual follow-up that can never be urgent.
+ * Wow is first (#720) — it is the only faction with a design in hand.
  */
-export const DUEL_SEAL_BY_SLUG: Record<string, ComponentType<DuelSealConfirmProps>> = {}
+export const DUEL_SEAL_BY_SLUG: Record<string, ComponentType<DuelSealConfirmProps>> = {
+  wow: WowDuelSealConfirm,
+}
 
 /** Parallel MOBILE registry (#494 form-factor dispatch). */
-export const MOBILE_DUEL_SEAL_BY_SLUG: Record<string, ComponentType<DuelSealConfirmProps>> = {}
+export const MOBILE_DUEL_SEAL_BY_SLUG: Record<string, ComponentType<DuelSealConfirmProps>> = {
+  wow: WowMobileDuelSealConfirm,
+}
 
 /**
  * The dispatcher the composer mounts. Skinned by the TASK's faction (the

--- a/frontend/src/components/duel/WowDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowDuelSealConfirm.tsx
@@ -1,0 +1,172 @@
+/**
+ * Warriors of Whimsy DESKTOP duel seal-confirm (#720) — design panel 2b.
+ *
+ * The Default dialog's content, re-hung inside a centred `wow.exe` window:
+ * traffic-light title bar, dotted board, notepad scrap for the stakes and the
+ * roster, lo-fi pink confirm. Same beat, Wow's hand.
+ *
+ * Pure frame. `StakesTiles` computes the win/lose figures from `useGameConfig()`
+ * and the viewer's own faction (Snide's 0.0× lose falls out by construction),
+ * `RaceRoster` reads `is_submitted`, and the `pending` vs `active` copy branch is
+ * the same one the Default skin makes. Nothing here recomputes or drops any of it.
+ *
+ * The design's hardcoded `+90 / +30` and `0.5×` are deliberately absent: those
+ * are Wow's live numbers and the slot owns them. So is 2c's "can't edit while the
+ * duel runs" — during `active` the reopen is free, and #718's `reopenNote` says so.
+ *
+ * Copy is faction-neutral by decision (#718): the design's witch voice is tone
+ * reference, not strings. No new locale keys.
+ */
+import { useTranslation } from 'react-i18next'
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const TITLE_FROM = 'var(--faction-wow-title-from)'
+const TITLE_TO = 'var(--faction-wow-title-to)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const DOT = 'var(--faction-wow-dot)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const SCRIPT = 'var(--faction-wow-card-font)'
+
+function Sparkle({ size, color }: { size: number; color: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <path
+        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+export default function WowDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+}: DuelSealConfirmProps) {
+  const { t } = useTranslation('praxis')
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+
+  // Opponent tokens, same rule as the Default dialog and the rail: the foreign
+  // duelist looks foreign even inside Wow's window.
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: CARD_MUTED, bodyFont: 'var(--font-body)' }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('duelSeal.heading')}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{
+        padding: 'var(--space-lg)',
+        background: 'radial-gradient(circle, rgba(0,0,0,0.55), rgba(0,0,0,0.75))',
+      }}
+    >
+      <div
+        className="w-full max-w-[460px]"
+        style={{
+          borderRadius: 12,
+          overflow: 'hidden',
+          border: `2px solid ${WIN_BORDER}`,
+          borderLeft: `4px solid ${accent}`,
+          boxShadow: `0 14px 34px color-mix(in srgb, ${accent} 30%, transparent)`,
+          color: CARD_TEXT,
+          fontFamily: 'var(--font-body)',
+        }}
+      >
+        {/* title bar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            padding: 'var(--space-sm) var(--space-md)',
+            background: `linear-gradient(180deg, ${TITLE_FROM}, ${TITLE_TO})`,
+            borderBottom: `2px solid ${WIN_BORDER}`,
+            color: TITLE_TEXT,
+          }}
+        >
+          <Sparkle size={12} color={TITLE_TEXT} />
+          <h2 style={{ fontFamily: SCRIPT, fontSize: 'var(--text-title)', fontWeight: 700 }}>
+            {t('duelSeal.heading')}
+          </h2>
+        </div>
+
+        {/* dotted board */}
+        <div
+          style={{
+            padding: 'var(--space-lg)',
+            background: BODY_BG,
+            backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+            backgroundSize: '13px 13px',
+          }}
+        >
+          <p style={{ fontSize: 'var(--text-content)', lineHeight: 1.5 }}>
+            {duel.status === 'pending'
+              ? t('duelSeal.bodyPending', { name: foe.display_name })
+              : t('duelSeal.bodyActive', { name: foe.display_name })}
+          </p>
+
+          {/* The free-reopen half of the truth — same condition as the Default
+              skin, because it is the same fact, not a Wow flourish. */}
+          {duel.status === 'active' && !foe.is_submitted && (
+            <p
+              style={{
+                marginTop: 'var(--space-sm)',
+                fontSize: 'var(--text-sm)',
+                color: 'var(--color-success)',
+              }}
+            >
+              {t('duelSeal.reopenNote', { name: foe.display_name })}
+            </p>
+          )}
+
+          {/* notepad scrap: the two-outcome tiles and the race roster */}
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              background: NOTEPAD_BG,
+              border: `1.5px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 8,
+              padding: 'var(--space-md)',
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+
+          <div style={{ marginTop: 'var(--space-lg)' }}>
+            <SealActions onConfirm={onConfirm} onCancel={onCancel} busy={busy} theme={theme} />
+          </div>
+          {/* ponytail: SealActions keeps its shared btn-outline / btn-primary
+              pair rather than growing a Wow gradient-button skin slot. The
+              global [Cancel] … [Submit] order (#646) is worth more here than a
+              pink button, and adding a skin prop would be foundation work. */}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
@@ -1,0 +1,166 @@
+/**
+ * Warriors of Whimsy MOBILE duel seal-confirm (#720) — design panel 1b.
+ *
+ * The same content as the desktop window (2b is explicitly "the mobile sheet laid
+ * out for the wider frame"), rebuilt as a bottom sheet: full-bleed on the page
+ * background, chrome pinned to a rounded top edge, actions last so the thumb
+ * lands on them. Single-column — no grid, per SPEC-faction-ui-profile §1a.
+ *
+ * Pure frame, same as the desktop skin: `StakesTiles` and `RaceRoster` own every
+ * figure and the `pending`/`active` copy branch is the shared one. No new locale
+ * keys — per-faction voice was declined for this epic (#718).
+ */
+import { useTranslation } from 'react-i18next'
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const TITLE_FROM = 'var(--faction-wow-title-from)'
+const TITLE_TO = 'var(--faction-wow-title-to)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const DOT = 'var(--faction-wow-dot)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const CARD_MUTED = 'var(--faction-wow-card-muted)'
+const SCRIPT = 'var(--faction-wow-card-font)'
+
+/** The sheet's grab handle, standing in for the desktop window's traffic lights. */
+function SheetHandle({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'block',
+        width: 40,
+        height: 4,
+        borderRadius: 2,
+        background: color,
+        opacity: 0.5,
+        margin: '0 auto',
+      }}
+    />
+  )
+}
+
+export default function WowMobileDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+}: DuelSealConfirmProps) {
+  const { t } = useTranslation('praxis')
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: CARD_MUTED, bodyFont: 'var(--font-body)' }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('duelSeal.heading')}
+      className="fixed inset-0 z-50 flex flex-col justify-end"
+      style={{ background: 'var(--color-bg-page)' }}
+    >
+      <div
+        style={{
+          borderTop: `2px solid ${WIN_BORDER}`,
+          borderTopLeftRadius: 18,
+          borderTopRightRadius: 18,
+          overflow: 'hidden',
+          boxShadow: `0 -8px 26px color-mix(in srgb, ${accent} 24%, transparent)`,
+          color: CARD_TEXT,
+          fontFamily: 'var(--font-body)',
+        }}
+      >
+        {/* sheet header */}
+        <div
+          style={{
+            padding: 'var(--space-sm) var(--space-lg) var(--space-md)',
+            background: `linear-gradient(180deg, ${TITLE_FROM}, ${TITLE_TO})`,
+            borderBottom: `2px solid ${WIN_BORDER}`,
+            color: TITLE_TEXT,
+          }}
+        >
+          <SheetHandle color={TITLE_TEXT} />
+          <h2
+            style={{
+              marginTop: 'var(--space-sm)',
+              fontFamily: SCRIPT,
+              fontSize: 'var(--text-title)',
+              fontWeight: 700,
+              textAlign: 'center',
+            }}
+          >
+            {t('duelSeal.heading')}
+          </h2>
+        </div>
+
+        <div
+          style={{
+            padding: 'var(--space-lg)',
+            background: BODY_BG,
+            backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+            backgroundSize: '13px 13px',
+          }}
+        >
+          <p style={{ fontSize: 'var(--text-content)', lineHeight: 1.5 }}>
+            {duel.status === 'pending'
+              ? t('duelSeal.bodyPending', { name: foe.display_name })
+              : t('duelSeal.bodyActive', { name: foe.display_name })}
+          </p>
+
+          {duel.status === 'active' && !foe.is_submitted && (
+            <p
+              style={{
+                marginTop: 'var(--space-sm)',
+                fontSize: 'var(--text-sm)',
+                color: 'var(--color-success)',
+              }}
+            >
+              {t('duelSeal.reopenNote', { name: foe.display_name })}
+            </p>
+          )}
+
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              background: NOTEPAD_BG,
+              border: `1.5px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 10,
+              padding: 'var(--space-md)',
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+
+          {/* ponytail: actions keep the shared SealActions pair — thumb-sized
+              styling would need a skin slot on the shared component, which is
+              foundation work, not a skin change. */}
+          <div style={{ marginTop: 'var(--space-lg)' }}>
+            <SealActions onConfirm={onConfirm} onCancel={onCancel} busy={busy} theme={theme} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Duel skin slot-invariant guard (#720), the `archetypeSlots.test.tsx` shape
+ * applied to the two duel registries.
+ *
+ * A skin owns the FRAME and may arrange the slots however its faction likes; it
+ * may never DROP one and may never recompute one. Both registries are walked
+ * (plus their Default fallback), so the faction skins that follow Wow fail here
+ * the moment one of them loses a slot.
+ *
+ * Two registries, two techniques:
+ *  - The RAIL skins receive their slots as already-rendered `ReactNode` props,
+ *    so sentinel nodes prove passthrough directly — and prove, by construction,
+ *    that the skin could not have recomputed anything.
+ *  - The SEAL skins mount the real `StakesTiles` / `RaceRoster` / `SealActions`,
+ *    so the assertion is on the anchors those slots leave behind. The game
+ *    config is mocked; this is about composition, not transport.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { GameConfigOut, FactionConfigOut } from '../../../api/gameConfig'
+import type { DuelDetailOut, DuelSideOut } from '../../../api/duel'
+
+function faction(slug: string, win: number, lose: number): FactionConfigOut {
+  return {
+    slug,
+    can_always_rejoin: false,
+    own_task_modifier: 1.0,
+    other_task_modifier: 1.0,
+    collab_own_modifier: 1.0,
+    collab_other_modifier: 1.0,
+    duel_win_modifier: win,
+    duel_loss_modifier: lose,
+  }
+}
+
+const CONFIG = {
+  factions: [faction('wow', 1.5, 0.5), faction('snide', 2.0, 0.0)],
+} as unknown as GameConfigOut
+
+vi.mock('../../../hooks/useGameConfig', () => ({
+  useGameConfig: () => CONFIG,
+}))
+
+const { DefaultDuelSealConfirm, DUEL_SEAL_BY_SLUG, MOBILE_DUEL_SEAL_BY_SLUG } = await import(
+  '../DuelSealConfirm'
+)
+const { DefaultDuelRail, DUEL_RAIL_BY_SLUG, MOBILE_DUEL_RAIL_BY_SLUG } = await import(
+  '../../../pages/praxisDetail/DuelCrossLink'
+)
+
+function side(overrides: Partial<DuelSideOut>): DuelSideOut {
+  return {
+    character_id: 1,
+    praxis_id: 10,
+    display_name: 'Ada',
+    faction_slug: 'wow',
+    avatar_url: null,
+    is_submitted: false,
+    points_from_votes: 0,
+    ...overrides,
+  } as DuelSideOut
+}
+
+const DUEL = {
+  id: 5,
+  status: 'active',
+  forfeited_by_character_id: null,
+  challenger: side({ character_id: 1, display_name: 'Ada', faction_slug: 'wow' }),
+  opponent: side({ character_id: 2, praxis_id: 11, display_name: 'Rax', faction_slug: 'snide' }),
+} as unknown as DuelDetailOut
+
+describe('duel seal skins render every slot', () => {
+  const skins = [
+    ['default', DefaultDuelSealConfirm],
+    ...Object.entries(DUEL_SEAL_BY_SLUG),
+    ...Object.entries(MOBILE_DUEL_SEAL_BY_SLUG).map(([slug, skin]) => [`${slug} (mobile)`, skin]),
+  ] as const
+
+  it.each(skins)('%s keeps stakes, roster and actions', (_name, Skin) => {
+    const html = renderToStaticMarkup(
+      <Skin
+        duel={DUEL}
+        viewerCharacterId={1}
+        taskPointValue={60}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    const text = html.replace(/<[^>]*>/g, ' ')
+    // StakesTiles: the wow win figure (60 × 1.5) and the lose figure (60 × 0.5).
+    expect(text).toContain('90')
+    expect(text).toContain('30')
+    // RaceRoster: the opponent's row.
+    expect(text).toContain('Rax')
+    // SealActions: two buttons, cancel then confirm.
+    expect(html.match(/<button/g) ?? []).toHaveLength(2)
+    // The dialog contract the composer relies on.
+    expect(html).toContain('role="dialog"')
+  })
+})
+
+describe('duel rail skins render every slot', () => {
+  const skins = [
+    ['default', DefaultDuelRail],
+    ...Object.entries(DUEL_RAIL_BY_SLUG),
+    ...Object.entries(MOBILE_DUEL_RAIL_BY_SLUG).map(([slug, skin]) => [`${slug} (mobile)`, skin]),
+  ] as const
+
+  it.each(skins)('%s passes headline, tally, note and body through', (_name, Skin) => {
+    const html = renderToStaticMarkup(
+      <Skin
+        accent="var(--faction-snide)"
+        soft="var(--faction-snide-light)"
+        maxWidth="42rem"
+        headline={<span>SLOT_HEADLINE</span>}
+        tally={<span>SLOT_TALLY</span>}
+        note={<span>SLOT_NOTE</span>}
+        body={<span>SLOT_BODY</span>}
+      />,
+    )
+    expect(html).toContain('SLOT_HEADLINE')
+    expect(html).toContain('SLOT_TALLY')
+    expect(html).toContain('SLOT_NOTE')
+    expect(html).toContain('SLOT_BODY')
+  })
+
+  // declined / forfeited legitimately arrive with no race left; a skin must not
+  // crash or invent one.
+  it.each(skins)('%s survives the empty-body states', (_name, Skin) => {
+    const html = renderToStaticMarkup(
+      <Skin
+        accent="var(--faction-snide)"
+        soft="var(--faction-snide-light)"
+        maxWidth="42rem"
+        headline={<span>SLOT_HEADLINE</span>}
+        tally={null}
+        note={null}
+        body={null}
+      />,
+    )
+    expect(html).toContain('SLOT_HEADLINE')
+  })
+})

--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -18,8 +18,13 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
+import type { ComponentType } from 'react'
 import type { GameConfigOut, FactionConfigOut } from '../../../api/gameConfig'
 import type { DuelDetailOut, DuelSideOut } from '../../../api/duel'
+// Type-only, so these are erased before the vi.mock hoist and can't defeat the
+// dynamic imports below.
+import type { DuelSealConfirmProps } from '../DuelSealConfirm'
+import type { DuelRailSkinProps } from '../../../pages/praxisDetail/DuelCrossLink'
 
 function faction(slug: string, win: number, lose: number): FactionConfigOut {
   return {
@@ -71,11 +76,16 @@ const DUEL = {
 } as unknown as DuelDetailOut
 
 describe('duel seal skins render every slot', () => {
-  const skins = [
+  // Annotated as a tuple array rather than `as const`: the spreads widen to
+  // (string | ComponentType)[] otherwise, and it.each then can't match the
+  // two-arg callback signature.
+  const skins: [string, ComponentType<DuelSealConfirmProps>][] = [
     ['default', DefaultDuelSealConfirm],
     ...Object.entries(DUEL_SEAL_BY_SLUG),
-    ...Object.entries(MOBILE_DUEL_SEAL_BY_SLUG).map(([slug, skin]) => [`${slug} (mobile)`, skin]),
-  ] as const
+    ...Object.entries(MOBILE_DUEL_SEAL_BY_SLUG).map(
+      ([slug, skin]) => [`${slug} (mobile)`, skin] as [string, ComponentType<DuelSealConfirmProps>],
+    ),
+  ]
 
   it.each(skins)('%s keeps stakes, roster and actions', (_name, Skin) => {
     const html = renderToStaticMarkup(
@@ -101,11 +111,13 @@ describe('duel seal skins render every slot', () => {
 })
 
 describe('duel rail skins render every slot', () => {
-  const skins = [
+  const skins: [string, ComponentType<DuelRailSkinProps>][] = [
     ['default', DefaultDuelRail],
     ...Object.entries(DUEL_RAIL_BY_SLUG),
-    ...Object.entries(MOBILE_DUEL_RAIL_BY_SLUG).map(([slug, skin]) => [`${slug} (mobile)`, skin]),
-  ] as const
+    ...Object.entries(MOBILE_DUEL_RAIL_BY_SLUG).map(
+      ([slug, skin]) => [`${slug} (mobile)`, skin] as [string, ComponentType<DuelRailSkinProps>],
+    ),
+  ]
 
   it.each(skins)('%s passes headline, tally, note and body through', (_name, Skin) => {
     const html = renderToStaticMarkup(

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -28,10 +28,12 @@
  *              winner / "you forfeited" for the thrower; the thrown-side link
  *              404s gracefully (it's a plain link, so it never breaks this page).
  */
-import type { CSSProperties } from "react";
+import type { CSSProperties, ComponentType, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { factionCssVar, factionName } from "../../utils/factions";
+import { pickVariant } from "../../utils/factionDispatch";
+import { useFormFactor } from "../../hooks/useFormFactor";
 import { mediaUrl } from "../../utils/media";
 import type { PraxisOut } from "../../api/praxis";
 import type { DuelDetailOut, DuelSideOut } from "../../api/duel";
@@ -41,6 +43,8 @@ import {
   StakesTiles,
   type DuelSlotTheme,
 } from "../../components/duel/shared";
+import WowDuelRail from "./duelRails/WowDuelRail";
+import WowMobileDuelRail from "./duelRails/WowMobileDuelRail";
 
 /**
  * The rail is mounted by the dispatcher, above the archetype, so it can't read
@@ -54,6 +58,92 @@ const RAIL_WIDTH_BY_SLUG: Record<string, string> = {
   wow: "720px", // WowPraxisDetail
 };
 const DEFAULT_RAIL_WIDTH = "42rem";
+
+/* -------------------------------------------------------------------------- */
+/* Skin contract (#720)                                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * What a rail SKIN receives. Every branch — forfeited-pre-empts-status, the
+ * per-`DuelStatus` table, and the slot composition inside `body` — is resolved
+ * by the dispatcher below and handed over as already-rendered nodes. A skin
+ * therefore *cannot* recompute a figure or re-derive a status; it can only
+ * arrange these four slots inside its own chrome. It must never drop one.
+ *
+ * `accent`/`soft` are the OPPONENT's faction tokens (the foreign element looks
+ * foreign, per #310) and are handed down pre-resolved so a skin never re-reads
+ * the faction registry either.
+ */
+export interface DuelRailSkinProps {
+  /** Opponent-faction accent, pre-resolved to a CSS var reference. */
+  accent: string;
+  /** Opponent-faction soft/light wash, pre-resolved. */
+  soft: string;
+  /** The archetype-matched rail width for the TASK's faction. */
+  maxWidth: string;
+  /** The state headline — one line per branch. Always present. */
+  headline: ReactNode;
+  /** Settled-only live score pair. `null` in every other state. */
+  tally: ReactNode | null;
+  /** Settled-only "who's ahead" note. `null` in every other state. */
+  note: ReactNode | null;
+  /** Roster + next-step + stakes. `null` for declined and forfeited, which have no race left. */
+  body: ReactNode | null;
+}
+
+/** The plain rail: a soft wash with an accent edge, the shape #313 shipped. */
+export function DefaultDuelRail({
+  accent,
+  soft,
+  maxWidth,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const wrapper: CSSProperties = {
+    maxWidth,
+    margin: "16px 0",
+    padding: "12px 16px",
+    borderLeft: `3px solid ${accent}`,
+    background: soft,
+    fontFamily: "var(--font-body)",
+    fontSize: "var(--text-sm)",
+    color: "var(--color-text)",
+  };
+  return (
+    <div style={wrapper}>
+      {tally ? (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
+          {headline}
+          {tally}
+        </div>
+      ) : (
+        headline
+      )}
+      {note}
+      {body}
+    </div>
+  );
+}
+
+/** Per-faction rail skins (#720 registers Wow; one issue per faction after). */
+export const DUEL_RAIL_BY_SLUG: Record<string, ComponentType<DuelRailSkinProps>> = {
+  wow: WowDuelRail,
+};
+
+/** Parallel MOBILE registry (#494 form-factor dispatch). */
+export const MOBILE_DUEL_RAIL_BY_SLUG: Record<string, ComponentType<DuelRailSkinProps>> = {
+  wow: WowMobileDuelRail,
+};
 
 function OpponentBadge({ side }: { side: DuelSideOut }) {
   const { t } = useTranslation("praxis");
@@ -108,16 +198,27 @@ export default function DuelCrossLink({
   const accent = factionCssVar(foe.faction_slug);
   const soft = factionCssVar(foe.faction_slug, "light");
 
-  const wrapper: CSSProperties = {
+  // The skin is chosen by the TASK's faction (like the archetype it sits above);
+  // only the tokens above are the opponent's.
+  const formFactor = useFormFactor();
+  const Skin =
+    formFactor === "mobile"
+      ? pickVariant(
+          MOBILE_DUEL_RAIL_BY_SLUG,
+          praxis.task_faction_slug,
+          DefaultDuelRail,
+        )
+      : pickVariant(
+          DUEL_RAIL_BY_SLUG,
+          praxis.task_faction_slug,
+          DefaultDuelRail,
+        );
+
+  const frame = {
+    accent,
+    soft,
     maxWidth:
       RAIL_WIDTH_BY_SLUG[praxis.task_faction_slug ?? ""] ?? DEFAULT_RAIL_WIDTH,
-    margin: "16px 0",
-    padding: "12px 16px",
-    borderLeft: `3px solid ${accent}`,
-    background: soft,
-    fontFamily: "var(--font-body)",
-    fontSize: "var(--text-sm)",
-    color: "var(--color-text)",
   };
 
   const theme: DuelSlotTheme = { accent };
@@ -147,27 +248,33 @@ export default function DuelCrossLink({
   if (forfeited) {
     const iForfeited = duel.forfeited_by_character_id === me.character_id;
     return (
-      <div style={wrapper}>
-        {iForfeited ? (
-          <span>{t("duelCrossLink.youForfeited")}</span>
-        ) : (
-          <span>
-            <strong>{t("duelCrossLink.wonByDefault")}</strong>
-            {t("duelCrossLink.wonByDefaultSuffix", { name: foe.display_name })}
-            {foe.praxis_id != null && (
-              <>
-                {" "}
-                (
-                <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
-                  {t("duelCrossLink.theirEntry")}
-                </Link>
-                )
-              </>
-            )}
-            .
-          </span>
-        )}
-      </div>
+      <Skin
+        {...frame}
+        tally={null}
+        note={null}
+        body={null}
+        headline={
+          iForfeited ? (
+            <span>{t("duelCrossLink.youForfeited")}</span>
+          ) : (
+            <span>
+              <strong>{t("duelCrossLink.wonByDefault")}</strong>
+              {t("duelCrossLink.wonByDefaultSuffix", { name: foe.display_name })}
+              {foe.praxis_id != null && (
+                <>
+                  {" "}
+                  (
+                  <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
+                    {t("duelCrossLink.theirEntry")}
+                  </Link>
+                  )
+                </>
+              )}
+              .
+            </span>
+          )
+        }
+      />
     );
   }
 
@@ -176,10 +283,15 @@ export default function DuelCrossLink({
   // StakesTiles swaps its win/lose pair for the solo-fallback line.
   if (duel.status === "pending") {
     return (
-      <div style={wrapper}>
-        <span>{t("duelCrossLink.pending", { name: foe.display_name })}</span>
-        {body(true)}
-      </div>
+      <Skin
+        {...frame}
+        tally={null}
+        note={null}
+        headline={
+          <span>{t("duelCrossLink.pending", { name: foe.display_name })}</span>
+        }
+        body={body(true)}
+      />
     );
   }
 
@@ -188,9 +300,15 @@ export default function DuelCrossLink({
   // No roster, no stakes: there is nothing left to race for or win.
   if (duel.status === "declined") {
     return (
-      <div style={wrapper}>
-        <span>{t("duelCrossLink.declined", { name: foe.display_name })}</span>
-      </div>
+      <Skin
+        {...frame}
+        tally={null}
+        note={null}
+        body={null}
+        headline={
+          <span>{t("duelCrossLink.declined", { name: foe.display_name })}</span>
+        }
+      />
     );
   }
 
@@ -198,10 +316,17 @@ export default function DuelCrossLink({
   // voting isn't open and at most one side has cast.
   if (duel.status === "active") {
     return (
-      <div style={wrapper}>
-        <span style={{ fontWeight: 700 }}>{t("duelCrossLink.dueling", { name: foe.display_name })}</span>
-        {body(true)}
-      </div>
+      <Skin
+        {...frame}
+        tally={null}
+        note={null}
+        headline={
+          <span style={{ fontWeight: 700 }}>
+            {t("duelCrossLink.dueling", { name: foe.display_name })}
+          </span>
+        }
+        body={body(true)}
+      />
     );
   }
 
@@ -214,18 +339,12 @@ export default function DuelCrossLink({
       ? t("duelCrossLink.standing.ahead")
       : t("duelCrossLink.standing.behind");
   return (
-    <div style={wrapper}>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          gap: 12,
-          flexWrap: "wrap",
-        }}
-      >
+    <Skin
+      {...frame}
+      headline={
         <span>
-          <span style={{ fontWeight: 700 }}>{t("duelCrossLink.duel")}</span> {t("duelCrossLink.vs")}{" "}
+          <span style={{ fontWeight: 700 }}>{t("duelCrossLink.duel")}</span>{" "}
+          {t("duelCrossLink.vs")}{" "}
           {foe.praxis_id != null ? (
             <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
               <OpponentBadge side={foe} />
@@ -234,16 +353,20 @@ export default function DuelCrossLink({
             <OpponentBadge side={foe} />
           )}
         </span>
+      }
+      tally={
         <span style={{ whiteSpace: "nowrap" }}>
           <strong>{me.points_from_votes}</strong>
           <span style={{ opacity: 0.6 }}> — </span>
           <strong>{foe.points_from_votes}</strong>
         </span>
-      </div>
-      <div style={{ marginTop: 4, fontSize: "var(--text-xs)", opacity: 0.85 }}>
-        {t("duelCrossLink.live", { standing })}
-      </div>
-      {body(false)}
-    </div>
+      }
+      note={
+        <div style={{ marginTop: 4, fontSize: "var(--text-xs)", opacity: 0.85 }}>
+          {t("duelCrossLink.live", { standing })}
+        </div>
+      }
+      body={body(false)}
+    />
   );
 }

--- a/frontend/src/pages/praxisDetail/duelRails/WowDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/WowDuelRail.tsx
@@ -1,0 +1,126 @@
+/**
+ * Warriors of Whimsy DESKTOP duel rail (#720) — the duel context as a second
+ * `wow.exe` window docked above the praxis, matching the design's panels 2b/2c.
+ *
+ * Pure frame. Every slot arrives pre-rendered from `DuelCrossLink`: the
+ * per-`DuelStatus` branch table, the cast roster, the next-step line and the
+ * stakes arithmetic all live in `components/duel/shared.tsx` and the dispatcher
+ * above it. This file decides only where the pink goes.
+ *
+ * Two things the design got wrong and are deliberately NOT reproduced (#718
+ * settled both): 2c's "sealed — can't edit while the duel runs" forfeit framing
+ * (that panel is `status === 'active'`, where unsubmitting is a free neutral
+ * reopen — forfeit only begins at `settled`), and 2c's two-pane workspace (the
+ * rail keeps its existing mount above the archetype; no praxis-detail surface
+ * has a two-column layout and mobile forbids one outright).
+ *
+ * Tokens are the `--faction-wow-*` set WowEditPraxis / WowPraxisDetail already
+ * use — no new variables. `accent`/`soft` still arrive from the OPPONENT's
+ * faction and are spent on the edge that faces them, so a foreign duelist keeps
+ * tinting the window even inside Wow chrome.
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const TITLE_FROM = 'var(--faction-wow-title-from)'
+const TITLE_TO = 'var(--faction-wow-title-to)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const DOT = 'var(--faction-wow-dot)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const SCRIPT = 'var(--faction-wow-card-font)'
+
+/** The kit's four-point sparkle, the window-title ornament on every Wow surface. */
+function Sparkle({ size, color }: { size: number; color: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <path
+        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+export default function WowDuelRail({
+  accent,
+  maxWidth,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const shell: CSSProperties = {
+    maxWidth,
+    margin: 'var(--space-lg) 0',
+    borderRadius: 12,
+    overflow: 'hidden',
+    // The opponent's colour rides the left edge; the rest of the window is Wow's.
+    border: `2px solid ${WIN_BORDER}`,
+    borderLeft: `4px solid ${accent}`,
+    boxShadow: `0 10px 24px color-mix(in srgb, ${accent} 20%, transparent)`,
+    fontFamily: 'var(--font-body)',
+    fontSize: 'var(--text-sm)',
+    color: CARD_TEXT,
+  }
+
+  return (
+    <div style={shell}>
+      {/* title bar — headline left, live tally right, exactly the .exe chrome
+          WowEditPraxis and WowPraxisDetail already wear */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-sm) var(--space-md)',
+          background: `linear-gradient(180deg, ${TITLE_FROM}, ${TITLE_TO})`,
+          borderBottom: `2px solid ${WIN_BORDER}`,
+          color: TITLE_TEXT,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Sparkle size={12} color={TITLE_TEXT} />
+        <span style={{ fontFamily: SCRIPT, fontSize: 'var(--text-content)', fontWeight: 700 }}>
+          {headline}
+        </span>
+        {tally && <span style={{ marginLeft: 'auto', fontWeight: 700 }}>{tally}</span>}
+      </div>
+
+      {/* dotted board holding the notepad scrap */}
+      <div
+        style={{
+          padding: 'var(--space-md)',
+          background: BODY_BG,
+          backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+          backgroundSize: '13px 13px',
+        }}
+      >
+        {note}
+        {body && (
+          <div
+            style={{
+              marginTop: note ? 'var(--space-sm)' : 0,
+              background: NOTEPAD_BG,
+              border: `1.5px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 8,
+              padding: 'var(--space-md)',
+            }}
+          >
+            {body}
+          </div>
+        )}
+        {/* ponytail: `declined` and `forfeited` arrive with body === null, so the
+            board renders as a bare dotted strip under the title bar. That is the
+            correct empty state — there is no race left — and it costs no branch
+            here, so no bespoke "duel is over" ornament is drawn for it.
+            ponytail: the design's soft `background: soft` wash is dropped; Wow's
+            own BODY_BG already reads as a tinted surface and layering the
+            opponent's wash under the dot grid muddied both. */}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/duelRails/WowMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/WowMobileDuelRail.tsx
@@ -1,0 +1,132 @@
+/**
+ * Warriors of Whimsy MOBILE duel rail (#720) — panel 1c of the design.
+ *
+ * The desktop window, thumbed down: the title bar loses its side-by-side tally
+ * (a score pair and a script headline on one phone-width row wrap into mush) and
+ * the tally drops to its own line above the notepad, where it reads as the
+ * scoreboard it is. Single-column throughout — SPEC-faction-ui-profile §1a
+ * forbids a fixed-px grid on the mobile path, and this surface has no need of one.
+ *
+ * Pure frame, same contract as the desktop skin: every slot arrives already
+ * rendered from `DuelCrossLink`, and none of the duel's arithmetic or status
+ * branching is visible from here.
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const WIN_BORDER = 'var(--faction-wow-win-border)'
+const TITLE_FROM = 'var(--faction-wow-title-from)'
+const TITLE_TO = 'var(--faction-wow-title-to)'
+const TITLE_TEXT = 'var(--faction-wow-title-text)'
+const BODY_BG = 'var(--faction-wow-body-bg)'
+const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
+const DOT = 'var(--faction-wow-dot)'
+const CARD_TEXT = 'var(--faction-wow-card-text)'
+const SCRIPT = 'var(--faction-wow-card-font)'
+
+/** The phone window's three traffic lights — smaller than the desktop set. */
+function TitleDots() {
+  const colors = [
+    'var(--faction-wow-scrap-deep)',
+    'var(--faction-wow-tape)',
+    'var(--faction-wow-ivy-leaf)',
+  ]
+  return (
+    <span style={{ display: 'flex', gap: 'var(--space-xs)' }} aria-hidden>
+      {colors.map((color) => (
+        <span
+          key={color}
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: color,
+            border: '1.2px solid rgba(255,255,255,0.7)',
+          }}
+        />
+      ))}
+    </span>
+  )
+}
+
+export default function WowMobileDuelRail({
+  accent,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  // ponytail: `maxWidth` is intentionally ignored on mobile. The rail is
+  // full-bleed inside the phone column, so the desktop archetype-width map has
+  // nothing to line up with here.
+  const shell: CSSProperties = {
+    margin: 'var(--space-md) 0',
+    borderRadius: 16,
+    overflow: 'hidden',
+    border: `2px solid ${WIN_BORDER}`,
+    borderLeft: `4px solid ${accent}`,
+    boxShadow: `0 8px 22px color-mix(in srgb, ${accent} 20%, transparent)`,
+    fontFamily: 'var(--font-body)',
+    fontSize: 'var(--text-sm)',
+    color: CARD_TEXT,
+  }
+
+  return (
+    <div style={shell}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-sm) var(--space-md)',
+          background: `linear-gradient(180deg, ${TITLE_FROM}, ${TITLE_TO})`,
+          borderBottom: `2px solid ${WIN_BORDER}`,
+          color: TITLE_TEXT,
+        }}
+      >
+        <TitleDots />
+        <span style={{ fontFamily: SCRIPT, fontSize: 'var(--text-content)', fontWeight: 700 }}>
+          {headline}
+        </span>
+      </div>
+
+      <div
+        style={{
+          padding: 'var(--space-md)',
+          background: BODY_BG,
+          backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
+          backgroundSize: '13px 13px',
+        }}
+      >
+        {tally && (
+          <div
+            style={{
+              fontFamily: SCRIPT,
+              fontSize: 'var(--text-title)',
+              fontWeight: 700,
+              textAlign: 'center',
+              marginBottom: 'var(--space-xs)',
+            }}
+          >
+            {tally}
+          </div>
+        )}
+        {note}
+        {body && (
+          <div
+            style={{
+              marginTop: 'var(--space-sm)',
+              background: NOTEPAD_BG,
+              border: `1.5px solid ${NOTEPAD_BORDER}`,
+              borderRadius: 10,
+              padding: 'var(--space-md)',
+            }}
+          >
+            {body}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Wow skins for the duel seal-confirm and the duel rail, desktop + mobile. Purely visual on top of #718 (PR #740) — every figure and every branch stays in `components/duel/shared.tsx` and the rail dispatcher.

**The design URL was not reachable from this environment**, so this is built from the issue's written spec plus the panel descriptions (1b / 2b / 1c / 2c) and Wow's existing `--faction-wow-*` chrome vocabulary in `WowEditPraxis` / `WowPraxisDetail`. No new CSS variables, no new locale keys.

## What landed

**a. The rail became skinnable.** #718 shipped `DuelCrossLink` with no registries, so the issue's "register in the rail's two registries" had nothing to register into. Rather than have a Wow rail re-walk the per-`DuelStatus` table, the frame is now a contract:

```ts
export interface DuelRailSkinProps {
  accent: string; soft: string; maxWidth: string
  headline: ReactNode; tally: ReactNode | null; note: ReactNode | null; body: ReactNode | null
}
```

The dispatcher resolves forfeited-pre-empts-status, the status table, the opponent tokens and the slot composition, then hands the skin **already-rendered nodes**. A skin therefore *structurally cannot* recompute a figure or re-derive a status — it can only arrange four slots. `DefaultDuelRail` composes them exactly as the old markup did; `DUEL_RAIL_BY_SLUG` / `MOBILE_DUEL_RAIL_BY_SLUG` dispatch on the TASK's faction via `pickVariant`, like the archetype it sits above.

**b. Four Wow skins**, all pure frame:
- `duelRails/WowDuelRail.tsx` — the duel context as a second `wow.exe` window: traffic-light title bar carrying the headline in `--faction-wow-card-font`, live tally right, dotted board holding a notepad scrap.
- `duelRails/WowMobileDuelRail.tsx` — same window thumbed down; the tally drops out of the title bar onto its own centred line (a script headline and a score pair on one phone row wrap into mush). Single-column, no grid.
- `WowDuelSealConfirm.tsx` — panel 2b, centred `.exe` window, two-outcome tiles + roster in the notepad scrap.
- `WowMobileDuelSealConfirm.tsx` — panel 1b, bottom sheet with a grab handle, actions last for the thumb.

**c. `duelSkinSlots.test.tsx`** — the `archetypeSlots.test.tsx` shape for both registries. Rail skins get sentinel nodes (passthrough proven directly); seal skins mount the real slots and are asserted on their anchors, including the empty-body `declined`/`forfeited` case.

## What I deliberately did NOT take from the design

Per the issue, all three already corrected by #718: 2c's forfeit rail and "can't edit while the duel runs" (2c is `status === 'active'`, where the reopen is free — `duelSeal.reopenNote` renders there unchanged), the hardcoded `+90 / +30` and `0.5x` (live from `useGameConfig()`), and 2c's two-pane workspace (the rail keeps its existing mount above the archetype).

## Decisions

- **Building the rail seam rather than stopping.** It's an additive gap, not a contradiction, and the seal file two directories over already showed the exact pattern to copy. Flagging it as the one place I went beyond "compose existing slots".
- **`SealActions` keeps its shared `btn-outline` / `btn-primary` pair** in both Wow dialogs. A pink gradient button would need a skin slot on the shared component — foundation work, not a skin change — and the global `[Cancel] … [Submit]` order (#646) is worth more than the button. Marked `ponytail:`.
- **Mobile rail ignores `maxWidth`** — full-bleed in the phone column, nothing to line up with. Marked `ponytail:`.
- **The opponent's accent rides the left border** on all four skins, so a foreign duelist still tints the surface from inside Wow chrome.

## Verification

`tsc --noEmit` clean · `vite build` clean · `eslint --max-warnings=0` clean · **901 tests pass (101 files)**, 9 of them new. The four new files are not grandfathered against `no-raw-style-values` and use `--space-*` / `--text-*` throughout.

**Visual QA is outstanding** — no dev stack and no screenshot capability here, so nothing in this PR has been seen rendered. Everything above is types, lint and tests only.

## What to eyeball

- **Wow rail width vs. the archetype under it.** Wow's praxis-detail archetype is `maxWidth: 720` (`WowPraxisDetail.tsx:152`) and `RAIL_WIDTH_BY_SLUG` already carries a `wow: "720px"` row from #718 — worth confirming the two edges actually line up now that the rail wears a bordered window instead of a left-edge wash.
- The **Wow rail on a live `active` duel**: does a second pink window above the praxis window read as context, or as a duplicate?
- The **`declined` / `forfeited`** rail — `body` is null, so the dotted board renders as a bare strip under the title bar. Intended, but check it doesn't look broken.
- The **seal dialog**: desktop centred window vs. mobile bottom sheet, and the opponent-faction border on both.
- **A Snide opponent** against a Wow task — green accent inside pink chrome is the loudest tint combination this ships.
- **Dark mode** on all four surfaces (`[data-theme="dark"]` repoints the whole `--faction-wow-*` set; nothing here branches on theme).
- The **Default rail is unchanged by intent** — it should look byte-identical to before this PR.

Closes #720
