### PR TITLE
Tokenize fontSize across the character-profile surfaces (slice 4)

### DIFF
--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -228,7 +228,7 @@ export default function CharacterProfile() {
                       : "var(--color-danger)",
                 color: "var(--color-text-on-accent)",
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 8,
+                fontSize: "var(--text-xs)",
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
                 padding: "4px 0",
@@ -282,7 +282,7 @@ export default function CharacterProfile() {
               disabled={relationshipLoading}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 8,
+                fontSize: "var(--text-xs)",
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
                 padding: "4px 0",
@@ -303,7 +303,7 @@ export default function CharacterProfile() {
                 background: "none",
                 color: "var(--color-danger)",
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: 8,
+                fontSize: "var(--text-xs)",
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
                 padding: "3px 0",
@@ -321,7 +321,7 @@ export default function CharacterProfile() {
           <p
             className="font-body"
             style={{
-              fontSize: 8,
+              fontSize: "var(--text-content)",
               color: "var(--color-danger)",
               marginTop: 4,
               textAlign: "center",

--- a/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
@@ -60,7 +60,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <div
         style={{
           fontFamily: MONO,
-          fontSize: 9,
+          fontSize: 'var(--text-sm)',
           letterSpacing: '0.24em',
           textTransform: 'uppercase',
           color: MUTED,
@@ -69,7 +69,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       >
         {eyebrow}
       </div>
-      <h2 style={{ fontFamily: SERIF, fontStyle: 'italic', fontWeight: 300, fontSize: 32, color: INK, margin: 0 }}>
+      <h2 style={{ fontFamily: SERIF, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-heading)', color: INK, margin: 0 }}>
         {title}
       </h2>
     </div>
@@ -133,7 +133,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: MONO,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.14em',
     textTransform: 'uppercase',
     color: MUTED,
@@ -146,7 +146,7 @@ const kit: ProfileKit = {
       badge={badge}
       last={last}
       dividerColor={RULE}
-      nameStyle={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 17, color: INK, lineHeight: 1.2 }}
+      nameStyle={{ fontFamily: SERIF, fontStyle: 'italic', color: INK, lineHeight: 1.2 }}
       medallion={(glyph) => (
         <span
           style={{

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -25,7 +25,7 @@ import type { ProfileBodyProps } from '../FactionProfileBody'
 
 const EYEBROW: CSSProperties = {
   fontFamily: 'var(--font-body)',
-  fontSize: 10,
+  fontSize: 'var(--text-base)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: 'var(--color-text-tertiary)',
@@ -37,7 +37,7 @@ function SectionHeading({ title, eyebrow }: { title: string; eyebrow?: string })
     <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
       <h2
         className="font-display italic"
-        style={{ fontSize: 24, margin: 0, color: 'var(--color-text-primary)' }}
+        style={{ fontSize: 'var(--text-title)', margin: 0, color: 'var(--color-text-primary)' }}
       >
         {title}
       </h2>
@@ -148,7 +148,7 @@ function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
       </span>
       <div
         className="font-display italic"
-        style={{ fontSize: 15, color: 'var(--color-text-primary)', lineHeight: 1.15 }}
+        style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)', lineHeight: 1.15 }}
       >
         {badge.name}
       </div>
@@ -211,13 +211,13 @@ export default function DefaultProfileBody({
           >
             <div
               className="font-display italic"
-              style={{ fontSize: 19, color: 'var(--color-text-primary)' }}
+              style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}
             >
               {t('profile.praxisEmptyTitle')}
             </div>
             <div
               className="font-body"
-              style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginTop: 5 }}
+              style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginTop: 5 }}
             >
               {t('profile.praxisEmptyBody')}
             </div>
@@ -314,7 +314,7 @@ export default function DefaultProfileBody({
             <h1
               className="font-display italic"
               style={{
-                fontSize: 44,
+                fontSize: 'var(--text-display)',
                 lineHeight: 0.98,
                 margin: 0,
                 color: 'var(--faction-default-card-text)',
@@ -337,7 +337,7 @@ export default function DefaultProfileBody({
                 <>
                   <span
                     className="font-display italic"
-                    style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}
+                    style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}
                   >
                     {t('profile.unaffiliatedPending')}
                   </span>
@@ -354,7 +354,7 @@ export default function DefaultProfileBody({
               )}
               <span
                 className="font-body"
-                style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}
+                style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)' }}
               >
                 {t('profile.handleJoined', { username: character.username, joined })}
               </span>
@@ -401,10 +401,10 @@ export default function DefaultProfileBody({
                       lineHeight: 1,
                     }}
                   >
-                    <span style={{ ...EYEBROW, fontSize: 7, letterSpacing: '0.1em' }}>{t('profile.lvl')}</span>
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-xs)', letterSpacing: '0.1em' }}>{t('profile.lvl')}</span>
                     <span
                       className="font-display italic"
-                      style={{ fontSize: 22, color: 'var(--color-text-primary)' }}
+                      style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}
                     >
                       {character.level}
                     </span>
@@ -423,11 +423,11 @@ export default function DefaultProfileBody({
                   >
                     <span
                       className="font-body"
-                      style={{ fontSize: 10, color: 'var(--color-text-secondary)' }}
+                      style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}
                     >
                       {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
                     </span>
-                    <span style={{ ...EYEBROW, fontSize: 9, letterSpacing: '0.08em' }}>
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-sm)', letterSpacing: '0.08em' }}>
                       {t('profile.nextLevel', { level: progression.nextLevel })}
                     </span>
                   </div>
@@ -451,7 +451,7 @@ export default function DefaultProfileBody({
                   </div>
                   <div
                     className="font-body"
-                    style={{ fontSize: 9, color: 'var(--color-text-tertiary)', marginTop: 5 }}
+                    style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)', marginTop: 5 }}
                   >
                     {t('profile.ptsToNext', { score: character.score, threshold: progression.nextThreshold })}
                   </div>
@@ -487,14 +487,14 @@ export default function DefaultProfileBody({
             >
               <h2
                 className="font-display italic"
-                style={{ fontSize: 22, margin: 0, color: 'var(--color-text-primary)' }}
+                style={{ fontSize: 'var(--text-title)', margin: 0, color: 'var(--color-text-primary)' }}
               >
                 {t('profile.badgesHeading')}
               </h2>
               <span
                 style={{
                   ...EYEBROW,
-                  fontSize: 9,
+                  fontSize: 'var(--text-sm)',
                   letterSpacing: '0.1em',
                   marginLeft: 'auto',
                   border: '1px solid var(--color-border-strong)',

--- a/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
@@ -58,13 +58,13 @@ function toRoman(value: number): string {
 function heading(title: string, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 18 }}>
-      <div style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 13, color: MUTED, marginBottom: 4 }}>
+      <div style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 'var(--text-lg)', color: MUTED, marginBottom: 4 }}>
         {eyebrow}
       </div>
       <h2
         style={{
           fontFamily: DISPLAY,
-          fontSize: 26,
+          fontSize: 'var(--text-heading)',
           letterSpacing: '0.06em',
           color: VELLUM_TEXT,
           margin: 0,
@@ -155,7 +155,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: DISPLAY,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.14em',
     textTransform: 'uppercase',
     color: MUTED,
@@ -168,7 +168,7 @@ const kit: ProfileKit = {
       badge={badge}
       last={last}
       dividerColor="rgba(176,134,58,0.28)"
-      nameStyle={{ fontFamily: DISPLAY, fontSize: 14, color: VELLUM_TEXT, lineHeight: 1.2, letterSpacing: '0.03em' }}
+      nameStyle={{ fontFamily: DISPLAY, color: VELLUM_TEXT, lineHeight: 1.2, letterSpacing: '0.03em' }}
       medallion={(glyph) => (
         <span
           style={{

--- a/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
@@ -33,7 +33,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <div
         style={{
           fontFamily: MONO,
-          fontSize: 10,
+          fontSize: 'var(--text-base)',
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
           color: MUTED,
@@ -45,7 +45,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <h2
         style={{
           fontFamily: BEBAS,
-          fontSize: 34,
+          fontSize: 'var(--text-heading)',
           letterSpacing: '0.03em',
           color: PAPER_TEXT,
           margin: 0,
@@ -135,7 +135,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: MONO,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.1em',
     textTransform: 'uppercase',
     color: MUTED,
@@ -148,7 +148,7 @@ const kit: ProfileKit = {
       badge={badge}
       last={last}
       dividerColor="rgba(34,26,18,0.18)"
-      nameStyle={{ fontFamily: BEBAS, fontSize: 18, letterSpacing: '0.02em', color: INK, lineHeight: 1.15 }}
+      nameStyle={{ fontFamily: BEBAS, letterSpacing: '0.02em', color: INK, lineHeight: 1.15 }}
       medallion={(glyph) => (
         <span
           style={{

--- a/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
@@ -34,7 +34,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <div
         style={{
           fontFamily: FONT,
-          fontSize: 9,
+          fontSize: 'var(--text-sm)',
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           color: signal(65),
@@ -46,7 +46,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <h2
         style={{
           fontFamily: FONT,
-          fontSize: 24,
+          fontSize: 'var(--text-heading)',
           letterSpacing: '0.06em',
           textTransform: 'uppercase',
           color: PHOSPHOR,
@@ -130,7 +130,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: FONT,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.12em',
     textTransform: 'uppercase',
     color: signal(70),
@@ -145,7 +145,6 @@ const kit: ProfileKit = {
       dividerColor={signal(22)}
       nameStyle={{
         fontFamily: FONT,
-        fontSize: 13,
         textTransform: 'uppercase',
         letterSpacing: '0.04em',
         color: PHOSPHOR,

--- a/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
@@ -31,7 +31,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <div
         style={{
           fontFamily: TYPE,
-          fontSize: 10,
+          fontSize: 'var(--text-base)',
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
           color: PAPER,
@@ -43,7 +43,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <h2
         style={{
           fontFamily: IMPACT,
-          fontSize: 34,
+          fontSize: 'var(--text-heading)',
           letterSpacing: '0.02em',
           textTransform: 'uppercase',
           color: ACID,
@@ -138,7 +138,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: TYPE,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.1em',
     textTransform: 'uppercase',
     color: PINK,
@@ -151,7 +151,7 @@ const kit: ProfileKit = {
       badge={badge}
       last={last}
       dividerColor="rgba(20,17,11,0.25)"
-      nameStyle={{ fontFamily: MARKER, fontSize: 16, color: INK, lineHeight: 1.15 }}
+      nameStyle={{ fontFamily: MARKER, color: INK, lineHeight: 1.15 }}
       medallion={(glyph) => (
         <span
           style={{

--- a/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
@@ -30,7 +30,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <div
         style={{
           fontFamily: EYEBROW,
-          fontSize: 8,
+          fontSize: 'var(--text-xs)',
           letterSpacing: '0.26em',
           textTransform: 'uppercase',
           color: MUTED,
@@ -39,7 +39,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       >
         {eyebrow}
       </div>
-      <h2 style={{ fontFamily: DISPLAY, fontSize: 30, lineHeight: 1, color: INK, margin: 0 }}>
+      <h2 style={{ fontFamily: DISPLAY, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: 0 }}>
         {title}
       </h2>
     </div>
@@ -125,7 +125,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: EYEBROW,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.1em',
     textTransform: 'uppercase',
     color: MUTED,
@@ -139,7 +139,7 @@ const kit: ProfileKit = {
       badge={badge}
       last={last}
       dividerColor={LINE}
-      nameStyle={{ fontFamily: DISPLAY, fontSize: 15, color: INK, lineHeight: 1.15 }}
+      nameStyle={{ fontFamily: DISPLAY, color: INK, lineHeight: 1.15 }}
       medallion={(glyph) => (
         <span
           style={{

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -50,7 +50,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <span
         style={{
           fontFamily: DISPLAY,
-          fontSize: 28,
+          fontSize: 'var(--text-heading)',
           color: ACCENT,
           background: 'var(--faction-wow-tape)',
           padding: '2px 12px',
@@ -60,7 +60,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       >
         {title}
       </span>
-      <span style={{ fontFamily: EYEBROW, fontSize: 10, color: MUTED }}>{eyebrow}</span>
+      <span style={{ fontFamily: EYEBROW, fontSize: 'var(--text-base)', color: MUTED }}>{eyebrow}</span>
     </div>
   )
 }
@@ -136,7 +136,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: EYEBROW,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.1em',
     textTransform: 'uppercase',
     color: MUTED,
@@ -150,7 +150,7 @@ const kit: ProfileKit = {
       badge={badge}
       last={last}
       dividerColor="var(--faction-wow-notepad-border)"
-      nameStyle={{ fontFamily: DISPLAY, fontSize: 18, color: INK, lineHeight: 1.15 }}
+      nameStyle={{ fontFamily: DISPLAY, color: INK, lineHeight: 1.15 }}
       medallion={(glyph) => (
         <span
           style={{

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -64,7 +64,13 @@ export interface ProfileKit {
   headerDecoration?: ReactNode
   /** Optional wrapper chrome placed AROUND the shared CredentialCard. */
   credentialFrame?: (card: ReactNode) => ReactNode
-  /** px font-size for the big display name (default 48). */
+  /** px font-size for the big display name (default 48).
+   *  ornament: masthead display type. Each archetype's name size is optical
+   *  compensation for its own display font (Bebas Neue at 72 and IM Fell
+   *  English at 56 read at the same optical weight) — it is the archetype's
+   *  identity (§270), sits far above the content floor, and so stays raw.
+   *  This is the ONE size a kit may carry; a kit's `badgeRow` `nameStyle`
+   *  must NOT set fontSize — the shared `BadgeRow` owns that. */
   nameSize?: number
   /** Optional CSS text-shadow / transform on the name. */
   nameExtra?: CSSProperties
@@ -210,7 +216,10 @@ export function BadgeRow({
       }}
     >
       {medallion(<Art size={16} />)}
-      <div style={nameStyle}>{badge.name}</div>
+      {/* Badge NAMES are functional text (#459: the glyph is the ornament, the
+          label is read). The shared row owns the size so no kit can drop a
+          badge name below the content floor. */}
+      <div style={{ ...nameStyle, fontSize: 'var(--text-content)' }}>{badge.name}</div>
     </div>
   )
 }
@@ -277,7 +286,7 @@ export function ProfileSkin({
             <div
               style={{
                 fontFamily: kit.displayFont,
-                fontSize: 19,
+                fontSize: 'var(--text-title)',
                 color: kit.ink,
               }}
             >
@@ -286,7 +295,7 @@ export function ProfileSkin({
             <div
               style={{
                 fontFamily: kit.bodyFont ?? kit.eyebrowFont,
-                fontSize: 11,
+                fontSize: 'var(--text-content)',
                 color: kit.muted,
                 marginTop: 5,
               }}
@@ -368,7 +377,7 @@ export function ProfileSkin({
               <div
                 style={{
                   fontFamily: kit.eyebrowFont,
-                  fontSize: 9,
+                  fontSize: 'var(--text-sm)',
                   letterSpacing: '0.22em',
                   textTransform: 'uppercase',
                   color: kit.muted,
@@ -381,6 +390,7 @@ export function ProfileSkin({
               <h1
                 style={{
                   fontFamily: kit.displayFont,
+                  // ornament: masthead display type, per-archetype identity (see ProfileKit.nameSize)
                   fontSize: kit.nameSize ?? 48,
                   lineHeight: 0.98,
                   margin: 0,
@@ -395,7 +405,8 @@ export function ProfileSkin({
               <div
                 style={{
                   fontFamily: kit.bodyFont ?? kit.eyebrowFont,
-                  fontSize: 12,
+                  // handle + join date: the handle is a name, so this is read, not scanned
+                  fontSize: 'var(--text-content)',
                   color: kit.muted,
                   marginTop: 10,
                 }}
@@ -434,7 +445,7 @@ export function ProfileSkin({
                       <span
                         style={{
                           fontFamily: kit.eyebrowFont,
-                          fontSize: 7,
+                          fontSize: 'var(--text-xs)',
                           letterSpacing: '0.12em',
                           textTransform: 'uppercase',
                           color: kit.muted,
@@ -445,7 +456,7 @@ export function ProfileSkin({
                       <span
                         style={{
                           fontFamily: kit.displayFont,
-                          fontSize: 22,
+                          fontSize: 'var(--text-title)',
                           color: kit.accent,
                         }}
                       >
@@ -467,7 +478,8 @@ export function ProfileSkin({
                       <span
                         style={{
                           fontFamily: kit.bodyFont ?? kit.eyebrowFont,
-                          fontSize: 10,
+                          // points into level: a number the player cares about
+                          fontSize: 'var(--text-content)',
                           color: kit.muted,
                         }}
                       >
@@ -476,7 +488,7 @@ export function ProfileSkin({
                       <span
                         style={{
                           fontFamily: kit.eyebrowFont,
-                          fontSize: 9,
+                          fontSize: 'var(--text-sm)',
                           letterSpacing: '0.1em',
                           textTransform: 'uppercase',
                           color: kit.muted,
@@ -507,7 +519,8 @@ export function ProfileSkin({
                       <div
                         style={{
                           fontFamily: kit.bodyFont ?? kit.eyebrowFont,
-                          fontSize: 9,
+                          // absolute score toward the next threshold: read, not scanned
+                          fontSize: 'var(--text-content)',
                           color: kit.muted,
                           marginTop: 5,
                         }}
@@ -550,7 +563,7 @@ export function ProfileSkin({
                   marginBottom: 14,
                 }}
               >
-                <h2 style={{ fontFamily: kit.displayFont, fontSize: 22, margin: 0, color: kit.ink }}>
+                <h2 style={{ fontFamily: kit.displayFont, fontSize: 'var(--text-title)', margin: 0, color: kit.ink }}>
                   {kit.badgeTitle}
                 </h2>
                 <span style={kit.badgeChipStyle}>{t('profile.badgesEarned', { count: badges.length })}</span>

--- a/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
@@ -62,7 +62,7 @@ export default function DefaultProfile({
         )}
         <h1
           className="font-display italic font-medium"
-          style={{ fontSize: 26, marginTop: 12, color: 'var(--color-text-primary)', overflowWrap: 'anywhere' }}
+          style={{ fontSize: 'var(--text-heading)', marginTop: 12, color: 'var(--color-text-primary)', overflowWrap: 'anywhere' }}
         >
           {character.display_name}
         </h1>
@@ -98,7 +98,7 @@ export default function DefaultProfile({
       {badges.length > 0 && (
         <div style={{ marginBottom: 18 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-            <h2 className="font-display italic" style={{ fontSize: 18, color: 'var(--color-text-primary)' }}>
+            <h2 className="font-display italic" style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}>
               {t('profile.badgesHeading')}
             </h2>
             <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)' }}>
@@ -174,7 +174,7 @@ function Stat({ label, value, divider }: { label: string; value: number; divider
         borderLeft: divider ? '1px solid var(--color-border)' : undefined,
       }}
     >
-      <div className="font-display italic" style={{ fontSize: 22, fontWeight: 700, color: 'var(--color-text-primary)' }}>
+      <div className="font-display italic" style={{ fontSize: 'var(--text-title)', fontWeight: 700, color: 'var(--color-text-primary)' }}>
         {value}
       </div>
       <div className="eyebrow" style={{ color: 'var(--color-text-tertiary)', marginTop: 2 }}>
@@ -225,7 +225,7 @@ function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
           <Art size={16} />
         </span>
       </span>
-      <div className="font-display italic" style={{ fontSize: 15, color: 'var(--color-text-primary)' }}>
+      <div className="font-display italic" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}>
         {badge.name}
       </div>
     </div>
@@ -240,7 +240,7 @@ function SegTab({ on, onClick, children }: { on: boolean; onClick: () => void; c
       style={{
         flex: 1,
         fontFamily: "'Courier Prime', monospace",
-        fontSize: 11,
+        fontSize: 'var(--text-lg)',
         fontWeight: on ? 700 : 400,
         letterSpacing: '0.08em',
         textTransform: 'uppercase',


### PR DESCRIPTION
**Part of #623.** Slice 4: `pages/characterProfile/**` + `pages/CharacterProfile.tsx`.

## Count

| | raw `fontSize: N` |
|---|---|
| before | **63** |
| after | **0** |

`grep -rn 'fontSize: [0-9]' src/pages/characterProfile src/pages/CharacterProfile.tsx` returns nothing.

One ornament survives as a non-literal: `fontSize: kit.nameSize ?? 48` in `profileSkin.tsx` (see below).

## The skin-owns-size bug — found, and it was not where it looked

`ProfileKit` carries two sizes. They are not the same kind of thing.

- **`nameSize` (48–72) is not the bug.** It is masthead display type, and each value is optical compensation for that archetype's own display font — Bebas Neue at 72 and IM Fell English at 56 read at the same optical weight. It is the archetype's identity (§270), it sits far above the content floor, so it stays raw and annotated.
- **`badgeRow`'s `nameStyle` was the bug.** Every kit set `fontSize` there, at 13–18px. Badge *names* are functional text — per #459 the glyph is the ornament, the label is read — so all seven were sitting below the floor, in a style object the kit had no business sizing. The shared `BadgeRow` now owns that size at `--text-content`, and the seven kits dropped the property. A kit can no longer push a badge name under the floor.

The `ProfileKit.nameSize` docblock now states which of the two is allowed and why.

## Judgement call worth a look: section headings converge

The seven faction section headings were 24/26/28/30/32/34. They are now all `--text-heading`.

This is the one change that could read as flattening the archetypes, so the reasoning: §4a says a faction picks a headline font, a colour and an ornament — **never its own type size** — and "there are no per-faction size exceptions". The identity is carried by DISPLAY / BEBAS / IMPACT / MARKER / SERIF and the surrounding chrome (Wow's tape strip, Snide's acid slab), all untouched. Happy to revert to per-faction sizes if you read §270 as beating §4a here.

## Promotions to the content floor

Nothing a player reads is left below 18px:

- badge names (desktop, mobile, all seven factions)
- the handle + joined line — **a handle is a name, so it is read**, per the #696 collaborator-roster call
- the "faction pending" note on unaffiliated profiles
- both progression readouts ("n / n pts this level", "score / threshold pts") — §4 counts level and points as numbers a player cares about
- the praxis empty-state body
- **the relationship error message, which was 8px** — the worst offender in the slice

Uppercase-and-letterspaced eyebrows, the "{n} earned" chip, the friend/foe buttons and the segmented control stayed label tier. The `lvl` micro-label inside the 46px ring went to `--text-xs` (8).

## Deliberately NOT done

- **Spacing untouched** — `padding`/`margin`/`gap` are #750.
- **No file left `.eslint-legacy-raw-styles.txt`.** All 11 still carry raw spacing (2–22 sites each), so none qualifies to be delisted on both axes. Expected; the list shrinks when #750 lands.
- Because the files stay legacy-listed the rule is off for them, so an `eslint-disable` directive would be unused — surviving ornament carries a plain `// ornament:` comment instead.
- **#586 hoisting: none applied.** No static inline style object in these files was free of a prop or closure dependency, and the brief said not to restructure to manufacture one.

## Verification

`tsc --noEmit` clean · `vite build` clean · `eslint` on the slice clean · **901/901** unit tests pass.

**Visual QA is outstanding** — I cannot screenshot and there is no dev stack in this worktree. Every change is a size change, so this needs eyes.

## What to eyeball

Load a profile with **at least one badge** and a **non-zero level** on each:

1. **Unaffiliated (`na`)** — `DefaultProfileBody`. Biggest diff (30 lines). Hero name 44 → 42; check the spectrum band still frames it. Check the progression panel, where three lines went to 18px and the panel will be taller.
2. **UA** — heading was 30, and its 8px eyebrow at 0.26em tracking went to `--text-xs`.
3. **Everymen** and **S.N.I.D.E.** — headings shrank 34 → 32; Bebas and IMPACT are the two most size-sensitive faces here.
4. **Warriors of Whimsy** — heading 28 → 32 sits **on the tape strip**; confirm the strip grew with it and the word did not overrun the tape.
5. **Ephemerists** — biggest heading jump (26 → 32) in Cinzel, plus a script-italic eyebrow at 13 → 12.
6. **Singularity** — heading 24 → 32 in Share Tech Mono, uppercase at 0.06em tracking. Most likely to wrap.
7. **Albescent** — heading was already exactly 32, so only its badge names moved.
8. **Mobile default profile** — name 26 → 32, stats row values 22 → 24, segmented Praxis/Tasks control 11 → 12. Confirm nothing overflows at 360px.
9. **Friend/foe rail** on someone else's profile — trigger a relationship error to see the message at 18px in a 220px-max column.

Badge names are now 18px everywhere; on Everymen (Bebas) and Wow they got smaller, on Ephemerists larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)