### PR TITLE
Retire avgFontSize: the vote tally joins the shared type scale

### DIFF
--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -124,7 +124,6 @@ export default function AlbescentVote({
           muted: 'var(--faction-albescent-card-muted)',
           accent: 'var(--faction-albescent-card-accent)',
           accentFont: FONT,
-          avgFontSize: 16,
           errorColor: 'var(--faction-albescent-card-accent)',
           avgLetterSpacing: '0.04em',
         }}

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -113,7 +113,6 @@ export default function EphemeristsVote({
           muted: "var(--eph-muted)",
           accent: "var(--eph-rubric)",
           accentFont: "var(--eph-display)",
-          avgFontSize: 15,
           errorColor: "var(--eph-rubric)",
           avgLetterSpacing: "0.02em",
         }}

--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -110,7 +110,6 @@ export default function EverymenVote({ praxisId, currentValue, points, totalVote
           muted: 'var(--everymen-muted)',
           accent: 'var(--everymen-red)',
           accentFont: 'var(--faction-everymen-card-font)',
-          avgFontSize: 15,
           errorColor: 'var(--everymen-red)',
           avgLetterSpacing: '0.04em',
         }}

--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -126,7 +126,6 @@ export default function SingularityVote({ praxisId, currentValue, points, totalV
           muted: 'color-mix(in srgb, var(--faction-singularity-card-muted) 60%, transparent)',
           accent: 'var(--faction-singularity-card-accent)',
           accentFont: 'var(--font-faction-terminal)',
-          avgFontSize: 17,
           errorColor: 'var(--color-danger)',
           avgLetterSpacing: '0.08em',
         }}

--- a/frontend/src/components/vote/SnideVote.tsx
+++ b/frontend/src/components/vote/SnideVote.tsx
@@ -104,7 +104,6 @@ export default function SnideVote({ praxisId, currentValue, points, totalVotes }
           muted: 'var(--color-text-secondary)',
           accent: 'var(--faction-snide)',
           accentFont: 'var(--faction-snide-font-impact)',
-          avgFontSize: 18,
           errorColor: 'var(--color-danger)',
         }}
       />

--- a/frontend/src/components/vote/UaVote.tsx
+++ b/frontend/src/components/vote/UaVote.tsx
@@ -107,7 +107,6 @@ export default function UaVote({
           muted: 'var(--faction-ua-card-muted)',
           accent: 'var(--faction-ua-card-accent)',
           accentFont: PLATE_FONT,
-          avgFontSize: 16,
           errorColor: 'var(--ua-orange-deep)',
           avgLetterSpacing: '0.04em',
         }}

--- a/frontend/src/components/vote/VoteShell.tsx
+++ b/frontend/src/components/vote/VoteShell.tsx
@@ -14,11 +14,15 @@ export function VoteLoginGate() {
   return <p className="eyebrow">{t('chrome.loginGate')}</p>
 }
 
+/**
+ * A skin carries font, colour and letter-spacing — never a size. The shared
+ * chrome owns every size here, off the `--text-*` scale (WORLD_ZERO_STYLE §4a:
+ * "if a skin is setting a size, the size has escaped the scale").
+ */
 export interface VoteSummaryTheme {
   muted: string
   accent: string
   accentFont: string
-  avgFontSize: number
   errorColor: string
   avgLetterSpacing?: string
 }
@@ -64,11 +68,14 @@ export function VoteSummary({
             values={{ points }}
             components={{
               1: (
+                // The points figure is emphasis inside a running sentence, so it
+                // inherits the paragraph's --text-content (18px) rather than
+                // carrying a size of its own. The skin's contribution is the
+                // accent colour and face; weight comes from <b>.
                 <b
                   style={{
                     color: theme.accent,
                     fontFamily: theme.accentFont,
-                    fontSize: theme.avgFontSize,
                   }}
                 />
               ),

--- a/frontend/src/components/vote/WowVote.tsx
+++ b/frontend/src/components/vote/WowVote.tsx
@@ -112,7 +112,6 @@ export default function WowVote({ praxisId, currentValue, points, totalVotes }: 
           muted: 'var(--faction-wow-card-muted)',
           accent: 'var(--faction-wow)',
           accentFont: 'var(--faction-wow-card-font)',
-          avgFontSize: 16,
           errorColor: 'var(--color-danger)',
         }}
       />

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
@@ -91,7 +91,6 @@ export function MobileStarVote({
             muted: 'var(--color-text-tertiary)',
             accent,
             accentFont,
-            avgFontSize: 15,
             errorColor: 'var(--color-danger)',
           }}
         />


### PR DESCRIPTION
Closes #774

## What was wrong

`VoteSummaryTheme.avgFontSize` was a numeric font size living inside a skin theme object, applied as `fontSize: theme.avgFontSize`. Seven skins each filled it with their own value — 15 / 16 / 17 / 18 — which is a **parallel per-faction type scale** running alongside the real one. `WORLD_ZERO_STYLE.md` §4a forbids exactly this on two counts: *"Skins don't own type size"* and *"Both scales are global, not per-faction… There are no per-faction size or spacing exceptions."*

The ratchet was blind at both ends, as the issue diagnoses: `avgFontSize` isn't in `STYLE_PROPS` (definitions invisible), and `theme.avgFontSize` is a `MemberExpression`, not a `Literal` (use site invisible). Same shape as the ternary hole closed in #770.

## The fix, and why it isn't a token substitution

The tally copy is `"{{count}} votes · <1>{{points}}</1> pts"` — the `<1>` wraps the points figure as **emphasis inside a running sentence**, and the enclosing `<p>` already carries `fontSize: var(--text-content)`.

So the size is deleted outright and the `<b>` inherits 18px. It keeps the skin's accent colour, accent face and `avgLetterSpacing`; `<b>` supplies the weight. That is the emphasis, without a size knob.

Deliberately **not** a mechanical token swap. `--text-sm` is 9px, not 14px — mapping "15 → `--text-sm`" would have *shrunk* five factions to 9px, which is the precise regression #769 documents from the earlier sweep. Picking by role rather than by nearest number, nothing here gets smaller:

| Skin | Before | After |
|---|---|---|
| Ephemerists, Everymen, mobile praxis detail | 15 | 18 |
| Albescent, UA, WOW | 16 | 18 |
| Singularity | 17 | 18 |
| Snide | 18 | 18 (unchanged) |

Five of the seven were **below the 18px content floor**, so this is a readability fix as much as a tidiness one.

## Scope note

The issue's table lists six skins; there are in fact **seven**, and there is an eighth caller the table misses — `pages/praxisDetail/mobileArchetypes/shared.tsx` also filled `avgFontSize: 15`. Without it the prop could not actually be deleted. All 10 sites across 9 files are gone; `grep -rn avgFontSize frontend/src/` returns nothing.

`components/vote/VoteUI.tsx` is **untouched**, to stay clear of the parallel registry refactor in #782.

## Ask #2 — audit for other size fields in theme/skin interfaces

Swept for `*FontSize` / `*Size` fields. Four hits, all already legitimate and documented:

- `SnideVote.StampVisual.fontSize` — rubber-stamp ornament, already carries per-line `eslint-disable` + rationale (§4a ornament hatch).
- `profileSkin.nameSize` — masthead display type, documented in-place as "the ONE size a kit may carry", far above the floor.
- `FactionAvatar` `fontSize` — computed `Math.round(dim * 0.44)`, initials scaled to the circle; ornament geometry, not a scale.
- `UaSigil.fontSize` — sigil ornament. (`usePagedResource.pageSize` is not a style.)

`avgFontSize` was the only *undocumented* one. Ask #3 (should the rule flag any property whose name ends in `FontSize`) is left as a documented note for #763 rather than actioned here — it needs a rule-side change, and a name-suffix heuristic would not have caught this one at the use site anyway.

## Verification

`tsc --noEmit` clean (only the 8 known `Cannot find module 'node:fs'` stale-junction false alarms from PR #675, none in touched files) · `vite build` ✓ · `eslint --max-warnings=0` ✓ · 925 tests / 102 files pass. No backend files touched.

## Visual QA is OUTSTANDING

I cannot screenshot in this environment, so **nothing below has been looked at**. Every faction's tally line changes size, so this needs a human eye.

### What to eyeball

The votes/points tally line ("N votes · **P** pts") on **desktop praxis detail** and **mobile praxis detail**, for all seven factions:

1. **Albescent** — 16 → 18
2. **Ephemerists** — 15 → 18
3. **Everymen** — 15 → 18
4. **Singularity** — 17 → 18, and it has the widest letter-spacing (`0.08em`); check the terminal face doesn't now wrap
5. **Snide** — 18 → 18, the only no-op; it is the control, it should look identical
6. **UA** — 16 → 18
7. **WOW** — 16 → 18

Plus the **mobile praxis-detail** shared vote block (15 → 18), which themes by the *viewer's* faction, so it wants a pass under more than one affiliation.

Specifically worth checking: the accent faces are display fonts (Impact, Bebas, blackletter, terminal) and render at different optical sizes for the same px, so the +1–3px lift may read larger in some skins than others; and whether any narrow card now wraps the tally onto two lines. Per §4's geometry doctrine, a wrap means the container should widen — not that the type should shrink back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
