### PR TITLE
Collapse the no-op spectrum ternaries and retire the stale factionCssVar comment (#754)

### DIFF
--- a/frontend/src/pages/players/Constellation.tsx
+++ b/frontend/src/pages/players/Constellation.tsx
@@ -277,8 +277,9 @@ function SkyNode({
   const { t } = useTranslation('common')
   const { entry, size, faded, crowned } = node
   const character = entry.character
-  // factionCssVar resolves an unknown slug to the `ua` theme, so unaffiliated
-  // branches on isKnownFaction first (#636 / ADR-0039).
+  // Unaffiliated hands its points no colour at all, leaving the .rainbow-ink
+  // gradient clip to paint them (ADR-0039). See the isKnownFaction docblock in
+  // utils/factions for what `known` means and why `na` is outside it (#749).
   const known = isKnownFaction(character.faction_slug)
   const pointsColor = known ? factionCssVar(character.faction_slug) : undefined
   const badgeDim = Math.max(18, Math.round(size * 0.3))

--- a/frontend/src/pages/players/Meadow.tsx
+++ b/frontend/src/pages/players/Meadow.tsx
@@ -274,8 +274,9 @@ export function MeadowBloom({
   champion?: boolean
 }) {
   const slug = character?.faction_slug ?? null
-  // factionCssVar resolves an unknown slug to the `ua` theme, so unaffiliated
-  // branches on isKnownFaction first (#636 / ADR-0039).
+  // The bloom spends its spectrum across petals, so it must know whether the
+  // slug has one hue or seven before asking for a colour (ADR-0039). See the
+  // isKnownFaction docblock in utils/factions for why `na` is not known (#749).
   const known = isKnownFaction(slug)
   const petalColor = (index: number): string => {
     if (champion) return 'var(--meadow-champion-petal)'

--- a/frontend/src/pages/players/RosterTable.tsx
+++ b/frontend/src/pages/players/RosterTable.tsx
@@ -170,11 +170,13 @@ export default function RosterTable({ players, myCharId }: RosterTableProps) {
 
 function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
   const { character, rank, points } = row
-  // Unaffiliated players own the spectrum, not a borrowed orange: factionCssVar
-  // silently resolves an unknown slug to the `ua` theme (#636 / ADR-0039), so
-  // every faction-coloured ornament here branches on isKnownFaction first.
+  // Unaffiliated players own the spectrum, not a borrowed orange (ADR-0039).
+  // `known` gates only the ornaments that can actually hold a gradient — the
+  // left accent bar and the .rainbow-ink points numeral. `color` is scalar-only
+  // and needs no branch: factionCssVar maps `na` to --faction-default itself.
+  // See the isKnownFaction docblock in utils/factions for why (#749/#754).
   const known = isKnownFaction(character.faction_slug)
-  const color = known ? factionCssVar(character.faction_slug) : 'var(--faction-default)'
+  const color = factionCssVar(character.faction_slug)
   const accent = known ? color : 'var(--faction-default-rainbow)'
   const badges = character.badges ?? []
 
@@ -184,11 +186,10 @@ function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
       style={{
         gridTemplateColumns: '56px 1fr 120px 64px 72px',
         padding: 'var(--space-md) var(--space-lg)',
-        background: isMe
-          ? known
-            ? factionCssVar(character.faction_slug, 'light')
-            : 'var(--faction-default-light)'
-          : 'transparent',
+        // Flat tint for every slug: it sits behind body text, where no single
+        // ink is legible across the spectrum (#649). `na` resolves to
+        // --faction-default-light on its own.
+        background: isMe ? factionCssVar(character.faction_slug, 'light') : 'transparent',
       }}
     >
       {/* Faction left accent */}

--- a/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
@@ -13,6 +13,7 @@ import type { ReactElement } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
 import type { CharacterOut, CurrentUser } from '../../../api/auth'
+import { FACTION_RAINBOW_ORDER } from '../../../utils/factions'
 
 const mocks = vi.hoisted(() => ({
   formFactor: 'desktop' as 'mobile' | 'desktop',
@@ -379,5 +380,66 @@ describe('Default players directory content + navigation', () => {
       <DefaultPlayers characters={[]} loading={false} error={null} myCharId={null} />,
     )
     expect(text).toContain('No players match this filter.')
+  })
+})
+
+/**
+ * #754 — the roster row's faction treatment, asserted as the property a reader
+ * would check on screen rather than as a token spelling: an unaffiliated row
+ * borrows *no* faction's hue and wears the spectrum, an affiliated row wears
+ * exactly its own and no spectrum.
+ *
+ * This is the boundary #749 broke. That regression made isKnownFaction('na')
+ * true, which silently dropped .rainbow-ink from the points numeral and greyed
+ * every unaffiliated ornament — caught below by the rainbow-ink assertion.
+ */
+describe('roster row faction treatment (#754)', () => {
+  // Scope assertions to one roster row. Two things would otherwise be measured
+  // by mistake: the page header paints a rainbow rule out of all seven faction
+  // variables, and every roster player may also be an orb in the sky above, so
+  // the same profile link appears twice with different ornament rules.
+  function rowHtml(html: string, characterId: number): string {
+    const roster = html.indexOf('data-testid="mobile-roster"')
+    expect(roster, 'roster section rendered').toBeGreaterThan(-1)
+    const link = html.indexOf(`href="/characters/${characterId}"`, roster)
+    expect(link, `roster row ${characterId} rendered`).toBeGreaterThan(-1)
+    // Back up to the opening `<a`: href renders last, so slicing from it would
+    // drop the row's own style attribute (its border-left and isMe wash).
+    return html.slice(html.lastIndexOf('<a', link), html.indexOf('</a>', link))
+  }
+
+  const factionHuesIn = (markup: string): string[] =>
+    FACTION_RAINBOW_ORDER.filter((slug) => markup.includes(`--faction-${slug}`))
+
+  it('gives the unaffiliated row the spectrum and no borrowed faction hue', () => {
+    const { html } = render(
+      <DefaultPlayers characters={PLAYERS} loading={false} error={null} myCharId={null} />,
+    )
+    const row = rowHtml(html, 33) // Molly, faction_slug: null
+
+    expect(row, 'points are gradient-clipped').toContain('rainbow-ink')
+    expect(factionHuesIn(row), 'wears no single faction hue').toEqual([])
+  })
+
+  it('gives an affiliated row its own solid hue and no spectrum', () => {
+    const { html } = render(
+      <DefaultPlayers characters={PLAYERS} loading={false} error={null} myCharId={null} />,
+    )
+    const row = rowHtml(html, 11) // Perpetua, faction_slug: 'everymen'
+
+    expect(row, 'a solid hue needs no gradient clip').not.toContain('rainbow-ink')
+    expect(factionHuesIn(row), 'wears its own hue, alone').toEqual(['everymen'])
+  })
+
+  it('washes your own unaffiliated row neutral rather than in a faction tint', () => {
+    const { html } = render(
+      <DefaultPlayers characters={PLAYERS} loading={false} error={null} myCharId={33} />,
+    )
+    const row = rowHtml(html, 33)
+
+    // The wash sits behind body text, where no ink is legible across seven
+    // stops (#649) — so it stays flat, but it still must not borrow a hue.
+    expect(factionHuesIn(row), 'own-row tint borrows no faction').toEqual([])
+    expect(row, 'still the neutral tint, not a bare surface').toContain('--faction-default-light')
   })
 })

--- a/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
+++ b/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
@@ -192,7 +192,10 @@ function Roster({ players, myCharId }: { players: RankedPlayer[]; myCharId: numb
   const resetPaging = () => setVisible(PAGE_STEP)
 
   return (
-    <section className="mt-8">
+    // Every roster player may also be an orb in the sky above, so their profile
+    // link appears twice on the page; the testid lets a test say which one it
+    // means (#754).
+    <section className="mt-8" data-testid="mobile-roster">
       <h2
         className="font-display italic content-title mb-3"
         style={{ color: 'var(--color-text-primary)' }}

--- a/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
+++ b/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
@@ -230,9 +230,14 @@ function Roster({ players, myCharId }: { players: RankedPlayer[]; myCharId: numb
           {t('leaderboard.mobile.allFactions')}
         </Chip>
         {factionChips.map(({ slug }) => {
-          // factionCssVar resolves an unknown slug to the `ua` theme, so the
-          // unaffiliated ring branches on isKnownFaction first (#636/ADR-0039).
-          const ring = isKnownFaction(slug) ? factionCssVar(slug) : 'var(--faction-default)'
+          // Scalar-only, so no isKnownFaction branch: Chip spends `tint` on a
+          // border colour and a box-shadow ring, and a gradient is invalid in
+          // both. The unaffiliated selection ring stays neutral by necessity —
+          // the spectrum arrives on this chip through the FactionSigil glyph
+          // below, which draws --faction-default-ring. factionCssVar already
+          // maps `na` to --faction-default; see the isKnownFaction docblock in
+          // utils/factions for why that is the design, not a fallback (#754).
+          const ring = factionCssVar(slug)
           return (
             <Chip
               key={slug}
@@ -298,10 +303,13 @@ function Roster({ players, myCharId }: { players: RankedPlayer[]; myCharId: numb
 function PlayerRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
   const { t } = useTranslation('common')
   const { character, rank, points } = row
-  // See RosterTable: factionCssVar resolves an unknown slug to the `ua` theme,
-  // so unaffiliated ornament branches on isKnownFaction first (#636/ADR-0039).
+  // `known` gates the one ornament that CAN carry the spectrum here: the points
+  // numeral, which swaps to the .rainbow-ink gradient clip below (ADR-0039).
+  // `color` is scalar-only — a 4px border-left and two text colours — so it has
+  // no gradient branch to make; factionCssVar maps `na` to --faction-default by
+  // itself. See the isKnownFaction docblock in utils/factions (#749/#754).
   const known = isKnownFaction(character.faction_slug)
-  const color = known ? factionCssVar(character.faction_slug) : 'var(--faction-default)'
+  const color = factionCssVar(character.faction_slug)
   const badges = character.badges ?? []
 
   return (
@@ -316,11 +324,11 @@ function PlayerRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
         // points numeral already carry the spectrum for an unaffiliated row.
         borderLeft: `4px solid ${color}`,
         textDecoration: 'none',
-        background: isMe
-          ? known
-            ? factionCssVar(character.faction_slug, 'light')
-            : 'var(--faction-default-light)'
-          : undefined,
+        // Your own row's wash stays a flat tint for every slug: it sits behind
+        // body text, and no single ink is legible across the spectrum (#649), so
+        // factionFill has no wash shape to reach for. `na` resolves to
+        // --faction-default-light on its own.
+        background: isMe ? factionCssVar(character.faction_slug, 'light') : undefined,
       }}
     >
       {/* Rank */}


### PR DESCRIPTION
Closes #754

## What this is

A cleanup PR, and the honest answer to the issue's own open question. The issue asked whether the unaffiliated filter chip should be made visibly rainbow, and pre-authorised the smaller fix if a site turns out to be scalar-only. **All of them are**, so this PR removes dead code and locks the behaviour down with a test rather than changing what you see.

## 1. The no-ops (confirmed, three sites — plus a fourth)

`isKnownFaction(slug) ? factionCssVar(slug) : "var(--faction-default)"` produces the same string on both branches: `CSS_KEY.na = "default"`, so `factionCssVar("na")` *is* `"var(--faction-default)"`.

Each site was checked for whether a gradient could actually render there before swapping:

| Site | What consumes it | Verdict |
|---|---|---|
| `DefaultPlayers` filter chip `tint` | `border: 1px solid ${ring}` + `box-shadow` ring | scalar-only — a gradient is invalid in both |
| `DefaultPlayers` `PlayerRow` `color` | 4px `border-left`, rank colour, points colour | scalar-only |
| `DefaultPlayers` `PlayerRow` isMe wash | `background` — but behind body text | flat by design (#649: no ink is legible across 7 stops), and `factionFill` has no wash shape |
| `RosterTable` `RosterRow` (**not in the issue's list**) | same dead `color` ternary + same isMe wash | same, collapsed with them |

So `factionFill` is not reachable at any of them, and all four collapse to the plain call. The sibling `accent` in `RosterTable` is a **live** rainbow branch and is untouched.

**The unaffiliated chip is already not grey**, which the issue didn't account for: its glyph is `<FactionSigil slug={null}>`, which draws `--faction-default-ring` (the conic rainbow). What is grey is only the *selected-state* ring.

## 2. Stale comments — six sites, not four

The "factionCssVar falls back to the `ua` theme" claim is gone repo-wide; each site now points at the `isKnownFaction` docblock that owns the rule instead of paraphrasing it, since paraphrasing is how it drifted into #749.

Two corrections to the issue's list:
- **`FactionAvatar.tsx:228` was already fine** at HEAD — it says "Unaffiliated glows neutral: a spectrum ring has no one colour to throw", which is accurate. Untouched. Its ternary is live (`--glow-neutral` != `--faction-default`).
- **`Constellation.tsx:280` and `Meadow.tsx:277` carried the stale claim and weren't listed.** Comment-only here; both branches are live.

## 3. Test

Asserts the observable property, not a token spelling: an unaffiliated row borrows *no* faction hue and wears the spectrum; an affiliated row wears exactly its own and no spectrum.

Mutation-checked — forcing `known` true (the #749 regression) fails it.

One thing worth knowing: the first draft of these assertions **passed while measuring the wrong element**. Every roster player may also be an orb in the sky above, so their profile link renders twice under different ornament rules. The roster section gained a `data-testid` to pin the assertions to the row.

## Verification

- `tsc --noEmit` — no errors in any touched file (only the known `node:fs`/`node:url` stale-junction false alarms from PR #675, in files this PR doesn't touch)
- `vitest run` — **928 passed / 102 files**
- `eslint .` — clean across the whole frontend (ratchet green)
- `vite build` — succeeds

## Visual QA is OUTSTANDING

I cannot screenshot and there is no dev stack in this environment, so **nothing here has been looked at**. The change is argued to be a no-op from the resolution rules, not observed to be one.

### What to eyeball

The **mobile Players page**, with an unaffiliated and an affiliated player side by side, in **both light and dark**:

1. **Nothing should have changed.** That is the whole claim — if any of these look different from `main`, the no-op reasoning is wrong somewhere.
2. Unaffiliated roster row: rainbow-clipped points numeral, spectrum avatar ring, **grey** 4px left edge.
3. Affiliated roster row: solid faction hue on the left edge, rank and points.
4. Your own row (log in as each): tinted wash — faction tint when affiliated, neutral grey when not.
5. Faction filter chips, selected and unselected: the unaffiliated chip's *glyph* should be the rainbow ring; its *selection* ring is grey.
6. Desktop roster (`RosterTable`) too, since it was pulled in: rows plus the left accent bar, which should still be a real rainbow for unaffiliated.

### Deferred to `frontend-style`

Making the unaffiliated chip's **selected-state ring** actually spectral is a design call I deliberately did not take. It needs a `Chip` API change — `tint` is a `string` spent on a border colour and a `box-shadow`, and a gradient renders in *neither*. It would mean a border-image / padding-box frame plus dropping the glow for `na`, on a shared component with 8 other call sites (`PraxisCard`, `RosterTable`). Worth its own issue if the rainbow selection ring is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
