### PR TITLE
Duel skins: Everymen (desktop + mobile)

### DIFF
--- a/frontend/src/components/duel/EverymenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/EverymenDuelSealConfirm.tsx
@@ -1,0 +1,277 @@
+/**
+ * Everymen DESKTOP duel seal-confirm (#721) — the design's `EvDuelDialog.dc.html`.
+ *
+ * Everymen files everything as paperwork, so the one irreversible beat in the
+ * duel becomes a stamped form served over the composer: red masthead with a
+ * faint guilloche and a rotated dashed division seal, a red→gold stripe rule,
+ * the opponent on a bordered card, the stakes in a hard-bordered panel, and a
+ * tan footer band. Cream paper, ink rules, hard zero-blur shadows — the idiom
+ * `EverymenEditPraxis` and `EverymenPraxisDetail` already wear, no new tokens.
+ *
+ * BOTH MODES, ONE FILE (#751). `mode` is `submit` or `forfeit` and
+ * `useDuelSealCopy` owns every string that differs — heading, body, the
+ * free-reopen note, the confirm label and the destructive tone. This skin
+ * re-derives none of it; in particular the reopen note's
+ * `active && !foe.is_submitted` condition is the shared one, because it is a
+ * fact about the duel rather than an Everymen flourish. What the mode DOES
+ * change here is chrome: the forfeit dialog drops its title a tier and repaints
+ * the stakes panel from tan paper to ink with a red-tinted shadow, so the
+ * costly dialog does not look like the routine one.
+ *
+ * Pure frame otherwise. `StakesTiles` computes the win/lose figures from the
+ * viewer's own faction config (Snide's 0.0× lose falls out by construction),
+ * `RaceRoster` reads `is_submitted`, and `SealActions` owns the global
+ * [Cancel] … [Submit] order (#646). None is dropped in either mode.
+ *
+ * The mock's "FORM D-02" eyebrow and "WHAT'S AT STAKE" rubric are deliberately
+ * NOT transcribed: they are invented copy with no `praxis.json` key, and copy is
+ * faction-neutral by decision (#718). Their ornament — the gold letterspaced
+ * rule and the dashed divider — is kept; their words are not.
+ */
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const CREAM = 'var(--everymen-cream)'
+const INK = 'var(--everymen-ink)'
+const PAPER_TEXT = 'var(--everymen-paper-text)'
+const MUTED = 'var(--everymen-muted)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const POSTER = 'var(--font-accent)' // Bebas Neue
+const BODY = 'var(--font-body)'
+
+/** The masthead's faint radial guilloche, as on `EverymenBackdrop`. */
+const GUILLOCHE =
+  `repeating-conic-gradient(from 0deg at 50% -8%, color-mix(in srgb, ${CREAM} 10%, transparent) 0 5deg, transparent 5deg 11deg)`
+
+export default function EverymenDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  // Opponent tokens, the same rule as the rail and the Default dialog: the
+  // foreign duelist looks foreign even inside Everymen's own paperwork (#310).
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+
+  // The stakes panel flips to ink in forfeit mode, so the slots inside it need
+  // the light muted tone to stay legible. This is a MODE branch, not a theme
+  // branch — dark mode is handled entirely by the token cascade.
+  const onInk = copy.danger
+  const theme: DuelSlotTheme = { accent, muted: onInk ? CREAM : MUTED, bodyFont: BODY }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{
+        padding: 'var(--space-lg)',
+        background: 'radial-gradient(circle, rgba(0,0,0,0.55), rgba(0,0,0,0.75))',
+      }}
+    >
+      <div
+        className="w-full max-w-[460px]"
+        style={{
+          background: PAPER,
+          color: PAPER_TEXT,
+          fontFamily: BODY,
+          border: `3px solid ${INK}`,
+          // Exaggerated hard offset, zero blur — the dialog is a document
+          // physically laid on top of the composer.
+          boxShadow: `14px 14px 0 color-mix(in srgb, ${INK} 30%, transparent)`,
+        }}
+      >
+        {/* ── Stamped red masthead ── */}
+        <div
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            padding: 'var(--space-lg) var(--space-xl)',
+            background: RED,
+            backgroundImage: GUILLOCHE,
+            color: CREAM,
+          }}
+        >
+          {/* Duel-division seal: a rotated dashed medallion, pure ornament. */}
+          <span
+            aria-hidden
+            style={{
+              position: 'absolute',
+              top: -14,
+              right: -14,
+              width: 92,
+              height: 92,
+              borderRadius: '50%',
+              border: `2px dashed ${CREAM}`,
+              opacity: 0.45,
+              transform: 'rotate(-12deg)',
+            }}
+          />
+          {/* Gold rule standing in for the mock's form-reference eyebrow, which
+              was invented copy with no catalog key. */}
+          <span
+            aria-hidden
+            style={{ display: 'block', width: 56, height: 3, background: GOLD, marginBottom: 'var(--space-sm)' }}
+          />
+          <h2
+            style={{
+              position: 'relative',
+              margin: 0,
+              fontFamily: POSTER,
+              fontWeight: 400,
+              // The forfeit dialog speaks quieter than the routine one — a tier
+              // down, not a raw number. Both sit in the Content ramp (§4a).
+              fontSize: onInk ? 'var(--text-heading)' : 'var(--text-display)',
+              lineHeight: 1,
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+              textShadow: `3px 3px 0 color-mix(in srgb, ${INK} 55%, transparent)`,
+            }}
+          >
+            {copy.heading}
+          </h2>
+        </div>
+
+        {/* red→gold stripe rule */}
+        <div
+          aria-hidden
+          style={{ height: 7, background: `linear-gradient(90deg, ${RED} 0 50%, ${GOLD} 50% 100%)` }}
+        />
+
+        <div style={{ padding: 'var(--space-xl)' }}>
+          {/* ── Opponent card: ink monogram disc on tan stock ── */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-md)',
+              padding: 'var(--space-sm) var(--space-md)',
+              background: PAPER_DEEP,
+              border: `2px solid ${INK}`,
+              borderLeft: `5px solid ${accent}`,
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                flexShrink: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 38,
+                height: 38,
+                borderRadius: '50%',
+                background: INK,
+                color: CREAM,
+                fontFamily: POSTER,
+                fontSize: 'var(--text-title)',
+                lineHeight: 1,
+                boxShadow: `inset 0 0 0 2px ${PAPER_DEEP}, inset 0 0 0 3px ${accent}`,
+              }}
+            >
+              {foe.display_name.slice(0, 1)}
+            </span>
+            <span className="content-text" style={{ fontFamily: POSTER, letterSpacing: '0.05em', minWidth: 0 }}>
+              {foe.display_name}
+            </span>
+          </div>
+
+          {/* ── The body line. Forfeit mode is the destructive one and says so. ── */}
+          <p
+            className="content-text"
+            style={{
+              marginTop: 'var(--space-lg)',
+              lineHeight: 1.6,
+              ...(copy.danger ? { color: RED, fontWeight: 700 } : {}),
+            }}
+          >
+            {copy.body}
+          </p>
+
+          {/* The free-reopen half of the truth — the shared condition, not an
+              Everymen one. A forfeit has no such note and `copy.note` is null. */}
+          {copy.note && (
+            <p
+              className="content-text"
+              style={{ marginTop: 'var(--space-sm)', color: 'var(--color-success)' }}
+            >
+              {copy.note}
+            </p>
+          )}
+
+          {/* dashed divider — the mock's rubric rule, minus its invented words */}
+          <div
+            aria-hidden
+            style={{ marginTop: 'var(--space-lg)', borderTop: `2px dashed color-mix(in srgb, ${INK} 45%, transparent)` }}
+          />
+
+          {/* ── Stakes + roster panel. Tan stock normally; ink with a red-tinted
+              shadow in forfeit mode, where the figures are the cost. ── */}
+          <div
+            style={{
+              marginTop: 'var(--space-lg)',
+              padding: 'var(--space-md)',
+              background: onInk ? INK : PAPER_DEEP,
+              color: onInk ? CREAM : PAPER_TEXT,
+              border: `2px solid ${INK}`,
+              boxShadow: onInk
+                ? `4px 4px 0 color-mix(in srgb, ${RED} 45%, transparent)`
+                : `3px 3px 0 color-mix(in srgb, ${INK} 18%, transparent)`,
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+        </div>
+
+        {/* ── Footer band ── */}
+        <div
+          style={{
+            padding: 'var(--space-md) var(--space-xl)',
+            background: PAPER_DEEP,
+            borderTop: `2px solid ${INK}`,
+          }}
+        >
+          {/* ponytail: SealActions keeps its shared btn-outline / btn-primary
+              pair rather than growing an Everymen stamped-button slot. The
+              global [Cancel] … [Submit] order (#646) and the shared `danger`
+              tone are worth more than a poster button, and adding a skin prop
+              to the shared component would be foundation work. */}
+          <SealActions
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            busy={busy}
+            confirmLabel={copy.confirmLabel}
+            danger={copy.danger}
+            theme={theme}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/duel/EverymenMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/EverymenMobileDuelSealConfirm.tsx
@@ -1,0 +1,228 @@
+/**
+ * Everymen MOBILE duel seal-confirm (#721) — the desktop form as a full-screen
+ * dispatch, the shape `EvPraxisPhone.dc.html` implies.
+ *
+ * Same document, thumbed: the panel goes full-bleed on the page background with
+ * no floating shadow (there is nothing for it to float above), the masthead
+ * loses its exaggerated offset, the footer band pins to the bottom so the thumb
+ * lands on the actions, and the middle scrolls. Single-column throughout —
+ * SPEC-faction-ui-profile §1a forbids a fixed-px grid on the mobile path.
+ *
+ * Both modes (#751), same as the desktop skin: `useDuelSealCopy` owns every
+ * string that differs and the forfeit dialog re-dresses the stakes panel in ink
+ * rather than dropping it. `StakesTiles`, `RaceRoster` and `SealActions` are all
+ * present in both modes — none of the duel's arithmetic lives here.
+ */
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const CREAM = 'var(--everymen-cream)'
+const INK = 'var(--everymen-ink)'
+const PAPER_TEXT = 'var(--everymen-paper-text)'
+const MUTED = 'var(--everymen-muted)'
+const RED = 'var(--everymen-red)'
+const GOLD = 'var(--everymen-gold)'
+const POSTER = 'var(--font-accent)'
+const BODY = 'var(--font-body)'
+
+const GUILLOCHE =
+  `repeating-conic-gradient(from 0deg at 50% -8%, color-mix(in srgb, ${CREAM} 10%, transparent) 0 5deg, transparent 5deg 11deg)`
+
+export default function EverymenMobileDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const onInk = copy.danger
+  const theme: DuelSlotTheme = { accent, muted: onInk ? CREAM : MUTED, bodyFont: BODY }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex flex-col"
+      style={{ background: PAPER, color: PAPER_TEXT, fontFamily: BODY }}
+    >
+      {/* ── Stamped red masthead ── */}
+      <div
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          flexShrink: 0,
+          padding: 'var(--space-lg)',
+          background: RED,
+          backgroundImage: GUILLOCHE,
+          color: CREAM,
+          borderBottom: `3px solid ${INK}`,
+        }}
+      >
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: -18,
+            right: -18,
+            width: 88,
+            height: 88,
+            borderRadius: '50%',
+            border: `2px dashed ${CREAM}`,
+            opacity: 0.45,
+            transform: 'rotate(-12deg)',
+          }}
+        />
+        <span
+          aria-hidden
+          style={{ display: 'block', width: 48, height: 3, background: GOLD, marginBottom: 'var(--space-sm)' }}
+        />
+        <h2
+          style={{
+            position: 'relative',
+            margin: 0,
+            fontFamily: POSTER,
+            fontWeight: 400,
+            // A tier down in forfeit mode, as on desktop — the costly dialog
+            // does not shout. Both are Content-ramp tokens (§4a).
+            fontSize: onInk ? 'var(--text-title)' : 'var(--text-heading)',
+            lineHeight: 1,
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase',
+            textShadow: `2px 2px 0 color-mix(in srgb, ${INK} 55%, transparent)`,
+          }}
+        >
+          {copy.heading}
+        </h2>
+      </div>
+
+      <div
+        aria-hidden
+        style={{ flexShrink: 0, height: 6, background: `linear-gradient(90deg, ${RED} 0 50%, ${GOLD} 50% 100%)` }}
+      />
+
+      {/* ── Scrolling middle ── */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-lg)' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-md)',
+            padding: 'var(--space-sm) var(--space-md)',
+            background: PAPER_DEEP,
+            border: `2px solid ${INK}`,
+            borderLeft: `5px solid ${accent}`,
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 34,
+              height: 34,
+              borderRadius: '50%',
+              background: INK,
+              color: CREAM,
+              fontFamily: POSTER,
+              fontSize: 'var(--text-title)',
+              lineHeight: 1,
+              boxShadow: `inset 0 0 0 2px ${PAPER_DEEP}, inset 0 0 0 3px ${accent}`,
+            }}
+          >
+            {foe.display_name.slice(0, 1)}
+          </span>
+          <span className="content-text" style={{ fontFamily: POSTER, letterSpacing: '0.05em', minWidth: 0 }}>
+            {foe.display_name}
+          </span>
+        </div>
+
+        <p
+          className="content-text"
+          style={{
+            marginTop: 'var(--space-lg)',
+            lineHeight: 1.6,
+            ...(copy.danger ? { color: RED, fontWeight: 700 } : {}),
+          }}
+        >
+          {copy.body}
+        </p>
+
+        {copy.note && (
+          <p
+            className="content-text"
+            style={{ marginTop: 'var(--space-sm)', color: 'var(--color-success)' }}
+          >
+            {copy.note}
+          </p>
+        )}
+
+        <div
+          aria-hidden
+          style={{ marginTop: 'var(--space-lg)', borderTop: `2px dashed color-mix(in srgb, ${INK} 45%, transparent)` }}
+        />
+
+        <div
+          style={{
+            marginTop: 'var(--space-lg)',
+            padding: 'var(--space-md)',
+            background: onInk ? INK : PAPER_DEEP,
+            color: onInk ? CREAM : PAPER_TEXT,
+            border: `2px solid ${INK}`,
+            boxShadow: onInk ? `4px 4px 0 color-mix(in srgb, ${RED} 45%, transparent)` : 'none',
+          }}
+        >
+          <StakesTiles
+            viewerFactionSlug={me.faction_slug}
+            opponentFactionSlug={foe.faction_slug}
+            opponentName={foe.display_name}
+            taskPointValue={taskPointValue}
+            status={duel.status}
+            theme={theme}
+          />
+          <RaceRoster me={me} foe={foe} theme={theme} />
+        </div>
+      </div>
+
+      {/* ── Pinned footer band ── */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: 'var(--space-md) var(--space-lg)',
+          background: PAPER_DEEP,
+          borderTop: `2px solid ${INK}`,
+        }}
+      >
+        {/* ponytail: the shared SealActions pair again — thumb-sized styling
+            would need a skin slot on the shared component, which is foundation
+            work rather than a skin change. */}
+        <SealActions
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          busy={busy}
+          confirmLabel={copy.confirmLabel}
+          danger={copy.danger}
+          theme={theme}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/factions/everymen.ts
+++ b/frontend/src/factions/everymen.ts
@@ -13,12 +13,16 @@ import type { FactionManifest } from './manifest'
 import EverymenAvatar from '../components/avatar/EverymenAvatar'
 import EverymenBackdrop from '../components/backdrop/EverymenBackdrop'
 import EverymenComment from '../components/comments/voices/EverymenComment'
+import EverymenDuelRail from '../pages/praxisDetail/duelRails/EverymenDuelRail'
+import EverymenDuelSealConfirm from '../components/duel/EverymenDuelSealConfirm'
 import EverymenEditPraxis from '../pages/editPraxis/archetypes/EverymenEditPraxis'
 import EverymenFactionBody from '../pages/factionDetail/archetypes/EverymenFactionBody'
 import EverymenFactionHero from '../components/cards/EverymenFactionHero'
 import EverymenFactionPage from '../pages/factionDetail/mobileArchetypes/EverymenFactionPage'
 import EverymenFeedFrame from '../components/feed/EverymenFeedFrame'
 import EverymenHome from '../pages/fieldDesk/mobileArchetypes/EverymenHome'
+import EverymenMobileDuelRail from '../pages/praxisDetail/duelRails/EverymenMobileDuelRail'
+import EverymenMobileDuelSealConfirm from '../components/duel/EverymenMobileDuelSealConfirm'
 import EverymenMobileEditPraxis from '../pages/editPraxis/mobileArchetypes/EverymenComposer'
 import EverymenMobilePraxisCard from '../components/praxisCard/mobile/EverymenMobilePraxisCard'
 import EverymenMobilePraxisDetail from '../pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail'
@@ -53,6 +57,8 @@ export const EVERYMEN_MANIFEST: FactionManifest = {
   factionHero: () => EverymenFactionHero,
   factionBody: () => EverymenFactionBody,
   profileBody: () => EverymenProfileBody,
+  duelSeal: () => EverymenDuelSealConfirm,
+  duelRail: () => EverymenDuelRail,
   mobileTaskCard: () => EverymenMobileTaskCard,
   mobilePraxisCard: () => EverymenMobilePraxisCard,
   mobileTaskDetail: () => EverymenMobileTaskDetail,
@@ -60,4 +66,6 @@ export const EVERYMEN_MANIFEST: FactionManifest = {
   mobileEditPraxis: () => EverymenMobileEditPraxis,
   mobileFactionPage: () => EverymenFactionPage,
   mobileFieldDesk: () => EverymenHome,
+  mobileDuelSeal: () => EverymenMobileDuelSealConfirm,
+  mobileDuelRail: () => EverymenMobileDuelRail,
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1271,6 +1271,14 @@
   .snide-pulse { animation: snide-pulse 1.6s ease-in-out infinite; }
 }
 
+/* Everymen duel rail — the "live" dot on the settled-standing strip pulses like a
+   dispatch-board indicator (#721). Stilled for reduced-motion, same as its
+   neighbours: the dot's meaning is carried by the note's copy, never by motion. */
+@keyframes ev-duel-pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.35; transform: scale(0.82); } }
+@media (prefers-reduced-motion: no-preference) {
+  .ev-duel-pulse { animation: ev-duel-pulse 1.1s ease-in-out infinite; }
+}
+
 /* Character-sidebar progress bar — rainbow fill drifts left→right. Stilled for reduced-motion. */
 @keyframes cs-shimmer { to { background-position: 200% 0; } }
 @media (prefers-reduced-motion: no-preference) {

--- a/frontend/src/pages/praxisDetail/duelRails/EverymenDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EverymenDuelRail.tsx
@@ -1,0 +1,168 @@
+/**
+ * Everymen DESKTOP duel rail (#721) — the duel filed as a stamped dispatch,
+ * matching the design's `EvDuelRail.dc.html`.
+ *
+ * Everymen's shipped idiom is a union broadside on paper: cream field, heavy ink
+ * rule, a hard offset shadow with no blur, and a red→gold stripe. The rail wears
+ * it as a form pinned above the work report — the same vocabulary
+ * `EverymenPraxisDetail` and `EverymenEditPraxis` already use, no new tokens.
+ *
+ * Pure frame. Every slot arrives already rendered from `DuelCrossLink`: the
+ * per-`DuelStatus` branch table, the cast roster, the next-step line and the
+ * stakes arithmetic all live in `components/duel/shared.tsx`. Nothing here
+ * recomputes a figure, re-derives a state, or touches a string.
+ *
+ * WHAT THE MOCK DRAWS THAT THIS CONTRACT CANNOT (deliberate, not missed):
+ * the mock gives each roster row its own bordered tan box, splits the tally into
+ * separate YOU / THEM cells, and hangs a red ▸ on the next-step line. All three
+ * live *inside* `body` / `tally`, which arrive as single opaque nodes — a skin
+ * that reached in to re-render them would be recomputing slots, which is exactly
+ * what the split forbids. The idiom is therefore carried at the frame level:
+ * paper + ink border + accent edge + hard shadow outside, an ink-bordered tan
+ * panel around the body, and a hard-bordered box around the tally.
+ *
+ * `accent`/`soft` are the OPPONENT's faction tokens (#310) and are spent on the
+ * left edge, the header wash and the stripe, so a foreign duelist keeps tinting
+ * an otherwise wholly Everymen form.
+ *
+ * No `fontSize` anywhere on a container (#769): the slots size themselves via
+ * their own role classes, and a wrapper size overrides all of them at once. The
+ * skin owns font, colour and ornament only (WORLD_ZERO_STYLE §4a).
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const CREAM = 'var(--everymen-cream)'
+const INK = 'var(--everymen-ink)'
+const PAPER_TEXT = 'var(--everymen-paper-text)'
+const GOLD = 'var(--everymen-gold)'
+const POSTER = 'var(--font-accent)' // Bebas Neue — the condensed display face
+const BODY = 'var(--font-body)'
+
+/**
+ * The dispatch-board indicator on the settled-standing strip. Motion is
+ * decoration: the note it sits beside says the same thing in words, and the
+ * keyframe is behind `prefers-reduced-motion` in index.css.
+ */
+function LiveDot({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden
+      className="ev-duel-pulse"
+      style={{
+        flexShrink: 0,
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        background: color,
+        border: `1px solid ${INK}`,
+      }}
+    />
+  )
+}
+
+export default function EverymenDuelRail({
+  accent,
+  maxWidth,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const shell: CSSProperties = {
+    maxWidth,
+    margin: 'var(--space-lg) 0',
+    background: PAPER,
+    color: PAPER_TEXT,
+    fontFamily: BODY,
+    border: `2px solid ${INK}`,
+    // The opponent's colour rides the edge that faces them.
+    borderLeft: `7px solid ${accent}`,
+    // Hard offset, zero blur — the poster shadow the archetype already wears.
+    boxShadow: `6px 6px 0 color-mix(in srgb, ${INK} 26%, transparent)`,
+  }
+
+  return (
+    <div style={shell}>
+      {/* accent→gold stripe rule, the Everymen masthead signature */}
+      <div
+        aria-hidden
+        style={{ height: 5, background: `linear-gradient(90deg, ${accent} 0 50%, ${GOLD} 50% 100%)` }}
+      />
+
+      {/* Header band: the state headline on an accent wash, tally boxed at the
+          right. `tally` is settled-only and arrives null otherwise — no height
+          is reserved for it. */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-md)',
+          flexWrap: 'wrap',
+          padding: 'var(--space-sm) var(--space-lg)',
+          background: `color-mix(in srgb, ${accent} 12%, transparent)`,
+          borderBottom: `2px solid ${INK}`,
+        }}
+      >
+        <span aria-hidden style={{ color: accent, lineHeight: 1 }}>
+          ⚔
+        </span>
+        <span style={{ fontFamily: POSTER, letterSpacing: '0.06em', minWidth: 0 }}>
+          {headline}
+        </span>
+        {tally && (
+          <span
+            style={{
+              marginLeft: 'auto',
+              padding: 'var(--space-xs) var(--space-sm)',
+              background: INK,
+              color: CREAM,
+              border: `2px solid ${INK}`,
+              fontFamily: POSTER,
+            }}
+          >
+            {tally}
+          </span>
+        )}
+      </div>
+
+      <div style={{ padding: 'var(--space-md) var(--space-lg) var(--space-lg)' }}>
+        {/* Settled-only standing strip: an accent wash with the live indicator. */}
+        {note && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-sm)',
+              padding: 'var(--space-xs) var(--space-sm)',
+              background: `color-mix(in srgb, ${accent} 14%, transparent)`,
+              borderLeft: `3px solid ${accent}`,
+            }}
+          >
+            <LiveDot color={accent} />
+            <span style={{ minWidth: 0 }}>{note}</span>
+          </div>
+        )}
+
+        {/* The race panel. `declined` and `forfeited` arrive with body === null —
+            no panel is drawn and no substitute roster is invented, because
+            there is no race left to report. */}
+        {body && (
+          <div
+            style={{
+              marginTop: note ? 'var(--space-md)' : 0,
+              padding: 'var(--space-md)',
+              background: PAPER_DEEP,
+              border: `2px solid ${INK}`,
+              boxShadow: `3px 3px 0 color-mix(in srgb, ${INK} 18%, transparent)`,
+            }}
+          >
+            {body}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/duelRails/EverymenMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EverymenMobileDuelRail.tsx
@@ -1,0 +1,136 @@
+/**
+ * Everymen MOBILE duel rail (#721) — the desktop dispatch, thumbed down, as
+ * `EvPraxisPhone.dc.html` pins it above the work report.
+ *
+ * Two changes from the desktop skin, both forced by phone width rather than
+ * chosen: the tally leaves the header row (a boxed score pair and a condensed
+ * headline on one narrow row wrap into mush) and drops to its own full-width
+ * scoreboard band, and the hard offset shadow shrinks so it does not push the
+ * card off the viewport. Single-column throughout — SPEC-faction-ui-profile §1a
+ * forbids a fixed-px grid on the mobile path, and this surface needs none.
+ *
+ * Pure frame, same contract as the desktop skin: every slot arrives already
+ * rendered from `DuelCrossLink`, so none of the duel's arithmetic or status
+ * branching is visible from here. No `fontSize` on any container (#769).
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const PAPER = 'var(--everymen-paper)'
+const PAPER_DEEP = 'var(--everymen-paper-deep)'
+const CREAM = 'var(--everymen-cream)'
+const INK = 'var(--everymen-ink)'
+const PAPER_TEXT = 'var(--everymen-paper-text)'
+const GOLD = 'var(--everymen-gold)'
+const POSTER = 'var(--font-accent)'
+const BODY = 'var(--font-body)'
+
+export default function EverymenMobileDuelRail({
+  accent,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  // ponytail: `maxWidth` is intentionally ignored. The rail is full-bleed inside
+  // the phone column, so the desktop archetype-width map has nothing to line up
+  // with here — the same call WowMobileDuelRail makes.
+  const shell: CSSProperties = {
+    margin: 'var(--space-md) 0',
+    background: PAPER,
+    color: PAPER_TEXT,
+    fontFamily: BODY,
+    border: `2px solid ${INK}`,
+    borderLeft: `6px solid ${accent}`,
+    boxShadow: `4px 4px 0 color-mix(in srgb, ${INK} 24%, transparent)`,
+  }
+
+  return (
+    <div style={shell}>
+      <div
+        aria-hidden
+        style={{ height: 4, background: `linear-gradient(90deg, ${accent} 0 50%, ${GOLD} 50% 100%)` }}
+      />
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-sm) var(--space-md)',
+          background: `color-mix(in srgb, ${accent} 12%, transparent)`,
+          borderBottom: `2px solid ${INK}`,
+        }}
+      >
+        <span aria-hidden style={{ color: accent, lineHeight: 1 }}>
+          ⚔
+        </span>
+        <span style={{ fontFamily: POSTER, letterSpacing: '0.06em', minWidth: 0 }}>
+          {headline}
+        </span>
+      </div>
+
+      <div style={{ padding: 'var(--space-md)' }}>
+        {/* Settled-only scoreboard band — its own row on a phone, where the
+            header cannot hold it alongside the headline. */}
+        {tally && (
+          <div
+            style={{
+              padding: 'var(--space-xs) var(--space-sm)',
+              marginBottom: 'var(--space-sm)',
+              background: INK,
+              color: CREAM,
+              border: `2px solid ${INK}`,
+              fontFamily: POSTER,
+              textAlign: 'center',
+            }}
+          >
+            {tally}
+          </div>
+        )}
+
+        {note && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-sm)',
+              padding: 'var(--space-xs) var(--space-sm)',
+              background: `color-mix(in srgb, ${accent} 14%, transparent)`,
+              borderLeft: `3px solid ${accent}`,
+            }}
+          >
+            <span
+              aria-hidden
+              className="ev-duel-pulse"
+              style={{
+                flexShrink: 0,
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background: accent,
+                border: `1px solid ${INK}`,
+              }}
+            />
+            <span style={{ minWidth: 0 }}>{note}</span>
+          </div>
+        )}
+
+        {/* `declined` / `forfeited` arrive with body === null: no panel, and no
+            invented roster to fill the gap. */}
+        {body && (
+          <div
+            style={{
+              marginTop: note ? 'var(--space-md)' : 0,
+              padding: 'var(--space-md)',
+              background: PAPER_DEEP,
+              border: `2px solid ${INK}`,
+            }}
+          >
+            {body}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Everymen skins for the duel **rail** and the duel **seal-confirm**, desktop + mobile, as a stamped government form / field dispatch. Purely visual: Everymen duels already behaved correctly through the Default skin.

Closes #721

## What landed

Four new files plus four manifest fields:

| File | Manifest field |
|---|---|
| `components/duel/EverymenDuelSealConfirm.tsx` | `duelSeal` |
| `components/duel/EverymenMobileDuelSealConfirm.tsx` | `mobileDuelSeal` |
| `pages/praxisDetail/duelRails/EverymenDuelRail.tsx` | `duelRail` |
| `pages/praxisDetail/duelRails/EverymenMobileDuelRail.tsx` | `mobileDuelRail` |

All four registered in `frontend/src/factions/everymen.ts` as **thunks** (`duelSeal: () => EverymenDuelSealConfirm`), per the import-cycle note in `manifest.ts`. `duelSkinSlots.test.tsx` was not touched — it walks the manifest and picked the skins up on its own (now 31 cases, with `everymen` and `everymen (mobile)` passing in both modes).

One CSS addition: `@keyframes ev-duel-pulse` + `.ev-duel-pulse` in `index.css`, behind `prefers-reduced-motion`, for the settled-state live dot. **No new colour tokens** — the existing `--everymen-*` palette (paper / paper-deep / cream / ink / muted / red / gold) already had every shade the mock needed, and no file contains a colour literal.

## Where the contract overruled the mock

The rail receives `body`, `tally`, `note` and `headline` as **already-rendered opaque nodes**, so three things the mock draws are structurally out of reach for a skin: per-roster-row bordered boxes, the tally split into separate YOU/THEM cells, and the red `▸` on the next-step line — all of those live *inside* those nodes. Reaching in would mean recomputing slots. The Everymen idiom is instead carried at the frame level (paper field, 2px ink border, accent left edge, hard zero-blur offset shadow, accent→gold stripe, accent-wash header band, boxed tally, tan hard-bordered body panel). This is documented in each file's docblock.

Also honoured over the mock, as the issue specified: `body === null` in `declined`/`forfeited` draws no substitute roster, `tally`/`note` reserve no height outside settled, and `StakesTiles` owns the `pending` collapse.

Two strings the mock invented — "FORM D-02" and "WHAT'S AT STAKE" — were **not** transcribed: they have no `praxis.json` key and copy is faction-neutral by decision (#718). Their ornament (the gold rule, the dashed divider) is kept; their words are not. Every string in these files resolves through `useDuelSealCopy` / the shared slots.

## #751 and #769

Both seal skins render **both modes**. `useDuelSealCopy` owns every string that differs — including the reopen note's `active && !foe.is_submitted` condition, which is re-derived nowhere. What the mode changes here is chrome only: the forfeit dialog drops its title one Content-ramp tier and repaints the stakes panel from tan paper to ink with a red-tinted hard shadow, so the costly dialog does not look like the routine one. Neither mode drops a slot.

Per #769, **no container in any of the four files sets `fontSize`**. The rails' "does not impose a Label-tier size on its slots" assertion passes for both.

## What to eyeball

Visual QA is **outstanding** — I cannot screenshot and there is no dev stack in this worktree. Verified via `tsc --noEmit`, `eslint`, `vitest` (1006 passed) and `vite build` only.

Worth a human pass, on an **Everymen task** (the surfaces dispatch on the task's faction, not the viewer's), with a **non-Everymen opponent** so the accent is visibly foreign:

**Rail — five states × desktop/mobile × light/dark**
1. `pending` — headline only; no tally, no note; stakes region collapses to the single solo-fallback line. Check the tan body panel does not look empty or lopsided.
2. `active` — roster + next-step + win/lose tiles in the tan panel; still no tally/note.
3. `settled` — the tally box in the header (desktop) vs. its own full-width band (mobile), plus the accent-wash note strip with the pulsing dot. Confirm the dot stills under reduced-motion.
4. `declined` — `body === null`: header band and stripe only, no panel. Confirm it doesn't read as broken.
5. `forfeited` — same empty-body shape, from both the winner's and the thrower's side.

**Seal dialog — both modes × desktop/mobile × light/dark**
- `submit` in `active`: the green reopen note should appear only while the opponent has *not* cast.
- `submit` in `pending`: stakes collapse to one line inside the panel.
- `forfeit` (only reachable at `settled`): smaller title, ink stakes panel with the red-tinted shadow, red confirm button. Check `--color-success` on the win tile and the roster's "sealed" green are still legible **on ink**, in both themes — that ink panel is the highest-risk contrast surface here.
- Dark mode generally: `--everymen-paper` flips to a near-black and `--everymen-cream` to a light tone, so the ink-on-paper borders get subtle. Worth confirming the 2px ink rules still read as structure.
- The mobile dialog is a full-screen sheet with a pinned footer and a scrolling middle — check the footer stays put with a long opponent name and a long forfeit cost sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
