### PR TITLE
Constellation: responsive circular stage, per-orb rank + points, three-chip legend (#730)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -60,8 +60,12 @@
       "factionsCount_other": "{{count}} factions",
       "taglineEra": "The closer to the sun, the higher you've climbed this era.",
       "taglineAllTime": "The closer to the sun, the higher you've climbed of all time.",
-      "legendEra": "Bigger sigil = more era points · closer to the sun = higher rank.",
-      "legendAllTime": "Bigger sigil = more all-time points · closer to the sun = higher rank.",
+      "legend": {
+        "sizeEra": "Bigger sigil = more era points",
+        "sizeAllTime": "Bigger sigil = more all-time points",
+        "crown": "Crown = the lead",
+        "faint": "Faint = still at zero"
+      },
       "zeroState": "The era is young — no one has climbed yet.",
       "skyLabel": "The standings, drawn as a night sky of players.",
       "you": "You",

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -8,7 +8,9 @@ import { FACTION_RAINBOW_ORDER, factionCssVar } from '../utils/factions'
 import type { CharacterOut, CurrentUser } from '../api/auth'
 import { useFormFactor } from '../hooks/useFormFactor'
 import { pickVariant } from '../utils/factionDispatch'
-import Constellation, { type RankedPlayer } from './players/Constellation'
+import { type RankedPlayer } from './players/Constellation'
+import SkyCanvas, { DESKTOP_SKY_MAX_WIDTH } from './players/SkyCanvas'
+import SkyLegend from './players/SkyLegend'
 import RosterTable from './players/RosterTable'
 import DefaultPlayers, {
   type PlayersDirectoryProps,
@@ -22,6 +24,10 @@ type ScoreMode = 'era' | 'alltime'
 // through to the Default directory skin; bespoke faction directories can
 // register here later.
 export const MOBILE_ARCHETYPE_BY_SLUG: Record<string, MobileSkin> = {}
+
+/** Orbs in the desktop sky. Mobile shows 6 (`DefaultPlayers`); at the ~294px
+ *  radius the 900px stage yields there is room for 12 (#730 §2). */
+const DESKTOP_SKY_POPULATION = 12
 
 export default function Leaderboard() {
   const { user } = useAuth()
@@ -90,10 +96,6 @@ function DesktopLeaderboard({
     scoreMode === 'era'
       ? t('leaderboard.desktop.taglineEra')
       : t('leaderboard.desktop.taglineAllTime')
-  const legend =
-    scoreMode === 'era'
-      ? t('leaderboard.desktop.legendEra')
-      : t('leaderboard.desktop.legendAllTime')
 
   if (loading) {
     return (
@@ -169,16 +171,17 @@ function DesktopLeaderboard({
           {tagline}
         </p>
 
-        <Constellation
+        {/* The stage measures itself and caps at 900px — desktop used to hand
+            Constellation a hardcoded 620×460 island in a ~1200px box (#730 §1). */}
+        <SkyCanvas
           players={ranked}
           maxScore={maxScore}
           myCharId={myCharId}
-          population={12}
+          population={DESKTOP_SKY_POPULATION}
+          maxWidth={DESKTOP_SKY_MAX_WIDTH}
         />
 
-        <p className="content-text mt-3" style={{ color: 'var(--color-text-secondary)' }}>
-          {legend}
-        </p>
+        <SkyLegend scoreMode={scoreMode} />
       </section>
 
       {/* ── Full roster ── */}

--- a/frontend/src/pages/players/Constellation.tsx
+++ b/frontend/src/pages/players/Constellation.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { CharacterOut } from '../../api/auth'
-import { factionCssVar } from '../../utils/factions'
-import { mediaUrl } from '../../utils/media'
+import { factionCssVar, isKnownFaction } from '../../utils/factions'
+import FactionAvatar from '../../components/avatar/FactionAvatar'
 
 /** A character with its computed standing, shared by the sky and the roster. */
 export interface RankedPlayer {
@@ -22,10 +22,11 @@ interface ConstellationProps {
   myCharId: number | null
   /** How many of the top players get a star. Mobile (#657) passes a smaller N. */
   population?: number
-  /** Fixed coordinate box; positions are computed in px so equal offsets are
-   *  equal distances regardless of the fluid column width (see epic #654 §1). */
-  stageWidth?: number
-  stageHeight?: number
+  /** Measured coordinate box, supplied by `SkyCanvas` on both form factors.
+   *  Positions are computed in px so equal offsets are equal distances
+   *  regardless of the fluid column width (see epic #654 §1). */
+  stageWidth: number
+  stageHeight: number
 }
 
 const GOLDEN_ANGLE_DEG = 137.5
@@ -34,6 +35,10 @@ const RING_COUNT = 4
 const NODE_MIN = 30
 const NODE_MAX = 92
 const NODE_ZERO_STATE = 44
+/** Breathing room between the outermost ring and the stage edge, for the orb
+ *  plus its label stack. At the 900px desktop cap this leaves a ~294px radius,
+ *  roughly double the old fixed-620px stage (#730 §1). */
+const STAGE_MARGIN = 88
 // Deterministic sparkle field, expressed as fractions of the stage box so it
 // scales with any stageWidth/stageHeight (mobile reuses a smaller box).
 const SPARKLES: ReadonlyArray<{ fx: number; fy: number; r: number }> = [
@@ -49,6 +54,13 @@ const SPARKLES: ReadonlyArray<{ fx: number; fy: number; r: number }> = [
   { fx: 0.44, fy: 0.5, r: 0.9 },
 ]
 
+/** Radius of the outermost ring for a measured stage. The sky is circular, so
+ *  the SHORTER side governs — which is why capping the width alone never fixed
+ *  the cramping (`min(900, 460)` is still 460). Exported for the geometry test. */
+export function skyRadius(stageWidth: number, stageHeight: number): number {
+  return Math.min(stageWidth, stageHeight) / 2 - STAGE_MARGIN
+}
+
 interface PlacedNode {
   entry: RankedPlayer
   /** px offset from the stage centre. */
@@ -60,24 +72,26 @@ interface PlacedNode {
   pinned: boolean
 }
 
-export default function Constellation({
-  players,
-  maxScore,
-  myCharId,
-  population = 12,
-  stageWidth = 620,
-  stageHeight = 460,
-}: ConstellationProps) {
-  const { t } = useTranslation('common')
-
-  const centreX = stageWidth / 2
-  const centreY = stageHeight / 2
-  // Leave room for the largest orb + its label below the outermost ring.
-  const radius = Math.min(stageWidth, stageHeight) / 2 - 88
+/**
+ * Vogel / golden-angle spiral placement, extracted so the geometry can be
+ * asserted without a DOM (#730 — this is a layout bug you cannot screenshot).
+ * Radius rises monotonically with rank, so "closer to the sun = higher rank" is
+ * literally true (epic #654). The champion sits ON the sun.
+ */
+export function placeOrbs(
+  sky: RankedPlayer[],
+  radius: number,
+  maxScore: number,
+): PlacedNode[] {
   const zeroState = maxScore <= 0
+  const skyCount = Math.max(sky.length, 1)
 
-  const sky = players.slice(0, population)
-  const skyCount = sky.length
+  // The champion's orb is the largest and sits at r=0, so the runner-up's
+  // spiral radius (0.29r) can be smaller than the two orbs' combined radii.
+  // A floor on every non-champion orbit fixes that without breaking
+  // monotonicity; it is capped as a fraction of the radius so it stays inert on
+  // the phone's small stage rather than flinging rank 2 past the outer ring.
+  const minOrbit = Math.min(NODE_MAX + 4, radius * 0.33)
 
   const nodeSize = (points: number): number => {
     if (zeroState) return NODE_ZERO_STATE
@@ -86,18 +100,17 @@ export default function Constellation({
     return NODE_MIN + (NODE_MAX - NODE_MIN) * Math.min(fraction, 1)
   }
 
-  const placed: PlacedNode[] = sky.map((entry, index) => {
+  return sky.map((entry, index) => {
     let x: number
     let y: number
     if (zeroState) {
       // One even ring — nobody has climbed, so nobody is nearer the centre.
-      const angle = (index / Math.max(skyCount, 1)) * 2 * Math.PI - Math.PI / 2
+      const angle = (index / skyCount) * 2 * Math.PI - Math.PI / 2
       x = radius * Math.cos(angle)
       y = radius * Math.sin(angle)
     } else {
-      // Vogel / golden-angle spiral: radius rises monotonically with rank, so
-      // "closer to the sun = higher rank" is literally true. Champion at centre.
-      const nodeRadius = radius * Math.sqrt(index / Math.max(skyCount, 1))
+      const spiral = radius * Math.sqrt(index / skyCount)
+      const nodeRadius = index === 0 ? 0 : Math.max(spiral, minOrbit)
       const angle = (index * GOLDEN_ANGLE_DEG * Math.PI) / 180
       x = nodeRadius * Math.cos(angle)
       y = nodeRadius * Math.sin(angle)
@@ -112,6 +125,27 @@ export default function Constellation({
       pinned: false,
     }
   })
+}
+
+export default function Constellation({
+  players,
+  maxScore,
+  myCharId,
+  population = 12,
+  stageWidth,
+  stageHeight,
+}: ConstellationProps) {
+  const { t } = useTranslation('common')
+
+  const centreX = stageWidth / 2
+  const centreY = stageHeight / 2
+  const radius = skyRadius(stageWidth, stageHeight)
+  const zeroState = maxScore <= 0
+
+  const sky = players.slice(0, population)
+  const skyCount = sky.length
+
+  const placed = placeOrbs(sky, radius, maxScore)
 
   // Viewer outside the sky: pin their sigil just past the outermost ring on a
   // dashed tether so it never implies a truthful radius.
@@ -158,8 +192,8 @@ export default function Constellation({
         }}
       />
 
-      {/* Fixed-width stage: all px offsets are measured from its centre, so the
-          fluid column width can't distort the metaphor. */}
+      {/* The stage: all px offsets are measured from its centre, so the fluid
+          column width can't distort the metaphor. */}
       <div
         style={{
           position: 'absolute',
@@ -241,6 +275,22 @@ export default function Constellation({
   )
 }
 
+/** The crown that marks the lead. Exported so the legend chip can reuse the one
+ *  glyph instead of drawing a second crown (#730 §3). */
+export function SkyCrown({ size = 26 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={Math.round(size * 0.77)}
+      viewBox="0 0 26 20"
+      fill="var(--sky-crown)"
+      aria-hidden
+    >
+      <path d="M2 6l4 4 7-8 7 8 4-4-2 12H4z" />
+    </svg>
+  )
+}
+
 function SkyNode({
   node,
   centreX,
@@ -255,7 +305,11 @@ function SkyNode({
   const { t } = useTranslation('common')
   const { entry, size, faded, crowned, pinned } = node
   const character = entry.character
-  const color = factionCssVar(character.faction_slug)
+  // factionCssVar resolves an unknown slug to the `ua` theme, so unaffiliated
+  // branches on isKnownFaction first (#636 / ADR-0039).
+  const known = isKnownFaction(character.faction_slug)
+  const pointsColor = known ? factionCssVar(character.faction_slug) : undefined
+  const badgeDim = Math.max(18, Math.round(size * 0.3))
 
   return (
     <Link
@@ -273,43 +327,35 @@ function SkyNode({
         width: Math.max(size, 84),
       }}
     >
-      {crowned && (
-        <svg
-          width={26}
-          height={20}
-          viewBox="0 0 26 20"
-          fill="var(--sky-crown)"
-          aria-hidden
-          className="mb-0.5"
-        >
-          <path d="M2 6l4 4 7-8 7 8 4-4-2 12H4z" />
-        </svg>
-      )}
+      {crowned && <SkyCrown />}
 
-      {/* Orb — faded via opacity for zero-score players; the name stays legible. */}
-      <span
-        aria-hidden
-        style={{
-          width: size,
-          height: size,
-          borderRadius: '50%',
-          overflow: 'hidden',
-          opacity: faded ? 0.4 : 1,
-          border: `2px solid ${color}`,
-          boxShadow: `0 0 ${crowned ? 22 : 12}px var(--sky-glow)`,
-          background: character.avatar_url
-            ? undefined
-            : `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${color})`,
-          flex: 'none',
-        }}
-      >
-        {character.avatar_url && (
-          <img
-            src={mediaUrl(character.avatar_url)}
-            alt=""
-            style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-          />
-        )}
+      {/* ponytail: the orb IS the roster avatar at a sky-sized dim — FactionAvatar
+          already carries the faction ring, the sigil corner mark, the img/monogram
+          fallback and the unaffiliated spectrum, so the bespoke circle + <img>
+          this used to hand-roll is deleted. `glow` supplies the halo. */}
+      <span style={{ position: 'relative', lineHeight: 0, opacity: faded ? 0.4 : 1 }}>
+        <FactionAvatar character={character} size={Math.round(size)} glow />
+
+        {/* Rank badge — a small disc on the orb's shoulder. */}
+        <span
+          className="font-body flex items-center justify-center"
+          aria-hidden
+          style={{
+            position: 'absolute',
+            left: -badgeDim / 3,
+            top: -badgeDim / 3,
+            width: badgeDim,
+            height: badgeDim,
+            borderRadius: '50%',
+            background: 'var(--sky-bg)',
+            border: '1px solid var(--sky-ring)',
+            color: 'var(--sky-name)',
+            fontSize: 'var(--text-sm)',
+            lineHeight: 1,
+          }}
+        >
+          {entry.rank}
+        </span>
       </span>
 
       <span
@@ -325,10 +371,18 @@ function SkyNode({
         {character.display_name}
       </span>
 
-      {crowned && (
+      {/* Points, in the faction hue — or the shared .rainbow-ink gradient clip
+          for unaffiliated, matching the roster row (#729 / ADR-0039). */}
+      {!pinned && (
         <span
-          className="italic"
-          style={{ fontSize: 'var(--text-title)', color: 'var(--sky-name)', lineHeight: 1.1 }}
+          className={known ? 'font-body' : 'font-body rainbow-ink'}
+          style={{
+            fontSize: 'var(--text-content)',
+            fontWeight: 700,
+            lineHeight: 1.1,
+            // .rainbow-ink sets its own transparent colour — don't hand it one.
+            ...(known ? { color: pointsColor } : null),
+          }}
         >
           {entry.points}
         </span>

--- a/frontend/src/pages/players/SkyCanvas.tsx
+++ b/frontend/src/pages/players/SkyCanvas.tsx
@@ -11,6 +11,11 @@ export const DESKTOP_SKY_MAX_WIDTH = 900
 export const DESKTOP_SKY_ASPECT = 0.85
 /** A phone column is already narrow, so its stage is taller than wide. */
 export const MOBILE_SKY_ASPECT = 1.08
+/** Pre-measurement stage width. The first paint (and every server/static render,
+ *  where no effect runs and `clientWidth` is 0) must still draw a real sky — a
+ *  `width > 0` guard renders NOTHING under `renderToStaticMarkup`, which would
+ *  quietly hollow out the players tests into vacuous passes (#730). */
+export const FALLBACK_SKY_WIDTH = 360
 
 export interface SkyCanvasProps {
   players: RankedPlayer[]
@@ -44,12 +49,16 @@ export default function SkyCanvas({
   aspect = DESKTOP_SKY_ASPECT,
 }: SkyCanvasProps) {
   const ref = useRef<HTMLDivElement>(null)
-  const [width, setWidth] = useState(0)
+  // Seeded, never 0: see FALLBACK_SKY_WIDTH. The measurement then corrects it on
+  // mount and on every resize.
+  const [width, setWidth] = useState(Math.min(maxWidth ?? FALLBACK_SKY_WIDTH, FALLBACK_SKY_WIDTH))
 
   useEffect(() => {
     const element = ref.current
     if (!element) return
-    const measure = () => setWidth(element.clientWidth)
+    const measure = () => {
+      if (element.clientWidth > 0) setWidth(element.clientWidth)
+    }
     measure()
     if (typeof ResizeObserver === 'undefined') return
     const observer = new ResizeObserver(measure)
@@ -58,17 +67,15 @@ export default function SkyCanvas({
   }, [])
 
   return (
-    <div ref={ref} className="mx-auto" style={{ maxWidth, minHeight: 320 }}>
-      {width > 0 && (
-        <Constellation
-          players={players}
-          maxScore={maxScore}
-          myCharId={myCharId}
-          population={population}
-          stageWidth={width}
-          stageHeight={Math.round(width * aspect)}
-        />
-      )}
+    <div ref={ref} className="mx-auto" style={{ maxWidth }}>
+      <Constellation
+        players={players}
+        maxScore={maxScore}
+        myCharId={myCharId}
+        population={population}
+        stageWidth={width}
+        stageHeight={Math.round(width * aspect)}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/players/SkyCanvas.tsx
+++ b/frontend/src/pages/players/SkyCanvas.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react'
+import Constellation, { type RankedPlayer } from './Constellation'
+
+/** Desktop cap. Uncapped the sky sprawls on an ultrawide and shoves the roster
+ *  far down the page; 900px keeps it a hero, not a horizon (#730 §1). */
+export const DESKTOP_SKY_MAX_WIDTH = 900
+/** Height as a fraction of width. The sky is CIRCULAR — `min(w, h)` is the
+ *  radius basis inside Constellation, so the stage must be tall or the height
+ *  stays the binding constraint and the radius never grows. 900 × 0.85 ≈ 765,
+ *  which yields the ~294px target radius (#730 §1). */
+export const DESKTOP_SKY_ASPECT = 0.85
+/** A phone column is already narrow, so its stage is taller than wide. */
+export const MOBILE_SKY_ASPECT = 1.08
+
+export interface SkyCanvasProps {
+  players: RankedPlayer[]
+  maxScore: number
+  myCharId: number | null
+  population: number
+  /** Cap the stage; omit for the phone, where the column is the cap. */
+  maxWidth?: number
+  aspect?: number
+}
+
+/**
+ * The one measuring wrapper for the constellation, shared by BOTH form factors.
+ *
+ * ponytail: this used to be a private helper in DefaultPlayers while desktop
+ * passed a magic 620×460 constant — so a ResizeObserver on one side and a
+ * hardcoded island on the other. Lifting it here DELETES the desktop constant
+ * and the duplicate, rather than adding a third path.
+ *
+ * The width cap is plain CSS `maxWidth` on the measured element, so the measured
+ * width is already the capped width — no second clamp in JS. Positions inside
+ * Constellation stay in px measured from the stage centre, so equal offsets are
+ * equal distances regardless of the fluid column width (epic #654 §1).
+ */
+export default function SkyCanvas({
+  players,
+  maxScore,
+  myCharId,
+  population,
+  maxWidth,
+  aspect = DESKTOP_SKY_ASPECT,
+}: SkyCanvasProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+    const measure = () => setWidth(element.clientWidth)
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref} className="mx-auto" style={{ maxWidth, minHeight: 320 }}>
+      {width > 0 && (
+        <Constellation
+          players={players}
+          maxScore={maxScore}
+          myCharId={myCharId}
+          population={population}
+          stageWidth={width}
+          stageHeight={Math.round(width * aspect)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/players/SkyLegend.tsx
+++ b/frontend/src/pages/players/SkyLegend.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { SkyCrown } from './Constellation'
+
+/**
+ * The sky's key, as three icon chips (#730 §3).
+ *
+ * It used to be one run-on sentence per score mode. Only the FIRST chip is
+ * mode-dependent ("era points" / "all-time points") — the crown and the faint
+ * orb mean the same thing in both modes — so this is four catalog keys, not six.
+ *
+ * Each icon sits on a `--sky-bg` swatch so the crown and the orbs read exactly
+ * as they do inside the sky; the page around the legend is ordinary page chrome,
+ * so its labels use the page text tokens rather than the `--sky-*` ink.
+ */
+export interface SkyLegendProps {
+  scoreMode: 'era' | 'alltime'
+}
+
+export default function SkyLegend({ scoreMode }: SkyLegendProps) {
+  const { t } = useTranslation('common')
+
+  return (
+    <ul
+      className="flex flex-wrap items-center list-none mt-3"
+      style={{ gap: 'var(--space-lg)', padding: 0, margin: 0 }}
+    >
+      <LegendChip icon={<SigilScaleIcon />}>
+        {scoreMode === 'era'
+          ? t('leaderboard.desktop.legend.sizeEra')
+          : t('leaderboard.desktop.legend.sizeAllTime')}
+      </LegendChip>
+      <LegendChip icon={<SkyCrown size={20} />}>
+        {t('leaderboard.desktop.legend.crown')}
+      </LegendChip>
+      <LegendChip icon={<FaintOrbIcon />}>{t('leaderboard.desktop.legend.faint')}</LegendChip>
+    </ul>
+  )
+}
+
+function LegendChip({ icon, children }: { icon: ReactNode; children: ReactNode }) {
+  return (
+    <li className="flex items-center" style={{ gap: 'var(--space-sm)' }}>
+      <span
+        aria-hidden
+        className="flex items-center justify-center rounded-full"
+        style={{
+          // Ornament geometry: a fixed swatch that frames the glyph (#730 §4a).
+          width: 34,
+          height: 34,
+          flex: 'none',
+          background: 'var(--sky-bg)',
+          border: '1px solid var(--sky-ring)',
+        }}
+      >
+        {icon}
+      </span>
+      <span className="content-text font-body" style={{ color: 'var(--color-text-secondary)' }}>
+        {children}
+      </span>
+    </li>
+  )
+}
+
+/** Two sigil dots, small beside large — "bigger sigil = more points". */
+function SigilScaleIcon() {
+  return (
+    <svg width={24} height={20} viewBox="0 0 24 20" aria-hidden>
+      <circle cx={6} cy={13} r={3.5} fill="var(--sky-name-muted)" />
+      <circle cx={16} cy={10} r={7} fill="var(--sky-crown)" opacity={0.9} />
+    </svg>
+  )
+}
+
+/** One barely-there orb — "faint = still at zero". */
+function FaintOrbIcon() {
+  return (
+    <svg width={20} height={20} viewBox="0 0 20 20" aria-hidden>
+      <circle cx={10} cy={10} r={7} fill="var(--sky-name)" opacity={0.25} />
+    </svg>
+  )
+}

--- a/frontend/src/pages/players/SkyLegend.tsx
+++ b/frontend/src/pages/players/SkyLegend.tsx
@@ -22,8 +22,8 @@ export default function SkyLegend({ scoreMode }: SkyLegendProps) {
 
   return (
     <ul
-      className="flex flex-wrap items-center list-none mt-3"
-      style={{ gap: 'var(--space-lg)', padding: 0, margin: 0 }}
+      className="flex flex-wrap items-center list-none mt-3 p-0 m-0"
+      style={{ gap: 'var(--space-lg)' }}
     >
       <LegendChip icon={<SigilScaleIcon />}>
         {scoreMode === 'era'

--- a/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
@@ -30,7 +30,9 @@ vi.mock('../../../api/leaderboard', () => ({
 
 import Leaderboard from '../../Leaderboard'
 import DefaultPlayers from '../mobileArchetypes/DefaultPlayers'
-import Constellation, { type RankedPlayer } from '../Constellation'
+import Constellation, { skyRadius, type RankedPlayer } from '../Constellation'
+import SkyCanvas, { DESKTOP_SKY_MAX_WIDTH } from '../SkyCanvas'
+import SkyLegend from '../SkyLegend'
 import RosterTable from '../RosterTable'
 
 function render(element: ReactElement): { html: string; text: string } {
@@ -82,10 +84,14 @@ describe('players page form-factor dispatch', () => {
   })
 })
 
+// The sky is positioned in measured px, so a direct render must be handed a
+// stage. SkyCanvas supplies this in the app; these dims stand in for it.
+const STAGE = { stageWidth: 900, stageHeight: 765 }
+
 describe('desktop constellation (#656)', () => {
   it('links every star to its public profile, champion first', () => {
     const { html } = render(
-      <Constellation players={ranked(PLAYERS)} maxScore={2140} myCharId={null} />,
+      <Constellation players={ranked(PLAYERS)} maxScore={2140} myCharId={null} {...STAGE} />,
     )
     expect(html).toContain('href="/characters/11"')
     expect(html).toContain('href="/characters/22"')
@@ -94,8 +100,67 @@ describe('desktop constellation (#656)', () => {
 
   it('shows the zero state and no crown when nobody has climbed', () => {
     const flat = PLAYERS.map((c) => ({ ...c, score: 0 }))
-    const { text } = render(<Constellation players={ranked(flat)} maxScore={0} myCharId={null} />)
+    const { text } = render(
+      <Constellation players={ranked(flat)} maxScore={0} myCharId={null} {...STAGE} />,
+    )
     expect(text).toContain('The era is young')
+  })
+
+  // #730 §2: every orb carries its rank and its points, not just the champion.
+  it('carries a rank number and the points on each orb', () => {
+    const { text } = render(
+      <Constellation players={ranked(PLAYERS)} maxScore={2140} myCharId={null} {...STAGE} />,
+    )
+    expect(text, 'champion name').toContain('Perpetua')
+    expect(text, 'per-orb points').toContain('2140')
+    expect(text, 'a lower-ranked orb keeps its points').toContain('340')
+  })
+
+  // #730 §1: the radius is the binding half of the cramping bug. A 900x765
+  // stage must yield roughly double the old fixed 620x460 stage's 142px.
+  it('grows the sky radius with the measured stage', () => {
+    expect(skyRadius(620, 460)).toBe(142)
+    expect(skyRadius(900, 765)).toBeGreaterThan(280)
+  })
+
+  // The unaffiliated spectrum is a class, never a faction colour (ADR-0039).
+  it('paints unaffiliated points with the rainbow ink, not a faction hue', () => {
+    const { html } = render(
+      <Constellation players={ranked(PLAYERS)} maxScore={2140} myCharId={null} {...STAGE} />,
+    )
+    expect(html).toContain('rainbow-ink')
+  })
+})
+
+describe('sky legend (#730 §3)', () => {
+  it('names all three chips, with the era wording on the size chip', () => {
+    const { text } = render(<SkyLegend scoreMode="era" />)
+    expect(text).toContain('more era points')
+    expect(text).toContain('Crown')
+    expect(text).toContain('still at zero')
+  })
+
+  it('swaps only the size chip in all-time mode', () => {
+    const { text } = render(<SkyLegend scoreMode="alltime" />)
+    expect(text).toContain('more all-time points')
+    expect(text).toContain('Crown')
+  })
+})
+
+describe('SkyCanvas measuring wrapper (#730 §1)', () => {
+  // Regression: an earlier draft guarded on `width > 0`. With no DOM the effect
+  // never runs, so the sky vanished and every assertion above went vacuous.
+  it('renders a sky before any measurement has happened', () => {
+    const { html } = render(
+      <SkyCanvas
+        players={ranked(PLAYERS)}
+        maxScore={2140}
+        myCharId={null}
+        population={12}
+        maxWidth={DESKTOP_SKY_MAX_WIDTH}
+      />,
+    )
+    expect(html).toContain('href="/characters/11"')
   })
 })
 

--- a/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
+++ b/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { CharacterOut } from '../../../api/auth'
@@ -15,7 +15,9 @@ import FactionAvatar from '../../../components/avatar/FactionAvatar'
 import FactionSigil from '../../../components/cards/FactionSigil'
 import LevelGem from '../../../components/ui/LevelGem'
 import { ChipRow, Chip } from '../../../components/ui/ChipRow'
-import Constellation, { type RankedPlayer } from '../Constellation'
+import { type RankedPlayer } from '../Constellation'
+import SkyCanvas, { MOBILE_SKY_ASPECT } from '../SkyCanvas'
+import SkyLegend from '../SkyLegend'
 
 export interface PlayersDirectoryProps {
   characters: CharacterOut[]
@@ -81,10 +83,6 @@ export default function DefaultPlayers({ characters, loading, error, myCharId }:
     scoreMode === 'era'
       ? t('leaderboard.desktop.taglineEra')
       : t('leaderboard.desktop.taglineAllTime')
-  const legend =
-    scoreMode === 'era'
-      ? t('leaderboard.desktop.legendEra')
-      : t('leaderboard.desktop.legendAllTime')
 
   return (
     <div className="py-4" data-testid="mobile-players-directory">
@@ -149,61 +147,19 @@ export default function DefaultPlayers({ characters, loading, error, myCharId }:
             {tagline}
           </p>
 
-          <SkyCanvas players={ranked} maxScore={maxScore} myCharId={myCharId} />
+          <SkyCanvas
+            players={ranked}
+            maxScore={maxScore}
+            myCharId={myCharId}
+            population={SKY_POPULATION}
+            aspect={MOBILE_SKY_ASPECT}
+          />
 
-          <p className="content-text mt-3" style={{ color: 'var(--color-text-secondary)' }}>
-            {legend}
-          </p>
+          <SkyLegend scoreMode={scoreMode} />
 
           {/* ── Full roster ── */}
           <Roster players={ranked} myCharId={myCharId} />
         </>
-      )}
-    </div>
-  )
-}
-
-/**
- * Measures its own width so the Constellation's spiral radius is derived from
- * the real phone-column width rather than a magic constant — 6 labelled orbs on
- * a ~360px canvas is tight, so equal offsets must be equal px (epic #654 §1).
- * The stage is drawn slightly taller than wide so `min(w, h)` — the radius
- * basis inside Constellation — tracks the measured width.
- */
-function SkyCanvas({
-  players,
-  maxScore,
-  myCharId,
-}: {
-  players: RankedPlayer[]
-  maxScore: number
-  myCharId: number | null
-}) {
-  const ref = useRef<HTMLDivElement>(null)
-  const [width, setWidth] = useState(0)
-
-  useEffect(() => {
-    const element = ref.current
-    if (!element) return
-    const measure = () => setWidth(element.clientWidth)
-    measure()
-    if (typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(measure)
-    observer.observe(element)
-    return () => observer.disconnect()
-  }, [])
-
-  return (
-    <div ref={ref} style={{ minHeight: 320 }}>
-      {width > 0 && (
-        <Constellation
-          players={players}
-          maxScore={maxScore}
-          myCharId={myCharId}
-          population={SKY_POPULATION}
-          stageWidth={width}
-          stageHeight={Math.round(width * 1.08)}
-        />
       )}
     </div>
   )


### PR DESCRIPTION
Finishes the constellation stage rework. Builds on the recovered WIP commit
`895ae51` (shared `SkyCanvas` + reworked `Constellation`), which was committed
but never wired up.

Closes #730

## §1 — responsive stage, one measuring wrapper
- `pages/players/SkyCanvas.tsx` is now the only measuring wrapper. The private
  duplicate inside `DefaultPlayers.tsx` is **deleted** — that file is a net −45
  lines.
- Desktop stops passing the hardcoded `620×460`. It renders through `SkyCanvas`
  with `maxWidth={DESKTOP_SKY_MAX_WIDTH}` (900) and `aspect` 0.85, so the stage
  is ~900×765 and `skyRadius` goes 142 → ~294px, roughly double. The cap is
  plain CSS `maxWidth` on the measured element, so the measured width *is* the
  capped width — no second clamp in JS.
- The sky stays circular; a taller hero that pushes the roster down is intended.

## §2 — per-orb content
Already present in the recovered `Constellation.tsx` and verified here: numbered
rank badge on each orb, points below the name in the faction hue with the shared
`.rainbow-ink` gradient for `na` (ADR-0039), orbs drawn by `FactionAvatar` with
its `size` prop widened from `'sm' | 'md'` to accept a pixel number.

## §3 — legend
New `pages/players/SkyLegend.tsx` replaces the run-on sentence on **both** form
factors with three icon chips. Four new keys under
`leaderboard.desktop.legend.*` (`sizeEra`/`sizeAllTime`/`crown`/`faint`) — only
the size chip is mode-dependent. The old `legendEra`/`legendAllTime` keys are
removed. The crown chip reuses the exported `SkyCrown` glyph.

## Bug fixed from the recovered WIP
`SkyCanvas` rendered `{width > 0 && <Constellation/>}`. The test harness is
`renderToStaticMarkup` only — no jsdom — so effects never run and `clientWidth`
is 0; the sky rendered **nothing** in every test, which would have silently
gutted `playersDirectory.test.tsx` into vacuous passes. The measurement is now
seeded with a non-zero `FALLBACK_SKY_WIDTH` and only overwritten by a real
measurement, with a regression test asserting a sky renders pre-measurement.

## Verification
`tsc --noEmit` clean (only the known stale-junction `node:fs`/`node:url` false
alarms from PR #675), `vite build` OK, `eslint src` clean, `vitest run` 913/913
across 102 files.

**Visual QA is outstanding** — I cannot screenshot and there is no dev stack, so
every claim above is from types, lint and static-markup tests, not from looking
at the page.

## What to eyeball
- The sky at a narrow (~700px), medium (~1200px) and ultrawide (~2560px) window
  — it should fill up to 900px and then stop, never sprawl.
- An `na` player's points: the rainbow gradient, not a flat orange.
- The champion's crown, and that the rank badges do not collide with it.
- A zero-score field: the even ring, faint orbs, and the "era is young" copy.
- Mobile: 6 orbs, the stage still slightly taller than wide, chips wrapping.
- The three legend chips on both light and dark themes — the dark icon swatch on
  a light page is the one deliberate new visual, and is the thing most likely to
  want `frontend-style`'s opinion.
