### PR TITLE
Spacing ratchet: exempt zero, document the ornament-spacing carve-out

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -159,7 +159,11 @@ Both scales are **global, not per-faction**. A faction picks a headline font, a 
 
 **Skins don't own type size.** A skin style object (`inputStyle`, `textareaStyle`, `markdownStyle`, and friends) carries `fontFamily`, `fontStyle`, `color`, `lineHeight` — **never `fontSize`**. The shared control owns the size, via a role class (`.content-text` / `.content-title`) or a `--text-*` token. This is the rule above made enforceable: if a skin is setting a size, the size has escaped the scale.
 
+**Zero is exempt.** `padding: 0` / `margin: 0` / `gap: 0` stay as written. Zero is the *absence* of spacing rather than a choice from the scale — it is unit-less and theme-invariant, so it carries none of the drift the scale exists to prevent. There is deliberately no `--space-none` token: spelling "nothing" as `var(--space-none)` is churn, not clarity. The lint rule exempts the literal `0`.
+
 **Not covered by the rule:** ornament geometry (`width`/`height`/`top`/`inset` on decorative marks, sprocket holes, tape strips, corner brackets) is illustration, not layout spacing, and stays in raw pixels.
+
+**Ornament spacing.** The same carve-out extends to `padding`/`margin`/`gap` *inside* an ornamental composition — the lead between stacked stencil lines, the inset of a stamp within its border, the offset of a taped label. Rounding those to the nearest rung reflows the composition, and §6's "do not regularize card sizes" applies to an archetype's internal rhythm as much as to its outer dimensions. Such a value keeps its raw pixels behind the same per-line hatch ornament `fontSize` uses. The test is unchanged: spacing that positions **layout** takes a token; spacing that positions **illustration** is ornament. When genuinely unsure, it is layout — the carve-out is narrow, and a gutter between two paragraphs is never ornament.
 
 ### The ornament escape hatch
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -111,6 +111,11 @@ const RAW_PX_STRING = /^-?\d+(\.\d+)?px(\s+-?\d+(\.\d+)?px){0,3}$/
 
 function isRawPxValue(node) {
   if (node.type !== 'Literal') return false
+  // Zero is exempt: it is the absence of spacing, not a choice from the scale.
+  // It is unit-less and theme-invariant, so it carries none of the drift the
+  // token scale exists to prevent — and there is deliberately no --space-none
+  // token to migrate the ~222 `padding: 0` sites onto (#750).
+  if (node.value === 0) return false
   if (typeof node.value === 'number') return true
   if (typeof node.value === 'string') return RAW_PX_STRING.test(node.value.trim())
   return false


### PR DESCRIPTION
Unblocks every #750 slice. Two decisions, both confirmed by Molly.

## 1. Zero is exempt (the blocker)

`local/no-raw-style-values` flagged `padding: 0` / `margin: 0` / `gap: 0` via a bare `typeof node.value === 'number'` check — but there is no `--space-none` token, so **~222 sites across `frontend/src` had no valid migration target**. Every slice agent hit this within minutes.

Zero is the *absence* of spacing, not a choice from the scale: unit-less, theme-invariant, and carrying none of the drift the token scale exists to prevent. The alternative — adding `--space-none: 0` — meant 222 lines of churn to spell "nothing".

## 2. Ornament spacing carve-out (documentation only)

The scale covers ~37% of real values; **1,078 sit off it** (6, 10, 14, 18, 20…). §4a already settled that layout spacing rounds to the nearest rung — it names `gap: 6` explicitly. But rounding *inside* an ornamental composition reflows it: 6→8 is +33%. §4a now says spacing that positions **illustration** is ornament and keeps raw pixels behind the same per-line hatch ornament `fontSize` uses; spacing that positions **layout** takes a token. When unsure, it is layout.

## Verification

Ran eslint against a fixture:

| Input | Result |
|---|---|
| `padding: 0, margin: 0, gap: 0` | passes ✅ |
| `padding: 13` | still errors ✅ |
| `gap: "6px 10px"` (string shorthand) | still errors ✅ |

Pre-existing and unchanged: `margin: "0"` as a string already passed, since the regex only matches values ending in `px`. Now consistent with the exemption rather than a loophole.

## What to eyeball

Nothing visual — this changes no rendered output. It only widens what the linter accepts and documents two rules. The visual consequences arrive with the slice PRs.

Part of #750