### PR TITLE
Tokenize fontSize: mobile task list, propose-task, character create/edit (slice 7)

### DIFF
--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -175,7 +175,6 @@ src/pages/taskDetail/mobileArchetypes/SnideTaskDetail.tsx
 src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
 src/pages/taskDetail/mobileArchetypes/WowTaskDetail.tsx
 src/pages/Tasks.tsx
-src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
 src/pages/tasks/mobileArchetypes/cards/AlbescentMobileTaskCard.tsx
 src/pages/tasks/mobileArchetypes/cards/DefaultMobileTaskCard.tsx
 src/pages/tasks/mobileArchetypes/cards/EphemeristsMobileTaskCard.tsx

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
@@ -46,7 +46,7 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
         <button type="button" onClick={() => navigate('/')} style={backBtn} aria-label={t('createCharacter.cancel')}>
           ‹
         </button>
-        <span className="eyebrow" style={{ fontSize: 10 }}>{t('createCharacter.mobile.title')}</span>
+        <span className="eyebrow">{t('createCharacter.mobile.title')}</span>
         <span style={{ width: 28 }} />
       </div>
 
@@ -57,6 +57,7 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
             {avatarPreview ? (
               <img src={avatarPreview} alt={handle} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : (
+              // ornament: "+" is a glyph-as-icon, sized to the 104px photo ring, not text
               <span style={{ fontSize: 26, color: 'var(--color-text-secondary)' }}>+</span>
             )}
           </span>
@@ -79,6 +80,7 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
           maxLength={NAME_MAX}
           placeholder={t('createCharacter.namePlaceholder')}
           autoFocus
+          className="content-text"
           style={field}
         />
         <div style={metaRow}>
@@ -107,7 +109,7 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
                   }}
                 >
                   <span style={{ width: 12, height: 12, borderRadius: '50%', background: factionCssVar(slug), flexShrink: 0 }} />
-                  <span style={{ fontFamily: factionCssVar(slug, 'card-font'), fontSize: 14, color: 'var(--color-text-primary)' }}>
+                  <span className="content-text" style={{ fontFamily: factionCssVar(slug, 'card-font'), color: 'var(--color-text-primary)' }}>
                     {factionName(slug)}
                   </span>
                 </button>
@@ -118,9 +120,9 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
       )}
 
       {/* Born-unaffiliated explainer */}
-      <p style={help}>{t('createCharacter.mobile.help')}</p>
+      <p className="content-text" style={help}>{t('createCharacter.mobile.help')}</p>
 
-      {error && <p style={errorBox}>{error}</p>}
+      {error && <p className="content-text" style={errorBox}>{error}</p>}
 
       {/* Sticky Create bar */}
       <div style={stickyBar}>
@@ -149,6 +151,7 @@ const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 22,
 const topRow: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
 const backBtn: CSSProperties = {
   width: 28, height: 28, background: 'none', border: 'none', cursor: 'pointer',
+  // ornament: the back chevron is a glyph-as-icon sized to its 28px hit target
   fontSize: 24, lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
 }
 const ringBtn: CSSProperties = {
@@ -161,18 +164,18 @@ const ringInner: CSSProperties = {
   background: 'var(--color-bg-surface-alt)',
 }
 const label: CSSProperties = {
-  display: 'block', fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+  display: 'block', fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase',
   color: 'var(--color-text-secondary)',
 }
 const field: CSSProperties = {
   display: 'block', width: '100%', marginTop: 8, boxSizing: 'border-box',
   background: 'var(--color-bg-page)', border: '1px solid var(--color-border-strong)',
-  borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)', fontSize: 15,
+  borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)',
   color: 'var(--color-text-primary)', padding: '12px 13px',
 }
 const metaRow: CSSProperties = {
   display: 'flex', justifyContent: 'space-between', marginTop: 6,
-  fontFamily: 'var(--font-body)', fontSize: 10,
+  fontFamily: 'var(--font-body)', fontSize: 'var(--text-base)',
 }
 const pickerCell: CSSProperties = {
   display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer', width: '100%',
@@ -180,11 +183,11 @@ const pickerCell: CSSProperties = {
   borderRadius: 8, padding: '13px 14px', textAlign: 'left',
 }
 const help: CSSProperties = {
-  fontFamily: 'var(--font-body)', fontSize: 12, lineHeight: 1.6,
+  fontFamily: 'var(--font-body)', lineHeight: 1.6,
   color: 'var(--color-text-tertiary)', margin: 0,
 }
 const errorBox: CSSProperties = {
-  fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-danger)',
+  fontFamily: 'var(--font-body)', color: 'var(--color-danger)',
   border: '1px solid var(--color-danger)', borderRadius: 6, padding: '10px 12px', margin: 0,
 }
 const stickyBar: CSSProperties = {
@@ -194,7 +197,7 @@ const stickyBar: CSSProperties = {
   paddingTop: 8,
 }
 const primaryBtn: CSSProperties = {
-  width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 13,
+  width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-xl)',
   letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700,
   color: 'var(--color-bg-page)', background: 'var(--color-text-primary)',
   border: 'none', padding: '15px 24px', borderRadius: 12,

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -58,7 +58,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
         <button type="button" onClick={() => navigate(`/characters/${id}`)} style={backBtn} aria-label={t('editCharacter.cancel')}>
           ‹
         </button>
-        <span className="eyebrow" style={{ fontSize: 10 }}>{t('editCharacter.heading')}</span>
+        <span className="eyebrow">{t('editCharacter.heading')}</span>
         <span style={{ width: 28 }} />
       </div>
 
@@ -69,6 +69,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
             {character.avatar_url ? (
               <img src={mediaUrl(character.avatar_url)} alt={character.username} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : (
+              // ornament: the fallback monogram is illustration, sized to the 96px ring
               <span style={{ fontFamily: 'var(--faction-default-card-font)', fontStyle: 'italic', fontSize: 34, color: 'var(--color-text-primary)' }}>
                 {initial}
               </span>
@@ -78,7 +79,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
         <div className="eyebrow" style={{ marginTop: 12, color: 'var(--faction-default-card-muted)' }}>
           {t('editCharacter.mobile.changePhoto')}
         </div>
-        {avatarError && <p style={{ ...errorBox, marginTop: 8 }}>{avatarError}</p>}
+        {avatarError && <p className="content-text" style={{ ...errorBox, marginTop: 8 }}>{avatarError}</p>}
       </div>
       <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarChange} style={{ display: 'none' }} />
 
@@ -90,6 +91,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
           onChange={(e) => setDisplayName(e.target.value)}
           maxLength={50}
           placeholder={t('editCharacter.displayNamePlaceholder')}
+          className="content-text"
           style={field}
         />
       </div>
@@ -102,6 +104,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
           onChange={(e) => setBio(e.target.value)}
           maxLength={500}
           placeholder={t('editCharacter.storyPlaceholder')}
+          className="content-text"
           style={field}
         />
       </div>
@@ -109,17 +112,17 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
       {/* Faction — read-only link out to Factions */}
       <div>
         <label style={label}>{t('editCharacter.mobile.factionLabel')}</label>
-        <Link to={factionHref} style={factionRow}>
+        <Link to={factionHref} className="content-text" style={factionRow}>
           <span>{factionSlug ? factionName(factionSlug) : t('editCharacter.mobile.unaffiliated')}</span>
           <span aria-hidden style={{ color: 'var(--color-text-tertiary)' }}>›</span>
         </Link>
-        <p style={help}>{t('editCharacter.mobile.factionHelp')}</p>
+        <p className="content-text" style={help}>{t('editCharacter.mobile.factionHelp')}</p>
       </div>
 
       {/* Delete — two-tap confirm */}
       {confirmingDelete ? (
         <div style={confirmRow}>
-          <span style={{ fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-text-secondary)' }}>
+          <span className="content-text" style={{ fontFamily: 'var(--font-body)', color: 'var(--color-text-secondary)' }}>
             {t('editCharacter.mobile.deleteConfirm')}
           </span>
           <div style={{ display: 'flex', gap: 10 }}>
@@ -137,7 +140,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
         </button>
       )}
 
-      {error && <p style={errorBox}>{error}</p>}
+      {error && <p className="content-text" style={errorBox}>{error}</p>}
 
       {/* Sticky Save bar */}
       <div style={stickyBar}>
@@ -166,6 +169,7 @@ const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 20,
 const topRow: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
 const backBtn: CSSProperties = {
   width: 28, height: 28, background: 'none', border: 'none', cursor: 'pointer',
+  // ornament: the back chevron is a glyph-as-icon sized to its 28px hit target
   fontSize: 24, lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
 }
 const ringBtn: CSSProperties = {
@@ -178,29 +182,29 @@ const ringInner: CSSProperties = {
   background: 'var(--faction-default-card-bg)',
 }
 const label: CSSProperties = {
-  display: 'block', fontSize: 9, letterSpacing: '0.16em', textTransform: 'uppercase',
+  display: 'block', fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase',
   color: 'var(--color-text-secondary)', marginBottom: 8,
 }
 const field: CSSProperties = {
   display: 'block', width: '100%', boxSizing: 'border-box',
   background: 'var(--color-bg-page)', border: '1px solid var(--color-border-strong)',
-  borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)', fontSize: 15,
+  borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)',
   color: 'var(--color-text-primary)', padding: '12px 13px',
 }
 const factionRow: CSSProperties = {
   display: 'flex', alignItems: 'center', justifyContent: 'space-between',
   background: 'var(--color-bg-surface-alt)', border: '1px solid var(--color-border-strong)',
   borderRadius: 8, padding: '12px 13px', textDecoration: 'none',
-  fontFamily: 'var(--font-body)', fontSize: 15, color: 'var(--color-text-secondary)',
+  fontFamily: 'var(--font-body)', color: 'var(--color-text-secondary)',
 }
 const help: CSSProperties = {
-  fontFamily: 'var(--font-body)', fontSize: 11, lineHeight: 1.6,
+  fontFamily: 'var(--font-body)', lineHeight: 1.6,
   color: 'var(--color-text-tertiary)', margin: '8px 0 0',
 }
 const deleteBtn: CSSProperties = {
   width: '100%', cursor: 'pointer', background: 'none', textAlign: 'center',
   border: '1px solid var(--color-danger)', borderRadius: 8, padding: '12px',
-  fontFamily: 'var(--font-body)', fontSize: 12, letterSpacing: '0.1em',
+  fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)', letterSpacing: '0.1em',
   textTransform: 'uppercase', color: 'var(--color-danger)',
 }
 const confirmRow: CSSProperties = {
@@ -210,15 +214,15 @@ const confirmRow: CSSProperties = {
 const confirmCancel: CSSProperties = {
   flex: 1, cursor: 'pointer', background: 'var(--color-bg-surface)',
   border: '1px solid var(--color-border-strong)', borderRadius: 8, padding: '10px',
-  fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-text-primary)',
+  fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)', color: 'var(--color-text-primary)',
 }
 const confirmDelete: CSSProperties = {
   flex: 1, cursor: 'pointer', background: 'var(--color-danger)', border: 'none',
-  borderRadius: 8, padding: '10px', fontFamily: 'var(--font-body)', fontSize: 12,
+  borderRadius: 8, padding: '10px', fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)',
   letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-bg-page)',
 }
 const errorBox: CSSProperties = {
-  fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--color-danger)',
+  fontFamily: 'var(--font-body)', color: 'var(--color-danger)',
   border: '1px solid var(--color-danger)', borderRadius: 6, padding: '10px 12px', margin: 0,
 }
 const stickyBar: CSSProperties = {
@@ -228,7 +232,7 @@ const stickyBar: CSSProperties = {
   paddingTop: 8,
 }
 const primaryBtn: CSSProperties = {
-  width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 13,
+  width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-xl)',
   letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700,
   color: 'var(--color-bg-page)', background: 'var(--color-text-primary)',
   border: 'none', padding: '15px 24px', borderRadius: 12,

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PageTitle from "../../../components/ui/PageTitle";
@@ -6,6 +7,78 @@ import { factionCssVar, factionName, getAllFactions } from "../../../utils/facti
 import type { ProposeTaskState } from "../useProposeTask";
 
 const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+
+const breadcrumbStyle: CSSProperties = {
+  fontSize: "var(--text-sm)",
+  letterSpacing: "0.1em",
+  color: "var(--color-text-tertiary)",
+};
+
+const descriptionTextareaStyle: CSSProperties = {
+  width: "100%",
+  fontFamily: "'Courier Prime', monospace",
+  lineHeight: 1.7,
+  color: "var(--color-text-primary)",
+  background: "transparent",
+  border: "none",
+  outline: "none",
+  resize: "vertical",
+  minHeight: 120,
+};
+
+const notesTextareaStyle: CSSProperties = {
+  width: "100%",
+  fontFamily: "'Courier Prime', monospace",
+  color: "var(--color-text-primary)",
+  background: "transparent",
+  border: "1px solid var(--color-border)",
+  borderRadius: 6,
+  padding: "0.6rem 0.7rem",
+  outline: "none",
+  resize: "vertical",
+};
+
+const tooLongStyle: CSSProperties = {
+  color: "#dc2626",
+  display: "block",
+  marginTop: 2,
+};
+
+const basePointsInputStyle: CSSProperties = {
+  width: 80,
+  fontFamily: "'Courier Prime', monospace",
+  fontWeight: 700,
+  color: "var(--color-text-primary)",
+  background: "transparent",
+  border: "none",
+  borderBottom: "2px solid var(--color-border-strong)",
+  outline: "none",
+  textAlign: "center",
+};
+
+const tipsListStyle: CSSProperties = {
+  color: "var(--color-text-primary)",
+  lineHeight: 1.6,
+  paddingLeft: 14,
+  listStyleType: "disc",
+};
+
+const tipsBodyStyle: CSSProperties = {
+  color: "var(--color-text-secondary)",
+  lineHeight: 1.6,
+};
+
+const submitNoteStyle: CSSProperties = {
+  color: "var(--color-text-tertiary)",
+  marginLeft: "auto",
+};
+
+const submitDashStyle: CSSProperties = {
+  position: "absolute",
+  inset: 3,
+  border: "1px dashed rgba(255,255,255,0.25)",
+  pointerEvents: "none",
+};
 
 const FACTION_DESCRIPTOR_KEY = {
   ua: "proposeTask.factionDescriptor.ua",
@@ -73,14 +146,14 @@ export default function DefaultProposeTask({
           {isMetaTask ? (
             <>
               <p
-                className="font-display italic"
-                style={{ fontSize: 22, color, marginBottom: 6 }}
+                className="content-title font-display italic"
+                style={{ color, marginBottom: 6 }}
               >
                 {t("proposeTask.successMeta.heading")}
               </p>
               <p
-                className="font-body"
-                style={{ fontSize: 10, color: "var(--color-text-secondary)" }}
+                className="content-text font-body"
+                style={{ color: "var(--color-text-secondary)" }}
               >
                 {t("proposeTask.successMeta.body", {
                   faction: factionName(factionSlug),
@@ -90,14 +163,14 @@ export default function DefaultProposeTask({
           ) : (
             <>
               <p
-                className="font-display italic"
-                style={{ fontSize: 22, color, marginBottom: 6 }}
+                className="content-title font-display italic"
+                style={{ color, marginBottom: 6 }}
               >
                 {t("proposeTask.successTask.heading")}
               </p>
               <p
-                className="font-body"
-                style={{ fontSize: 10, color: "var(--color-text-secondary)" }}
+                className="content-text font-body"
+                style={{ color: "var(--color-text-secondary)" }}
               >
                 {t("proposeTask.successTask.body")}
               </p>
@@ -113,11 +186,7 @@ export default function DefaultProposeTask({
       {/* Breadcrumb */}
       <nav
         className="font-body mb-4"
-        style={{
-          fontSize: 9,
-          letterSpacing: "0.1em",
-          color: "var(--color-text-tertiary)",
-        }}
+        style={breadcrumbStyle}
       >
         <Link to="/tasks" style={{ color: "inherit", textDecoration: "none" }}>
           {t("breadcrumb.tasks")}
@@ -179,7 +248,7 @@ export default function DefaultProposeTask({
                         background: factionCssVar(slug),
                         color: "var(--color-text-on-accent)",
                         fontFamily: "'Courier Prime', monospace",
-                        fontSize: 8,
+                        fontSize: "var(--text-xs)",
                         fontWeight: 700,
                         textTransform: "uppercase",
                         letterSpacing: "0.07em",
@@ -228,7 +297,7 @@ export default function DefaultProposeTask({
                   style={{
                     width: "100%",
                     fontFamily: "'Courier Prime', monospace",
-                    fontSize: 22,
+                    fontSize: "var(--text-title)",
                     fontWeight: 700,
                     color: "var(--color-text-primary)",
                     background: "transparent",
@@ -249,19 +318,14 @@ export default function DefaultProposeTask({
                 />
                 <span
                   className={`eyebrow self-end ${title.length >= 180 ? "text-red-600" : ""}`}
-                  style={{ fontSize: 7, marginTop: 4 }}
+                  style={{ marginTop: 4 }}
                 >
                   {title.length}/200
                 </span>
                 {title.length >= 200 && (
                   <span
-                    className="font-body"
-                    style={{
-                      fontSize: 10,
-                      color: "#dc2626",
-                      display: "block",
-                      marginTop: 2,
-                    }}
+                    className="content-text font-body"
+                    style={tooLongStyle}
                   >
                     {t("proposeTask.fields.name.tooLong")}
                   </span>
@@ -283,34 +347,19 @@ export default function DefaultProposeTask({
                   onChange={(e) => setDescription(e.target.value)}
                   disabled={submitting}
                   placeholder={t("proposeTask.fields.description.placeholder")}
-                  style={{
-                    width: "100%",
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: 13,
-                    lineHeight: 1.7,
-                    color: "var(--color-text-primary)",
-                    background: "transparent",
-                    border: "none",
-                    outline: "none",
-                    resize: "vertical",
-                    minHeight: 120,
-                  }}
+                  className="content-text"
+                  style={descriptionTextareaStyle}
                 />
                 <span
                   className={`eyebrow self-end ${description.length >= 4500 ? "text-red-600" : ""}`}
-                  style={{ fontSize: 7, marginTop: 4 }}
+                  style={{ marginTop: 4 }}
                 >
                   {description.length}/5000
                 </span>
                 {description.length >= 5000 && (
                   <span
-                    className="font-body"
-                    style={{
-                      fontSize: 10,
-                      color: "#dc2626",
-                      display: "block",
-                      marginTop: 2,
-                    }}
+                    className="content-text font-body"
+                    style={tooLongStyle}
                   >
                     {t("proposeTask.fields.description.tooLong")}
                   </span>
@@ -343,18 +392,8 @@ export default function DefaultProposeTask({
                       }
                       disabled={submitting}
                       placeholder={t("proposeTask.fields.basePoints.placeholder")}
-                      style={{
-                        width: 80,
-                        fontFamily: "'Courier Prime', monospace",
-                        fontSize: 20,
-                        fontWeight: 700,
-                        color: "var(--color-text-primary)",
-                        background: "transparent",
-                        border: "none",
-                        borderBottom: "2px solid var(--color-border-strong)",
-                        outline: "none",
-                        textAlign: "center",
-                      }}
+                      className="content-title"
+                      style={basePointsInputStyle}
                     />
                     <span
                       className="eyebrow"
@@ -381,17 +420,10 @@ export default function DefaultProposeTask({
                       }
                       disabled={submitting}
                       placeholder={t("proposeTask.fields.bonusPoints.placeholder")}
+                      className="content-title"
                       style={{
-                        width: 80,
-                        fontFamily: "'Courier Prime', monospace",
-                        fontSize: 20,
-                        fontWeight: 700,
-                        color: "var(--color-text-primary)",
-                        background: "transparent",
-                        border: "none",
+                        ...basePointsInputStyle,
                         borderBottom: `2px solid ${color}`,
-                        outline: "none",
-                        textAlign: "center",
                       }}
                     />
                     <span
@@ -451,9 +483,8 @@ export default function DefaultProposeTask({
                       }}
                     />
                     <span
-                      className="font-body"
+                      className="content-text font-body"
                       style={{
-                        fontSize: 11,
                         color: "var(--color-text-primary)",
                         fontWeight: isMetaTask ? 700 : 400,
                       }}
@@ -491,18 +522,8 @@ export default function DefaultProposeTask({
                   onChange={(e) => setNotes(e.target.value)}
                   disabled={submitting}
                   placeholder={t("proposeTask.fields.notes.placeholder")}
-                  style={{
-                    width: "100%",
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: 11,
-                    color: "var(--color-text-primary)",
-                    background: "transparent",
-                    border: "1px solid var(--color-border)",
-                    borderRadius: 6,
-                    padding: "0.6rem 0.7rem",
-                    outline: "none",
-                    resize: "vertical",
-                  }}
+                  className="content-text"
+                  style={notesTextareaStyle}
                   onFocus={(e) => {
                     e.currentTarget.style.borderColor = color;
                   }}
@@ -533,9 +554,8 @@ export default function DefaultProposeTask({
                     : t("proposeTask.preview.taskHeading", { faction: fname })}
                 </span>
                 <p
-                  className="font-body"
+                  className="content-text font-body"
                   style={{
-                    fontSize: 12,
                     fontWeight: 700,
                     color: "var(--color-text-primary)",
                     marginBottom: 2,
@@ -545,9 +565,8 @@ export default function DefaultProposeTask({
                 </p>
                 {description && (
                   <p
-                    className="font-body"
+                    className="content-text font-body"
                     style={{
-                      fontSize: 9,
                       color: "var(--color-text-secondary)",
                       lineHeight: 1.4,
                       overflow: "hidden",
@@ -592,9 +611,8 @@ export default function DefaultProposeTask({
 
             {error && (
               <p
-                className="font-body"
+                className="content-text font-body"
                 style={{
-                  fontSize: 10,
                   color: "var(--color-danger)",
                   marginBottom: 12,
                 }}
@@ -612,7 +630,7 @@ export default function DefaultProposeTask({
                   background: color,
                   color: "var(--color-text-on-accent)",
                   fontFamily: "'Courier Prime', monospace",
-                  fontSize: 12,
+                  fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   textTransform: "uppercase",
                   letterSpacing: "0.15em",
@@ -624,12 +642,7 @@ export default function DefaultProposeTask({
                 }}
               >
                 <span
-                  style={{
-                    position: "absolute",
-                    inset: 3,
-                    border: "1px dashed rgba(255,255,255,0.25)",
-                    pointerEvents: "none",
-                  }}
+                  style={submitDashStyle}
                 />
                 {submitting
                   ? t("proposeTask.submit.busy")
@@ -641,17 +654,13 @@ export default function DefaultProposeTask({
                 type="button"
                 onClick={handleCancel}
                 className="btn-outline"
-                style={{ fontSize: 10, padding: "8px 16px" }}
+                style={{ fontSize: "var(--text-base)", padding: "8px 16px" }}
               >
                 {t("proposeTask.submit.cancel")}
               </button>
               <span
-                className="font-body"
-                style={{
-                  fontSize: 8,
-                  color: "var(--color-text-tertiary)",
-                  marginLeft: "auto",
-                }}
+                className="content-text font-body"
+                style={submitNoteStyle}
               >
                 {t("proposeTask.submit.note")}
               </span>
@@ -666,14 +675,8 @@ export default function DefaultProposeTask({
               {t("proposeTask.tips.goodTaskHeading")}
             </p>
             <ul
-              className="font-body"
-              style={{
-                fontSize: 9,
-                color: "var(--color-text-primary)",
-                lineHeight: 1.6,
-                paddingLeft: 14,
-                listStyleType: "disc",
-              }}
+              className="content-text font-body"
+              style={tipsListStyle}
             >
               {(
                 t("proposeTask.tips.goodTaskItems", {
@@ -688,12 +691,8 @@ export default function DefaultProposeTask({
           <div className="sidebar-card" style={{ padding: "14px 16px" }}>
             <p className="eyebrow mb-2">{t("proposeTask.tips.nextHeading")}</p>
             <p
-              className="font-body"
-              style={{
-                fontSize: 9,
-                color: "var(--color-text-secondary)",
-                lineHeight: 1.6,
-              }}
+              className="content-text font-body"
+              style={tipsBodyStyle}
             >
               {t("proposeTask.tips.nextBody")}
             </p>

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -41,7 +41,7 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
     <div className="py-4" data-testid="mobile-tasks-browse">
       <h1
         className="font-display italic font-medium mb-1"
-        style={{ fontSize: 26, color: 'var(--color-text-primary)', lineHeight: 1.1 }}
+        style={{ fontSize: 'var(--text-heading)', color: 'var(--color-text-primary)', lineHeight: 1.1 }}
       >
         {tc('nav.tasks')}
       </h1>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/AlbescentMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/AlbescentMobileTaskCard.tsx
@@ -22,7 +22,7 @@ const ink = (pct: number) => `color-mix(in srgb, ${INK} ${pct}%, transparent)`
 
 const kicker: CSSProperties = {
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.28em',
   textTransform: 'uppercase',
   color: ink(30),
@@ -46,23 +46,24 @@ export default function AlbescentMobileTaskCard({ task, points }: { task: TaskOu
     >
       <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
         <AlbescentSigil size={16} opacity={0.75} />
-        <i style={{ fontFamily: MONO, fontSize: 8, letterSpacing: '0.22em', textTransform: 'uppercase', color: ink(24), fontStyle: 'normal' }}>
+        <i style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.22em', textTransform: 'uppercase', color: ink(24), fontStyle: 'normal' }}>
           {factionName(task.primary_faction_slug)}
         </i>
       </span>
 
-      <h2 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 19, lineHeight: 1.28, color: INK, margin: 0, overflowWrap: 'anywhere' }}>
+      <h2 className="content-title" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, lineHeight: 1.28, color: INK, margin: 0, overflowWrap: 'anywhere' }}>
         {task.title}
       </h2>
 
       <MobileTaskDescription
         text={task.description}
-        style={{ fontFamily: MONO, fontSize: 10, lineHeight: 1.6, color: ink(42), margin: 0 }}
+        className="content-text"
+        style={{ fontFamily: MONO, lineHeight: 1.6, color: ink(42), margin: 0 }}
       />
 
       <div className="flex items-center justify-between" style={{ marginTop: 2, borderTop: `1px solid ${ink(7)}`, paddingTop: 10 }}>
         <span style={{ ...kicker, letterSpacing: '0.2em', color: ink(24) }}>{t('mobile.level', { level: task.level_required })}</span>
-        <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 16, color: ink(55) }}>{t('mobile.points', { points })}</span>
+        <span style={{ fontFamily: FONT, fontStyle: 'italic', fontSize: 'var(--text-xl)', color: ink(55) }}>{t('mobile.points', { points })}</span>
       </div>
     </Link>
   )

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/DefaultMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/DefaultMobileTaskCard.tsx
@@ -37,8 +37,8 @@ export default function DefaultMobileTaskCard({ task, points }: { task: TaskOut;
 
       {/* Title */}
       <h2
-        className="font-display italic font-medium"
-        style={{ fontSize: 18, lineHeight: 1.15, color: 'var(--color-text-primary)' }}
+        className="content-title font-display italic font-medium"
+        style={{ lineHeight: 1.15, color: 'var(--color-text-primary)' }}
       >
         {task.title}
       </h2>
@@ -46,8 +46,8 @@ export default function DefaultMobileTaskCard({ task, points }: { task: TaskOut;
       {/* Description — clamp to two lines */}
       <MobileTaskDescription
         text={task.description}
-        className="font-body"
-        style={{ fontSize: 13, lineHeight: 1.5, color: 'var(--color-text-secondary)' }}
+        className="content-text font-body"
+        style={{ lineHeight: 1.5, color: 'var(--color-text-secondary)' }}
       />
 
       {/* Footer — points + level */}
@@ -55,7 +55,7 @@ export default function DefaultMobileTaskCard({ task, points }: { task: TaskOut;
         <span
           style={{
             fontFamily: "'Courier Prime', monospace",
-            fontSize: 12,
+            fontSize: 'var(--text-lg)',
             fontWeight: 700,
             color: 'var(--color-text-primary)',
             background: 'var(--color-bg-surface-alt)',

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/EphemeristsMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/EphemeristsMobileTaskCard.tsx
@@ -22,7 +22,7 @@ const SCRIPT = 'var(--eph-script)'
 
 const kicker: CSSProperties = {
   fontFamily: DISPLAY,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -45,22 +45,23 @@ export default function EphemeristsMobileTaskCard({ task, points }: { task: Task
         textDecoration: 'none',
       }}
     >
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: DISPLAY, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: DISPLAY, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
         <i style={{ width: 7, height: 7, borderRadius: '50%', background: color, flex: 'none' }} />
         {factionName(task.primary_faction_slug)}
       </span>
 
-      <h2 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 19, lineHeight: 1.15, color: TEXT, margin: 0 }}>
+      <h2 className="content-title" style={{ fontFamily: DISPLAY, fontWeight: 700, lineHeight: 1.15, color: TEXT, margin: 0 }}>
         {task.title}
       </h2>
 
       <MobileTaskDescription
         text={task.description}
-        style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 14, lineHeight: 1.5, color: MUTED, margin: 0 }}
+        className="content-text"
+        style={{ fontFamily: SCRIPT, fontStyle: 'italic', lineHeight: 1.5, color: MUTED, margin: 0 }}
       />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
-        <span style={{ fontFamily: DISPLAY, fontSize: 12, letterSpacing: '0.04em', color: TEXT, background: VELLUM_DEEP, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>
+        <span style={{ fontFamily: DISPLAY, fontSize: 'var(--text-lg)', letterSpacing: '0.04em', color: TEXT, background: VELLUM_DEEP, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>
           {t('mobile.points', { points })}
         </span>
         <span style={{ ...kicker, color: MUTED }}>{t('mobile.level', { level: task.level_required })}</span>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/EverymenMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/EverymenMobileTaskCard.tsx
@@ -21,7 +21,7 @@ const BODY_FONT = 'var(--font-body)'
 
 const kicker: CSSProperties = {
   fontFamily: BODY_FONT,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -51,17 +51,18 @@ export default function EverymenMobileTaskCard({ task, points }: { task: TaskOut
         {factionName(task.primary_faction_slug)}
       </span>
 
-      <h2 style={{ fontFamily: ACCENT_FONT, fontSize: 22, lineHeight: 1, letterSpacing: '0.01em', color: INK, margin: 0 }}>
+      <h2 className="content-title" style={{ fontFamily: ACCENT_FONT, lineHeight: 1, letterSpacing: '0.01em', color: INK, margin: 0 }}>
         {task.title}
       </h2>
 
       <MobileTaskDescription
         text={task.description}
-        style={{ fontFamily: BODY_FONT, fontSize: 13, lineHeight: 1.5, color: MUTED, margin: 0 }}
+        className="content-text"
+        style={{ fontFamily: BODY_FONT, lineHeight: 1.5, color: MUTED, margin: 0 }}
       />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
-        <span style={{ fontFamily: ACCENT_FONT, fontSize: 15, letterSpacing: '0.04em', color: INK, background: GOLD, padding: '3px 10px' }}>
+        <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.04em', color: INK, background: GOLD, padding: '3px 10px' }}>
           {t('mobile.points', { points })}
         </span>
         <span style={{ ...kicker }}>{t('mobile.level', { level: task.level_required })}</span>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/SingularityMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/SingularityMobileTaskCard.tsx
@@ -24,7 +24,7 @@ const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, t
 
 const kicker: CSSProperties = {
   fontFamily: FONT,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: signal(60),
@@ -47,23 +47,24 @@ export default function SingularityMobileTaskCard({ task, points }: { task: Task
         textDecoration: 'none',
       }}
     >
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: FONT, fontSize: 8, letterSpacing: '0.14em', textTransform: 'uppercase', color: SIGNAL }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.14em', textTransform: 'uppercase', color: SIGNAL }}>
         <i style={{ width: 7, height: 7, background: color, flex: 'none' }} />
         {factionName(task.primary_faction_slug)}
       </span>
 
-      <h2 style={{ fontFamily: FONT, fontSize: 15, lineHeight: 1.3, color: PHOSPHOR, margin: 0, overflowWrap: 'anywhere' }}>
+      <h2 className="content-title" style={{ fontFamily: FONT, lineHeight: 1.3, color: PHOSPHOR, margin: 0, overflowWrap: 'anywhere' }}>
         {'> '}
         {task.title}
       </h2>
 
       <MobileTaskDescription
         text={task.description}
-        style={{ fontFamily: FONT, fontSize: 11, lineHeight: 1.5, color: phosphor(55), margin: 0 }}
+        className="content-text"
+        style={{ fontFamily: FONT, lineHeight: 1.5, color: phosphor(55), margin: 0 }}
       />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2, borderTop: `1px solid ${signal(20)}`, paddingTop: 8 }}>
-        <span style={{ fontFamily: FONT, fontSize: 12, letterSpacing: '0.04em', color: PHOSPHOR, border: `1px solid ${signal(38)}`, padding: '3px 9px' }}>
+        <span style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.04em', color: PHOSPHOR, border: `1px solid ${signal(38)}`, padding: '3px 9px' }}>
           {t('mobile.points', { points })}
         </span>
         <span style={{ ...kicker }}>{t('mobile.level', { level: task.level_required })}</span>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/SnideMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/SnideMobileTaskCard.tsx
@@ -25,7 +25,7 @@ const CARD_SHADOW = '5px 6px 0 rgba(0,0,0,.5)'
 
 const kicker: CSSProperties = {
   fontFamily: TYPE,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -56,22 +56,23 @@ export default function SnideMobileTaskCard({ task, points }: { task: TaskOut; p
         aria-hidden
         style={{ position: 'absolute', inset: 0, pointerEvents: 'none', backgroundImage: 'radial-gradient(rgba(182,255,46,0.07) 32%, transparent 34%)', backgroundSize: '5px 5px' }}
       />
-      <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: TYPE, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
+      <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: TYPE, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
         <i style={{ width: 7, height: 7, background: color, flex: 'none' }} />
         {factionName(task.primary_faction_slug)}
       </span>
 
-      <h2 style={{ position: 'relative', fontFamily: COND, fontSize: 21, letterSpacing: '0.02em', lineHeight: 1.1, color: TEXT, margin: 0 }}>
+      <h2 className="content-title" style={{ position: 'relative', fontFamily: COND, letterSpacing: '0.02em', lineHeight: 1.1, color: TEXT, margin: 0 }}>
         {task.title}
       </h2>
 
       <MobileTaskDescription
         text={task.description}
-        style={{ position: 'relative', fontFamily: TYPE, fontSize: 12.5, lineHeight: 1.5, color: MUTED, margin: 0 }}
+        className="content-text"
+        style={{ position: 'relative', fontFamily: TYPE, lineHeight: 1.5, color: MUTED, margin: 0 }}
       />
 
       <div className="flex items-center gap-3" style={{ position: 'relative', marginTop: 2 }}>
-        <span style={{ fontFamily: IMPACT, fontSize: 13, letterSpacing: '0.02em', color: INK, background: ACID, padding: '3px 9px' }}>
+        <span style={{ fontFamily: IMPACT, fontSize: 'var(--text-xl)', letterSpacing: '0.02em', color: INK, background: ACID, padding: '3px 9px' }}>
           {t('mobile.points', { points })}
         </span>
         <span style={{ ...kicker, color: MUTED }}>{t('mobile.level', { level: task.level_required })}</span>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
@@ -24,7 +24,7 @@ const MONO = 'var(--font-body)'
 
 const kicker: CSSProperties = {
   fontFamily: MONO,
-  fontSize: 8,
+  fontSize: 'var(--text-xs)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -50,22 +50,23 @@ export default function UaMobileTaskCard({ task, points }: { task: TaskOut; poin
         textDecoration: 'none',
       }}
     >
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: ENGRAVED, fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
         <i style={{ width: 7, height: 7, borderRadius: '50%', background: color, flex: 'none' }} />
         {factionName(task.primary_faction_slug)}
       </span>
 
-      <h2 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 19, lineHeight: 1.15, color: INK, margin: 0 }}>
+      <h2 className="content-title" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, lineHeight: 1.15, color: INK, margin: 0 }}>
         {task.title}
       </h2>
 
       <MobileTaskDescription
         text={task.description}
-        style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 13, lineHeight: 1.5, color: SUB, margin: 0 }}
+        className="content-text"
+        style={{ fontFamily: DISPLAY, fontStyle: 'italic', lineHeight: 1.5, color: SUB, margin: 0 }}
       />
 
       <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
-        <span style={{ fontFamily: ENGRAVED, fontSize: 12, letterSpacing: '0.04em', color: INK, background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>
+        <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.04em', color: INK, background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: '3px 9px' }}>
           {t('mobile.points', { points })}
         </span>
         <span style={{ ...kicker, color: MUTED }}>{t('mobile.level', { level: task.level_required })}</span>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/WowMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/WowMobileTaskCard.tsx
@@ -61,25 +61,26 @@ export default function WowMobileTaskCard({ task, points }: { task: TaskOut; poi
         }}
       >
         <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: '13px 15px', display: 'flex', flexDirection: 'column', gap: 7 }}>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 'var(--text-sm)', letterSpacing: '0.14em', textTransform: 'uppercase', color }}>
             <Sparkle size={10} color={color} />
             {t('wow.mobile.cardMeta', { faction: factionName(task.primary_faction_slug), points })}
           </span>
 
-          <h2 style={{ fontFamily: SCRIPT, fontSize: 22, lineHeight: 1.05, color: TITLE_TEXT, margin: 0, overflowWrap: 'anywhere' }}>
+          <h2 className="content-title" style={{ fontFamily: SCRIPT, lineHeight: 1.05, color: TITLE_TEXT, margin: 0, overflowWrap: 'anywhere' }}>
             {task.title}
           </h2>
 
           <MobileTaskDescription
             text={task.description}
-            style={{ fontFamily: BODY, fontSize: 12, lineHeight: 1.5, color: CARD_MUTED, margin: 0 }}
+            className="content-text"
+            style={{ fontFamily: BODY, lineHeight: 1.5, color: CARD_MUTED, margin: 0 }}
           />
 
           <div className="flex items-center gap-3" style={{ marginTop: 2 }}>
-            <span style={{ fontFamily: BODY, fontSize: 12, fontWeight: 700, color: PINK_DEEP, background: BODY_BG, border: `1px solid ${NOTEPAD_BORDER}`, borderRadius: 999, padding: '3px 11px' }}>
+            <span style={{ fontFamily: BODY, fontSize: 'var(--text-lg)', fontWeight: 700, color: PINK_DEEP, background: BODY_BG, border: `1px solid ${NOTEPAD_BORDER}`, borderRadius: 999, padding: '3px 11px' }}>
               {t('mobile.points', { points })}
             </span>
-            <span style={{ fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}>
+            <span style={{ fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}>
               {t('mobile.level', { level: task.level_required })}
             </span>
           </div>


### PR DESCRIPTION
**Part of #623** — slice 7 of the site-wide raw-`fontSize` sweep.

## Count

| | raw `fontSize: N` |
|---|---|
| before | **85** |
| after | **4** (all annotated ornament) |

Repo-wide the total goes 918 → 838.

The 4 survivors are glyphs-as-icons and one monogram, each with a plain
`// ornament: <why>` comment: the back chevron (24px, sized to its 28px hit
target) in both character skins, the `+` photo glyph (26px, sized to the 104px
ring), and the fallback avatar monogram (34px, sized to the 96px ring). Verified
via `esbuild` that these comments compile away rather than leaking into the DOM.

## Decisions

**Mobile task cards (8 files).** Task rows are scanned, so kickers, faction
tags, points chips and level meta stay Label tier. Titles and descriptions are
read, so they take `.content-title` / `.content-text`. This matches the desktop
task cards' slot decisions from #629 — notably the points line, which is Label
tier on desktop (`--text-sm`), so the mobile points chip stays Label too rather
than being promoted as a "number a player cares about". The two form factors
do not drift.

Card title sizes flatten across factions (15–22px → 24). That is deliberate:
`WORLD_ZERO_STYLE.md` §4a says both scales are global and "a faction picks a
headline font, a colour, and an ornament — never its own type size". Every card
keeps its bespoke frame, font, fill and ornament.

**Propose-a-task.** A working surface, not a flavour surface. The task-name
input, description/notes textareas, numeric point inputs, metatask checkbox
label, "too long" and submit errors, live preview strip and tips column are all
functional text and move to `.content-text` / `.content-title`. Breadcrumb,
faction pennant chip and submit/cancel buttons are chrome and stay Label.

**Character create/edit.** #623 flags these as "Not flavor". Typed text (name,
tagline), the explainer, faction row and help, the delete-confirm question and
every error box promote. Calling-picker rows are a choice a player reads, so
they promote too.

**One judgement call worth review:** form field labels here are uppercase +
letter-spaced, which §4's role vocabulary defines as hand-rolled `.eyebrow` →
Label tier. I kept them at `--text-sm` rather than promoting them, even though
the brief leaned toward promoting field labels generally. The mechanical rule
("uppercase + letter-spacing is an eyebrow") felt like the more reliable guide,
and the actual reading surfaces around them all promoted. Easy to flip.

Four spans carried an inline `fontSize` on top of `.eyebrow`; §4 says the class
owns the size, so those overrides are simply deleted.

## Also

- Folds in **#586**: 10 static inline style objects hoisted to module scope in
  `DefaultProposeTask.tsx`.
- `DefaultTasks.tsx` leaves `.eslint-legacy-raw-styles.txt` — it is the only file
  in scope clean on both axes. The other 11 keep raw `padding`/`margin`/`gap`
  (deferred to #750) and stay listed, so no `eslint-disable` hatch is used.

## Verification

`tsc --noEmit` clean · `vite build` clean · `eslint .` clean (exit 0) ·
**901/901 vitest pass**.

**Visual QA is outstanding** — I cannot screenshot in this environment, and the
content-floor promotions change rendered sizes by design.

## What to eyeball

1. **Mobile task list** (`/tasks` at mobile width) — all 7 faction skins plus
   Default. Titles now 24px and descriptions 18px in a 2-line clamp: check
   nothing overflows its frame, especially Singularity (title was 15px, the
   biggest jump) and Wow's notepad card.
2. **Mobile task list points chips** — snapped to the nearest Label token
   (Albescent 16→14, Everymen 15→14, Snide 13→14). Check the pills still fit.
3. **Propose a task** — the two-column form. Description/notes textareas and the
   point inputs are now 18/24px; confirm the 80px-wide point inputs still hold
   3 digits, and that the tips column at 18px does not blow out its 280px rail.
4. **Propose-task preview strip** — title and clamped description both 18px now.
5. **Character create** (mobile, first run) — name field, explainer, sticky
   Create bar; and the calling picker, which only appears when the account
   holds invitations.
6. **Character edit** (mobile) — name + tagline fields, faction row, and the
   two-tap delete confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)