### PR TITLE
Spacing ratchet: large rungs, close two lint blind spots, tie-break rule

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -152,8 +152,18 @@ There is deliberately no `.content-heading` / `.content-display` / `.content-sco
 | `--space-lg`  | 16px  |
 | `--space-xl`  | 24px  |
 | `--space-2xl` | 32px  |
+| `--space-3xl` | 40px  |
+| `--space-4xl` | 48px  |
+| `--space-5xl` | 64px  |
+| `--space-6xl` | 96px  |
+
+The rungs through `2xl` are for spacing **within** a component; `3xl` and up are for the space **around** one — section breaks, hero padding, sticky-footer clearance. The step widens on purpose: at that size a 4px difference is not a design decision anyone is making.
 
 **Rule:** `padding`, `margin`, and `gap` take a `--space-*` token — never a raw pixel value. If you're about to write `padding: 13` or `gap: 6`, stop and pick the nearest token. This mirrors the typography rule: the scale is the vocabulary, and a value outside it is a bug, not a nuance.
+
+**Ties round up.** 20px sits exactly between `--space-lg` and `--space-xl`, and it is one of the most common raw values in the codebase; "nearest" does not resolve it. Round up. §4's *type wins; geometry yields* is the reason — text sizes rose site-wide in #627/#623, so containers giving up room is the wrong direction. The exception is an intentionally **asymmetric** inset (`"24px 24px 22px 20px"`), where rounding every side up flattens the asymmetry into a uniform box; there, round the tie down and keep the shape.
+
+**Never compose with `calc()` to dodge the scale.** `calc(var(--space-2xl) + var(--space-lg))` is a 48px value wearing a disguise — it passes the linter and tells the next reader nothing. If a needed value has no rung, that is a gap in the scale to raise, not to route around.
 
 Both scales are **global, not per-faction**. A faction picks a headline font, a colour, and an ornament — never its own type size or spacing. There are no per-faction size or spacing exceptions.
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -107,17 +107,32 @@ const STYLE_PROPS = new Set([
   'rowGap',
   'columnGap',
 ])
-const RAW_PX_STRING = /^-?\d+(\.\d+)?px(\s+-?\d+(\.\d+)?px){0,3}$/
+const RAW_PX_COMPONENT = /^-?\d+(\.\d+)?px$/
+
+// A shorthand string is a violation if ANY of its components is a raw pixel
+// value. Matching the WHOLE string against a px-only pattern (as this once did)
+// meant a single bare `0` or `auto` disarmed the rule entirely, so
+// `"0 0 14px"`, `"12px 0"` and `"0 auto 26px"` all passed silently — and a file
+// carrying them could be delisted while still holding raw values (#750).
+function hasRawPxComponent(value) {
+  return value.trim().split(/\s+/).some((part) => RAW_PX_COMPONENT.test(part))
+}
 
 function isRawPxValue(node) {
-  if (node.type !== 'Literal') return false
   // Zero is exempt: it is the absence of spacing, not a choice from the scale.
   // It is unit-less and theme-invariant, so it carries none of the drift the
   // token scale exists to prevent — and there is deliberately no --space-none
   // token to migrate the ~222 `padding: 0` sites onto (#750).
-  if (node.value === 0) return false
+  if (node.type === 'Literal' && node.value === 0) return false
+  // A ternary hides raw values from a Literal-only check: `fontSize: big ? 15 : 14`
+  // read as clean and survived the whole #623 sweep. Recurse into both branches
+  // so "the raw count reached zero" means what it says (#750).
+  if (node.type === 'ConditionalExpression') {
+    return isRawPxValue(node.consequent) || isRawPxValue(node.alternate)
+  }
+  if (node.type !== 'Literal') return false
   if (typeof node.value === 'number') return true
-  if (typeof node.value === 'string') return RAW_PX_STRING.test(node.value.trim())
+  if (typeof node.value === 'string') return hasRawPxComponent(node.value)
   return false
 }
 

--- a/frontend/src/components/cards/AlbescentTaskCard.tsx
+++ b/frontend/src/components/cards/AlbescentTaskCard.tsx
@@ -119,6 +119,7 @@ export default function AlbescentTaskCard({ task, displayPoints, onSignup }: Pro
             style={{
               background: "none",
               border: "none",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: 1px lead holding the letterpress hairline against its label; the nearest rung detaches the rule.
               padding: "0 0 1px",
               cursor: "pointer",
               fontFamily: MONO,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -316,6 +316,16 @@
   --space-lg: 16px;
   --space-xl: 24px;
   --space-2xl: 32px;
+  /* Page-level gutters. The rungs above exist for spacing WITHIN a component;
+     these are for the space AROUND one — section breaks, hero padding, sticky
+     footer clearance. Without them large values had nowhere to go but a
+     calc() sum of smaller rungs, which is arithmetic homework at the call
+     site. The step widens deliberately: at this size a 4px difference is not
+     a design decision anyone is making (#750). */
+  --space-3xl: 40px;
+  --space-4xl: 48px;
+  --space-5xl: 64px;
+  --space-6xl: 96px;
 
   /* ── Filter stamp dashed-border (inverts with active state bg) ── */
   --stamp-active-dashed: rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
Three gaps found by slice agents mid-sweep. All confirmed by measurement before acting.

## 1. The scale had no rungs above 32px

Real page-level gutters run 40–96px (47 sites). With nothing above `--space-2xl`, slice 1 had to write:

```js
padding: "calc(var(--space-2xl) + var(--space-sm)) calc(var(--space-2xl) + var(--space-lg)) calc(var(--space-2xl) + var(--space-md))"
```

That is `40px 48px 44px` as arithmetic homework. Rounding instead (90px footer gutter → 32px) would have been a layout change, not a tokenization — so the agent was right to refuse both, and the real gap was the scale.

Adds `--space-3xl` 40 · `--space-4xl` 48 · `--space-5xl` 64 · `--space-6xl` 96, sized from the measured distribution. The step widens deliberately: at that size a 4px difference is not a decision anyone is making. The dense small end — the part 'don't widen the scale' protects — is untouched.

## 2. One bare `0` disarmed the string check

`RAW_PX_STRING` required *every* component to end in `px`:

| Value | Before | After |
|---|---|---|
| `"6px 10px"` | caught | caught |
| `"0 0 14px"` | **escaped** | caught |
| `"12px 0"` | **escaped** | caught |
| `"0 auto 26px"` | **escaped** | caught |
| `"0 auto"` | passes | passes |

Found independently by slices 1, 2 and 4. This is the serious one: **it caught a live violation in `AlbescentTaskCard.tsx`, a file already delisted** — i.e. the ratchet had declared a file clean while it still held a raw value. That 1px hairline lead is genuine ornament and now carries a phase-2 directive.

## 3. Ternaries were invisible to the rule

`isRawPxValue` only inspected `Literal` nodes, so `fontSize: big ? 15 : 14` (`SnideTaskDetail.tsx:41`) **survived the entire #623 sweep**. Now recurses into both branches, so "the raw count reached zero" means what it says.

## Also recorded in §4a

Two rules slices 2 and 4 each derived independently, having no contact with each other:

- **Ties round up** — 20px is one of the most common raw values and sits exactly between rungs; "nearest" doesn't resolve it. §4's *type wins; geometry yields* settles the direction. Exception: an intentionally asymmetric inset, where rounding every side up flattens the shape.
- **No `calc()` composition** to dodge a missing rung — it passes lint and tells the next reader nothing. A missing value is a gap to raise, not route around.

## Verification

Fixture covering all nine cases behaves exactly as intended. Whole tree: `eslint src --report-unused-disable-directives` **exit 0**, `vite build` clean. Remaining `tsc` `node:*` noise is the known stale-junction false alarm (PR #675).

## What to eyeball

Nothing yet — this changes no rendered output. It adds tokens nothing uses so far and tightens what the linter rejects. The visual consequences arrive with the slice PRs, where the new large rungs replace the `calc()` sums.

Part of #750