### PR TITLE
Tokenize fontSize in components/cards (#623 slice 6) — 104 → 36, ornament kept

### DIFF
--- a/frontend/src/components/cards/AlbescentFactionHero.tsx
+++ b/frontend/src/components/cards/AlbescentFactionHero.tsx
@@ -78,7 +78,7 @@ export default function AlbescentFactionHero({
           <div
             style={{
               fontFamily: MONO,
-              fontSize: 7.5,
+              fontSize: "var(--text-xs)",
               letterSpacing: "0.28em",
               textTransform: "uppercase",
               color: ink(22),
@@ -96,6 +96,7 @@ export default function AlbescentFactionHero({
               fontFamily: FONT,
               fontStyle: "italic",
               fontWeight: 300,
+              // ornament: vellum wordmark — the Albescent hero's display type
               fontSize: 60,
               lineHeight: 0.94,
               color: INK,
@@ -110,7 +111,7 @@ export default function AlbescentFactionHero({
           <div
             style={{
               fontFamily: MONO,
-              fontSize: 9,
+              fontSize: "var(--text-sm)",
               letterSpacing: "0.34em",
               textTransform: "uppercase",
               color: ink(28),
@@ -122,7 +123,7 @@ export default function AlbescentFactionHero({
 
           {/* Blurb — the faction's own description */}
           {description && (
-            <p style={{ fontFamily: MONO, fontSize: 9.5, lineHeight: 1.74, color: ink(46), maxWidth: 490, marginBottom: 26 }}>
+            <p className="content-text" style={{ fontFamily: MONO, lineHeight: 1.74, color: ink(46), maxWidth: 490, marginBottom: 26 }}>
               {description}
             </p>
           )}
@@ -131,10 +132,11 @@ export default function AlbescentFactionHero({
           <div style={{ display: "flex", gap: 26, flexWrap: "wrap" }}>
             {stats.map((s) => (
               <div key={s.label} style={{ paddingTop: 12, borderTop: `1px solid ${BORDER}`, minWidth: 80 }}>
+                {/* ornament: ledger numeral in the vellum display face, sized to its cap-height; already above the content floor */}
                 <div style={{ fontFamily: FONT, fontStyle: "italic", fontWeight: 300, fontSize: 26, lineHeight: 1, color: ink(68), marginBottom: 5 }}>
                   {s.value}
                 </div>
-                <div style={{ fontFamily: MONO, fontSize: 7, letterSpacing: "0.2em", textTransform: "uppercase", color: ink(26) }}>
+                <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.2em", textTransform: "uppercase", color: ink(26) }}>
                   {s.label}
                 </div>
               </div>

--- a/frontend/src/components/cards/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/cards/EphemeristsFactionHero.tsx
@@ -80,7 +80,7 @@ export default function EphemeristsFactionHero({
           <div
             style={{
               fontFamily: "var(--eph-serif)",
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: "0.28em",
               textTransform: "uppercase",
               color: "var(--eph-gold-light)",
@@ -93,6 +93,7 @@ export default function EphemeristsFactionHero({
             style={{
               fontFamily: "var(--eph-display)",
               fontWeight: 800,
+              // ornament: codex wordmark — display serif at 0.88 leading with a letterpress shadow
               fontSize: 52,
               lineHeight: 0.88,
               letterSpacing: "0.02em",
@@ -111,7 +112,7 @@ export default function EphemeristsFactionHero({
               color: "var(--eph-gold-light)",
               fontFamily: "var(--eph-display)",
               fontWeight: 600,
-              fontSize: 14,
+              fontSize: "var(--text-xl)",
               letterSpacing: "0.26em",
               padding: "5px 16px",
               border: "1px solid var(--eph-gold-deep)",
@@ -120,9 +121,9 @@ export default function EphemeristsFactionHero({
             {i18n.t("feed:factionHero.ephemerists.motto")}
           </div>
           <p
+            className="content-text"
             style={{
               fontFamily: "var(--eph-serif)",
-              fontSize: 13.5,
               lineHeight: 1.6,
               maxWidth: 580,
               margin: "14px 0 0",
@@ -130,12 +131,14 @@ export default function EphemeristsFactionHero({
             }}
           >
             {description ?? i18n.t("feed:factionHero.ephemerists.descriptionFallback")}
+            {/* Gloss is a full catalog sentence -> content floor; the script face and
+                the dimmed parchment carry the hierarchy instead of a smaller size. */}
             <span
+              className="content-text"
               style={{
                 display: "block",
                 fontFamily: "var(--eph-script)",
                 fontStyle: "italic",
-                fontSize: 11.5,
                 color: "color-mix(in srgb, var(--eph-parchment) 62%, transparent)",
                 marginTop: 8,
               }}
@@ -167,10 +170,10 @@ export default function EphemeristsFactionHero({
                   borderTop: i > 0 ? "1px solid color-mix(in srgb, var(--eph-gold-light) 18%, transparent)" : undefined,
                 }}
               >
-                <span style={{ fontFamily: "var(--eph-serif)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "color-mix(in srgb, var(--eph-parchment) 75%, transparent)" }}>
+                <span style={{ fontFamily: "var(--eph-serif)", fontSize: "var(--text-sm)", letterSpacing: "0.14em", textTransform: "uppercase", color: "color-mix(in srgb, var(--eph-parchment) 75%, transparent)" }}>
                   {s.label}
                 </span>
-                <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: 24, lineHeight: 0.85, color: "var(--eph-gold-light)" }}>
+                <span className="content-title" style={{ fontFamily: "var(--eph-display)", fontWeight: 700, lineHeight: 0.85, color: "var(--eph-gold-light)" }}>
                   {s.value}
                 </span>
               </div>

--- a/frontend/src/components/cards/EverymenFactionCard.tsx
+++ b/frontend/src/components/cards/EverymenFactionCard.tsx
@@ -106,6 +106,7 @@ export default function EverymenCard({
           background: "var(--everymen-ink)",
           color: "var(--everymen-gold)",
           textAlign: "center",
+          // ornament: struck banner ribbon across the card head — illustration, not chrome
           fontFamily: "var(--faction-everymen-card-font)",
           fontSize: 15,
           letterSpacing: "0.34em",
@@ -143,7 +144,7 @@ export default function EverymenCard({
         <div
           style={{
             fontFamily: "var(--font-body)",
-            fontSize: 10,
+            fontSize: "var(--text-base)",
             letterSpacing: "0.3em",
             textTransform: "uppercase",
             color: "var(--everymen-gold)",
@@ -156,6 +157,7 @@ export default function EverymenCard({
         {/* big Bebas headline = faction name */}
         <h1
           style={{
+            // ornament: union-poster headline — Bebas at 0.84 leading, the archetype's voice
             fontFamily: "var(--faction-everymen-card-font)",
             fontSize: 60,
             lineHeight: 0.84,
@@ -175,6 +177,7 @@ export default function EverymenCard({
             marginTop: 16,
             background: "var(--everymen-ink)",
             color: "var(--everymen-gold)",
+            // ornament: struck motto plaque — poster type set to the ink block
             fontFamily: "var(--faction-everymen-card-font)",
             fontSize: 16,
             letterSpacing: "0.2em",
@@ -187,9 +190,9 @@ export default function EverymenCard({
 
         {/* blurb from description */}
         <p
+          className="content-text"
           style={{
             fontFamily: "var(--font-body)",
-            fontSize: 13,
             lineHeight: 1.65,
             maxWidth: 420,
             margin: "18px auto 0",
@@ -231,13 +234,14 @@ export default function EverymenCard({
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
+                  // ornament: the checkmark is a dingbat glyph used as an icon in a 22px chip
                   fontFamily: "var(--faction-everymen-card-font)",
                   fontSize: 14,
                 }}
               >
                 ✓
               </span>
-              <span style={{ fontFamily: "var(--font-body)", fontSize: 12.5, color: "var(--everymen-cream)" }}>
+              <span className="content-text" style={{ fontFamily: "var(--font-body)", color: "var(--everymen-cream)" }}>
                 {perk}
               </span>
             </div>

--- a/frontend/src/components/cards/EverymenFactionHero.tsx
+++ b/frontend/src/components/cards/EverymenFactionHero.tsx
@@ -119,7 +119,7 @@ export default function EverymenFactionHero({
             <div
               style={{
                 fontFamily: "var(--font-body)",
-                fontSize: 10,
+                fontSize: "var(--text-base)",
                 letterSpacing: "0.3em",
                 textTransform: "uppercase",
                 color: GOLD,
@@ -131,6 +131,7 @@ export default function EverymenFactionHero({
             <h1
               style={{
                 fontFamily: "var(--font-accent)",
+                // ornament: union-poster wordmark — accent face at 0.82 leading, hard drop shadow
                 fontSize: 76,
                 lineHeight: 0.82,
                 letterSpacing: "0.01em",
@@ -148,6 +149,7 @@ export default function EverymenFactionHero({
                 marginTop: 12,
                 background: INK,
                 color: GOLD,
+                // ornament: struck motto plaque — poster type set to the ink block
                 fontFamily: "var(--font-accent)",
                 fontSize: 17,
                 letterSpacing: "0.18em",
@@ -157,9 +159,9 @@ export default function EverymenFactionHero({
               {i18n.t("feed:factionHero.everymen.motto")}
             </div>
             <p
+              className="content-text"
               style={{
                 fontFamily: "var(--font-body)",
-                fontSize: 12.5,
                 lineHeight: 1.6,
                 maxWidth: 560,
                 margin: "13px 0 0",
@@ -199,7 +201,7 @@ export default function EverymenFactionHero({
               <span
                 style={{
                   fontFamily: "var(--font-body)",
-                  fontSize: 9,
+                  fontSize: "var(--text-sm)",
                   letterSpacing: "0.14em",
                   textTransform: "uppercase",
                   color: CREAM,
@@ -208,6 +210,7 @@ export default function EverymenFactionHero({
               >
                 {s.label}
               </span>
+              {/* ornament: ledger numeral in the poster face, sized to its cap-height; above the floor already */}
               <span style={{ fontFamily: "var(--font-accent)", fontSize: 34, lineHeight: 0.8, color: GOLD }}>
                 {s.value}
               </span>

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -285,13 +285,14 @@ function WowCard({
               display: "inline-flex",
               alignItems: "center",
               gap: 4,
-              fontSize: 10.5,
+              fontSize: "var(--text-md)",
               color: titleText,
               letterSpacing: "0.03em",
             }}
           >
             <WowSigil size={10} color={titleText} /> {i18n.t("feed:identity.wow.windowTitle")}
           </span>
+          {/* ornament: ▭ ✕ are drawn window-chrome glyphs used as icons, not text */}
           <span
             style={{
               marginLeft: "auto",
@@ -359,6 +360,7 @@ function WowCard({
             >
               <StatusBadge status={status} slug="wow" />
             </div>
+            {/* ornament: faction name in Caveat at notepad-headline size — the archetype's voice */}
             <div
               style={{
                 fontFamily: factionCssVar("wow", "card-font"),
@@ -373,8 +375,8 @@ function WowCard({
             </div>
             {desc && (
               <div
+                className="card-description"
                 style={{
-                  fontSize: 10,
                   lineHeight: 1.5,
                   color: factionCssVar("wow", "card-muted"),
                 }}
@@ -466,8 +468,8 @@ function SnideCard({
           }}
         >
           <div
+            className="card-description"
             style={{
-              fontSize: 8,
               color: factionCssVar("snide", "card-muted"),
               lineHeight: 1.5,
             }}
@@ -476,8 +478,8 @@ function SnideCard({
           </div>
           <div style={{ background: "var(--color-border)" }} />
           <div
+            className="card-description"
             style={{
-              fontSize: 8,
               color: factionCssVar("snide", "card-muted"),
               lineHeight: 1.5,
             }}
@@ -534,7 +536,7 @@ function EphemeristsCard({
           <div
             style={{
               fontFamily: "var(--eph-serif)",
-              fontSize: 8,
+              fontSize: "var(--text-xs)",
               letterSpacing: "0.26em",
               textTransform: "uppercase",
               color: "var(--eph-gold-light)",
@@ -543,6 +545,7 @@ function EphemeristsCard({
           >
             {i18n.t("feed:factionCard.ephemerists.eyebrow")}
           </div>
+          {/* ornament: codex frontispiece wordmark — display serif with a letterpress shadow */}
           <div
             style={{
               fontFamily: "var(--eph-display)",
@@ -699,7 +702,7 @@ function SingularityCard({
         )}
         <div
           style={{
-            fontSize: 8,
+            fontSize: "var(--text-xs)",
             color: "var(--faction-singularity-card-muted)",
             textTransform: "uppercase",
             letterSpacing: "0.15em",
@@ -735,8 +738,8 @@ function SingularityCard({
         </div>
         {desc && (
           <div
+            className="card-description"
             style={{
-              fontSize: 9,
               color: "var(--faction-singularity-card-muted)",
               lineHeight: 1.5,
               marginBottom: 10,

--- a/frontend/src/components/cards/FactionSelectCard.tsx
+++ b/frontend/src/components/cards/FactionSelectCard.tsx
@@ -57,24 +57,25 @@ function UaSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelect
       <div style={{ position: "relative", flex: 1, padding: "22px 26px 0", display: "flex", flexDirection: "column" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
           <div>
-            <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 10, letterSpacing: "0.32em", color: "var(--ua-gold)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.ua.masthead")}</div>
+            <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: "var(--text-base)", letterSpacing: "0.32em", color: "var(--ua-gold)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.ua.masthead")}</div>
+            {/* ornament: gilt-placard wordmark — display type at 0.9 leading, the UA archetype's voice */}
             <div style={{ fontFamily: "var(--font-faction-gilt)", fontStyle: "italic", fontWeight: 800, fontSize: 52, lineHeight: 0.9, letterSpacing: "0.01em", marginTop: 8 }}>{i18n.t("feed:factionSelect.ua.wordmark")}</div>
-            <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: 12, letterSpacing: "0.24em", color: "var(--ua-sub)", textTransform: "uppercase", marginTop: 3 }}>{i18n.t("feed:factionSelect.ua.subtitle")}</div>
+            <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: "var(--text-lg)", letterSpacing: "0.24em", color: "var(--ua-sub)", textTransform: "uppercase", marginTop: 3 }}>{i18n.t("feed:factionSelect.ua.subtitle")}</div>
           </div>
           <UaSigil width={44} height={53} />
         </div>
         <div style={{ height: 2, background: "var(--ua-gilt)", margin: "16px 0 13px", opacity: 0.85 }} />
-        <p style={{ margin: 0, fontFamily: "var(--font-faction-gilt)", fontStyle: "italic", fontSize: 16, lineHeight: 1.4, color: "var(--ua-ink)" }}>
+        <p className="content-text" style={{ margin: 0, fontFamily: "var(--font-faction-gilt)", fontStyle: "italic", lineHeight: 1.4, color: "var(--ua-ink)" }}>
           {i18n.t("feed:factionSelect.ua.blurb")}
         </p>
       </div>
       <div style={{ position: "relative", padding: "0 26px 20px" }}>
-        <div style={{ fontSize: 10, letterSpacing: "0.04em", color: "var(--ua-sub)", marginBottom: 11 }}>
+        <div style={{ fontSize: "var(--text-base)", letterSpacing: "0.04em", color: "var(--ua-sub)", marginBottom: 11 }}>
           {status}{members != null && <> · <span style={{ color: "var(--ua-muted)" }}>{i18n.t("feed:factionSelect.ua.members", { count: members })}</span></>}
         </div>
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer", border: "1px solid var(--ua-gold)", background: "transparent",
-          color: "var(--ua-orange)", fontFamily: "var(--font-faction-engraved-caps)", fontSize: 13, letterSpacing: "0.18em",
+          color: "var(--ua-orange)", fontFamily: "var(--font-faction-engraved-caps)", fontSize: "var(--text-xl)", letterSpacing: "0.18em",
           textTransform: "uppercase", padding: "10px", transition: "background 140ms, color 140ms",
         }}
           onMouseEnter={(e) => { e.currentTarget.style.background = "var(--ua-orange)"; e.currentTarget.style.color = "var(--ua-paper)"; }}
@@ -100,22 +101,25 @@ function WOWSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelec
         <span style={{ display: "flex", gap: 6 }}>
           {["#f6c75e", "#7fc59e", "#ec5f99"].map((color) => <i key={color} style={{ width: 11, height: 11, borderRadius: "50%", background: color, border: "1px solid rgba(0,0,0,0.15)" }} />)}
         </span>
-        <span style={{ fontSize: 12, color: "var(--gestalt-title-text)", letterSpacing: "0.02em" }}>{i18n.t("feed:identity.wow.windowTitle")}</span>
+        <span style={{ fontSize: "var(--text-lg)", color: "var(--gestalt-title-text)", letterSpacing: "0.02em" }}>{i18n.t("feed:identity.wow.windowTitle")}</span>
+        {/* ornament: ▢ ✕ are drawn window-chrome glyphs used as icons, not text */}
         <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--gestalt-title-text)", opacity: 0.7 }}>▢ ✕</span>
       </div>
       <div style={{ flex: 1, padding: "14px 20px 0", position: "relative" }}>
+        {/* ornament: hand-script faction name, the whimsy.exe window's display type */}
         <div style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 27, lineHeight: 1.1, color: "var(--gestalt-ink)", whiteSpace: "nowrap" }}>
           <span style={{ display: "inline-block", verticalAlign: "-3px", marginRight: 6 }}><WowSigil size={18} color="var(--faction-wow)" /></span>{i18n.t("feed:factionSelect.wow.name")}
         </div>
-        <p style={{ margin: "13px 0 0", fontSize: 12, lineHeight: 1.6, color: "var(--gestalt-ink-soft)" }}>
+        <p className="content-text" style={{ margin: "13px 0 0", lineHeight: 1.6, color: "var(--gestalt-ink-soft)" }}>
           {i18n.t("feed:factionSelect.wow.blurb")}
         </p>
       </div>
       <div style={{ padding: "0 20px 16px" }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, marginBottom: 11 }}>
-          <div style={{ transform: "rotate(-1.5deg)", background: "var(--gestalt-pink-lt)", color: "var(--gestalt-ink)", fontSize: 10.5, padding: "5px 10px", borderRadius: 4 }}>{status}</div>
-          {members != null && <div style={{ flexShrink: 0, fontSize: 9.5, letterSpacing: "0.04em", color: "var(--gestalt-label)" }}>{i18n.t("feed:factionSelect.wow.members", { count: members })}</div>}
+          <div style={{ transform: "rotate(-1.5deg)", background: "var(--gestalt-pink-lt)", color: "var(--gestalt-ink)", fontSize: "var(--text-md)", padding: "5px 10px", borderRadius: 4 }}>{status}</div>
+          {members != null && <div style={{ flexShrink: 0, fontSize: "var(--text-sm)", letterSpacing: "0.04em", color: "var(--gestalt-label)" }}>{i18n.t("feed:factionSelect.wow.members", { count: members })}</div>}
         </div>
+        {/* ornament: CTA is set in the faction's hand-script at display size — shrinking it to a label token would flatten the archetype (§270) */}
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer",
           border: "1.5px solid var(--gestalt-pink)", borderRadius: 7, background: "var(--gestalt-pink)", color: "#fff",
@@ -141,17 +145,19 @@ function SnideSelectCard({ state = "locked", members, onVisit }: Omit<FactionSel
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
           <SnideSigil size={40} color="var(--snide-acid)" />
           <div>
+            {/* ornament: ransom-dispatch wordmark — Anton slammed at 0.85 leading */}
             <div style={{ fontFamily: "var(--font-faction-anton)", fontSize: 34, lineHeight: 0.85, color: "var(--snide-paper)", letterSpacing: "0.02em" }}>{i18n.t("feed:identity.snide.wordmark")}</div>
-            <div style={{ fontSize: 10, letterSpacing: "0.14em", color: "var(--snide-acid)", marginTop: 4, textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.snide.masthead")}</div>
+            <div style={{ fontSize: "var(--text-base)", letterSpacing: "0.14em", color: "var(--snide-acid)", marginTop: 4, textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.snide.masthead")}</div>
           </div>
         </div>
         <div style={{ borderTop: "1px dashed rgba(255,255,255,0.25)", margin: "16px 0 12px" }} />
-        <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.65, color: "var(--snide-paper)" }}>
+        <p className="content-text" style={{ margin: 0, lineHeight: 1.65, color: "var(--snide-paper)" }}>
           {i18n.t("feed:factionSelect.snide.blurb")}
         </p>
       </div>
       <div style={{ position: "relative", padding: "0 24px 20px" }}>
-        <div style={{ fontFamily: "var(--font-faction-marker)", fontSize: 14, color: "var(--snide-pink)", transform: "rotate(-1deg)", marginBottom: 10 }}>{status}</div>
+        <div style={{ fontFamily: "var(--font-faction-marker)", fontSize: "var(--text-xl)", color: "var(--snide-pink)", transform: "rotate(-1deg)", marginBottom: 10 }}>{status}</div>
+        {/* ornament: CTA is Anton condensed caps, part of the ransom-note voice, not label chrome */}
         <button onClick={onVisit} style={{
           display: "flex", alignItems: "center", justifyContent: "space-between", width: "100%", cursor: "pointer",
           border: "2px solid var(--snide-acid)", background: "transparent", color: "var(--snide-acid)",
@@ -159,7 +165,7 @@ function SnideSelectCard({ state = "locked", members, onVisit }: Omit<FactionSel
         }}
           onMouseEnter={(e) => { e.currentTarget.style.background = "var(--snide-acid)"; e.currentTarget.style.color = "var(--snide-ink)"; }}
           onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--snide-acid)"; }}
-        ><span>{i18n.t("feed:factionSelect.snide.cta")}</span>{members != null && <span style={{ fontSize: 10 }}>{i18n.t("feed:factionSelect.snide.members", { count: members })}</span>}</button>
+        ><span>{i18n.t("feed:factionSelect.snide.cta")}</span>{members != null && <span style={{ fontSize: "var(--text-base)" }}>{i18n.t("feed:factionSelect.snide.members", { count: members })}</span>}</button>
       </div>
     </div>
   );
@@ -174,27 +180,28 @@ function EphemeristsSelectCard({ state = "locked", members, onVisit }: Omit<Fact
       border: "1px solid var(--eph-gold-deep)", boxShadow: "0 8px 26px rgba(20,59,84,0.4)", display: "flex", flexDirection: "column",
     }}>
       <div style={{ position: "absolute", inset: 9, border: "1px solid rgba(180,150,80,0.35)", pointerEvents: "none" }} />
-      <div style={{ position: "absolute", top: 16, right: 18, fontSize: 9, letterSpacing: "0.1em", color: "var(--eph-gold-light)", opacity: 0.7, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
+      <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-sm)", letterSpacing: "0.1em", color: "var(--eph-gold-light)", opacity: 0.7, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
       <div style={{ position: "relative", flex: 1, padding: "22px 24px 0" }}>
         <div style={{ display: "flex", alignItems: "center", gap: 13 }}>
           <span style={{ width: 46, height: 46, borderRadius: "50%", border: "1.5px solid var(--eph-gold)", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
             <EphemeristsSigil size={26} color="var(--eph-gold-light)" stroke={1.4} />
           </span>
           <div>
-            <div style={{ fontSize: 9, letterSpacing: "0.24em", color: "var(--eph-gold-light)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
+            <div style={{ fontSize: "var(--text-sm)", letterSpacing: "0.24em", color: "var(--eph-gold-light)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
+            {/* ornament: codex-leaf wordmark — engraved caps with a hard letterpress shadow */}
             <div style={{ fontFamily: "var(--font-faction-engraved)", fontWeight: 800, fontSize: 26, lineHeight: 1, letterSpacing: "0.03em", color: "var(--eph-parchment)", marginTop: 4, textShadow: "1px 1px 0 var(--eph-field-deep)" }}>{i18n.t("feed:identity.ephemerists.wordmark")}</div>
           </div>
         </div>
         <div style={{ height: 1.5, background: "linear-gradient(90deg, var(--eph-gold) 0%, transparent 100%)", margin: "16px 0 13px" }} />
-        <p style={{ margin: 0, fontFamily: "var(--font-faction-codex-script)", fontStyle: "italic", fontSize: 17, lineHeight: 1.45, color: "var(--eph-parchment)" }}>
+        <p className="content-text" style={{ margin: 0, fontFamily: "var(--font-faction-codex-script)", fontStyle: "italic", lineHeight: 1.45, color: "var(--eph-parchment)" }}>
           {i18n.t("feed:factionSelect.ephemerists.blurb")}
         </p>
       </div>
       <div style={{ position: "relative", padding: "0 24px 20px" }}>
-        <div style={{ fontSize: 10.5, letterSpacing: "0.03em", color: "var(--eph-gold-light)", marginBottom: 11 }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.ephemerists.members", { count: members })}`}</div>
+        <div style={{ fontSize: "var(--text-md)", letterSpacing: "0.03em", color: "var(--eph-gold-light)", marginBottom: 11 }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.ephemerists.members", { count: members })}`}</div>
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer", border: "1px solid var(--eph-gold)", background: "transparent", color: "var(--eph-gold-light)",
-          fontFamily: "var(--font-faction-engraved)", fontWeight: 600, fontSize: 13, letterSpacing: "0.16em", padding: "10px", textTransform: "uppercase",
+          fontFamily: "var(--font-faction-engraved)", fontWeight: 600, fontSize: "var(--text-xl)", letterSpacing: "0.16em", padding: "10px", textTransform: "uppercase",
         }}
           onMouseEnter={(e) => { e.currentTarget.style.background = "var(--eph-gold)"; e.currentTarget.style.color = "var(--eph-field-deep)"; }}
           onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--eph-gold-light)"; }}
@@ -219,23 +226,24 @@ function SingularitySelectCard({ state = "locked", members, onVisit }: Omit<Fact
         {Array.from({ length: 9 }).map((_, i) => <i key={i} style={{ width: 6, height: 6, borderRadius: 1, background: "rgba(96,165,250,0.5)" }} />)}
       </div>
       <div style={{ position: "relative", flex: 1, padding: "16px 18px 0" }}>
-        <div style={{ fontSize: 11, letterSpacing: "0.14em", color: "#60a5fa", textTransform: "uppercase" }}>
+        <div style={{ fontSize: "var(--text-md)", letterSpacing: "0.14em", color: "#60a5fa", textTransform: "uppercase" }}>
           {i18n.t("feed:identity.singularity.protocol")}<span style={{ display: "inline-block", width: 6, height: 11, background: green, marginLeft: 4, verticalAlign: "middle", animation: "wz-blink 1s step-end infinite" }} />
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 11, marginTop: 12 }}>
           <SingularitySigil size={30} color={green} />
+          {/* ornament: terminal-printout faction name — display-size mono, the archetype's banner */}
           <span style={{ fontSize: 30, color: green, letterSpacing: "0.02em" }}>{i18n.t("feed:factionSelect.singularity.name")}</span>
         </div>
-        <p style={{ margin: "14px 0 0", fontSize: 12, lineHeight: 1.65, color: "#8fe6ac" }}>
+        <p className="content-text" style={{ margin: "14px 0 0", lineHeight: 1.65, color: "#8fe6ac" }}>
           &gt; {i18n.t("feed:factionSelect.singularity.blurb")}
         </p>
       </div>
       <div style={{ position: "relative", padding: "0 18px 18px" }}>
-        <div style={{ fontSize: 11, color: "#60a5fa", marginBottom: 10 }}>{status}{members != null && <span style={{ float: "right", color: green }}>{i18n.t("feed:factionSelect.singularity.members", { count: members })}</span>}</div>
+        <div style={{ fontSize: "var(--text-md)", color: "#60a5fa", marginBottom: 10 }}>{status}{members != null && <span style={{ float: "right", color: green }}>{i18n.t("feed:factionSelect.singularity.members", { count: members })}</span>}</div>
         <button onClick={onVisit} style={{
           display: "flex", alignItems: "center", width: "100%", cursor: "pointer", gap: 8,
           border: "1px solid #2563eb", background: "rgba(37,99,235,0.14)", color: green,
-          fontFamily: "var(--font-faction-terminal)", fontSize: 14, letterSpacing: "0.06em", padding: "9px 13px",
+          fontFamily: "var(--font-faction-terminal)", fontSize: "var(--text-xl)", letterSpacing: "0.06em", padding: "9px 13px",
         }}
           onMouseEnter={(e) => { e.currentTarget.style.background = green; e.currentTarget.style.color = "#050f08"; }}
           onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(37,99,235,0.14)"; e.currentTarget.style.color = green; }}
@@ -258,7 +266,7 @@ function EverymenSelectCard({ state = "locked", members, onVisit }: Omit<Faction
       <div style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.5,
         background: "repeating-conic-gradient(from 0deg at 50% 34%, var(--everymen-field-deep) 0deg 7deg, transparent 7deg 14deg)" }} />
       <div style={{ position: "relative", background: "var(--everymen-ink)", color: "var(--everymen-gold)", textAlign: "center",
-        fontFamily: "var(--font-faction-poster)", fontSize: 14, letterSpacing: "0.3em", padding: "6px 0" }}>{i18n.t("feed:factionSelect.everymen.banner")}</div>
+        fontFamily: "var(--font-faction-poster)", fontSize: "var(--text-xl)", letterSpacing: "0.3em", padding: "6px 0" }}>{i18n.t("feed:factionSelect.everymen.banner")}</div>
       <div style={{ height: 3, background: "var(--everymen-gold)" }} />
       <div style={{ position: "relative", flex: 1, padding: "14px 22px 0", textAlign: "center" }}>
         <div style={{ display: "flex", justifyContent: "center", marginBottom: 6 }}>
@@ -267,12 +275,15 @@ function EverymenSelectCard({ state = "locked", members, onVisit }: Omit<Faction
             <EverymenSigil size={30} color="var(--everymen-red)" />
           </span>
         </div>
+        {/* ornament: union-poster headline — poster type at 0.86 leading with a hard drop shadow */}
         <div style={{ fontFamily: "var(--font-faction-poster)", fontSize: 40, lineHeight: 0.86, color: "var(--everymen-cream)", textShadow: "2px 2px 0 var(--everymen-ink)" }}>{i18n.t("feed:factionSelect.everymen.headline")}</div>
+        {/* ornament: struck plaque — the block is the illustration, its lettering is set to the plate */}
         <div style={{ display: "inline-block", marginTop: 11, background: "var(--everymen-ink)", color: "var(--everymen-gold)",
           fontFamily: "var(--font-faction-poster)", fontSize: 13, letterSpacing: "0.2em", padding: "3px 14px" }}>{i18n.t("feed:factionSelect.everymen.plaque")}</div>
       </div>
       <div style={{ position: "relative", padding: "10px 22px 18px", textAlign: "center" }}>
-        <div style={{ fontSize: 10, color: "var(--everymen-cream)", opacity: 0.9, marginBottom: 10 }}>{status}</div>
+        <div style={{ fontSize: "var(--text-base)", color: "var(--everymen-cream)", opacity: 0.9, marginBottom: 10 }}>{status}</div>
+        {/* ornament: CTA is poster type — the shout is the archetype; a label token would flatten it (§270) */}
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer", border: "2px solid var(--everymen-ink)", background: "var(--everymen-gold)", color: "var(--everymen-ink)",
           fontFamily: "var(--font-faction-poster)", fontSize: 22, letterSpacing: "0.1em", padding: "8px",
@@ -293,20 +304,21 @@ function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit<Factio
       <div style={{ position: "absolute", inset: 12, border: "1px solid var(--al-border-faint)", pointerEvents: "none" }} />
       <div style={{ position: "relative", flex: 1, padding: "26px 30px 0", display: "flex", flexDirection: "column" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-          <div style={{ fontFamily: "var(--font-body)", fontSize: 9, letterSpacing: "0.34em", color: "var(--al-text-muted)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.albescent.eyebrow")}</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-sm)", letterSpacing: "0.34em", color: "var(--al-text-muted)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.albescent.eyebrow")}</div>
           <AlbescentSigil size={26} color="var(--al-ink)" />
         </div>
+        {/* ornament: vellum-letter name — the archetype's calligraphic display type */}
         <div style={{ fontFamily: "var(--font-faction-vellum)", fontStyle: "italic", fontWeight: 600, fontSize: 40, lineHeight: 1, letterSpacing: "0.01em", marginTop: 16 }}>{i18n.t("feed:factionSelect.albescent.name")}</div>
         <div style={{ width: 44, height: 1, background: "var(--al-text)", opacity: 0.5, margin: "13px 0" }} />
-        <p style={{ margin: 0, fontStyle: "italic", fontSize: 16, lineHeight: 1.45, color: "var(--al-ink)" }}>
+        <p className="content-text" style={{ margin: 0, fontStyle: "italic", lineHeight: 1.45, color: "var(--al-ink)" }}>
           {i18n.t("feed:factionSelect.albescent.blurb")}
         </p>
       </div>
       <div style={{ position: "relative", padding: "14px 30px 22px" }}>
-        <div style={{ fontFamily: "var(--font-body)", fontSize: 9.5, letterSpacing: "0.06em", color: "var(--al-text-muted)", marginBottom: 13, textTransform: "uppercase" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.albescent.members", { count: members })}`}</div>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-sm)", letterSpacing: "0.06em", color: "var(--al-text-muted)", marginBottom: 13, textTransform: "uppercase" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.albescent.members", { count: members })}`}</div>
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer", border: "1px solid var(--al-text)", background: "transparent", color: "var(--al-text)",
-          fontFamily: "var(--font-body)", fontSize: 10.5, letterSpacing: "0.22em", padding: "11px", textTransform: "uppercase", transition: "background 140ms, color 140ms",
+          fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.22em", padding: "11px", textTransform: "uppercase", transition: "background 140ms, color 140ms",
         }}
           onMouseEnter={(e) => { e.currentTarget.style.background = "var(--al-text)"; e.currentTarget.style.color = "var(--al-surface)"; }}
           onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--al-text)"; }}

--- a/frontend/src/components/cards/SingularityFactionHero.tsx
+++ b/frontend/src/components/cards/SingularityFactionHero.tsx
@@ -115,7 +115,7 @@ export default function SingularityFactionHero({
           {/* boot lines */}
           <div
             style={{
-              fontSize: 8.5,
+              fontSize: "var(--text-sm)",
               letterSpacing: "0.18em",
               color: signal(55),
               marginBottom: 14,
@@ -138,6 +138,7 @@ export default function SingularityFactionHero({
           <h1
             style={{
               fontFamily: FONT,
+              // ornament: terminal wordmark — the Singularity hero's display type
               fontSize: 56,
               lineHeight: 0.9,
               letterSpacing: "0.04em",
@@ -152,7 +153,7 @@ export default function SingularityFactionHero({
           {/* motto */}
           <div
             style={{
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: "0.28em",
               color: signal(70),
               textTransform: "uppercase",
@@ -164,8 +165,8 @@ export default function SingularityFactionHero({
 
           {/* blurb */}
           <p
+            className="content-text"
             style={{
-              fontSize: 11,
               lineHeight: 1.7,
               color: phosphor(60),
               maxWidth: 520,
@@ -225,7 +226,7 @@ export default function SingularityFactionHero({
           >
             <div
               style={{
-                fontSize: 7,
+                fontSize: "var(--text-xs)",
                 letterSpacing: "0.2em",
                 color: signal(55),
                 textTransform: "uppercase",
@@ -249,7 +250,7 @@ export default function SingularityFactionHero({
               >
                 <span
                   style={{
-                    fontSize: 7.5,
+                    fontSize: "var(--text-xs)",
                     letterSpacing: "0.14em",
                     color: signal(50),
                     textTransform: "uppercase",
@@ -257,6 +258,7 @@ export default function SingularityFactionHero({
                 >
                   {s.label}
                 </span>
+                {/* ornament: readout numeral sized to the terminal face; above the content floor already */}
                 <span style={{ fontSize: 20, lineHeight: 1, color: PHOSPHOR }}>
                   {s.value}
                 </span>

--- a/frontend/src/components/cards/SingularityTaskCard.tsx
+++ b/frontend/src/components/cards/SingularityTaskCard.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { TaskOut } from "../../api/tasks";
 import i18n from "../../i18n";
@@ -18,29 +19,154 @@ interface Props {
   onSignup?: (id: number) => void;
 }
 
+// Static style objects, hoisted to module scope (#586) -- none of these close
+// over a prop, so re-allocating them on every render bought nothing.
+
+const TERMINAL_TEXT = "var(--faction-singularity-card-text)";
+const HARD_BORDER = "var(--faction-singularity-border-hard)";
+const MUTED = "var(--faction-singularity-card-muted)";
+
+const sprocketRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-around",
+  gap: "var(--space-sm)",
+  padding: "var(--space-xs) var(--space-lg)",
+};
+
+const sprocketHoleStyle: CSSProperties = {
+  width: 6,
+  height: 4,
+  background: "rgba(10,26,14)",
+  border: `1px solid var(--faction-singularity-card-accent, ${HARD_BORDER})`,
+  borderRadius: 1,
+};
+
+const cardShellStyle: CSSProperties = {
+  minWidth: 180,
+  maxWidth: 224,
+  flex: "0 1 204px",
+  background: "var(--faction-singularity-card-bg)",
+  border: `1px solid ${HARD_BORDER}`,
+  position: "relative",
+  fontFamily: factionCssVar("singularity", "card-font"),
+  color: TERMINAL_TEXT,
+  overflow: "hidden",
+};
+
+const scanlineStyle: CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  backgroundImage:
+    "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)",
+  pointerEvents: "none",
+  zIndex: 1,
+};
+
+/** Corner brackets -- one per corner; only the two drawn edges differ. */
+const cornerBase: CSSProperties = { position: "absolute", width: 10, height: 10 };
+const cornerTopLeft: CSSProperties = {
+  ...cornerBase, top: 3, left: 3,
+  borderTop: `1px solid ${TERMINAL_TEXT}`, borderLeft: `1px solid ${TERMINAL_TEXT}`,
+};
+const cornerTopRight: CSSProperties = {
+  ...cornerBase, top: 3, right: 3,
+  borderTop: `1px solid ${TERMINAL_TEXT}`, borderRight: `1px solid ${TERMINAL_TEXT}`,
+};
+const cornerBottomLeft: CSSProperties = {
+  ...cornerBase, bottom: 3, left: 3,
+  borderBottom: `1px solid ${TERMINAL_TEXT}`, borderLeft: `1px solid ${TERMINAL_TEXT}`,
+};
+const cornerBottomRight: CSSProperties = {
+  ...cornerBase, bottom: 3, right: 3,
+  borderBottom: `1px solid ${TERMINAL_TEXT}`, borderRight: `1px solid ${TERMINAL_TEXT}`,
+};
+
+const bodyStyle: CSSProperties = {
+  padding: "var(--space-xs) var(--space-md) var(--space-sm)",
+  position: "relative",
+  zIndex: 2,
+};
+
+const eyebrowStyle: CSSProperties = {
+  fontSize: "var(--text-xs)",
+  color: MUTED,
+  textTransform: "uppercase",
+  letterSpacing: "0.15em",
+  marginBottom: "var(--space-sm)",
+};
+
+const caretStyle: CSSProperties = {
+  display: "inline-block",
+  width: 5,
+  height: 9,
+  background: TERMINAL_TEXT,
+  marginLeft: "var(--space-xs)",
+  verticalAlign: "middle",
+  animation: "blink 1s step-end infinite",
+};
+
+const linkStyle: CSSProperties = { textDecoration: "none", color: "inherit" };
+
+const titleStyle: CSSProperties = {
+  marginBottom: "var(--space-sm)",
+  lineHeight: 1.3,
+  overflowWrap: "anywhere",
+};
+
+const metaStyle: CSSProperties = {
+  fontSize: "var(--text-xs)",
+  color: MUTED,
+  lineHeight: 1.6,
+  marginBottom: "var(--space-sm)",
+};
+
+const pointsStyle: CSSProperties = { color: TERMINAL_TEXT, fontWeight: 700 };
+
+const descriptionStyle: CSSProperties = {
+  color: MUTED,
+  lineHeight: 1.4,
+  marginBottom: "var(--space-sm)",
+  overflow: "hidden",
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+};
+
+const signupStyle: CSSProperties = {
+  background: "transparent",
+  color: TERMINAL_TEXT,
+  border: `1px solid ${TERMINAL_TEXT}`,
+  fontFamily: factionCssVar("singularity", "card-font"),
+  fontSize: "var(--text-xs)",
+  textTransform: "uppercase",
+  letterSpacing: "0.1em",
+  padding: "var(--space-xs) var(--space-sm)",
+  cursor: "pointer",
+  marginBottom: "var(--space-xs)",
+};
+
+const footerStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  borderTop: `1px solid ${HARD_BORDER}`,
+  paddingTop: "var(--space-xs)",
+};
+
+const levelPillStyle: CSSProperties = {
+  border: `1px solid ${TERMINAL_TEXT}`,
+  color: TERMINAL_TEXT,
+  fontSize: "var(--text-xs)",
+  padding: "0 var(--space-xs)",
+  borderRadius: 6,
+  textTransform: "uppercase",
+};
+
 /** Row of sprocket holes */
 function SprocketHoles() {
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "space-around",
-        gap: "var(--space-sm)",
-        padding: "var(--space-xs) var(--space-lg)",
-      }}
-    >
+    <div style={sprocketRowStyle}>
       {Array.from({ length: 5 }).map((_, index) => (
-        <div
-          key={index}
-          style={{
-            width: 6,
-            height: 4,
-            background: "rgba(10,26,14)",
-            border:
-              "1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))",
-            borderRadius: 1,
-          }}
-        />
+        <div key={index} style={sprocketHoleStyle} />
       ))}
     </div>
   );
@@ -52,146 +178,41 @@ export default function SingularityTaskCard({
   onSignup,
 }: Props) {
   return (
-    <div
-      style={{
-        minWidth: 180,
-        maxWidth: 224,
-        flex: "0 1 204px",
-        background: "var(--faction-singularity-card-bg)",
-        border: "1px solid var(--faction-singularity-border-hard)",
-        position: "relative",
-        fontFamily: factionCssVar("singularity", "card-font"),
-        color: "var(--faction-singularity-card-text)",
-        overflow: "hidden",
-      }}
-    >
+    <div style={cardShellStyle}>
       {/* Scanline overlay */}
-      <div
-        style={{
-          position: "absolute",
-          inset: 0,
-          backgroundImage:
-            "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)",
-          pointerEvents: "none",
-          zIndex: 1,
-        }}
-      />
+      <div style={scanlineStyle} />
 
       {/* Corner brackets */}
-      <div
-        style={{
-          position: "absolute",
-          top: 3,
-          left: 3,
-          width: 10,
-          height: 10,
-          borderTop: "1px solid var(--faction-singularity-card-text)",
-          borderLeft: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          top: 3,
-          right: 3,
-          width: 10,
-          height: 10,
-          borderTop: "1px solid var(--faction-singularity-card-text)",
-          borderRight: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: 3,
-          left: 3,
-          width: 10,
-          height: 10,
-          borderBottom: "1px solid var(--faction-singularity-card-text)",
-          borderLeft: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: 3,
-          right: 3,
-          width: 10,
-          height: 10,
-          borderBottom: "1px solid var(--faction-singularity-card-text)",
-          borderRight: "1px solid var(--faction-singularity-card-text)",
-        }}
-      />
+      <div style={cornerTopLeft} />
+      <div style={cornerTopRight} />
+      <div style={cornerBottomLeft} />
+      <div style={cornerBottomRight} />
 
       <SprocketHoles />
 
-      <div
-        style={{
-          padding: "var(--space-xs) var(--space-md) var(--space-sm)",
-          position: "relative",
-          zIndex: 2,
-        }}
-      >
+      <div style={bodyStyle}>
         {/* Header — eyebrow, stays label-tier (§4 content-text floor). */}
-        <div
-          style={{
-            fontSize: "var(--text-xs)",
-            color: "var(--faction-singularity-card-muted)",
-            textTransform: "uppercase",
-            letterSpacing: "0.15em",
-            marginBottom: "var(--space-sm)",
-          }}
-        >
+        <div style={eyebrowStyle}>
           {i18n.t("feed:identity.singularity.protocol")}
-          <span
-            style={{
-              display: "inline-block",
-              width: 5,
-              height: 9,
-              background: "var(--faction-singularity-card-text)",
-              marginLeft: "var(--space-xs)",
-              verticalAlign: "middle",
-              animation: "blink 1s step-end infinite",
-            }}
-          />
+          <span style={caretStyle} />
         </div>
 
         <Link
           to={`/tasks/${task.id}`}
-          style={{ textDecoration: "none", color: "inherit" }}
+          style={linkStyle}
         >
           {/* Task title — a title, so .content-title per #627's re-cut (§4). */}
-          <div
-            className="content-title"
-            style={{
-              marginBottom: "var(--space-sm)",
-              lineHeight: 1.3,
-              overflowWrap: "anywhere",
-            }}
-          >
+          <div className="content-title" style={titleStyle}>
             {"> "}
             {task.title}
           </div>
         </Link>
 
-        <div
-          style={{
-            fontSize: "var(--text-xs)",
-            color: "var(--faction-singularity-card-muted)",
-            lineHeight: 1.6,
-            marginBottom: "var(--space-sm)",
-          }}
-        >
+        <div style={metaStyle}>
           <div>
             {i18n.t("feed:taskCard.singularity.pointsLabel")}{" "}
             {/* Points value — a score, so .content-title per #627's re-cut (§4). */}
-            <span
-              className="content-title"
-              style={{
-                color: "var(--faction-singularity-card-text)",
-                fontWeight: 700,
-              }}
-            >
+            <span className="content-title" style={pointsStyle}>
               {displayPoints}
             </span>
           </div>
@@ -205,18 +226,7 @@ export default function SingularityTaskCard({
         {task.description && (
           /* Body copy on the content floor (.content-text, 18px). The card was
              widened to ~204px in #628 so the floor has no exceptions. */
-          <div
-            className="content-text"
-            style={{
-              color: "var(--faction-singularity-card-muted)",
-              lineHeight: 1.4,
-              marginBottom: "var(--space-sm)",
-              overflow: "hidden",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-            }}
-          >
+          <div className="content-text" style={descriptionStyle}>
             {task.description}
           </div>
         )}
@@ -224,42 +234,15 @@ export default function SingularityTaskCard({
         {onSignup && (
           <button
             onClick={() => onSignup(task.id)}
-            style={{
-              background: "transparent",
-              color: "var(--faction-singularity-card-text)",
-              border: "1px solid var(--faction-singularity-card-text)",
-              fontFamily: factionCssVar("singularity", "card-font"),
-              fontSize: "var(--text-xs)",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              padding: "var(--space-xs) var(--space-sm)",
-              cursor: "pointer",
-              marginBottom: "var(--space-xs)",
-            }}
+            style={signupStyle}
           >
             {">"} {i18n.t("feed:taskCard.singularity.signup")}
           </button>
         )}
 
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "flex-end",
-            borderTop: "1px solid var(--faction-singularity-border-hard)",
-            paddingTop: "var(--space-xs)",
-          }}
-        >
+        <div style={footerStyle}>
           {/* Level pill — badge label, stays label-tier (§4). */}
-          <span
-            style={{
-              border: "1px solid var(--faction-singularity-card-text)",
-              color: "var(--faction-singularity-card-text)",
-              fontSize: "var(--text-xs)",
-              padding: "0 var(--space-xs)",
-              borderRadius: 6,
-              textTransform: "uppercase",
-            }}
-          >
+          <span style={levelPillStyle}>
             {i18n.t("feed:taskCard.singularity.levelPill", {
               level: task.level_required,
             })}

--- a/frontend/src/components/cards/SnideFactionHero.tsx
+++ b/frontend/src/components/cards/SnideFactionHero.tsx
@@ -117,7 +117,7 @@ export default function SnideFactionHero({
               background: "var(--faction-snide-tape)",
               color: "var(--faction-snide-ink)",
               fontFamily: "var(--faction-snide-font-type)",
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: "0.05em",
               padding: "3px 12px",
               transform: "rotate(-1.5deg)",
@@ -130,6 +130,7 @@ export default function SnideFactionHero({
           <h1
             style={{
               fontFamily: "var(--faction-snide-font-impact)",
+              // ornament: ransom wordmark — impact face skewed and slammed at 0.8 leading
               fontSize: 82,
               lineHeight: 0.8,
               letterSpacing: "0.02em",
@@ -144,7 +145,7 @@ export default function SnideFactionHero({
           <div
             style={{
               fontFamily: "var(--font-body)",
-              fontSize: 10,
+              fontSize: "var(--text-base)",
               letterSpacing: "0.16em",
               textTransform: "uppercase",
               color: "#b7b5a7",
@@ -161,6 +162,7 @@ export default function SnideFactionHero({
               marginTop: 14,
               background: "var(--faction-snide-acid)",
               color: "var(--faction-snide-ink)",
+              // ornament: motto slapped on an acid sticker, rotated -2deg — illustration, not chrome
               fontFamily: "var(--faction-snide-font-black)",
               fontSize: 15,
               letterSpacing: "0.02em",
@@ -172,9 +174,9 @@ export default function SnideFactionHero({
             {i18n.t("feed:factionHero.snide.motto")}
           </div>
           <p
+            className="content-text"
             style={{
               fontFamily: "var(--font-body)",
-              fontSize: 12.5,
               lineHeight: 1.6,
               maxWidth: 560,
               margin: "16px 0 0",
@@ -254,6 +256,7 @@ export default function SnideFactionHero({
             >
               <div
                 style={{
+                  // ornament: chit numeral in the impact face; above the content floor already
                   fontFamily: "var(--faction-snide-font-impact)",
                   fontSize: 30,
                   lineHeight: 0.85,
@@ -266,7 +269,7 @@ export default function SnideFactionHero({
               <div
                 style={{
                   fontFamily: "var(--font-body)",
-                  fontSize: 8.5,
+                  fontSize: "var(--text-xs)",
                   letterSpacing: "0.1em",
                   textTransform: "uppercase",
                   color: "#cfcdbf",

--- a/frontend/src/components/cards/SnideMasthead.tsx
+++ b/frontend/src/components/cards/SnideMasthead.tsx
@@ -37,7 +37,7 @@ export default function SnideMasthead({
       </span>
       <span
         style={{
-          fontSize: 7,
+          fontSize: "var(--text-xs)",
           letterSpacing: "0.16em",
           textTransform: "uppercase",
           color: factionCssVar("snide", "card-muted"),

--- a/frontend/src/components/cards/UaFactionHero.tsx
+++ b/frontend/src/components/cards/UaFactionHero.tsx
@@ -93,7 +93,7 @@ export default function UaFactionHero({
               <div
                 style={{
                   fontFamily: ENGRAVED,
-                  fontSize: 11,
+                  fontSize: "var(--text-md)",
                   letterSpacing: "0.16em",
                   textTransform: "uppercase",
                   color: ACCENT,
@@ -106,7 +106,7 @@ export default function UaFactionHero({
               <div
                 style={{
                   fontFamily: ENGRAVED,
-                  fontSize: 8,
+                  fontSize: "var(--text-xs)",
                   letterSpacing: "0.3em",
                   textTransform: "uppercase",
                   color: MUTED,
@@ -122,6 +122,7 @@ export default function UaFactionHero({
                   fontFamily: DISPLAY,
                   fontStyle: "italic",
                   fontWeight: 700,
+                  // ornament: gilt regal wordmark — the UA hero's display type
                   fontSize: 54,
                   lineHeight: 1.04,
                   letterSpacing: "0.01em",
@@ -140,10 +141,10 @@ export default function UaFactionHero({
 
               {/* statement */}
               <p
+                className="content-text"
                 style={{
                   fontFamily: DISPLAY,
                   fontStyle: "italic",
-                  fontSize: 15,
                   lineHeight: 1.7,
                   color: SUB,
                   maxWidth: 560,
@@ -172,7 +173,7 @@ export default function UaFactionHero({
                   <span
                     style={{
                       fontFamily: ENGRAVED,
-                      fontSize: 8.5,
+                      fontSize: "var(--text-xs)",
                       letterSpacing: "0.12em",
                       textTransform: "uppercase",
                       color: MUTED,
@@ -181,11 +182,11 @@ export default function UaFactionHero({
                     {s.label}
                   </span>
                   <span
+                    className="content-title"
                     style={{
                       fontFamily: DISPLAY,
                       fontStyle: "italic",
                       fontWeight: 700,
-                      fontSize: 23,
                       lineHeight: 1,
                       color: ACCENT,
                     }}

--- a/frontend/src/components/cards/WowFactionHero.tsx
+++ b/frontend/src/components/cards/WowFactionHero.tsx
@@ -152,7 +152,7 @@ export default function WowFactionHero({
             <div
               style={{
                 fontFamily: BODY,
-                fontSize: 10,
+                fontSize: "var(--text-base)",
                 letterSpacing: "0.2em",
                 textTransform: "uppercase",
                 color: MUTED,
@@ -164,6 +164,7 @@ export default function WowFactionHero({
             <h1
               style={{
                 fontFamily: SCRIPT,
+                // ornament: hand-script wordmark — the Whimsy hero's display type
                 fontSize: 52,
                 fontWeight: 700,
                 lineHeight: 0.9,
@@ -174,13 +175,13 @@ export default function WowFactionHero({
             >
               {name}
             </h1>
-            <div style={{ fontFamily: SCRIPT, fontSize: 24, color: PINK, marginTop: 2 }}>
+            <div style={{ fontFamily: SCRIPT, fontSize: "var(--text-title)", color: PINK, marginTop: 2 }}>
               {i18n.t("feed:factionHero.wow.motto")}
             </div>
             <p
+              className="content-text"
               style={{
                 fontFamily: BODY,
-                fontSize: 11,
                 lineHeight: 1.6,
                 color: MUTED,
                 maxWidth: 440,
@@ -210,13 +211,14 @@ export default function WowFactionHero({
                 }}
               >
                 <Sparkle size={18} color={s.color} />
+                {/* ornament: charm numeral in the hand-script face; above the content floor already */}
                 <span style={{ fontFamily: SCRIPT, fontSize: 28, fontWeight: 700, lineHeight: 1, color: s.color }}>
                   {s.value}
                 </span>
                 <span
                   style={{
                     fontFamily: BODY,
-                    fontSize: 8,
+                    fontSize: "var(--text-xs)",
                     letterSpacing: "0.1em",
                     textTransform: "uppercase",
                     color: INK,

--- a/frontend/src/components/cards/ephemeristsAtoms.tsx
+++ b/frontend/src/components/cards/ephemeristsAtoms.tsx
@@ -119,7 +119,7 @@ export function EphEyebrow({
           style={{
             fontFamily: "var(--eph-script)",
             fontStyle: "italic",
-            fontSize: 8.5,
+            fontSize: "var(--text-xs)",
             color: dark
               ? "var(--eph-muted)"
               : "color-mix(in srgb, var(--eph-parchment) 65%, transparent)",


### PR DESCRIPTION
**Part of #623** — Slice 6, `frontend/src/components/cards/**`.

## Counts

| | |
|---|---|
| Raw `fontSize: N` before | **104** |
| Raw `fontSize: N` after | **36** |
| Promoted / tokenized | 68 |
| **Deliberately kept as ornament** | **36** (every one annotated) |

The interesting number is the 36 kept. #623 called this slice "mostly genuine
ornament" and that held: it is seven faction wordmarks, seven ledger numerals,
four struck plaques/banners/stickers, three display-font CTAs, and three
dingbat glyph clusters. Every survivor carries a plain `// ornament: <why>`
comment naming the reason.

## The real win: seven faction descriptions

The functional-text promotions clustered almost entirely on one string —
**the faction description**, which a player reads to decide whether to join:

| Surface | Was | Now |
|---|---|---|
| 7 × `FactionSelectCard` blurbs | 12 – 17px | `.content-text` (18) |
| 7 × `*FactionHero` blurbs | 9.5 – 15px | `.content-text` (18) |
| `FactionCard` WOW / Snide / Singularity | 10 / 8 / 9px | `.card-description` (18) |
| `EverymenFactionCard` blurb + perk list | 13 / 12.5px | `.content-text` (18) |

`FactionCard`'s UA, Ephemerists and Albescent arms already carried
`.card-description`; the other three never got it. They match now.

Also promoted: the Ephemerists hero **gloss** (a full catalog sentence, was
11.5px script) — its script face and dimmed parchment now carry the hierarchy
its smaller size used to. UA's 23px regalia numeral and Ephemerists' 24px stat
numeral take `.content-title`.

Everything else scanned rather than read — eyebrows, mastheads, house lines,
boot lines, status lines, member counts, stat labels, body-font CTAs — took a
Label token.

## Judgement calls worth a second opinion

1. **Ledger / stat numerals kept raw** (20 – 34px across the seven heroes).
   These are "numbers a player cares about" and so read as Content by §4, but
   they are all *already above* the 18px floor, and each is sized to its own
   display face's cap-height — Anton at 30 and Caveat at 28 are not the same
   optical size. Snapping all seven onto 18/24/32 would be visible churn across
   seven bespoke heroes with no reader benefit, so I applied §270 and kept them.
   The two within 1px of a token (UA 23, Eph 24) *were* promoted. Easy to
   reverse if you disagree.

2. **Display-font CTAs kept raw** — WOW `Caveat 21`, Everymen `poster 22`,
   Snide `Anton 15`. §4 files button chrome under Label (max 14), but shrinking
   these would flatten three archetypes. The rule I applied throughout: a
   *display* font outside the label ramp is ornament; a body/mono font, or
   anything already on a token, is a Label token.

3. **Snide `FactionCard` description** is a two-column newsprint grid that was
   set at 8px. It is now at the 18px floor, so the two columns will be tight.
   Per the geometry doctrine that is correct — type wins, geometry yields — but
   the fix is to collapse or widen that grid, which is layout, not `fontSize`,
   so I left it. **Flagging it as the most likely thing to look wrong.**

## Also in here

Folds in **#586** for `SingularityTaskCard.tsx`: 17 closure-free inline style
objects hoisted to module scope, matching `components/layout/Sidebar.tsx`.
Nothing was restructured to make it static. That file had no raw `fontSize`
left, so this is pure cleanup.

## Scope discipline

- `fontSize` **only**. No `padding` / `margin` / `gap` touched — that is #750.
- **No file leaves `.eslint-legacy-raw-styles.txt`.** All twelve still have
  spacing violations (5 – 26 each), so none is clean on both axes. Because they
  stay listed the rule stays off for them, so an `eslint-disable-next-line`
  would be an *unused* directive — ornament is annotated with a plain comment
  instead.
- No colour, no dark-mode, no `.tsx` business logic touched.

## Verification

`tsc --noEmit` clean, `vite build` clean, `eslint src/components/cards` clean.

**Visual QA is outstanding** — the Browser-pane renderer times out in this
environment and there is no dev stack, so nothing here has been seen rendered.

## What to eyeball

1. **`/factions` directory grid** — all seven `FactionSelectCard` tiles at the
   360×300 ceiling. The blurb went from 12–17px to 18px inside a fixed-height
   box; check none overflow past the CTA. Ephemerists (17→18) and UA (16→18)
   moved least; **WOW, Snide and Singularity (12–12.5→18) moved most.**
2. **`FactionSelectCard` at 375px mobile**, single-column — same blurbs, less width.
3. **Snide `FactionCard`** — the two-column newsprint description at 18px. See
   judgement call 3; expect this one to want a layout follow-up.
4. **All seven `*FactionHero` blocks** on each faction detail page. Confirm the
   wordmarks are untouched (60 / 52 / 76 / 56 / 82 / 54 / 52) and that the
   bigger blurb has not pushed the stat ledger out of the hero.
5. **Ephemerists hero specifically** — the gloss is now the same size as the
   paragraph above it. Does the script face alone still read as subordinate?
6. **`EverymenFactionCard`** — blurb and perk list both at 18px; the perk rows
   sit next to a fixed 22px checkmark chip that did *not* grow.
7. **`SingularityTaskCard`** — should be pixel-identical; it is a pure refactor.
8. Light **and** dark for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
