### PR TITLE
Duel forfeit confirm: promote the inline prompt to a dispatched dialog (#751)

### DIFF
--- a/frontend/src/components/duel/DuelSealConfirm.tsx
+++ b/frontend/src/components/duel/DuelSealConfirm.tsx
@@ -18,19 +18,42 @@
  * useFormFactor(), primary action autofocuses, no focus trap. Mounted once from
  * the EditPraxis dispatcher, so all 16 composer surfaces inherit it.
  *
- * The Default skin below is the only one this issue ships; the registries exist
- * so per-faction skins (#720 for Wow, one issue per faction after) are a map row
- * and nothing else. Skins own the FRAME only — every figure and every branch
- * lives in `duel/shared.tsx`.
+ * The Default skin below is the only one this issue ships; the manifest seam
+ * exists so per-faction skins (#720 for Wow, one issue per faction after) are a
+ * `duelSeal` / `mobileDuelSeal` row and nothing else. Skins own the FRAME only —
+ * every figure and every branch lives in `duel/shared.tsx`.
+ *
+ * TWO MODES, ONE SURFACE (#751)
+ * -----------------------------
+ * The same dialog also confirms a FORFEIT — pulling back a settled duel side,
+ * which was an inline text expand on the praxis-detail page until now. It is the
+ * one duel moment with a genuinely irreversible consequence and was the only one
+ * with no skinnable surface, while the *reversible* moment (this one) got a full
+ * dialog in #718.
+ *
+ * It rides the `mode` prop rather than a `duelForfeit` / `mobileDuelForfeit`
+ * pair of manifest keys, because the two dialogs are ~90% the same component:
+ * same frame, same roster, same stakes tiles, same footer. Only the title, the
+ * body, and the confirm label differ, and `useDuelSealCopy` owns all three. Each
+ * faction therefore stays TWO files that each handle two modes, instead of four
+ * files — which is the whole reason this landed before the six skin issues
+ * (#721–#726).
  */
 import type { } from 'react'
-import { useTranslation } from 'react-i18next'
 import type { DuelDetailOut } from '../../api/duel'
 import { useFormFactor } from '../../hooks/useFormFactor'
 import { factionCssVar } from '../../utils/factions'
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
-import { duelSides, RaceRoster, SealActions, StakesTiles, type DuelSlotTheme } from './shared'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSealMode,
+  type DuelSlotTheme,
+} from './shared'
 
 export interface DuelSealConfirmProps {
   duel: DuelDetailOut
@@ -41,6 +64,11 @@ export interface DuelSealConfirmProps {
   onConfirm: () => void
   onCancel: () => void
   busy?: boolean
+  /**
+   * Which beat this dialog is confirming (#751). Optional and defaulting to
+   * `'submit'`, so every existing mount site is unchanged. See `DuelSealMode`.
+   */
+  mode?: DuelSealMode
 }
 
 export function DefaultDuelSealConfirm({
@@ -50,11 +78,12 @@ export function DefaultDuelSealConfirm({
   onConfirm,
   onCancel,
   busy,
+  mode = 'submit',
 }: DuelSealConfirmProps) {
-  const { t } = useTranslation('praxis')
   const formFactor = useFormFactor()
   const isMobile = formFactor === 'mobile'
   const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
 
   // Tokens come from the OPPONENT's faction, matching the read-page rail: the
   // opponent is the foreign element and should look foreign (grilled #310).
@@ -65,7 +94,7 @@ export function DefaultDuelSealConfirm({
     <div
       role="dialog"
       aria-modal="true"
-      aria-label={t('duelSeal.heading')}
+      aria-label={copy.heading}
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{
         background: isMobile
@@ -87,26 +116,25 @@ export function DefaultDuelSealConfirm({
           className="font-display"
           style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}
         >
-          {t('duelSeal.heading')}
+          {copy.heading}
         </h2>
 
         <p
           className="font-body"
-          style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)' }}
+          style={{
+            fontSize: 'var(--text-sm)',
+            color: copy.danger ? 'var(--color-danger)' : 'var(--color-text-secondary)',
+          }}
         >
-          {duel.status === 'pending'
-            ? t('duelSeal.bodyPending', { name: foe.display_name })
-            : t('duelSeal.bodyActive', { name: foe.display_name })}
+          {copy.body}
         </p>
 
-        {/* The free-reopen half of the truth: until they cast, nothing is stuck.
-            Only meaningful once the duel is live — a pending duel can't settle. */}
-        {duel.status === 'active' && !foe.is_submitted && (
+        {copy.note && (
           <p
             className="font-body"
             style={{ fontSize: 'var(--text-xs)', color: 'var(--color-success)' }}
           >
-            {t('duelSeal.reopenNote', { name: foe.display_name })}
+            {copy.note}
           </p>
         )}
 
@@ -121,7 +149,14 @@ export function DefaultDuelSealConfirm({
 
         <RaceRoster me={me} foe={foe} theme={theme} />
 
-        <SealActions onConfirm={onConfirm} onCancel={onCancel} busy={busy} theme={theme} />
+        <SealActions
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          busy={busy}
+          confirmLabel={copy.confirmLabel}
+          danger={copy.danger}
+          theme={theme}
+        />
       </div>
     </div>
   )

--- a/frontend/src/components/duel/WowDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowDuelSealConfirm.tsx
@@ -17,13 +17,13 @@
  * Copy is faction-neutral by decision (#718): the design's witch voice is tone
  * reference, not strings. No new locale keys.
  */
-import { useTranslation } from 'react-i18next'
 import { factionCssVar } from '../../utils/factions'
 import {
   duelSides,
   RaceRoster,
   SealActions,
   StakesTiles,
+  useDuelSealCopy,
   type DuelSlotTheme,
 } from './shared'
 import type { DuelSealConfirmProps } from './DuelSealConfirm'
@@ -58,9 +58,10 @@ export default function WowDuelSealConfirm({
   onConfirm,
   onCancel,
   busy,
+  mode = 'submit',
 }: DuelSealConfirmProps) {
-  const { t } = useTranslation('praxis')
   const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
 
   // Opponent tokens, same rule as the Default dialog and the rail: the foreign
   // duelist looks foreign even inside Wow's window.
@@ -71,7 +72,7 @@ export default function WowDuelSealConfirm({
     <div
       role="dialog"
       aria-modal="true"
-      aria-label={t('duelSeal.heading')}
+      aria-label={copy.heading}
       className="fixed inset-0 z-50 flex items-center justify-center"
       style={{
         padding: 'var(--space-lg)',
@@ -104,7 +105,7 @@ export default function WowDuelSealConfirm({
         >
           <Sparkle size={12} color={TITLE_TEXT} />
           <h2 style={{ fontFamily: SCRIPT, fontSize: 'var(--text-title)', fontWeight: 700 }}>
-            {t('duelSeal.heading')}
+            {copy.heading}
           </h2>
         </div>
 
@@ -117,15 +118,20 @@ export default function WowDuelSealConfirm({
             backgroundSize: '13px 13px',
           }}
         >
-          <p style={{ fontSize: 'var(--text-content)', lineHeight: 1.5 }}>
-            {duel.status === 'pending'
-              ? t('duelSeal.bodyPending', { name: foe.display_name })
-              : t('duelSeal.bodyActive', { name: foe.display_name })}
+          <p
+            style={{
+              fontSize: 'var(--text-content)',
+              lineHeight: 1.5,
+              ...(copy.danger ? { color: 'var(--color-danger)', fontWeight: 700 } : {}),
+            }}
+          >
+            {copy.body}
           </p>
 
           {/* The free-reopen half of the truth — same condition as the Default
-              skin, because it is the same fact, not a Wow flourish. */}
-          {duel.status === 'active' && !foe.is_submitted && (
+              skin, because it is the same fact, not a Wow flourish. A forfeit
+              has no such note, and `copy.note` is null there. */}
+          {copy.note && (
             <p
               style={{
                 marginTop: 'var(--space-sm)',
@@ -133,7 +139,7 @@ export default function WowDuelSealConfirm({
                 color: 'var(--color-success)',
               }}
             >
-              {t('duelSeal.reopenNote', { name: foe.display_name })}
+              {copy.note}
             </p>
           )}
 
@@ -159,7 +165,14 @@ export default function WowDuelSealConfirm({
           </div>
 
           <div style={{ marginTop: 'var(--space-lg)' }}>
-            <SealActions onConfirm={onConfirm} onCancel={onCancel} busy={busy} theme={theme} />
+            <SealActions
+              onConfirm={onConfirm}
+              onCancel={onCancel}
+              busy={busy}
+              confirmLabel={copy.confirmLabel}
+              danger={copy.danger}
+              theme={theme}
+            />
           </div>
           {/* ponytail: SealActions keeps its shared btn-outline / btn-primary
               pair rather than growing a Wow gradient-button skin slot. The

--- a/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
@@ -10,13 +10,13 @@
  * figure and the `pending`/`active` copy branch is the shared one. No new locale
  * keys — per-faction voice was declined for this epic (#718).
  */
-import { useTranslation } from 'react-i18next'
 import { factionCssVar } from '../../utils/factions'
 import {
   duelSides,
   RaceRoster,
   SealActions,
   StakesTiles,
+  useDuelSealCopy,
   type DuelSlotTheme,
 } from './shared'
 import type { DuelSealConfirmProps } from './DuelSealConfirm'
@@ -58,9 +58,10 @@ export default function WowMobileDuelSealConfirm({
   onConfirm,
   onCancel,
   busy,
+  mode = 'submit',
 }: DuelSealConfirmProps) {
-  const { t } = useTranslation('praxis')
   const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
 
   const accent = factionCssVar(foe.faction_slug, 'card-accent')
   const theme: DuelSlotTheme = { accent, muted: CARD_MUTED, bodyFont: 'var(--font-body)' }
@@ -69,7 +70,7 @@ export default function WowMobileDuelSealConfirm({
     <div
       role="dialog"
       aria-modal="true"
-      aria-label={t('duelSeal.heading')}
+      aria-label={copy.heading}
       className="fixed inset-0 z-50 flex flex-col justify-end"
       style={{ background: 'var(--color-bg-page)' }}
     >
@@ -103,7 +104,7 @@ export default function WowMobileDuelSealConfirm({
               textAlign: 'center',
             }}
           >
-            {t('duelSeal.heading')}
+            {copy.heading}
           </h2>
         </div>
 
@@ -115,13 +116,17 @@ export default function WowMobileDuelSealConfirm({
             backgroundSize: '13px 13px',
           }}
         >
-          <p style={{ fontSize: 'var(--text-content)', lineHeight: 1.5 }}>
-            {duel.status === 'pending'
-              ? t('duelSeal.bodyPending', { name: foe.display_name })
-              : t('duelSeal.bodyActive', { name: foe.display_name })}
+          <p
+            style={{
+              fontSize: 'var(--text-content)',
+              lineHeight: 1.5,
+              ...(copy.danger ? { color: 'var(--color-danger)', fontWeight: 700 } : {}),
+            }}
+          >
+            {copy.body}
           </p>
 
-          {duel.status === 'active' && !foe.is_submitted && (
+          {copy.note && (
             <p
               style={{
                 marginTop: 'var(--space-sm)',
@@ -129,7 +134,7 @@ export default function WowMobileDuelSealConfirm({
                 color: 'var(--color-success)',
               }}
             >
-              {t('duelSeal.reopenNote', { name: foe.display_name })}
+              {copy.note}
             </p>
           )}
 
@@ -157,7 +162,14 @@ export default function WowMobileDuelSealConfirm({
               styling would need a skin slot on the shared component, which is
               foundation work, not a skin change. */}
           <div style={{ marginTop: 'var(--space-lg)' }}>
-            <SealActions onConfirm={onConfirm} onCancel={onCancel} busy={busy} theme={theme} />
+            <SealActions
+              onConfirm={onConfirm}
+              onCancel={onCancel}
+              busy={busy}
+              confirmLabel={copy.confirmLabel}
+              danger={copy.danger}
+              theme={theme}
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -74,6 +74,24 @@ const DUEL = {
   opponent: side({ character_id: 2, praxis_id: 11, display_name: 'Rax', faction_slug: 'snide' }),
 } as unknown as DuelDetailOut
 
+/**
+ * A settled duel with both sides cast — the only state in which unsubmitting is
+ * a forfeit (`praxis.py` forfeits at `status == settled` only), so it is the
+ * state the forfeit dialog actually opens in.
+ */
+const SETTLED_DUEL = {
+  ...DUEL,
+  status: 'settled',
+  challenger: side({ character_id: 1, display_name: 'Ada', faction_slug: 'wow', is_submitted: true }),
+  opponent: side({
+    character_id: 2,
+    praxis_id: 11,
+    display_name: 'Rax',
+    faction_slug: 'snide',
+    is_submitted: true,
+  }),
+} as unknown as DuelDetailOut
+
 describe('duel seal skins render every slot', () => {
   // Annotated as a tuple array rather than `as const`: the spreads widen to
   // (string | ComponentType)[] otherwise, and it.each then can't match the
@@ -86,14 +104,25 @@ describe('duel seal skins render every slot', () => {
     ),
   ]
 
-  it.each(skins)('%s keeps stakes, roster and actions', (_name, Skin) => {
+  // Both modes, every skin (#751). The seal dialog doubles as the forfeit
+  // dialog, so a skin that renders every slot in `submit` and quietly drops one
+  // in `forfeit` — the mode with the irreversible consequence — fails here
+  // rather than in front of a player.
+  const cases: [string, ComponentType<DuelSealConfirmProps>, 'submit' | 'forfeit', DuelDetailOut][] =
+    skins.flatMap(([name, Skin]) => [
+      [name, Skin, 'submit', DUEL] as const,
+      [name, Skin, 'forfeit', SETTLED_DUEL] as const,
+    ])
+
+  it.each(cases)('%s keeps stakes, roster and actions in %s mode', (_name, Skin, mode, duel) => {
     const html = renderToStaticMarkup(
       <Skin
-        duel={DUEL}
+        duel={duel}
         viewerCharacterId={1}
         taskPointValue={60}
         onConfirm={() => {}}
         onCancel={() => {}}
+        mode={mode}
       />,
     )
     const text = html.replace(/<[^>]*>/g, ' ')
@@ -106,6 +135,50 @@ describe('duel seal skins render every slot', () => {
     expect(html.match(/<button/g) ?? []).toHaveLength(2)
     // The dialog contract the composer relies on.
     expect(html).toContain('role="dialog"')
+  })
+
+  // The mode branch itself: each mode must actually SAY its own thing, so a
+  // skin can't satisfy the slot walk above by hardcoding the submit copy.
+  it.each(skins)('%s speaks the forfeit copy in forfeit mode', (_name, Skin) => {
+    const render = (mode: 'submit' | 'forfeit', duel: DuelDetailOut) =>
+      renderToStaticMarkup(
+        <Skin
+          duel={duel}
+          viewerCharacterId={1}
+          taskPointValue={60}
+          onConfirm={() => {}}
+          onCancel={() => {}}
+          mode={mode}
+        />,
+      ).replace(/<[^>]*>/g, ' ')
+
+    const forfeit = render('forfeit', SETTLED_DUEL)
+    // duelForfeit.confirmPrompt + duelForfeit.action, the shipped keys the
+    // inline prompt already used.
+    expect(forfeit).toContain('FORFEITS the duel')
+    expect(forfeit).toContain('Forfeit')
+    // duelForfeit.cost, interpolated with the SNIDE-aware lose figure.
+    expect(forfeit).toContain('Rax wins by default')
+    // The submit-mode heading must NOT leak into the forfeit dialog.
+    expect(forfeit).not.toContain('Seal the duel?')
+
+    const submit = render('submit', DUEL)
+    expect(submit).toContain('Seal the duel?')
+    expect(submit).not.toContain('FORFEITS the duel')
+  })
+
+  // Default mode is `submit`, so every existing mount site is untouched.
+  it('defaults to submit mode when no mode is passed', () => {
+    const html = renderToStaticMarkup(
+      <DefaultDuelSealConfirm
+        duel={DUEL}
+        viewerCharacterId={1}
+        taskPointValue={60}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(html.replace(/<[^>]*>/g, ' ')).toContain('Seal the duel?')
   })
 })
 

--- a/frontend/src/components/duel/shared.tsx
+++ b/frontend/src/components/duel/shared.tsx
@@ -362,12 +362,111 @@ export function NextStepLine({
 }
 
 /* -------------------------------------------------------------------------- */
+/* Seal copy — the one thing that differs between the two modes               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Which irreversible beat the seal dialog is standing in for (#751).
+ *
+ *  - `submit` — casting your side. Today's dialog, unchanged.
+ *  - `forfeit` — pulling back a SETTLED duel side, which hands the win to the
+ *    opponent permanently. Used to be an inline expand on the praxis-detail
+ *    page: the one duel moment with a genuinely irreversible consequence, and
+ *    the only one with no skinnable surface.
+ *
+ * Deliberately NOT a second pair of surface keys. A forfeit dialog is the seal
+ * dialog with different words — same frame, same stakes, same roster, same
+ * footer — so each faction writes two files, not four (#751, ADR-free ruling on
+ * the manifest seam after #782).
+ */
+export type DuelSealMode = 'submit' | 'forfeit'
+
+/** Everything that varies between the modes, resolved once for every skin. */
+export interface DuelSealCopy {
+  /** Dialog title, also its `aria-label`. */
+  heading: string
+  /** The main body line. */
+  body: string
+  /**
+   * Reassurance line under the body, or `null` when the state has none. Only
+   * `submit` has one (the free-reopen note); a forfeit has nothing reassuring
+   * left to say, which is the point.
+   */
+  note: string | null
+  /** Confirm-button label. */
+  confirmLabel: string
+  /** Whether the confirm button should wear the destructive tone. */
+  danger: boolean
+}
+
+/**
+ * The mode branch, written once so no skin re-implements it.
+ *
+ * Copy is the shipped `duelSeal.*` / `duelForfeit.*` catalog verbatim — the
+ * forfeit strings are the ones the inline prompt already used, so promoting it
+ * to a dialog changes the frame and nothing a player reads. `duelForfeit.cost`
+ * needs live stakes, so this is a hook; the figures come from the same
+ * `useDuelStakes` the rail and the tiles use, which is how a Snide duelist is
+ * correctly told they keep 0 rather than some invented "half".
+ */
+export function useDuelSealCopy(
+  mode: DuelSealMode,
+  duel: DuelDetailOut,
+  viewerCharacterId: number | null | undefined,
+  taskPointValue: number | null | undefined,
+): DuelSealCopy {
+  const { t } = useTranslation('praxis')
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  // Unconditional: hooks may not sit behind the mode branch.
+  const stakes = useDuelStakes(me.faction_slug, foe.faction_slug, taskPointValue)
+
+  if (mode === 'forfeit') {
+    const cost = stakes
+      ? t('duelForfeit.cost', {
+          name: foe.display_name,
+          points: formatPoints(stakes.lose),
+          win: formatPoints(stakes.win),
+        })
+      : null
+    return {
+      heading: t('duelForfeit.action'),
+      // Falls back to the prompt alone until the game config lands, rather
+      // than rendering a sentence with a hole where the number goes.
+      body: cost ? `${t('duelForfeit.confirmPrompt')} ${cost}` : t('duelForfeit.confirmPrompt'),
+      note: null,
+      confirmLabel: t('duelForfeit.action'),
+      danger: true,
+    }
+  }
+
+  return {
+    heading: t('duelSeal.heading'),
+    body:
+      duel.status === 'pending'
+        ? t('duelSeal.bodyPending', { name: foe.display_name })
+        : t('duelSeal.bodyActive', { name: foe.display_name }),
+    // The free-reopen half of the truth: until they cast, nothing is stuck.
+    // Only meaningful once the duel is live — a pending duel can't settle.
+    note:
+      duel.status === 'active' && !foe.is_submitted
+        ? t('duelSeal.reopenNote', { name: foe.display_name })
+        : null,
+    confirmLabel: t('duelSeal.confirm'),
+    danger: false,
+  }
+}
+
+/* -------------------------------------------------------------------------- */
 /* SealActions — the confirm / cancel pair                                    */
 /* -------------------------------------------------------------------------- */
 
 /**
  * The dialog's action pair. Global order is [Cancel] … [Submit] (#646), so the
  * affirmative sits on the right on every surface.
+ *
+ * `danger` repaints the confirm button destructively for the forfeit mode
+ * (#751). It lives here rather than in each skin because the tone is a fact
+ * about the action, not a faction flourish — a forfeit is red in every voice.
  */
 export function SealActions({
   onConfirm,
@@ -375,6 +474,7 @@ export function SealActions({
   busy,
   confirmLabel,
   cancelLabel,
+  danger,
   theme,
 }: {
   onConfirm: () => void
@@ -382,6 +482,7 @@ export function SealActions({
   busy?: boolean
   confirmLabel?: ReactNode
   cancelLabel?: ReactNode
+  danger?: boolean
   theme: DuelSlotTheme
 }) {
   const { t } = useTranslation('praxis')
@@ -405,6 +506,13 @@ export function SealActions({
           fontSize: 'var(--text-sm)',
           fontFamily: theme.bodyFont ?? DEFAULT_THEME.bodyFont,
           opacity: busy ? 0.5 : 1,
+          ...(danger
+            ? {
+                background: 'var(--color-danger)',
+                borderColor: 'var(--color-danger)',
+                color: 'var(--color-text-on-accent)',
+              }
+            : {}),
         }}
       >
         {confirmLabel ?? t('duelSeal.confirm')}

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -17,8 +17,7 @@ import { Link } from 'react-router-dom'
 import { reframeLabel } from '../../components/vote/voteReframes'
 import { TaskCrown } from '../../components/cards/TaskCrown'
 import { CollabRoster } from '../../components/collab/CollabRoster'
-import { duelSides, formatPoints, useDuelStakes } from '../../components/duel/shared'
-import type { DuelDetailOut } from '../../api/duel'
+import DuelSealConfirm from '../../components/duel/DuelSealConfirm'
 import type { PraxisDetailState } from './usePraxisDetail'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
 import type { VoteSummary } from '../../api/votes'
@@ -310,39 +309,6 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
 
 // ── Owner actions ─────────────────────────────────────────────────────────────
 
-/**
- * The cost line on a settled duel's unsubmit confirm (#718).
- *
- * Its own component so the stakes hook runs unconditionally, below
- * PraxisOwnerActions' early returns. Figures come from the same `useDuelStakes`
- * the rail and the seal dialog use, so a Snide duelist is correctly told they
- * keep 0 rather than some invented "half".
- */
-function ForfeitCostLine({
-  duel,
-  viewerCharacterId,
-  taskPointValue,
-}: {
-  duel: DuelDetailOut
-  viewerCharacterId: number | null | undefined
-  taskPointValue: number | null | undefined
-}) {
-  const { t } = useTranslation('praxis')
-  const { me, foe } = duelSides(duel, viewerCharacterId)
-  const stakes = useDuelStakes(me.faction_slug, foe.faction_slug, taskPointValue)
-  return (
-    <span className="font-body" style={{ fontSize: 'var(--text-xs)', color: 'var(--color-danger)' }}>
-      {t('duelForfeit.confirmPrompt')}{' '}
-      {stakes &&
-        t('duelForfeit.cost', {
-          name: foe.display_name,
-          points: formatPoints(stakes.lose),
-          win: formatPoints(stakes.win),
-        })}
-    </span>
-  )
-}
-
 export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
   const { praxis, isOwner, user, duel, withdrawing, showWithdrawConfirm, setShowWithdrawConfirm, withdrawError, handleWithdraw, handleResubmit } = state
@@ -389,23 +355,42 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
               {withdrawing ? t('detail.owner.submitting') : t('detail.owner.submit')}
             </button>
           )
+        ) : forfeitsOnUnsubmit && duel ? (
+          /* A forfeit is the one irreversible duel beat, so it gets the same
+             dispatched dialog the (reversible) seal confirm got in #718 rather
+             than an inline text expand (#751). The trigger stays put and the
+             dialog mounts over it as a fixed overlay. Skinned by the TASK's
+             faction, matching the composer's own dispatch. */
+          <>
+            <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-danger)' }}>
+              {t('duelForfeit.action')}
+            </button>
+            {showWithdrawConfirm && (
+              <DuelSealConfirm
+                mode="forfeit"
+                taskFactionSlug={praxis.task_faction_slug}
+                duel={duel}
+                viewerCharacterId={viewerCharacterId}
+                taskPointValue={praxis.task_point_value}
+                onConfirm={handleWithdraw}
+                onCancel={() => setShowWithdrawConfirm(false)}
+                busy={withdrawing}
+              />
+            )}
+          </>
         ) : !showWithdrawConfirm ? (
-          <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: forfeitsOnUnsubmit ? 'var(--color-danger)' : 'var(--color-text-tertiary)' }}>
-            {forfeitsOnUnsubmit ? t('duelForfeit.action') : t('detail.owner.unsubmit')}
+          <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
+            {t('detail.owner.unsubmit')}
           </button>
         ) : (
           <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
-            {forfeitsOnUnsubmit && duel ? (
-              <ForfeitCostLine duel={duel} viewerCharacterId={user?.character?.id} taskPointValue={praxis.task_point_value} />
-            ) : (
-              <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('detail.owner.confirmPrompt')}</span>
-            )}
+            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('detail.owner.confirmPrompt')}</span>
             <button
               onClick={handleWithdraw}
               disabled={withdrawing}
               style={{ background: 'rgba(220,38,38,0.1)', border: '1.5px solid var(--color-danger)', color: 'var(--color-danger)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', padding: 'var(--space-xs) var(--space-md)', cursor: 'pointer', borderRadius: 0 }}
             >
-              {withdrawing ? t('detail.owner.submitting') : forfeitsOnUnsubmit ? t('duelForfeit.action') : t('detail.owner.confirmUnsubmit')}
+              {withdrawing ? t('detail.owner.submitting') : t('detail.owner.confirmUnsubmit')}
             </button>
             <button onClick={() => setShowWithdrawConfirm(false)} className="btn-outline" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)' }}>{t('detail.owner.cancel')}</button>
           </div>


### PR DESCRIPTION
Promotes the duel forfeit confirmation from an inline text expand to the same dispatched dialog the submit confirm got in #718 — **without adding a second pair of registries.**

Closes #751

## What changed

`mode: 'submit' | 'forfeit'` is now an optional prop on `DuelSealConfirmProps`, defaulting to `'submit'`. Every existing mount site is untouched.

The mode branch lives in **one** place: a new `useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)` hook in `components/duel/shared.tsx`, returning `{ heading, body, note, confirmLabel, danger }`. Skins render those five fields in their own frame instead of making the branch themselves, so adding a faction skin stays "write the frame" and can't drift from the copy rules.

- `submit` — `duelSeal.heading` / `bodyPending` / `bodyActive`, plus the free-reopen `reopenNote` under the same `active && !foe.is_submitted` condition as before. Byte-identical output to `main`.
- `forfeit` — `duelForfeit.action` as heading + confirm label, `duelForfeit.confirmPrompt` + `duelForfeit.cost` as body, destructive tone.

The `ForfeitCostLine` component in `pages/praxisDetail/shared.tsx` is deleted; its `useDuelStakes` call moved into the hook, so the Snide-aware lose figure (0.0×, not an invented "half") is still what a forfeiting duelist reads.

### Registry seam

Uses the existing `duelSeal` / `mobileDuelSeal` manifest keys via `surfaceMap`. **No new `FactionManifest` fields** — a forfeit-specific surface key would be exactly the third and fourth registry this issue exists to avoid. Each faction stays two files that each handle two modes, which is why this lands before #721–#726.

Both registered Wow skins (desktop + mobile) now handle both modes.

## Guard

`duelSkinSlots.test.tsx` walks every registered skin in **both** modes (16 tests, up from 5), so a skin that renders every slot in `submit` but drops one in `forfeit` fails CI. Plus two assertions the slot walk alone can't make: that each mode actually speaks its own copy (a skin can't pass by hardcoding the submit strings), and that omitting `mode` still yields `submit`.

Mutation-verified: pinning `useDuelSealCopy('submit', ...)` in the Wow skin fails `wow speaks the forfeit copy in forfeit mode`, as intended.

## Two judgement calls worth a look

1. **Forfeit heading is `duelForfeit.action` ("Forfeit").** The catalog has no forfeit-specific heading key, and the brief forbids inventing strings, so the heading reuses the action label and the issue's specified `confirmPrompt` + `cost` pair becomes the body verbatim. If you'd rather have a distinct heading, that's a one-key catalog addition.
2. **`SealActions` grew an optional `danger?: boolean`.** The brief said `confirmLabel` / `cancelLabel` needed no change — that still holds — but "danger tone on the confirm button" needed *somewhere* to live. It's on the shared component rather than in each skin because a forfeit is red in every faction's voice; it's a fact about the action, not a flourish. Uses `var(--color-danger)` / `var(--color-text-on-accent)`, no raw hex.

## Verification

- `tsc --noEmit` — clean (only the known `node:fs`/`node:url` stale-junction false alarms from PR #675, present on `main` too)
- `vitest run` — 991 passed / 105 files
- `npm run lint` — clean, exit 0
- `vite build` — built in 3.23s

**Visual QA is outstanding.** I can't screenshot (no dev stack in this environment), so every claim above is from tests, tsc, and lint — nothing here has been seen rendered.

## What to eyeball

The forfeit dialog only appears in one narrow state: **your own duel praxis, duel `status === 'settled'` (both sides cast), not already forfeited** — i.e. the praxis-detail page where the unsubmit control reads "Forfeit" in red.

1. **Desktop, Wow-faction task** — click Forfeit. The `wow.exe` window should open centred with "Forfeit" in the title bar, the red prompt + cost sentence as body, no green reopen note, stakes tiles and roster in the notepad scrap, and a red confirm button reading "Forfeit".
2. **Mobile, Wow-faction task** — same, as the bottom sheet. Check the red body text is legible on the dotted `--faction-wow-body-bg`, in **both light and dark**.
3. **Any non-Wow faction task** (Default skin) — same states; confirm the red confirm button clears AA against `--color-text-on-accent` in dark mode. This is the contrast question I'd most want a human eye on.
4. **Snide as the forfeiting side** — the cost line should say they keep **0**, not a fraction.
5. **Regression: the submit dialog** — compose a duel praxis and hit publish in `pending` and in `active`. Should be pixel-identical to `main`, including the green reopen note.
6. **Regression: ordinary unsubmit** — a solo or collab praxis, and an `active` (not settled) duel side. Both must keep the old **inline** confirm row, not the dialog. The `active` duel case is the one to check deliberately: pulling back there is free, and it must not have acquired forfeit language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
