### PR TITLE
Allow proposing unaffiliated (cross-faction) tasks (#704)

### DIFF
--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -9,6 +9,7 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.faction import Faction, FactionStatus
 from models.task import Task, TaskStatus
+from services.faction_service import UNAFFILIATED_FACTION_SLUG
 
 
 async def _set_character_level(
@@ -559,6 +560,28 @@ async def test_propose_task_faction_slug_stored(
     assert resp.status_code == 201
     data = resp.json()
     assert data["primary_faction_slug"] == "ua"
+
+
+@pytest.mark.asyncio
+async def test_propose_task_without_faction_is_unaffiliated(
+    client: AsyncClient,
+    character2: Character,
+    auth_headers2: dict,
+):
+    """Omitting primary_faction_slug proposes an UNAFFILIATED (cross-faction)
+    task rather than defaulting to some faction. This is the contract the
+    propose-task form's "Unaffiliated" option relies on (#704)."""
+    resp = await client.post(
+        "/tasks",
+        json={
+            "title": "Cross-Faction Task",
+            "point_value": 10,
+            "level_required": 0,
+        },
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["primary_faction_slug"] == UNAFFILIATED_FACTION_SLUG
 
 
 @pytest.mark.asyncio

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -594,9 +594,10 @@
       "heading": "Meta task proposed!",
       "body": "An admin will review it. Once activated, {{faction}} players can apply it to their praxes for a points bonus."
     },
-    "factionSelectorLabel": "Choose a faction for this task",
+    "factionSelectorLabel": "Choose a faction for this task, or leave it open to everyone",
     "factionDescriptor": {
-      "ua": "Unaffiliated",
+      "na": "Anyone",
+      "ua": "Academy",
       "wow": "Collective",
       "everymen": "Mobilize",
       "snide": "Mischief",
@@ -635,7 +636,8 @@
     },
     "metaToggle": {
       "label": "Create as meta task",
-      "hint": "applies as a bonus to all {{faction}} submissions"
+      "hint": "applies as a bonus to all {{faction}} submissions",
+      "hintNoFaction": "pick a faction above — meta tasks must belong to one"
     },
     "preview": {
       "metaHeading": "Meta task preview — {{faction}}",

--- a/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Unaffiliated task proposal (#704). The backend has always accepted a null
+ * `primary_faction_slug` and stored the `na` sentinel; the form was the gap —
+ * it defaulted to UA and offered no control that could produce `na`.
+ *
+ * No jsdom in this repo, so we assert on renderToStaticMarkup output. That is
+ * enough here because DefaultProposeTask is a pure function of the state prop.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so copy keys resolve to English text.
+import '../../../i18n'
+import DefaultProposeTask from '../archetypes/DefaultProposeTask'
+import {
+  UNAFFILIATED_FACTION_SLUG,
+  type ProposeTaskState,
+} from '../useProposeTask'
+
+function state(overrides: Partial<ProposeTaskState> = {}): ProposeTaskState {
+  return {
+    isLoggedIn: true,
+    canProposeTask: true,
+    canProposeMetatask: false,
+    currentLevel: 6,
+    success: false,
+    factions: [],
+    title: '',
+    setTitle: () => {},
+    description: '',
+    setDescription: () => {},
+    pointValue: '10',
+    setPointValue: () => {},
+    levelRequired: 0,
+    setLevelRequired: () => {},
+    factionSlug: UNAFFILIATED_FACTION_SLUG,
+    setFactionSlug: () => {},
+    notes: '',
+    setNotes: () => {},
+    isMetaTask: false,
+    setIsMetaTask: () => {},
+    metaBonusValue: '10',
+    setMetaBonusValue: () => {},
+    submitting: false,
+    error: null,
+    handleSubmit: async () => {},
+    handleCancel: () => {},
+    ...overrides,
+  }
+}
+
+function render(overrides: Partial<ProposeTaskState> = {}): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <DefaultProposeTask state={state(overrides)} />
+    </MemoryRouter>,
+  )
+}
+
+describe('propose task — unaffiliated option', () => {
+  it('offers an unaffiliated choice alongside the real factions', () => {
+    const text = render().replace(/<[^>]*>/g, '')
+    expect(text).toContain('Unaffiliated')
+    expect(text).toContain('Anyone')
+    // The registry factions are still listed.
+    expect(text).toContain('Everymen')
+  })
+
+  it('gives the unaffiliated pennant the rainbow, never a borrowed faction hue', () => {
+    // ADR-0039: `na` has no hue, so it takes the spectrum as a frame rather
+    // than resolving to `default` grey or impersonating UA orange (#749).
+    expect(render()).toContain('--faction-default-rainbow')
+  })
+
+  it('keeps a real faction on its solid hue', () => {
+    expect(render({ factionSlug: 'ua' })).toContain('var(--faction-ua)')
+  })
+
+  it('tells a metatask author to pick a faction while unaffiliated', () => {
+    const unaffiliated = render({ canProposeMetatask: true }).replace(
+      /<[^>]*>/g,
+      '',
+    )
+    expect(unaffiliated).toContain('meta tasks must belong to one')
+
+    const affiliated = render({
+      canProposeMetatask: true,
+      factionSlug: 'wow',
+    }).replace(/<[^>]*>/g, '')
+    expect(affiliated).toContain('applies as a bonus to all')
+  })
+})

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -3,8 +3,17 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PageTitle from "../../../components/ui/PageTitle";
 import FilterLevelNodes from "../../../components/ui/FilterLevelNodes";
-import { factionCssVar, factionName, getAllFactions } from "../../../utils/factions";
-import type { ProposeTaskState } from "../useProposeTask";
+import {
+  factionCssVar,
+  factionFill,
+  factionName,
+  getAllFactions,
+  isKnownFaction,
+} from "../../../utils/factions";
+import {
+  UNAFFILIATED_FACTION_SLUG,
+  type ProposeTaskState,
+} from "../useProposeTask";
 
 const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8];
 
@@ -80,7 +89,27 @@ const submitDashStyle: CSSProperties = {
   pointerEvents: "none",
 };
 
+/** Shape/type of the selector pennant; the FILL is picked per-slug below. */
+const basePennantStyle: CSSProperties = {
+  display: "block",
+  fontFamily: "'Courier Prime', monospace",
+  fontSize: "var(--text-xs)",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.07em",
+  padding: "var(--space-xs) var(--space-md)",
+  marginBottom: "var(--space-xs)",
+};
+
+/** Solid-hue pennant fill — only for slugs that pass isKnownFaction. */
+const knownPennantFillStyle = (slug: string): CSSProperties => ({
+  background: factionCssVar(slug),
+  color: "var(--color-text-on-accent)",
+  textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+});
+
 const FACTION_DESCRIPTOR_KEY = {
+  na: "proposeTask.factionDescriptor.na",
   ua: "proposeTask.factionDescriptor.ua",
   wow: "proposeTask.factionDescriptor.wow",
   everymen: "proposeTask.factionDescriptor.everymen",
@@ -134,6 +163,15 @@ export default function DefaultProposeTask({
 
   const color = factionCssVar(factionSlug);
   const fname = factionName(factionSlug);
+
+  // Unaffiliated leads the picker: it is the default, and it is a state rather
+  // than a faction, so it is an extra option here rather than a registry entry
+  // (ADR-0039). Everything after it comes from the API, falling back to the
+  // static registry before the fetch lands.
+  const factionOptions: string[] = [
+    UNAFFILIATED_FACTION_SLUG,
+    ...(factions.length > 0 ? factions : getAllFactions()).map((f) => f.slug),
+  ];
 
   if (success) {
     return (
@@ -219,10 +257,9 @@ export default function DefaultProposeTask({
               {t("proposeTask.factionSelectorLabel")}
             </span>
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-sm)" }}>
-              {(factions.length > 0 ? factions : getAllFactions()).map((f) => {
-                const slug =
-                  "slug" in f ? f.slug : (f as { slug: string }).slug;
+              {factionOptions.map((slug) => {
                 const active = factionSlug === slug;
+                const known = isKnownFaction(slug);
                 return (
                   <button
                     key={slug}
@@ -244,17 +281,14 @@ export default function DefaultProposeTask({
                     <span
                       className="pennant-shape"
                       style={{
-                        display: "block",
-                        background: factionCssVar(slug),
-                        color: "var(--color-text-on-accent)",
-                        fontFamily: "'Courier Prime', monospace",
-                        fontSize: "var(--text-xs)",
-                        fontWeight: 700,
-                        textTransform: "uppercase",
-                        letterSpacing: "0.07em",
-                        padding: "var(--space-xs) var(--space-md)",
-                        textShadow: "0 1px 2px rgba(0,0,0,0.3)",
-                        marginBottom: "var(--space-xs)",
+                        ...basePennantStyle,
+                        // A real faction flies its solid hue with on-accent ink.
+                        // `na` has no hue — it gets the spectrum as a FRAME
+                        // around paper with ink text, because no single ink is
+                        // legible across the rainbow (ADR-0039, factionFill).
+                        ...(known
+                          ? knownPennantFillStyle(slug)
+                          : factionFill(slug, "pill")),
                       }}
                     >
                       {factionName(slug)}
@@ -497,10 +531,11 @@ export default function DefaultProposeTask({
                         color: "var(--color-text-tertiary)",
                       }}
                     >
-                      {t("proposeTask.metaToggle.hint", {
-                        faction:
-                          factionSlug !== "na" ? factionName(factionSlug) : "",
-                      })}
+                      {isKnownFaction(factionSlug)
+                        ? t("proposeTask.metaToggle.hint", {
+                            faction: factionName(factionSlug),
+                          })
+                        : t("proposeTask.metaToggle.hintNoFaction")}
                     </span>
                   </label>
                 </div>

--- a/frontend/src/pages/proposeTask/useProposeTask.ts
+++ b/frontend/src/pages/proposeTask/useProposeTask.ts
@@ -19,6 +19,15 @@ import { useAuth } from "../../auth/AuthContext";
 import { extractError } from "../../utils/errors";
 import i18n from "../../i18n";
 
+/**
+ * The unaffiliated sentinel (ADR-0030 / ADR-0039). Mirrors the backend's
+ * `UNAFFILIATED_FACTION_SLUG` (`services/faction_service.py`): a task carrying
+ * this slug is generic / cross-faction, owned by no faction. Unaffiliated is a
+ * state rather than a faction, so it is deliberately absent from the faction
+ * registry — the picker offers it as an explicit extra option (#704).
+ */
+export const UNAFFILIATED_FACTION_SLUG = "na";
+
 export interface ProposeTaskState {
   // Gating (faction-agnostic guards live in the dispatcher)
   isLoggedIn: boolean;
@@ -65,7 +74,9 @@ export function useProposeTask(): ProposeTaskState {
   const [description, setDescription] = useState("");
   const [pointValue, setPointValue] = useState<string>("10");
   const [levelRequired, setLevelRequired] = useState<number | "">(0);
-  const [factionSlug, setFactionSlug] = useState("ua");
+  // Cross-faction is the neutral starting point: a default must not quietly
+  // encode an affiliation the proposer never chose (#704, #709).
+  const [factionSlug, setFactionSlug] = useState(UNAFFILIATED_FACTION_SLUG);
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -93,7 +104,9 @@ export function useProposeTask(): ProposeTaskState {
     // admin). If the viewer isn't eligible the 403 surfaces via extractError.
     if (
       isMetaTask &&
-      (!factionSlug || factionSlug === "na" || factionSlug === "ua")
+      (!factionSlug ||
+        factionSlug === UNAFFILIATED_FACTION_SLUG ||
+        factionSlug === "ua")
     ) {
       setError(i18n.t("forms:proposeTask.errors.metaFactionRequired"));
       return;


### PR DESCRIPTION
Closes #704

The backend was already done: `TaskCreate.primary_faction_slug` is optional and
`services/task.py` coerces a missing slug to the `na` sentinel on both create and
update. The gap was entirely in the propose-task form, which defaulted to UA and
offered no control that could produce `na`.

## What changed

**`useProposeTask.ts`**
- Named the sentinel: `export const UNAFFILIATED_FACTION_SLUG = "na"`, mirroring
  the backend's `services/faction_service.py` constant.
- The form now starts **unaffiliated** instead of `"ua"`. Cross-faction is the
  neutral starting point — a default should not quietly encode an affiliation the
  proposer never chose (per the grill, and consistent with #709 / ADR-0019).
- The metatask guard still rejects `na` (a metatask must belong to a faction);
  it now reads through the constant instead of a bare literal.
- The wire format is unchanged — submit already sent
  `primary_faction_slug: factionSlug || undefined`.

**`archetypes/DefaultProposeTask.tsx`**
- The faction picker now renders an explicit **Unaffiliated / "Anyone"** option,
  first in the list. It is an *extra option*, not a registry entry — `na` stays
  out of `FACTION_COLORS` / `getAllFactions()`, keeping the "a state, not a
  faction" doctrine intact (ADR-0039).
- Its pennant is styled with `factionFill(slug, "pill")`, so it picks up the
  spectrum-as-a-frame treatment rather than a hardcoded grey. Real factions keep
  their existing solid-hue pennant byte-for-byte — the branch is on
  `isKnownFaction`, testing the *mapped value* and never key presence (#749).
- Two previously dead branches are now live and were both fixed rather than left
  as-is: the metatask hint no longer interpolates an empty faction name (new
  `metaToggle.hintNoFaction` copy tells the author to pick a faction), and the
  faction descriptor now has an `na` row.

**`locales/en/forms.json`**
- New `proposeTask.factionDescriptor.na` ("Anyone") and
  `proposeTask.metaToggle.hintNoFaction`.
- **Fixed the bug in the issue's screenshot**: `factionDescriptor.ua` literally
  read `"Unaffiliated"`, which is why the UA pennant claimed to be unaffiliated.
  It is now `"Academy"` (UA is the Gilt Salon / a regal academy). This copy was
  actively wrong before and would have been outright confusing sitting next to a
  real Unaffiliated option.
- Selector label widened to mention the open choice.

**Tests**
- `pages/proposeTask/__tests__/unaffiliatedOption.test.tsx` (4 new): the option
  renders alongside the real factions, `na` gets `--faction-default-rainbow`
  rather than a borrowed hue, a real faction keeps its solid hue, and the
  metatask hint switches on affiliation.
- `backend/tests/integration/test_tasks.py` (1 new): `POST /tasks` **omitting**
  `primary_faction_slug` stores the unaffiliated sentinel. The existing suite
  exercised that path but never asserted the resulting slug — it is now the
  pinned contract this form depends on. **No backend source changed.**

## Verification

- `tsc --noEmit` — clean (only the known stale-junction `node:fs`/`node:url`
  false alarm from PR #675).
- `vite build` — passes.
- `eslint src/pages/proposeTask` — clean.
- `vitest run` — 929 passed / 929.
- `pytest tests/integration/test_tasks.py` — 61 passed (dedicated `wz704_test` DB).

**Visual QA is outstanding.** I cannot screenshot in this environment and there is
no dev stack running, so every claim above is verified by types, lint and tests
only — nothing here has been looked at.

## What to eyeball

1. **The Unaffiliated pennant.** `.pennant-shape` applies a `clip-path` polygon,
   and `factionFill(…, "pill")` paints the rainbow on the *border-box*. The
   clip will shave the angled left/right edges of that frame. It should still
   read as a rainbow-edged pennant, but this is the one spot I'd expect a
   designer to want to adjust.
2. **Contrast of the ink on the paper interior**, light and dark, versus the
   solid-hue pennants sitting next to it.
3. **The rest of the form goes neutral grey when unaffiliated is selected** —
   the accent `color`, the left border, the preview strip tint and the submit
   button all resolve through `factionCssVar` to `--faction-default-*`. That is
   the documented scalar behaviour, but the default form state is now grey where
   it used to open in UA orange, so it is a visible change to the page's first
   impression. If it wants the rainbow somewhere (e.g. a spectrum rule on the
   preview strip), that is a design call for `frontend-style`, not something I
   invented here.
4. **Copy check on `"Academy"` for UA** and `"Anyone"` for `na` — one-word
   descriptors matching the existing Collective / Mobilize / Mischief set.
5. `albescent` still has **no** descriptor row, so its button renders an empty
   descriptor line. Pre-existing; left alone as out of scope.
