### PR TITLE
UA hero stat labels: route laundered literals through the copy catalog (#775)

### DIFF
--- a/frontend/src/components/cards/UaFactionHero.tsx
+++ b/frontend/src/components/cards/UaFactionHero.tsx
@@ -7,7 +7,8 @@ import { UaSigil, MottoRibbon } from "./UaSigil";
  * The masthead reads as an art-academy museum plate: a gold museum frame
  * (--ua-gilt) around a parchment field, a heraldic crest, a regal serif
  * wordmark, a Latin motto cartouche, and the three counts engraved as salon
- * regalia (patrons / commissions / acquisitions). Ported from the UA design kit
+ * regalia. The regalia wording lives in the copy catalog
+ * (feed:factionHero.ua.stats.*), not here. Ported from the UA design kit
  * (UaTaskDetail hero / ua.css); conforms to {@link FactionHeroProps}.
  *
  * UA is ALWAYS LIGHT: its --faction-ua-* / --ua-* tokens are identical in both
@@ -47,9 +48,9 @@ export default function UaFactionHero({
 }: FactionHeroProps) {
   // The salon engraves its own counts — page passes raw numbers only.
   const stats = [
-    { value: members, label: "patrons" },
-    { value: tasks, label: "commissions" },
-    { value: praxes, label: "acquisitions" },
+    { value: members, label: i18n.t("feed:factionHero.ua.stats.members") },
+    { value: tasks, label: i18n.t("feed:factionHero.ua.stats.tasks") },
+    { value: praxes, label: i18n.t("feed:factionHero.ua.stats.praxes") },
   ];
 
   return (

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -620,8 +620,8 @@ export default function SnideEditPraxis({ state }: Props) {
           <PublishButton
             state={state}
             skin={{
-              idleLabel: "FILE IT & RUN",
-              busyLabel: "running...",
+              idleLabel: t("editPraxis.snide.publishIdle"),
+              busyLabel: t("editPraxis.snide.publishBusy"),
               ornament: (
                 <span
                   aria-hidden


### PR DESCRIPTION
Closes #775

Three user-facing English strings sat in a data structure in `UaFactionHero`, where the `jsx-text-only` i18n rule could never see them — the same laundering shape as #770's ternaries and #773's `avgFontSize`.

## The useful surprise: the copy was already in the catalog

Both fixes turned out to be **pure wiring, not missing copy**. The catalog entries already existed with byte-identical strings; the components simply weren't reading them:

- `feed.json` already had `factionHero.ua.stats` = `patrons` / `commissions` / `acquisitions`
- `forms.json` already had `editPraxis.snide.publishIdle` = `FILE IT & RUN` and `.publishBusy` = `running...`

**No catalog file is touched by this PR.** That includes `frontend/src/locales/en/factions.json`, which another agent is editing later in this batch — so there is no rebase surface there at all.

Because the strings are identical, **rendered output is unchanged**. This is a maintainability fix: the words are now editable from the catalog without touching a component (ADR-0032).

## Changes

**1. `UaFactionHero.tsx` — the reported defect**

```js
{ value: members, label: "patrons" }   →   { value: members, label: i18n.t("feed:factionHero.ua.stats.members") }
```

...and likewise for tasks/praxes. This matches the key shape all six sibling heroes already use (`feed:factionHero.<slug>.stats.{members,tasks,praxes}`) — the issue offered `factions.json` as a guess, but the siblings are unanimously in `feed.json`, so I followed them rather than inventing a shape.

Also dropped the three words from the component docstring, which was caching the same copy and would rot when a copy editor changed the catalog.

**2. `SnideEditPraxis.tsx` — a sibling holdout found by the sweep (item 2)**

The six other faction heroes were all clean, so UA was the only hero. But widening the sweep to *all* data-structure-laundered literals found one more live violation: `SnideEditPraxis` was the lone holdout among 18 composers, hardcoding its publish button copy into a `skin` prop object while the other 17 call `t(...)`. Same root cause, same PR.

## Item 3: the lint gap — not fixed, documented

I looked at whether `i18next/no-literal-string` could flag literals assigned to a property named `label`/`title`/`text`. **It cannot practically, and I did not force it.**

- The plugin's `jsx-attributes` include/exclude applies to *JSX attributes*, not object-literal properties. `label:` inside a plain object is invisible to every mode the plugin offers. Catching it needs a **new custom rule** (in the shape of `local/no-raw-style-values`) walking `Property` nodes.
- `eslint.config.js` already documents why the broader `jsx-only` mode was rejected: it "drowns in prop/discriminant noise that can't be excluded cleanly."
- My sweep supplies the evidence that a property-name rule would land the same way. Across the whole frontend, the only two *live* violations were the two fixed here. The remaining matches are all things such a rule would wrongly flag:
  - test fixtures (`title: "Photosynthesis"`, `title: "Reforestation"`, ~15 sites)
  - `pages/editPraxis/blocks/markdownToolbar.ts` `PLACEHOLDER` — an explicitly documented carve-out; that's markdown document text the author overtypes, deliberately not catalog copy
  - `components/cards/ephemeristsAtoms.tsx` `CONCORD[].label` — see below

  So the rule would be near-100% false positives against a now-empty true-positive set, and would need a suppression at every site. The gap is real; the cost of closing it currently exceeds the benefit.

## Incidental finding (NOT changed here — flagging for a decision)

`components/cards/ephemeristsAtoms.tsx` `CONCORD[].label` (`"apocryphal"`, `"disputed"`, `"plausible"`, `"corroborated"`, `"canonical"`) is **dead data**. `EphemeristsVote.tsx` renders `TIERS = VOTE_REFRAMES['ephemerists'].tiers`, which is already i18n-backed by `votes:ephemerists.*`; it consumes only `fill`/`ink` from `CONCORD` via `CONCORD_VISUALS`. The `label` field is never read.

It is therefore not a user-facing i18n defect, but it *is* a duplicated copy of catalog strings that will silently drift when someone edits `votes.json` — and the comment on `EphemeristsVote.tsx:16` already asserts "labels come from voteReframes", which is true of what renders but contradicts the atom still carrying them. Deleting the field is a ~6-line cleanup. I left it out to keep this PR scoped; happy to do it here or as a follow-up.

## Verification

Run in-worktree (`tsc --version` confirmed as a real 5.9.3, not the silent-absent-binary false pass):

- `tsc --noEmit` — **0 real errors**. 11 reported, all 11 the known `node:fs`/`node:url`/`node:path` stale-junction false alarm from PR #675, all in test files, none in touched files.
- `vite build` — clean, 734 modules
- `eslint .` (full, as CI runs it) — **exit 0**
- `vitest run` — **984 passed / 105 files**, 0 failures

## What to eyeball

Visual QA is outstanding — I cannot screenshot (the Browser pane renderer times out) and there is no dev stack available. Rendered strings are unchanged, so any visual difference would indicate a bug, not an intended change.

1. **Faction page → UA (`/factions/ua`)** — the hero's right-hand engraved side column. The three regalia labels must still read **patrons / commissions / acquisitions** in small-caps engraved type, with correct counts beside them. A blank label or a raw key like `feed:factionHero.ua.stats.members` means namespace resolution failed. This is the primary thing to check.
2. **UA hero at a faction with zero members/tasks/praxes** — confirm the `0` counts still render beside their labels.
3. **The other six faction heroes** (`/factions/{snide,wow,ephemerists,everymen,singularity,albescent}`) — untouched, but a quick pass confirms no shared-namespace regression.
4. **Praxis composer as a S.N.I.D.E. character** — the publish button must still read **FILE IT & RUN**, and flip to **running...** while a submit is in flight (the busy state is the easier one to miss). Desktop archetype specifically; the mobile Snide composer was already correct and is untouched.
5. **Narrow viewport on the UA faction page** — the stat column is `flex-shrink: 0` at a fixed width; worth confirming nothing about the label swap changed wrapping.

No styling decisions were made in this PR; nothing was deferred to `frontend-style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
