### PR TITLE
Snide duel skins: xerox-punk clipping for the rail and the seal dialog (#722)

### DIFF
--- a/frontend/src/components/duel/SnideDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideDuelSealConfirm.tsx
@@ -1,0 +1,204 @@
+/**
+ * S.N.I.D.E. DESKTOP duel seal-confirm (#722) — the rail's zine clipping scaled
+ * up to a dialog: photocopier-black ground under the same 5px halftone screen, a
+ * 2px acid-green border, the opponent's colour on a fat left edge, and a hard
+ * offset shadow tinted hot pink. Square corners throughout.
+ *
+ * Pure frame. `StakesTiles` computes the win/lose figures from `useGameConfig()`
+ * and the VIEWER's own faction — which is why a Snide duelist correctly reads a
+ * literal **0** in the lose tile (2.0× / 0.0×, `eras/era_1.py`). That zero is the
+ * faction's whole personality, not a missing value, and nothing here special-
+ * cases it. `RaceRoster` reads `is_submitted`; `useDuelSealCopy` owns the
+ * heading, body, note, confirm label and danger tone for both modes. This file
+ * re-derives none of it.
+ *
+ * TWO MODES (#751). `submit` and `forfeit` render the same slots in the same
+ * order; only the chrome around the body line changes. In `forfeit` the body sits
+ * in a REDACTION BAR — a blacked-out panel with a pink hard shadow, the design's
+ * "black bar dropped on the page" — because a forfeit is the one duel beat with
+ * a consequence you cannot undo. The copy for it is the shipped `duelForfeit.*`
+ * catalog, via the shared hook, unchanged.
+ *
+ * Copy is faction-neutral by decision (#718): Snide's voice is visual only. No
+ * new locale keys, and no string in this file.
+ */
+import type { CSSProperties } from 'react'
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const INK = 'var(--faction-snide-ink)'
+const ACID = 'var(--faction-snide-acid)'
+const PINK = 'var(--faction-snide-pink)'
+const PAPER = 'var(--faction-snide-paper)'
+const MUTED = 'var(--faction-snide-card-muted)'
+const MARKER = 'var(--faction-snide-font-marker)'
+
+/** The xerox screen: a 1px dot on a 5px grid, barely there. */
+const HALFTONE: CSSProperties = {
+  backgroundColor: INK,
+  backgroundImage: `radial-gradient(color-mix(in srgb, ${PAPER} 20%, transparent) 1px, transparent 1px)`,
+  backgroundSize: '5px 5px',
+}
+
+/**
+ * The ransom-note masthead strip: cut squares of acid and pink at broken angles.
+ * Ornament — not an icon, not text, and carrying none of the dialog's meaning.
+ */
+export function RansomStrip() {
+  return (
+    <span style={{ display: 'flex', gap: 'var(--space-xs)' }} aria-hidden>
+      {[ACID, PINK, ACID, PINK].map((color, index) => (
+        <span
+          key={color + String(index)}
+          style={{
+            width: index % 2 === 0 ? 12 : 7,
+            height: index % 2 === 0 ? 7 : 12,
+            background: color,
+            transform: `rotate(${(index - 1.5) * 7}deg)`,
+          }}
+        />
+      ))}
+    </span>
+  )
+}
+
+export default function SnideDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  // Opponent tokens, same rule as the Default dialog and the rail: the foreign
+  // duelist looks foreign even on Snide's own paper.
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: 'var(--font-body)' }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{
+        padding: 'var(--space-lg)',
+        background: 'radial-gradient(circle, rgba(0,0,0,0.6), rgba(0,0,0,0.82))',
+      }}
+    >
+      <div
+        className="w-full max-w-[460px]"
+        style={{
+          ...HALFTONE,
+          border: `2px solid ${ACID}`,
+          borderLeft: `7px solid ${accent}`,
+          boxShadow: `6px 6px 0 color-mix(in srgb, ${PINK} 55%, transparent)`,
+          color: PAPER,
+          fontFamily: 'var(--font-body)',
+        }}
+      >
+        {/* masthead: accent wash under a dashed acid rule */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            flexWrap: 'wrap',
+            padding: 'var(--space-sm) var(--space-md)',
+            background: `color-mix(in srgb, ${accent} 16%, transparent)`,
+            borderBottom: `2px dashed ${ACID}`,
+          }}
+        >
+          <RansomStrip />
+          <h2 style={{ fontFamily: MARKER, fontSize: 'var(--text-title)' }}>{copy.heading}</h2>
+        </div>
+
+        <div style={{ padding: 'var(--space-lg)' }}>
+          {/* forfeit: the body goes behind a redaction bar — blacked out, pink
+              hard shadow, acid edge. `copy.danger` is the mode's own signal, so
+              this branches on the tone rather than on the mode name. */}
+          <p
+            style={{
+              lineHeight: 1.5,
+              fontSize: 'var(--text-content)',
+              ...(copy.danger
+                ? {
+                    padding: 'var(--space-md)',
+                    background: INK,
+                    borderLeft: `4px solid ${PINK}`,
+                    boxShadow: `4px 4px 0 color-mix(in srgb, ${PINK} 70%, transparent)`,
+                    color: PINK,
+                    fontWeight: 700,
+                  }
+                : {}),
+            }}
+          >
+            {copy.body}
+          </p>
+
+          {/* The free-reopen half of the truth — same condition as every other
+              skin, because it is the same fact. A forfeit has no such note and
+              `copy.note` is null there. */}
+          {copy.note && (
+            <p
+              style={{
+                marginTop: 'var(--space-sm)',
+                fontSize: 'var(--text-sm)',
+                color: ACID,
+              }}
+            >
+              {copy.note}
+            </p>
+          )}
+
+          {/* pasted-up panel: the stakes tiles and the race roster on one scrap */}
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              padding: 'var(--space-md)',
+              border: `1px solid color-mix(in srgb, ${PAPER} 28%, transparent)`,
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+
+          {/* ponytail: SealActions keeps its shared btn-outline / btn-primary
+              pair rather than growing a Snide poster-button skin slot. The
+              global [Cancel] … [Submit] order (#646) and the shared destructive
+              tone matter more here than an acid-green button, and adding a skin
+              prop to the shared component would be foundation work. */}
+          <div style={{ marginTop: 'var(--space-lg)' }}>
+            <SealActions
+              onConfirm={onConfirm}
+              onCancel={onCancel}
+              busy={busy}
+              confirmLabel={copy.confirmLabel}
+              danger={copy.danger}
+              theme={theme}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/duel/SnideMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideMobileDuelSealConfirm.tsx
@@ -1,0 +1,167 @@
+/**
+ * S.N.I.D.E. MOBILE duel seal-confirm (#722) — the same clipping as the desktop
+ * dialog, rebuilt as a bottom sheet: full-bleed on the page background, the
+ * halftone panel pinned to the bottom edge with its acid rule along the top, and
+ * the actions last so the thumb lands on them. Single column — no grid, per
+ * SPEC-faction-ui-profile §1a.
+ *
+ * Pure frame, same as the desktop skin: `StakesTiles` owns the win/lose
+ * arithmetic (Snide's 0.0× lose tile renders a literal 0 by construction),
+ * `RaceRoster` owns the cast status, and `useDuelSealCopy` owns both modes'
+ * heading, body, note, confirm label and tone. Nothing is recomputed or dropped.
+ *
+ * `forfeit` mode wears the same redaction bar as the desktop dialog — the one
+ * beat with an irreversible consequence gets the black bar on both form factors.
+ *
+ * Copy is faction-neutral by decision (#718). No new locale keys.
+ */
+import type { CSSProperties } from 'react'
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import { RansomStrip } from './SnideDuelSealConfirm'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const INK = 'var(--faction-snide-ink)'
+const ACID = 'var(--faction-snide-acid)'
+const PINK = 'var(--faction-snide-pink)'
+const PAPER = 'var(--faction-snide-paper)'
+const MUTED = 'var(--faction-snide-card-muted)'
+const MARKER = 'var(--faction-snide-font-marker)'
+
+const HALFTONE: CSSProperties = {
+  backgroundColor: INK,
+  backgroundImage: `radial-gradient(color-mix(in srgb, ${PAPER} 20%, transparent) 1px, transparent 1px)`,
+  backgroundSize: '5px 5px',
+}
+
+export default function SnideMobileDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: 'var(--font-body)' }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex flex-col justify-end"
+      style={{ background: 'var(--color-bg-page)' }}
+    >
+      <div
+        style={{
+          ...HALFTONE,
+          borderTop: `3px solid ${ACID}`,
+          borderLeft: `7px solid ${accent}`,
+          color: PAPER,
+          fontFamily: 'var(--font-body)',
+        }}
+      >
+        {/* sheet header — the desktop masthead, centred for the phone */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            padding: 'var(--space-md) var(--space-lg)',
+            background: `color-mix(in srgb, ${accent} 16%, transparent)`,
+            borderBottom: `2px dashed ${ACID}`,
+          }}
+        >
+          <RansomStrip />
+          <h2
+            style={{
+              fontFamily: MARKER,
+              fontSize: 'var(--text-title)',
+              textAlign: 'center',
+            }}
+          >
+            {copy.heading}
+          </h2>
+        </div>
+
+        <div style={{ padding: 'var(--space-lg)' }}>
+          <p
+            style={{
+              lineHeight: 1.5,
+              fontSize: 'var(--text-content)',
+              ...(copy.danger
+                ? {
+                    padding: 'var(--space-md)',
+                    background: INK,
+                    borderLeft: `4px solid ${PINK}`,
+                    boxShadow: `4px 4px 0 color-mix(in srgb, ${PINK} 70%, transparent)`,
+                    color: PINK,
+                    fontWeight: 700,
+                  }
+                : {}),
+            }}
+          >
+            {copy.body}
+          </p>
+
+          {copy.note && (
+            <p
+              style={{
+                marginTop: 'var(--space-sm)',
+                fontSize: 'var(--text-sm)',
+                color: ACID,
+              }}
+            >
+              {copy.note}
+            </p>
+          )}
+
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              padding: 'var(--space-md)',
+              border: `1px solid color-mix(in srgb, ${PAPER} 28%, transparent)`,
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+
+          {/* ponytail: actions keep the shared SealActions pair — thumb-sized
+              styling would need a skin slot on the shared component, which is
+              foundation work, not a skin change. */}
+          <div style={{ marginTop: 'var(--space-lg)' }}>
+            <SealActions
+              onConfirm={onConfirm}
+              onCancel={onCancel}
+              busy={busy}
+              confirmLabel={copy.confirmLabel}
+              danger={copy.danger}
+              theme={theme}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/factions/snide.ts
+++ b/frontend/src/factions/snide.ts
@@ -11,6 +11,10 @@
 import type { FactionManifest } from './manifest'
 
 import SnideAvatar from '../components/avatar/SnideAvatar'
+import SnideDuelRail from '../pages/praxisDetail/duelRails/SnideDuelRail'
+import SnideDuelSealConfirm from '../components/duel/SnideDuelSealConfirm'
+import SnideMobileDuelRail from '../pages/praxisDetail/duelRails/SnideMobileDuelRail'
+import SnideMobileDuelSealConfirm from '../components/duel/SnideMobileDuelSealConfirm'
 import SnideBackdrop from '../components/backdrop/SnideBackdrop'
 import SnideComment from '../components/comments/voices/SnideComment'
 import SnideEditPraxis from '../pages/editPraxis/archetypes/SnideEditPraxis'
@@ -53,6 +57,8 @@ export const SNIDE_MANIFEST: FactionManifest = {
   factionHero: () => SnideFactionHero,
   factionBody: () => SnideFactionBody,
   profileBody: () => SnideProfileBody,
+  duelSeal: () => SnideDuelSealConfirm,
+  duelRail: () => SnideDuelRail,
   mobileTaskCard: () => SnideMobileTaskCard,
   mobilePraxisCard: () => SnideMobilePraxisCard,
   mobileTaskDetail: () => SnideMobileTaskDetail,
@@ -60,4 +66,6 @@ export const SNIDE_MANIFEST: FactionManifest = {
   mobileEditPraxis: () => SnideMobileEditPraxis,
   mobileFactionPage: () => SnideFactionPage,
   mobileFieldDesk: () => SnideHome,
+  mobileDuelSeal: () => SnideMobileDuelSealConfirm,
+  mobileDuelRail: () => SnideMobileDuelRail,
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1263,6 +1263,14 @@
   .sg-rotate { animation: sg-rotate 120s linear infinite; }
 }
 
+/* S.N.I.D.E. duel rail — the settled-state dot flickers like a failing xerox
+   lamp. Class-gated on reduced-motion like every other faction animation, so a
+   component never writes `animation:` inline and bypasses the gate. (#722) */
+@keyframes snide-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+@media (prefers-reduced-motion: no-preference) {
+  .snide-pulse { animation: snide-pulse 1.6s ease-in-out infinite; }
+}
+
 /* Character-sidebar progress bar — rainbow fill drifts left→right. Stilled for reduced-motion. */
 @keyframes cs-shimmer { to { background-position: 200% 0; } }
 @media (prefers-reduced-motion: no-preference) {

--- a/frontend/src/pages/praxisDetail/duelRails/SnideDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SnideDuelRail.tsx
@@ -1,0 +1,167 @@
+/**
+ * S.N.I.D.E. DESKTOP duel rail (#722) — the duel context as a xerox-punk zine
+ * clipping: near-black photocopier ground under a fine halftone screen, a 2px
+ * acid-green border, the opponent's colour on a fat 7px left edge, and a hard
+ * offset shadow tinted hot pink. No radius anywhere — this is paper cut with a
+ * knife, not a window.
+ *
+ * Pure frame. Every slot arrives pre-rendered from `DuelCrossLink`: the
+ * per-`DuelStatus` branch table, the cast roster, the next-step line and the
+ * stakes arithmetic all live in `components/duel/shared.tsx`. This file decides
+ * only where the acid and the pink go. It recomputes nothing and drops nothing.
+ *
+ * NO WRAPPER `fontSize` (#769). The shell sets font family, colour and ornament
+ * and no size at all; each slot arrives already sized by its own role class. The
+ * one text size this file sets is on the headline leaf itself, at content tier.
+ *
+ * NO INVENTED COPY. The design mock letters a "⚔ DUELING" eyebrow into the
+ * header — but `duelCrossLink.dueling` already ships the glyph and the word
+ * inside the `headline` slot, and copy is faction-neutral by decision (#718).
+ * Reproducing the eyebrow would either duplicate the headline or introduce a
+ * string outside the catalog, so the header's ransom ornament is purely
+ * non-textual and the headline carries all the words.
+ *
+ * Tokens are the shipped `--faction-snide-*` set that SnidePraxisDetail and the
+ * Snide cards already wear — the mock's raw hex is relationship reference only.
+ * `accent`/`soft` still arrive from the OPPONENT's faction and are spent on the
+ * edge that faces them, so a foreign duelist keeps tinting the clipping.
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const INK = 'var(--faction-snide-ink)'
+const ACID = 'var(--faction-snide-acid)'
+const PINK = 'var(--faction-snide-pink)'
+const PAPER = 'var(--faction-snide-paper)'
+const MARKER = 'var(--faction-snide-font-marker)'
+
+/** The xerox screen: a 1px dot on a 5px grid, barely there. */
+const HALFTONE: CSSProperties = {
+  backgroundColor: INK,
+  backgroundImage: `radial-gradient(color-mix(in srgb, ${PAPER} 20%, transparent) 1px, transparent 1px)`,
+  backgroundSize: '5px 5px',
+}
+
+/**
+ * Cut-out squares from a ransom note, alternating acid and pink. Ornament, not
+ * an icon and not text — the header's only non-slot mark.
+ */
+function RansomStrip() {
+  return (
+    <span style={{ display: 'flex', gap: 'var(--space-xs)' }} aria-hidden>
+      {[ACID, PINK, ACID].map((color, index) => (
+        <span
+          key={color + String(index)}
+          style={{
+            width: index === 1 ? 6 : 10,
+            height: index === 1 ? 10 : 6,
+            background: color,
+            transform: `rotate(${(index - 1) * 8}deg)`,
+          }}
+        />
+      ))}
+    </span>
+  )
+}
+
+export default function SnideDuelRail({
+  accent,
+  maxWidth,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const shell: CSSProperties = {
+    ...HALFTONE,
+    maxWidth,
+    margin: 'var(--space-lg) 0',
+    border: `2px solid ${ACID}`,
+    // The opponent's colour rides the fat left edge; the rest is Snide's.
+    borderLeft: `7px solid ${accent}`,
+    // Hard offset shadow, no blur — a photocopy of a photocopy, tinted pink.
+    boxShadow: `6px 6px 0 color-mix(in srgb, ${PINK} 55%, transparent)`,
+    fontFamily: 'var(--font-body)',
+    // No `fontSize` here (#769): the slots size themselves, and a wrapper size
+    // overrides every one of them at once. A skin owns font, colour, ornament.
+    color: PAPER,
+  }
+
+  return (
+    <div style={shell}>
+      {/* masthead: accent wash under a dashed acid rule */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          flexWrap: 'wrap',
+          padding: 'var(--space-sm) var(--space-md)',
+          background: `color-mix(in srgb, ${accent} 16%, transparent)`,
+          borderBottom: `2px dashed ${ACID}`,
+        }}
+      >
+        <RansomStrip />
+        <span style={{ fontFamily: MARKER, fontSize: 'var(--text-title)' }}>{headline}</span>
+        {tally && (
+          <span
+            style={{
+              marginLeft: 'auto',
+              padding: 'var(--space-xs) var(--space-sm)',
+              background: ACID,
+              color: INK,
+              border: `2px solid ${PAPER}`,
+              fontWeight: 700,
+            }}
+          >
+            {tally}
+          </span>
+        )}
+      </div>
+
+      <div style={{ padding: 'var(--space-md)' }}>
+        {note && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 'var(--space-sm)',
+              padding: 'var(--space-xs) var(--space-sm)',
+              background: `color-mix(in srgb, ${accent} 18%, transparent)`,
+              borderLeft: `3px solid ${ACID}`,
+            }}
+          >
+            <span
+              aria-hidden
+              className="snide-pulse"
+              style={{
+                width: 7,
+                height: 7,
+                flex: '0 0 auto',
+                borderRadius: '50%',
+                background: ACID,
+              }}
+            />
+            {note}
+          </div>
+        )}
+        {body && (
+          <div
+            style={{
+              marginTop: note ? 'var(--space-sm)' : 0,
+              padding: 'var(--space-md)',
+              border: `1px solid color-mix(in srgb, ${PAPER} 28%, transparent)`,
+            }}
+          >
+            {body}
+          </div>
+        )}
+      </div>
+      {/* ponytail: `declined` and `forfeited` arrive with body === null and no
+          tally, so the clipping shrinks to its masthead. That IS the state —
+          there is no race left — and no substitute roster is drawn for it. The
+          mock's per-row accent edge and its separate YOU/THEM tally cells are
+          likewise absent: both live inside slots this frame receives whole. */}
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/duelRails/SnideMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SnideMobileDuelRail.tsx
@@ -1,0 +1,114 @@
+/**
+ * S.N.I.D.E. MOBILE duel rail (#722) — the desktop clipping thumbed down.
+ *
+ * Two changes and no more: the masthead loses its side-by-side tally (a score
+ * pair and a marker-face headline on one phone-width row wrap into mush) and the
+ * tally drops to its own full-width scoreboard band under the rule, where it
+ * reads as the ransom-note block it is. Single column throughout —
+ * SPEC-faction-ui-profile §1a forbids a fixed-px grid on the mobile path.
+ *
+ * Pure frame, same contract as the desktop skin: every slot arrives already
+ * rendered from `DuelCrossLink`, and none of the duel's arithmetic or status
+ * branching is visible from here. No wrapper `fontSize` (#769).
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const INK = 'var(--faction-snide-ink)'
+const ACID = 'var(--faction-snide-acid)'
+const PINK = 'var(--faction-snide-pink)'
+const PAPER = 'var(--faction-snide-paper)'
+const MARKER = 'var(--faction-snide-font-marker)'
+
+export default function SnideMobileDuelRail({
+  accent,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  // ponytail: `maxWidth` is intentionally ignored on mobile. The rail is
+  // full-bleed inside the phone column, so the desktop archetype-width map has
+  // nothing to line up with here.
+  const shell: CSSProperties = {
+    backgroundColor: INK,
+    backgroundImage: `radial-gradient(color-mix(in srgb, ${PAPER} 20%, transparent) 1px, transparent 1px)`,
+    backgroundSize: '5px 5px',
+    margin: 'var(--space-md) 0',
+    border: `2px solid ${ACID}`,
+    borderLeft: `7px solid ${accent}`,
+    boxShadow: `5px 5px 0 color-mix(in srgb, ${PINK} 55%, transparent)`,
+    fontFamily: 'var(--font-body)',
+    // No `fontSize` here (#769): the slots size themselves, and a wrapper size
+    // overrides every one of them at once. A skin owns font, colour, ornament.
+    color: PAPER,
+  }
+
+  return (
+    <div style={shell}>
+      <div
+        style={{
+          padding: 'var(--space-sm) var(--space-md)',
+          background: `color-mix(in srgb, ${accent} 16%, transparent)`,
+          borderBottom: `2px dashed ${ACID}`,
+        }}
+      >
+        <span style={{ fontFamily: MARKER, fontSize: 'var(--text-title)' }}>{headline}</span>
+      </div>
+
+      <div style={{ padding: 'var(--space-md)' }}>
+        {tally && (
+          <div
+            style={{
+              padding: 'var(--space-xs) var(--space-sm)',
+              marginBottom: 'var(--space-sm)',
+              background: ACID,
+              color: INK,
+              border: `2px solid ${PAPER}`,
+              fontWeight: 700,
+              textAlign: 'center',
+            }}
+          >
+            {tally}
+          </div>
+        )}
+        {note && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 'var(--space-sm)',
+              padding: 'var(--space-xs) var(--space-sm)',
+              background: `color-mix(in srgb, ${accent} 18%, transparent)`,
+              borderLeft: `3px solid ${ACID}`,
+            }}
+          >
+            <span
+              aria-hidden
+              className="snide-pulse"
+              style={{
+                width: 7,
+                height: 7,
+                flex: '0 0 auto',
+                borderRadius: '50%',
+                background: ACID,
+              }}
+            />
+            {note}
+          </div>
+        )}
+        {body && (
+          <div
+            style={{
+              marginTop: note ? 'var(--space-sm)' : 0,
+              padding: 'var(--space-md)',
+              border: `1px solid color-mix(in srgb, ${PAPER} 28%, transparent)`,
+            }}
+          >
+            {body}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Four Snide duel skins — desktop + mobile seal dialog, desktop + mobile rail — registered as four thunks on `frontend/src/factions/snide.ts`.

Snide reads as a **xerox-punk zine clipping**: photocopier-black ground under a fine 5px halftone screen, a 2px acid-green border, the opponent's colour on a fat 7px left edge, and a hard offset shadow tinted hot pink. Square corners everywhere — paper cut with a knife, not a window.

### Decisions worth reviewing

- **No invented copy, at the cost of one mock element.** The mock letters a `⚔ DUELING` eyebrow into the rail masthead, but `duelCrossLink.dueling` already ships that glyph and word inside the `headline` slot. Reproducing the eyebrow would either duplicate the headline or add a string outside the catalog, so the masthead ornament (`RansomStrip`) is purely non-textual and every word comes from `praxis.json` via `t()`.
- **The forfeit redaction bar rides `copy.danger`, not the mode name.** In `forfeit` mode the body paragraph sits in a blacked-out panel with a pink hard shadow and acid edge — the design's "black bar dropped on the page". It branches on the tone the shared hook already computes, so no skin re-derives the mode.
- **Mock elements that live inside slots are not reproduced.** The two-cell YOU/THEM tally and the per-row accent edge on the roster both require splitting nodes the rail receives whole; the tally renders as one acid-on-ink ransom block instead. Noted in a `ponytail` comment at the site.
- **One new CSS addition:** `@keyframes snide-pulse` + `.snide-pulse` in `index.css`, gated behind `prefers-reduced-motion: no-preference` like every other faction animation — so no component writes `animation:` inline and bypasses the gate. No new colour variables were needed; the mock's hex maps onto the shipped `--faction-snide-*` set.
- **No wrapper `fontSize` (#769).** Both rails set font family, colour and ornament and no size at all; the `duelSkinSlots` Label-tier guard passes. The one size either rail sets is on the headline leaf, at content tier.

### What to eyeball

Visual QA is **outstanding** — this environment cannot screenshot and has no dev stack. Verified by `tsc --noEmit`, `vite build`, `eslint` (clean on all five touched files) and the full 1006-test vitest suite.

Rail, all five states on a Snide-faction task:
- `pending` — no tally, no note; `StakesTiles` collapses to the solo-fallback line. Masthead + body panel only.
- `active` — roster + next-step + win/lose tiles, no tally, no note.
- `settled` — acid-on-ink tally block top-right (desktop) / full-width band (mobile), plus the accent-wash note strip with the pulsing acid dot.
- `declined` and `forfeited` — `body` and `tally` are both `null`, so the clipping shrinks to its masthead. Confirm it reads as deliberate and reserves no empty height.

Seal dialog, both modes:
- `submit` — plain body paragraph, acid-green reopen note when the opponent hasn't cast.
- `forfeit` — body inside the redaction bar; no reopen note (correct, `copy.note` is null); confirm button in the shared destructive tone.

Specifically:
- **The zero-lose stakes tile.** A Snide duelist is 2.0× win / **0.0×** lose, so "IF YOU LOSE" legitimately renders `0`, in `--color-danger`. Not a bug, not special-cased — `StakesTiles` computes it.
- **Dark mode**, both surfaces. Snide's ground is dark-in-light already (Singularity precedent), so the light and dark renders should differ only by the deeper `--faction-snide-card-bg` and the brighter accent.
- **A foreign opponent's accent** on the left edge and the masthead wash — pick a duel against a UA or Ephemerists player and check the tint reads against the acid border.
- **Mobile sheet** — single column, actions last, no horizontal scroll at 360px.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)
