### PR TITLE
Tokenize fontSize in the mobile faction-page skins (#623 slice 2)

### DIFF
--- a/frontend/src/pages/factionDetail/mobileArchetypes/AlbescentFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/AlbescentFactionPage.tsx
@@ -90,6 +90,19 @@ const joinButton: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
+const cancelButton: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 'var(--text-base)',
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: ink(45),
+  background: 'transparent',
+  border: `1px solid ${ink(14)}`,
+  padding: '11px 16px',
+  cursor: 'pointer',
+}
+
 export default function AlbescentFactionPage({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation('factions')
   const { faction, members, tasks, recentPraxis, membership } = state
@@ -199,17 +212,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
                   type="button"
                   onClick={() => setConfirming(false)}
                   disabled={membership.joining}
-                  style={{
-                    fontFamily: MONO,
-                    fontSize: 'var(--text-base)',
-                    letterSpacing: '0.12em',
-                    textTransform: 'uppercase',
-                    color: ink(45),
-                    background: 'transparent',
-                    border: `1px solid ${ink(14)}`,
-                    padding: '11px 16px',
-                    cursor: 'pointer',
-                  }}
+                  style={cancelButton}
                 >
                   {t('detail.join.cancel')}
                 </button>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/AlbescentFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/AlbescentFactionPage.tsx
@@ -31,7 +31,7 @@ const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
 
 const kicker: CSSProperties = {
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: ink(30),
@@ -56,6 +56,7 @@ function Witness({ name, size }: { name: string; size: number }) {
         fontFamily: FONT,
         fontStyle: 'italic',
         fontWeight: 300,
+        // ornament: avatar monogram, sized from the circle it sits in — geometry, not text.
         fontSize: size * 0.42,
         color: ink(55),
       }}
@@ -68,7 +69,7 @@ function Witness({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: MONO, fontSize: 9, letterSpacing: '0.2em', textTransform: 'uppercase', color: ink(40) }}>
+      <span style={{ fontFamily: MONO, fontSize: 'var(--text-sm)', letterSpacing: '0.2em', textTransform: 'uppercase', color: ink(40) }}>
         {children}
       </span>
       <span style={{ flex: 1, height: 1, background: ink(8) }} />
@@ -79,7 +80,7 @@ function SectionHead({ children }: { children: ReactNode }) {
 const joinButton: CSSProperties = {
   width: '100%',
   fontFamily: MONO,
-  fontSize: 11,
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.16em',
   textTransform: 'uppercase',
   color: PAGE,
@@ -117,10 +118,11 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
           <AlbescentSigil size={34} />
         </div>
         <div style={{ ...kicker, letterSpacing: '0.3em', color: ink(40) }}>{t('albescent.mobile.eyebrow')}</div>
+        {/* ornament: masthead display type — the Record's hand-set title is the skin's identity (§4/§270). */}
         <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 34, lineHeight: 1.08, color: INK, margin: '6px 0 0' }}>
           {name}
         </h1>
-        <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, lineHeight: 1.6, color: ink(52), margin: '10px auto 0', maxWidth: 320 }}>
+        <p className="content-text" style={{ fontFamily: FONT, fontStyle: 'italic', lineHeight: 1.6, color: ink(52), margin: '10px auto 0', maxWidth: 320 }}>
           {factionDescription(faction.slug)}
         </p>
         <div style={{ display: 'flex', gap: 8, marginTop: 18, justifyContent: 'center' }}>
@@ -137,7 +139,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: ink(45), margin: 0 }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: FONT, fontStyle: 'italic', color: ink(45), margin: 0 }}>{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -151,7 +153,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: ink(45), margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: FONT, fontStyle: 'italic', color: ink(45), margin: 0 }}>{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -162,7 +164,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
       </section>
 
       {membership.state === 'gate' && (
-        <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: ink(45), marginTop: 24 }}>
+        <p className="content-text" style={{ fontFamily: FONT, fontStyle: 'italic', color: ink(45), marginTop: 24 }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -171,7 +173,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: MONO, color: 'var(--color-danger)' }}>{membership.joinError}</p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -179,7 +181,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
             </button>
           ) : (
             <>
-              <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 14, color: INK }}>
+              <p className="content-text" style={{ fontFamily: FONT, fontStyle: 'italic', color: INK }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -199,7 +201,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
                   disabled={membership.joining}
                   style={{
                     fontFamily: MONO,
-                    fontSize: 10,
+                    fontSize: 'var(--text-base)',
                     letterSpacing: '0.12em',
                     textTransform: 'uppercase',
                     color: ink(45),
@@ -223,7 +225,7 @@ export default function AlbescentFactionPage({ state }: { state: FactionDetailSt
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ flex: '0 1 120px', textAlign: 'center', border: `1px solid ${ink(9)}`, padding: '10px 14px' }}>
-      <b style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 20, display: 'block', lineHeight: 1, color: INK }}>
+      <b className="content-title" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, display: 'block', lineHeight: 1, color: INK }}>
         {value}
       </b>
       <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
@@ -246,15 +248,15 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 16, color: ink(45), width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 'var(--text-xl)', color: ink(45), width: 16, flex: 'none' }}>{rank}</span>
       <Witness name={member.display_name} size={28} />
       <span
+        className="content-text"
         style={{
           flex: 1,
           minWidth: 0,
           fontFamily: FONT,
           fontStyle: 'italic',
-          fontSize: 15,
           color: INK,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -263,7 +265,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.08em', textTransform: 'uppercase', color: ink(38), flex: 'none' }}>
+      <span style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.08em', textTransform: 'uppercase', color: ink(38), flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/DefaultFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/DefaultFactionPage.tsx
@@ -47,10 +47,11 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
           color: 'var(--color-text-on-accent)',
         }}
       >
+        {/* ornament: masthead display type — the hero wordmark is the skin's identity (§4/§270). */}
         <h1 className="font-display italic font-medium" style={{ fontSize: 26, lineHeight: 1.1 }}>
           {name}
         </h1>
-        <p className="font-body" style={{ fontSize: 11, opacity: 0.92, marginTop: 5, lineHeight: 1.5 }}>
+        <p className="font-body content-text" style={{ opacity: 0.92, marginTop: 5, lineHeight: 1.5 }}>
           {factionDescription(faction.slug)}
         </p>
         <div style={{ display: 'flex', gap: 20, marginTop: 15 }}>
@@ -72,7 +73,7 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
       <section className="mt-6">
         <h2 className="eyebrow mb-2">{t('mobile.topMembers')}</h2>
         {topMembers.length === 0 ? (
-          <p className="font-body text-muted text-sm">{t('mobile.membersEmpty')}</p>
+          <p className="font-body text-muted content-text">{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -86,7 +87,7 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
       <section className="mt-6">
         <h2 className="eyebrow mb-2">{t('mobile.recentPraxis')}</h2>
         {recentPraxis.length === 0 ? (
-          <p className="font-body text-muted text-sm">{t('mobile.praxisEmpty')}</p>
+          <p className="font-body text-muted content-text">{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -97,7 +98,7 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
       </section>
 
       {membership.state === 'gate' && (
-        <p className="font-body text-sm text-muted mt-6">
+        <p className="font-body text-muted content-text mt-6">
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -106,7 +107,7 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p className="font-body text-sm text-red-600">{membership.joinError}</p>
+            <p className="font-body content-text text-red-600">{membership.joinError}</p>
           )}
           {!confirming ? (
             <button
@@ -118,7 +119,7 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
             </button>
           ) : (
             <>
-              <p className="font-body text-sm" style={{ color: 'var(--color-text-primary)' }}>
+              <p className="font-body content-text" style={{ color: 'var(--color-text-primary)' }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -138,7 +139,7 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
                   disabled={membership.joining}
                   style={{
                     fontFamily: 'var(--font-body)',
-                    fontSize: 11,
+                    fontSize: 'var(--text-md)',
                     letterSpacing: '0.08em',
                     textTransform: 'uppercase',
                     color: 'var(--color-text-secondary)',
@@ -163,7 +164,7 @@ export default function DefaultFactionPage({ state }: { state: FactionDetailStat
 const JOIN_BUTTON_STYLE = {
   width: '100%',
   fontFamily: 'var(--font-body)',
-  fontSize: 14,
+  fontSize: 'var(--text-xl)',
   fontWeight: 700,
   letterSpacing: '0.04em',
   color: 'var(--color-text-on-accent)',
@@ -177,11 +178,16 @@ const JOIN_BUTTON_STYLE = {
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div>
-      <b className="font-display italic" style={{ fontSize: 18, display: 'block', lineHeight: 1 }}>
+      <b className="font-display italic content-title" style={{ display: 'block', lineHeight: 1 }}>
         {value}
       </b>
       <span
-        style={{ fontSize: 8, letterSpacing: '0.16em', textTransform: 'uppercase', opacity: 0.85 }}
+        style={{
+          fontSize: 'var(--text-xs)',
+          letterSpacing: '0.16em',
+          textTransform: 'uppercase',
+          opacity: 0.85,
+        }}
       >
         {label}
       </span>
@@ -213,16 +219,15 @@ function MemberRow({
     >
       <span
         className="font-display italic"
-        style={{ fontSize: 16, color: accent, width: 18, flex: 'none' }}
+        style={{ fontSize: 'var(--text-xl)', color: accent, width: 18, flex: 'none' }}
       >
         {rank}
       </span>
       <span
-        className="font-body"
+        className="font-body content-text"
         style={{
           flex: 1,
           minWidth: 0,
-          fontSize: 14,
           color: 'var(--color-text-primary)',
           overflow: 'hidden',
           textOverflow: 'ellipsis',

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
@@ -37,7 +37,7 @@ const SCRIPT = 'var(--eph-script)'
 
 const kicker: CSSProperties = {
   fontFamily: DISPLAY,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -61,6 +61,7 @@ function Medallion({ name, size }: { name: string; size: number }) {
         justifyContent: 'center',
         fontFamily: DISPLAY,
         fontWeight: 700,
+        // ornament: avatar monogram, sized from the circle it sits in — geometry, not text.
         fontSize: size * 0.42,
         color: RUBRIC,
       }}
@@ -73,7 +74,7 @@ function Medallion({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: DISPLAY, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: TEXT }}>
+      <span style={{ fontFamily: DISPLAY, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: TEXT }}>
         {children}
       </span>
       <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
@@ -85,7 +86,7 @@ const joinButton: CSSProperties = {
   width: '100%',
   fontFamily: DISPLAY,
   fontWeight: 700,
-  fontSize: 13,
+  fontSize: 'var(--text-xl)',
   letterSpacing: '0.1em',
   textTransform: 'uppercase',
   color: PARCHMENT,
@@ -115,10 +116,11 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
           <EphemeristsSigil size={13} color={LAPIS} />
           <span style={{ ...kicker, color: LAPIS }}>{t('ephemerists.mobile.eyebrow')}</span>
         </div>
+        {/* ornament: masthead display type — the illuminated title is the skin's identity (§4/§270). */}
         <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 32, lineHeight: 1.05, color: TEXT, margin: '4px 0 0' }}>
           {name}
         </h1>
-        <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, lineHeight: 1.6, color: MUTED, margin: '8px 0 0' }}>
+        <p className="content-text" style={{ fontFamily: SCRIPT, fontStyle: 'italic', lineHeight: 1.6, color: MUTED, margin: '8px 0 0' }}>
           {factionDescription(faction.slug)}
         </p>
         <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
@@ -135,7 +137,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: MUTED, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: SCRIPT, fontStyle: 'italic', color: MUTED, margin: 0 }}>{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -149,7 +151,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: MUTED, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: SCRIPT, fontStyle: 'italic', color: MUTED, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -160,7 +162,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
       </section>
 
       {membership.state === 'gate' && (
-        <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: MUTED, marginTop: 24 }}>
+        <p className="content-text" style={{ fontFamily: SCRIPT, fontStyle: 'italic', color: MUTED, marginTop: 24 }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -169,7 +171,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p style={{ fontFamily: SERIF, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: SERIF, color: 'var(--color-danger)' }}>{membership.joinError}</p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -177,7 +179,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
             </button>
           ) : (
             <>
-              <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, color: TEXT }}>
+              <p className="content-text" style={{ fontFamily: SCRIPT, fontStyle: 'italic', color: TEXT }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -197,7 +199,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
                   disabled={membership.joining}
                   style={{
                     fontFamily: DISPLAY,
-                    fontSize: 11,
+                    fontSize: 'var(--text-md)',
                     letterSpacing: '0.1em',
                     textTransform: 'uppercase',
                     color: MUTED,
@@ -221,7 +223,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ flex: '1 1 0', textAlign: 'center', background: VELLUM_DEEP, border: `1px solid ${GOLD}`, padding: '10px 6px' }}>
-      <b style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 20, display: 'block', lineHeight: 1, color: TEXT }}>
+      <b className="content-title" style={{ fontFamily: DISPLAY, fontWeight: 700, display: 'block', lineHeight: 1, color: TEXT }}>
         {value}
       </b>
       <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
@@ -245,15 +247,15 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 16, color: RUBRIC, width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-xl)', color: RUBRIC, width: 16, flex: 'none' }}>{rank}</span>
       <Medallion name={member.display_name} size={28} />
       <span
+        className="content-text"
         style={{
           flex: 1,
           minWidth: 0,
           fontFamily: DISPLAY,
           fontWeight: 700,
-          fontSize: 15,
           color: TEXT,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -262,7 +264,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.06em', color: LAPIS, flex: 'none' }}>
+      <span style={{ fontFamily: DISPLAY, fontSize: 'var(--text-sm)', letterSpacing: '0.06em', color: LAPIS, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
@@ -96,6 +96,19 @@ const joinButton: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
+const cancelButton: CSSProperties = {
+  fontFamily: DISPLAY,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: MUTED,
+  background: 'transparent',
+  border: `1px solid ${GOLD_DEEP}`,
+  padding: '11px 16px',
+  cursor: 'pointer',
+}
+
 export default function EphemeristsFactionPage({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation('factions')
   const { faction, members, tasks, recentPraxis, membership } = state
@@ -197,17 +210,7 @@ export default function EphemeristsFactionPage({ state }: { state: FactionDetail
                   type="button"
                   onClick={() => setConfirming(false)}
                   disabled={membership.joining}
-                  style={{
-                    fontFamily: DISPLAY,
-                    fontSize: 'var(--text-md)',
-                    letterSpacing: '0.1em',
-                    textTransform: 'uppercase',
-                    color: MUTED,
-                    background: 'transparent',
-                    border: `1px solid ${GOLD_DEEP}`,
-                    padding: '11px 16px',
-                    cursor: 'pointer',
-                  }}
+                  style={cancelButton}
                 >
                   {t('detail.join.cancel')}
                 </button>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
@@ -33,7 +33,7 @@ const BODY_FONT = 'var(--font-body)'
 
 const kicker: CSSProperties = {
   fontFamily: BODY_FONT,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -70,6 +70,7 @@ function Seal({ name, size }: { name: string; size: number }) {
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: ACCENT_FONT,
+        // ornament: avatar monogram, sized from the seal it sits in — geometry, not text.
         fontSize: size * 0.5,
         color: RED,
       }}
@@ -82,7 +83,7 @@ function Seal({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, letterSpacing: '0.04em', color: INK, whiteSpace: 'nowrap' }}>
+      <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.04em', color: INK, whiteSpace: 'nowrap' }}>
         {children}
       </span>
       <span style={{ flex: 1, height: 3, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
@@ -93,7 +94,7 @@ function SectionHead({ children }: { children: ReactNode }) {
 const joinButton: CSSProperties = {
   width: '100%',
   fontFamily: ACCENT_FONT,
-  fontSize: 17,
+  fontSize: 'var(--text-xl)',
   letterSpacing: '0.08em',
   color: CREAM,
   background: RED,
@@ -124,10 +125,11 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
         </div>
         <div style={{ height: 4, background: GOLD }} />
         <div style={{ padding: '20px 18px' }}>
+          {/* ornament: masthead display type — the sign-painted title is the skin's identity (§4/§270). */}
           <h1 style={{ fontFamily: ACCENT_FONT, fontSize: 40, lineHeight: 0.92, letterSpacing: '0.01em', color: CREAM, textShadow: `2px 2px 0 ${INK}`, margin: 0 }}>
             {name}
           </h1>
-          <p style={{ fontFamily: BODY_FONT, fontSize: 12, lineHeight: 1.6, color: CREAM, margin: '10px 0 0' }}>
+          <p className="content-text" style={{ fontFamily: BODY_FONT, lineHeight: 1.6, color: CREAM, margin: '10px 0 0' }}>
             {factionDescription(faction.slug)}
           </p>
           <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
@@ -145,7 +147,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: BODY_FONT, color: MUTED, margin: 0 }}>{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -159,7 +161,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: BODY_FONT, color: MUTED, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -170,7 +172,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
       </section>
 
       {membership.state === 'gate' && (
-        <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, marginTop: 24 }}>
+        <p className="content-text" style={{ fontFamily: BODY_FONT, color: MUTED, marginTop: 24 }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -179,7 +181,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p style={{ fontFamily: BODY_FONT, fontSize: 12, color: RED }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: BODY_FONT, color: RED }}>{membership.joinError}</p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -187,7 +189,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
             </button>
           ) : (
             <>
-              <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: INK }}>
+              <p className="content-text" style={{ fontFamily: BODY_FONT, color: INK }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -207,7 +209,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
                   disabled={membership.joining}
                   style={{
                     fontFamily: ACCENT_FONT,
-                    fontSize: 15,
+                    fontSize: 'var(--text-xl)',
                     letterSpacing: '0.06em',
                     color: MUTED,
                     background: PAPER_DEEP,
@@ -230,7 +232,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ flex: '1 1 0', textAlign: 'center', background: INK, border: `1.5px solid ${GOLD}`, padding: '10px 6px' }}>
-      <b style={{ fontFamily: ACCENT_FONT, fontSize: 22, display: 'block', lineHeight: 0.9, color: GOLD }}>
+      <b className="content-title" style={{ fontFamily: ACCENT_FONT, display: 'block', lineHeight: 0.9, color: GOLD }}>
         {value}
       </b>
       <span style={{ ...kicker, marginTop: 5, display: 'block', color: CREAM }}>{label}</span>
@@ -254,14 +256,14 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: ACCENT_FONT, fontSize: 18, color: RED, width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', color: RED, width: 16, flex: 'none' }}>{rank}</span>
       <Seal name={member.display_name} size={28} />
       <span
+        className="content-text"
         style={{
           flex: 1,
           minWidth: 0,
           fontFamily: ACCENT_FONT,
-          fontSize: 17,
           letterSpacing: '0.02em',
           color: INK,
           overflow: 'hidden',

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
@@ -103,6 +103,18 @@ const joinButton: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
+const cancelButton: CSSProperties = {
+  fontFamily: ACCENT_FONT,
+  fontSize: 'var(--text-xl)',
+  letterSpacing: '0.06em',
+  color: MUTED,
+  background: PAPER_DEEP,
+  border: `1.5px solid ${INK}`,
+  padding: '11px 16px',
+  cursor: 'pointer',
+}
+
 export default function EverymenFactionPage({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation('factions')
   const { faction, members, tasks, recentPraxis, membership } = state
@@ -207,16 +219,7 @@ export default function EverymenFactionPage({ state }: { state: FactionDetailSta
                   type="button"
                   onClick={() => setConfirming(false)}
                   disabled={membership.joining}
-                  style={{
-                    fontFamily: ACCENT_FONT,
-                    fontSize: 'var(--text-xl)',
-                    letterSpacing: '0.06em',
-                    color: MUTED,
-                    background: PAPER_DEEP,
-                    border: `1.5px solid ${INK}`,
-                    padding: '11px 16px',
-                    cursor: 'pointer',
-                  }}
+                  style={cancelButton}
                 >
                   {t('detail.join.cancel')}
                 </button>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
@@ -83,7 +83,7 @@ function Seal({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.04em', color: INK, whiteSpace: 'nowrap' }}>
+      <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', letterSpacing: '0.04em', color: INK, whiteSpace: 'nowrap' }}>
         {children}
       </span>
       <span style={{ flex: 1, height: 3, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
@@ -34,7 +34,7 @@ const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, t
 
 const kicker: CSSProperties = {
   fontFamily: FONT,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: signal(60),
@@ -57,6 +57,7 @@ function NodeGlyph({ name, size }: { name: string; size: number }) {
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: FONT,
+        // ornament: avatar monogram, sized from the node it sits in — geometry, not text.
         fontSize: size * 0.36,
         color: SIGNAL,
       }}
@@ -69,7 +70,7 @@ function NodeGlyph({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: PHOSPHOR }}>
+      <span style={{ fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: PHOSPHOR }}>
         {children}
       </span>
       <span style={{ flex: 1, height: 1, background: signal(30) }} />
@@ -80,7 +81,7 @@ function SectionHead({ children }: { children: ReactNode }) {
 const joinButton: CSSProperties = {
   width: '100%',
   fontFamily: FONT,
-  fontSize: 13,
+  fontSize: 'var(--text-xl)',
   letterSpacing: '0.12em',
   textTransform: 'uppercase',
   color: VOID,
@@ -113,11 +114,12 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
         />
         <div style={{ position: 'relative' }}>
           <div style={{ ...kicker, color: PHOSPHOR }}>{t('singularity.mobile.eyebrow')}</div>
+          {/* ornament: masthead display type — the terminal banner is the skin's identity (§4/§270). */}
           <h1 style={{ fontFamily: FONT, fontSize: 26, lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', margin: '6px 0 0' }}>
             {'> '}
             {name}
           </h1>
-          <p style={{ fontFamily: FONT, fontSize: 11, lineHeight: 1.7, color: phosphor(60), margin: '10px 0 0' }}>
+          <p className="content-text" style={{ fontFamily: FONT, lineHeight: 1.7, color: phosphor(60), margin: '10px 0 0' }}>
             {factionDescription(faction.slug)}
           </p>
           <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
@@ -135,7 +137,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50), margin: 0 }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: FONT, color: phosphor(50), margin: 0 }}>{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -149,7 +151,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(50), margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: FONT, color: phosphor(50), margin: 0 }}>{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -160,7 +162,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
       </section>
 
       {membership.state === 'gate' && (
-        <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(55), marginTop: 24 }}>
+        <p className="content-text" style={{ fontFamily: FONT, color: phosphor(55), marginTop: 24 }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -169,7 +171,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p style={{ fontFamily: FONT, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: FONT, color: 'var(--color-danger)' }}>{membership.joinError}</p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -177,7 +179,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
             </button>
           ) : (
             <>
-              <p style={{ fontFamily: FONT, fontSize: 12, lineHeight: 1.6, color: phosphor(72) }}>
+              <p className="content-text" style={{ fontFamily: FONT, lineHeight: 1.6, color: phosphor(72) }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -197,7 +199,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
                   disabled={membership.joining}
                   style={{
                     fontFamily: FONT,
-                    fontSize: 11,
+                    fontSize: 'var(--text-md)',
                     letterSpacing: '0.1em',
                     textTransform: 'uppercase',
                     color: signal(60),
@@ -221,7 +223,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ flex: '1 1 0', textAlign: 'center', background: signal(8), border: `1px solid ${signal(28)}`, padding: '10px 6px' }}>
-      <b style={{ fontFamily: FONT, fontSize: 18, display: 'block', lineHeight: 1, color: PHOSPHOR }}>
+      <b className="content-title" style={{ fontFamily: FONT, display: 'block', lineHeight: 1, color: PHOSPHOR }}>
         {value}
       </b>
       <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
@@ -245,14 +247,14 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: FONT, fontSize: 14, color: SIGNAL, width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: FONT, fontSize: 'var(--text-xl)', color: SIGNAL, width: 16, flex: 'none' }}>{rank}</span>
       <NodeGlyph name={member.display_name} size={28} />
       <span
+        className="content-text"
         style={{
           flex: 1,
           minWidth: 0,
           fontFamily: FONT,
-          fontSize: 13,
           color: PHOSPHOR,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -261,7 +263,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: FONT, fontSize: 9, letterSpacing: '0.04em', color: AMBER, flex: 'none' }}>
+      <span style={{ fontFamily: FONT, fontSize: 'var(--text-sm)', letterSpacing: '0.04em', color: AMBER, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
@@ -92,6 +92,19 @@ const joinButton: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
+const cancelButton: CSSProperties = {
+  fontFamily: FONT,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: signal(60),
+  background: 'transparent',
+  border: `1px solid ${signal(38)}`,
+  padding: '11px 16px',
+  cursor: 'pointer',
+}
+
 export default function SingularityFactionPage({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation('factions')
   const { faction, members, tasks, recentPraxis, membership } = state
@@ -197,17 +210,7 @@ export default function SingularityFactionPage({ state }: { state: FactionDetail
                   type="button"
                   onClick={() => setConfirming(false)}
                   disabled={membership.joining}
-                  style={{
-                    fontFamily: FONT,
-                    fontSize: 'var(--text-md)',
-                    letterSpacing: '0.1em',
-                    textTransform: 'uppercase',
-                    color: signal(60),
-                    background: 'transparent',
-                    border: `1px solid ${signal(38)}`,
-                    padding: '11px 16px',
-                    cursor: 'pointer',
-                  }}
+                  style={cancelButton}
                 >
                   {t('detail.join.cancel')}
                 </button>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
@@ -97,6 +97,19 @@ const joinButton: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
+const cancelButton: CSSProperties = {
+  fontFamily: TYPE,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  color: MUTED,
+  background: 'transparent',
+  border: `1px solid ${LINE}`,
+  padding: '11px 16px',
+  cursor: 'pointer',
+}
+
 export default function SnideFactionPage({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation('factions')
   const { faction, members, tasks, recentPraxis, membership } = state
@@ -199,17 +212,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
                   type="button"
                   onClick={() => setConfirming(false)}
                   disabled={membership.joining}
-                  style={{
-                    fontFamily: TYPE,
-                    fontSize: 'var(--text-md)',
-                    letterSpacing: '0.06em',
-                    textTransform: 'uppercase',
-                    color: MUTED,
-                    background: 'transparent',
-                    border: `1px solid ${LINE}`,
-                    padding: '11px 16px',
-                    cursor: 'pointer',
-                  }}
+                  style={cancelButton}
                 >
                   {t('detail.join.cancel')}
                 </button>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
@@ -41,7 +41,7 @@ const CARD_SHADOW = '5px 6px 0 rgba(0,0,0,.5)'
 
 const kicker: CSSProperties = {
   fontFamily: TYPE,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -62,6 +62,7 @@ function Mug({ name, size }: { name: string; size: number }) {
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: IMPACT,
+        // ornament: avatar monogram, sized from the mugshot it sits in — geometry, not text.
         fontSize: size * 0.46,
         color: INK,
       }}
@@ -74,7 +75,7 @@ function Mug({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: COND, fontSize: 15, letterSpacing: '0.06em', textTransform: 'uppercase', color: ACID }}>
+      <span style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', color: ACID }}>
         {children}
       </span>
       <span style={{ flex: 1, height: 1, background: LINE }} />
@@ -85,7 +86,7 @@ function SectionHead({ children }: { children: ReactNode }) {
 const joinButton: CSSProperties = {
   width: '100%',
   fontFamily: BLACK,
-  fontSize: 13,
+  fontSize: 'var(--text-xl)',
   letterSpacing: '0.06em',
   textTransform: 'uppercase',
   color: PAPER,
@@ -116,10 +117,11 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
         <span aria-hidden style={{ position: 'absolute', top: -11, left: 26, width: 64, height: 24, background: TAPE, transform: 'rotate(-5deg)', opacity: 0.92 }} />
         <div style={{ position: 'relative' }}>
           <div style={{ ...kicker, color: ACID }}>{t('snide.mobile.eyebrow')}</div>
+          {/* ornament: masthead display type — the flyposted title is the skin's identity (§4/§270). */}
           <h1 style={{ fontFamily: COND, fontSize: 34, letterSpacing: '0.02em', lineHeight: 1.02, color: TEXT, margin: '4px 0 0' }}>
             {name}
           </h1>
-          <p style={{ fontFamily: TYPE, fontSize: 12.5, lineHeight: 1.6, color: MUTED, margin: '8px 0 0' }}>
+          <p className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.6, color: MUTED, margin: '8px 0 0' }}>
             {factionDescription(faction.slug)}
           </p>
           <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
@@ -137,7 +139,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p style={{ fontFamily: MARKER, fontSize: 14, color: MUTED, margin: 0, transform: 'rotate(-1deg)' }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: MARKER, color: MUTED, margin: 0, transform: 'rotate(-1deg)' }}>{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -151,7 +153,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p style={{ fontFamily: MARKER, fontSize: 14, color: MUTED, margin: 0, transform: 'rotate(-1deg)' }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: MARKER, color: MUTED, margin: 0, transform: 'rotate(-1deg)' }}>{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -162,7 +164,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
       </section>
 
       {membership.state === 'gate' && (
-        <p style={{ fontFamily: MARKER, fontSize: 14, color: MUTED, marginTop: 24, transform: 'rotate(-1deg)' }}>
+        <p className="content-text" style={{ fontFamily: MARKER, color: MUTED, marginTop: 24, transform: 'rotate(-1deg)' }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -171,7 +173,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p style={{ fontFamily: TYPE, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: TYPE, color: 'var(--color-danger)' }}>{membership.joinError}</p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -179,7 +181,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
             </button>
           ) : (
             <>
-              <p style={{ fontFamily: COND, fontSize: 15, letterSpacing: '0.02em', color: WALL_TEXT }}>
+              <p className="content-text" style={{ fontFamily: COND, letterSpacing: '0.02em', color: WALL_TEXT }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -199,7 +201,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
                   disabled={membership.joining}
                   style={{
                     fontFamily: TYPE,
-                    fontSize: 11,
+                    fontSize: 'var(--text-md)',
                     letterSpacing: '0.06em',
                     textTransform: 'uppercase',
                     color: MUTED,
@@ -223,7 +225,7 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ flex: '1 1 0', textAlign: 'center', background: 'rgba(255,255,255,0.04)', border: `1px solid ${LINE}`, padding: '10px 6px' }}>
-      <b style={{ fontFamily: IMPACT, fontSize: 20, display: 'block', lineHeight: 1, color: ACID }}>
+      <b className="content-title" style={{ fontFamily: IMPACT, display: 'block', lineHeight: 1, color: ACID }}>
         {value}
       </b>
       <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
@@ -248,14 +250,14 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: IMPACT, fontSize: 16, color: ACID, width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: IMPACT, fontSize: 'var(--text-xl)', color: ACID, width: 16, flex: 'none' }}>{rank}</span>
       <Mug name={member.display_name} size={28} />
       <span
+        className="content-text"
         style={{
           flex: 1,
           minWidth: 0,
           fontFamily: COND,
-          fontSize: 16,
           letterSpacing: '0.02em',
           color: TEXT,
           overflow: 'hidden',
@@ -265,7 +267,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: TYPE, fontSize: 9, letterSpacing: '0.06em', color: MUTED, flex: 'none' }}>
+      <span style={{ fontFamily: TYPE, fontSize: 'var(--text-sm)', letterSpacing: '0.06em', color: MUTED, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
@@ -39,7 +39,7 @@ const MONO = 'var(--font-body)'
 
 const kicker: CSSProperties = {
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -64,6 +64,7 @@ function Medallion({ name, size }: { name: string; size: number }) {
         fontFamily: DISPLAY,
         fontStyle: 'italic',
         fontWeight: 700,
+        // ornament: avatar monogram, sized from the medallion it sits in - geometry, not text.
         fontSize: size * 0.42,
         color: ACCENT,
       }}
@@ -76,7 +77,7 @@ function Medallion({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: ENGRAVED, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
+      <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
         {children}
       </span>
       <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
@@ -87,7 +88,7 @@ function SectionHead({ children }: { children: ReactNode }) {
 const joinButton: CSSProperties = {
   width: '100%',
   fontFamily: ENGRAVED,
-  fontSize: 13,
+  fontSize: 'var(--text-xl)',
   letterSpacing: '0.12em',
   textTransform: 'uppercase',
   color: PAPER_WARM,
@@ -127,10 +128,11 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
             }}
           >
             <div style={{ ...kicker, color: ACCENT }}>{t('ua.mobile.eyebrow')}</div>
+            {/* ornament: masthead display type - the engraved title is the skin's identity (§4/§270). */}
             <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 34, lineHeight: 1.05, color: INK, margin: '4px 0 0' }}>
               {name}
             </h1>
-            <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 13, lineHeight: 1.6, color: SUB, margin: '8px 0 0' }}>
+            <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', lineHeight: 1.6, color: SUB, margin: '8px 0 0' }}>
               {factionDescription(faction.slug)}
             </p>
             <div style={{ display: 'flex', gap: 8, marginTop: 15 }}>
@@ -149,7 +151,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, margin: 0 }}>{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -163,7 +165,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -174,7 +176,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
       </section>
 
       {membership.state === 'gate' && (
-        <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: SUB, marginTop: 24 }}>
+        <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, marginTop: 24 }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -183,7 +185,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p style={{ fontFamily: MONO, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: MONO, color: 'var(--color-danger)' }}>{membership.joinError}</p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -191,7 +193,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
             </button>
           ) : (
             <>
-              <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: INK }}>
+              <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: INK }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -211,7 +213,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
                   disabled={membership.joining}
                   style={{
                     fontFamily: ENGRAVED,
-                    fontSize: 11,
+                    fontSize: 'var(--text-md)',
                     letterSpacing: '0.1em',
                     textTransform: 'uppercase',
                     color: SUB,
@@ -235,7 +237,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ flex: '1 1 0', textAlign: 'center', background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: '10px 6px' }}>
-      <b style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 20, display: 'block', lineHeight: 1, color: INK }}>
+      <b className="content-title" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, display: 'block', lineHeight: 1, color: INK }}>
         {value}
       </b>
       <span style={{ ...kicker, marginTop: 5, display: 'block' }}>{label}</span>
@@ -259,15 +261,15 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 16, color: ACCENT, width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-xl)', color: ACCENT, width: 16, flex: 'none' }}>{rank}</span>
       <Medallion name={member.display_name} size={28} />
       <span
+        className="content-text"
         style={{
           flex: 1,
           minWidth: 0,
           fontFamily: DISPLAY,
           fontStyle: 'italic',
-          fontSize: 15,
           color: INK,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -276,7 +278,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.06em', color: GOLD, flex: 'none' }}>
+      <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.06em', color: GOLD, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
@@ -64,7 +64,7 @@ function Medallion({ name, size }: { name: string; size: number }) {
         fontFamily: DISPLAY,
         fontStyle: 'italic',
         fontWeight: 700,
-        // ornament: avatar monogram, sized from the medallion it sits in - geometry, not text.
+        // ornament: avatar monogram, sized from the medallion it sits in — geometry, not text.
         fontSize: size * 0.42,
         color: ACCENT,
       }}
@@ -99,6 +99,19 @@ const joinButton: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
+const cancelButton: CSSProperties = {
+  fontFamily: ENGRAVED,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: SUB,
+  background: 'transparent',
+  border: `1px solid ${LINE}`,
+  padding: '11px 16px',
+  cursor: 'pointer',
+}
+
 export default function UaFactionPage({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation('factions')
   const { faction, members, tasks, recentPraxis, membership } = state
@@ -128,7 +141,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
             }}
           >
             <div style={{ ...kicker, color: ACCENT }}>{t('ua.mobile.eyebrow')}</div>
-            {/* ornament: masthead display type - the engraved title is the skin's identity (§4/§270). */}
+            {/* ornament: masthead display type — the engraved title is the skin's identity (§4/§270). */}
             <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 34, lineHeight: 1.05, color: INK, margin: '4px 0 0' }}>
               {name}
             </h1>
@@ -211,17 +224,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
                   type="button"
                   onClick={() => setConfirming(false)}
                   disabled={membership.joining}
-                  style={{
-                    fontFamily: ENGRAVED,
-                    fontSize: 'var(--text-md)',
-                    letterSpacing: '0.1em',
-                    textTransform: 'uppercase',
-                    color: SUB,
-                    background: 'transparent',
-                    border: `1px solid ${LINE}`,
-                    padding: '11px 16px',
-                    cursor: 'pointer',
-                  }}
+                  style={cancelButton}
                 >
                   {t('detail.join.cancel')}
                 </button>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/WowFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/WowFactionPage.tsx
@@ -64,6 +64,7 @@ function Avatar({ name, size }: { name: string; size: number }) {
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: SCRIPT,
+        // ornament: avatar monogram, sized from the sticker it sits in - geometry, not text.
         fontSize: size * 0.5,
         color: ON_ACCENT,
       }}
@@ -76,7 +77,7 @@ function Avatar({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontFamily: SCRIPT, fontSize: 24, color: TITLE_TEXT }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontFamily: SCRIPT, fontSize: 'var(--text-title)', color: TITLE_TEXT }}>
         <Sparkle size={13} color={PINK} />
         {children}
       </span>
@@ -92,7 +93,7 @@ const joinButton: CSSProperties = {
   justifyContent: 'center',
   gap: 8,
   fontFamily: BODY,
-  fontSize: 13,
+  fontSize: 'var(--text-xl)',
   fontWeight: 700,
   letterSpacing: '0.1em',
   textTransform: 'uppercase',
@@ -156,7 +157,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
           {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
             <span key={c} style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }} />
           ))}
-          <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 18, color: TITLE_TEXT }}>
+          <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}>
             <Sparkle size={11} color={TITLE_TEXT} />
             {t('wow.mobile.eyebrow')}
           </span>
@@ -168,11 +169,12 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
             color: TITLE_TEXT,
           }}
         >
+          {/* ornament: masthead display type - the hand-lettered title is the skin's identity (§4/§270). */}
           <h1 style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: SCRIPT, fontSize: 36, lineHeight: 0.95, margin: 0 }}>
             <Sparkle size={18} color={TITLE_TEXT} />
             {name}
           </h1>
-          <p style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.6, color: PINK_DEEP, margin: '8px 0 0' }}>
+          <p className="content-text" style={{ fontFamily: BODY, lineHeight: 1.6, color: PINK_DEEP, margin: '8px 0 0' }}>
             {factionDescription(faction.slug)}
           </p>
           <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
@@ -183,14 +185,14 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
       </section>
 
       {membership.state === 'member' && (
-        <p style={{ fontFamily: SCRIPT, fontSize: 18, color: PINK, margin: '12px 0 0' }}>{t('mobile.memberBadge')}</p>
+        <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK, margin: '12px 0 0' }}>{t('mobile.memberBadge')}</p>
       )}
 
       {/* Top members */}
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK, margin: 0 }}>{t('mobile.membersEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -204,7 +206,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -215,7 +217,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
       </section>
 
       {membership.state === 'gate' && (
-        <p style={{ fontFamily: BODY, fontSize: 12, color: CARD_MUTED, marginTop: 24, lineHeight: 1.6 }}>
+        <p className="content-text" style={{ fontFamily: BODY, color: CARD_MUTED, marginTop: 24, lineHeight: 1.6 }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -224,7 +226,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p style={{ fontFamily: BODY, fontSize: 12, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: BODY, color: 'var(--color-danger)' }}>{membership.joinError}</p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -233,7 +235,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
             </button>
           ) : (
             <>
-              <p style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.6, color: CARD_TEXT }}>
+              <p className="content-text" style={{ fontFamily: BODY, lineHeight: 1.6, color: CARD_TEXT }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
@@ -253,7 +255,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
                   disabled={membership.joining}
                   style={{
                     fontFamily: BODY,
-                    fontSize: 11,
+                    fontSize: 'var(--text-md)',
                     letterSpacing: '0.1em',
                     textTransform: 'uppercase',
                     color: CARD_MUTED,
@@ -278,8 +280,8 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ flex: '1 1 0', textAlign: 'center', background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 12, padding: '11px 6px' }}>
-      <b style={{ fontFamily: SCRIPT, fontSize: 24, display: 'block', lineHeight: 1, color: TITLE_TEXT }}>{value}</b>
-      <span style={{ fontSize: 8, letterSpacing: '0.16em', textTransform: 'uppercase', color: CARD_MUTED, marginTop: 5, display: 'block' }}>
+      <b className="content-title" style={{ fontFamily: SCRIPT, display: 'block', lineHeight: 1, color: TITLE_TEXT }}>{value}</b>
+      <span style={{ fontSize: 'var(--text-xs)', letterSpacing: '0.16em', textTransform: 'uppercase', color: CARD_MUTED, marginTop: 5, display: 'block' }}>
         {label}
       </span>
     </div>
@@ -302,14 +304,14 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: SCRIPT, fontSize: 'var(--text-xl)', color: PINK, width: 16, flex: 'none' }}>{rank}</span>
       <Avatar name={member.display_name} size={28} />
       <span
+        className="content-text"
         style={{
           flex: 1,
           minWidth: 0,
           fontFamily: SCRIPT,
-          fontSize: 19,
           color: TITLE_TEXT,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -318,7 +320,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: BODY, fontSize: 9, letterSpacing: '0.04em', color: PINK_DEEP, flex: 'none' }}>
+      <span style={{ fontFamily: BODY, fontSize: 'var(--text-sm)', letterSpacing: '0.04em', color: PINK_DEEP, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/WowFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/WowFactionPage.tsx
@@ -64,7 +64,7 @@ function Avatar({ name, size }: { name: string; size: number }) {
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: SCRIPT,
-        // ornament: avatar monogram, sized from the sticker it sits in - geometry, not text.
+        // ornament: avatar monogram, sized from the sticker it sits in — geometry, not text.
         fontSize: size * 0.5,
         color: ON_ACCENT,
       }}
@@ -103,6 +103,20 @@ const joinButton: CSSProperties = {
   borderRadius: 14,
   padding: '13px 16px',
   boxShadow: `0 6px 16px color-mix(in srgb, ${PINK} 30%, transparent)`,
+  cursor: 'pointer',
+}
+
+/** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
+const cancelButton: CSSProperties = {
+  fontFamily: BODY,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: CARD_MUTED,
+  background: 'transparent',
+  border: `1.5px solid ${NOTEPAD_BORDER}`,
+  borderRadius: 12,
+  padding: '11px 16px',
   cursor: 'pointer',
 }
 
@@ -169,7 +183,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
             color: TITLE_TEXT,
           }}
         >
-          {/* ornament: masthead display type - the hand-lettered title is the skin's identity (§4/§270). */}
+          {/* ornament: masthead display type — the hand-lettered title is the skin's identity (§4/§270). */}
           <h1 style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: SCRIPT, fontSize: 36, lineHeight: 0.95, margin: 0 }}>
             <Sparkle size={18} color={TITLE_TEXT} />
             {name}
@@ -253,18 +267,7 @@ export default function WowFactionPage({ state }: { state: FactionDetailState })
                   type="button"
                   onClick={() => setConfirming(false)}
                   disabled={membership.joining}
-                  style={{
-                    fontFamily: BODY,
-                    fontSize: 'var(--text-md)',
-                    letterSpacing: '0.1em',
-                    textTransform: 'uppercase',
-                    color: CARD_MUTED,
-                    background: 'transparent',
-                    border: `1.5px solid ${NOTEPAD_BORDER}`,
-                    borderRadius: 12,
-                    padding: '11px 16px',
-                    cursor: 'pointer',
-                  }}
+                  style={cancelButton}
                 >
                   {t('detail.join.cancel')}
                 </button>


### PR DESCRIPTION
**Part of #623** (slice 2 — `pages/factionDetail/mobileArchetypes`).

Sweeps every raw `fontSize` in the eight mobile faction-page skins.

## Count

| | Raw `fontSize` |
|---|---|
| Before | **114** |
| After | **8** — one annotated ornament per skin |

The eight survivors are the hero wordmarks (26–40px), each carrying
`// ornament: masthead display type — … is the skin's identity (§4/§270)`.
#623 names "masthead display type" as genuine ornament, and the guardrail
protects each archetype's display type as its identity — tokenizing eight
bespoke wordmarks to one shared value is exactly the flattening §270 forbids.

Eight computed avatar monograms (`fontSize: size * 0.42` and friends) are also
annotated as ornament geometry. They never matched `fontSize: [0-9]` so they
don't move the count.

## The slot mapping

These eight skins are the same eight slots in eight dresses, so the sweep was
applied by slot rather than per element:

| Slot | Outcome |
|---|---|
| Faction description, empty states, gate hint, join confirm, join error | `.content-text` |
| Member display name | `.content-text` |
| Hero stat number (members / tasks) | `.content-title` |
| Section heads, rank ordinals, join + cancel buttons | Label token (`--text-md` / `--text-xl`) |
| Kickers, eyebrows, member level/score micro-labels | `--text-xs` / `--text-sm` |
| Hero wordmark, avatar monogram | ornament, raw + annotated |

Every promotion prefers the **role class** over an inline token, so most sites
lose their `fontSize` line entirely rather than trading a number for a var.

Two judgement calls worth a reviewer's eye:

- **Where a raw value already equalled a token exactly, that token was used** —
  zero visual change, value tokenized, no flattening. This is why WOW's section
  head is `--text-title` (was 24) and Everymen's is `--text-content` (was 18)
  while the tighter uppercase section heads in the other skins take a Label
  token. A section head that is uppercase + letterspaced at ≤12px is an eyebrow;
  one set at 18–24px in a display face is a heading. They are classified as what
  they are, not by slot name alone.
- **Rank ordinals are Label** (`--text-xl`) in all eight, per §4's "corner
  counters". WOW's drops 20 → 14 and Everymen's 18 → 14; both keep their script
  and colour.

`DefaultFactionPage` also had five Tailwind `text-sm` prose sites (empty states,
gate hint, join error, confirm copy) — all full sentences below the floor, all
promoted to `.content-text`.

## Also in here

- **#586 fold-in:** the Cancel affordance beside Join was an inline literal
  rebuilt every render in all seven bespoke skins, with no closure or prop
  dependency. Hoisted to a module-scope `cancelButton: CSSProperties`, matching
  `Sidebar.tsx`.

## Deliberately NOT in here

- **No file leaves `.eslint-legacy-raw-styles.txt`.** All eight still carry raw
  `padding`/`margin`/`gap` (5–15 each, 80 total), which is issue #750's scope.
  Because they stay listed the rule is off for them, so an `eslint-disable-next-line`
  directive would be *unused* — surviving ornament is annotated with a plain
  `// ornament:` comment instead of #623's per-line hatch. The hatch becomes
  available for these files once #750 clears the spacing.
- No spacing, no colour, no `.tsx` business logic.

## Verification

`tsc --noEmit` clean · `eslint` clean · `vitest` 901/901 pass · `vite build` clean.
Confirmed `.content-text` / `.content-title` actually survive Tailwind's purge
into the built CSS (they live in `@layer components`, so this is not automatic).

**Visual QA is outstanding** — I cannot screenshot in this environment.

## What to eyeball

Each at a phone width, `/factions/<slug>`:

1. **`/factions/wow`** — biggest deltas. Rank ordinals 20 → 14 in Caveat script; the two empty-state lines 20 → 18; window-chrome titlebar eyebrow and hero stats unchanged at 18/24.
2. **`/factions/everymen`** — section heads (`TOP MEMBERS` / `RECENT PRAXIS`) held at 18 but now tokenized; member names 17 → 18; Cancel button 15 → 14 in the poster face.
3. **`/factions/snide`** — section head 15 → 14; member names 16 → 18; check the `rotate(-1deg)` marker empty states still sit right at 18.
4. **`/factions/ua`** and **`/factions/ephemerists`** — member names 15 → 18 in an italic display face; watch for the roster row's `textOverflow: ellipsis` truncating earlier than before.
5. **`/factions/singularity`** — most prose was 11–12px, so this skin gains the most; check the phosphor terminal block doesn't overflow.
6. **`/factions/albescent`** — always-light; hero description 14 → 18 inside `maxWidth: 320`.
7. **`/factions/na`** (Default skin) — the five Tailwind `text-sm` → `.content-text` promotions, plus the sticky Join bar.

Across all eight, the roster row is the place most likely to need the container
to yield: rank + avatar + name + level/score now carries an 18px name where it
used to carry 13–17px.

## Note for the desktop sibling

`pages/factionDetail/archetypes` is being swept in parallel. Two decisions there
ought to match, and I did not reach across: **hero wordmarks stay raw as
annotated masthead ornament**, and **member display names are `.content-text`**.
Worth a cross-check before both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
