### PR TITLE
Tokenize fontSize in the seven desktop faction bodies (#623 slice 1)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -161,7 +161,31 @@ Both scales are **global, not per-faction**. A faction picks a headline font, a 
 
 **Not covered by the rule:** ornament geometry (`width`/`height`/`top`/`inset` on decorative marks, sprocket holes, tape strips, corner brackets) is illustration, not layout spacing, and stays in raw pixels.
 
-**Enforcement.** The `local/no-raw-style-values` ESLint rule fails the build on a raw numeric `fontSize`/`padding`/`margin`/`gap` in an inline style. Files not yet migrated are grandfathered in `frontend/.eslint-legacy-raw-styles.txt`. **That list only ever shrinks** — migrating a file means deleting its line; no file may ever be added to it.
+### The ornament escape hatch
+
+Some type is illustration rather than text: a marker scrawl, a stamp, a tape label, a punch-card header, a condensed poster face, hand-lettering on a pinned index card. It carries a raw pixel size on purpose, because rounding it to the nearest token would flatten one archetype into another. §6's "do not regularize card sizes" applies to type too.
+
+The test is what the size is *doing*, not how big it is. Display-face type whose optical size is not the text scale is ornament even at 13px; anything a player actually reads is content even at 30px. **When you are genuinely unsure, it is ornament** — the content-text floor is a rule about reading, not about every number in the file.
+
+Ornament that keeps a raw value must say so **at the site**, so the exemption is legible to the next reader instead of hiding behind a filename in a list. This is a **two-phase** state, because a file's `fontSize` axis and its spacing axis migrate on different schedules (#623 and #750):
+
+**Phase 1 — file still grandfathered (the rule is off for it).** Annotate with a plain comment. An `eslint-disable` directive here would be an *unused* directive, since the rule never fires on a listed file:
+
+```js
+// ornament: hand-lettered Caveat — handwriting on the board, not typeset copy.
+fontSize: 19,
+```
+
+**Phase 2 — file delisted (the rule is on for it).** The comment becomes the directive, and the exemption turns per-line and self-documenting instead of per-file and invisible:
+
+```js
+// eslint-disable-next-line local/no-raw-style-values -- ornament: hand-lettered Caveat.
+fontSize: 19,
+```
+
+A file only moves to phase 2 when it is clean on **both** axes — no un-annotated raw `fontSize` *and* no raw `padding`/`margin`/`gap`. Tokenizing only the type leaves it in phase 1.
+
+**Enforcement.** The `local/no-raw-style-values` ESLint rule fails the build on a raw numeric `fontSize`/`padding`/`margin`/`gap` in an inline style. Files not yet migrated are grandfathered in `frontend/.eslint-legacy-raw-styles.txt`. **That list only ever shrinks** — migrating a file means deleting its line; no file may ever be added to it. The hatch above is what keeps that literally true: ornament is not a permanent residue on the list, it is a per-line directive on a delisted file. The list reaches **empty** when #750 (the spacing sweep) closes and the last file moves to phase 2.
 
 ---
 

--- a/frontend/src/pages/factionDetail/archetypes/AlbescentFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/AlbescentFactionBody.tsx
@@ -53,7 +53,7 @@ function SectionHeading({ kicker, title, count }: { kicker: string; title: strin
       <div
         style={{
           fontFamily: MONO,
-          fontSize: 7,
+          fontSize: "var(--text-xs)",
           letterSpacing: "0.26em",
           textTransform: "uppercase",
           color: FAINT,
@@ -63,6 +63,7 @@ function SectionHeading({ kicker, title, count }: { kicker: string; title: strin
         {kicker}
         {count !== undefined ? ` · ${count}` : ""}
       </div>
+      {/* ornament: the archive's light italic plate cut, a step above the content ramp. */}
       <h2 style={{ fontFamily: FONT, fontStyle: "italic", fontWeight: 300, fontSize: 26, lineHeight: 1, color: INK, margin: 0 }}>
         {title}
       </h2>
@@ -73,7 +74,7 @@ function SectionHeading({ kicker, title, count }: { kicker: string; title: strin
 
 function Quiet({ children }: { children: ReactNode }) {
   return (
-    <p style={{ fontFamily: FONT, fontStyle: "italic", fontSize: 15, color: MUTED, margin: 0 }}>
+    <p className="content-text" style={{ fontFamily: FONT, fontStyle: "italic", color: MUTED, margin: 0 }}>
       {children}
     </p>
   );

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -48,7 +48,7 @@ export default function DefaultFactionBody({
           {t("detail.default.membersHeading", { total: members.length })}
         </h2>
         {members.length === 0 ? (
-          <p className="font-body text-muted text-sm">{t("detail.membersEmpty")}</p>
+          <p className="font-body text-muted content-text">{t("detail.membersEmpty")}</p>
         ) : (
           <div className="flex flex-wrap gap-3">
             {members.map((m) => (
@@ -73,7 +73,7 @@ export default function DefaultFactionBody({
           {t("detail.default.tasksHeading", { total: tasks.length })}
         </h2>
         {tasks.length === 0 ? (
-          <p className="font-body text-muted text-sm">{t("detail.default.tasksEmpty")}</p>
+          <p className="font-body text-muted content-text">{t("detail.default.tasksEmpty")}</p>
         ) : (
           <div style={CARD_GRID}>
             {tasks.map((task) => (
@@ -96,7 +96,7 @@ export default function DefaultFactionBody({
       <section className="mb-8">
         <h2 className="eyebrow mb-3">{t("detail.default.recentHeading")}</h2>
         {recentPraxis.length === 0 ? (
-          <p className="font-body text-muted text-sm">
+          <p className="font-body text-muted content-text">
             {t("detail.default.recentEmpty")}
           </p>
         ) : (

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -57,21 +57,32 @@ const PLATE: CSSProperties = {
   boxShadow: "0 6px 20px color-mix(in srgb, var(--eph-ink) 10%, transparent)",
 };
 
+const KICKER: CSSProperties = {
+  fontFamily: SCRIPT,
+  fontStyle: "italic",
+  // ornament: calligraphic marginal flourish under the rubric, not copy.
+  fontSize: 13,
+  color: MUTED,
+  margin: "4px 0 18px",
+};
+
 function Kicker({ children }: { children: ReactNode }) {
-  return (
-    <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 13, color: MUTED, margin: "4px 0 18px" }}>
-      {children}
-    </div>
-  );
+  return <div style={KICKER}>{children}</div>;
 }
+
+const SECTION_HEADING: CSSProperties = {
+  fontFamily: DISPLAY,
+  fontWeight: 700,
+  // ornament: the codex's Cinzel rubric cut, a step above the content ramp.
+  fontSize: 30,
+  letterSpacing: "0.03em",
+  margin: 0,
+  color: INK,
+};
 
 /** Cinzel section title with a lapis last word, mirroring the design. */
 function SectionHeading({ children }: { children: ReactNode }) {
-  return (
-    <h2 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 30, letterSpacing: "0.03em", margin: 0, color: INK }}>
-      {children}
-    </h2>
-  );
+  return <h2 style={SECTION_HEADING}>{children}</h2>;
 }
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
@@ -129,7 +140,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
           <Foxing opacity={0.5} />
           <div style={{ position: "relative", zIndex: 2, display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
             <EphemeristsSigil size={15} color={RUBRIC} />
-            <span style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 11, letterSpacing: "0.22em", textTransform: "uppercase", color: GOLD_DEEP }}>
+            <span style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: "var(--text-md)", letterSpacing: "0.22em", textTransform: "uppercase", color: GOLD_DEEP }}>
               {t("ephemerists.apparatus.heading")}
             </span>
             <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
@@ -137,12 +148,12 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
           <div style={{ position: "relative", zIndex: 2, display: "flex", flexDirection: "column", gap: 12 }}>
             {paragraphs.length ? (
               paragraphs.map((para, i) => (
-                <p key={i} style={{ fontFamily: SERIF, fontSize: 14.5, lineHeight: 1.78, color: TEXT, margin: 0 }}>
+                <p key={i} className="content-text" style={{ fontFamily: SERIF, lineHeight: 1.78, color: TEXT, margin: 0 }}>
                   {para}
                 </p>
               ))
             ) : (
-              <p style={{ fontFamily: SERIF, fontSize: 14.5, lineHeight: 1.78, color: MUTED, margin: 0 }}>
+              <p className="content-text" style={{ fontFamily: SERIF, lineHeight: 1.78, color: MUTED, margin: 0 }}>
                 {t("ephemerists.apparatus.empty")}
               </p>
             )}
@@ -154,7 +165,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
           <SectionHeading>{t("ephemerists.tasks.heading")}</SectionHeading>
           <Kicker>{t("ephemerists.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
-            <p style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 14, color: MUTED }}>
+            <p className="content-text" style={{ fontFamily: SCRIPT, fontStyle: "italic", color: MUTED }}>
               {t("ephemerists.tasks.empty")}
             </p>
           ) : (
@@ -180,7 +191,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
           <SectionHeading>{t("ephemerists.praxis.heading")}</SectionHeading>
           <Kicker>{t("ephemerists.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
-            <p style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 14, color: MUTED }}>
+            <p className="content-text" style={{ fontFamily: SCRIPT, fontStyle: "italic", color: MUTED }}>
               {t("ephemerists.praxis.empty")}
             </p>
           ) : (
@@ -212,7 +223,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
         {/* ③ THE ROAD — join / gate / standing */}
         {membership.state !== "none" && (
           <div style={{ ...PLATE, boxShadow: "0 8px 24px color-mix(in srgb, var(--eph-ink) 12%, transparent)", padding: 0 }}>
-            <div style={{ background: LAPIS, color: PARCHMENT, padding: "9px 16px", fontFamily: DISPLAY, fontWeight: 600, fontSize: 12, letterSpacing: "0.2em", textTransform: "uppercase", boxShadow: `inset 0 -2px 0 ${GOLD}` }}>
+            <div style={{ background: LAPIS, color: PARCHMENT, padding: "9px 16px", fontFamily: DISPLAY, fontWeight: 600, fontSize: "var(--text-lg)", letterSpacing: "0.2em", textTransform: "uppercase", boxShadow: `inset 0 -2px 0 ${GOLD}` }}>
               {t("ephemerists.road.heading")}
             </div>
             <div style={{ position: "relative", padding: "22px 20px" }}>
@@ -220,10 +231,11 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
               <div style={{ position: "relative", zIndex: 2 }}>
                 {membership.state === "member" && (
                   <div>
+                    {/* ornament: Cinzel codex display title. */}
                     <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 22, lineHeight: 1.02, color: INK }}>
                       {t("ephemerists.road.memberTitle")}
                     </div>
-                    <div style={{ fontFamily: SERIF, fontSize: 13, color: MUTED, margin: "10px 0 0" }}>
+                    <div style={{ fontFamily: SERIF, fontSize: "var(--text-xl)", color: MUTED, margin: "10px 0 0" }}>
                       <Trans t={t} i18nKey="ephemerists.road.memberStanding">
                         Standing · <span style={{ fontStyle: "italic", color: RUBRIC }}>keeper of the road</span>
                       </Trans>
@@ -233,18 +245,19 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
 
                 {membership.state === "eligible" && !confirming && (
                   <div>
+                    {/* ornament: calligraphic flourish + Cinzel codex display title. */}
                     <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 13, color: GOLD_DEEP, marginBottom: 5 }}>
                       {t("ephemerists.road.eligibleKicker")}
                     </div>
                     <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 23, lineHeight: 1.02, color: INK, marginBottom: 10 }}>
                       {t("ephemerists.road.eligibleTitle")}
                     </div>
-                    <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.6, color: TEXT, marginBottom: 18 }}>
+                    <div className="content-text" style={{ fontFamily: SERIF, lineHeight: 1.6, color: TEXT, marginBottom: 18 }}>
                       {t("ephemerists.road.eligibleBody")}
                     </div>
                     <button
                       onClick={() => setConfirming(true)}
-                      style={{ width: "100%", fontFamily: DISPLAY, fontWeight: 600, fontSize: 13, letterSpacing: "0.14em", color: PARCHMENT, background: LAPIS, border: "none", padding: 12, boxShadow: `inset 0 0 0 1px ${GOLD}, 0 6px 16px color-mix(in srgb, var(--eph-field-deep) 40%, transparent)`, cursor: "pointer" }}
+                      style={{ width: "100%", fontFamily: DISPLAY, fontWeight: 600, fontSize: "var(--text-xl)", letterSpacing: "0.14em", color: PARCHMENT, background: LAPIS, border: "none", padding: 12, boxShadow: `inset 0 0 0 1px ${GOLD}, 0 6px 16px color-mix(in srgb, var(--eph-field-deep) 40%, transparent)`, cursor: "pointer" }}
                     >
                       {t("ephemerists.road.joinButton")}
                     </button>
@@ -253,7 +266,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
 
                 {membership.state === "eligible" && confirming && (
                   <div>
-                    <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.6, color: TEXT, marginBottom: 14 }}>
+                    <div className="content-text" style={{ fontFamily: SERIF, lineHeight: 1.6, color: TEXT, marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
@@ -263,13 +276,13 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                         : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
-                      <div style={{ fontFamily: SERIF, fontSize: 12, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                      <div className="content-text" style={{ fontFamily: SERIF, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
                     )}
                     <div style={{ display: "flex", gap: 8 }}>
                       <button
                         onClick={() => void membership.join()}
                         disabled={membership.joining}
-                        style={{ flex: 1, fontFamily: DISPLAY, fontWeight: 600, fontSize: 12, letterSpacing: "0.12em", color: PARCHMENT, background: LAPIS, border: "none", padding: 11, boxShadow: `inset 0 0 0 1px ${GOLD}`, cursor: membership.joining ? "not-allowed" : "pointer" }}
+                        style={{ flex: 1, fontFamily: DISPLAY, fontWeight: 600, fontSize: "var(--text-lg)", letterSpacing: "0.12em", color: PARCHMENT, background: LAPIS, border: "none", padding: 11, boxShadow: `inset 0 0 0 1px ${GOLD}`, cursor: membership.joining ? "not-allowed" : "pointer" }}
                       >
                         {membership.joining
                           ? t("ephemerists.road.joining")
@@ -278,7 +291,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                       <button
                         onClick={() => setConfirming(false)}
                         disabled={membership.joining}
-                        style={{ fontFamily: SERIF, fontStyle: "italic", fontSize: 12, letterSpacing: "0.06em", color: MUTED, background: "transparent", border: `1px solid ${HAIRLINE}`, padding: "11px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
+                        style={{ fontFamily: SERIF, fontStyle: "italic", fontSize: "var(--text-lg)", letterSpacing: "0.06em", color: MUTED, background: "transparent", border: `1px solid ${HAIRLINE}`, padding: "11px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
                       >
                         {t("detail.join.cancel")}
                       </button>
@@ -288,13 +301,14 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
 
                 {membership.state === "gate" && (
                   <div>
+                    {/* ornament: calligraphic flourish + Cinzel codex display title. */}
                     <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 13, color: GOLD_DEEP, marginBottom: 5 }}>
                       {t("ephemerists.road.gateKicker")}
                     </div>
                     <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 21, lineHeight: 1.08, color: INK, marginBottom: 11 }}>
                       {t("ephemerists.road.gateTitle")}
                     </div>
-                    <div style={{ fontFamily: SERIF, fontSize: 13, lineHeight: 1.65, color: TEXT }}>
+                    <div className="content-text" style={{ fontFamily: SERIF, lineHeight: 1.65, color: TEXT }}>
                       {t("ephemerists.road.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
@@ -330,16 +344,18 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                   }}
                 />
                 <div style={{ position: "relative", zIndex: 2, padding: "20px 18px 18px" }}>
+                  {/* ornament: calligraphic caption on the illuminated plate. */}
                   <div style={{ fontFamily: SCRIPT, fontStyle: "italic", fontSize: 11, letterSpacing: "0.06em", color: GOLD_LIGHT, marginBottom: 12 }}>
                     {t("ephemerists.spotlight.label")}
                   </div>
                   <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
                     <Medallion name={spot.display_name} size={72} spotlight />
                   </div>
+                  {/* ornament: Cinzel name plate on the illuminated spotlight. */}
                   <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 22, lineHeight: 1, color: PARCHMENT }}>
                     {spot.display_name}
                   </div>
-                  <div style={{ fontFamily: SERIF, fontSize: 8.5, letterSpacing: "0.1em", textTransform: "uppercase", color: `color-mix(in srgb, ${PARCHMENT} 70%, transparent)`, marginTop: 6 }}>
+                  <div style={{ fontFamily: SERIF, fontSize: "var(--text-sm)", letterSpacing: "0.1em", textTransform: "uppercase", color: `color-mix(in srgb, ${PARCHMENT} 70%, transparent)`, marginTop: 6 }}>
                     {t("ephemerists.spotlight.stat", {
                       grade: grade(spot.level),
                       score: spot.all_time_score.toLocaleString(),
@@ -352,11 +368,11 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
 
           <div style={{ ...PLATE, boxShadow: "0 4px 14px color-mix(in srgb, var(--eph-ink) 8%, transparent)", padding: "18px 20px 14px" }}>
             <Foxing opacity={0.4} />
-            <div style={{ position: "relative", zIndex: 2, fontFamily: DISPLAY, fontWeight: 600, fontSize: 11, letterSpacing: "0.2em", textTransform: "uppercase", color: GOLD_DEEP, marginBottom: 12 }}>
+            <div style={{ position: "relative", zIndex: 2, fontFamily: DISPLAY, fontWeight: 600, fontSize: "var(--text-md)", letterSpacing: "0.2em", textTransform: "uppercase", color: GOLD_DEEP, marginBottom: 12 }}>
               {t("ephemerists.roster.heading")}
             </div>
             {roster.length === 0 ? (
-              <p style={{ position: "relative", zIndex: 2, fontFamily: SCRIPT, fontStyle: "italic", fontSize: 14, color: MUTED }}>
+              <p className="content-text" style={{ position: "relative", zIndex: 2, fontFamily: SCRIPT, fontStyle: "italic", color: MUTED }}>
                 {spot
                   ? t("ephemerists.roster.emptyWithSpotlight")
                   : t("detail.membersEmpty")}
@@ -370,11 +386,11 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                 >
                   <Medallion name={m.display_name} size={32} />
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontFamily: SERIF, fontSize: 15, color: TEXT, lineHeight: 1.1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    <div className="content-text" style={{ fontFamily: SERIF, color: TEXT, lineHeight: 1.1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                       {m.display_name}
                     </div>
                   </div>
-                  <span style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 11, color: RUBRIC }}>
+                  <span style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: "var(--text-md)", color: RUBRIC }}>
                     {t("ephemerists.roster.level", { grade: grade(m.level) })}
                   </span>
                 </Link>

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -72,24 +72,45 @@ function WovenRule({ height = 3 }: { height?: number }) {
   );
 }
 
+const SECTION_HEADING_ROW: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 14,
+  marginBottom: 6,
+  flexWrap: "wrap",
+};
+
+const SECTION_HEADING_TEXT: CSSProperties = {
+  fontFamily: BEBAS,
+  // ornament: victory-poster display cut in condensed Bebas — poster type, not a read heading.
+  fontSize: 34,
+  letterSpacing: "0.04em",
+  margin: 0,
+  color: INK,
+  whiteSpace: "nowrap",
+};
+
 function SectionHeading({ children, right }: { children: ReactNode; right?: ReactNode }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 6, flexWrap: "wrap" }}>
-      <h2 style={{ fontFamily: BEBAS, fontSize: 34, letterSpacing: "0.04em", margin: 0, color: INK, whiteSpace: "nowrap" }}>
-        {children}
-      </h2>
+    <div style={SECTION_HEADING_ROW}>
+      <h2 style={SECTION_HEADING_TEXT}>{children}</h2>
       <WovenRule />
       {right}
     </div>
   );
 }
 
+const KICKER: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: "var(--text-sm)",
+  letterSpacing: "0.2em",
+  textTransform: "uppercase",
+  color: MUTED,
+  marginBottom: 18,
+};
+
 function Kicker({ children }: { children: ReactNode }) {
-  return (
-    <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.2em", textTransform: "uppercase", color: MUTED, marginBottom: 18 }}>
-      {children}
-    </div>
-  );
+  return <div style={KICKER}>{children}</div>;
 }
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
@@ -141,7 +162,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
         <div style={{ ...PAPER_FRAME, padding: "24px 28px 26px" }}>
           <Halftone />
           <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 10, marginBottom: 15 }}>
-            <span style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
+            <span style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
               {t("everymen.charter.heading")}
             </span>
             <span style={{ flex: 1, height: 2, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
@@ -149,12 +170,12 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
           <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 11 }}>
             {paragraphs.length ? (
               paragraphs.map((para, i) => (
-                <p key={i} style={{ fontFamily: MONO, fontSize: 12.5, lineHeight: 1.75, color: INK, margin: 0 }}>
+                <p key={i} className="content-text" style={{ fontFamily: MONO, lineHeight: 1.75, color: INK, margin: 0 }}>
                   {para}
                 </p>
               ))
             ) : (
-              <p style={{ fontFamily: MONO, fontSize: 12.5, lineHeight: 1.75, color: MUTED, margin: 0 }}>
+              <p className="content-text" style={{ fontFamily: MONO, lineHeight: 1.75, color: MUTED, margin: 0 }}>
                 {t("everymen.charter.empty")}
               </p>
             )}
@@ -166,7 +187,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
           <SectionHeading>{t("everymen.tasks.heading")}</SectionHeading>
           <Kicker>{t("everymen.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
-            <p style={{ fontFamily: MONO, fontSize: 11, color: MUTED }}>{t("everymen.tasks.empty")}</p>
+            <p className="content-text" style={{ fontFamily: MONO, color: MUTED }}>{t("everymen.tasks.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 24, alignItems: "flex-start" }}>
               {tasks.map((task) => (
@@ -190,7 +211,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
           <SectionHeading>{t("everymen.praxis.heading")}</SectionHeading>
           <Kicker>{t("everymen.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
-            <p style={{ fontFamily: MONO, fontSize: 11, color: MUTED }}>{t("everymen.praxis.empty")}</p>
+            <p className="content-text" style={{ fontFamily: MONO, color: MUTED }}>{t("everymen.praxis.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
@@ -220,6 +241,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
         {/* ③ THE ROLL — join / gate / standing */}
         {membership.state !== "none" && (
           <div style={{ ...PAPER_FRAME, padding: 0 }}>
+            {/* ornament: printed banner across the top of the roll — Bebas poster furniture. */}
             <div style={{ background: RED, color: CREAM, textAlign: "center", padding: "7px 0", fontFamily: BEBAS, fontSize: 16, letterSpacing: "0.16em", borderBottom: `2px solid ${GOLD}` }}>
               {t("everymen.roll.heading")}
             </div>
@@ -228,10 +250,11 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
               <div style={{ position: "relative" }}>
                 {membership.state === "member" && (
                   <div>
+                    {/* ornament: Bebas poster headline set tight (lineHeight 0.9). */}
                     <div style={{ fontFamily: BEBAS, fontSize: 30, lineHeight: 0.9, color: INK }}>
                       {t("everymen.roll.memberTitle")}
                     </div>
-                    <div style={{ fontFamily: MONO, fontSize: 11, color: MUTED, margin: "9px 0 0" }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-md)", color: MUTED, margin: "9px 0 0" }}>
                       <Trans t={t} i18nKey="everymen.roll.memberStanding">
                         Standing · <b style={{ color: RED }}>card-carrying</b>
                       </Trans>
@@ -241,15 +264,17 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
 
                 {membership.state === "eligible" && !confirming && (
                   <div>
-                    <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: 5 }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: 5 }}>
                       {t("everymen.roll.eligibleKicker")}
                     </div>
+                    {/* ornament: Bebas poster headline set tight (lineHeight 0.9). */}
                     <div style={{ fontFamily: BEBAS, fontSize: 32, lineHeight: 0.9, color: INK, marginBottom: 9 }}>
                       {t("everymen.roll.eligibleTitle")}
                     </div>
-                    <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.6, color: INK, marginBottom: 18 }}>
+                    <div className="content-text" style={{ fontFamily: MONO, lineHeight: 1.6, color: INK, marginBottom: 18 }}>
                       {t("everymen.roll.eligibleBody")}
                     </div>
+                    {/* ornament: Bebas is a condensed poster face — its optical size is not the text scale. */}
                     <button
                       onClick={() => setConfirming(true)}
                       style={{ width: "100%", fontFamily: BEBAS, fontSize: 18, letterSpacing: "0.12em", color: CREAM, background: RED, border: "none", padding: 12, boxShadow: `3px 4px 0 ${INK}`, cursor: "pointer" }}
@@ -261,7 +286,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
 
                 {membership.state === "eligible" && confirming && (
                   <div>
-                    <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
+                    <div className="content-text" style={{ fontFamily: MONO, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
@@ -271,12 +296,13 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                         : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
-                      <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                      <div className="content-text" style={{ fontFamily: MONO, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
                     )}
                     <div style={{ display: "flex", gap: 8 }}>
                       <button
                         onClick={() => void membership.join()}
                         disabled={membership.joining}
+                        // ornament: Bebas is a condensed poster face — its optical size is not the text scale.
                         style={{ flex: 1, fontFamily: BEBAS, fontSize: 16, letterSpacing: "0.1em", color: CREAM, background: RED, border: "none", padding: 10, cursor: membership.joining ? "not-allowed" : "pointer" }}
                       >
                         {membership.joining
@@ -286,7 +312,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                       <button
                         onClick={() => setConfirming(false)}
                         disabled={membership.joining}
-                        style={{ fontFamily: MONO, fontSize: 9, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, background: "transparent", border: `1.5px solid color-mix(in srgb, ${INK} 30%, transparent)`, padding: "10px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
+                        style={{ fontFamily: MONO, fontSize: "var(--text-sm)", fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, background: "transparent", border: `1.5px solid color-mix(in srgb, ${INK} 30%, transparent)`, padding: "10px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
                       >
                         {t("detail.join.cancel")}
                       </button>
@@ -296,13 +322,14 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
 
                 {membership.state === "gate" && (
                   <div>
-                    <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: 5 }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: 5 }}>
                       {t("everymen.roll.gateKicker")}
                     </div>
+                    {/* ornament: Bebas poster headline set tight (lineHeight 0.92). */}
                     <div style={{ fontFamily: BEBAS, fontSize: 30, lineHeight: 0.92, color: INK, marginBottom: 11 }}>
                       {t("everymen.roll.gateTitle")}
                     </div>
-                    <div style={{ fontFamily: MONO, fontSize: 11, lineHeight: 1.65, color: INK }}>
+                    <div className="content-text" style={{ fontFamily: MONO, lineHeight: 1.65, color: INK }}>
                       {t("everymen.roll.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
@@ -322,16 +349,17 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                   style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.5, background: `repeating-conic-gradient(from 0deg at 50% 30%, color-mix(in srgb, var(--everymen-red-deep) 60%, transparent) 0deg 8deg, transparent 8deg 16deg)` }}
                 />
                 <div style={{ position: "relative", zIndex: 2, padding: "20px 18px 18px" }}>
-                  <div style={{ fontFamily: MONO, fontSize: 7, letterSpacing: "0.3em", textTransform: "uppercase", color: GOLD, marginBottom: 12 }}>
+                  <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.3em", textTransform: "uppercase", color: GOLD, marginBottom: 12 }}>
                     {t("everymen.spotlight.label")}
                   </div>
                   <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
                     <Medallion name={spot.display_name} size={74} invert />
                   </div>
+                  {/* ornament: the spotlight's printed name plate, Bebas on the sunburst. */}
                   <div style={{ fontFamily: BEBAS, fontSize: 32, lineHeight: 0.9, color: CREAM, textShadow: "2px 2px 0 rgba(0,0,0,.4)" }}>
                     {spot.display_name}
                   </div>
-                  <div style={{ fontFamily: MONO, fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase", color: GOLD, marginTop: 6 }}>
+                  <div style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.08em", textTransform: "uppercase", color: GOLD, marginTop: 6 }}>
                     {t("everymen.spotlight.stat", {
                       level: spot.level,
                       score: spot.all_time_score.toLocaleString(),
@@ -344,11 +372,11 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
 
           <div style={{ ...PAPER_FRAME, padding: "16px 18px 12px" }}>
             <Halftone />
-            <div style={{ position: "relative", fontFamily: MONO, fontSize: 9, letterSpacing: "0.22em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
+            <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.22em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
               {t("everymen.roster.heading")}
             </div>
             {roster.length === 0 ? (
-              <p style={{ position: "relative", fontFamily: MONO, fontSize: 11, color: MUTED }}>
+              <p className="content-text" style={{ position: "relative", fontFamily: MONO, color: MUTED }}>
                 {spot
                   ? t("everymen.roster.emptyWithSpotlight")
                   : t("detail.membersEmpty")}
@@ -361,6 +389,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                   style={{ position: "relative", display: "flex", alignItems: "center", gap: 12, padding: "8px 0", borderBottom: `1px solid color-mix(in srgb, ${INK} 16%, transparent)`, textDecoration: "none" }}
                 >
                   <Medallion name={m.display_name} size={32} />
+                  {/* ornament: roster set in condensed Bebas — its optical size is not the text scale. */}
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontFamily: BEBAS, fontSize: 19, lineHeight: 1, color: INK, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                       {m.display_name}

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -70,43 +70,45 @@ const PANEL: CSSProperties = {
   border: `1px solid ${signal(42)}`,
 };
 
+const SECTION_HEADING_ROW: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+  marginBottom: 6,
+};
+
+const SECTION_HEADING_TEXT: CSSProperties = {
+  fontFamily: FONT,
+  // ornament: the terminal's banner cut, a step above the content ramp.
+  fontSize: 28,
+  letterSpacing: "0.04em",
+  margin: 0,
+  color: PHOSPHOR,
+  textTransform: "uppercase",
+  whiteSpace: "nowrap",
+};
+
 /** Section heading — uppercase phosphor title trailing a signal rule. */
 function SectionHeading({ children }: { children: ReactNode }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6 }}>
-      <h2
-        style={{
-          fontFamily: FONT,
-          fontSize: 28,
-          letterSpacing: "0.04em",
-          margin: 0,
-          color: PHOSPHOR,
-          textTransform: "uppercase",
-          whiteSpace: "nowrap",
-        }}
-      >
-        {children}
-      </h2>
+    <div style={SECTION_HEADING_ROW}>
+      <h2 style={SECTION_HEADING_TEXT}>{children}</h2>
       <span style={{ flex: 1, height: 1, minWidth: 30, background: signal(30) }} />
     </div>
   );
 }
 
+const KICKER: CSSProperties = {
+  fontFamily: FONT,
+  fontSize: "var(--text-xs)",
+  letterSpacing: "0.24em",
+  textTransform: "uppercase",
+  color: phosphor(40),
+  marginBottom: 18,
+};
+
 function Kicker({ children }: { children: ReactNode }) {
-  return (
-    <div
-      style={{
-        fontFamily: FONT,
-        fontSize: 7.5,
-        letterSpacing: "0.24em",
-        textTransform: "uppercase",
-        color: phosphor(40),
-        marginBottom: 18,
-      }}
-    >
-      {children}
-    </div>
-  );
+  return <div style={KICKER}>{children}</div>;
 }
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
@@ -165,7 +167,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
             style={{
               position: "relative",
               fontFamily: FONT,
-              fontSize: 9,
+              fontSize: "var(--text-sm)",
               letterSpacing: "0.14em",
               color: signal(55),
               marginBottom: 14,
@@ -178,9 +180,9 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
               paragraphs.map((para, i) => (
                 <p
                   key={i}
+                  className="content-text"
                   style={{
                     fontFamily: FONT,
-                    fontSize: 11.5,
                     lineHeight: 1.8,
                     color: phosphor(72),
                     margin: 0,
@@ -190,7 +192,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                 </p>
               ))
             ) : (
-              <p style={{ fontFamily: FONT, fontSize: 11.5, lineHeight: 1.8, color: phosphor(45), margin: 0 }}>
+              <p className="content-text" style={{ fontFamily: FONT, lineHeight: 1.8, color: phosphor(45), margin: 0 }}>
                 {t("singularity.manifest.empty")}
               </p>
             )}
@@ -202,7 +204,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
           <SectionHeading>{t("singularity.tasks.heading")}</SectionHeading>
           <Kicker>{t("singularity.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
-            <p style={{ fontFamily: FONT, fontSize: 11, color: phosphor(45) }}>
+            <p className="content-text" style={{ fontFamily: FONT, color: phosphor(45) }}>
               {t("singularity.tasks.empty")}
             </p>
           ) : (
@@ -228,7 +230,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
           <SectionHeading>{t("singularity.praxis.heading")}</SectionHeading>
           <Kicker>{t("singularity.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
-            <p style={{ fontFamily: FONT, fontSize: 11, color: phosphor(45) }}>
+            <p className="content-text" style={{ fontFamily: FONT, color: phosphor(45) }}>
               {t("singularity.praxis.empty")}
             </p>
           ) : (
@@ -273,7 +275,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
               <span
                 style={{
                   fontFamily: FONT,
-                  fontSize: 11,
+                  fontSize: "var(--text-md)",
                   letterSpacing: "0.22em",
                   textTransform: "uppercase",
                   color: VOID,
@@ -281,7 +283,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
               >
                 {t("singularity.access.heading")}
               </span>
-              <span style={{ fontFamily: FONT, fontSize: 8, letterSpacing: "0.1em", color: phosphor(60) }}>
+              <span style={{ fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.1em", color: phosphor(60) }}>
                 {t("singularity.access.reLabel")}
               </span>
             </div>
@@ -290,10 +292,11 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
               <div style={{ position: "relative" }}>
                 {membership.state === "member" && (
                   <div>
+                    {/* ornament: terminal display title. */}
                     <div style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1, color: PHOSPHOR, letterSpacing: "0.04em" }}>
                       {t("singularity.access.memberTitle")}
                     </div>
-                    <div style={{ fontFamily: FONT, fontSize: 10, color: signal(60), margin: "10px 0 0", letterSpacing: "0.04em" }}>
+                    <div style={{ fontFamily: FONT, fontSize: "var(--text-base)", color: signal(60), margin: "10px 0 0", letterSpacing: "0.04em" }}>
                       <Trans t={t} i18nKey="singularity.access.memberStanding">
                         array · <span style={{ color: SIGNAL }}>online</span>
                       </Trans>
@@ -303,13 +306,14 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
 
                 {membership.state === "eligible" && !confirming && (
                   <div>
-                    <div style={{ fontFamily: FONT, fontSize: 8, letterSpacing: "0.2em", color: signal(50), marginBottom: 7 }}>
+                    <div style={{ fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.2em", color: signal(50), marginBottom: 7 }}>
                       {t("singularity.access.eligibleKicker")}
                     </div>
+                    {/* ornament: terminal display title. */}
                     <div style={{ fontFamily: FONT, fontSize: 22, lineHeight: 1.05, color: PHOSPHOR, letterSpacing: "0.03em", marginBottom: 10 }}>
                       {t("singularity.access.eligibleTitle")}
                     </div>
-                    <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.65, color: phosphor(60), marginBottom: 18 }}>
+                    <div className="content-text" style={{ fontFamily: FONT, lineHeight: 1.65, color: phosphor(60), marginBottom: 18 }}>
                       {t("singularity.access.eligibleBody")}
                     </div>
                     <button
@@ -317,7 +321,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                       style={{
                         width: "100%",
                         fontFamily: FONT,
-                        fontSize: 11,
+                        fontSize: "var(--text-md)",
                         letterSpacing: "0.14em",
                         textTransform: "uppercase",
                         color: VOID,
@@ -335,7 +339,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
 
                 {membership.state === "eligible" && confirming && (
                   <div>
-                    <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.7, color: phosphor(72), marginBottom: 14 }}>
+                    <div className="content-text" style={{ fontFamily: FONT, lineHeight: 1.7, color: phosphor(72), marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
@@ -345,7 +349,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                         : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
-                      <div style={{ fontFamily: FONT, fontSize: 9, color: "var(--color-danger)", marginBottom: 8 }}>
+                      <div className="content-text" style={{ fontFamily: FONT, color: "var(--color-danger)", marginBottom: 8 }}>
                         {membership.joinError}
                       </div>
                     )}
@@ -356,7 +360,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                         style={{
                           flex: 1,
                           fontFamily: FONT,
-                          fontSize: 10,
+                          fontSize: "var(--text-base)",
                           letterSpacing: "0.12em",
                           textTransform: "uppercase",
                           color: VOID,
@@ -375,7 +379,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                         disabled={membership.joining}
                         style={{
                           fontFamily: FONT,
-                          fontSize: 8,
+                          fontSize: "var(--text-xs)",
                           letterSpacing: "0.16em",
                           textTransform: "uppercase",
                           color: signal(60),
@@ -393,13 +397,14 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
 
                 {membership.state === "gate" && (
                   <div>
-                    <div style={{ fontFamily: FONT, fontSize: 8, letterSpacing: "0.2em", color: signal(50), marginBottom: 7 }}>
+                    <div style={{ fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.2em", color: signal(50), marginBottom: 7 }}>
                       {t("singularity.access.gateKicker")}
                     </div>
+                    {/* ornament: terminal display title. */}
                     <div style={{ fontFamily: FONT, fontSize: 20, lineHeight: 1.1, color: PHOSPHOR, letterSpacing: "0.03em", marginBottom: 11 }}>
                       {t("singularity.access.gateTitle", { faction: factionName(faction.slug) })}
                     </div>
-                    <div style={{ fontFamily: FONT, fontSize: 10, lineHeight: 1.7, color: phosphor(60) }}>
+                    <div className="content-text" style={{ fontFamily: FONT, lineHeight: 1.7, color: phosphor(60) }}>
                       {t("singularity.access.gateBody")}
                     </div>
                   </div>
@@ -423,16 +428,16 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                 }}
               >
                 <Scanlines opacity={0.014} />
-                <div style={{ position: "relative", fontFamily: FONT, fontSize: 7, letterSpacing: "0.28em", color: phosphor(45), marginBottom: 12 }}>
+                <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.28em", color: phosphor(45), marginBottom: 12 }}>
                   {t("singularity.spotlight.label")}
                 </div>
                 <div style={{ position: "relative", display: "flex", justifyContent: "center", marginBottom: 12 }}>
                   <NodeGlyph name={spot.display_name} size={72} />
                 </div>
-                <div style={{ position: "relative", fontFamily: FONT, fontSize: 24, lineHeight: 1, color: PHOSPHOR, letterSpacing: "0.03em" }}>
+                <div className="content-title" style={{ position: "relative", fontFamily: FONT, lineHeight: 1, color: PHOSPHOR, letterSpacing: "0.03em" }}>
                   {spot.display_name}
                 </div>
-                <div style={{ position: "relative", fontFamily: FONT, fontSize: 8, letterSpacing: "0.1em", color: signal(55), marginTop: 6, textTransform: "uppercase" }}>
+                <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.1em", color: signal(55), marginTop: 6, textTransform: "uppercase" }}>
                   {t("singularity.spotlight.stat", {
                     level: spot.level,
                     score: spot.all_time_score.toLocaleString(),
@@ -444,11 +449,11 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
 
           <div style={{ ...PANEL, padding: "16px 16px 12px" }}>
             <Scanlines />
-            <div style={{ position: "relative", fontFamily: FONT, fontSize: 7, letterSpacing: "0.24em", textTransform: "uppercase", color: phosphor(40), marginBottom: 12 }}>
+            <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.24em", textTransform: "uppercase", color: phosphor(40), marginBottom: 12 }}>
               {t("singularity.roster.heading")}
             </div>
             {array.length === 0 ? (
-              <p style={{ position: "relative", fontFamily: FONT, fontSize: 11, color: phosphor(45) }}>
+              <p className="content-text" style={{ position: "relative", fontFamily: FONT, color: phosphor(45) }}>
                 {spot
                   ? t("singularity.roster.emptyWithSpotlight")
                   : t("singularity.roster.empty")}
@@ -471,9 +476,9 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                   <NodeGlyph name={m.display_name} size={30} />
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div
+                      className="content-text"
                       style={{
                         fontFamily: FONT,
-                        fontSize: 12,
                         color: PHOSPHOR,
                         lineHeight: 1.1,
                         letterSpacing: "0.03em",
@@ -485,7 +490,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                       {m.display_name}
                     </div>
                   </div>
-                  <span style={{ fontFamily: FONT, fontSize: 10, color: AMBER, letterSpacing: "0.04em" }}>
+                  <span style={{ fontFamily: FONT, fontSize: "var(--text-base)", color: AMBER, letterSpacing: "0.04em" }}>
                     {t("singularity.roster.level", { level: m.level })}
                   </span>
                 </Link>

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -101,42 +101,54 @@ function Tape({ style }: { style: CSSProperties }) {
   );
 }
 
+const SECTION_HEADING_ROW: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+  marginBottom: 8,
+  flexWrap: "wrap",
+};
+
+const SECTION_HEADING_TEXT: CSSProperties = {
+  fontFamily: IMPACT,
+  // ornament: skewed Impact stencil — the ransom-dispatch masthead cut, not a heading you read.
+  fontSize: 30,
+  letterSpacing: "0.02em",
+  color: ACID,
+  textTransform: "uppercase",
+  transform: "skewX(-5deg)",
+  whiteSpace: "nowrap",
+};
+
+const SECTION_HEADING_RULE: CSSProperties = {
+  flex: 1,
+  height: 4,
+  minWidth: 40,
+  background: `repeating-linear-gradient(90deg, ${GREEN} 0 14px, ${PINK} 14px 22px, transparent 22px 30px)`,
+};
+
 /** Acid section title (skewed) trailing a green/pink barcode rule. */
 function SectionHeading({ children }: { children: ReactNode }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 8, flexWrap: "wrap" }}>
-      <span
-        style={{
-          fontFamily: IMPACT,
-          fontSize: 30,
-          letterSpacing: "0.02em",
-          color: ACID,
-          textTransform: "uppercase",
-          transform: "skewX(-5deg)",
-          whiteSpace: "nowrap",
-        }}
-      >
-        {children}
-      </span>
-      <span
-        style={{
-          flex: 1,
-          height: 4,
-          minWidth: 40,
-          background: `repeating-linear-gradient(90deg, ${GREEN} 0 14px, ${PINK} 14px 22px, transparent 22px 30px)`,
-        }}
-      />
+    <div style={SECTION_HEADING_ROW}>
+      <span style={SECTION_HEADING_TEXT}>{children}</span>
+      <span style={SECTION_HEADING_RULE} />
     </div>
   );
 }
 
+const KICKER: CSSProperties = {
+  fontFamily: MARKER,
+  // ornament: hand-scrawled marker aside slapped over the flyer — illustration, not copy.
+  fontSize: 16,
+  color: PINK,
+  transform: "rotate(-1deg)",
+  marginBottom: 18,
+};
+
 /** Scrawled marker kicker. */
 function Kicker({ children }: { children: ReactNode }) {
-  return (
-    <div style={{ fontFamily: MARKER, fontSize: 16, color: PINK, transform: "rotate(-1deg)", marginBottom: 18 }}>
-      {children}
-    </div>
-  );
+  return <div style={KICKER}>{children}</div>;
 }
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
@@ -196,6 +208,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
               style={{
                 position: "relative",
                 fontFamily: MARKER,
+                // ornament: marker scrawl heading on the taped xerox flyer.
                 fontSize: 26,
                 color: GREEN,
                 transform: "rotate(-1deg)",
@@ -207,12 +220,12 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
             <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 10 }}>
               {paragraphs.length ? (
                 paragraphs.map((para, i) => (
-                  <p key={i} style={{ fontFamily: TYPE, fontSize: 12, lineHeight: 1.75, color: INK, margin: 0 }}>
+                  <p key={i} className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.75, color: INK, margin: 0 }}>
                     {para}
                   </p>
                 ))
               ) : (
-                <p style={{ fontFamily: TYPE, fontSize: 12, lineHeight: 1.75, color: "color-mix(in srgb, var(--faction-snide-ink) 60%, transparent)", margin: 0 }}>
+                <p className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.75, color: "color-mix(in srgb, var(--faction-snide-ink) 60%, transparent)", margin: 0 }}>
                   {t("snide.about.empty")}
                 </p>
               )}
@@ -225,7 +238,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
           <SectionHeading>{t("snide.tasks.heading")}</SectionHeading>
           <Kicker>{t("snide.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
-            <p style={{ fontFamily: TYPE, fontSize: 12, color: MUTED }}>{t("snide.tasks.empty")}</p>
+            <p className="content-text" style={{ fontFamily: TYPE, color: MUTED }}>{t("snide.tasks.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 24, alignItems: "flex-start" }}>
               {tasks.map((task) => (
@@ -249,7 +262,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
           <SectionHeading>{t("snide.praxis.heading")}</SectionHeading>
           <Kicker>{t("snide.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
-            <p style={{ fontFamily: TYPE, fontSize: 12, color: MUTED }}>{t("snide.praxis.empty")}</p>
+            <p className="content-text" style={{ fontFamily: TYPE, color: MUTED }}>{t("snide.praxis.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
@@ -293,20 +306,22 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                   marginBottom: 16,
                 }}
               >
+                {/* ornament: condensed letterhead rule of the dispatch — printed furniture, not copy. */}
                 <span style={{ fontFamily: COND, fontSize: 14, letterSpacing: "0.22em", color: ACID }}>
                   {t("snide.dispatch.letterhead")}
                 </span>
-                <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
+                <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
                   {t("snide.dispatch.reLabel")}
                 </span>
               </div>
               <div style={{ position: "relative" }}>
                 {membership.state === "member" && (
                   <div>
+                    {/* ornament: Impact stencil headline set tight (lineHeight 0.9) — poster type. */}
                     <div style={{ fontFamily: IMPACT, fontSize: 26, lineHeight: 0.9, color: ACID, textTransform: "uppercase" }}>
                       {t("snide.dispatch.memberTitle")}
                     </div>
-                    <div style={{ fontFamily: MONO, fontSize: 10.5, color: MUTED, margin: "9px 0 0" }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-md)", color: MUTED, margin: "9px 0 0" }}>
                       <Trans t={t} i18nKey="snide.dispatch.memberStanding">
                         Standing · <b style={{ color: PINK }}>accomplice</b>
                       </Trans>
@@ -316,13 +331,14 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
 
                 {membership.state === "eligible" && !confirming && (
                   <div>
+                    {/* ornament: marker scrawl + Impact stencil headline — poster type. */}
                     <div style={{ fontFamily: MARKER, fontSize: 16, color: PINK, transform: "rotate(-1.5deg)", marginBottom: 6 }}>
                       {t("snide.dispatch.eligibleKicker")}
                     </div>
                     <div style={{ fontFamily: IMPACT, fontSize: 24, lineHeight: 0.9, color: ACID, textTransform: "uppercase", marginBottom: 8 }}>
                       {t("snide.dispatch.eligibleTitle")}
                     </div>
-                    <div style={{ fontFamily: TYPE, fontSize: 10.5, lineHeight: 1.5, color: "#d8d6c8", marginBottom: 16 }}>
+                    <div className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.5, color: "#d8d6c8", marginBottom: 16 }}>
                       {t("snide.dispatch.eligibleBody")}
                     </div>
                     <button
@@ -332,7 +348,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                         background: PINK,
                         color: "#fff",
                         fontFamily: BLACK,
-                        fontSize: 14,
+                        fontSize: "var(--text-xl)",
                         padding: 12,
                         border: "none",
                         transform: "rotate(-1deg)",
@@ -347,7 +363,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
 
                 {membership.state === "eligible" && confirming && (
                   <div>
-                    <div style={{ fontFamily: TYPE, fontSize: 11, lineHeight: 1.6, color: "#e7e4d8", marginBottom: 14 }}>
+                    <div className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.6, color: "#e7e4d8", marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
@@ -357,7 +373,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                         : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
-                      <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>
+                      <div className="content-text" style={{ fontFamily: MONO, color: "var(--color-danger)", marginBottom: 8 }}>
                         {membership.joinError}
                       </div>
                     )}
@@ -370,7 +386,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                           background: PINK,
                           color: "#fff",
                           fontFamily: BLACK,
-                          fontSize: 13,
+                          fontSize: "var(--text-xl)",
                           padding: 11,
                           border: "none",
                           cursor: membership.joining ? "not-allowed" : "pointer",
@@ -385,7 +401,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                         disabled={membership.joining}
                         style={{
                           fontFamily: COND,
-                          fontSize: 13,
+                          fontSize: "var(--text-xl)",
                           letterSpacing: "0.12em",
                           textTransform: "uppercase",
                           color: MUTED,
@@ -403,13 +419,14 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
 
                 {membership.state === "gate" && (
                   <div>
+                    {/* ornament: marker scrawl + Impact stencil headline — poster type. */}
                     <div style={{ fontFamily: MARKER, fontSize: 16, color: PINK, transform: "rotate(-1.5deg)", marginBottom: 6 }}>
                       {t("snide.dispatch.gateKicker")}
                     </div>
                     <div style={{ fontFamily: IMPACT, fontSize: 24, lineHeight: 0.9, color: ACID, textTransform: "uppercase", marginBottom: 10 }}>
                       {t("snide.dispatch.gateTitle")}
                     </div>
-                    <div style={{ fontFamily: TYPE, fontSize: 10.5, lineHeight: 1.6, color: "#d8d6c8" }}>
+                    <div className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.6, color: "#d8d6c8" }}>
                       {t("snide.dispatch.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
@@ -427,6 +444,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                 <Tape style={{ top: -9, left: 26, width: 56, height: 22, transform: "rotate(-6deg)" }} />
                 <div style={{ ...INK_PANEL, border: `2px solid ${ACID}`, boxShadow: "5px 6px 0 rgba(0,0,0,.3)", padding: "18px 16px 16px", textAlign: "center" }}>
                   <Halftone on="ink" />
+                  {/* ornament: WANTED-poster furniture — wide-tracked condensed caps + marker scrawl. */}
                   <div style={{ position: "relative", fontFamily: COND, fontSize: 13, letterSpacing: "0.35em", color: PINK }}>
                     {t("snide.spotlight.wanted")}
                   </div>
@@ -436,10 +454,11 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                   <div style={{ position: "relative", display: "flex", justifyContent: "center", marginBottom: 10 }}>
                     <Mugshot name={spot.display_name} size={70} invert />
                   </div>
+                  {/* ornament: the mugshot's stencilled name plate. */}
                   <div style={{ position: "relative", fontFamily: IMPACT, fontSize: 30, lineHeight: 0.9, color: ACID, textTransform: "uppercase" }}>
                     {spot.display_name}
                   </div>
-                  <div style={{ position: "relative", fontFamily: MONO, fontSize: 9, letterSpacing: "0.08em", textTransform: "uppercase", color: "#cfcdbf", marginTop: 4 }}>
+                  <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.08em", textTransform: "uppercase", color: "#cfcdbf", marginTop: 4 }}>
                     {t("snide.spotlight.stat", {
                       level: spot.level,
                       score: spot.all_time_score.toLocaleString(),
@@ -453,11 +472,12 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
           <div style={{ position: "relative", transform: "rotate(-0.6deg)" }}>
             <div style={{ ...PAPER_PANEL, boxShadow: "4px 5px 0 rgba(0,0,0,.2)", padding: "16px 16px 12px" }}>
               <Halftone on="paper" />
+              {/* ornament: marker scrawl heading on the rap sheet. */}
               <div style={{ position: "relative", fontFamily: MARKER, fontSize: 22, color: GREEN, transform: "rotate(-1deg)", marginBottom: 10 }}>
                 {t("snide.roster.heading")}
               </div>
               {rapSheet.length === 0 ? (
-                <p style={{ position: "relative", fontFamily: TYPE, fontSize: 12, color: "color-mix(in srgb, var(--faction-snide-ink) 60%, transparent)" }}>
+                <p className="content-text" style={{ position: "relative", fontFamily: TYPE, color: "color-mix(in srgb, var(--faction-snide-ink) 60%, transparent)" }}>
                   {spot
                     ? t("snide.roster.emptyWithSpotlight")
                     : t("detail.membersEmpty")}
@@ -479,11 +499,11 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                   >
                     <Mugshot name={m.display_name} size={30} />
                     <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontFamily: MARKER, fontSize: 16, color: INK, lineHeight: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      <div className="content-text" style={{ fontFamily: MARKER, color: INK, lineHeight: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                         {m.display_name}
                       </div>
                     </div>
-                    <span style={{ fontFamily: COND, fontSize: 13, letterSpacing: "0.06em", color: PINK_DEEP }}>
+                    <span style={{ fontFamily: COND, fontSize: "var(--text-xl)", letterSpacing: "0.06em", color: PINK_DEEP }}>
                       {t("snide.roster.level", { level: m.level })}
                     </span>
                   </Link>

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -65,21 +65,38 @@ function Grain() {
   );
 }
 
+const KICKER: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: "var(--text-xs)",
+  letterSpacing: "0.26em",
+  textTransform: "uppercase",
+  color: MUTED,
+  marginBottom: 7,
+};
+
 function Kicker({ children }: { children: ReactNode }) {
-  return (
-    <div style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.26em", textTransform: "uppercase", color: MUTED, marginBottom: 7 }}>
-      {children}
-    </div>
-  );
+  return <div style={KICKER}>{children}</div>;
 }
+
+const SECTION_HEADING_WRAP: CSSProperties = { marginBottom: 20 };
+
+const SECTION_HEADING_TEXT: CSSProperties = {
+  fontFamily: DISPLAY,
+  fontStyle: "italic",
+  fontWeight: 700,
+  // ornament: the salon's engraved plate cut, a step above the content ramp;
+  // rounding it to --text-heading would flatten it into the other archetypes.
+  fontSize: 30,
+  lineHeight: 1,
+  color: INK,
+  margin: 0,
+};
 
 function SectionHeading({ kicker, children }: { kicker: string; children: ReactNode }) {
   return (
-    <div style={{ marginBottom: 20 }}>
+    <div style={SECTION_HEADING_WRAP}>
       <Kicker>{kicker}</Kicker>
-      <h2 style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 30, lineHeight: 1, color: INK, margin: 0 }}>
-        {children}
-      </h2>
+      <h2 style={SECTION_HEADING_TEXT}>{children}</h2>
     </div>
   );
 }
@@ -135,7 +152,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
         <div style={{ ...PLATE, padding: "26px 30px 28px" }}>
           <Grain />
           <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
-            <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.26em", textTransform: "uppercase", color: MUTED }}>
+            <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.26em", textTransform: "uppercase", color: MUTED }}>
               {t("ua.prospectus.heading")}
             </span>
             <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD_LT}, transparent)` }} />
@@ -143,12 +160,12 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
           <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 12 }}>
             {paragraphs.length ? (
               paragraphs.map((para, i) => (
-                <p key={i} style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 15, lineHeight: 1.75, color: INK, margin: 0 }}>
+                <p key={i} className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.75, color: INK, margin: 0 }}>
                   {para}
                 </p>
               ))
             ) : (
-              <p style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 15, lineHeight: 1.75, color: SUB, margin: 0 }}>
+              <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.75, color: SUB, margin: 0 }}>
                 {t("ua.prospectus.empty")}
               </p>
             )}
@@ -159,7 +176,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
         <div>
           <SectionHeading kicker={t("ua.tasks.kicker")}>{t("ua.tasks.heading")}</SectionHeading>
           {tasks.length === 0 ? (
-            <p style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 14, color: SUB }}>{t("ua.tasks.empty")}</p>
+            <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", color: SUB }}>{t("ua.tasks.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 26, alignItems: "flex-start" }}>
               {tasks.map((task) => (
@@ -182,7 +199,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
         <div>
           <SectionHeading kicker={t("ua.praxis.kicker")}>{t("ua.praxis.heading")}</SectionHeading>
           {recentPraxis.length === 0 ? (
-            <p style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 14, color: SUB }}>{t("ua.praxis.empty")}</p>
+            <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", color: SUB }}>{t("ua.praxis.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
@@ -214,7 +231,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
           <div style={{ ...PLATE, boxShadow: `0 8px 24px rgba(60,40,10,.12), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`, padding: "24px 22px" }}>
             <Grain />
             <div style={{ position: "relative", display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
-              <span style={{ fontFamily: MONO, fontSize: 8, letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
+              <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
                 {t("ua.registry.heading")}
               </span>
               <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD_LT}, transparent)` }} />
@@ -222,10 +239,10 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
             <div style={{ position: "relative" }}>
               {membership.state === "member" && (
                 <div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 1, color: INK }}>
+                  <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1, color: INK }}>
                     {t("ua.registry.memberTitle")}
                   </div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, color: SUB, margin: "10px 0 0" }}>
+                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: "var(--text-xl)", color: SUB, margin: "10px 0 0" }}>
                     <Trans t={t} i18nKey="ua.registry.memberStanding">
                       Standing · <span style={{ color: ACCENT }}>enrolled</span>
                     </Trans>
@@ -235,16 +252,16 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
               {membership.state === "eligible" && !confirming && (
                 <div>
-                  <div style={{ fontFamily: ENGRAVED, fontSize: 10, letterSpacing: "0.1em", color: GOLD, marginBottom: 5 }}>{t("ua.registry.eligibleKicker")}</div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 1.02, color: INK, marginBottom: 10 }}>
+                  <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-base)", letterSpacing: "0.1em", color: GOLD, marginBottom: 5 }}>{t("ua.registry.eligibleKicker")}</div>
+                  <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1.02, color: INK, marginBottom: 10 }}>
                     {t("ua.registry.eligibleTitle")}
                   </div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.55, color: SUB, marginBottom: 18 }}>
+                  <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.55, color: SUB, marginBottom: 18 }}>
                     {t("ua.registry.eligibleBody")}
                   </div>
                   <button
                     onClick={() => setConfirming(true)}
-                    style={{ width: "100%", fontFamily: ENGRAVED, fontSize: 11, letterSpacing: "0.14em", color: PAPER_WARM, background: ACCENT, border: "none", padding: 12, boxShadow: "0 6px 16px rgba(194,84,31,.28)", cursor: "pointer" }}
+                    style={{ width: "100%", fontFamily: ENGRAVED, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: PAPER_WARM, background: ACCENT, border: "none", padding: 12, boxShadow: "0 6px 16px rgba(194,84,31,.28)", cursor: "pointer" }}
                   >
                     {t("ua.registry.joinButton")}
                   </button>
@@ -253,7 +270,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
               {membership.state === "eligible" && confirming && (
                 <div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
+                  <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.6, color: INK, marginBottom: 14 }}>
                     {membership.currentFactionSlug &&
                     membership.currentFactionSlug !== "na"
                       ? t("ua.registry.confirmSwitch", {
@@ -263,13 +280,13 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                       : t("ua.registry.confirm", { faction: factionName(faction.slug) })}
                   </div>
                   {membership.joinError && (
-                    <div style={{ fontFamily: MONO, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                    <div className="content-text" style={{ fontFamily: MONO, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
                   )}
                   <div style={{ display: "flex", gap: 8 }}>
                     <button
                       onClick={() => void membership.join()}
                       disabled={membership.joining}
-                      style={{ flex: 1, fontFamily: ENGRAVED, fontSize: 11, letterSpacing: "0.12em", color: PAPER_WARM, background: ACCENT, border: "none", padding: 11, cursor: membership.joining ? "not-allowed" : "pointer" }}
+                      style={{ flex: 1, fontFamily: ENGRAVED, fontSize: "var(--text-md)", letterSpacing: "0.12em", color: PAPER_WARM, background: ACCENT, border: "none", padding: 11, cursor: membership.joining ? "not-allowed" : "pointer" }}
                     >
                       {membership.joining
                         ? t("ua.registry.joining")
@@ -278,7 +295,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                     <button
                       onClick={() => setConfirming(false)}
                       disabled={membership.joining}
-                      style={{ fontFamily: ENGRAVED, fontSize: 10, letterSpacing: "0.12em", color: SUB, background: "transparent", border: `1px solid ${LINE}`, padding: "11px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
+                      style={{ fontFamily: ENGRAVED, fontSize: "var(--text-base)", letterSpacing: "0.12em", color: SUB, background: "transparent", border: `1px solid ${LINE}`, padding: "11px 14px", cursor: membership.joining ? "not-allowed" : "pointer" }}
                     >
                       {t("detail.join.cancel")}
                     </button>
@@ -288,11 +305,11 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
               {membership.state === "gate" && (
                 <div>
-                  <div style={{ fontFamily: ENGRAVED, fontSize: 10, letterSpacing: "0.1em", color: GOLD, marginBottom: 5 }}>{t("ua.registry.gateKicker")}</div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 23, lineHeight: 1.04, color: INK, marginBottom: 12 }}>
+                  <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-base)", letterSpacing: "0.1em", color: GOLD, marginBottom: 5 }}>{t("ua.registry.gateKicker")}</div>
+                  <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1.04, color: INK, marginBottom: 12 }}>
                     {t("ua.registry.gateTitle")}
                   </div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 13, lineHeight: 1.65, color: SUB }}>
+                  <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.65, color: SUB }}>
                     {t("ua.registry.gateBody", { faction: factionName(faction.slug) })}
                   </div>
                 </div>
@@ -309,16 +326,16 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
               <div style={{ padding: 11, background: GILT, boxShadow: "0 12px 28px rgba(60,40,10,.22), inset 0 0 0 1px rgba(255,255,255,.45)" }}>
                 <div style={{ padding: 4, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
                   <div style={{ background: PAPER_WARM, border: `1px solid ${LINE}`, padding: "20px 18px 18px", textAlign: "center" }}>
-                    <div style={{ fontFamily: MONO, fontSize: 7, letterSpacing: "0.3em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.3em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
                       {t("ua.spotlight.label")}
                     </div>
                     <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
                       <Medallion name={spot.display_name} size={72} spotlight />
                     </div>
-                    <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: 24, lineHeight: 1, color: INK }}>
+                    <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1, color: INK }}>
                       {spot.display_name}
                     </div>
-                    <div style={{ fontFamily: ENGRAVED, fontSize: 8, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, marginTop: 8 }}>
+                    <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-xs)", letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, marginTop: 8 }}>
                       {t("ua.spotlight.stat", {
                         anno: anno(spot.level),
                         score: spot.all_time_score.toLocaleString(),
@@ -332,11 +349,11 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
           <div style={{ ...PLATE, boxShadow: `0 4px 14px rgba(60,40,10,.08), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`, padding: "18px 20px 14px" }}>
             <Grain />
-            <div style={{ position: "relative", fontFamily: MONO, fontSize: 8, letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
+            <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED, marginBottom: 12 }}>
               {t("ua.roster.heading")}
             </div>
             {register.length === 0 ? (
-              <p style={{ position: "relative", fontFamily: DISPLAY, fontStyle: "italic", fontSize: 14, color: SUB }}>
+              <p className="content-text" style={{ position: "relative", fontFamily: DISPLAY, fontStyle: "italic", color: SUB }}>
                 {spot
                   ? t("ua.roster.emptyWithSpotlight")
                   : t("detail.membersEmpty")}
@@ -350,11 +367,11 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                 >
                   <Medallion name={m.display_name} size={32} />
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: 15, color: INK, lineHeight: 1.1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", color: INK, lineHeight: 1.1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                       {m.display_name}
                     </div>
                   </div>
-                  <span style={{ fontFamily: ENGRAVED, fontSize: 9, letterSpacing: "0.08em", color: GOLD }}>
+                  <span style={{ fontFamily: ENGRAVED, fontSize: "var(--text-sm)", letterSpacing: "0.08em", color: GOLD }}>
                     {t("ua.roster.level", { anno: anno(m.level) })}
                   </span>
                 </Link>

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -103,36 +103,38 @@ function Tape({ color, style }: { color: string; style?: CSSProperties }) {
   );
 }
 
+const SECTION_HEADING: CSSProperties = {
+  display: "inline-block",
+  fontFamily: SCRIPT,
+  // ornament: hand-lettered Caveat on a kraft sticker — the sticker is drawn, not typeset.
+  fontSize: 28,
+  fontWeight: 700,
+  lineHeight: 1,
+  color: INK,
+  background: CARD_BG,
+  border: `1px solid ${NOTEPAD_BORDER}`,
+  borderRadius: 8,
+  padding: "1px 12px",
+  transform: "rotate(-1.5deg)",
+  boxShadow: `0 2px 5px ${BOARD_SHADOW}`,
+};
+
 /** Section heading — a Caveat label tacked to a little kraft sticker. */
 function SectionHeading({ children }: { children: ReactNode }) {
-  return (
-    <span
-      style={{
-        display: "inline-block",
-        fontFamily: SCRIPT,
-        fontSize: 28,
-        fontWeight: 700,
-        lineHeight: 1,
-        color: INK,
-        background: CARD_BG,
-        border: `1px solid ${NOTEPAD_BORDER}`,
-        borderRadius: 8,
-        padding: "1px 12px",
-        transform: "rotate(-1.5deg)",
-        boxShadow: `0 2px 5px ${BOARD_SHADOW}`,
-      }}
-    >
-      {children}
-    </span>
-  );
+  return <span style={SECTION_HEADING}>{children}</span>;
 }
 
+const KICKER: CSSProperties = {
+  fontFamily: BODY,
+  fontSize: "var(--text-sm)",
+  letterSpacing: "0.18em",
+  textTransform: "uppercase",
+  color: MUTED,
+  margin: "8px 0 2px",
+};
+
 function Kicker({ children }: { children: ReactNode }) {
-  return (
-    <div style={{ fontFamily: BODY, fontSize: 8.5, letterSpacing: "0.18em", textTransform: "uppercase", color: MUTED, margin: "8px 0 2px" }}>
-      {children}
-    </div>
-  );
+  return <div style={KICKER}>{children}</div>;
 }
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
@@ -199,18 +201,19 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
           >
             {/* red margin rule */}
             <div style={{ position: "absolute", left: 32, top: 0, bottom: 0, width: 2, background: `color-mix(in srgb, ${PINK} 55%, transparent)` }} />
+            {/* ornament: hand-lettered Caveat — handwriting on the board, not typeset copy. */}
             <div style={{ fontFamily: SCRIPT, fontSize: 30, fontWeight: 700, color: ACCENT, lineHeight: 1, marginBottom: 10 }}>
               {t("wow.manifesto.heading")}
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
               {paragraphs.length ? (
                 paragraphs.map((para, i) => (
-                  <p key={i} style={{ fontFamily: BODY, fontSize: 11.5, lineHeight: 1.85, color: MUTED, margin: 0 }}>
+                  <p key={i} className="content-text" style={{ fontFamily: BODY, lineHeight: 1.85, color: MUTED, margin: 0 }}>
                     {para}
                   </p>
                 ))
               ) : (
-                <p style={{ fontFamily: BODY, fontSize: 11.5, lineHeight: 1.85, color: MUTED, margin: 0 }}>
+                <p className="content-text" style={{ fontFamily: BODY, lineHeight: 1.85, color: MUTED, margin: 0 }}>
                   {t("wow.manifesto.empty")}
                 </p>
               )}
@@ -223,7 +226,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
           <SectionHeading>{t("wow.tasks.heading")}</SectionHeading>
           <Kicker>{t("wow.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
-            <p style={{ fontFamily: BODY, fontSize: 11, color: MUTED, marginTop: 12 }}>{t("wow.tasks.empty")}</p>
+            <p className="content-text" style={{ fontFamily: BODY, color: MUTED, marginTop: 12 }}>{t("wow.tasks.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 26, alignItems: "flex-start", marginTop: 16 }}>
               {tasks.map((task) => (
@@ -247,7 +250,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
           <SectionHeading>{t("wow.praxis.heading")}</SectionHeading>
           <Kicker>{t("wow.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
-            <p style={{ fontFamily: BODY, fontSize: 11, color: MUTED, marginTop: 12 }}>{t("wow.praxis.empty")}</p>
+            <p className="content-text" style={{ fontFamily: BODY, color: MUTED, marginTop: 12 }}>{t("wow.praxis.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: 22, alignItems: "flex-start", marginTop: 16 }}>
               {recentPraxis.map((praxis) => (
@@ -295,7 +298,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                   <span style={{ width: 9, height: 9, borderRadius: "50%", background: ACCENT }} />
                   <span style={{ width: 9, height: 9, borderRadius: "50%", background: IVY_LEAF }} />
                 </span>
-                <span style={{ marginLeft: "auto", fontFamily: BODY, fontSize: 9.5, color: TITLE_TEXT }}>{t("wow.join.windowTitle")}</span>
+                <span style={{ marginLeft: "auto", fontFamily: BODY, fontSize: "var(--text-base)", color: TITLE_TEXT }}>{t("wow.join.windowTitle")}</span>
               </div>
 
               <div style={{ background: NOTEPAD, padding: 18 }}>
@@ -304,10 +307,11 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                     <div style={{ display: "flex", justifyContent: "center", marginBottom: 6 }}>
                       <Sparkle size={30} color={ACCENT} />
                     </div>
+                    {/* ornament: hand-lettered Caveat — handwriting on the board, not typeset copy. */}
                     <div style={{ fontFamily: SCRIPT, fontSize: 25, fontWeight: 700, color: IVY, lineHeight: 1 }}>
                       {t("wow.join.memberTitle")}
                     </div>
-                    <div style={{ fontFamily: BODY, fontSize: 10.5, color: MUTED, marginTop: 6 }}>
+                    <div style={{ fontFamily: BODY, fontSize: "var(--text-md)", color: MUTED, marginTop: 6 }}>
                       <Trans t={t} i18nKey="wow.join.memberStanding">
                         Standing · <b style={{ color: ACCENT }}>coven witch</b>
                       </Trans>
@@ -317,10 +321,11 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
 
                 {membership.state === "eligible" && !confirming && (
                   <div style={{ textAlign: "center" }}>
+                    {/* ornament: hand-lettered Caveat — handwriting on the board, not typeset copy. */}
                     <div style={{ fontFamily: SCRIPT, fontSize: 26, fontWeight: 700, color: ACCENT, lineHeight: 1, marginBottom: 6 }}>
                       {t("wow.join.eligibleTitle")}
                     </div>
-                    <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.55, color: MUTED, marginBottom: 14 }}>
+                    <div className="content-text" style={{ fontFamily: BODY, lineHeight: 1.55, color: MUTED, marginBottom: 14 }}>
                       {t("wow.join.eligibleBody")}
                     </div>
                     <button
@@ -328,7 +333,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                       style={{
                         width: "100%",
                         fontFamily: BODY,
-                        fontSize: 11.5,
+                        fontSize: "var(--text-lg)",
                         fontWeight: 700,
                         letterSpacing: "0.06em",
                         textTransform: "uppercase",
@@ -348,7 +353,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
 
                 {membership.state === "eligible" && confirming && (
                   <div>
-                    <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
+                    <div className="content-text" style={{ fontFamily: BODY, lineHeight: 1.6, color: INK, marginBottom: 14 }}>
                       {membership.currentFactionSlug &&
                       membership.currentFactionSlug !== "na"
                         ? t("detail.join.confirmSwitch", {
@@ -358,7 +363,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                         : t("detail.join.confirm", { faction: factionName(faction.slug) })}
                     </div>
                     {membership.joinError && (
-                      <div style={{ fontFamily: BODY, fontSize: 10, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
+                      <div className="content-text" style={{ fontFamily: BODY, color: "var(--color-danger)", marginBottom: 8 }}>{membership.joinError}</div>
                     )}
                     <div style={{ display: "flex", gap: 8 }}>
                       <button
@@ -367,7 +372,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                         style={{
                           flex: 1,
                           fontFamily: BODY,
-                          fontSize: 11,
+                          fontSize: "var(--text-md)",
                           fontWeight: 700,
                           letterSpacing: "0.06em",
                           textTransform: "uppercase",
@@ -388,7 +393,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                         disabled={membership.joining}
                         style={{
                           fontFamily: BODY,
-                          fontSize: 10,
+                          fontSize: "var(--text-base)",
                           letterSpacing: "0.1em",
                           textTransform: "uppercase",
                           color: MUTED,
@@ -411,11 +416,12 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                       <span style={{ marginTop: 3 }}>
                         <Sparkle size={20} color={IVY} />
                       </span>
+                      {/* ornament: hand-lettered Caveat — handwriting on the board, not typeset copy. */}
                       <span style={{ fontFamily: SCRIPT, fontSize: 23, fontWeight: 700, color: ACCENT, lineHeight: 1.2 }}>
                         {t("wow.join.gateTitle")}
                       </span>
                     </div>
-                    <div style={{ fontFamily: BODY, fontSize: 10.5, lineHeight: 1.55, color: MUTED }}>
+                    <div className="content-text" style={{ fontFamily: BODY, lineHeight: 1.55, color: MUTED }}>
                       {t("wow.join.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
@@ -453,13 +459,14 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                   <Avatar name={spot.display_name} size={60} />
                 </div>
                 <div style={{ padding: "8px 4px 14px", textAlign: "center" }}>
-                  <div style={{ fontFamily: BODY, fontSize: 8, letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
+                  <div style={{ fontFamily: BODY, fontSize: "var(--text-xs)", letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
                     {t("wow.spotlight.label")}
                   </div>
+                  {/* ornament: hand-lettered Caveat — handwriting on the board, not typeset copy. */}
                   <div style={{ fontFamily: SCRIPT, fontSize: 26, fontWeight: 700, color: ACCENT, lineHeight: 1 }}>
                     {spot.display_name}
                   </div>
-                  <div style={{ fontFamily: BODY, fontSize: 8.5, color: INK, marginTop: 2 }}>
+                  <div style={{ fontFamily: BODY, fontSize: "var(--text-sm)", color: INK, marginTop: 2 }}>
                     {t("wow.spotlight.stat", {
                       level: spot.level,
                       score: spot.all_time_score.toLocaleString(),
@@ -482,11 +489,12 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                 padding: "14px 16px",
               }}
             >
+              {/* ornament: hand-lettered Caveat — handwriting on the board, not typeset copy. */}
               <div style={{ fontFamily: SCRIPT, fontSize: 23, fontWeight: 700, color: ACCENT, lineHeight: 1, marginBottom: 8 }}>
                 {t("wow.roster.heading")}
               </div>
               {roster.length === 0 ? (
-                <p style={{ fontFamily: BODY, fontSize: 11, color: MUTED }}>
+                <p className="content-text" style={{ fontFamily: BODY, color: MUTED }}>
                   {spot
                     ? t("wow.roster.emptyWithSpotlight")
                     : t("detail.membersEmpty")}
@@ -504,6 +512,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                         flex: 1,
                         minWidth: 0,
                         fontFamily: SCRIPT,
+                        // ornament: hand-lettered Caveat roster name.
                         fontSize: 19,
                         color: INK,
                         lineHeight: 1,
@@ -514,7 +523,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
                     >
                       {m.display_name}
                     </span>
-                    <span style={{ fontFamily: BODY, fontSize: 9, color: ACCENT }}>
+                    <span style={{ fontFamily: BODY, fontSize: "var(--text-sm)", color: ACCENT }}>
                       {t("wow.roster.level", { level: m.level })}
                     </span>
                   </Link>


### PR DESCRIPTION
Part of #623 — slice 1 of the site-wide fontSize tokenization sweep: the seven desktop faction bodies under `frontend/src/pages/factionDetail/archetypes/`.

## Count

**172 → 46 raw `fontSize` values.** All 46 survivors are annotated ornament.

| File | Before | After |
|---|---|---|
| `SnideFactionBody` | 30 | 13 |
| `EverymenFactionBody` | 28 | 10 |
| `EphemeristsFactionBody` | 28 | 9 |
| `WowFactionBody` | 26 | 8 |
| `SingularityFactionBody` | 29 | 4 |
| `UaFactionBody` | 28 | 1 |
| `AlbescentFactionBody` | 3 | 1 |
| `DefaultFactionBody` | 0 | 0 |

## The line I drew

The archetypes don't classify uniformly, because their type systems differ. The rule that made it consistent:

> **A display face whose optical size is not the text scale is ornament, even at 13px. Anything a player reads is content, even at 30px.**

That gives each skin a clean, statable boundary instead of a per-element judgement call:

- **WoW** — Caveat hand-lettering is ornament; `--font-body` is the reading face. All 8 survivors are Caveat sites.
- **Everymen** — Bebas is a condensed poster face. All 10 survivors are Bebas sites.
- **S.N.I.D.E.** — Impact stencils, marker scrawl and WANTED-poster furniture are ornament; the typewriter face is read.
- **Ephemerists** — Cinzel display titles and calligraphic script flourishes are ornament; the serif is read.
- **Singularity** — one mono face throughout, so size alone carries role. Only 4 terminal display titles stay raw; the primary-node name landed exactly on `--text-title`.
- **UA** — the reading face *is* the display serif, so almost everything promotes. Only the 30px salon section heading stays raw.

Rounding policy for label-tier values: nearest token, ties round **up** (readability, and the floor doctrine biases upward).

Prose promotions use the role **classes** (`.content-text`, `.content-title`) rather than an inline token, so the win is deleting the inline `fontSize` outright — 40+ inline declarations removed, not merely rewritten. Verified `.content-text` / `.content-title` survive the Tailwind purge in the built CSS.

## Two things worth a look

1. **`DefaultFactionBody` had zero raw `fontSize` but was still below the floor** — its three empty-state paragraphs sat at Tailwind `text-sm` (14px). Same content-floor violation, different notation. Swapped for `.content-text`. Flagging because a `grep 'fontSize: [0-9]'` sweep of the rest of the repo will not find this class of defect.
2. **Nothing was delisted from `.eslint-legacy-raw-styles.txt`,** by design. Every file still carries raw spacing (~185 values, issue #750). `DefaultFactionBody` is clean on numeric spacing but has string spacing (`padding: "6px 10px"`), so it stays listed too. Because the rule is off for these files, surviving ornament carries a plain `// ornament: <why>` comment — an `eslint-disable-next-line` there would be an *unused* directive.

## Doc

`WORLD_ZERO_STYLE.md` §4a gains an "ornament escape hatch" subsection documenting the two-phase state (plain comment while grandfathered → per-line eslint directive once delisted), the ornament-vs-content test, and the condition for delisting (clean on **both** axes). It states plainly that the list reaches empty only when #750 closes, which keeps "the list only ever shrinks" literally true.

## Verification

`tsc --noEmit` clean, `vite build` clean, `eslint` clean on the directory. Committed per-file so each faction's diff is reviewable on its own.

**Visual QA is outstanding** — I cannot screenshot in this environment.

## What to eyeball

Visit each faction page (`/factions/<slug>`) and check the promoted prose has grown to 18px without breaking its container, and that the ornament still reads as ornament:

- **`/factions/ua`** — highest-churn file (28 → 1). Prospectus paragraphs 15→18px and the register member names 15→18px inside the narrow right rail; the registry titles moved 23→24px. If anything overflows, the fix is a wider container, not smaller type (§4 geometry doctrine).
- **`/factions/snide`** — the taped dispatch rail is the tightest column in the slice. About paragraphs and the join/gate body copy went 10.5–12 → 18px, and roster names 16 → 18px in the marker face. Most likely place to need a container widened.
- **`/factions/wow`** — join.exe window is narrow; its body copy went 10.5 → 18px. Confirm the Caveat headings still visibly outrank the body now that body copy is larger.
- **`/factions/everymen`** — same check: Bebas headlines vs. the enlarged mono body. The spotlight eyebrow moved 7 → 8px.
- **`/factions/singularity`** — terminal prose 11.5 → 18px against fixed scanline geometry; also the only file where I promoted a name to `.content-title`.
- **`/factions/ephemerists`** — verify the script-italic kickers still read as marginal flourishes next to the now-larger serif body.
- **`/factions/albescent`** and any **`na`/unaffiliated** faction (Default body) — smallest diffs, quickest confirmations.

Worth checking **dark mode** on Ephemerists and WoW (both flip through the cascade) and one **narrow viewport**, since the right rail is where enlarged text is most likely to collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
