### PR TITLE
Tokenize spacing in characterProfile/fieldDesk/characterPaths/settings (#750 slice 6) + delist

### DIFF
--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -1,5 +1,3 @@
-src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
-src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
 src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
 src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
 src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -1,9 +1,1 @@
-src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
-src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
-src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
-src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
-src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
-src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
-src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
-src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
 src/pages/Leaderboard.tsx

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -1,6 +1,5 @@
 src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
 src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
-src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
 src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
 src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
 src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
@@ -10,4 +9,3 @@ src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
 src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
 src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
 src/pages/Leaderboard.tsx
-src/pages/settings/mobileArchetypes/DefaultSettings.tsx

--- a/frontend/.eslint-legacy-raw-styles.txt
+++ b/frontend/.eslint-legacy-raw-styles.txt
@@ -1,14 +1,5 @@
 src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
 src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
-src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
-src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
-src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
-src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
-src/pages/characterProfile/archetypes/profileSkin.tsx
-src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
-src/pages/characterProfile/archetypes/SnideProfileBody.tsx
-src/pages/characterProfile/archetypes/UaProfileBody.tsx
-src/pages/characterProfile/archetypes/WowProfileBody.tsx
 src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
 src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
 src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
@@ -57,15 +57,22 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
             {avatarPreview ? (
               <img src={avatarPreview} alt={handle} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : (
-              // ornament: "+" is a glyph-as-icon, sized to the 104px photo ring, not text
-              <span style={{ fontSize: 26, color: 'var(--color-text-secondary)' }}>+</span>
+              <span
+                style={{
+                  // eslint-disable-next-line local/no-raw-style-values -- ornament: "+" is a glyph-as-icon, sized to the 104px photo ring, not text
+                  fontSize: 26,
+                  color: 'var(--color-text-secondary)',
+                }}
+              >
+                +
+              </span>
             )}
           </span>
         </button>
-        <div className="eyebrow" style={{ marginTop: 12, color: 'var(--faction-default-card-muted)' }}>
+        <div className="eyebrow" style={{ marginTop: 'var(--space-md)', color: 'var(--faction-default-card-muted)' }}>
           {avatarPreview ? t('createCharacter.mobile.changePhoto') : t('createCharacter.mobile.addPhoto')}
         </div>
-        <div className="eyebrow" style={{ marginTop: 6, color: 'var(--color-text-tertiary)' }}>
+        <div className="eyebrow" style={{ marginTop: 'var(--space-sm)', color: 'var(--color-text-tertiary)' }}>
           {t('createCharacter.mobile.step')}
         </div>
       </div>
@@ -95,7 +102,7 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
       {showPicker && (
         <div>
           <label style={label}>{t('createCharacter.callingLabel')}</label>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)', marginTop: 'var(--space-sm)' }}>
             {invited.map((slug) => {
               const selected = factionSlug === slug
               return (
@@ -147,15 +154,19 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
 
 // --- token-driven styles (single column, no hardcoded hex) ------------------
 
-const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 22, paddingBottom: 96 }
+const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 'var(--space-xl)', paddingBottom: 'var(--space-6xl)' }
 const topRow: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
 const backBtn: CSSProperties = {
   width: 28, height: 28, background: 'none', border: 'none', cursor: 'pointer',
-  // ornament: the back chevron is a glyph-as-icon sized to its 28px hit target
-  fontSize: 24, lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
+  // eslint-disable-next-line local/no-raw-style-values -- ornament: the back chevron is a glyph-as-icon sized to its 28px hit target
+  fontSize: 24,
+  lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
 }
 const ringBtn: CSSProperties = {
-  width: 104, height: 104, borderRadius: '50%', padding: 3, cursor: 'pointer',
+  width: 104, height: 104, borderRadius: '50%',
+  // eslint-disable-next-line local/no-raw-style-values -- ornament: rainbow ring thickness drawn around the 104px photo well; the nearest rung (4px) thickens the band by a third.
+  padding: 3,
+  cursor: 'pointer',
   border: 'none', background: 'var(--faction-default-rainbow)',
 }
 const ringInner: CSSProperties = {
@@ -168,19 +179,19 @@ const label: CSSProperties = {
   color: 'var(--color-text-secondary)',
 }
 const field: CSSProperties = {
-  display: 'block', width: '100%', marginTop: 8, boxSizing: 'border-box',
+  display: 'block', width: '100%', marginTop: 'var(--space-sm)', boxSizing: 'border-box',
   background: 'var(--color-bg-page)', border: '1px solid var(--color-border-strong)',
   borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)',
-  color: 'var(--color-text-primary)', padding: '12px 13px',
+  color: 'var(--color-text-primary)', padding: 'var(--space-md)',
 }
 const metaRow: CSSProperties = {
-  display: 'flex', justifyContent: 'space-between', marginTop: 6,
+  display: 'flex', justifyContent: 'space-between', marginTop: 'var(--space-sm)',
   fontFamily: 'var(--font-body)', fontSize: 'var(--text-base)',
 }
 const pickerCell: CSSProperties = {
-  display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer', width: '100%',
+  display: 'flex', alignItems: 'center', gap: 'var(--space-md)', cursor: 'pointer', width: '100%',
   background: 'var(--color-bg-surface)', border: '1px solid var(--color-border-strong)',
-  borderRadius: 8, padding: '13px 14px', textAlign: 'left',
+  borderRadius: 8, padding: 'var(--space-md) var(--space-lg)', textAlign: 'left',
 }
 const help: CSSProperties = {
   fontFamily: 'var(--font-body)', lineHeight: 1.6,
@@ -188,17 +199,17 @@ const help: CSSProperties = {
 }
 const errorBox: CSSProperties = {
   fontFamily: 'var(--font-body)', color: 'var(--color-danger)',
-  border: '1px solid var(--color-danger)', borderRadius: 6, padding: '10px 12px', margin: 0,
+  border: '1px solid var(--color-danger)', borderRadius: 6, padding: 'var(--space-md)', margin: 0,
 }
 const stickyBar: CSSProperties = {
   position: 'sticky',
   bottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
   marginTop: 'auto',
-  paddingTop: 8,
+  paddingTop: 'var(--space-sm)',
 }
 const primaryBtn: CSSProperties = {
   width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-xl)',
   letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700,
   color: 'var(--color-bg-page)', background: 'var(--color-text-primary)',
-  border: 'none', padding: '15px 24px', borderRadius: 12,
+  border: 'none', padding: 'var(--space-lg) var(--space-xl)', borderRadius: 12,
 }

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -69,17 +69,24 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
             {character.avatar_url ? (
               <img src={mediaUrl(character.avatar_url)} alt={character.username} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : (
-              // ornament: the fallback monogram is illustration, sized to the 96px ring
-              <span style={{ fontFamily: 'var(--faction-default-card-font)', fontStyle: 'italic', fontSize: 34, color: 'var(--color-text-primary)' }}>
+              <span
+                style={{
+                  fontFamily: 'var(--faction-default-card-font)',
+                  fontStyle: 'italic',
+                  // eslint-disable-next-line local/no-raw-style-values -- ornament: the fallback monogram is illustration, sized to the 96px ring
+                  fontSize: 34,
+                  color: 'var(--color-text-primary)',
+                }}
+              >
                 {initial}
               </span>
             )}
           </span>
         </button>
-        <div className="eyebrow" style={{ marginTop: 12, color: 'var(--faction-default-card-muted)' }}>
+        <div className="eyebrow" style={{ marginTop: 'var(--space-md)', color: 'var(--faction-default-card-muted)' }}>
           {t('editCharacter.mobile.changePhoto')}
         </div>
-        {avatarError && <p className="content-text" style={{ ...errorBox, marginTop: 8 }}>{avatarError}</p>}
+        {avatarError && <p className="content-text" style={{ ...errorBox, marginTop: 'var(--space-sm)' }}>{avatarError}</p>}
       </div>
       <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarChange} style={{ display: 'none' }} />
 
@@ -125,7 +132,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
           <span className="content-text" style={{ fontFamily: 'var(--font-body)', color: 'var(--color-text-secondary)' }}>
             {t('editCharacter.mobile.deleteConfirm')}
           </span>
-          <div style={{ display: 'flex', gap: 10 }}>
+          <div style={{ display: 'flex', gap: 'var(--space-md)' }}>
             <button type="button" onClick={() => setConfirmingDelete(false)} style={confirmCancel}>
               {t('editCharacter.cancel')}
             </button>
@@ -165,15 +172,19 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
 
 // --- token-driven styles (single column, no hardcoded hex) ------------------
 
-const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 20, paddingBottom: 96 }
+const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 'var(--space-xl)', paddingBottom: 'var(--space-6xl)' }
 const topRow: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
 const backBtn: CSSProperties = {
   width: 28, height: 28, background: 'none', border: 'none', cursor: 'pointer',
-  // ornament: the back chevron is a glyph-as-icon sized to its 28px hit target
-  fontSize: 24, lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
+  // eslint-disable-next-line local/no-raw-style-values -- ornament: the back chevron is a glyph-as-icon sized to its 28px hit target
+  fontSize: 24,
+  lineHeight: 1, color: 'var(--color-text-primary)', padding: 0,
 }
 const ringBtn: CSSProperties = {
-  width: 96, height: 96, borderRadius: '50%', padding: 3, cursor: 'pointer',
+  width: 96, height: 96, borderRadius: '50%',
+  // eslint-disable-next-line local/no-raw-style-values -- ornament: rainbow ring thickness drawn around the 96px avatar well; the nearest rung (4px) thickens the band by a third.
+  padding: 3,
+  cursor: 'pointer',
   border: 'none', background: 'var(--faction-default-rainbow)',
 }
 const ringInner: CSSProperties = {
@@ -183,57 +194,57 @@ const ringInner: CSSProperties = {
 }
 const label: CSSProperties = {
   display: 'block', fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase',
-  color: 'var(--color-text-secondary)', marginBottom: 8,
+  color: 'var(--color-text-secondary)', marginBottom: 'var(--space-sm)',
 }
 const field: CSSProperties = {
   display: 'block', width: '100%', boxSizing: 'border-box',
   background: 'var(--color-bg-page)', border: '1px solid var(--color-border-strong)',
   borderRadius: 8, outline: 'none', fontFamily: 'var(--font-body)',
-  color: 'var(--color-text-primary)', padding: '12px 13px',
+  color: 'var(--color-text-primary)', padding: 'var(--space-md)',
 }
 const factionRow: CSSProperties = {
   display: 'flex', alignItems: 'center', justifyContent: 'space-between',
   background: 'var(--color-bg-surface-alt)', border: '1px solid var(--color-border-strong)',
-  borderRadius: 8, padding: '12px 13px', textDecoration: 'none',
+  borderRadius: 8, padding: 'var(--space-md)', textDecoration: 'none',
   fontFamily: 'var(--font-body)', color: 'var(--color-text-secondary)',
 }
 const help: CSSProperties = {
   fontFamily: 'var(--font-body)', lineHeight: 1.6,
-  color: 'var(--color-text-tertiary)', margin: '8px 0 0',
+  color: 'var(--color-text-tertiary)', margin: 'var(--space-sm) 0 0',
 }
 const deleteBtn: CSSProperties = {
   width: '100%', cursor: 'pointer', background: 'none', textAlign: 'center',
-  border: '1px solid var(--color-danger)', borderRadius: 8, padding: '12px',
+  border: '1px solid var(--color-danger)', borderRadius: 8, padding: 'var(--space-md)',
   fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)', letterSpacing: '0.1em',
   textTransform: 'uppercase', color: 'var(--color-danger)',
 }
 const confirmRow: CSSProperties = {
-  display: 'flex', flexDirection: 'column', gap: 12,
-  border: '1px solid var(--color-danger)', borderRadius: 8, padding: '14px',
+  display: 'flex', flexDirection: 'column', gap: 'var(--space-md)',
+  border: '1px solid var(--color-danger)', borderRadius: 8, padding: 'var(--space-lg)',
 }
 const confirmCancel: CSSProperties = {
   flex: 1, cursor: 'pointer', background: 'var(--color-bg-surface)',
-  border: '1px solid var(--color-border-strong)', borderRadius: 8, padding: '10px',
+  border: '1px solid var(--color-border-strong)', borderRadius: 8, padding: 'var(--space-md)',
   fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)', color: 'var(--color-text-primary)',
 }
 const confirmDelete: CSSProperties = {
   flex: 1, cursor: 'pointer', background: 'var(--color-danger)', border: 'none',
-  borderRadius: 8, padding: '10px', fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)',
+  borderRadius: 8, padding: 'var(--space-md)', fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)',
   letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-bg-page)',
 }
 const errorBox: CSSProperties = {
   fontFamily: 'var(--font-body)', color: 'var(--color-danger)',
-  border: '1px solid var(--color-danger)', borderRadius: 6, padding: '10px 12px', margin: 0,
+  border: '1px solid var(--color-danger)', borderRadius: 6, padding: 'var(--space-md)', margin: 0,
 }
 const stickyBar: CSSProperties = {
   position: 'sticky',
   bottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
   marginTop: 'auto',
-  paddingTop: 8,
+  paddingTop: 'var(--space-sm)',
 }
 const primaryBtn: CSSProperties = {
   width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-xl)',
   letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700,
   color: 'var(--color-bg-page)', background: 'var(--color-text-primary)',
-  border: 'none', padding: '15px 24px', borderRadius: 12,
+  border: 'none', padding: 'var(--space-lg) var(--space-xl)', borderRadius: 12,
 }

--- a/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
@@ -56,7 +56,7 @@ function InkLaurel() {
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
-    <div style={{ marginBottom: 18 }}>
+    <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div
         style={{
           fontFamily: MONO,
@@ -64,7 +64,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           letterSpacing: '0.24em',
           textTransform: 'uppercase',
           color: MUTED,
-          marginBottom: 8,
+          marginBottom: 'var(--space-sm)',
         }}
       >
         {eyebrow}
@@ -92,20 +92,20 @@ const kit: ProfileKit = {
     background: SURFACE,
     border: `1px solid ${BORDER}`,
     boxShadow: '0 4px 20px -12px rgba(0,0,0,0.18)',
-    padding: '40px 44px',
-    marginBottom: 44,
+    padding: 'var(--space-3xl) var(--space-4xl)',
+    marginBottom: 'var(--space-4xl)',
   },
   nameSize: 62,
   nameExtra: { fontStyle: 'italic', fontWeight: 300 },
   playerEyebrow: 'Player · Albescent · the unranked order',
   progressionStyle: {
-    marginTop: 24,
+    marginTop: 'var(--space-xl)',
     background: SURFACE,
     border: `1px solid ${RULE}`,
-    padding: '18px 20px',
+    padding: 'var(--space-lg) var(--space-xl)',
     display: 'flex',
     alignItems: 'center',
-    gap: 18,
+    gap: 'var(--space-lg)',
     maxWidth: 440,
   },
   ringLabel: 'lvl',
@@ -120,7 +120,7 @@ const kit: ProfileKit = {
   },
   emptyStateStyle: {
     border: `1px dashed ${ACCENT}`,
-    padding: 34,
+    padding: 'var(--space-2xl)',
     textAlign: 'center',
     background: SURFACE,
   },
@@ -129,7 +129,7 @@ const kit: ProfileKit = {
   badgeBoardStyle: {
     border: `1px solid ${BORDER}`,
     background: SURFACE,
-    padding: '4px 16px',
+    padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
     fontFamily: MONO,
@@ -139,7 +139,7 @@ const kit: ProfileKit = {
     color: MUTED,
     marginLeft: 'auto',
     border: `1px solid ${BORDER}`,
-    padding: '3px 9px',
+    padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -34,7 +34,7 @@ const EYEBROW: CSSProperties = {
 /** Section heading: display-italic title + optional eyebrow + a soft rainbow rule. */
 function SectionHeading({ title, eyebrow }: { title: string; eyebrow?: string }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
       <h2
         className="font-display italic"
         style={{ fontSize: 'var(--text-title)', margin: 0, color: 'var(--color-text-primary)' }}
@@ -112,8 +112,8 @@ function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 11,
-        padding: '10px 0',
+        gap: 'var(--space-md)',
+        padding: 'var(--space-md) 0',
         borderBottom: last ? 'none' : '1px solid var(--color-border)',
       }}
     >
@@ -123,6 +123,7 @@ function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
           width: 34,
           height: 34,
           borderRadius: '50%',
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: spectrum ring thickness on a 34px medallion; the nearest rung (4px) is a 60% thicker ring and visibly shrinks the inner disc.
           padding: 2.5,
           background: 'var(--faction-default-ring)',
           display: 'flex',
@@ -192,7 +193,7 @@ export default function DefaultProfileBody({
     : 0
 
   const mainColumn = (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 34, minWidth: 0 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2xl)', minWidth: 0 }}>
       {/* ── ⑤ Praxis ── */}
       <section>
         <SectionHeading
@@ -204,7 +205,7 @@ export default function DefaultProfileBody({
             style={{
               border: '1.5px dashed var(--color-border-strong)',
               borderRadius: 12,
-              padding: 30,
+              padding: 'var(--space-2xl)',
               textAlign: 'center',
               background: 'var(--color-bg-surface-alt)',
             }}
@@ -217,7 +218,7 @@ export default function DefaultProfileBody({
             </div>
             <div
               className="font-body"
-              style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginTop: 5 }}
+              style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginTop: 'var(--space-xs)' }}
             >
               {t('profile.praxisEmptyBody')}
             </div>
@@ -261,19 +262,19 @@ export default function DefaultProfileBody({
           position: 'relative',
           overflow: 'hidden',
           borderRadius: 16,
-          padding: 5,
+          padding: 'var(--space-xs)',
           background: 'var(--faction-default-rainbow)',
           boxShadow: '0 20px 50px -26px rgba(0,0,0,0.4)',
-          marginBottom: 30,
+          marginBottom: 'var(--space-2xl)',
         }}
       >
         <div
           style={{
             borderRadius: 12,
             background: 'var(--faction-default-card-bg)',
-            padding: '26px 28px',
+            padding: 'var(--space-xl)',
             display: 'flex',
-            gap: 30,
+            gap: 'var(--space-2xl)',
             alignItems: 'center',
             flexWrap: 'wrap',
           }}
@@ -291,7 +292,7 @@ export default function DefaultProfileBody({
           </div>
 
           <div style={{ flex: 1, minWidth: 280 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-sm)' }}>
               <span
                 aria-hidden
                 style={{
@@ -328,9 +329,9 @@ export default function DefaultProfileBody({
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: 10,
+                gap: 'var(--space-md)',
                 flexWrap: 'wrap',
-                marginTop: 10,
+                marginTop: 'var(--space-md)',
               }}
             >
               {isUnaffiliated && (
@@ -364,14 +365,14 @@ export default function DefaultProfileBody({
             {progression && (
               <div
                 style={{
-                  marginTop: 20,
+                  marginTop: 'var(--space-xl)',
                   border: '1px solid var(--color-border-strong)',
                   borderRadius: 12,
-                  padding: '14px 16px',
+                  padding: 'var(--space-lg)',
                   background: 'var(--color-bg-surface-alt)',
                   display: 'flex',
                   alignItems: 'center',
-                  gap: 16,
+                  gap: 'var(--space-lg)',
                   maxWidth: 440,
                 }}
               >
@@ -418,7 +419,7 @@ export default function DefaultProfileBody({
                       display: 'flex',
                       justifyContent: 'space-between',
                       alignItems: 'baseline',
-                      marginBottom: 6,
+                      marginBottom: 'var(--space-sm)',
                     }}
                   >
                     <span
@@ -451,7 +452,7 @@ export default function DefaultProfileBody({
                   </div>
                   <div
                     className="font-body"
-                    style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)', marginTop: 5 }}
+                    style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)', marginTop: 'var(--space-xs)' }}
                   >
                     {t('profile.ptsToNext', { score: character.score, threshold: progression.nextThreshold })}
                   </div>
@@ -461,7 +462,7 @@ export default function DefaultProfileBody({
 
             {/* friend/foe — kept feature, faction-skinned, folded into the header */}
             {identityActions && (
-              <div style={{ marginTop: 16, maxWidth: 220 }}>{identityActions}</div>
+              <div style={{ marginTop: 'var(--space-lg)', maxWidth: 220 }}>{identityActions}</div>
             )}
           </div>
         </div>
@@ -474,7 +475,7 @@ export default function DefaultProfileBody({
           style={{
             display: 'grid',
             gridTemplateColumns: 'minmax(0, 1fr) fit-content(300px)',
-            gap: 30,
+            gap: 'var(--space-2xl)',
             alignItems: 'start',
           }}
         >
@@ -483,7 +484,7 @@ export default function DefaultProfileBody({
           {/* ── ③ Badges — hidden entirely when the character has none ── */}
           <aside>
             <div
-              style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}
+              style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}
             >
               <h2
                 className="font-display italic"
@@ -499,7 +500,7 @@ export default function DefaultProfileBody({
                   marginLeft: 'auto',
                   border: '1px solid var(--color-border-strong)',
                   borderRadius: 20,
-                  padding: '3px 9px',
+                  padding: 'var(--space-xs) var(--space-sm)',
                 }}
               >
                 {t('profile.badgesEarned', { count: badges.length })}
@@ -510,7 +511,7 @@ export default function DefaultProfileBody({
                 border: '1px solid var(--color-border)',
                 borderRadius: 12,
                 background: 'var(--color-bg-surface-alt)',
-                padding: '4px 14px',
+                padding: 'var(--space-xs) var(--space-lg)',
               }}
             >
               {badges.map((badge, index) => (

--- a/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
@@ -57,8 +57,8 @@ function toRoman(value: number): string {
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
-    <div style={{ marginBottom: 18 }}>
-      <div style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 'var(--text-lg)', color: MUTED, marginBottom: 4 }}>
+    <div style={{ marginBottom: 'var(--space-lg)' }}>
+      <div style={{ fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 'var(--text-lg)', color: MUTED, marginBottom: 'var(--space-xs)' }}>
         {eyebrow}
       </div>
       <h2
@@ -92,9 +92,9 @@ const kit: ProfileKit = {
     background: `linear-gradient(160deg, ${LAPIS}, var(--eph-lapis-deep))`,
     border: `2px solid ${GOLD}`,
     boxShadow: `0 0 0 4px ${CREAM}, 0 0 0 6px var(--eph-ink), 0 18px 40px -20px rgba(0,0,0,0.6)`,
-    padding: '34px 40px',
-    marginBottom: 44,
-    marginTop: 6,
+    padding: 'var(--space-2xl) var(--space-3xl)',
+    marginBottom: 'var(--space-4xl)',
+    marginTop: 'var(--space-sm)',
   },
   headerDecoration: (
     <>
@@ -118,14 +118,14 @@ const kit: ProfileKit = {
   nameExtra: { color: CREAM, textShadow: '0 2px 6px rgba(5,19,28,0.6)', letterSpacing: '0.02em' },
   playerEyebrow: 'Player · The Ephemerists',
   progressionStyle: {
-    marginTop: 22,
+    marginTop: 'var(--space-xl)',
     background: 'rgba(5,19,28,0.35)',
     border: `1px solid ${GOLD}`,
     boxShadow: `inset 0 0 0 3px rgba(5,19,28,0.25)`,
-    padding: '16px 18px',
+    padding: 'var(--space-lg)',
     display: 'flex',
     alignItems: 'center',
-    gap: 16,
+    gap: 'var(--space-lg)',
     maxWidth: 440,
   },
   ringLabel: 'grade',
@@ -142,7 +142,7 @@ const kit: ProfileKit = {
   },
   emptyStateStyle: {
     border: `1.5px dashed ${GOLD_DEEP}`,
-    padding: 30,
+    padding: 'var(--space-2xl)',
     textAlign: 'center',
     background: VELLUM,
   },
@@ -151,7 +151,7 @@ const kit: ProfileKit = {
   badgeBoardStyle: {
     border: `1px solid ${GOLD_DEEP}`,
     background: VELLUM,
-    padding: '4px 14px',
+    padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
     fontFamily: DISPLAY,
@@ -161,7 +161,7 @@ const kit: ProfileKit = {
     color: MUTED,
     marginLeft: 'auto',
     border: `1px solid ${GOLD_DEEP}`,
-    padding: '3px 9px',
+    padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow

--- a/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
@@ -29,7 +29,7 @@ const SUNBURST =
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
-    <div style={{ marginBottom: 16 }}>
+    <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div
         style={{
           fontFamily: MONO,
@@ -37,7 +37,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
           color: MUTED,
-          marginBottom: 5,
+          marginBottom: 'var(--space-xs)',
         }}
       >
         {eyebrow}
@@ -57,7 +57,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <div
         style={{
           height: 4,
-          marginTop: 8,
+          marginTop: 'var(--space-sm)',
           background: `repeating-linear-gradient(90deg, ${RED} 0 14px, ${GOLD} 14px 28px)`,
         }}
       />
@@ -81,9 +81,9 @@ const kit: ProfileKit = {
     background: `linear-gradient(150deg, ${RED}, var(--everymen-red-deep))`,
     border: `3px solid ${INK}`,
     boxShadow: '8px 10px 0 rgba(0,0,0,0.4)',
-    padding: '34px 40px',
-    marginBottom: 44,
-    marginTop: 6,
+    padding: 'var(--space-2xl) var(--space-3xl)',
+    marginBottom: 'var(--space-4xl)',
+    marginTop: 'var(--space-sm)',
   },
   headerDecoration: (
     <>
@@ -101,13 +101,13 @@ const kit: ProfileKit = {
   nameExtra: { color: CREAM, textShadow: '3px 3px 0 rgba(0,0,0,0.3)', letterSpacing: '0.02em' },
   playerEyebrow: 'Player · The Everymen',
   progressionStyle: {
-    marginTop: 22,
+    marginTop: 'var(--space-xl)',
     background: INK,
     borderLeft: `5px solid ${GOLD}`,
-    padding: '16px 18px',
+    padding: 'var(--space-lg)',
     display: 'flex',
     alignItems: 'center',
-    gap: 16,
+    gap: 'var(--space-lg)',
     maxWidth: 440,
   },
   ringLabel: 'lvl',
@@ -122,7 +122,7 @@ const kit: ProfileKit = {
   },
   emptyStateStyle: {
     border: `2px dashed ${INK}`,
-    padding: 30,
+    padding: 'var(--space-2xl)',
     textAlign: 'center',
     background: CREAM,
   },
@@ -131,7 +131,7 @@ const kit: ProfileKit = {
   badgeBoardStyle: {
     border: `3px solid ${INK}`,
     background: CREAM,
-    padding: '4px 14px',
+    padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
     fontFamily: MONO,
@@ -141,7 +141,7 @@ const kit: ProfileKit = {
     color: MUTED,
     marginLeft: 'auto',
     border: `1px solid ${INK}`,
-    padding: '3px 9px',
+    padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow

--- a/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
@@ -30,7 +30,7 @@ const SCANLINES =
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
-    <div style={{ marginBottom: 16 }}>
+    <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div
         style={{
           fontFamily: FONT,
@@ -38,7 +38,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           color: signal(65),
-          marginBottom: 6,
+          marginBottom: 'var(--space-sm)',
         }}
       >
         {'>'} {eyebrow}
@@ -56,7 +56,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       >
         {title}
       </h2>
-      <div style={{ height: 1, marginTop: 8, background: signal(30) }} />
+      <div style={{ height: 1, marginTop: 'var(--space-sm)', background: signal(30) }} />
     </div>
   )
 }
@@ -78,8 +78,8 @@ const kit: ProfileKit = {
     background: VOID,
     border: `1px solid ${BORDER}`,
     boxShadow: `inset 0 0 0 1px ${signal(18)}`,
-    padding: '32px 34px',
-    marginBottom: 40,
+    padding: 'var(--space-2xl)',
+    marginBottom: 'var(--space-3xl)',
   },
   headerDecoration: (
     <div
@@ -95,13 +95,13 @@ const kit: ProfileKit = {
   },
   playerEyebrow: '> PLAYER: SINGULARITY // NODE STATUS: ONLINE',
   progressionStyle: {
-    marginTop: 22,
+    marginTop: 'var(--space-xl)',
     background: VOID,
     border: `1px solid ${signal(40)}`,
-    padding: '16px 18px',
+    padding: 'var(--space-lg)',
     display: 'flex',
     alignItems: 'center',
-    gap: 16,
+    gap: 'var(--space-lg)',
     maxWidth: 440,
   },
   ringLabel: 'lvl',
@@ -117,7 +117,7 @@ const kit: ProfileKit = {
   },
   emptyStateStyle: {
     border: `1px dashed ${signal(50)}`,
-    padding: 30,
+    padding: 'var(--space-2xl)',
     textAlign: 'center',
     background: VOID,
   },
@@ -126,7 +126,7 @@ const kit: ProfileKit = {
   badgeBoardStyle: {
     border: `1px solid ${signal(40)}`,
     background: VOID,
-    padding: '4px 14px',
+    padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
     fontFamily: FONT,
@@ -136,7 +136,7 @@ const kit: ProfileKit = {
     color: signal(70),
     marginLeft: 'auto',
     border: `1px solid ${signal(40)}`,
-    padding: '3px 9px',
+    padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow

--- a/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
@@ -27,7 +27,7 @@ const JAGGED =
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
-    <div style={{ marginBottom: 16 }}>
+    <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div
         style={{
           fontFamily: TYPE,
@@ -35,7 +35,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
           color: PAPER,
-          marginBottom: 5,
+          marginBottom: 'var(--space-xs)',
         }}
       >
         {eyebrow}
@@ -54,7 +54,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       >
         {title}
       </h2>
-      <div style={{ height: 2, marginTop: 8, borderTop: `2px dashed ${PINK}` }} />
+      <div style={{ height: 2, marginTop: 'var(--space-sm)', borderTop: `2px dashed ${PINK}` }} />
     </div>
   )
 }
@@ -76,8 +76,8 @@ const kit: ProfileKit = {
     background: INK,
     border: `1px solid ${ACID}`,
     boxShadow: '8px 10px 0 rgba(0,0,0,0.55)',
-    padding: '38px 34px 30px',
-    marginBottom: 40,
+    padding: 'var(--space-3xl) var(--space-2xl) var(--space-2xl)',
+    marginBottom: 'var(--space-3xl)',
   },
   headerDecoration: (
     <div
@@ -103,13 +103,13 @@ const kit: ProfileKit = {
   nameExtra: { transform: 'skewX(-5deg)', textShadow: `3px 3px 0 ${PINK}`, textTransform: 'uppercase' },
   playerEyebrow: 'Player · S.N.I.D.E.',
   progressionStyle: {
-    marginTop: 22,
+    marginTop: 'var(--space-xl)',
     background: INK,
     border: `2px solid ${ACID}`,
-    padding: '16px 18px',
+    padding: 'var(--space-lg)',
     display: 'flex',
     alignItems: 'center',
-    gap: 16,
+    gap: 'var(--space-lg)',
     maxWidth: 440,
   },
   ringLabel: 'lvl',
@@ -125,7 +125,7 @@ const kit: ProfileKit = {
   },
   emptyStateStyle: {
     border: `2px dashed ${ACID}`,
-    padding: 30,
+    padding: 'var(--space-2xl)',
     textAlign: 'center',
     background: INK,
   },
@@ -134,7 +134,7 @@ const kit: ProfileKit = {
   badgeBoardStyle: {
     border: `2px solid ${ACID}`,
     background: PAPER,
-    padding: '4px 14px',
+    padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
     fontFamily: TYPE,
@@ -144,7 +144,7 @@ const kit: ProfileKit = {
     color: PINK,
     marginLeft: 'auto',
     border: `1px solid ${PINK}`,
-    padding: '3px 9px',
+    padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow

--- a/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
@@ -26,7 +26,7 @@ const BODY = "'EB Garamond', Georgia, serif"
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
-    <div style={{ marginBottom: 18 }}>
+    <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div
         style={{
           fontFamily: EYEBROW,
@@ -34,7 +34,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           letterSpacing: '0.26em',
           textTransform: 'uppercase',
           color: MUTED,
-          marginBottom: 7,
+          marginBottom: 'var(--space-sm)',
         }}
       >
         {eyebrow}
@@ -64,8 +64,8 @@ const kit: ProfileKit = {
     background: PAPER,
     border: `1px solid ${LINE}`,
     boxShadow: 'inset 0 0 0 4px var(--ua-paper), inset 0 0 0 5px var(--ua-line-soft)',
-    padding: '34px 40px',
-    marginBottom: 40,
+    padding: 'var(--space-2xl) var(--space-3xl)',
+    marginBottom: 'var(--space-3xl)',
   },
   headerDecoration: (
     <div
@@ -80,8 +80,8 @@ const kit: ProfileKit = {
     />
   ),
   credentialFrame: (card) => (
-    <div style={{ padding: 12, background: GILT }}>
-      <div style={{ padding: 4, background: 'linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))' }}>
+    <div style={{ padding: 'var(--space-md)', background: GILT }}>
+      <div style={{ padding: 'var(--space-xs)', background: 'linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))' }}>
         {card}
       </div>
     </div>
@@ -89,14 +89,14 @@ const kit: ProfileKit = {
   nameSize: 56,
   playerEyebrow: 'Player · University of Asthmatics',
   progressionStyle: {
-    marginTop: 22,
+    marginTop: 'var(--space-xl)',
     background: 'var(--ua-paper-warm)',
     border: `1px solid ${ACCENT}`,
     boxShadow: 'inset 0 0 0 3px var(--ua-paper-warm), inset 0 0 0 4px var(--ua-line-soft)',
-    padding: '16px 18px',
+    padding: 'var(--space-lg)',
     display: 'flex',
     alignItems: 'center',
-    gap: 16,
+    gap: 'var(--space-lg)',
     maxWidth: 440,
   },
   ringLabel: 'anno',
@@ -112,7 +112,7 @@ const kit: ProfileKit = {
   },
   emptyStateStyle: {
     border: `1.5px dashed ${ACCENT}`,
-    padding: 30,
+    padding: 'var(--space-2xl)',
     textAlign: 'center',
     background: PAPER,
   },
@@ -121,7 +121,7 @@ const kit: ProfileKit = {
   badgeBoardStyle: {
     border: `1px solid ${LINE}`,
     background: PAPER,
-    padding: '4px 14px',
+    padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
     fontFamily: EYEBROW,
@@ -132,7 +132,7 @@ const kit: ProfileKit = {
     marginLeft: 'auto',
     border: `1px solid ${LINE}`,
     borderRadius: 20,
-    padding: '3px 9px',
+    padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow
@@ -147,6 +147,7 @@ const kit: ProfileKit = {
             width: 34,
             height: 34,
             borderRadius: '50%',
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: gilt ring thickness on a 34px medallion; the nearest rung (4px) is a 60% thicker ring and visibly shrinks the inner disc.
             padding: 2.5,
             background: GILT,
             display: 'flex',

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -46,14 +46,14 @@ function Pin({ left, right }: { left?: number; right?: number }) {
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
-    <div style={{ marginBottom: 16, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+    <div style={{ marginBottom: 'var(--space-lg)', display: 'inline-flex', alignItems: 'center', gap: 'var(--space-md)' }}>
       <span
         style={{
           fontFamily: DISPLAY,
           fontSize: 'var(--text-heading)',
           color: ACCENT,
           background: 'var(--faction-wow-tape)',
-          padding: '2px 12px',
+          padding: 'var(--space-xs) var(--space-md)',
           transform: 'rotate(-1.5deg)',
           display: 'inline-block',
         }}
@@ -80,8 +80,8 @@ const kit: ProfileKit = {
     background: 'var(--faction-wow-notepad-bg)',
     border: `1px solid ${BORDER}`,
     borderRadius: 16,
-    padding: '30px 34px',
-    marginBottom: 34,
+    padding: 'var(--space-2xl)',
+    marginBottom: 'var(--space-2xl)',
     transform: 'rotate(-0.4deg)',
     boxShadow: '0 12px 30px -18px rgba(0,0,0,0.4)',
   },
@@ -99,14 +99,14 @@ const kit: ProfileKit = {
   nameSize: 56,
   playerEyebrow: 'Player · Warriors of Whimsy',
   progressionStyle: {
-    marginTop: 22,
+    marginTop: 'var(--space-xl)',
     background: SURFACE,
     border: `1px solid ${BORDER}`,
     borderRadius: 10,
-    padding: '16px 18px',
+    padding: 'var(--space-lg)',
     display: 'flex',
     alignItems: 'center',
-    gap: 16,
+    gap: 'var(--space-lg)',
     maxWidth: 440,
   },
   ringLabel: 'lvl',
@@ -122,7 +122,7 @@ const kit: ProfileKit = {
   emptyStateStyle: {
     border: `1.5px dashed ${ACCENT}`,
     borderRadius: 14,
-    padding: 30,
+    padding: 'var(--space-2xl)',
     textAlign: 'center',
     background: SURFACE,
   },
@@ -132,7 +132,7 @@ const kit: ProfileKit = {
     border: `1px solid ${BORDER}`,
     borderRadius: 12,
     background: SURFACE,
-    padding: '4px 14px',
+    padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
     fontFamily: EYEBROW,
@@ -143,7 +143,7 @@ const kit: ProfileKit = {
     marginLeft: 'auto',
     border: `1px solid ${BORDER}`,
     borderRadius: 20,
-    padding: '3px 9px',
+    padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -210,8 +210,8 @@ export function BadgeRow({
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 11,
-        padding: '10px 0',
+        gap: 'var(--space-md)',
+        padding: 'var(--space-md) 0',
         borderBottom: last ? 'none' : `1px solid ${dividerColor}`,
       }}
     >
@@ -277,7 +277,7 @@ export function ProfileSkin({
   )
 
   const mainColumn = (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 34, minWidth: 0 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2xl)', minWidth: 0 }}>
       {/* ── ⑤ Praxis ── */}
       <section>
         {kit.sectionHeading('Praxis', kit.praxisEyebrow(character.display_name))}
@@ -297,7 +297,7 @@ export function ProfileSkin({
                 fontFamily: kit.bodyFont ?? kit.eyebrowFont,
                 fontSize: 'var(--text-content)',
                 color: kit.muted,
-                marginTop: 5,
+                marginTop: 'var(--space-xs)',
               }}
             >
               {kit.praxisEmpty.body}
@@ -339,7 +339,9 @@ export function ProfileSkin({
       style={{
         position: 'relative',
         background: kit.pageBackground,
-        padding: '32px 28px',
+        // asymmetric inset: the 28px side rounds DOWN so the page frame keeps
+        // its taller-than-wide shape instead of flattening to a uniform box.
+        padding: 'var(--space-2xl) var(--space-xl)',
         borderRadius: 16,
         overflow: 'hidden',
       }}
@@ -364,7 +366,7 @@ export function ProfileSkin({
               position: 'relative',
               zIndex: 2,
               display: 'flex',
-              gap: 34,
+              gap: 'var(--space-2xl)',
               alignItems: 'center',
               flexWrap: 'wrap',
             }}
@@ -381,7 +383,7 @@ export function ProfileSkin({
                   letterSpacing: '0.22em',
                   textTransform: 'uppercase',
                   color: kit.muted,
-                  marginBottom: 8,
+                  marginBottom: 'var(--space-sm)',
                 }}
               >
                 {kit.playerEyebrow}
@@ -390,7 +392,9 @@ export function ProfileSkin({
               <h1
                 style={{
                   fontFamily: kit.displayFont,
-                  // ornament: masthead display type, per-archetype identity (see ProfileKit.nameSize)
+                  // ornament: masthead display type, per-archetype identity (see ProfileKit.nameSize).
+                  // No eslint-disable here: the rule does not recurse into `??`, so this
+                  // never reports and a directive would be flagged as unused.
                   fontSize: kit.nameSize ?? 48,
                   lineHeight: 0.98,
                   margin: 0,
@@ -408,7 +412,7 @@ export function ProfileSkin({
                   // handle + join date: the handle is a name, so this is read, not scanned
                   fontSize: 'var(--text-content)',
                   color: kit.muted,
-                  marginTop: 10,
+                  marginTop: 'var(--space-md)',
                 }}
               >
                 {t('profile.handleJoined', { username: character.username, joined })}
@@ -472,7 +476,7 @@ export function ProfileSkin({
                         display: 'flex',
                         justifyContent: 'space-between',
                         alignItems: 'baseline',
-                        marginBottom: 6,
+                        marginBottom: 'var(--space-sm)',
                       }}
                     >
                       <span
@@ -522,7 +526,7 @@ export function ProfileSkin({
                           // absolute score toward the next threshold: read, not scanned
                           fontSize: 'var(--text-content)',
                           color: kit.muted,
-                          marginTop: 5,
+                          marginTop: 'var(--space-xs)',
                         }}
                       >
                         {kit.scoreFootnote(character.score, progression.nextThreshold)}
@@ -534,7 +538,7 @@ export function ProfileSkin({
 
               {/* friend/foe — kept feature, faction-skinned, folded into header */}
               {identityActions && (
-                <div style={{ marginTop: 16, maxWidth: 220 }}>{identityActions}</div>
+                <div style={{ marginTop: 'var(--space-lg)', maxWidth: 220 }}>{identityActions}</div>
               )}
             </div>
           </div>
@@ -547,7 +551,7 @@ export function ProfileSkin({
             style={{
               display: 'grid',
               gridTemplateColumns: 'minmax(0, 1fr) 300px',
-              gap: 30,
+              gap: 'var(--space-2xl)',
               alignItems: 'start',
             }}
           >
@@ -559,8 +563,8 @@ export function ProfileSkin({
                 style={{
                   display: 'flex',
                   alignItems: 'center',
-                  gap: 10,
-                  marginBottom: 14,
+                  gap: 'var(--space-md)',
+                  marginBottom: 'var(--space-lg)',
                 }}
               >
                 <h2 style={{ fontFamily: kit.displayFont, fontSize: 'var(--text-title)', margin: 0, color: kit.ink }}>

--- a/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
@@ -62,11 +62,11 @@ export default function DefaultProfile({
         )}
         <h1
           className="font-display italic font-medium"
-          style={{ fontSize: 'var(--text-heading)', marginTop: 12, color: 'var(--color-text-primary)', overflowWrap: 'anywhere' }}
+          style={{ fontSize: 'var(--text-heading)', marginTop: 'var(--space-md)', color: 'var(--color-text-primary)', overflowWrap: 'anywhere' }}
         >
           {character.display_name}
         </h1>
-        <div className="eyebrow" style={{ marginTop: 5, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <div className="eyebrow" style={{ marginTop: 'var(--space-xs)', display: 'inline-flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
           <i style={{ width: 8, height: 8, borderRadius: 2, background: color, flex: 'none' }} />
           {t('leaderboard.mobile.factionLevel', {
             faction: factionName(character.faction_slug),
@@ -75,14 +75,14 @@ export default function DefaultProfile({
         </div>
 
         {/* friend/foe — kept feature (#459), faction-skinned, folded under identity */}
-        {identityActions && <div style={{ marginTop: 14, maxWidth: 220, width: '100%' }}>{identityActions}</div>}
+        {identityActions && <div style={{ marginTop: 'var(--space-lg)', maxWidth: 220, width: '100%' }}>{identityActions}</div>}
       </div>
 
       {/* ── Stats row — real fields only ── */}
       <div
         style={{
           display: 'flex',
-          margin: '18px 0',
+          margin: 'var(--space-lg) 0',
           border: '1px solid var(--color-border)',
           borderRadius: 12,
           background: 'var(--color-bg-surface-alt)',
@@ -96,8 +96,8 @@ export default function DefaultProfile({
 
       {/* ── ③ Badges — hidden entirely when empty ── */}
       {badges.length > 0 && (
-        <div style={{ marginBottom: 18 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <div style={{ marginBottom: 'var(--space-lg)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', marginBottom: 'var(--space-sm)' }}>
             <h2 className="font-display italic" style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}>
               {t('profile.badgesHeading')}
             </h2>
@@ -110,7 +110,7 @@ export default function DefaultProfile({
               border: '1px solid var(--color-border)',
               borderRadius: 12,
               background: 'var(--color-bg-surface-alt)',
-              padding: '2px 14px',
+              padding: 'var(--space-xs) var(--space-lg)',
             }}
           >
             {badges.map((badge, index) => (
@@ -124,12 +124,12 @@ export default function DefaultProfile({
       <div
         style={{
           display: 'flex',
-          gap: 4,
-          padding: 4,
+          gap: 'var(--space-xs)',
+          padding: 'var(--space-xs)',
           borderRadius: 999,
           background: 'var(--color-bg-surface-alt)',
           border: '1px solid var(--color-border)',
-          marginBottom: 14,
+          marginBottom: 'var(--space-lg)',
         }}
       >
         <SegTab on={segment === 'praxis'} onClick={() => setSegment('praxis')}>
@@ -170,14 +170,14 @@ function Stat({ label, value, divider }: { label: string; value: number; divider
       style={{
         flex: 1,
         textAlign: 'center',
-        padding: '12px 6px',
+        padding: 'var(--space-md) var(--space-sm)',
         borderLeft: divider ? '1px solid var(--color-border)' : undefined,
       }}
     >
       <div className="font-display italic" style={{ fontSize: 'var(--text-title)', fontWeight: 700, color: 'var(--color-text-primary)' }}>
         {value}
       </div>
-      <div className="eyebrow" style={{ color: 'var(--color-text-tertiary)', marginTop: 2 }}>
+      <div className="eyebrow" style={{ color: 'var(--color-text-tertiary)', marginTop: 'var(--space-xs)' }}>
         {label}
       </div>
     </div>
@@ -191,8 +191,8 @@ function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 11,
-        padding: '10px 0',
+        gap: 'var(--space-md)',
+        padding: 'var(--space-md) 0',
         borderBottom: last ? 'none' : '1px solid var(--color-border)',
       }}
     >
@@ -202,6 +202,7 @@ function BadgeRow({ badge, last }: { badge: BadgeOut; last: boolean }) {
           width: 34,
           height: 34,
           borderRadius: '50%',
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: spectrum ring thickness on a 34px medallion; the nearest rung (4px) is a 60% thicker ring and visibly shrinks the inner disc.
           padding: 2.5,
           background: 'var(--faction-default-ring)',
           display: 'flex',
@@ -248,7 +249,7 @@ function SegTab({ on, onClick, children }: { on: boolean; onClick: () => void; c
         background: on ? 'var(--color-text-primary)' : 'transparent',
         border: 'none',
         borderRadius: 999,
-        padding: '9px 0',
+        padding: 'var(--space-sm) 0',
         minHeight: 36,
         cursor: 'pointer',
       }}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/AlbescentHome.tsx
@@ -41,7 +41,7 @@ function Sheet({ children }: { children: ReactNode }) {
         background: SHEET,
         border: `1px solid ${ink(10)}`,
         boxShadow: '0 2px 18px rgba(0,0,0,0.045), 0 1px 3px rgba(0,0,0,0.04)',
-        padding: 18,
+        padding: 'var(--space-lg)',
       }}
     >
       {children}
@@ -63,23 +63,23 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
     <div
       data-skin="albescent"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: PAGE }}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: MONO, color: INK, background: PAGE }}
     >
       {/* Masthead — the Mark and a hairline */}
       <header>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-sm)' }}>
           <AlbescentSigil size={26} />
           <div style={kicker}>{t('nav.home')}</div>
         </div>
         <h1 style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: 0 }}>
           {t('fieldDesk.home.albescent.masthead')}
         </h1>
-        <div style={{ height: 1, marginTop: 10, background: ink(10) }} />
+        <div style={{ height: 1, marginTop: 'var(--space-md)', background: ink(10) }} />
       </header>
 
       {/* ── The keeper's sheet ── */}
       <Sheet>
-        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-lg)' }}>
           <span style={kicker}>{t('fieldDesk.home.albescent.charEyebrow')}</span>
           <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: ink(50), textDecoration: 'none', borderBottom: `1px solid ${ink(20)}` }}>
             {t('fieldDesk.home.edit')}
@@ -99,7 +99,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
                 style={{ objectFit: 'cover' }}
               />
             ) : (
-              // ornament: avatar initial sized to its 52px ring, not text
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 52px ring, not text
               <span style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 22, color: ink(55) }}>
                 {character.display_name[0]?.toUpperCase()}
               </span>
@@ -113,7 +113,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ ...kicker, marginTop: 5, letterSpacing: '0.14em' }}>
+            <div className="truncate" style={{ ...kicker, marginTop: 'var(--space-xs)', letterSpacing: '0.14em' }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -124,21 +124,21 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
             <div style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-title)', lineHeight: 1, color: ink(60) }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
-            <div style={{ ...kicker, marginTop: 3 }}>{t('fieldDesk.home.stats.points')}</div>
+            <div style={{ ...kicker, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 16 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
               className="text-center"
-              style={{ flex: '1 1 0', minWidth: 0, border: `1px solid ${ink(9)}`, padding: '11px 6px' }}
+              style={{ flex: '1 1 0', minWidth: 0, border: `1px solid ${ink(9)}`, padding: 'var(--space-md) var(--space-sm)' }}
             >
               <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
                 {stat.value}
               </div>
-              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+              <div style={{ ...kicker, marginTop: 'var(--space-sm)' }}>{stat.label}</div>
             </div>
           ))}
         </div>
@@ -149,7 +149,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: '11px 16px', fontFamily: FONT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
+          style={{ background: SHEET, border: `1px solid ${ink(10)}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: FONT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: ink(40) }}>→</span>
@@ -158,7 +158,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
 
       {/* ── Work in hand ── */}
       <Sheet>
-        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-md)' }}>
           <span style={{ fontFamily: MONO, fontSize: 'var(--text-sm)', letterSpacing: '0.2em', textTransform: 'uppercase', color: ink(40) }}>
             {t('fieldDesk.home.albescent.questsHeading')}
           </span>
@@ -179,14 +179,14 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
                 key={praxis.id}
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
-                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${ink(8)}`, textDecoration: 'none' }}
+                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${ink(8)}`, textDecoration: 'none' }}
               >
                 <AlbescentSigil size={14} opacity={0.7} />
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: FONT, fontStyle: 'italic', fontWeight: 300, fontSize: 'var(--text-content)', lineHeight: 1.2, color: INK }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ ...kicker, marginTop: 3, letterSpacing: '0.14em' }}>
+                  <div className="truncate" style={{ ...kicker, marginTop: 'var(--space-xs)', letterSpacing: '0.14em' }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -195,7 +195,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.14em', textTransform: 'uppercase', color: ink(35), padding: '4px 9px', border: `1px solid ${ink(12)}` }}
+                  style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.14em', textTransform: 'uppercase', color: ink(35), padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${ink(12)}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -210,7 +210,7 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: MONO, fontSize: 'var(--text-base)', letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: PAGE, background: INK, border: `1px solid ${INK}`, textDecoration: 'none' }}
+          style={{ fontFamily: MONO, fontSize: 'var(--text-base)', letterSpacing: '0.16em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: PAGE, background: INK, border: `1px solid ${INK}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -218,9 +218,9 @@ export default function AlbescentHome({ state }: { state: FieldDeskHomeState }) 
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: MONO, fontSize: 'var(--text-base)', letterSpacing: '0.16em', textTransform: 'uppercase', padding: 14, color: ink(55), background: 'transparent', border: `1px solid ${ink(16)}`, textDecoration: 'none' }}
+            style={{ fontFamily: MONO, fontSize: 'var(--text-base)', letterSpacing: '0.16em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: ink(55), background: 'transparent', border: `1px solid ${ink(16)}`, textDecoration: 'none' }}
           >
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 13, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -35,19 +35,19 @@ const statTileStyle: CSSProperties = {
   background: 'var(--color-bg-surface-alt)',
   border: '1px solid var(--color-border)',
   borderRadius: 9,
-  padding: '11px 6px',
+  padding: 'var(--space-md) var(--space-sm)',
   minWidth: 0,
 }
 const pendingPillStyle: CSSProperties = {
   background: 'var(--color-bg-surface)',
   border: '1px solid var(--color-border)',
   borderRadius: 999,
-  padding: '10px 16px',
+  padding: 'var(--space-md) var(--space-lg)',
   color: 'var(--color-text-primary)',
   textDecoration: 'none',
 }
 const primaryActionStyle: CSSProperties = {
-  padding: 15,
+  padding: 'var(--space-lg)',
   borderRadius: 12,
   fontSize: 'var(--text-lg)',
   letterSpacing: '0.12em',
@@ -78,7 +78,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
   ]
 
   return (
-    <div data-skin="default" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+    <div data-skin="default" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
       {/* App-bar row: kicker + FieldDesk title */}
       <header>
         <div className="eyebrow" style={{ color: 'var(--color-text-secondary)' }}>
@@ -97,7 +97,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
           background: 'var(--color-bg-surface)',
           border: '1px solid var(--color-border)',
           borderRadius: 'var(--radius-xl)',
-          padding: 16,
+          padding: 'var(--space-lg)',
         }}
       >
         <span
@@ -111,11 +111,11 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             background: 'var(--faction-default-rainbow)',
           }}
         />
-        <div className="flex items-center justify-between mb-4" style={{ marginTop: 4 }}>
+        <div className="flex items-center justify-between mb-4" style={{ marginTop: 'var(--space-xs)' }}>
           <span className="eyebrow" style={{ color: 'var(--color-text-secondary)' }}>
             {t('fieldDesk.home.charEyebrow')}
           </span>
-          <div className="flex items-center" style={{ gap: 14 }}>
+          <div className="flex items-center" style={{ gap: 'var(--space-lg)' }}>
             <button
               type="button"
               onClick={() => setSwitcherOpen(true)}
@@ -137,7 +137,13 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
         <div className="flex items-center gap-3.5">
           <div
             className="shrink-0 rounded-full"
-            style={{ width: 56, height: 56, padding: 3, background: 'var(--faction-default-ring)' }}
+            style={{
+              width: 56,
+              height: 56,
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: spectrum ring thickness drawn around a 56px avatar; the nearest rung (4px) thickens the band by a third.
+              padding: 3,
+              background: 'var(--faction-default-ring)',
+            }}
           >
             {character.avatar_url ? (
               <img
@@ -169,7 +175,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                 type="button"
                 onClick={() => setSwitcherOpen(true)}
                 aria-label={t('fieldDesk.home.switcher.title')}
-                // ornament: ▾ dingbat used as an icon, sized to the name row
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: ▾ dingbat used as an icon, sized to the name row
                 style={{ flex: 'none', background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontSize: 14, lineHeight: 1, color: 'var(--color-text-tertiary)' }}
               >
                 <span aria-hidden>{CARET_DOWN}</span>
@@ -178,7 +184,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             <div
               className="truncate"
               style={{
-                marginTop: 5,
+                marginTop: 'var(--space-xs)',
                 fontFamily: 'var(--font-body)',
                 fontSize: 'var(--text-base)',
                 letterSpacing: '0.14em',
@@ -202,7 +208,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 16 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
@@ -214,7 +220,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
               </div>
               <div
                 className="eyebrow"
-                style={{ marginTop: 6, color: 'var(--color-text-secondary)' }}
+                style={{ marginTop: 'var(--space-sm)', color: 'var(--color-text-secondary)' }}
               >
                 {stat.label}
               </div>
@@ -241,7 +247,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
           background: 'var(--color-bg-surface)',
           border: '1px solid var(--color-border)',
           borderRadius: 'var(--radius-xl)',
-          padding: 16,
+          padding: 'var(--space-lg)',
         }}
       >
         <div className="flex items-center gap-2.5 mb-3">
@@ -270,7 +276,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{
-                  padding: '12px 0',
+                  padding: 'var(--space-md) 0',
                   borderTop: index === 0 ? undefined : '1px solid var(--color-border)',
                   textDecoration: 'none',
                 }}
@@ -286,7 +292,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                   <div
                     className="truncate"
                     style={{
-                      marginTop: 3,
+                      marginTop: 'var(--space-xs)',
                       fontFamily: 'var(--font-body)',
                       fontSize: 'var(--text-sm)',
                       letterSpacing: '0.1em',
@@ -304,7 +310,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                   className="shrink-0 eyebrow"
                   style={{
                     color: 'var(--faction-default-card-muted)',
-                    padding: '4px 9px',
+                    padding: 'var(--space-xs) var(--space-sm)',
                     border: '1px solid var(--color-border-strong)',
                     borderRadius: 999,
                   }}
@@ -332,7 +338,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             className="font-body flex-1 flex items-center justify-center gap-2"
             style={secondaryActionStyle}
           >
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
@@ -50,7 +50,7 @@ function Leaf({ children }: { children: ReactNode }) {
         background: VELLUM,
         border: `1px solid ${GOLD_DEEP}`,
         boxShadow: '0 10px 24px rgba(42,29,18,0.14)',
-        padding: 16,
+        padding: 'var(--space-lg)',
       }}
     >
       {children}
@@ -72,23 +72,23 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
     <div
       data-skin="ephemerists"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: SERIF, color: TEXT, background: VELLUM_DEEP }}
     >
       {/* Cinzel running-head */}
       <header>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: RUBRIC }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', color: RUBRIC }}>
           <EphemeristsSigil size={13} color={LAPIS} />
           <span style={kicker}>{t('nav.home')}</span>
         </div>
-        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1.05, color: TEXT, margin: '4px 0 0' }}>
+        <h1 style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1.05, color: TEXT, margin: 'var(--space-xs) 0 0' }}>
           {t('fieldDesk.home.ephemerists.masthead')}
         </h1>
-        <div style={{ height: 1, marginTop: 9, background: goldRule }} />
+        <div style={{ height: 1, marginTop: 'var(--space-sm)', background: goldRule }} />
       </header>
 
       {/* ── Observer leaf ── */}
       <Leaf>
-        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-lg)' }}>
           <span style={{ ...kicker, color: RUBRIC }}>{t('fieldDesk.home.ephemerists.charEyebrow')}</span>
           <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: LAPIS, textDecoration: 'none' }}>
             {t('fieldDesk.home.edit')}
@@ -96,7 +96,17 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="shrink-0" style={{ width: 56, height: 56, borderRadius: '50%', padding: 2, background: GOLD_DEEP }}>
+          <div
+            className="shrink-0"
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: '50%',
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: gold ring thickness drawn around a 56px avatar; the nearest rung (4px) doubles the band.
+              padding: 2,
+              background: GOLD_DEEP,
+            }}
+          >
             {character.avatar_url ? (
               <img
                 src={mediaUrl(character.avatar_url)}
@@ -107,7 +117,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center rounded-full"
-                // ornament: avatar initial sized to its 56px gilt ring, not text
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 56px gilt ring, not text
                 style={{ background: VELLUM_DEEP, fontFamily: DISPLAY, fontWeight: 700, fontSize: 24, color: RUBRIC }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -122,7 +132,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: DISPLAY, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
+            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: DISPLAY, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -133,21 +143,21 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
             <div style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: RUBRIC }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
-            <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
+            <div style={{ ...kicker, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 16 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
               className="text-center"
-              style={{ flex: '1 1 0', minWidth: 0, background: VELLUM_DEEP, border: `1px solid ${GOLD_DEEP}`, padding: '11px 6px' }}
+              style={{ flex: '1 1 0', minWidth: 0, background: VELLUM_DEEP, border: `1px solid ${GOLD_DEEP}`, padding: 'var(--space-md) var(--space-sm)' }}
             >
               <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1, color: TEXT }}>
                 {stat.value}
               </div>
-              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+              <div style={{ ...kicker, marginTop: 'var(--space-sm)' }}>{stat.label}</div>
             </div>
           ))}
         </div>
@@ -158,7 +168,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: '10px 16px', fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: TEXT, textDecoration: 'none' }}
+          style={{ background: VELLUM, border: `1px solid ${GOLD_DEEP}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: SCRIPT, fontStyle: 'italic', fontSize: 'var(--text-content)', color: TEXT, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: RUBRIC }}>›</span>
@@ -167,7 +177,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
 
       {/* ── Surveys underway ── */}
       <Leaf>
-        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-md)' }}>
           <span style={{ fontFamily: DISPLAY, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: TEXT }}>
             {t('fieldDesk.home.ephemerists.questsHeading')}
           </span>
@@ -188,14 +198,14 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
                 key={praxis.id}
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
-                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
+                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
               >
                 <span className="shrink-0" style={{ width: 9, height: 9, borderRadius: '50%', background: RUBRIC }} />
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1.15, color: TEXT }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: DISPLAY, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: DISPLAY, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -204,7 +214,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: DISPLAY, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: LAPIS, padding: '4px 9px', border: `1px solid ${GOLD_DEEP}` }}
+                  style={{ fontFamily: DISPLAY, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: LAPIS, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${GOLD_DEEP}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -219,7 +229,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-lg)', letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: PARCHMENT, background: RUBRIC, border: `1px solid ${GOLD}`, textDecoration: 'none' }}
+          style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-lg)', letterSpacing: '0.1em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: PARCHMENT, background: RUBRIC, border: `1px solid ${GOLD}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -227,9 +237,9 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-lg)', letterSpacing: '0.1em', textTransform: 'uppercase', padding: 14, color: TEXT, background: VELLUM, border: `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
+            style={{ fontFamily: DISPLAY, fontWeight: 700, fontSize: 'var(--text-lg)', letterSpacing: '0.1em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: TEXT, background: VELLUM, border: `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
           >
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
@@ -60,7 +60,7 @@ function Plate({ children, style }: { children: ReactNode; style?: CSSProperties
         backgroundImage: 'radial-gradient(color-mix(in srgb, var(--everymen-ink) 6%, transparent) 0.6px, transparent 0.9px)',
         backgroundSize: '5px 5px',
         border: `2px solid ${INK}`,
-        padding: 16,
+        padding: 'var(--space-lg)',
         ...style,
       }}
     >
@@ -71,7 +71,7 @@ function Plate({ children, style }: { children: ReactNode; style?: CSSProperties
 
 function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-md)' }}>
       <span style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', letterSpacing: '0.06em', color: INK, whiteSpace: 'nowrap' }}>
         {title}
       </span>
@@ -95,7 +95,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
     <div
       data-skin="everymen"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: BODY_FONT, color: INK, background: PAPER }}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: BODY_FONT, color: INK, background: PAPER }}
     >
       {/* Masthead billboard */}
       <header style={{ border: `3px solid ${INK}`, background: RED, color: CREAM, overflow: 'hidden' }}>
@@ -103,10 +103,10 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
           style={{
             display: 'flex',
             alignItems: 'center',
-            gap: 8,
+            gap: 'var(--space-sm)',
             background: INK,
             color: GOLD,
-            padding: '8px 14px',
+            padding: 'var(--space-sm) var(--space-lg)',
           }}
         >
           <CogSeal size={16} />
@@ -125,7 +125,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             color: CREAM,
             textShadow: `2px 2px 0 ${INK}`,
             margin: 0,
-            padding: '16px 16px 18px',
+            padding: 'var(--space-lg) var(--space-lg) var(--space-lg)',
           }}
         >
           {t('fieldDesk.home.title')}
@@ -134,7 +134,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
 
       {/* ── The worker on the roll ── */}
       <Plate>
-        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-lg)' }}>
           <span style={kicker}>{t('fieldDesk.home.everymen.charEyebrow')}</span>
           <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: RED, textDecoration: 'none' }}>
             {t('fieldDesk.home.edit')}
@@ -142,7 +142,17 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="shrink-0" style={{ width: 56, height: 56, padding: 3, background: GOLD, border: `2px solid ${INK}` }}>
+          <div
+            className="shrink-0"
+            style={{
+              width: 56,
+              height: 56,
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: gold ring thickness inside the 2px ink border of a 56px avatar; the nearest rung (4px) thickens the band by a third.
+              padding: 3,
+              background: GOLD,
+              border: `2px solid ${INK}`,
+            }}
+          >
             {character.avatar_url ? (
               <img
                 src={mediaUrl(character.avatar_url)}
@@ -153,7 +163,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center"
-                // ornament: avatar initial sized to its 56px gold plate, not text
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 56px gold plate, not text
                 style={{ background: PAPER_DEEP, fontFamily: ACCENT_FONT, fontSize: 26, color: RED }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -168,7 +178,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ ...kicker, marginTop: 5 }}>
+            <div className="truncate" style={{ ...kicker, marginTop: 'var(--space-xs)' }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -179,22 +189,22 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             <div style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-title)', lineHeight: 0.9, color: RED }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
-            <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
+            <div style={{ ...kicker, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
           </div>
         </div>
 
         {/* Points seals */}
-        <div className="flex gap-2" style={{ marginTop: 16 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
               className="text-center"
-              style={{ flex: '1 1 0', minWidth: 0, background: PAPER_DEEP, border: `1.5px solid ${INK}`, padding: '11px 6px' }}
+              style={{ flex: '1 1 0', minWidth: 0, background: PAPER_DEEP, border: `1.5px solid ${INK}`, padding: 'var(--space-md) var(--space-sm)' }}
             >
               <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-title)', lineHeight: 0.9, color: INK }}>
                 {stat.value}
               </div>
-              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+              <div style={{ ...kicker, marginTop: 'var(--space-sm)' }}>{stat.label}</div>
             </div>
           ))}
         </div>
@@ -205,7 +215,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: PAPER, border: `1.5px solid ${INK}`, padding: '10px 16px', fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', letterSpacing: '0.04em', color: INK, textDecoration: 'none' }}
+          style={{ background: PAPER, border: `1.5px solid ${INK}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', letterSpacing: '0.04em', color: INK, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: RED }}>›</span>
@@ -234,14 +244,14 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
                 key={praxis.id}
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
-                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid color-mix(in srgb, var(--everymen-ink) 20%, transparent)`, textDecoration: 'none' }}
+                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid color-mix(in srgb, var(--everymen-ink) 20%, transparent)`, textDecoration: 'none' }}
               >
                 <span className="shrink-0" style={{ width: 10, height: 10, background: RED }} />
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', lineHeight: 1.05, color: INK }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ ...kicker, marginTop: 3 }}>
+                  <div className="truncate" style={{ ...kicker, marginTop: 'var(--space-xs)' }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -250,7 +260,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: BODY_FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: '4px 9px' }}
+                  style={{ fontFamily: BODY_FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: 'var(--space-xs) var(--space-sm)' }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -265,7 +275,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 14, color: CREAM, background: RED, border: `2px solid ${INK}`, textDecoration: 'none' }}
+          style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 'var(--space-lg)', color: CREAM, background: RED, border: `2px solid ${INK}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -273,9 +283,9 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 14, color: INK, background: PAPER_DEEP, border: `2px solid ${INK}`, textDecoration: 'none' }}
+            style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 'var(--space-lg)', color: INK, background: PAPER_DEEP, border: `2px solid ${INK}`, textDecoration: 'none' }}
           >
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
@@ -125,7 +125,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             color: CREAM,
             textShadow: `2px 2px 0 ${INK}`,
             margin: 0,
-            padding: 'var(--space-lg) var(--space-lg) var(--space-lg)',
+            padding: 'var(--space-lg)',
           }}
         >
           {t('fieldDesk.home.title')}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
@@ -46,7 +46,7 @@ function Cursor() {
         display: 'inline-block',
         width: 6,
         height: 11,
-        marginLeft: 4,
+        marginLeft: 'var(--space-xs)',
         verticalAlign: 'middle',
         background: PHOSPHOR,
         animation: 'blink 1s step-end infinite',
@@ -58,7 +58,7 @@ function Cursor() {
 /** Void readout panel with a signal-blue hairline and corner brackets. */
 function Panel({ children }: { children: ReactNode }) {
   return (
-    <div style={{ position: 'relative', overflow: 'hidden', background: VOID, border: `1px solid ${signal(42)}`, padding: 16 }}>
+    <div style={{ position: 'relative', overflow: 'hidden', background: VOID, border: `1px solid ${signal(42)}`, padding: 'var(--space-lg)' }}>
       {/* Scanline overlay */}
       <div
         aria-hidden
@@ -88,22 +88,22 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
     <div
       data-skin="singularity"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: FONT, color: PHOSPHOR, background: VOID }}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: FONT, color: PHOSPHOR, background: VOID }}
     >
       {/* Prompt masthead */}
       <header>
         <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: FONT, fontSize: 'var(--text-title)', lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.04em', margin: '4px 0 0' }}>
+        <h1 style={{ fontFamily: FONT, fontSize: 'var(--text-title)', lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.04em', margin: 'var(--space-xs) 0 0' }}>
           {'> '}
           {t('fieldDesk.home.singularity.masthead')}
           <Cursor />
         </h1>
-        <div style={{ height: 1, marginTop: 10, background: `linear-gradient(90deg, ${BORDER_HARD}, transparent)` }} />
+        <div style={{ height: 1, marginTop: 'var(--space-md)', background: `linear-gradient(90deg, ${BORDER_HARD}, transparent)` }} />
       </header>
 
       {/* ── Node panel ── */}
       <Panel>
-        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-lg)' }}>
           <span style={kicker}>{t('fieldDesk.home.singularity.charEyebrow')}</span>
           <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: PHOSPHOR, textDecoration: 'none' }}>
             {t('fieldDesk.home.edit')}
@@ -125,7 +125,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center"
-                // ornament: avatar initial sized to its 52px node ring, not text
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 52px node ring, not text
                 style={{ fontFamily: FONT, fontSize: 20, color: SIGNAL }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -140,7 +140,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: FONT, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
+            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -151,21 +151,21 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
             <div style={{ fontFamily: FONT, fontSize: 'var(--text-title)', lineHeight: 1, color: PHOSPHOR }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
-            <div style={{ ...kicker, marginTop: 3 }}>{t('fieldDesk.home.stats.points')}</div>
+            <div style={{ ...kicker, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 16 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
               className="text-center"
-              style={{ flex: '1 1 0', minWidth: 0, background: signal(8), border: `1px solid ${signal(28)}`, padding: '11px 6px' }}
+              style={{ flex: '1 1 0', minWidth: 0, background: signal(8), border: `1px solid ${signal(28)}`, padding: 'var(--space-md) var(--space-sm)' }}
             >
               <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1, color: PHOSPHOR }}>
                 {stat.value}
               </div>
-              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+              <div style={{ ...kicker, marginTop: 'var(--space-sm)' }}>{stat.label}</div>
             </div>
           ))}
         </div>
@@ -176,7 +176,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: '11px 16px', fontFamily: FONT, fontSize: 'var(--text-content)', color: PHOSPHOR, textDecoration: 'none' }}
+          style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: FONT, fontSize: 'var(--text-content)', color: PHOSPHOR, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: SIGNAL }}>›</span>
@@ -185,7 +185,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
 
       {/* ── Running functions ── */}
       <Panel>
-        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-md)' }}>
           <span style={{ fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: PHOSPHOR }}>
             {t('fieldDesk.home.singularity.questsHeading')}
           </span>
@@ -206,15 +206,15 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
                 key={praxis.id}
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
-                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${signal(14)}`, textDecoration: 'none' }}
+                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${signal(14)}`, textDecoration: 'none' }}
               >
-                {/* ornament: the prompt caret is a list bullet glyph, not text */}
+                {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the prompt caret is a list bullet glyph, not text */}
                 <span className="shrink-0" style={{ fontFamily: FONT, fontSize: 13, color: PHOSPHOR }}>›</span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.2, color: PHOSPHOR }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
+                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -223,7 +223,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: '4px 9px', border: `1px solid ${signal(30)}` }}
+                  style={{ fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${signal(30)}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -238,7 +238,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: VOID, background: PHOSPHOR, border: `1px solid ${PHOSPHOR}`, boxShadow: `0 0 16px ${phosphor(30)}`, textDecoration: 'none' }}
+          style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: VOID, background: PHOSPHOR, border: `1px solid ${PHOSPHOR}`, boxShadow: `0 0 16px ${phosphor(30)}`, textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -246,9 +246,9 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PHOSPHOR, background: 'transparent', border: `1px solid ${signal(40)}`, textDecoration: 'none' }}
+            style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: PHOSPHOR, background: 'transparent', border: `1px solid ${signal(40)}`, textDecoration: 'none' }}
           >
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
@@ -53,7 +53,7 @@ function RansomCard({ children, tilt = -1 }: { children: ReactNode; tilt?: numbe
         color: TEXT,
         border: `1px solid ${LINE}`,
         boxShadow: CARD_SHADOW,
-        padding: 16,
+        padding: 'var(--space-lg)',
         transform: `rotate(${tilt}deg)`,
         overflow: 'hidden',
       }}
@@ -85,20 +85,20 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
     <div
       data-skin="snide"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 18, fontFamily: TYPE, color: WALL_TEXT, background: WALL }}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: TYPE, color: WALL_TEXT, background: WALL }}
     >
       {/* Masthead — Bebas over an acid rule */}
       <header>
         <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: COND, fontSize: 'var(--text-display)', letterSpacing: '0.03em', lineHeight: 0.95, color: WALL_TEXT, margin: '2px 0 0' }}>
+        <h1 style={{ fontFamily: COND, fontSize: 'var(--text-display)', letterSpacing: '0.03em', lineHeight: 0.95, color: WALL_TEXT, margin: 'var(--space-xs) 0 0' }}>
           {t('fieldDesk.home.snide.masthead')}
         </h1>
-        <div style={{ height: 2, marginTop: 8, background: ACCENT_WALL }} />
+        <div style={{ height: 2, marginTop: 'var(--space-sm)', background: ACCENT_WALL }} />
       </header>
 
       {/* ── Operative file ── */}
       <RansomCard tilt={-1}>
-        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-lg)' }}>
           <span style={{ ...kicker, color: ACID }}>{t('fieldDesk.home.snide.charEyebrow')}</span>
           <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: PINK, textDecoration: 'none' }}>
             {t('fieldDesk.home.edit')}
@@ -110,7 +110,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
             {character.avatar_url ? (
               <img src={mediaUrl(character.avatar_url)} alt={character.display_name} className="w-full h-full" style={{ objectFit: 'cover' }} />
             ) : (
-              // ornament: avatar initial sized to its 56px acid tile, not text
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 56px acid tile, not text
               <span style={{ fontFamily: IMPACT, fontSize: 26, color: INK }}>{character.display_name[0]?.toUpperCase()}</span>
             )}
           </div>
@@ -122,7 +122,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: TYPE, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
+            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -133,21 +133,21 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
             <div style={{ fontFamily: IMPACT, fontSize: 'var(--text-title)', lineHeight: 1, color: ACID }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
-            <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
+            <div style={{ ...kicker, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 16 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
               className="text-center"
-              style={{ flex: '1 1 0', minWidth: 0, background: 'rgba(255,255,255,0.04)', border: `1px solid ${LINE}`, padding: '11px 6px' }}
+              style={{ flex: '1 1 0', minWidth: 0, background: 'rgba(255,255,255,0.04)', border: `1px solid ${LINE}`, padding: 'var(--space-md) var(--space-sm)' }}
             >
               <div className="truncate" style={{ fontFamily: IMPACT, fontSize: 'var(--text-content)', lineHeight: 1, color: TEXT }}>
                 {stat.value}
               </div>
-              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+              <div style={{ ...kicker, marginTop: 'var(--space-sm)' }}>{stat.label}</div>
             </div>
           ))}
         </div>
@@ -158,7 +158,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: INK, color: TEXT, border: `1px solid ${LINE}`, padding: '11px 16px', fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.03em', textDecoration: 'none' }}
+          style={{ background: INK, color: TEXT, border: `1px solid ${LINE}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.03em', textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: ACID }}>›</span>
@@ -167,7 +167,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
 
       {/* ── Jobs in play ── */}
       <RansomCard tilt={0.7}>
-        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-md)' }}>
           <span style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', color: ACID }}>
             {t('fieldDesk.home.snide.questsHeading')}
           </span>
@@ -188,14 +188,14 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
                 key={praxis.id}
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
-                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
+                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
               >
                 <span className="shrink-0" style={{ width: 9, height: 9, background: ACID }} />
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.02em', lineHeight: 1.15, color: TEXT }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -204,7 +204,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: ACID, padding: '4px 9px', border: `1px solid ${LINE}` }}
+                  style={{ fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: ACID, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -219,7 +219,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: BLACK, fontSize: 'var(--text-lg)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 15, color: 'var(--faction-snide-paper)', background: PINK, boxShadow: '2px 3px 0 rgba(0,0,0,.4)', textDecoration: 'none' }}
+          style={{ fontFamily: BLACK, fontSize: 'var(--text-lg)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: 'var(--faction-snide-paper)', background: PINK, boxShadow: '2px 3px 0 rgba(0,0,0,.4)', textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -227,9 +227,9 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 15, color: TEXT, background: INK, border: `1px solid ${ACID}`, textDecoration: 'none' }}
+            style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: TEXT, background: INK, border: `1px solid ${ACID}`, textDecoration: 'none' }}
           >
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1, color: ACID }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -44,12 +44,18 @@ function Plate({ children }: { children: ReactNode }) {
   return (
     <div
       style={{
-        padding: 8,
+        padding: 'var(--space-sm)',
         background: GILT,
         boxShadow: '0 10px 24px rgba(60,40,10,.18), inset 0 0 0 1px rgba(255,255,255,0.45)',
       }}
     >
-      <div style={{ padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+      <div
+        style={{
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: inner gold rule of the gilt double-border frame; the nearest rung (4px) merges it into the outer gilt band.
+          padding: 3,
+          background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
+        }}
+      >
         <div
           style={{
             position: 'relative',
@@ -58,7 +64,7 @@ function Plate({ children }: { children: ReactNode }) {
             backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
             backgroundSize: '5px 5px',
             border: `1px solid ${LINE}`,
-            padding: 16,
+            padding: 'var(--space-lg)',
           }}
         >
           {children}
@@ -82,20 +88,20 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
     <div
       data-skin="ua"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 14, fontFamily: MONO, color: INK, background: WALL }}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: MONO, color: INK, background: WALL }}
     >
       {/* Engraved masthead */}
       <header>
         <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: '2px 0 0' }}>
+        <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: 'var(--space-xs) 0 0' }}>
           {t('fieldDesk.home.ua.masthead')}
         </h1>
-        <div style={{ height: 1, marginTop: 9, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+        <div style={{ height: 1, marginTop: 'var(--space-sm)', background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
       </header>
 
       {/* ── Sitter plate ── */}
       <Plate>
-        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-lg)' }}>
           <span style={kicker}>{t('fieldDesk.home.ua.charEyebrow')}</span>
           <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: ACCENT, textDecoration: 'none' }}>
             {t('fieldDesk.home.edit')}
@@ -103,7 +109,17 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="shrink-0" style={{ width: 56, height: 56, borderRadius: '50%', padding: 3, background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
+          <div
+            className="shrink-0"
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: '50%',
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: gilt ring thickness drawn around a 56px avatar; the nearest rung (4px) thickens the band by a third.
+              padding: 3,
+              background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
+            }}
+          >
             {character.avatar_url ? (
               <img
                 src={mediaUrl(character.avatar_url)}
@@ -114,7 +130,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             ) : (
               <span
                 className="flex w-full h-full items-center justify-center rounded-full"
-                // ornament: avatar initial sized to its 56px medallion, not text
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 56px medallion, not text
                 style={{ background: PAPER_WARM, fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 24, color: ACCENT }}
               >
                 {character.display_name[0]?.toUpperCase()}
@@ -129,7 +145,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 5, fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: SUB }}>
+            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: SUB }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -140,21 +156,21 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: INK }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
-            <div style={{ ...kicker, marginTop: 2 }}>{t('fieldDesk.home.stats.points')}</div>
+            <div style={{ ...kicker, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 16 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
               className="text-center"
-              style={{ flex: '1 1 0', minWidth: 0, background: PAPER_WARM, border: `1px solid ${LINE}`, padding: '11px 6px' }}
+              style={{ flex: '1 1 0', minWidth: 0, background: PAPER_WARM, border: `1px solid ${LINE}`, padding: 'var(--space-md) var(--space-sm)' }}
             >
               <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
                 {stat.value}
               </div>
-              <div style={{ ...kicker, marginTop: 6 }}>{stat.label}</div>
+              <div style={{ ...kicker, marginTop: 'var(--space-sm)' }}>{stat.label}</div>
             </div>
           ))}
         </div>
@@ -165,7 +181,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999, padding: '10px 16px', fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
+          style={{ background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999, padding: 'var(--space-md) var(--space-lg)', fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
           <span aria-hidden style={{ color: ACCENT }}>›</span>
@@ -174,7 +190,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
 
       {/* ── Commissions at the easel ── */}
       <Plate>
-        <div className="flex items-center gap-2.5" style={{ marginBottom: 10 }}>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-md)' }}>
           <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
             {t('fieldDesk.home.ua.questsHeading')}
           </span>
@@ -195,14 +211,14 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
                 key={praxis.id}
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
-                style={{ padding: '12px 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
+                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
               >
                 <span className="shrink-0" style={{ width: 9, height: 9, borderRadius: '50%', background: ACCENT }} />
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 3, fontFamily: ENGRAVED, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: SUB }}>
+                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: ENGRAVED, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: SUB }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -211,7 +227,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: GOLD, padding: '4px 9px', border: `1px solid ${LINE}` }}
+                  style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: GOLD, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -226,7 +242,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
         <Link
           to="/tasks"
           className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: PAPER_WARM, background: ACCENT, border: `1px solid ${ACCENT}`, boxShadow: '0 6px 16px rgba(194,84,31,.28)', textDecoration: 'none' }}
+          style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: PAPER_WARM, background: ACCENT, border: `1px solid ${ACCENT}`, boxShadow: '0 6px 16px rgba(194,84,31,.28)', textDecoration: 'none' }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
@@ -234,9 +250,9 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
           <Link
             to="/propose-task"
             className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 14, color: INK, background: PAPER, border: `1px solid ${LINE}`, textDecoration: 'none' }}
+            style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: INK, background: PAPER, border: `1px solid ${LINE}`, textDecoration: 'none' }}
           >
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             <span>{t('actions.proposeTask')}</span>
           </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -57,8 +57,8 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 7,
-          padding: '8px 12px',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-sm) var(--space-md)',
           background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
           borderBottom: `2px solid ${WIN_BORDER}`,
         }}
@@ -70,7 +70,7 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
           />
         ))}
         <span
-          style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}
+          style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 'var(--space-xs)', fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}
         >
           <Sparkle size={11} color={TITLE_TEXT} />
           {title}
@@ -79,13 +79,13 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
       {/* dotted board */}
       <div
         style={{
-          padding: 12,
+          padding: 'var(--space-md)',
           background: BODY_BG,
           backgroundImage: `radial-gradient(${DOT} 1.4px, transparent 1.4px)`,
           backgroundSize: '13px 13px',
         }}
       >
-        <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: 13 }}>
+        <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: 'var(--space-md)' }}>
           {children}
         </div>
       </div>
@@ -98,13 +98,13 @@ const pinkButton: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: 7,
+  gap: 'var(--space-sm)',
   fontFamily: BODY,
   fontSize: 'var(--text-lg)',
   letterSpacing: '0.12em',
   textTransform: 'uppercase',
   fontWeight: 700,
-  padding: 15,
+  padding: 'var(--space-lg)',
   borderRadius: 14,
   color: ON_ACCENT,
   border: `1.5px solid ${WIN_BORDER}`,
@@ -117,12 +117,12 @@ const ghostButton: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: 6,
+  gap: 'var(--space-sm)',
   fontFamily: BODY,
   fontSize: 'var(--text-lg)',
   letterSpacing: '0.12em',
   textTransform: 'uppercase',
-  padding: 15,
+  padding: 'var(--space-lg)',
   borderRadius: 14,
   color: TITLE_TEXT,
   border: `1.5px solid ${NOTEPAD_BORDER}`,
@@ -147,7 +147,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
       style={{
         display: 'flex',
         flexDirection: 'column',
-        gap: 14,
+        gap: 'var(--space-lg)',
         fontFamily: BODY,
         color: CARD_TEXT,
         background: BODY_BG,
@@ -164,7 +164,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
 
       {/* ── Character window ── */}
       <Window title={t('fieldDesk.home.wow.charWindow')}>
-        <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-md)' }}>
           <span className="eyebrow" style={{ color: CARD_MUTED }}>
             {t('fieldDesk.home.wow.charEyebrow')}
           </span>
@@ -178,7 +178,17 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="shrink-0" style={{ width: 56, height: 56, borderRadius: '50%', padding: 3, background: PINK }}>
+          <div
+            className="shrink-0"
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: '50%',
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: pink ring thickness drawn around a 56px avatar; the nearest rung (4px) thickens the band by a third.
+              padding: 3,
+              background: PINK,
+            }}
+          >
             {character.avatar_url ? (
               <img
                 src={mediaUrl(character.avatar_url)}
@@ -192,7 +202,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                 style={{
                   background: 'radial-gradient(circle at 35% 28%, var(--faction-wow-title-from), var(--faction-wow))',
                   fontFamily: SCRIPT,
-                  // ornament: avatar initial sized to its 56px medallion, not text
+                  // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 56px medallion, not text
                   fontSize: 24,
                   color: ON_ACCENT,
                 }}
@@ -211,7 +221,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
             </Link>
             <div
               className="truncate"
-              style={{ marginTop: 4, fontSize: 'var(--text-base)', letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}
+              style={{ marginTop: 'var(--space-xs)', fontSize: 'var(--text-base)', letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}
             >
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
@@ -229,7 +239,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 14 }}>
+        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
@@ -240,13 +250,13 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                 background: 'var(--faction-wow-scrap-mid)',
                 border: `1px solid ${NOTEPAD_BORDER}`,
                 borderRadius: 12,
-                padding: '11px 6px',
+                padding: 'var(--space-md) var(--space-sm)',
               }}
             >
               <div className="truncate" style={{ fontFamily: SCRIPT, fontSize: 'var(--text-title)', lineHeight: 1, color: TITLE_TEXT }}>
                 {stat.value}
               </div>
-              <div className="eyebrow" style={{ marginTop: 5, color: CARD_MUTED }}>
+              <div className="eyebrow" style={{ marginTop: 'var(--space-xs)', color: CARD_MUTED }}>
                 {stat.label}
               </div>
             </div>
@@ -263,13 +273,13 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
             background: NOTEPAD_BG,
             border: `1.5px solid ${NOTEPAD_BORDER}`,
             borderRadius: 999,
-            padding: '10px 16px',
+            padding: 'var(--space-md) var(--space-lg)',
             fontSize: 'var(--text-content)',
             color: TITLE_TEXT,
             textDecoration: 'none',
           }}
         >
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
             <Sparkle size={12} color={PINK} />
             {t('fieldDesk.home.pending', { count: pendingCount })}
           </span>
@@ -279,8 +289,8 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
 
       {/* ── Quests window ── */}
       <Window title={t('fieldDesk.home.wow.questsWindow')}>
-        <div className="flex items-center gap-2.5" style={{ marginBottom: 8 }}>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}>
+        <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-sm)' }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-xs)', fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}>
             <Sparkle size={12} color={PINK} />
             {t('fieldDesk.home.wow.questsHeading')}
           </span>
@@ -302,7 +312,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{
-                  padding: '12px 0',
+                  padding: 'var(--space-md) 0',
                   borderTop: index === 0 ? undefined : `1px solid ${NOTEPAD_BORDER}`,
                   textDecoration: 'none',
                 }}
@@ -314,7 +324,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                   </div>
                   <div
                     className="truncate"
-                    style={{ marginTop: 4, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CARD_MUTED }}
+                    style={{ marginTop: 'var(--space-xs)', fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CARD_MUTED }}
                   >
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
@@ -324,7 +334,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0 eyebrow"
-                  style={{ color: PINK, padding: '4px 9px', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 999 }}
+                  style={{ color: PINK, padding: 'var(--space-xs) var(--space-sm)', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 999 }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -342,7 +352,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
         </Link>
         {canProposeTask && (
           <Link to="/propose-task" style={ghostButton}>
-            {/* ornament: "+" glyph used as an icon, sized to the button row */}
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
             <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
             {t('actions.proposeTask')}
           </Link>

--- a/frontend/src/pages/settings/mobileArchetypes/DefaultSettings.tsx
+++ b/frontend/src/pages/settings/mobileArchetypes/DefaultSettings.tsx
@@ -34,7 +34,7 @@ export default function DefaultSettings({ character, dark, onToggleTheme, onSign
   const charactersHref = character ? `/characters/${character.id}/edit` : '/characters/create'
 
   return (
-    <div data-testid="mobile-settings" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <div data-testid="mobile-settings" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
       <header>
         <h1
           className="font-display italic"
@@ -50,17 +50,23 @@ export default function DefaultSettings({ character, dark, onToggleTheme, onSign
           background: 'var(--color-bg-surface)',
           border: '1px solid var(--color-border)',
           borderRadius: 'var(--radius-xl)',
-          padding: 16,
+          padding: 'var(--space-lg)',
         }}
       >
-        <div className="eyebrow" style={{ color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+        <div className="eyebrow" style={{ color: 'var(--color-text-secondary)', marginBottom: 'var(--space-md)' }}>
           {t('settings.account.eyebrow')}
         </div>
         {character ? (
           <div className="flex items-center gap-3.5">
             <div
               className="shrink-0 rounded-full"
-              style={{ width: 52, height: 52, padding: 3, background: 'var(--faction-default-ring)' }}
+              style={{
+                width: 52,
+                height: 52,
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: spectrum ring thickness drawn around a 52px avatar; the nearest rung (4px) thickens the band by a third.
+                padding: 3,
+                background: 'var(--faction-default-ring)',
+              }}
             >
               {character.avatar_url ? (
                 <img
@@ -88,7 +94,7 @@ export default function DefaultSettings({ character, dark, onToggleTheme, onSign
               <div
                 className="truncate"
                 style={{
-                  marginTop: 4,
+                  marginTop: 'var(--space-xs)',
                   fontFamily: 'var(--font-body)',
                   fontSize: 'var(--text-base)',
                   letterSpacing: '0.14em',
@@ -110,7 +116,7 @@ export default function DefaultSettings({ character, dark, onToggleTheme, onSign
                 textDecoration: 'none',
                 border: '1px solid var(--color-border-strong)',
                 borderRadius: 999,
-                padding: '6px 11px',
+                padding: 'var(--space-sm) var(--space-md)',
               }}
             >
               {t('settings.account.viewProfile')}
@@ -131,18 +137,25 @@ export default function DefaultSettings({ character, dark, onToggleTheme, onSign
           background: 'var(--color-bg-surface)',
           border: '1px solid var(--color-border)',
           borderRadius: 'var(--radius-xl)',
-          padding: '16px',
+          padding: 'var(--space-lg)',
           textDecoration: 'none',
         }}
       >
         <div className="min-w-0 flex-1">
           <div style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}>{t('settings.characters.label')}</div>
-          <div style={{ marginTop: 2, fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}>
+          <div style={{ marginTop: 'var(--space-xs)', fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}>
             {t('settings.characters.hint')}
           </div>
         </div>
-        {/* ornament: chevron dingbat used as a row-affordance icon, not text */}
-        <span aria-hidden style={{ color: 'var(--color-text-tertiary)', fontSize: 18, lineHeight: 1 }}>
+        <span
+          aria-hidden
+          style={{
+            color: 'var(--color-text-tertiary)',
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: chevron dingbat used as a row-affordance icon, not text
+            fontSize: 18,
+            lineHeight: 1,
+          }}
+        >
           ›
         </span>
       </Link>
@@ -153,10 +166,10 @@ export default function DefaultSettings({ character, dark, onToggleTheme, onSign
           background: 'var(--color-bg-surface)',
           border: '1px solid var(--color-border)',
           borderRadius: 'var(--radius-xl)',
-          padding: '16px',
+          padding: 'var(--space-lg)',
         }}
       >
-        <div className="eyebrow" style={{ color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+        <div className="eyebrow" style={{ color: 'var(--color-text-secondary)', marginBottom: 'var(--space-md)' }}>
           {t('settings.appearance.eyebrow')}
         </div>
         <div className="flex items-center gap-3">
@@ -207,7 +220,7 @@ export default function DefaultSettings({ character, dark, onToggleTheme, onSign
         data-testid="settings-sign-out"
         className="font-body"
         style={{
-          padding: 15,
+          padding: 'var(--space-lg)',
           borderRadius: 12,
           fontSize: 'var(--text-lg)',
           letterSpacing: '0.12em',


### PR DESCRIPTION
Slice 6 of the spacing ratchet, combined with the per-file delisting of #623 and the Tailwind audit of #763.

Part of #750
Part of #623
Part of #763

## What changed

354 raw values across **21 files** in four directories — `characterProfile/**`, `fieldDesk/**`, `characterPaths/**`, `settings/**`. All 21 are now **deleted from `frontend/.eslint-legacy-raw-styles.txt`** (122 → 101 lines). Nothing was added to the list.

- **Spacing → `--space-*`**, ties rounded up per §4a. Numeric *and* string shorthand forms (`"11px 6px"`, `"12px 0"`, `"4px 0 0"`), which the numeric grep cannot see.
- **Ornament promoted phase-1 → phase-2.** Every surviving `// ornament:` comment became an `eslint-disable-next-line local/no-raw-style-values -- ornament: <why>` directive, justification preserved. JSX-container comments (`{/* ornament: … */}`) were promoted in place and verified to actually suppress.
- **Zero left alone** (#764): `padding: 0` / `margin: 0` untouched.

## Judgement calls

**Kept raw as ornament** — decorative *ring thickness*, always 2–3px with no rung within reach (the nearest rung is 4px, a 33–100% thicker band that visibly eats the inner disc):
- avatar/medallion spectrum, gilt, gold and pink rings across UA, Everymen, Ephemerists, WOW, Singularity and Default, desktop and mobile
- the inner gold rule of UA's gilt double-border frame

**Treated as layout, not ornament** — `marginTop: 2/3` on the kicker line under a display name in six Field Desk skins. That is a gutter between two lines of text, and §4a says a gutter is never ornament. All → `--space-xs`.

**Asymmetric insets.** `profileSkin`'s page frame `"32px 28px"` rounds the 28 *down* to keep the frame taller than wide. Elsewhere (`"40px 44px"`, `"18px 20px"`) rounding the tie *up* preserves the asymmetry, so the default up-rule applied.

## Two findings for the sweep

1. **The rule does not recurse into `??`.** `fontSize: kit.nameSize ?? 48` in `profileSkin.tsx` never reports, so an `eslint-disable` there is flagged *unused*. I left it as a plain comment with a note explaining why. Worth knowing before another slice tries to hatch a `??` default.
2. **#763 in this footprint is zero.** A naive grep reports 41 `text-xs`/`text-sm` hits; every one is a `--text-sm` CSS variable on a line that also happens to carry `className`. Scoping the grep to actual `className` contents gives **0**. No sub-floor Tailwind prose here — confirms the issue's own warning that the naive count inflates badly.

No `fontSize` was added to any skin style object, and no faction's internal rhythm was regularized against another's.

## Verification

- `npx eslint src --report-unused-disable-directives` — **exit 0 across the whole tree** with all 21 files delisted. This is the load-bearing check: it catches a premature delist and a misplaced directive.
- `npx tsc --noEmit` — clean (8 `node:fs`/`node:url`/`node:path` errors are the known stale-junction false alarm, PR #675).
- `npx vitest run` — **913 passing**, 102 files.
- `npx vite build` — clean.

## What to eyeball

**Visual QA is outstanding.** I cannot screenshot and there is no dev stack in this worktree; everything above is static verification only. Spacing moved by a few px in many places by design, so these want a human eye:

**Desktop — player profile** (`/characters/:id`), one per faction:
- UA, Everymen, Warriors of Whimsy, S.N.I.D.E., Ephemerists, Singularity, Albescent, and the Default/unaffiliated skin
- per skin: the identity header inset, the progression panel, section headings, the badges rail and its "n earned" chip, and the praxis empty state
- WOW specifically: the **scotch-tape band behind section titles** went `2px 12px` → `4px 12px`, so the tape sits ~4px taller. Most likely single visible change in the set.
- Default specifically: the **rainbow band** around the credential card went 5px → 4px.

**Mobile:**
- Field Desk home for all eight skins (UA, Everymen, WOW, S.N.I.D.E., Ephemerists, Singularity, Albescent, Default) — stat tiles, the roster rows, the avatar ring, and the "+" FAB
- Player profile (`DefaultProfile`) — stats row, segmented Praxis/Tasks toggle, badge rows
- Create Character and Edit Character — field insets, the photo ring, the sticky submit bar
- Settings — account header, the characters row, the dark-mode switch, sign out

Worth checking both themes, since several of these surfaces are always-dark (Singularity, S.N.I.D.E.) or always-light (UA, Albescent).
