### PR TITLE
Praxis card adopts the content role vocabulary (desktop + mobile)

### DIFF
--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -179,6 +179,16 @@ function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   );
 }
 
+/** The red margin rule down the Everymen ruled sheet. Static (#586). */
+const everymenMarginRule: CSSProperties = {
+  position: "absolute",
+  left: 22,
+  top: 0,
+  bottom: 0,
+  width: 1,
+  background: "rgba(220,80,80,0.2)",
+};
+
 function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
@@ -197,16 +207,7 @@ function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         transition: "background 150ms, color 150ms",
       }}
     >
-      <div
-        style={{
-          position: "absolute",
-          left: 22,
-          top: 0,
-          bottom: 0,
-          width: 1,
-          background: "rgba(220,80,80,0.2)",
-        }}
-      />
+      <div style={everymenMarginRule} />
       <AdminOverlay {...adminProps} />
       <PraxisBody
         praxis={praxis}
@@ -219,6 +220,42 @@ function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   );
 }
 
+/** The two offset scrap layers behind the WOW card, plus its tape. Static (#586). */
+const wowScrapDeep: CSSProperties = {
+  position: "absolute",
+  top: 10,
+  left: -4,
+  right: -4,
+  height: 24,
+  background: "var(--faction-wow-scrap-deep)",
+  border: "1.5px solid rgba(0,0,0,0.12)",
+  transform: "rotate(-4deg)",
+  borderRadius: 1,
+};
+
+const wowScrapMid: CSSProperties = {
+  position: "absolute",
+  top: 4,
+  left: -2,
+  right: -2,
+  height: 36,
+  background: "var(--faction-wow-scrap-mid)",
+  border: "1.5px solid rgba(0,0,0,0.12)",
+  transform: "rotate(3deg)",
+  borderRadius: 1,
+};
+
+const wowTape: CSSProperties = {
+  position: "absolute",
+  top: 5,
+  left: "50%",
+  transform: "translateX(-50%) rotate(-1deg)",
+  width: 48,
+  height: 14,
+  background: "var(--faction-wow-tape)",
+  borderRadius: 1,
+};
+
 function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
@@ -228,32 +265,8 @@ function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         minHeight: 140,
       }}
     >
-      <div
-        style={{
-          position: "absolute",
-          top: 10,
-          left: -4,
-          right: -4,
-          height: 24,
-          background: "var(--faction-wow-scrap-deep)",
-          border: "1.5px solid rgba(0,0,0,0.12)",
-          transform: "rotate(-4deg)",
-          borderRadius: 1,
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          top: 4,
-          left: -2,
-          right: -2,
-          height: 36,
-          background: "var(--faction-wow-scrap-mid)",
-          border: "1.5px solid rgba(0,0,0,0.12)",
-          transform: "rotate(3deg)",
-          borderRadius: 1,
-        }}
-      />
+      <div style={wowScrapDeep} />
+      <div style={wowScrapMid} />
       <div
         style={{
           position: "relative",
@@ -268,18 +281,7 @@ function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
           boxSizing: "border-box",
         }}
       >
-        <div
-          style={{
-            position: "absolute",
-            top: 5,
-            left: "50%",
-            transform: "translateX(-50%) rotate(-1deg)",
-            width: 48,
-            height: 14,
-            background: "var(--faction-wow-tape)",
-            borderRadius: 1,
-          }}
-        />
+        <div style={wowTape} />
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
@@ -296,6 +298,18 @@ function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
 const SNIDE_TORN_CLIP =
   "polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)";
 
+/** The torn top/bottom edges of the Snide scrap. Static (#586). */
+const snideTornBase: CSSProperties = {
+  position: "absolute",
+  left: 0,
+  right: 0,
+  height: 6,
+  background: "var(--color-bg-page)",
+  clipPath: SNIDE_TORN_CLIP,
+};
+const snideTornTop: CSSProperties = { ...snideTornBase, top: -1 };
+const snideTornBottom: CSSProperties = { ...snideTornBase, bottom: -1 };
+
 function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
   return (
@@ -310,28 +324,8 @@ function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
         transition: "background 150ms, color 150ms",
       }}
     >
-      <div
-        style={{
-          position: "absolute",
-          top: -1,
-          left: 0,
-          right: 0,
-          height: 6,
-          background: "var(--color-bg-page)",
-          clipPath: SNIDE_TORN_CLIP,
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: -1,
-          left: 0,
-          right: 0,
-          height: 6,
-          background: "var(--color-bg-page)",
-          clipPath: SNIDE_TORN_CLIP,
-        }}
-      />
+      <div style={snideTornTop} />
+      <div style={snideTornBottom} />
       <div className="snide-tape" style={{ top: -10, left: 22, transform: "rotate(-8deg)" }} />
       <SnideMasthead subtitle={t("card.masthead.snide")} />
       <AdminOverlay {...adminProps} />
@@ -408,32 +402,73 @@ function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
   );
 }
 
+/** Punch-card sprocket strip — the row and one hole. Static (#586). */
+const holeRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "center",
+  gap: "var(--space-sm)",
+  padding: "var(--space-xs) 0",
+};
+
+const holeStyle: CSSProperties = {
+  width: 6,
+  height: 4,
+  background: "rgba(10,26,14)",
+  border:
+    "1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))",
+  borderRadius: 1,
+};
+
 function SingularityHoles() {
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        gap: "var(--space-sm)",
-        padding: "var(--space-xs) 0",
-      }}
-    >
+    <div style={holeRowStyle}>
       {Array.from({ length: 5 }).map((_, index) => (
-        <div
-          key={index}
-          style={{
-            width: 6,
-            height: 4,
-            background: "rgba(10,26,14)",
-            border:
-              "1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))",
-            borderRadius: 1,
-          }}
-        />
+        <div key={index} style={holeStyle} />
       ))}
     </div>
   );
 }
+
+/** Terminal scanline wash + the four corner brackets. Static (#586). */
+const scanlineStyle: CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  backgroundImage:
+    "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)",
+  pointerEvents: "none",
+  zIndex: 1,
+};
+
+const cornerRule = "1px solid var(--faction-singularity-card-text)";
+const cornerBase: CSSProperties = { position: "absolute", width: 10, height: 10 };
+const cornerTopLeft: CSSProperties = {
+  ...cornerBase,
+  top: 3,
+  left: 3,
+  borderTop: cornerRule,
+  borderLeft: cornerRule,
+};
+const cornerTopRight: CSSProperties = {
+  ...cornerBase,
+  top: 3,
+  right: 3,
+  borderTop: cornerRule,
+  borderRight: cornerRule,
+};
+const cornerBottomLeft: CSSProperties = {
+  ...cornerBase,
+  bottom: 3,
+  left: 3,
+  borderBottom: cornerRule,
+  borderLeft: cornerRule,
+};
+const cornerBottomRight: CSSProperties = {
+  ...cornerBase,
+  bottom: 3,
+  right: 3,
+  borderBottom: cornerRule,
+  borderRight: cornerRule,
+};
 
 function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
@@ -449,60 +484,11 @@ function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps
         overflow: "hidden",
       }}
     >
-      <div
-        style={{
-          position: "absolute",
-          inset: 0,
-          backgroundImage:
-            "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)",
-          pointerEvents: "none",
-          zIndex: 1,
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          top: 3,
-          left: 3,
-          width: 10,
-          height: 10,
-          borderTop: "1px solid var(--faction-singularity-card-text)",
-          borderLeft: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          top: 3,
-          right: 3,
-          width: 10,
-          height: 10,
-          borderTop: "1px solid var(--faction-singularity-card-text)",
-          borderRight: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: 3,
-          left: 3,
-          width: 10,
-          height: 10,
-          borderBottom: "1px solid var(--faction-singularity-card-text)",
-          borderLeft: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: 3,
-          right: 3,
-          width: 10,
-          height: 10,
-          borderBottom: "1px solid var(--faction-singularity-card-text)",
-          borderRight: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
+      <div style={scanlineStyle} />
+      <div style={cornerTopLeft} />
+      <div style={cornerTopRight} />
+      <div style={cornerBottomLeft} />
+      <div style={cornerBottomRight} />
       <SingularityHoles />
       <div
         style={{ padding: "var(--space-sm) var(--space-lg) var(--space-md)", position: "relative", zIndex: 2 }}

--- a/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
@@ -43,7 +43,7 @@ export default function AlbescentMobilePraxisCard({ praxis }: { praxis: PraxisCa
           gap: 8,
           marginBottom: 12,
           fontFamily: 'var(--faction-albescent-mono)',
-          fontSize: 9,
+          fontSize: 'var(--text-sm)',
           letterSpacing: '0.22em',
           textTransform: 'uppercase',
           color: ink(30),

--- a/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
@@ -38,7 +38,7 @@ export default function DefaultMobilePraxisCard({ praxis }: { praxis: PraxisCard
             gap: 8,
             marginBottom: 12,
             fontFamily: "'Courier Prime', monospace",
-            fontSize: 9,
+            fontSize: 'var(--text-sm)',
             letterSpacing: '0.2em',
             textTransform: 'uppercase',
             color: 'var(--faction-default-card-muted)',

--- a/frontend/src/components/praxisCard/mobile/EphemeristsMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/EphemeristsMobilePraxisCard.tsx
@@ -42,7 +42,7 @@ export default function EphemeristsMobilePraxisCard({ praxis }: { praxis: Praxis
           borderBottom: '1px solid var(--eph-gold-deep)',
           boxShadow: '0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)',
           fontFamily: 'var(--eph-serif)',
-          fontSize: 9,
+          fontSize: 'var(--text-sm)',
           letterSpacing: '0.18em',
           textTransform: 'uppercase',
           color: 'var(--eph-rubric)',

--- a/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
@@ -45,7 +45,7 @@ export default function SingularityMobilePraxisCard({ praxis }: { praxis: Praxis
           style={{
             marginBottom: 12,
             fontFamily: "'Share Tech Mono', monospace",
-            fontSize: 9,
+            fontSize: 'var(--text-sm)',
             letterSpacing: '0.15em',
             textTransform: 'uppercase',
             color: 'var(--faction-singularity-card-muted)',

--- a/frontend/src/components/praxisCard/mobile/SnideMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/SnideMobilePraxisCard.tsx
@@ -53,7 +53,7 @@ export default function SnideMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
           gap: 8,
           marginBottom: 12,
           fontFamily: 'var(--faction-snide-font-type)',
-          fontSize: 9,
+          fontSize: 'var(--text-sm)',
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           color: accent,

--- a/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
@@ -41,7 +41,7 @@ export default function UaMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }
             gap: 8,
             marginBottom: 12,
             fontFamily: "'Marcellus SC', serif",
-            fontSize: 9,
+            fontSize: 'var(--text-sm)',
             letterSpacing: '0.14em',
             textTransform: 'uppercase',
             color: factionCssVar('ua', 'card-accent'),

--- a/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
@@ -62,7 +62,7 @@ export default function WowMobilePraxisCard({ praxis }: { praxis: PraxisCardOut 
             gap: 6,
             marginBottom: 12,
             fontFamily: "'Courier Prime', monospace",
-            fontSize: 9,
+            fontSize: 'var(--text-sm)',
             letterSpacing: '0.14em',
             textTransform: 'uppercase',
             color: accent,

--- a/frontend/src/components/praxisCard/mobile/shared.tsx
+++ b/frontend/src/components/praxisCard/mobile/shared.tsx
@@ -98,7 +98,7 @@ export function MobileByline({
           className="hover:underline"
           style={{
             fontFamily: theme.displayFont,
-            fontSize: 14,
+            fontSize: 'var(--text-xl)',
             fontWeight: 600,
             color: theme.ink,
             textDecoration: 'none',
@@ -112,7 +112,7 @@ export function MobileByline({
         <span
           style={{
             fontFamily: theme.bodyFont,
-            fontSize: 10,
+            fontSize: 'var(--text-base)',
             letterSpacing: '0.04em',
             color: theme.muted,
           }}
@@ -144,7 +144,7 @@ export function MobileTaskRef({
       className="hover:underline"
       style={{
         fontFamily: theme.bodyFont,
-        fontSize: 11,
+        fontSize: 'var(--text-content)',
         letterSpacing: '0.02em',
         color: theme.accent,
         textDecoration: 'none',
@@ -170,10 +170,9 @@ export function MobileTitle({
   return (
     <Link to={`/praxes/${praxis.id}`} style={{ textDecoration: 'none' }}>
       <h3
-        className="hover:underline"
+        className="content-title hover:underline"
         style={{
           fontFamily: theme.displayFont,
-          fontSize: 20,
           lineHeight: 1.15,
           color: theme.ink,
           margin: 0,
@@ -198,9 +197,9 @@ export function MobileBody({
   if (!praxis.body_text) return null
   return (
     <p
+      className="card-description"
       style={{
         fontFamily: theme.bodyFont,
-        fontSize: 13,
         lineHeight: 1.5,
         color: theme.muted,
         margin: 0,
@@ -245,7 +244,7 @@ export function MobileRoster({
       <span
         style={{
           fontFamily: theme.bodyFont,
-          fontSize: 10,
+          fontSize: 'var(--text-content)',
           color: theme.muted,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -278,7 +277,7 @@ export function MobileModeChip({
   if (!isDuel && !isPending) return null
   const chip: CSSProperties = {
     fontFamily: theme.bodyFont,
-    fontSize: 9,
+    fontSize: 'var(--text-sm)',
     letterSpacing: '0.14em',
     textTransform: 'uppercase',
     padding: '2px 8px',
@@ -370,10 +369,17 @@ export function MobileMediaGallery({
                   fontFamily: theme.bodyFont,
                 }}
               >
+                {/* ornament: dingbat glyph used as a media-type icon, not text */}
                 <span aria-hidden style={{ fontSize: 20, lineHeight: 1 }}>
                   {item.type === 'video' ? '▶' : '♪'}
                 </span>
-                <span style={{ fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+                <span
+                  style={{
+                    fontSize: 'var(--text-xs)',
+                    letterSpacing: '0.1em',
+                    textTransform: 'uppercase',
+                  }}
+                >
                   {item.type === 'video' ? t('mobileCard.mediaVideo') : t('mobileCard.mediaAudio')}
                 </span>
               </span>
@@ -389,7 +395,7 @@ export function MobileMediaGallery({
                   background: 'color-mix(in srgb, black 55%, transparent)',
                   color: 'white',
                   fontFamily: theme.displayFont,
-                  fontSize: 18,
+                  fontSize: 'var(--text-content)',
                   fontWeight: 700,
                 }}
               >
@@ -427,7 +433,7 @@ export function MobileVotedByMarker({
     <span
       style={{
         fontFamily: theme.bodyFont,
-        fontSize: 10,
+        fontSize: 'var(--text-base)',
         letterSpacing: '0.06em',
         textTransform: 'uppercase',
         color: theme.muted,

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -50,8 +50,8 @@ export function PraxisTitle({
   return (
     <Link to={`/praxes/${praxis.id}`}>
       <h3
-        className="font-display font-semibold leading-tight hover:underline"
-        style={{ fontSize: "var(--text-content)", marginBottom: "var(--space-sm)", ...style }}
+        className="content-title font-display font-semibold leading-tight hover:underline"
+        style={{ marginBottom: "var(--space-sm)", ...style }}
       >
         {praxis.title}
       </h3>
@@ -71,7 +71,7 @@ export function PraxisTaskLink({
     <Link
       to={`/tasks/${praxis.task_id}`}
       className="font-body hover:underline"
-      style={{ fontSize: "var(--text-xs)", ...style }}
+      style={{ fontSize: "var(--text-content)", ...style }}
     >
       {praxis.task_title}
     </Link>
@@ -275,9 +275,8 @@ export function PraxisExcerpt({
   if (!praxis.body_text) return null;
   return (
     <p
-      className="font-body"
+      className="card-description font-body"
       style={{
-        fontSize: "var(--text-sm)",
         marginTop: "var(--space-sm)",
         marginBottom: "0",
         lineHeight: 1.5,
@@ -365,7 +364,7 @@ export function PraxisRoster({
       </span>
       <span
         className="font-body"
-        style={{ fontSize: "var(--text-xs)", color: accent, minWidth: 0 }}
+        style={{ fontSize: "var(--text-content)", color: accent, minWidth: 0 }}
       >
         {names.join(", ")}
         {overflow > 0 ? ` ${t("mobileCard.rosterMore", { count: overflow })}` : ""}

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -621,9 +621,8 @@ export function AdminOverlay({
       )}
       {moderateError && (
         <p
-          className="font-body"
+          className="content-text font-body"
           style={{
-            fontSize: "var(--text-xs)",
             color: "var(--color-danger)",
             marginBottom: "var(--space-xs)",
           }}


### PR DESCRIPTION
Slice 5 of the fontSize sweep. Desktop and mobile praxis cards in one PR so the
two form factors cannot drift apart.

Closes #696

Part of #623

## Part A — desktop (#696)

The grill's premise correction held up: `praxisCard/shared.tsx` and
`PraxisCard.tsx` had **zero** raw `fontSize: N`. The defect was vocabulary —
the praxis card never adopted the role classes task cards use (post-#629), and
picked Label-tier tokens for Content-tier text. The four settled changes:

| Site | Before | After |
|---|---|---|
| praxis title | `--text-content` inline | `className="content-title"`, inline size deleted |
| task-title link | `--text-xs` (8px) | `--text-content` |
| body excerpt | `--text-sm` (9px) | `className="card-description"`, inline size deleted |
| roster names | `--text-xs` (8px) | `--text-content` |

The six Label-tier sites (footer meta, uppercase caption, level chip, avatar
initial, status chips, media caption) are untouched, as specified.

The excerpt keeps its inline clamp, margins and line-height — inline beats the
class, so **only font-size moves**. Spacing is #750 and deliberately untouched.

**The five `--text-xs` sites in `PraxisCard.tsx` all stay.** All five (`:159`
UA, `:387` Ephemerists, `:512` Singularity, `:598` Albescent, `:663` Default)
are faction mastheads — uppercase, letter-spaced running heads, scanned not
read. Genuine Label tier.

## Part B — mobile (#623, absorbed from #739)

Raw `fontSize` in `components/praxisCard/mobile`: **18 → 1** (the one survivor
is annotated ornament).

Each slot takes the same tier as its desktop twin. Label-tier slots map to the
token matching their current pixel, so nothing in that tier moves visually.

The media-type dingbat (▶/♪) keeps its raw `20` behind a plain `// ornament:`
comment rather than an `eslint-disable` — the file stays grandfathered because
its raw *spacing* is #750, so the directive would be reported unused. The
avatar initial stays computed (`size * 0.44`).

**No files delisted from `.eslint-legacy-raw-styles.txt`.** Every listed praxis
mobile file still has raw spacing, so none is clean on both axes yet. The two
desktop files were never on the list.

## Line numbers drifted

Located by content, not number. Two notes:

- Desktop line numbers matched the grill exactly.
- **#623's mobile labels are off.** It calls `:281` "body excerpt at 9px", but
  `:281` is the *mode chip*; the body excerpt is `:203` at 13px. `:376` is
  correctly the 8px caption. Both resolve unambiguously under Part A's
  slot-for-slot mapping, so this needed no guessing — but worth correcting in
  the epic.

## One judgement call to review

`c7b34d8` promotes the **AdminOverlay moderation error** from `--text-xs` (8px)
to `.content-text`. It appeared in *neither* the grill's change list nor its
leave-alone list, so it looked like an omission rather than a decision. It is a
full error sentence read for meaning, and #623's rule is that nothing a player
reads sits below `--text-content`. Isolated in its own commit — revert that one
commit if the omission was deliberate.

## Also folded in (#586)

`PraxisCard.tsx` is named in #586. Hoisted the fully-static frame style objects
to module scope (Singularity sprocket row/hole, scanline, four corner brackets;
Snide torn edges; WOW scrap layers and tape; Everymen margin rule), matching
`layout/Sidebar.tsx`. Values carried over verbatim. Styles closing over props
(`tint`/`muted`/`paper`, the Albescent `ink()` helper) were left alone.

## Verification

- `tsc --noEmit` — clean (the `node:fs`/`node:url` hits are the known stale-junction false alarm, PR #675)
- `eslint` on all praxis card files — clean
- `vitest run` — 901 passed / 101 files
- `vite build` — clean; confirmed `.content-title`, `.card-description` and
  `.content-text` all survive Tailwind's purge and emit real rules

**Visual QA is outstanding** — I cannot screenshot (the Browser pane renderer
times out) and there is no dev stack in this worktree.

## What to eyeball

- **Desktop praxis card**, solo / collab / duel, across all 8 skins (UA, Everymen, WOW, Snide, Ephemerists, Singularity, Albescent, Default) — the title jumps 18→24px and the task link 8→18px; check the title/score-hero row still balances and long task titles do not wrap badly.
- **Body excerpt at 18px** — still clamps to 2 lines, does not blow out card height.
- **Collab roster names at 18px** (was 8px) — the biggest single jump. Check a large crew still fits beside the avatar stack and the "+N more" tail sits right.
- **Mobile praxis card**, same three variants × all skins — title 20→24px, task ref 11→18px, roster 10→18px.
- **Mobile media gallery** — the ▶/♪ glyph should look unchanged; the caption under it should look unchanged.
- **Dark mode** on both form factors.
- The **moderation error** (admin, on a flagged praxis) now at 18px.