### PR TITLE
fix(factions): isKnownFaction excludes na so unaffiliated keeps the spectrum

### DIFF
--- a/frontend/src/utils/__tests__/isKnownFaction.test.ts
+++ b/frontend/src/utils/__tests__/isKnownFaction.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { factionCssVar, isKnownFaction } from "../factions";
+
+/**
+ * Pins the predicate that decides whether a surface paints a faction hue or
+ * reaches for the unaffiliated spectrum (ADR-0039).
+ *
+ * This regressed silently for a whole issue cycle: #418 added `na: "default"`
+ * to CSS_KEY, and the predicate tested key *presence*, so `na` started
+ * reporting as a real faction and every ornament went grey (#749). Nothing
+ * failed — the bug is a wrong colour, which no type or build check can see.
+ * These assertions are the guard.
+ */
+describe("isKnownFaction", () => {
+  it("returns false for `na` — unaffiliated is a state, not a faction", () => {
+    expect(isKnownFaction("na")).toBe(false);
+  });
+
+  it("returns false for null and undefined", () => {
+    expect(isKnownFaction(null)).toBe(false);
+    expect(isKnownFaction(undefined)).toBe(false);
+    expect(isKnownFaction("")).toBe(false);
+  });
+
+  it("returns true for a real faction slug", () => {
+    expect(isKnownFaction("snide")).toBe(true);
+  });
+
+  it("returns true for every registered faction", () => {
+    for (const slug of [
+      "ua",
+      "everymen",
+      "wow",
+      "snide",
+      "ephemerists",
+      "singularity",
+      "albescent",
+    ]) {
+      expect(isKnownFaction(slug), `${slug} should be known`).toBe(true);
+    }
+  });
+
+  it("returns false for an unregistered slug", () => {
+    expect(isKnownFaction("bogus")).toBe(false);
+  });
+
+  /**
+   * The consequence the four ornament call sites depend on: anything the
+   * predicate calls unknown resolves to the neutral `default` scalar, so those
+   * surfaces must supply the rainbow themselves rather than trusting
+   * factionCssVar. If this pair ever disagrees, unaffiliated goes grey again.
+   */
+  it("agrees with factionCssVar: unknown slugs resolve to the default scalar", () => {
+    for (const slug of ["na", "bogus", null, undefined]) {
+      expect(isKnownFaction(slug)).toBe(false);
+      expect(factionCssVar(slug)).toBe("var(--faction-default)");
+    }
+    expect(factionCssVar("snide")).toBe("var(--faction-snide)");
+  });
+});

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -73,8 +73,10 @@ const CSS_KEY: Record<string, string> = {
   singularity: "singularity",
   albescent: "albescent", // first-class (#232) — its own --faction-albescent-* set
   // `na` (unaffiliated) is a state, not a faction: it reads the neutral/rainbow
-  // --faction-default-* set (#418). Scalars resolve to grey here; the spectrum
-  // reaches fills only through factionFill() (ADR-0039).
+  // --faction-default-* set (#418), so factionCssVar('na') is grey, never a
+  // borrowed `ua` orange. The spectrum reaches fills through factionFill(), and
+  // ornament surfaces reach it by branching on isKnownFaction — which returns
+  // false for `na` precisely because it lands on `default` (ADR-0039, #749).
   na: "default",
 };
 
@@ -172,15 +174,22 @@ export function factionFill(
 /**
  * Is this slug a real faction with its own theme?
  *
- * Needed because factionCssVar() silently falls back to the `ua` theme for
- * anything it doesn't know — including `na` and null. Surfaces that owe the
- * unaffiliated player the spectrum rather than borrowed orange (ADR-0039) must
- * branch *before* asking for a faction variable. Aliases resolve first, so a
- * derived slug counts as known.
+ * Needed because factionCssVar() resolves anything it doesn't know — including
+ * `na` and null — to the `default` key, whose scalars are neutral grey. Surfaces
+ * that owe the unaffiliated player the spectrum (ADR-0039) must branch *before*
+ * asking for a faction variable, then reach for the rainbow themselves
+ * (`--faction-default-rainbow` / `--faction-default-ring`, or factionFill()).
+ *
+ * `na` IS a key in CSS_KEY (it maps to `default`, #418) but is deliberately not
+ * "known" here: membership means "has a resolvable theme", and `default` is the
+ * absence of a faction identity rather than one of them. Testing the mapped
+ * value, not key presence, is what keeps those two meanings apart — presence
+ * alone reported `na` as a real faction and turned every unaffiliated ornament
+ * grey (#749). Aliases resolve first, so a derived slug counts as known.
  */
 export function isKnownFaction(slug: string | null | undefined): boolean {
   const resolved = FACTION_ALIASES[slug ?? ""] ?? slug ?? "";
-  return resolved in CSS_KEY;
+  return resolved in CSS_KEY && CSS_KEY[resolved] !== "default";
 }
 
 /** Get faction color by slug, with fallback (raw hex — light mode only) */


### PR DESCRIPTION
`isKnownFaction("na")` returned `true`, so the four surfaces that branch on it *specifically* to give unaffiliated players the spectrum all took the `known` branch and asked `factionCssVar("na")` for a scalar — which resolves to `var(--faction-default)`, grey.

## Root cause

`CSS_KEY` gained `na: "default"` in #418 to stop unaffiliated impersonating UA orange. The predicate tested **key presence**:

```js
return resolved in CSS_KEY;   // `na` is a key → true
```

That entry fixed the orange half of #636 and silently inverted this predicate in the same stroke. Orange → grey; #636 closed on the visible half.

## Fix

```js
return resolved in CSS_KEY && CSS_KEY[resolved] !== "default";
```

Test the mapped value, not key presence: membership in `CSS_KEY` means "has a resolvable theme", and `default` is the *absence* of a faction identity, not one of them. One line, at the root — all four call sites route through this predicate, so none of them were touched.

Also updated the two stale comments that made this survive review: the `isKnownFaction` docstring and the `na:` comment in `CSS_KEY` both still claimed `factionCssVar` falls back to the **`ua` theme** for `na`. That stopped being true at #418. They now state what is actually true (`na` → `default` → grey scalar; the spectrum comes from `factionFill()` or an explicit rainbow token).

## Test

`frontend/src/utils/__tests__/isKnownFaction.test.ts` pins `na`/`null`/`undefined`/`""`/`bogus` → false, all seven real slugs → true, plus a pairing assertion that anything the predicate calls unknown resolves to `var(--faction-default)`.

Verified the test is a real guard: against the pre-fix predicate **2 of 6 fail**; against the fix all 6 pass. This regression was silent for a whole issue cycle — the bug is a wrong colour, which no type or build check can see, so the test is the point.

## Verification

`tsc --noEmit` clean, `vite build` ✓, `eslint` clean, full suite **907/907** across 102 files. (tsc also emits pre-existing `Cannot find module 'node:fs'/'node:url'` errors in files I never touched — the known stale-junction false alarm from #675.)

## Risk — visual confirmation is OUTSTANDING

I could not screenshot (no renderer, no dev stack), so **nothing here is eye-verified**. This matters more than usual: `.rainbow-ink` and `.level-gem-number-rainbow` use `background-clip:text`, which `frontend/src/index.css:942` warns **fails invisibly** — if the gradient token resolves to nothing the glyph renders *transparent, i.e. blank*, not wrong-coloured. A blank numeral would look like missing data, not a styling bug. That same comment notes contrast here cannot be machine-measured (axe punts on gradients, #651).

## What to eyeball

On the Players / leaderboard roster, for an **unaffiliated (`na`) character**, in **both light and dark**, **desktop and mobile**:

1. **Level gem stroke** — rainbow outline, not grey (`LevelGem.tsx:37`)
2. **Level gem numeral** — the digit is *visible* and rainbow-filled, not blank (the `background-clip:text` trap)
3. **Roster points numeral** — `.rainbow-ink`, visible and spectrum, not blank/grey (`RosterTable.tsx:176`)
4. **Row left edge accent** — rainbow, not grey
5. **Mobile player row** — same gem + accent (`DefaultPlayers.tsx:347`)
6. **Avatar glow** — neutral (`--glow-neutral`), unchanged; the ring itself already came from the skin dispatcher, which is why only *some* ornaments went grey

Sanity check while there: an affiliated character (e.g. S.N.I.D.E.) must be **unchanged** — solid faction hue everywhere.

## Notes for follow-up (not in scope here)

Three call sites carry comments repeating the same stale "resolves to the `ua` theme" claim — `RosterTable.tsx:172`, `DefaultPlayers.tsx:277` and `:345`, `FactionAvatar.tsx:228`. They're now doubly wrong (it's `default`, and `na` no longer reaches that branch). Left untouched to keep this a one-line root-cause fix; worth a comment-only sweep.

`DefaultPlayers.tsx:279` (the faction *filter chip*) is a behavioural no-op: both branches produce `var(--faction-default)` for `na`. It reads as spectrum-aware but isn't — if those chips are meant to show the unaffiliated chip in rainbow, that needs `factionFill(slug, "pill")` and is a separate change.

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
