### PR TITLE
Tokenize Field Desk fontSizes — mobile skins + roster (#623 slice 3)

### DIFF
--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -104,7 +104,7 @@ export default function FieldDesk() {
             ) : (
               <span style={{ ...pillAvatar, display: 'inline-block' }} />
             )}
-            <span style={{ fontSize: 9, color: 'var(--color-text-secondary)' }}>
+            <span style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)' }}>
               @{active.username} ·{' '}
               <b style={{ color: 'var(--color-text-primary)' }}>
                 {t('fieldDesk.livesInPlay', { count: lives.length })}
@@ -194,7 +194,7 @@ function NewSelfDossier({
       <button type="button" onClick={onBegin} style={dossierUnlocked} title={t('fieldDesk.beginNewSelfTitle')}>
         <div style={folderTab} />
         <div style={medallion}>+</div>
-        <div style={{ fontFamily: 'var(--font-display)', fontStyle: 'italic', fontWeight: 700, fontSize: 23, color: 'var(--color-text-primary)' }}>
+        <div className="content-title" style={dossierTitle}>
           {t('fieldDesk.beginNewSelf')}
         </div>
         <div style={slotOpen}>{t('fieldDesk.slotOpen')}</div>
@@ -203,11 +203,12 @@ function NewSelfDossier({
   }
   return (
     <div style={dossierLocked} aria-disabled>
+      {/* ornament: padlock dingbat used as an icon, sized to its slot — not text */}
       <div style={{ fontSize: 22 }}>🔒</div>
-      <div style={{ fontFamily: 'var(--font-display)', fontStyle: 'italic', fontWeight: 700, fontSize: 21, color: 'var(--color-text-secondary)', marginTop: 8 }}>
+      <div className="content-title" style={dossierTitleLocked}>
         {t('fieldDesk.secondSelfAwaits')}
       </div>
-      <div style={{ fontSize: 9.5, lineHeight: 1.6, color: 'var(--color-text-tertiary)', marginTop: 8, maxWidth: 200 }}>
+      <div className="content-text" style={gateHintStyle}>
         {t('fieldDesk.gateHint', {
           gateLevel,
           eraSuffix: eraName ? t('fieldDesk.gateHintEra', { eraName }) : '',
@@ -244,11 +245,32 @@ const pillAvatar: CSSProperties = {
   objectFit: 'cover',
   background: 'var(--color-bg-surface-alt)',
 }
+// Hoisted from NewSelfDossier (#586): static, no closure deps. The size comes
+// from .content-title; these only carry font, weight, colour and offset.
+const dossierTitle: CSSProperties = {
+  fontFamily: 'var(--font-display)',
+  fontStyle: 'italic',
+  fontWeight: 700,
+  color: 'var(--color-text-primary)',
+}
+const dossierTitleLocked: CSSProperties = {
+  ...dossierTitle,
+  color: 'var(--color-text-secondary)',
+  marginTop: 8,
+}
+const gateHintStyle: CSSProperties = {
+  lineHeight: 1.6,
+  color: 'var(--color-text-tertiary)',
+  marginTop: 8,
+  // Container yields to type (§4 geometry doctrine): the hint reads at
+  // --text-content now, so it gets the dossier's full inner width.
+  maxWidth: 226,
+}
 const headingStyle: CSSProperties = {
   fontFamily: 'var(--font-display)',
   fontStyle: 'italic',
   fontWeight: 700,
-  fontSize: 44,
+  fontSize: 'var(--text-display)',
   lineHeight: 1,
   color: 'var(--color-text-primary)',
   margin: 0,
@@ -270,7 +292,7 @@ const rosterRow: CSSProperties = {
 const footerHint: CSSProperties = {
   fontFamily: 'var(--font-display)',
   fontStyle: 'italic',
-  fontSize: 11,
+  fontSize: 'var(--text-content)',
   color: 'var(--color-text-tertiary)',
   marginTop: 36,
 }
@@ -316,12 +338,13 @@ const medallion: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  // ornament: the "+" is a glyph sized to the 48px medallion, not text
   fontSize: 28,
   color: 'var(--color-text-primary)',
   marginBottom: 14,
 }
 const slotOpen: CSSProperties = {
-  fontSize: 7.5,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.14em',
   textTransform: 'uppercase',
   color: 'var(--color-success)',

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
@@ -27,7 +27,7 @@ const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
 
 const kicker: CSSProperties = {
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.28em',
   textTransform: 'uppercase',
   color: ink(30),
@@ -71,7 +71,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
           <AlbescentSigil size={26} />
           <div style={kicker}>{t('nav.home')}</div>
         </div>
-        <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 32, lineHeight: 1, color: INK, margin: 0 }}>
+        <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: 0 }}>
           {t('fieldDesk.home.albescent.masthead')}
         </h1>
         <div style={{ height: 1, marginTop: 10, background: ink(10) }} />
@@ -99,6 +99,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
                 style={{ objectFit: 'cover' }}
               />
             ) : (
+              // ornament: avatar initial sized to its 52px ring, not text
               <span style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 22, color: ink(55) }}>
                 {character.display_name[0]?.toUpperCase()}
               </span>
@@ -108,7 +109,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 25, lineHeight: 1.05, color: INK, textDecoration: 'none' }}
+              style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-title)', lineHeight: 1.05, color: INK, textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
@@ -120,7 +121,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 26, lineHeight: 1, color: ink(60) }}>
+            <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-title)', lineHeight: 1, color: ink(60) }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div style={{ ...kicker, marginTop: 3 }}>{t('fieldDesk.home.stats.points')}</div>
@@ -134,7 +135,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
               className="text-center"
               style={{ flex: '1 1 0', minWidth: 0, border: `1px solid ${ink(9)}`, padding: '11px 6px' }}
             >
-              <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 20, lineHeight: 1, color: INK }}>
+              <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
                 {stat.value}
               </div>
               <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
@@ -148,7 +149,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: '11px 16px', fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: INK, textDecoration: 'none' }}
+          style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: '11px 16px', fontFamily: FONT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: ink(40) }}>→</span>
@@ -158,7 +159,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
       {/* ── Work in hand ── */}
       <Sheet>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
-          <span style={{ fontFamily: MONO, fontSize: 9, letterSpacing: '0.2em', textTransform: 'uppercase', color: ink(40) }}>
+          <span style={{ fontFamily: MONO, fontSize: 'var(--text-sm)', letterSpacing: '0.2em', textTransform: 'uppercase', color: ink(40) }}>
             {t('fieldDesk.home.albescent.questsHeading')}
           </span>
           <span style={{ flex: 1, height: 1, background: ink(8) }} />
@@ -168,7 +169,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
         </div>
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 15, color: ink(45), margin: 0 }}>
+          <p style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: ink(45), margin: 0 }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -182,7 +183,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
               >
                 <AlbescentSigil size={14} opacity={0.7} />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 17, lineHeight: 1.2, color: INK }}>
+                  <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-content)', lineHeight: 1.2, color: INK }}>
                     {praxis.task_title}
                   </div>
                   <div className="truncate" style={{ ...kicker, marginTop: 3, letterSpacing: '0.14em' }}>
@@ -194,7 +195,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.14em', textTransform: 'uppercase', color: ink(35), padding: '4px 9px', border: `1px solid ${ink(12)}` }}
+                  style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.14em', textTransform: 'uppercase', color: ink(35), padding: '4px 9px', border: `1px solid ${ink(12)}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -209,7 +210,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: PAGE, background: INK, border: `1px solid ${INK}`, textDecoration: 'none' }}
+          style={{ fontFamily: MONO, fontSize: 'var(--text-base)', letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: PAGE, background: INK, border: `1px solid ${INK}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -217,8 +218,9 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: MONO, fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: ink(55), background: 'transparent', border: `1px solid ${ink(16)}`, textDecoration: 'none' }}
+            style={{ fontFamily: MONO, fontSize: 'var(--text-base)', letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: ink(55), background: 'transparent', border: `1px solid ${ink(16)}`, textDecoration: 'none' }}
           >
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 13, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionCssVar, factionFill, factionName } from '../../../utils/factions'
@@ -23,6 +23,49 @@ import type { FieldDeskHomeState } from '../useFieldDeskHome'
 // const so the jsx-text-only literal rule doesn't read it as user-facing copy.
 const CARET_DOWN = '▾'
 
+// Static style objects, hoisted to module scope (#586) — no closure deps.
+const pageTitleStyle: CSSProperties = {
+  fontSize: 'var(--text-heading)',
+  lineHeight: 1,
+  color: 'var(--color-text-primary)',
+  margin: 0,
+}
+const statTileStyle: CSSProperties = {
+  flex: '1 1 0',
+  background: 'var(--color-bg-surface-alt)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 9,
+  padding: '11px 6px',
+  minWidth: 0,
+}
+const pendingPillStyle: CSSProperties = {
+  background: 'var(--color-bg-surface)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 999,
+  padding: '10px 16px',
+  color: 'var(--color-text-primary)',
+  textDecoration: 'none',
+}
+const primaryActionStyle: CSSProperties = {
+  padding: 15,
+  borderRadius: 12,
+  fontSize: 'var(--text-lg)',
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  fontWeight: 700,
+  color: 'var(--color-bg-page)',
+  background: 'var(--color-text-primary)',
+  border: '1px solid var(--color-text-primary)',
+  textDecoration: 'none',
+}
+const secondaryActionStyle: CSSProperties = {
+  ...primaryActionStyle,
+  fontWeight: undefined,
+  color: 'var(--color-text-primary)',
+  background: 'var(--color-bg-surface)',
+  border: '1px solid var(--color-border-strong)',
+}
+
 export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
   const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
@@ -41,7 +84,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
         <div className="eyebrow" style={{ color: 'var(--color-text-secondary)' }}>
           {t('nav.home')}
         </div>
-        <h1 className="font-display italic" style={{ fontSize: 30, lineHeight: 1, color: 'var(--color-text-primary)', margin: 0 }}>
+        <h1 className="font-display italic" style={pageTitleStyle}>
           {t('fieldDesk.home.title')}
         </h1>
       </header>
@@ -77,7 +120,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
               type="button"
               onClick={() => setSwitcherOpen(true)}
               className="eyebrow"
-              style={{ fontSize: 9, color: 'var(--faction-default-card-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+              style={{ color: 'var(--faction-default-card-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
             >
               {t('fieldDesk.home.switch')}
             </button>
@@ -116,8 +159,8 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             <div className="flex items-center gap-1.5" style={{ minWidth: 0 }}>
               <Link
                 to={`/characters/${character.id}`}
-                className="font-display italic block truncate"
-                style={{ fontSize: 24, lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+                className="font-display italic block truncate content-title"
+                style={{ lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
               >
                 {character.display_name}
               </Link>
@@ -126,6 +169,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                 type="button"
                 onClick={() => setSwitcherOpen(true)}
                 aria-label={t('fieldDesk.home.switcher.title')}
+                // ornament: ▾ dingbat used as an icon, sized to the name row
                 style={{ flex: 'none', background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontSize: 14, lineHeight: 1, color: 'var(--color-text-tertiary)' }}
               >
                 <span aria-hidden>{CARET_DOWN}</span>
@@ -136,7 +180,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
               style={{
                 marginTop: 5,
                 fontFamily: 'var(--font-body)',
-                fontSize: 10,
+                fontSize: 'var(--text-base)',
                 letterSpacing: '0.14em',
                 textTransform: 'uppercase',
                 color: 'var(--color-text-secondary)',
@@ -149,7 +193,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div className="font-display" style={{ fontSize: 26, lineHeight: 1, color: 'var(--color-text-primary)' }}>
+            <div className="font-display content-title" style={{ lineHeight: 1, color: 'var(--color-text-primary)' }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div className="eyebrow" style={{ color: 'var(--color-text-secondary)' }}>
@@ -163,16 +207,9 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             <div
               key={stat.label}
               className="text-center"
-              style={{
-                flex: '1 1 0',
-                background: 'var(--color-bg-surface-alt)',
-                border: '1px solid var(--color-border)',
-                borderRadius: 9,
-                padding: '11px 6px',
-                minWidth: 0,
-              }}
+              style={statTileStyle}
             >
-              <div className="font-display truncate" style={{ fontSize: 20, lineHeight: 1, color: 'var(--color-text-primary)' }}>
+              <div className="font-display truncate content-text" style={{ lineHeight: 1, color: 'var(--color-text-primary)' }}>
                 {stat.value}
               </div>
               <div
@@ -190,16 +227,8 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
       {pendingCount > 0 && (
         <Link
           to="/updates?filter=requests"
-          className="font-body flex items-center justify-between"
-          style={{
-            background: 'var(--color-bg-surface)',
-            border: '1px solid var(--color-border)',
-            borderRadius: 999,
-            padding: '10px 16px',
-            fontSize: 12,
-            color: 'var(--color-text-primary)',
-            textDecoration: 'none',
-          }}
+          className="font-body flex items-center justify-between content-text"
+          style={pendingPillStyle}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: 'var(--color-text-tertiary)' }}>›</span>
@@ -230,7 +259,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
         </div>
 
         {activeTasks.length === 0 ? (
-          <p className="font-body" style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+          <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -251,7 +280,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                   style={{ width: 10, height: 10, borderRadius: 3, ...factionFill(praxis.task_faction_slug, 'dot') }}
                 />
                 <div className="min-w-0 flex-1">
-                  <div className="font-display truncate" style={{ fontSize: 17, lineHeight: 1.2, color: 'var(--color-text-primary)' }}>
+                  <div className="font-display truncate content-text" style={{ lineHeight: 1.2, color: 'var(--color-text-primary)' }}>
                     {praxis.task_title}
                   </div>
                   <div
@@ -259,7 +288,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                     style={{
                       marginTop: 3,
                       fontFamily: 'var(--font-body)',
-                      fontSize: 9,
+                      fontSize: 'var(--text-sm)',
                       letterSpacing: '0.1em',
                       textTransform: 'uppercase',
                       color: 'var(--color-text-secondary)',
@@ -293,18 +322,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
         <Link
           to="/tasks"
           className="font-body flex-1 flex items-center justify-center"
-          style={{
-            padding: 15,
-            borderRadius: 12,
-            fontSize: 12,
-            letterSpacing: '0.12em',
-            textTransform: 'uppercase',
-            fontWeight: 700,
-            color: 'var(--color-bg-page)',
-            background: 'var(--color-text-primary)',
-            border: '1px solid var(--color-text-primary)',
-            textDecoration: 'none',
-          }}
+          style={primaryActionStyle}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -312,18 +330,9 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
           <Link
             to="/propose-task"
             className="font-body flex-1 flex items-center justify-center gap-2"
-            style={{
-              padding: 15,
-              borderRadius: 12,
-              fontSize: 12,
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              color: 'var(--color-text-primary)',
-              background: 'var(--color-bg-surface)',
-              border: '1px solid var(--color-border-strong)',
-              textDecoration: 'none',
-            }}
+            style={secondaryActionStyle}
           >
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
@@ -33,7 +33,7 @@ const SCRIPT = 'var(--eph-script)'
 
 const kicker: CSSProperties = {
   fontFamily: DISPLAY,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -80,7 +80,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
           <EphemeristsSigil size={13} color={LAPIS} />
           <span style={kicker}>{t('nav.home')}</span>
         </div>
-        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 28, lineHeight: 1.05, color: TEXT, margin: '4px 0 0' }}>
+        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1.05, color: TEXT, margin: '4px 0 0' }}>
           {t('fieldDesk.home.ephemerists.masthead')}
         </h1>
         <div style={{ height: 1, marginTop: 9, background: goldRule }} />
@@ -107,6 +107,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center rounded-full"
+                // ornament: avatar initial sized to its 56px gilt ring, not text
                 style={{ background: VELLUM_DEEP, fontFamily: DISPLAY, fontWeight: 700, fontSize: 24, color: RUBRIC }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -117,11 +118,11 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 24, lineHeight: 1, color: TEXT, textDecoration: 'none' }}
+              style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: TEXT, textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
+            <div className="truncate" style={{ marginTop: 5, fontFamily: DISPLAY, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -129,7 +130,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 24, lineHeight: 1, color: RUBRIC }}>
+            <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: RUBRIC }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
@@ -143,7 +144,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
               className="text-center"
               style={{ flex: '1 1 0', minWidth: 0, background: VELLUM_DEEP, border: `1px solid ${GOLD_DEEP}`, padding: '11px 6px' }}
             >
-              <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 20, lineHeight: 1, color: TEXT }}>
+              <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1, color: TEXT }}>
                 {stat.value}
               </div>
               <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
@@ -157,7 +158,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: '10px 16px', fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: TEXT, textDecoration: 'none' }}
+          style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: '10px 16px', fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: TEXT, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: RUBRIC }}>›</span>
@@ -167,7 +168,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
       {/* ── Surveys underway ── */}
       <Leaf>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
-          <span style={{ fontFamily: DISPLAY, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: TEXT }}>
+          <span style={{ fontFamily: DISPLAY, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: TEXT }}>
             {t('fieldDesk.home.ephemerists.questsHeading')}
           </span>
           <span style={{ flex: 1, height: 1, background: goldRule }} />
@@ -177,7 +178,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
         </div>
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 15, color: MUTED, margin: 0 }}>
+          <p style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: MUTED, margin: 0 }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -191,10 +192,10 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
               >
                 <span className="shrink-0" style={{ width: 9, height: 9, borderRadius: '50%', background: RUBRIC }} />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 17, lineHeight: 1.15, color: TEXT }}>
+                  <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1.15, color: TEXT }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: DISPLAY, fontSize: 8.5, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+                  <div className="truncate" style={{ marginTop: 3, fontFamily: DISPLAY, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -203,7 +204,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: DISPLAY, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: LAPIS, padding: '4px 9px', border: `1px solid ${GOLD_DEEP}` }}
+                  style={{ fontFamily: DISPLAY, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: LAPIS, padding: '4px 9px', border: `1px solid ${GOLD_DEEP}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -218,7 +219,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 12, letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: PARCHMENT, background: RUBRIC, border: `1px solid ${GOLD}`, textDecoration: 'none' }}
+          style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-lg)', letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: PARCHMENT, background: RUBRIC, border: `1px solid ${GOLD}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -226,8 +227,9 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 12, letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: TEXT, background: VELLUM, border: `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
+            style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-lg)', letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: TEXT, background: VELLUM, border: `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
           >
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
@@ -30,7 +30,7 @@ const BODY_FONT = 'var(--font-body)'
 
 const kicker: CSSProperties = {
   fontFamily: BODY_FONT,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -72,7 +72,7 @@ function Plate({ children, style }: { children: ReactNode; style?: CSSProperties
 function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-      <span style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: '0.06em', color: INK, whiteSpace: 'nowrap' }}>
+      <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', letterSpacing: '0.06em', color: INK, whiteSpace: 'nowrap' }}>
         {title}
       </span>
       <span style={{ flex: 1, height: 3, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
@@ -110,7 +110,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
           }}
         >
           <CogSeal size={16} />
-          <span style={{ fontFamily: ACCENT_FONT, fontSize: 14, letterSpacing: '0.2em' }}>
+          <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.2em' }}>
             {t('fieldDesk.home.everymen.masthead')}
           </span>
           <span style={{ ...kicker, marginLeft: 'auto', color: CREAM }}>{t('nav.home')}</span>
@@ -119,7 +119,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
         <h1
           style={{
             fontFamily: ACCENT_FONT,
-            fontSize: 34,
+            fontSize: 'var(--text-heading)',
             lineHeight: 0.95,
             letterSpacing: '0.02em',
             color: CREAM,
@@ -153,6 +153,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center"
+                // ornament: avatar initial sized to its 56px gold plate, not text
                 style={{ background: PAPER_DEEP, fontFamily: ACCENT_FONT, fontSize: 26, color: RED }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -163,7 +164,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: ACCENT_FONT, fontSize: 28, lineHeight: 0.95, color: INK, textDecoration: 'none' }}
+              style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-title)', lineHeight: 0.95, color: INK, textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
@@ -175,7 +176,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: ACCENT_FONT, fontSize: 28, lineHeight: 0.9, color: RED }}>
+            <div style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-title)', lineHeight: 0.9, color: RED }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
@@ -190,7 +191,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
               className="text-center"
               style={{ flex: '1 1 0', minWidth: 0, background: PAPER_DEEP, border: `1.5px solid ${INK}`, padding: '11px 6px' }}
             >
-              <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 22, lineHeight: 0.9, color: INK }}>
+              <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-title)', lineHeight: 0.9, color: INK }}>
                 {stat.value}
               </div>
               <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
@@ -204,7 +205,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: PAPER, border: `1.5px solid ${INK}`, padding: '10px 16px', fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.04em', color: INK, textDecoration: 'none' }}
+          style={{ background: PAPER, border: `1.5px solid ${INK}`, padding: '10px 16px', fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', letterSpacing: '0.04em', color: INK, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: RED }}>›</span>
@@ -223,7 +224,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
         />
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: BODY_FONT, fontSize: 13, color: MUTED, margin: 0 }}>
+          <p style={{ fontFamily: BODY_FONT, fontSize: 'var(--text-content)', color: MUTED, margin: 0 }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -237,7 +238,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
               >
                 <span className="shrink-0" style={{ width: 10, height: 10, background: RED }} />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 18, lineHeight: 1.05, color: INK }}>
+                  <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', lineHeight: 1.05, color: INK }}>
                     {praxis.task_title}
                   </div>
                   <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
@@ -249,7 +250,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: BODY_FONT, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: '4px 9px' }}
+                  style={{ fontFamily: BODY_FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: '4px 9px' }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -264,7 +265,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: '0.08em', padding: 14, color: CREAM, background: RED, border: `2px solid ${INK}`, textDecoration: 'none' }}
+          style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 14, color: CREAM, background: RED, border: `2px solid ${INK}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -272,8 +273,9 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: ACCENT_FONT, fontSize: 16, letterSpacing: '0.08em', padding: 14, color: INK, background: PAPER_DEEP, border: `2px solid ${INK}`, textDecoration: 'none' }}
+            style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 14, color: INK, background: PAPER_DEEP, border: `2px solid ${INK}`, textDecoration: 'none' }}
           >
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
@@ -31,7 +31,7 @@ const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, t
 
 const kicker: CSSProperties = {
   fontFamily: FONT,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: signal(60),
@@ -93,7 +93,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
       {/* Prompt masthead */}
       <header>
         <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: FONT, fontSize: 26, lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.04em', margin: '4px 0 0' }}>
+        <h1 style={{ fontFamily: FONT, fontSize: 'var(--text-title)', lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.04em', margin: '4px 0 0' }}>
           {'> '}
           {t('fieldDesk.home.singularity.masthead')}
           <Cursor />
@@ -125,6 +125,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center"
+                // ornament: avatar initial sized to its 52px node ring, not text
                 style={{ fontFamily: FONT, fontSize: 20, color: SIGNAL }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -135,11 +136,11 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: FONT, fontSize: 20, lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', textDecoration: 'none' }}
+              style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: FONT, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
+            <div className="truncate" style={{ marginTop: 5, fontFamily: FONT, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -147,7 +148,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1, color: PHOSPHOR }}>
+            <div style={{ fontFamily: FONT, fontSize: 'var(--text-title)', lineHeight: 1, color: PHOSPHOR }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div style={{ ...kicker, marginTop: 3 }}>{t('fieldDesk.home.stats.points')}</div>
@@ -161,7 +162,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
               className="text-center"
               style={{ flex: '1 1 0', minWidth: 0, background: signal(8), border: `1px solid ${signal(28)}`, padding: '11px 6px' }}
             >
-              <div className="truncate" style={{ fontFamily: FONT, fontSize: 18, lineHeight: 1, color: PHOSPHOR }}>
+              <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1, color: PHOSPHOR }}>
                 {stat.value}
               </div>
               <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
@@ -175,7 +176,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: '11px 16px', fontFamily: FONT, fontSize: 12, color: PHOSPHOR, textDecoration: 'none' }}
+          style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: '11px 16px', fontFamily: FONT, fontSize: 'var(--text-content)', color: PHOSPHOR, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: SIGNAL }}>›</span>
@@ -185,7 +186,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
       {/* ── Running functions ── */}
       <Panel>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
-          <span style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: PHOSPHOR }}>
+          <span style={{ fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: PHOSPHOR }}>
             {t('fieldDesk.home.singularity.questsHeading')}
           </span>
           <span style={{ flex: 1, height: 1, background: signal(30) }} />
@@ -195,7 +196,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
         </div>
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: FONT, fontSize: 12, color: phosphor(45), margin: 0 }}>
+          <p style={{ fontFamily: FONT, fontSize: 'var(--text-content)', color: phosphor(45), margin: 0 }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -207,12 +208,13 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
                 className="flex items-center gap-3"
                 style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${signal(14)}`, textDecoration: 'none' }}
               >
+                {/* ornament: the prompt caret is a list bullet glyph, not text */}
                 <span className="shrink-0" style={{ fontFamily: FONT, fontSize: 13, color: PHOSPHOR }}>›</span>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: FONT, fontSize: 14, lineHeight: 1.2, color: PHOSPHOR }}>
+                  <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.2, color: PHOSPHOR }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: FONT, fontSize: 8.5, letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
+                  <div className="truncate" style={{ marginTop: 3, fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -221,7 +223,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: FONT, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: '4px 9px', border: `1px solid ${signal(30)}` }}
+                  style={{ fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: '4px 9px', border: `1px solid ${signal(30)}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -236,7 +238,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: FONT, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: VOID, background: PHOSPHOR, border: `1px solid ${PHOSPHOR}`, boxShadow: `0 0 16px ${phosphor(30)}`, textDecoration: 'none' }}
+          style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: VOID, background: PHOSPHOR, border: `1px solid ${PHOSPHOR}`, boxShadow: `0 0 16px ${phosphor(30)}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -244,8 +246,9 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: FONT, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PHOSPHOR, background: 'transparent', border: `1px solid ${signal(40)}`, textDecoration: 'none' }}
+            style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PHOSPHOR, background: 'transparent', border: `1px solid ${signal(40)}`, textDecoration: 'none' }}
           >
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
@@ -37,7 +37,7 @@ const CARD_SHADOW = '5px 6px 0 rgba(0,0,0,.5)'
 
 const kicker: CSSProperties = {
   fontFamily: TYPE,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -90,7 +90,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
       {/* Masthead — Bebas over an acid rule */}
       <header>
         <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: COND, fontSize: 40, letterSpacing: '0.03em', lineHeight: 0.95, color: WALL_TEXT, margin: '2px 0 0' }}>
+        <h1 style={{ fontFamily: COND, fontSize: 'var(--text-display)', letterSpacing: '0.03em', lineHeight: 0.95, color: WALL_TEXT, margin: '2px 0 0' }}>
           {t('fieldDesk.home.snide.masthead')}
         </h1>
         <div style={{ height: 2, marginTop: 8, background: ACCENT_WALL }} />
@@ -110,6 +110,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
             {character.avatar_url ? (
               <img src={mediaUrl(character.avatar_url)} alt={character.display_name} className="w-full h-full" style={{ objectFit: 'cover' }} />
             ) : (
+              // ornament: avatar initial sized to its 56px acid tile, not text
               <span style={{ fontFamily: IMPACT, fontSize: 26, color: INK }}>{character.display_name[0]?.toUpperCase()}</span>
             )}
           </div>
@@ -117,11 +118,11 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: COND, fontSize: 26, letterSpacing: '0.03em', lineHeight: 1, color: TEXT, textDecoration: 'none' }}
+              style={{ fontFamily: COND, fontSize: 'var(--text-title)', letterSpacing: '0.03em', lineHeight: 1, color: TEXT, textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: TYPE, fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
+            <div className="truncate" style={{ marginTop: 5, fontFamily: TYPE, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -129,7 +130,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: IMPACT, fontSize: 24, lineHeight: 1, color: ACID }}>
+            <div style={{ fontFamily: IMPACT, fontSize: 'var(--text-title)', lineHeight: 1, color: ACID }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
@@ -143,7 +144,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
               className="text-center"
               style={{ flex: '1 1 0', minWidth: 0, background: 'rgba(255,255,255,0.04)', border: `1px solid ${LINE}`, padding: '11px 6px' }}
             >
-              <div className="truncate" style={{ fontFamily: IMPACT, fontSize: 20, lineHeight: 1, color: TEXT }}>
+              <div className="truncate" style={{ fontFamily: IMPACT, fontSize: 'var(--text-content)', lineHeight: 1, color: TEXT }}>
                 {stat.value}
               </div>
               <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
@@ -157,7 +158,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: INK, color: TEXT, border: `1px solid ${LINE}`, padding: '11px 16px', fontFamily: COND, fontSize: 15, letterSpacing: '0.03em', textDecoration: 'none' }}
+          style={{ background: INK, color: TEXT, border: `1px solid ${LINE}`, padding: '11px 16px', fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.03em', textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: ACID }}>›</span>
@@ -167,7 +168,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
       {/* ── Jobs in play ── */}
       <RansomCard tilt={0.7}>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
-          <span style={{ fontFamily: COND, fontSize: 15, letterSpacing: '0.06em', textTransform: 'uppercase', color: ACID }}>
+          <span style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', color: ACID }}>
             {t('fieldDesk.home.snide.questsHeading')}
           </span>
           <span style={{ flex: 1, height: 1, background: LINE }} />
@@ -177,7 +178,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
         </div>
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: MARKER, fontSize: 14, color: MUTED, margin: 0, transform: 'rotate(-1deg)' }}>
+          <p style={{ fontFamily: MARKER, fontSize: 'var(--text-content)', color: MUTED, margin: 0, transform: 'rotate(-1deg)' }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -191,10 +192,10 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
               >
                 <span className="shrink-0" style={{ width: 9, height: 9, background: ACID }} />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: COND, fontSize: 18, letterSpacing: '0.02em', lineHeight: 1.15, color: TEXT }}>
+                  <div className="truncate" style={{ fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.02em', lineHeight: 1.15, color: TEXT }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: TYPE, fontSize: 8.5, letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+                  <div className="truncate" style={{ marginTop: 3, fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -203,7 +204,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: TYPE, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: ACID, padding: '4px 9px', border: `1px solid ${LINE}` }}
+                  style={{ fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: ACID, padding: '4px 9px', border: `1px solid ${LINE}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -218,7 +219,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: BLACK, fontSize: 12, letterSpacing: '0.06em', textTransform: 'uppercase', padding: 15, color: 'var(--faction-snide-paper)', background: PINK, boxShadow: '2px 3px 0 rgba(0,0,0,.4)', textDecoration: 'none' }}
+          style={{ fontFamily: BLACK, fontSize: 'var(--text-lg)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 15, color: 'var(--faction-snide-paper)', background: PINK, boxShadow: '2px 3px 0 rgba(0,0,0,.4)', textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -226,8 +227,9 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: COND, fontSize: 15, letterSpacing: '0.06em', textTransform: 'uppercase', padding: 15, color: TEXT, background: INK, border: `1px solid ${ACID}`, textDecoration: 'none' }}
+            style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 15, color: TEXT, background: INK, border: `1px solid ${ACID}`, textDecoration: 'none' }}
           >
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1, color: ACID }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -33,7 +33,7 @@ const MONO = 'var(--font-body)'
 
 const kicker: CSSProperties = {
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -87,7 +87,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
       {/* Engraved masthead */}
       <header>
         <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 32, lineHeight: 1, color: INK, margin: '2px 0 0' }}>
+        <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: '2px 0 0' }}>
           {t('fieldDesk.home.ua.masthead')}
         </h1>
         <div style={{ height: 1, marginTop: 9, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
@@ -114,6 +114,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center rounded-full"
+                // ornament: avatar initial sized to its 56px medallion, not text
                 style={{ background: PAPER_WARM, fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 24, color: ACCENT }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -124,11 +125,11 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 26, lineHeight: 1, color: INK, textDecoration: 'none' }}
+              style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: INK, textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: SUB }}>
+            <div className="truncate" style={{ marginTop: 5, fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: SUB }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -136,7 +137,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 26, lineHeight: 1, color: INK }}>
+            <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: INK }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
@@ -150,7 +151,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
               className="text-center"
               style={{ flex: '1 1 0', minWidth: 0, background: PAPER_WARM, border: `1px solid ${LINE}`, padding: '11px 6px' }}
             >
-              <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 20, lineHeight: 1, color: INK }}>
+              <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
                 {stat.value}
               </div>
               <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
@@ -164,7 +165,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999, padding: '10px 16px', fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 14, color: INK, textDecoration: 'none' }}
+          style={{ background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999, padding: '10px 16px', fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: ACCENT }}>›</span>
@@ -174,7 +175,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
       {/* ── Commissions at the easel ── */}
       <Plate>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
-          <span style={{ fontFamily: ENGRAVED, fontSize: 11, letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
+          <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
             {t('fieldDesk.home.ua.questsHeading')}
           </span>
           <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
@@ -184,7 +185,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
         </div>
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 15, color: SUB, margin: 0 }}>
+          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-content)', color: SUB, margin: 0 }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -198,10 +199,10 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
               >
                 <span className="shrink-0" style={{ width: 9, height: 9, borderRadius: '50%', background: ACCENT }} />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 17, lineHeight: 1.15, color: INK }}>
+                  <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: ENGRAVED, fontSize: 8.5, letterSpacing: '0.1em', textTransform: 'uppercase', color: SUB }}>
+                  <div className="truncate" style={{ marginTop: 3, fontFamily: ENGRAVED, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: SUB }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -210,7 +211,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.1em', textTransform: 'uppercase', color: GOLD, padding: '4px 9px', border: `1px solid ${LINE}` }}
+                  style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: GOLD, padding: '4px 9px', border: `1px solid ${LINE}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -225,7 +226,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PAPER_WARM, background: ACCENT, border: `1px solid ${ACCENT}`, boxShadow: '0 6px 16px rgba(194,84,31,.28)', textDecoration: 'none' }}
+          style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PAPER_WARM, background: ACCENT, border: `1px solid ${ACCENT}`, boxShadow: '0 6px 16px rgba(194,84,31,.28)', textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -233,8 +234,9 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: INK, background: PAPER, border: `1px solid ${LINE}`, textDecoration: 'none' }}
+            style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: INK, background: PAPER, border: `1px solid ${LINE}`, textDecoration: 'none' }}
           >
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -70,7 +70,7 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
           />
         ))}
         <span
-          style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 18, color: TITLE_TEXT }}
+          style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}
         >
           <Sparkle size={11} color={TITLE_TEXT} />
           {title}
@@ -100,7 +100,7 @@ const pinkButton: CSSProperties = {
   justifyContent: 'center',
   gap: 7,
   fontFamily: BODY,
-  fontSize: 12,
+  fontSize: 'var(--text-lg)',
   letterSpacing: '0.12em',
   textTransform: 'uppercase',
   fontWeight: 700,
@@ -119,7 +119,7 @@ const ghostButton: CSSProperties = {
   justifyContent: 'center',
   gap: 6,
   fontFamily: BODY,
-  fontSize: 12,
+  fontSize: 'var(--text-lg)',
   letterSpacing: '0.12em',
   textTransform: 'uppercase',
   padding: 15,
@@ -157,7 +157,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
     >
       <header>
         <div className="eyebrow" style={{ color: CARD_MUTED }}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: SCRIPT, fontSize: 34, lineHeight: 0.9, color: TITLE_TEXT, margin: 0 }}>
+        <h1 style={{ fontFamily: SCRIPT, fontSize: 'var(--text-heading)', lineHeight: 0.9, color: TITLE_TEXT, margin: 0 }}>
           {t('fieldDesk.home.title')}
         </h1>
       </header>
@@ -192,6 +192,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                 style={{
                   background: 'radial-gradient(circle at 35% 28%, var(--faction-wow-title-from), var(--faction-wow))',
                   fontFamily: SCRIPT,
+                  // ornament: avatar initial sized to its 56px medallion, not text
                   fontSize: 24,
                   color: ON_ACCENT,
                 }}
@@ -204,13 +205,13 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: SCRIPT, fontSize: 30, lineHeight: 0.95, color: TITLE_TEXT, textDecoration: 'none' }}
+              style={{ fontFamily: SCRIPT, fontSize: 'var(--text-heading)', lineHeight: 0.95, color: TITLE_TEXT, textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
             <div
               className="truncate"
-              style={{ marginTop: 4, fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}
+              style={{ marginTop: 4, fontSize: 'var(--text-base)', letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}
             >
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
@@ -219,7 +220,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: SCRIPT, fontSize: 30, lineHeight: 1, color: TITLE_TEXT }}>
+            <div style={{ fontFamily: SCRIPT, fontSize: 'var(--text-heading)', lineHeight: 1, color: TITLE_TEXT }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
             <div className="eyebrow" style={{ color: CARD_MUTED }}>
@@ -242,7 +243,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                 padding: '11px 6px',
               }}
             >
-              <div className="truncate" style={{ fontFamily: SCRIPT, fontSize: 24, lineHeight: 1, color: TITLE_TEXT }}>
+              <div className="truncate" style={{ fontFamily: SCRIPT, fontSize: 'var(--text-title)', lineHeight: 1, color: TITLE_TEXT }}>
                 {stat.value}
               </div>
               <div className="eyebrow" style={{ marginTop: 5, color: CARD_MUTED }}>
@@ -263,7 +264,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
             border: `1.5px solid ${NOTEPAD_BORDER}`,
             borderRadius: 999,
             padding: '10px 16px',
-            fontSize: 12,
+            fontSize: 'var(--text-content)',
             color: TITLE_TEXT,
             textDecoration: 'none',
           }}
@@ -279,7 +280,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
       {/* ── Quests window ── */}
       <Window title={t('fieldDesk.home.wow.questsWindow')}>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 8 }}>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 20, color: TITLE_TEXT }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}>
             <Sparkle size={12} color={PINK} />
             {t('fieldDesk.home.wow.questsHeading')}
           </span>
@@ -290,7 +291,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
         </div>
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: SCRIPT, fontSize: 20, color: PINK, margin: 0 }}>
+          <p style={{ fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: PINK, margin: 0 }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -308,12 +309,12 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
               >
                 <span className="shrink-0" style={{ width: 10, height: 10, borderRadius: 3, background: PINK }} />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: SCRIPT, fontSize: 20, lineHeight: 1, color: TITLE_TEXT }}>
+                  <div className="truncate" style={{ fontFamily: SCRIPT, fontSize: 'var(--text-content)', lineHeight: 1, color: TITLE_TEXT }}>
                     {praxis.task_title}
                   </div>
                   <div
                     className="truncate"
-                    style={{ marginTop: 4, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color: CARD_MUTED }}
+                    style={{ marginTop: 4, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CARD_MUTED }}
                   >
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
@@ -341,6 +342,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
         </Link>
         {canProposeTask && (
           <Link to="/propose-task" style={ghostButton}>
+            {/* ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             {t('actions.proposeTask')}
           </Link>


### PR DESCRIPTION
Part of #623 — **slice 3: Field Desk (mobile skins + roster)**.

## Count

| | raw `fontSize: N` |
|---|---|
| before | **132** |
| after | **19** (all annotated ornament) |

`frontend/src/pages/fieldDesk/mobileArchetypes/**` (123) + `frontend/src/pages/FieldDesk.tsx` (9).

Note: #623's "Surface inventory" table does not list `fieldDesk/mobileArchetypes`. Its "Ask" section ("sweep every raw fontSize in `frontend/src`") is what this follows; the inventory undercounts the mobile skins.

## Classification rules applied

Two decisions settle almost every value, and they were applied uniformly across all 8 skins so the factions stay parallel slot-for-slot:

1. **Role decides the tier; nearest token within that tier preserves the skin.** A character name is Content in every skin, but WOW's Caveat name (30) lands on `--text-heading` while Singularity's terminal name (20) lands on `--text-content`. Snapping every name to one token would have flattened the archetypes, which §270 forbids; snapping to the nearest token inside the correct tier keeps each skin's optical hierarchy while getting every value onto the scale.
2. **The Field Desk is a working surface**, so the shared content slots got promoted to the floor in all 8 skins: the pending-requests pill (was 12–15), the empty-quests copy (12–15), and the task-title rows (14–20) are all now `--text-content` or above. These were the real floor violations — a player reads all three.

Uppercase + letter-spaced strings (kickers, task meta, praxis-type pills, button chrome) went to the Label tier as hand-rolled eyebrows per §4.

## Surviving ornament (19)

Only two shapes, both per §4's "glyphs used as icons":

- the avatar-initial letter in each skin, sized to its 52/56px medallion (8×)
- the `+` on the propose-task button (8×), plus WOW/Default's `▾` switcher caret, Singularity's `›` prompt bullet, and FieldDesk's `🔒` padlock

Each carries a plain `// ornament: <why>` comment. **No `eslint-disable` directives** — every file in this slice stays in `.eslint-legacy-raw-styles.txt` (see below), so the rule is off for them and a disable directive would be reported as unused.

## Legacy list: nothing delisted, deliberately

Every one of the 9 files still holds **13–20 raw `padding`/`margin`/`gap` values** (125 total). Spacing is #750 and out of scope here, so all 9 lines stay in `frontend/.eslint-legacy-raw-styles.txt`. They become delistable once #750 lands.

## Also folded in (#586)

Hoisted static inline style objects to module scope where the object was already being edited: `pageTitleStyle` / `statTileStyle` / `pendingPillStyle` / `primaryActionStyle` / `secondaryActionStyle` in `DefaultFieldDesk.tsx`, and `dossierTitle` / `dossierTitleLocked` / `gateHintStyle` in `FieldDesk.tsx`. Nothing was restructured to make an object static.

## One container yield

`FieldDesk.tsx` locked-dossier gate hint: promoted 9.5px → `--text-content`, and widened its `maxWidth` 200 → 226 (the dossier's full inner width) rather than shrinking the type. §4's geometry doctrine — "if the type doesn't fit, the container is too small."

## Verification

- `tsc --noEmit` clean
- `eslint` clean on the slice
- `vite build` clean
- `vitest` — 901 tests / 101 files pass

**Visual QA is outstanding** — I cannot screenshot (the Browser pane renderer times out) and there is no dev stack in this worktree.

## What to eyeball

All of these need a phone viewport (`useFormFactor() === 'mobile'`) with a carried life:

1. **The three promoted slots, per faction** — pending-requests pill, empty-quests line, task-title rows. These grew the most (some 12 → 18) and are the likeliest to wrap or overflow a `truncate`.
2. **Stat tiles (Points / Votes / Era), all 8 skins** — 3-across `flex: 1 1 0` with `truncate`. The Era value is a word, not a number; check "Era One" still fits at `--text-content`.
3. **WOW and Everymen specifically** — Caveat (script) and Bebas (condensed) are the two fonts whose optical size differs most from their px value, so the nearest-token snaps are most visible there. WOW name/score 30 → 32; Everymen buttons 16 → 14.
4. **Snide masthead** 40 → 42 (`--text-display`) — the widest masthead; check it doesn't wrap.
5. **FieldDesk roster (desktop, logged in)** — the locked "A second self awaits" dossier: the gate hint is now 18px in a 226px box, and `dossierBase` has `minHeight: 320` which the taller text may now exceed. Also the unlocked "Begin a new self" card at `.content-title`.
6. **Dark mode** on Everymen / Ephemerists / Default (the theme-aware skins). No colour changed, but larger text on the same surfaces is worth a contrast glance.
