### PR TITLE
Players redesign: the Meadow, a light-theme leaderboard viz (#684)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -350,7 +350,7 @@
      only and are deliberately NOT repeated under [data-theme="dark"] — the
      canvas never flips (epic #654 decision #8; same pattern as the rank colors
      above and the "Constants keep their role in both themes" faction tokens).
-     Decorative tokens (glow/ring/sparkle/tether) carry no AA duty. The three
+     Decorative tokens (glow/ring/sparkle/you-ring) carry no AA duty. The three
      text-bearing tokens are measured against --sky-bg and clear AA:
        --sky-name        #efe6d4 → 15.48:1
        --sky-crown       #f0c85a → 11.99:1 (gilt icon)
@@ -360,10 +360,39 @@
   --sky-glow: rgba(240, 202, 94, 0.16); /* warm gilt "sun" glow — central + orb boxShadow */
   --sky-ring: rgba(239, 230, 212, 0.12); /* faint orbit-ring stroke */
   --sky-sparkle: rgba(239, 230, 212, 0.55); /* starfield dots */
-  --sky-tether: rgba(239, 230, 212, 0.35); /* dashed pinned-viewer tether */
   --sky-crown: #f0c85a; /* gilt rank-1 crown */
   --sky-name: #efe6d4; /* node name/score — AA 15.48:1 */
   --sky-name-muted: #8a8070; /* faded/zero names + zero-state — AA 4.94:1 */
+  --sky-you: rgba(239, 230, 212, 0.7); /* "you" ring around the viewer's own orb (#684 §7) */
+
+  /* ── Meadow field (Players redesign, #684) ──
+     The Constellation's LIGHT-theme sibling. The --sky-* tokens above are
+     measured against a night canvas and invert into AA failures on a daylit
+     field, so this is a separate family rather than a re-point (#684 §9). The
+     Meadow only ever renders under the light theme (the dispatch in
+     Leaderboard.tsx hands dark to the Constellation), so these live in :root —
+     light's own scope — and are deliberately NOT repeated under
+     [data-theme="dark"].
+
+     Decorative tokens (bg/glow/field/stem/pollen/petal/you-ring) carry no AA
+     duty — the same carve-out the sky's ornament tokens got. Petal colour comes
+     from the faction palette at render time; NAMES ARE INK, never a faction
+     hue, exactly as the sky keeps names near-white and faction colour in the
+     orb border. The three text-bearing tokens are measured against
+     --meadow-bg (#eef4e2, relative luminance 0.8835) and clear AA:
+       --meadow-name        #1e1c17 → 15.13:1
+       --meadow-champion    #6d4b06 →  7.02:1 (champion's printed score)
+       --meadow-name-muted  #6b6553 →  5.17:1 (zero-score names + zero-state copy) */
+  --meadow-bg: #eef4e2; /* daylit field canvas */
+  --meadow-glow: rgba(255, 236, 168, 0.55); /* low sun glow behind the front bloom */
+  --meadow-field: rgba(140, 178, 108, 0.28); /* receding grass bands */
+  --meadow-stem: #7fa05a; /* flower stems */
+  --meadow-pollen: rgba(214, 168, 40, 0.55); /* drifting pollen motes */
+  --meadow-champion-petal: #f0c85a; /* golden bloom petals — decorative, not text */
+  --meadow-you: rgba(45, 40, 30, 0.55); /* "you" ring around the viewer's own bloom (#684 §7) */
+  --meadow-name: #1e1c17; /* bloom name — AA 15.13:1 */
+  --meadow-name-muted: #6b6553; /* faded/zero names + zero-state — AA 5.17:1 */
+  --meadow-champion: #6d4b06; /* champion's score — AA 7.02:1 */
 
   /* ── Level track node colors ── */
   --color-level-inactive: #c8c0b0;

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -66,6 +66,16 @@
         "crown": "Crown = the lead",
         "faint": "Faint = still at zero"
       },
+      "meadowTaglineEra": "The nearer the front of the field, the higher you've climbed this era.",
+      "meadowTaglineAllTime": "The nearer the front of the field, the higher you've climbed of all time.",
+      "meadowLegend": {
+        "sizeEra": "Bigger bloom = more era points",
+        "sizeAllTime": "Bigger bloom = more all-time points",
+        "crown": "Golden bloom, out front = the lead",
+        "faint": "Pale bloom = still at zero"
+      },
+      "meadowZeroState": "The season is young — the seeds are sown, but nothing has bloomed yet.",
+      "meadowLabel": "The standings, drawn as a sunlit field of players.",
       "zeroState": "The era is young — no one has climbed yet.",
       "skyLabel": "The standings, drawn as a night sky of players.",
       "you": "You",

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -8,7 +8,9 @@ import { FACTION_RAINBOW_ORDER, factionCssVar } from '../utils/factions'
 import type { CharacterOut, CurrentUser } from '../api/auth'
 import { useFormFactor } from '../hooks/useFormFactor'
 import { pickVariant } from '../utils/factionDispatch'
-import { type RankedPlayer } from './players/Constellation'
+import { useTheme } from '../hooks/useTheme'
+import Constellation, { type RankedPlayer } from './players/Constellation'
+import Meadow from './players/Meadow'
 import SkyCanvas, { DESKTOP_SKY_MAX_WIDTH } from './players/SkyCanvas'
 import SkyLegend from './players/SkyLegend'
 import RosterTable from './players/RosterTable'
@@ -56,7 +58,10 @@ export default function Leaderboard() {
   )
 }
 
-function DesktopLeaderboard({
+/** Exported for the players tests: `<Leaderboard/>` renders its Loading branch
+ *  under `renderToStaticMarkup` (no effect ever resolves the fetch), so asserting
+ *  the theme→viz dispatch through the page wrapper would pass vacuously. */
+export function DesktopLeaderboard({
   characters,
   loading,
   error,
@@ -68,8 +73,15 @@ function DesktopLeaderboard({
   user: CurrentUser | null
 }) {
   const { t } = useTranslation('common')
+  const { theme } = useTheme()
   const [scoreMode, setScoreMode] = useState<ScoreMode>('era')
   const myCharId = user?.character?.id ?? null
+
+  // The viz is THEME-BOUND, not a user toggle (#684 §1): a night sky for dark,
+  // a sunlit field for light. `useTheme` is the shared reactive cell (#701), so
+  // flipping the theme swaps the viz live. Same props either way — the two are
+  // siblings, not a component and its re-skin.
+  const meadow = theme === 'light'
 
   const pointsOf = (character: CharacterOut) =>
     scoreMode === 'era' ? character.score : character.all_time_score
@@ -92,8 +104,13 @@ function DesktopLeaderboard({
     scoreMode === 'era'
       ? t('leaderboard.desktop.eyebrowEra', { era: user?.era_name ?? '' })
       : t('leaderboard.desktop.eyebrowAllTime')
-  const tagline =
-    scoreMode === 'era'
+  // The tagline names the ENCODING, so it has to follow the viz: the sky's
+  // "closer to the sun" is a lie over a field where rank is depth, not radius.
+  const tagline = meadow
+    ? scoreMode === 'era'
+      ? t('leaderboard.desktop.meadowTaglineEra')
+      : t('leaderboard.desktop.meadowTaglineAllTime')
+    : scoreMode === 'era'
       ? t('leaderboard.desktop.taglineEra')
       : t('leaderboard.desktop.taglineAllTime')
 
@@ -179,9 +196,10 @@ function DesktopLeaderboard({
           myCharId={myCharId}
           population={DESKTOP_SKY_POPULATION}
           maxWidth={DESKTOP_SKY_MAX_WIDTH}
+          viz={meadow ? Meadow : Constellation}
         />
 
-        <SkyLegend scoreMode={scoreMode} />
+        <SkyLegend scoreMode={scoreMode} variant={meadow ? 'meadow' : 'sky'} />
       </section>
 
       {/* ── Full roster ── */}

--- a/frontend/src/pages/players/Constellation.tsx
+++ b/frontend/src/pages/players/Constellation.tsx
@@ -18,7 +18,10 @@ interface ConstellationProps {
   players: RankedPlayer[]
   /** Highest score in the field; 0 triggers the zero state. */
   maxScore: number
-  /** The viewer's own character id — pinned on a tether if outside the sky. */
+  /** The viewer's own character id. Their orb gets a "you" ring when it is in
+   *  the sky; when it is not, the sky says nothing and the roster's your-rank
+   *  strip carries "where am I" (#684 §§6-7 — this used to pin them on a
+   *  tether, which drew a sigil at a radius its rank had not earned). */
   myCharId: number | null
   /** How many of the top players get a star. Mobile (#657) passes a smaller N. */
   population?: number
@@ -69,7 +72,6 @@ interface PlacedNode {
   size: number
   faded: boolean
   crowned: boolean
-  pinned: boolean
 }
 
 /**
@@ -122,7 +124,6 @@ export function placeOrbs(
       size: nodeSize(entry.points),
       faded: !zeroState && entry.points <= 0,
       crowned: !zeroState && index === 0,
-      pinned: false,
     }
   })
 }
@@ -143,26 +144,8 @@ export default function Constellation({
   const zeroState = maxScore <= 0
 
   const sky = players.slice(0, population)
-  const skyCount = sky.length
 
   const placed = placeOrbs(sky, radius, maxScore)
-
-  // Viewer outside the sky: pin their sigil just past the outermost ring on a
-  // dashed tether so it never implies a truthful radius.
-  const mine = myCharId != null ? players.find((p) => p.character.id === myCharId) : undefined
-  const pinnedRadius = radius + 58
-  const pinnedNode: PlacedNode | null =
-    mine && mine.rank > skyCount
-      ? {
-          entry: mine,
-          x: 0,
-          y: pinnedRadius,
-          size: NODE_MIN,
-          faded: !zeroState && mine.points <= 0,
-          crowned: false,
-          pinned: true,
-        }
-      : null
 
   const ringRadii = zeroState
     ? [radius]
@@ -231,20 +214,9 @@ export default function Constellation({
               fill="var(--sky-sparkle)"
             />
           ))}
-          {pinnedNode && (
-            <line
-              x1={centreX}
-              y1={centreY + radius}
-              x2={centreX + pinnedNode.x}
-              y2={centreY + pinnedNode.y}
-              stroke="var(--sky-tether)"
-              strokeWidth={1}
-              strokeDasharray="4 4"
-            />
-          )}
         </svg>
 
-        {[...placed, ...(pinnedNode ? [pinnedNode] : [])].map((node) => (
+        {placed.map((node) => (
           <SkyNode
             key={node.entry.character.id}
             node={node}
@@ -303,7 +275,7 @@ function SkyNode({
   isMe: boolean
 }) {
   const { t } = useTranslation('common')
-  const { entry, size, faded, crowned, pinned } = node
+  const { entry, size, faded, crowned } = node
   const character = entry.character
   // factionCssVar resolves an unknown slug to the `ua` theme, so unaffiliated
   // branches on isKnownFaction first (#636 / ADR-0039).
@@ -333,7 +305,17 @@ function SkyNode({
           already carries the faction ring, the sigil corner mark, the img/monogram
           fallback and the unaffiliated spectrum, so the bespoke circle + <img>
           this used to hand-roll is deleted. `glow` supplies the halo. */}
-      <span style={{ position: 'relative', lineHeight: 0, opacity: faded ? 0.4 : 1 }}>
+      <span
+        style={{
+          position: 'relative',
+          lineHeight: 0,
+          opacity: faded ? 0.4 : 1,
+          // The "you" ring, symmetric with the Meadow's (#684 §7). The sky had
+          // no self-marker at all — `isMe` only ever fed the deleted pin.
+          borderRadius: '50%',
+          boxShadow: isMe ? '0 0 0 2px var(--sky-you)' : undefined,
+        }}
+      >
         <FactionAvatar character={character} size={Math.round(size)} glow />
 
         {/* Rank badge — a small disc on the orb's shoulder. */}
@@ -373,31 +355,30 @@ function SkyNode({
 
       {/* Points, in the faction hue — or the shared .rainbow-ink gradient clip
           for unaffiliated, matching the roster row (#729 / ADR-0039). */}
-      {!pinned && (
-        <span
-          className={known ? 'font-body' : 'font-body rainbow-ink'}
-          style={{
-            fontSize: 'var(--text-content)',
-            fontWeight: 700,
-            lineHeight: 1.1,
-            // .rainbow-ink sets its own transparent colour — don't hand it one.
-            ...(known ? { color: pointsColor } : null),
-          }}
-        >
-          {entry.points}
-        </span>
-      )}
+      <span
+        className={known ? 'font-body' : 'font-body rainbow-ink'}
+        style={{
+          fontSize: 'var(--text-content)',
+          fontWeight: 700,
+          lineHeight: 1.1,
+          // .rainbow-ink sets its own transparent colour — don't hand it one.
+          ...(known ? { color: pointsColor } : null),
+        }}
+      >
+        {entry.points}
+      </span>
 
-      {pinned && (
+      {isMe && (
         <span
           className="font-body uppercase"
           style={{
-            fontSize: 'var(--text-sm)',
+            fontSize: 'var(--text-lg)',
             letterSpacing: '0.15em',
+            lineHeight: 1.1,
             color: 'var(--sky-name-muted)',
           }}
         >
-          {isMe ? t('leaderboard.desktop.you') : character.display_name}
+          {t('leaderboard.desktop.you')}
         </span>
       )}
     </Link>

--- a/frontend/src/pages/players/Meadow.tsx
+++ b/frontend/src/pages/players/Meadow.tsx
@@ -1,0 +1,460 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { CharacterOut } from '../../api/auth'
+import { factionCssVar, isKnownFaction, FACTION_RAINBOW_ORDER } from '../../utils/factions'
+import FactionAvatar from '../../components/avatar/FactionAvatar'
+import type { RankedPlayer } from './Constellation'
+
+/**
+ * The Meadow — the LIGHT-theme standings visualization (#684).
+ *
+ * Sibling of `Constellation`, not a re-skin of it: same props, same data, a
+ * genuinely different vessel. The sky encodes rank as ORBITAL RADIUS; the field
+ * encodes rank as DEPTH — the champion blooms front-and-centre and each lower
+ * rank stands farther back. Depth is strictly monotonic per flower, so "the
+ * frontmost flower is #1" is literally true for every pair, the same invariant
+ * the Vogel spiral earned in epic #654 §1.
+ *
+ * Size means SCORE and only score (√-scaled and clamped, identical floor/ceiling
+ * logic to the sky's `nodeSize`). There is deliberately NO perspective
+ * size-scaling for depth — that would make one channel carry two meanings and
+ * a distant champion could be out-sized by a near nobody (#684 §3).
+ */
+interface MeadowProps {
+  /** Full ranked list, descending. The field shows the top `population`. */
+  players: RankedPlayer[]
+  /** Highest score in the field; 0 triggers the zero state. */
+  maxScore: number
+  /** The viewer's own character id — highlighted when inside the field (§7). */
+  myCharId: number | null
+  /** How many of the top players get a bloom. Mobile (#657) passes a smaller N. */
+  population?: number
+  /** Measured coordinate box, supplied by `SkyCanvas` on both form factors.
+   *  Positions are computed in px so equal offsets are equal distances
+   *  regardless of the fluid column width (epic #654 §1). */
+  stageWidth: number
+  stageHeight: number
+}
+
+const GOLDEN_ANGLE_DEG = 137.5
+/** Petals per bloom — seven, one per faction, echoing the spectrum sigil. */
+const PETAL_COUNT = 7
+// Bloom diameters (px). Deliberately the same ramp as the sky's orbs so the two
+// viz read at the same weight when the theme flips.
+const BLOOM_MIN = 30
+const BLOOM_MAX = 92
+const BLOOM_ZERO_STATE = 44
+/** Headroom above the farthest row for its bloom. */
+const FIELD_TOP_MARGIN = 84
+/** Room below the front row for the champion's bloom, name and score stack. */
+const FIELD_BOTTOM_MARGIN = 128
+/** Side gutter so a wide bloom's name never clips the stage edge. */
+const FIELD_SIDE_MARGIN = 104
+/** How much the horizontal spread narrows toward the back, for a sense of
+ *  recession that costs the size channel nothing. */
+const BACK_ROW_NARROWING = 0.45
+/** Deterministic pollen motes, as fractions of the stage box. */
+const POLLEN: ReadonlyArray<{ fx: number; fy: number; r: number }> = [
+  { fx: 0.1, fy: 0.22, r: 2 },
+  { fx: 0.74, fy: 0.16, r: 1.6 },
+  { fx: 0.88, fy: 0.46, r: 2.2 },
+  { fx: 0.22, fy: 0.58, r: 1.5 },
+  { fx: 0.62, fy: 0.7, r: 1.9 },
+  { fx: 0.36, fy: 0.82, r: 1.4 },
+  { fx: 0.52, fy: 0.12, r: 1.7 },
+  { fx: 0.06, fy: 0.48, r: 1.4 },
+  { fx: 0.92, fy: 0.72, r: 1.5 },
+]
+/** Grass bands, as fractions of the stage height — pure ornament. */
+const FIELD_BANDS: readonly number[] = [0.42, 0.58, 0.76, 0.96]
+
+export interface PlacedBloom {
+  entry: RankedPlayer
+  /** px, from the stage's left edge / top edge. */
+  x: number
+  y: number
+  size: number
+  /** 0 = frontmost. Strictly increasing with rank; unique per bloom. */
+  depth: number
+  faded: boolean
+  champion: boolean
+}
+
+/**
+ * Deterministic placement for the field, extracted so the depth invariant can be
+ * asserted directly rather than fished out of the DOM (the repo's test harness is
+ * `renderToStaticMarkup` — there is no layout to measure).
+ *
+ * Scored field: `y` decreases strictly with rank index, so every pair of blooms
+ * has a well-defined front/back and no two share a depth. `x` is a golden-angle
+ * sine so neighbouring ranks never land in the same column, with the champion
+ * pinned dead centre at index 0 (`sin 0 = 0`).
+ *
+ * Zero state: depth-ranking is dropped entirely (#684 §5) — a uniform grid of
+ * equal buds, because nobody has bloomed and a front row would be a lie.
+ */
+export function placeBlooms(
+  field: RankedPlayer[],
+  stageWidth: number,
+  stageHeight: number,
+  maxScore: number,
+): PlacedBloom[] {
+  const zeroState = maxScore <= 0
+  const count = Math.max(field.length, 1)
+  const spreadHalf = Math.max(stageWidth / 2 - FIELD_SIDE_MARGIN, BLOOM_MIN)
+  const fieldDepth = Math.max(stageHeight - FIELD_TOP_MARGIN - FIELD_BOTTOM_MARGIN, BLOOM_MIN)
+  const frontY = stageHeight - FIELD_BOTTOM_MARGIN
+  const centreX = stageWidth / 2
+
+  const bloomSize = (points: number): number => {
+    if (zeroState) return BLOOM_ZERO_STATE
+    // sqrt scale, clamped — score maps to area-ish, never below the floor.
+    const fraction = Math.sqrt(Math.max(points, 0) / maxScore)
+    return BLOOM_MIN + (BLOOM_MAX - BLOOM_MIN) * Math.min(fraction, 1)
+  }
+
+  if (zeroState) {
+    // Even scatter: a grid across the field, alternate rows nudged half a cell
+    // so it reads as sown rather than as a spreadsheet.
+    const columns = Math.max(Math.ceil(Math.sqrt(count)), 1)
+    const rows = Math.ceil(count / columns)
+    return field.map((entry, index) => {
+      const column = index % columns
+      const row = Math.floor(index / columns)
+      const cellWidth = (spreadHalf * 2) / columns
+      const rowShift = row % 2 === 0 ? 0 : cellWidth / 2
+      return {
+        entry,
+        x: centreX - spreadHalf + cellWidth * (column + 0.5) + rowShift - cellWidth / 4,
+        y: FIELD_TOP_MARGIN + (fieldDepth * (row + 0.5)) / Math.max(rows, 1),
+        size: BLOOM_ZERO_STATE,
+        depth: index,
+        faded: false,
+        champion: false,
+      }
+    })
+  }
+
+  return field.map((entry, index) => {
+    // sqrt compresses the far rows, which is what recession looks like — and it
+    // is strictly increasing, so the depth invariant survives it.
+    const depthFraction = count > 1 ? Math.sqrt(index / (count - 1)) : 0
+    const amplitude = spreadHalf * (1 - BACK_ROW_NARROWING * depthFraction)
+    const angle = (index * GOLDEN_ANGLE_DEG * Math.PI) / 180
+    return {
+      entry,
+      x: centreX + amplitude * Math.sin(angle),
+      y: frontY - depthFraction * fieldDepth,
+      size: bloomSize(entry.points),
+      depth: index,
+      faded: entry.points <= 0,
+      champion: index === 0,
+    }
+  })
+}
+
+export default function Meadow({
+  players,
+  maxScore,
+  myCharId,
+  population = 12,
+  stageWidth,
+  stageHeight,
+}: MeadowProps) {
+  const { t } = useTranslation('common')
+
+  const zeroState = maxScore <= 0
+  const field = players.slice(0, population)
+  const placed = placeBlooms(field, stageWidth, stageHeight, maxScore)
+
+  return (
+    <div
+      className="rounded-2xl overflow-hidden"
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: stageHeight,
+        background: 'var(--meadow-bg)',
+      }}
+      role="img"
+      aria-label={t('leaderboard.desktop.meadowLabel')}
+    >
+      {/* Low sun behind the front of the field. */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: stageHeight * 0.72,
+          width: stageWidth * 1.1,
+          height: stageWidth * 1.1,
+          transform: 'translate(-50%, -50%)',
+          background: 'radial-gradient(circle, var(--meadow-glow), transparent 70%)',
+          pointerEvents: 'none',
+        }}
+      />
+
+      <div
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: 0,
+          width: stageWidth,
+          height: stageHeight,
+          transform: 'translateX(-50%)',
+        }}
+      >
+        {/* Grass bands and pollen sit under the blooms in one SVG. */}
+        <svg
+          width={stageWidth}
+          height={stageHeight}
+          style={{ position: 'absolute', left: 0, top: 0, pointerEvents: 'none' }}
+          aria-hidden
+        >
+          {FIELD_BANDS.map((fraction, index) => (
+            <ellipse
+              key={index}
+              cx={stageWidth / 2}
+              cy={stageHeight * fraction}
+              rx={stageWidth * (0.5 + index * 0.12)}
+              ry={stageHeight * 0.07}
+              fill="var(--meadow-field)"
+            />
+          ))}
+          {POLLEN.map((mote, index) => (
+            <circle
+              key={index}
+              cx={mote.fx * stageWidth}
+              cy={mote.fy * stageHeight}
+              r={mote.r}
+              fill="var(--meadow-pollen)"
+            />
+          ))}
+        </svg>
+
+        {placed.map((bloom) => (
+          <Bloom
+            key={bloom.entry.character.id}
+            bloom={bloom}
+            stackHeight={placed.length}
+            isMe={bloom.entry.character.id === myCharId}
+          />
+        ))}
+      </div>
+
+      {zeroState && (
+        <p
+          className="font-body content-text"
+          style={{
+            position: 'absolute',
+            left: '50%',
+            bottom: 0,
+            transform: 'translateX(-50%)',
+            textAlign: 'center',
+            maxWidth: 300,
+            color: 'var(--meadow-name-muted)',
+          }}
+        >
+          {t('leaderboard.desktop.meadowZeroState')}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** A single flower: petals in the faction hue, avatar as the centre disc.
+ *  Exported so the legend can draw the same glyph rather than a second flower. */
+export function MeadowBloom({
+  size,
+  character,
+  champion = false,
+}: {
+  size: number
+  character?: CharacterOut
+  champion?: boolean
+}) {
+  const slug = character?.faction_slug ?? null
+  // factionCssVar resolves an unknown slug to the `ua` theme, so unaffiliated
+  // branches on isKnownFaction first (#636 / ADR-0039).
+  const known = isKnownFaction(slug)
+  const petalColor = (index: number): string => {
+    if (champion) return 'var(--meadow-champion-petal)'
+    // Unaffiliated wears the whole spectrum — one faction per petal, canonical
+    // order — rather than borrowing any single faction's hue (ADR-0039).
+    if (!known) return factionCssVar(FACTION_RAINBOW_ORDER[index % FACTION_RAINBOW_ORDER.length])
+    return factionCssVar(slug)
+  }
+  const washColor = champion ? 'var(--meadow-champion-petal)' : factionCssVar(slug, 'light')
+
+  return (
+    <span style={{ position: 'relative', display: 'block', width: size, height: size }}>
+      {/* Ornament geometry: the 100×100 viewBox is illustration, not layout. */}
+      <svg width={size} height={size} viewBox="0 0 100 100" aria-hidden>
+        {Array.from({ length: PETAL_COUNT }, (_, index) => (
+          <ellipse
+            key={`wash-${index}`}
+            cx={50}
+            cy={28}
+            rx={17}
+            ry={26}
+            fill={known || champion ? washColor : 'none'}
+            transform={`rotate(${(index * 360) / PETAL_COUNT + 180 / PETAL_COUNT} 50 50)`}
+          />
+        ))}
+        {Array.from({ length: PETAL_COUNT }, (_, index) => (
+          <ellipse
+            key={index}
+            cx={50}
+            cy={30}
+            rx={14}
+            ry={22}
+            fill={petalColor(index)}
+            transform={`rotate(${(index * 360) / PETAL_COUNT} 50 50)`}
+          />
+        ))}
+      </svg>
+      {character && (
+        <span
+          style={{
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            transform: 'translate(-50%, -50%)',
+            lineHeight: 0,
+          }}
+        >
+          {/* The centre disc IS the roster avatar — FactionAvatar already carries
+              the portrait, the monogram fallback, the faction ring and the
+              unaffiliated spectrum, so there is no second face renderer here. */}
+          <FactionAvatar character={character} size={Math.round(size * 0.44)} />
+        </span>
+      )}
+    </span>
+  )
+}
+
+function Bloom({
+  bloom,
+  stackHeight,
+  isMe,
+}: {
+  bloom: PlacedBloom
+  stackHeight: number
+  isMe: boolean
+}) {
+  const { t } = useTranslation('common')
+  const { entry, size, faded, champion, depth } = bloom
+  const character = entry.character
+  const badgeDim = Math.max(18, Math.round(size * 0.3))
+  const stemHeight = Math.round(size * 0.42)
+
+  return (
+    <Link
+      to={`/characters/${character.id}`}
+      className="font-display"
+      style={{
+        position: 'absolute',
+        left: bloom.x,
+        top: bloom.y,
+        // Frontmost = rank 1: the depth order IS the paint order, so a nearer
+        // bloom always overlaps a farther one.
+        zIndex: stackHeight - depth,
+        transform: 'translate(-50%, -50%)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textDecoration: 'none',
+        width: Math.max(size, 84),
+      }}
+    >
+      <span
+        style={{
+          position: 'relative',
+          lineHeight: 0,
+          opacity: faded ? 0.45 : 1,
+          // The "you" ring: a soft outline, present only when the viewer is
+          // actually in the field (#684 §7).
+          borderRadius: '50%',
+          boxShadow: isMe ? '0 0 0 2px var(--meadow-you)' : undefined,
+        }}
+      >
+        <MeadowBloom size={size} character={character} champion={champion} />
+
+        {/* Rank number, on the bloom's shoulder. */}
+        <span
+          className="font-body flex items-center justify-center"
+          aria-hidden
+          style={{
+            position: 'absolute',
+            left: -badgeDim / 3,
+            top: -badgeDim / 3,
+            width: badgeDim,
+            height: badgeDim,
+            borderRadius: '50%',
+            background: 'var(--meadow-bg)',
+            border: '1px solid var(--meadow-name-muted)',
+            color: 'var(--meadow-name)',
+            fontSize: 'var(--text-sm)',
+            lineHeight: 1,
+          }}
+        >
+          {entry.rank}
+        </span>
+      </span>
+
+      {/* Stem — ornament geometry, exempt from the spacing ramp (#684 §4a). */}
+      <span
+        aria-hidden
+        style={{ width: 2, height: stemHeight, background: 'var(--meadow-stem)', flex: 'none' }}
+      />
+
+      <span
+        className="italic truncate"
+        style={{
+          fontSize: 'var(--text-content)',
+          maxWidth: '100%',
+          textAlign: 'center',
+          color: faded ? 'var(--meadow-name-muted)' : 'var(--meadow-name)',
+          lineHeight: 1.1,
+        }}
+      >
+        {character.display_name}
+      </span>
+
+      {/* Points, in INK — never a faction hue. The petals already carry the
+          faction; #684 §9 keeps every text-bearing token on measured ink, exactly
+          as the sky keeps its names near-white. The champion gets the gilt ink.
+          Every bloom prints its points, matching the sky's orbs (#730 §2) — §8's
+          "champion's score printed below" predates that change. */}
+      <span
+        className="font-body"
+        style={{
+          fontSize: 'var(--text-content)',
+          fontWeight: 700,
+          lineHeight: 1.1,
+          color: champion
+            ? 'var(--meadow-champion)'
+            : faded
+              ? 'var(--meadow-name-muted)'
+              : 'var(--meadow-name)',
+        }}
+      >
+        {entry.points}
+      </span>
+
+      {isMe && (
+        <span
+          className="font-body uppercase"
+          style={{
+            fontSize: 'var(--text-lg)',
+            letterSpacing: '0.15em',
+            lineHeight: 1.1,
+            color: 'var(--meadow-name-muted)',
+          }}
+        >
+          {t('leaderboard.desktop.you')}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/frontend/src/pages/players/SkyCanvas.tsx
+++ b/frontend/src/pages/players/SkyCanvas.tsx
@@ -1,5 +1,16 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ComponentType } from 'react'
 import Constellation, { type RankedPlayer } from './Constellation'
+
+/** What a visualization must accept to be swappable into this canvas. The
+ *  Constellation and the Meadow are siblings on exactly these props (#684 §2). */
+export interface PlayersVizProps {
+  players: RankedPlayer[]
+  maxScore: number
+  myCharId: number | null
+  population?: number
+  stageWidth: number
+  stageHeight: number
+}
 
 /** Desktop cap. Uncapped the sky sprawls on an ultrawide and shoves the roster
  *  far down the page; 900px keeps it a hero, not a horizon (#730 §1). */
@@ -25,6 +36,10 @@ export interface SkyCanvasProps {
   /** Cap the stage; omit for the phone, where the column is the cap. */
   maxWidth?: number
   aspect?: number
+  /** Which viz to draw into the measured stage. Defaults to the Constellation,
+   *  so mobile (#657's concern, still sky-only) is untouched; the desktop
+   *  Leaderboard passes the Meadow under the light theme (#684 §§2, 10). */
+  viz?: ComponentType<PlayersVizProps>
 }
 
 /**
@@ -47,6 +62,7 @@ export default function SkyCanvas({
   population,
   maxWidth,
   aspect = DESKTOP_SKY_ASPECT,
+  viz: Viz = Constellation,
 }: SkyCanvasProps) {
   const ref = useRef<HTMLDivElement>(null)
   // Seeded, never 0: see FALLBACK_SKY_WIDTH. The measurement then corrects it on
@@ -68,7 +84,7 @@ export default function SkyCanvas({
 
   return (
     <div ref={ref} className="mx-auto" style={{ maxWidth }}>
-      <Constellation
+      <Viz
         players={players}
         maxScore={maxScore}
         myCharId={myCharId}

--- a/frontend/src/pages/players/SkyLegend.tsx
+++ b/frontend/src/pages/players/SkyLegend.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SkyCrown } from './Constellation'
+import { MeadowBloom } from './Meadow'
 
 /**
  * The sky's key, as three icon chips (#730 §3).
@@ -15,30 +16,51 @@ import { SkyCrown } from './Constellation'
  */
 export interface SkyLegendProps {
   scoreMode: 'era' | 'alltime'
+  /** Which viz the legend is the key TO. The three chips mean the same three
+   *  things in both, but the wording and the glyphs have to match what is
+   *  actually on the canvas — a "Crown = the lead" chip under a meadow that has
+   *  no crown is the mock-style lie epic #654 was grilled to prevent (#684). */
+  variant?: 'sky' | 'meadow'
 }
 
-export default function SkyLegend({ scoreMode }: SkyLegendProps) {
+export default function SkyLegend({ scoreMode, variant = 'sky' }: SkyLegendProps) {
   const { t } = useTranslation('common')
+  const meadow = variant === 'meadow'
+  const group = meadow ? 'meadowLegend' : 'legend'
 
   return (
     <ul
       className="flex flex-wrap items-center list-none mt-3 p-0 m-0"
       style={{ gap: 'var(--space-lg)' }}
     >
-      <LegendChip icon={<SigilScaleIcon />}>
+      <LegendChip variant={variant} icon={<SigilScaleIcon variant={variant} />}>
         {scoreMode === 'era'
-          ? t('leaderboard.desktop.legend.sizeEra')
-          : t('leaderboard.desktop.legend.sizeAllTime')}
+          ? t(`leaderboard.desktop.${group}.sizeEra`)
+          : t(`leaderboard.desktop.${group}.sizeAllTime`)}
       </LegendChip>
-      <LegendChip icon={<SkyCrown size={20} />}>
-        {t('leaderboard.desktop.legend.crown')}
+      <LegendChip
+        variant={variant}
+        icon={meadow ? <MeadowBloom size={22} champion /> : <SkyCrown size={20} />}
+      >
+        {t(`leaderboard.desktop.${group}.crown`)}
       </LegendChip>
-      <LegendChip icon={<FaintOrbIcon />}>{t('leaderboard.desktop.legend.faint')}</LegendChip>
+      <LegendChip variant={variant} icon={<FaintOrbIcon variant={variant} />}>
+        {t(`leaderboard.desktop.${group}.faint`)}
+      </LegendChip>
     </ul>
   )
 }
 
-function LegendChip({ icon, children }: { icon: ReactNode; children: ReactNode }) {
+function LegendChip({
+  icon,
+  children,
+  variant,
+}: {
+  icon: ReactNode
+  children: ReactNode
+  variant: 'sky' | 'meadow'
+}) {
+  const meadow = variant === 'meadow'
   return (
     <li className="flex items-center" style={{ gap: 'var(--space-sm)' }}>
       <span
@@ -49,8 +71,8 @@ function LegendChip({ icon, children }: { icon: ReactNode; children: ReactNode }
           width: 34,
           height: 34,
           flex: 'none',
-          background: 'var(--sky-bg)',
-          border: '1px solid var(--sky-ring)',
+          background: meadow ? 'var(--meadow-bg)' : 'var(--sky-bg)',
+          border: `1px solid ${meadow ? 'var(--meadow-field)' : 'var(--sky-ring)'}`,
         }}
       >
         {icon}
@@ -62,21 +84,34 @@ function LegendChip({ icon, children }: { icon: ReactNode; children: ReactNode }
   )
 }
 
-/** Two sigil dots, small beside large — "bigger sigil = more points". */
-function SigilScaleIcon() {
+/** Two dots, small beside large — "bigger sigil/bloom = more points". */
+function SigilScaleIcon({ variant }: { variant: 'sky' | 'meadow' }) {
+  const meadow = variant === 'meadow'
   return (
     <svg width={24} height={20} viewBox="0 0 24 20" aria-hidden>
-      <circle cx={6} cy={13} r={3.5} fill="var(--sky-name-muted)" />
-      <circle cx={16} cy={10} r={7} fill="var(--sky-crown)" opacity={0.9} />
+      <circle cx={6} cy={13} r={3.5} fill={meadow ? 'var(--meadow-stem)' : 'var(--sky-name-muted)'} />
+      <circle
+        cx={16}
+        cy={10}
+        r={7}
+        fill={meadow ? 'var(--meadow-champion-petal)' : 'var(--sky-crown)'}
+        opacity={0.9}
+      />
     </svg>
   )
 }
 
-/** One barely-there orb — "faint = still at zero". */
-function FaintOrbIcon() {
+/** One barely-there orb/bloom — "faint = still at zero". */
+function FaintOrbIcon({ variant }: { variant: 'sky' | 'meadow' }) {
   return (
     <svg width={20} height={20} viewBox="0 0 20 20" aria-hidden>
-      <circle cx={10} cy={10} r={7} fill="var(--sky-name)" opacity={0.25} />
+      <circle
+        cx={10}
+        cy={10}
+        r={7}
+        fill={variant === 'meadow' ? 'var(--meadow-name)' : 'var(--sky-name)'}
+        opacity={0.25}
+      />
     </svg>
   )
 }

--- a/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
@@ -16,10 +16,17 @@ import type { CharacterOut, CurrentUser } from '../../../api/auth'
 
 const mocks = vi.hoisted(() => ({
   formFactor: 'desktop' as 'mobile' | 'desktop',
+  theme: 'dark' as 'light' | 'dark',
 }))
 
 vi.mock('../../../hooks/useFormFactor', () => ({
   useFormFactor: () => mocks.formFactor,
+}))
+// The viz dispatch reads the shared reactive theme cell (#701). Driving the hook
+// directly is the dispatch decision itself — there is no DOM here for a real
+// `[data-theme]` attribute to cascade through.
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: mocks.theme, toggle: () => {} }),
 }))
 vi.mock('../../../auth/AuthContext', () => ({
   useAuth: () => ({ user: null as CurrentUser | null }),
@@ -28,9 +35,10 @@ vi.mock('../../../api/leaderboard', () => ({
   getLeaderboard: async () => [],
 }))
 
-import Leaderboard from '../../Leaderboard'
+import Leaderboard, { DesktopLeaderboard } from '../../Leaderboard'
 import DefaultPlayers from '../mobileArchetypes/DefaultPlayers'
 import Constellation, { skyRadius, type RankedPlayer } from '../Constellation'
+import Meadow, { placeBlooms } from '../Meadow'
 import SkyCanvas, { DESKTOP_SKY_MAX_WIDTH } from '../SkyCanvas'
 import SkyLegend from '../SkyLegend'
 import RosterTable from '../RosterTable'
@@ -130,6 +138,151 @@ describe('desktop constellation (#656)', () => {
     )
     expect(html).toContain('rainbow-ink')
   })
+
+  // #684 §§6-7: the pin/tether is GONE (it drew a sigil at a radius its rank had
+  // not earned); the sky gains the same in-viz "you" ring the meadow has.
+  it('rings the viewer own orb when in the sky, and never pins them when not', () => {
+    const inSky = render(
+      <Constellation players={ranked(PLAYERS)} maxScore={2140} myCharId={22} {...STAGE} />,
+    )
+    expect(inSky.html).toContain('--sky-you')
+    expect(inSky.text).toContain('You')
+
+    const outside = render(
+      <Constellation players={ranked(PLAYERS)} maxScore={2140} myCharId={999} population={2} {...STAGE} />,
+    )
+    expect(outside.html, 'no dashed tether survives').not.toContain('stroke-dasharray')
+    expect(outside.html, 'no pinned sigil outside the top N').not.toContain('href="/characters/33"')
+    expect(outside.html).not.toContain('--sky-you')
+  })
+})
+
+describe('light-theme meadow (#684)', () => {
+  it('links every bloom to its public profile, champion first', () => {
+    const { html } = render(
+      <Meadow players={ranked(PLAYERS)} maxScore={2140} myCharId={null} {...STAGE} />,
+    )
+    expect(html).toContain('href="/characters/11"')
+    expect(html).toContain('href="/characters/22"')
+    expect(html).toContain('href="/characters/33"')
+    // Champion first in document order — the field is painted front-to-back.
+    expect(html.indexOf('href="/characters/11"')).toBeLessThan(html.indexOf('href="/characters/22"'))
+  })
+
+  it('shows the meadow zero state and no golden champion when nothing has bloomed', () => {
+    const flat = PLAYERS.map((c) => ({ ...c, score: 0 }))
+    const { text, html } = render(
+      <Meadow players={ranked(flat)} maxScore={0} myCharId={null} {...STAGE} />,
+    )
+    expect(text, 'meadow copy, not the sky wording').toContain('The season is young')
+    expect(text).not.toContain('The era is young')
+    expect(html, 'no golden bloom in the zero state').not.toContain('--meadow-champion-petal')
+  })
+
+  it('rings the viewer own bloom only when they are in the field (§7)', () => {
+    const inField = render(
+      <Meadow players={ranked(PLAYERS)} maxScore={2140} myCharId={22} {...STAGE} />,
+    )
+    expect(inField.html).toContain('--meadow-you')
+    expect(inField.text).toContain('You')
+
+    const outsideField = render(
+      <Meadow players={ranked(PLAYERS)} maxScore={2140} myCharId={999} {...STAGE} />,
+    )
+    expect(outsideField.html, 'outside the top N the field says nothing').not.toContain(
+      '--meadow-you',
+    )
+  })
+
+  // The unaffiliated spectrum is never a single faction hue (ADR-0039): the
+  // `na` bloom wears one faction per petal.
+  it('paints an unaffiliated bloom with the whole spectrum, not one faction', () => {
+    const { html } = render(
+      <Meadow players={ranked(PLAYERS)} maxScore={2140} myCharId={null} {...STAGE} />,
+    )
+    expect(html).toContain('--faction-everymen')
+    expect(html).toContain('--faction-albescent')
+  })
+})
+
+// §3's load-bearing invariant. Asserted on the placement function, not the DOM —
+// there is no layout engine in this harness to measure.
+describe('meadow depth placement (#684 §3)', () => {
+  const MANY = Array.from({ length: 12 }, (_, index) =>
+    player({ id: 100 + index, display_name: `P${index}`, score: 1200 - index * 90 }),
+  )
+
+  it('gives every bloom a unique, strictly increasing depth', () => {
+    const blooms = placeBlooms(ranked(MANY), 900, 765, 1200)
+    const depths = blooms.map((b) => b.depth)
+    expect(new Set(depths).size, 'no two blooms share a depth').toBe(blooms.length)
+    for (let index = 1; index < blooms.length; index += 1) {
+      expect(depths[index], `rank ${index + 1} stands behind rank ${index}`).toBeGreaterThan(
+        depths[index - 1],
+      )
+      // Farther back = higher on the stage. Strict, so "the frontmost flower is
+      // #1" holds for every PAIR, not just for the champion.
+      expect(blooms[index].y).toBeLessThan(blooms[index - 1].y)
+    }
+  })
+
+  it('sizes blooms by score alone — never by depth', () => {
+    const blooms = placeBlooms(ranked(MANY), 900, 765, 1200)
+    for (let index = 1; index < blooms.length; index += 1) {
+      expect(blooms[index].size).toBeLessThan(blooms[index - 1].size)
+    }
+    // Two equal scores at different depths must be the same size.
+    const tied = ranked([
+      player({ id: 1, score: 500 }),
+      player({ id: 2, score: 500 }),
+      player({ id: 3, score: 900 }),
+    ])
+    const placed = placeBlooms(tied, 900, 765, 900)
+    const equalScored = placed.filter((b) => b.entry.points === 500)
+    expect(equalScored[0].size).toBe(equalScored[1].size)
+    expect(equalScored[0].y).not.toBe(equalScored[1].y)
+  })
+
+  it('drops depth ranking entirely in the zero state — uniform, even scatter', () => {
+    const flat = MANY.map((c) => ({ ...c, score: 0 }))
+    const blooms = placeBlooms(ranked(flat), 900, 765, 0)
+    const sizes = new Set(blooms.map((b) => b.size))
+    expect(sizes.size, 'every bud is the same size').toBe(1)
+    expect(blooms.some((b) => b.champion), 'nobody leads a field nobody has bloomed in').toBe(false)
+  })
+
+  it('is deterministic — the same input places identically', () => {
+    const first = placeBlooms(ranked(MANY), 900, 765, 1200)
+    const second = placeBlooms(ranked(MANY), 900, 765, 1200)
+    expect(first.map((b) => [b.x, b.y])).toEqual(second.map((b) => [b.x, b.y]))
+  })
+})
+
+describe('theme-bound viz dispatch (#684 §1)', () => {
+  // Rendered through DesktopLeaderboard, NOT <Leaderboard/>: the page wrapper
+  // shows "Loading…" here (no effect resolves the fetch), so a dispatch
+  // assertion against it would pass with nothing on screen.
+  const board = () => (
+    <DesktopLeaderboard characters={PLAYERS} loading={false} error={null} user={null} />
+  )
+
+  it('draws the meadow, in meadow words, under the light theme', () => {
+    mocks.theme = 'light'
+    const { html, text } = render(board())
+    expect(html, 'the meadow is really on screen').toContain('sunlit field of players')
+    expect(html).not.toContain('night sky of players')
+    expect(text, 'the tagline follows the encoding').toContain('nearer the front of the field')
+    expect(text).toContain('Bigger bloom')
+  })
+
+  it('draws the constellation, in sky words, under the dark theme', () => {
+    mocks.theme = 'dark'
+    const { html, text } = render(board())
+    expect(html).toContain('night sky of players')
+    expect(html).not.toContain('sunlit field of players')
+    expect(text).toContain('closer to the sun')
+    expect(text).toContain('Bigger sigil')
+  })
 })
 
 describe('sky legend (#730 §3)', () => {
@@ -144,6 +297,16 @@ describe('sky legend (#730 §3)', () => {
     const { text } = render(<SkyLegend scoreMode="alltime" />)
     expect(text).toContain('more all-time points')
     expect(text).toContain('Crown')
+  })
+
+  // The legend is the KEY to the encoding, so it has to describe the viz that is
+  // actually on screen — the meadow has blooms and no crown (#684).
+  it('keys the meadow in meadow words, with no crown', () => {
+    const { text } = render(<SkyLegend scoreMode="era" variant="meadow" />)
+    expect(text).toContain('Bigger bloom = more era points')
+    expect(text).toContain('Golden bloom')
+    expect(text).not.toContain('Crown')
+    expect(text).not.toContain('sigil')
   })
 })
 


### PR DESCRIPTION
Adds **the Meadow** — the light-theme standings visualization for `/leaderboard` — as a sibling of the Constellation rather than a re-skin of it.

Closes #684

## What landed

- **`pages/players/Meadow.tsx`** (new). Same props as `Constellation`, so it drops into `SkyCanvas` unchanged. Rank → **depth** (strictly monotonic, unique per bloom, so "the frontmost flower is #1" holds for every *pair*); score → **bloom size** only (√-scaled, clamped, identical floor/ceiling to the sky's `nodeSize` — deliberately no perspective size-scaling, which would make one channel carry two meanings). Placement is a pure exported `placeBlooms()` in px.
- **Flower anatomy.** Seven petals (one per faction, echoing the spectrum sigil), faction hue + its `light` wash; `FactionAvatar` as the centre disc; stem; italic name; champion = golden bloom, frontmost, no crown, score in gilt ink.
- **Unaffiliated** blooms wear one faction colour *per petal* in canonical `FACTION_RAINBOW_ORDER` rather than borrowing a single hue (ADR-0039 — `factionCssVar` resolves `na` to the `ua` theme, so this branches on `isKnownFaction` first).
- **Zero state** (`maxScore <= 0`): depth-ranking dropped entirely — uniform buds on an even grid, with its own meadow copy key.
- **Theme dispatch** in `Leaderboard.tsx` via the reactive `useTheme` (#701). `SkyCanvas` gained an optional `viz` prop defaulting to `Constellation`, so mobile (#657's concern) is untouched.
- **Pinning removed from the Constellation** (§6): `pinnedNode`, the dashed tether `<line>`, the `pinned` label branch and the now-dead `--sky-tether` token are gone.
- **Symmetric "you" marker** (§7): both viz now ring the viewer's own node when they are inside the top N, and show nothing when they are not.

## Measured AA — every text-bearing `--meadow-*` token

All against `--meadow-bg: #eef4e2` (relative luminance 0.8835). Ink, never a faction hue — faction colour lives in the petals only.

| Token | Value | Ratio | AA (4.5:1) |
|---|---|---|---|
| `--meadow-name` | `#1e1c17` | **15.13:1** | pass |
| `--meadow-champion` | `#6d4b06` | **7.02:1** | pass |
| `--meadow-name-muted` | `#6b6553` | **5.17:1** | pass |

Decorative tokens (`--meadow-bg`, `--meadow-glow`, `--meadow-field`, `--meadow-stem`, `--meadow-pollen`, `--meadow-champion-petal`, `--meadow-you`) carry no AA duty — the same carve-out the `--sky-*` ornament tokens got. Ratios are documented inline in `index.css` next to the sky block.

## Two judgement calls worth a look

1. **The legend and the tagline follow the viz.** The issue is silent on both, but "Crown = the lead" and "the closer to the sun" are *false* over a field where rank is depth and there is no crown — exactly the mock-style lie epic #654 was grilled to prevent. `SkyLegend` gained a `variant` prop and there are four new meadow copy keys. Say the word if you'd rather ship the sky wording under both.
2. **Every bloom prints its points**, not just the champion. §8 says "champion's score printed below, same as today" — but that predates #730 §2, which put points on *every* orb. Matching the sibling seemed truer to §8's own "informationally equivalent to a star" than matching its literal sentence.

## Verification

- `tsc --noEmit`: **no errors in any changed file.** (8 pre-existing `Cannot find module 'node:fs'` errors in three untouched test files — `@types/node` is genuinely absent from the local `node_modules`; CI's `npm ci` resolves it.)
- `vitest run`: **925/925 passing, 102 files** — 28 in the players suite, 10 of them new.
- `eslint`: **0 errors, 0 warnings** on `Meadow.tsx` (verified via `--format json` that the file was actually linted, not ignored) and across `pages/players` + `Leaderboard.tsx`. The new file is not on the grandfather list; no raw `fontSize`/`padding`/`margin`/`gap`.
- `vite build`: clean.

Two test notes: `<Leaderboard/>` renders its **Loading** branch under `renderToStaticMarkup` (no effect resolves the fetch), so the dispatch test renders `DesktopLeaderboard` directly — asserting through the page wrapper would have passed with nothing on screen. And the depth invariant is asserted on `placeBlooms()` directly, since there is no layout engine here to measure.

The issue asked for the Constellation's dead pinning assertions to be removed — **there were none to remove.** The tests never covered pinning; a new test now pins the *absence* of the tether and the pinned sigil.

## What to eyeball — visual QA is outstanding

I cannot screenshot and there is no dev stack here, so **nothing below has been seen by a human or a browser**. Everything above is tsc/vitest/eslint/build evidence only.

- Light theme: the meadow field as a whole — does the recession read without size-scaling?
- Dark theme: the constellation, unchanged apart from the removed tether.
- Toggling the theme live — the swap should be instant (this is what #701 bought).
- The champion bloom: golden, frontmost, score below.
- An **`na` (unaffiliated)** player's petals — the seven-faction spectrum, one hue per petal.
- The **zero-score field**: uniform buds, even scatter, meadow copy, no gold anywhere.
- The **"you" ring**, both when the viewer *is* in the top 12 and when they are *not* (nothing should appear in the viz in the second case) — in **both** viz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
