### PR TITLE
Ephemerists duel skins: the duel as a foxed vellum ledger (#724)

### DIFF
--- a/frontend/src/components/cards/ephemeristsAtoms.tsx
+++ b/frontend/src/components/cards/ephemeristsAtoms.tsx
@@ -57,18 +57,24 @@ export function EphemeristsSigil({
   );
 }
 
-/* ── Faint age-foxing stains (multiply-blended), for vellum surfaces ── */
+/* ── Faint age-foxing stains, for vellum surfaces ──
+   The blend MODE lives in `.eph-foxing` (index.css), not here: foxing
+   darkens light vellum (`multiply`) but must lighten the dark-theme
+   tobacco vellum (`screen`), or the blotches disappear into it. That flip
+   is a cascade job — a `dark ? …` ternary is forbidden (§8). Everything
+   else about the stain is theme-agnostic because the four blotch colours
+   are already --eph-* tokens. */
 export function Foxing({ opacity = 0.5 }: { opacity?: number }) {
   return (
     <div
       aria-hidden="true"
+      className="eph-foxing"
       style={{
         position: "absolute",
         inset: 0,
         pointerEvents: "none",
         opacity,
         zIndex: 1,
-        mixBlendMode: "multiply",
         backgroundImage: `
           radial-gradient(8px 6px at 18% 24%, color-mix(in srgb, var(--eph-ink) 14%, transparent), transparent 70%),
           radial-gradient(5px 5px at 78% 16%, color-mix(in srgb, var(--eph-gold-deep) 16%, transparent), transparent 70%),

--- a/frontend/src/components/duel/EphemeristsDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/EphemeristsDuelSealConfirm.tsx
@@ -1,0 +1,263 @@
+/**
+ * Ephemerists DESKTOP duel seal-confirm (#724) — the seal beat as a leaf of the
+ * codex: foxed vellum, hairline rules, an inscriptional-caps masthead over the
+ * manuscript double rule (ochre, blue ink 2px under it), and an italic hand for
+ * the body.
+ *
+ * TWO MODES, ONE FILE (#751). `mode` is `'submit'` or `'forfeit'` and every
+ * string for both comes from `useDuelSealCopy` — heading, body, note, confirm
+ * label and the danger tone. This skin re-derives none of it. The one place the
+ * mode changes the CHROME is the body: a forfeit is the single irreversible
+ * duel beat, and it is the single place this skin allows weight, setting the
+ * warning on an inked panel ruled in faded red. Everything else is identical
+ * between the modes, which is the point of the shared surface.
+ *
+ * PURE FRAME otherwise. `StakesTiles` owns the win/lose arithmetic (Snide's
+ * 0.0× lose falls out by construction) and the `pending` collapse to a single
+ * solo-fallback line; `RaceRoster` reads `is_submitted`; `SealActions` owns the
+ * global [Cancel] … [Submit] order (#646) and the destructive tone. None of the
+ * three is dropped or reimplemented in either mode.
+ *
+ * Copy is faction-neutral by decision (#718) — the design's antiquarian voice is
+ * tone reference, not strings, and no locale key is added. The one label this
+ * skin adds, the stakes rubric, is the shipped `duelStakes.heading`.
+ *
+ * Colours are the existing `--eph-*` block; no new variables. Structural
+ * hairlines mix from `--eph-vellum-text` (which flips to parchment in dark)
+ * rather than `--eph-ink` (which stays dark), so a rule stays visible on the
+ * dark-theme tobacco vellum.
+ */
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Foxing } from '../cards/ephemeristsAtoms'
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const OCHRE = 'var(--eph-gold)'
+const LAPIS = 'var(--eph-lapis)'
+const INK = 'var(--eph-ink)'
+const PARCHMENT = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+
+const HAIRLINE_FAINT = `1px solid color-mix(in srgb, ${TEXT} 12%, transparent)`
+const DOUBLE_RULE = `0 2px 0 -1px color-mix(in srgb, ${LAPIS} 45%, transparent)`
+
+/** The rubric mark — a scribe's sigil used as an icon. Not text. */
+export function Rubric({ glyph = '✧', color = RUBRIC }: { glyph?: string; color?: string }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        color,
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: rubric glyph, sized to the rule it leads.
+        fontSize: 11,
+        lineHeight: 1,
+      }}
+    >
+      {glyph}
+    </span>
+  )
+}
+
+/** A lettered rubric: mark, letterspaced red caps, then the double rule. */
+export function RubricHeading({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ marginTop: 'var(--space-lg)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
+        <Rubric />
+        {/* .eyebrow owns the size (§4); this contributes the inscriptional face
+            and the rubrication red only. */}
+        <span className="eyebrow" style={{ fontFamily: DISPLAY, color: RUBRIC }}>
+          {children}
+        </span>
+      </div>
+      <div
+        aria-hidden
+        style={{
+          marginTop: 'var(--space-xs)',
+          height: 1,
+          background: `color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+          boxShadow: DOUBLE_RULE,
+        }}
+      />
+    </div>
+  )
+}
+
+export default function EphemeristsDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { t } = useTranslation('praxis')
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  // Opponent tokens, the same rule as the Default dialog and the rail: the
+  // foreign duelist looks foreign even on the Ephemerists' own vellum.
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: SERIF }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{
+        padding: 'var(--space-lg)',
+        background: 'radial-gradient(circle, rgba(0,0,0,0.55), rgba(0,0,0,0.75))',
+      }}
+    >
+      <div
+        className="w-full max-w-[440px]"
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          background: VELLUM,
+          border: HAIRLINE_FAINT,
+          borderLeft: `4px solid ${accent}`,
+          fontFamily: SERIF,
+          color: TEXT,
+        }}
+      >
+        <Foxing opacity={0.4} />
+
+        <div style={{ position: 'relative', zIndex: 2 }}>
+          {/* Masthead — inscriptional caps over the manuscript double rule. */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 'var(--space-sm)',
+              padding: 'var(--space-md) var(--space-xl)',
+              background: `color-mix(in srgb, ${accent} 10%, transparent)`,
+              borderBottom: `1px solid color-mix(in srgb, ${OCHRE} 60%, transparent)`,
+              boxShadow: DOUBLE_RULE,
+            }}
+          >
+            <Rubric />
+            <h2
+              style={{
+                fontFamily: DISPLAY,
+                fontSize: 'var(--text-title)',
+                fontWeight: 600,
+                letterSpacing: '0.06em',
+              }}
+            >
+              {copy.heading}
+            </h2>
+          </div>
+
+          <div style={{ padding: 'var(--space-xl)' }}>
+            {/* The body. In `forfeit` this is the cost panel — the one place a
+                skin this quiet is allowed weight: inked stock, a faded-red rule
+                and mark, and the warning set in parchment. The red carries the
+                panel rather than the sentence, because rubric-on-ink is a
+                ~2.5:1 pairing and the warning is the text a player must read. */}
+            {copy.danger ? (
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 'var(--space-sm)',
+                  padding: 'var(--space-md)',
+                  background: INK,
+                  border: `1px solid ${RUBRIC}`,
+                  borderLeft: `3px solid ${RUBRIC}`,
+                  color: PARCHMENT,
+                }}
+              >
+                <Rubric glyph="❦" />
+                <p className="content-text" style={{ fontStyle: 'italic', lineHeight: 1.55 }}>
+                  {copy.body}
+                </p>
+              </div>
+            ) : (
+              <p className="content-text" style={{ fontStyle: 'italic', lineHeight: 1.55 }}>
+                {copy.body}
+              </p>
+            )}
+
+            {/* The free-reopen half of the truth, as a marginal gloss. Same
+                condition as every other skin, because it is the same fact — a
+                forfeit has none, and `copy.note` is null there. */}
+            {copy.note && (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  gap: 'var(--space-sm)',
+                  marginTop: 'var(--space-md)',
+                  padding: 'var(--space-xs) var(--space-md)',
+                  borderTop: `1px solid color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+                  borderBottom: `1px solid color-mix(in srgb, ${LAPIS} 45%, transparent)`,
+                  color: MUTED,
+                  fontStyle: 'italic',
+                }}
+              >
+                <Rubric glyph="❧" />
+                <p className="content-text">{copy.note}</p>
+              </div>
+            )}
+
+            <RubricHeading>{t('duelStakes.heading')}</RubricHeading>
+
+            {/* The ledger band: what it is worth, and who has cast. */}
+            <div
+              style={{
+                marginTop: 'var(--space-sm)',
+                padding: 'var(--space-md)',
+                background: VELLUM_DEEP,
+                border: HAIRLINE_FAINT,
+              }}
+            >
+              <StakesTiles
+                viewerFactionSlug={me.faction_slug}
+                opponentFactionSlug={foe.faction_slug}
+                opponentName={foe.display_name}
+                taskPointValue={taskPointValue}
+                status={duel.status}
+                theme={theme}
+              />
+              <RaceRoster me={me} foe={foe} theme={theme} />
+            </div>
+
+            {/* ponytail: SealActions keeps its shared btn-outline / btn-primary
+                pair. The mock wants ruled, unshadowed buttons; giving them an
+                Ephemerist face would mean a skin slot on the shared component,
+                which is foundation work, not a skin change — and the global
+                [Cancel] … [Submit] order (#646) matters more than the chrome. */}
+            <div style={{ marginTop: 'var(--space-xl)' }}>
+              <SealActions
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+                busy={busy}
+                confirmLabel={copy.confirmLabel}
+                danger={copy.danger}
+                theme={theme}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/duel/EphemeristsMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/EphemeristsMobileDuelSealConfirm.tsx
@@ -1,0 +1,194 @@
+/**
+ * Ephemerists MOBILE duel seal-confirm (#724) — the codex leaf as a bottom
+ * sheet: full-bleed on the page ground, the vellum pinned to a ruled top edge,
+ * the actions last so the thumb lands on them.
+ *
+ * Same vocabulary as the desktop leaf — foxed vellum, hairline rules, the
+ * ochre/blue-ink double rule, inscriptional-caps masthead, italic hand — and
+ * the same two modes (#751): `useDuelSealCopy` owns the heading, body, note,
+ * confirm label and danger tone for both, and the forfeit's inked cost panel is
+ * the one chrome difference between them.
+ *
+ * Single-column, no grid (SPEC-faction-ui-profile §1a). Pure frame: every
+ * figure comes from `StakesTiles`, every cast status from `RaceRoster`, and the
+ * action pair and its destructive tone from `SealActions`. The rubric mark and
+ * the rubric heading are shared with the desktop skin rather than re-declared.
+ */
+import { useTranslation } from 'react-i18next'
+import { Foxing } from '../cards/ephemeristsAtoms'
+import { factionCssVar } from '../../utils/factions'
+import { Rubric, RubricHeading } from './EphemeristsDuelSealConfirm'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const MUTED = 'var(--eph-muted)'
+const RUBRIC = 'var(--eph-rubric)'
+const OCHRE = 'var(--eph-gold)'
+const LAPIS = 'var(--eph-lapis)'
+const INK = 'var(--eph-ink)'
+const PARCHMENT = 'var(--eph-parchment)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+
+const HAIRLINE_FAINT = `1px solid color-mix(in srgb, ${TEXT} 12%, transparent)`
+const DOUBLE_RULE = `0 2px 0 -1px color-mix(in srgb, ${LAPIS} 45%, transparent)`
+
+export default function EphemeristsMobileDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { t } = useTranslation('praxis')
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: SERIF }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex flex-col justify-end"
+      style={{ background: 'var(--color-bg-page)' }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          background: VELLUM,
+          borderTop: `4px solid ${accent}`,
+          fontFamily: SERIF,
+          color: TEXT,
+        }}
+      >
+        <Foxing opacity={0.4} />
+
+        <div style={{ position: 'relative', zIndex: 2 }}>
+          {/* Masthead — centred on the sheet, over the double rule. */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              justifyContent: 'center',
+              gap: 'var(--space-sm)',
+              padding: 'var(--space-md) var(--space-lg)',
+              background: `color-mix(in srgb, ${accent} 10%, transparent)`,
+              borderBottom: `1px solid color-mix(in srgb, ${OCHRE} 60%, transparent)`,
+              boxShadow: DOUBLE_RULE,
+            }}
+          >
+            <Rubric />
+            <h2
+              style={{
+                fontFamily: DISPLAY,
+                fontSize: 'var(--text-title)',
+                fontWeight: 600,
+                letterSpacing: '0.05em',
+                textAlign: 'center',
+              }}
+            >
+              {copy.heading}
+            </h2>
+          </div>
+
+          <div style={{ padding: 'var(--space-lg)' }}>
+            {/* Forfeit: the inked cost panel, ruled and marked in faded red,
+                with the warning itself in parchment so it stays readable. */}
+            {copy.danger ? (
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 'var(--space-sm)',
+                  padding: 'var(--space-md)',
+                  background: INK,
+                  border: `1px solid ${RUBRIC}`,
+                  borderLeft: `3px solid ${RUBRIC}`,
+                  color: PARCHMENT,
+                }}
+              >
+                <Rubric glyph="❦" />
+                <p className="content-text" style={{ fontStyle: 'italic', lineHeight: 1.55 }}>
+                  {copy.body}
+                </p>
+              </div>
+            ) : (
+              <p className="content-text" style={{ fontStyle: 'italic', lineHeight: 1.55 }}>
+                {copy.body}
+              </p>
+            )}
+
+            {copy.note && (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  gap: 'var(--space-sm)',
+                  marginTop: 'var(--space-md)',
+                  padding: 'var(--space-xs) var(--space-sm)',
+                  borderTop: `1px solid color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+                  borderBottom: `1px solid color-mix(in srgb, ${LAPIS} 45%, transparent)`,
+                  color: MUTED,
+                  fontStyle: 'italic',
+                }}
+              >
+                <Rubric glyph="❧" />
+                <p className="content-text">{copy.note}</p>
+              </div>
+            )}
+
+            <RubricHeading>{t('duelStakes.heading')}</RubricHeading>
+
+            <div
+              style={{
+                marginTop: 'var(--space-sm)',
+                padding: 'var(--space-md)',
+                background: VELLUM_DEEP,
+                border: HAIRLINE_FAINT,
+              }}
+            >
+              <StakesTiles
+                viewerFactionSlug={me.faction_slug}
+                opponentFactionSlug={foe.faction_slug}
+                opponentName={foe.display_name}
+                taskPointValue={taskPointValue}
+                status={duel.status}
+                theme={theme}
+              />
+              <RaceRoster me={me} foe={foe} theme={theme} />
+            </div>
+
+            {/* ponytail: shared SealActions, same reasoning as the desktop leaf
+                — thumb-sized Ephemerist buttons would need a skin slot on the
+                shared component, which is foundation work. */}
+            <div style={{ marginTop: 'var(--space-xl)' }}>
+              <SealActions
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+                busy={busy}
+                confirmLabel={copy.confirmLabel}
+                danger={copy.danger}
+                theme={theme}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/factions/ephemerists.ts
+++ b/frontend/src/factions/ephemerists.ts
@@ -13,12 +13,16 @@ import type { FactionManifest } from './manifest'
 import EphemeristsAvatar from '../components/avatar/EphemeristsAvatar'
 import EphemeristsBackdrop from '../components/backdrop/EphemeristsBackdrop'
 import EphemeristsComment from '../components/comments/voices/EphemeristsComment'
+import EphemeristsDuelRail from '../pages/praxisDetail/duelRails/EphemeristsDuelRail'
+import EphemeristsDuelSealConfirm from '../components/duel/EphemeristsDuelSealConfirm'
 import EphemeristsEditPraxis from '../pages/editPraxis/archetypes/EphemeristsEditPraxis'
 import EphemeristsFactionBody from '../pages/factionDetail/archetypes/EphemeristsFactionBody'
 import EphemeristsFactionHero from '../components/cards/EphemeristsFactionHero'
 import EphemeristsFactionPage from '../pages/factionDetail/mobileArchetypes/EphemeristsFactionPage'
 import EphemeristsFeedFrame from '../components/feed/EphemeristsFeedFrame'
 import EphemeristsHome from '../pages/fieldDesk/mobileArchetypes/EphemeristsHome'
+import EphemeristsMobileDuelRail from '../pages/praxisDetail/duelRails/EphemeristsMobileDuelRail'
+import EphemeristsMobileDuelSealConfirm from '../components/duel/EphemeristsMobileDuelSealConfirm'
 import EphemeristsMobileEditPraxis from '../pages/editPraxis/mobileArchetypes/EphemeristsComposer'
 import EphemeristsMobilePraxisCard from '../components/praxisCard/mobile/EphemeristsMobilePraxisCard'
 import EphemeristsMobilePraxisDetail from '../pages/praxisDetail/mobileArchetypes/EphemeristsPraxisDetail'
@@ -53,6 +57,8 @@ export const EPHEMERISTS_MANIFEST: FactionManifest = {
   factionHero: () => EphemeristsFactionHero,
   factionBody: () => EphemeristsFactionBody,
   profileBody: () => EphemeristsProfileBody,
+  duelSeal: () => EphemeristsDuelSealConfirm,
+  duelRail: () => EphemeristsDuelRail,
   mobileTaskCard: () => EphemeristsMobileTaskCard,
   mobilePraxisCard: () => EphemeristsMobilePraxisCard,
   mobileTaskDetail: () => EphemeristsMobileTaskDetail,
@@ -60,4 +66,6 @@ export const EPHEMERISTS_MANIFEST: FactionManifest = {
   mobileEditPraxis: () => EphemeristsMobileEditPraxis,
   mobileFactionPage: () => EphemeristsFactionPage,
   mobileFieldDesk: () => EphemeristsHome,
+  mobileDuelSeal: () => EphemeristsMobileDuelSealConfirm,
+  mobileDuelRail: () => EphemeristsMobileDuelRail,
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1240,6 +1240,31 @@
   background: radial-gradient(120% 90% at 50% 6%, transparent 46%, color-mix(in srgb, var(--eph-vellum-deep) 58%, transparent));
 }
 
+/* ══════════════════════════════════════════════════════════════
+   EPHEMERISTS AGE-FOXING BLEND (#724) — the one Ephemerist ornament
+   that cannot be a colour token, because it is a *blend mode*.
+
+   Foxing is a stain: on light vellum it DARKENS the sheet, so `multiply`
+   is the physically right operator. On the dark-theme vellum
+   (--eph-vellum flips to a near-black tobacco) `multiply` has almost
+   nothing left to take away — the blotches vanish and, where they don't,
+   they read as mud. Dark-theme foxing is instead an age *bloom*: the
+   same four blotches lightening the sheet, so the operator flips to
+   `screen`.
+
+   This lives here rather than inline on the `Foxing` atom because a
+   `dark ? 'multiply' : 'screen'` ternary is exactly what §8 forbids;
+   the cascade owns the flip. (Only the MODE is set here — callers keep
+   passing their own `opacity` inline, which would win over any opacity
+   declared in this rule anyway.)
+   ══════════════════════════════════════════════════════════════ */
+.eph-foxing {
+  mix-blend-mode: multiply;
+}
+[data-theme="dark"] .eph-foxing {
+  mix-blend-mode: screen;
+}
+
 /* Homepage activity ticker — horizontal marquee + blinking "LIVE" dot. */
 @keyframes ticker-roll { from { transform: translateX(0); } to { transform: translateX(-50%); } }
 @keyframes wz-blink { 50% { opacity: 0; } }

--- a/frontend/src/pages/praxisDetail/duelRails/EphemeristsDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EphemeristsDuelRail.tsx
@@ -1,0 +1,221 @@
+/**
+ * Ephemerists DESKTOP duel rail (#724) — the duel context as an entry in a
+ * foxed vellum ledger.
+ *
+ * The quietest skin in the set. Nothing is hard-bordered: every division is a
+ * 1px rule, and the only "panel" is a shade of vellum. The header carries the
+ * manuscript's double rule — an ochre hairline with a blue-ink rule offset 2px
+ * beneath it — and an age-foxing overlay blends over the whole sheet with the
+ * real content lifted above it on z-index 2.
+ *
+ * PURE FRAME. `headline`, `tally`, `note` and `body` arrive already rendered
+ * from `DuelCrossLink`; the per-`DuelStatus` branch table, the roster, the
+ * next-step line and every stakes figure live in `components/duel/shared.tsx`.
+ * This file decides only where the rules go. In particular:
+ *  - `body` is `null` for `declined` and `forfeited` — there is no race left.
+ *    The ledger simply ends after the header, which is the correct empty state;
+ *    no substitute roster is drawn.
+ *  - `tally` and `note` are `null` outside `settled`, and no height is reserved
+ *    for them.
+ *
+ * DESIGN NOTES, where the mock and the contract disagree — the contract wins:
+ *  - The mock's eyebrow reads "CONTRA". That is *copy*, and duel copy is
+ *    faction-neutral by decision (#718): every string comes from `praxis.json`,
+ *    and there is no such key. Identity here is visual only, so the eyebrow is
+ *    the rubric glyph alone — ornament, not an invented Latin word.
+ *  - The mock rules the roster as two ledger lines and sets the stakes under a
+ *    "WHAT IS AT STAKE" rubric. Both sit *inside* the opaque `body` node, so a
+ *    skin cannot reach them. The ledger treatment is applied to the body band
+ *    as a whole and the rubric becomes an undecorated divider above it.
+ *  - The mock's tally is a two-cell ruled box. `tally` is one node carrying both
+ *    figures, so it gets one ruled box; splitting it would mean recomputing.
+ *
+ * No `fontSize` on any container (#769) — the slots size themselves and a
+ * wrapper size would silently override all of them at once. This skin
+ * contributes face, colour and rules only. `fontFamily` IS set, deliberately:
+ * that is a skin's to own (WORLD_ZERO_STYLE §4a).
+ *
+ * Colours are the existing `--eph-*` token block; no new variables. Structural
+ * hairlines are mixed from `--eph-vellum-text` rather than `--eph-ink`, because
+ * ink stays dark in both themes while vellum-text flips to parchment — an
+ * ink-based rule is invisible on the dark tobacco vellum.
+ */
+import type { CSSProperties } from 'react'
+import { Foxing } from '../../../components/cards/ephemeristsAtoms'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const RUBRIC = 'var(--eph-rubric)'
+const OCHRE = 'var(--eph-gold)'
+const LAPIS = 'var(--eph-lapis)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+
+/** Hairline: a rule, not a border. Everything on this sheet is drawn at 1px. */
+const HAIRLINE = `1px solid color-mix(in srgb, ${TEXT} 22%, transparent)`
+const HAIRLINE_FAINT = `1px solid color-mix(in srgb, ${TEXT} 12%, transparent)`
+
+/**
+ * The manuscript double rule: an ochre hairline with a blue-ink rule ruled 2px
+ * under it. Drawn as a box-shadow so it costs no element and never affects
+ * layout — the second line is a second ruling of the same edge.
+ */
+const DOUBLE_RULE = `0 2px 0 -1px color-mix(in srgb, ${LAPIS} 45%, transparent)`
+
+/** The rubric mark — a scribe's sigil, used as an icon. Not text. */
+function Rubric({ glyph = '✧' }: { glyph?: string }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        color: RUBRIC,
+        // ornament: a scribe's mark used as an icon, sized to the rule it leads
+        // — not type on the content scale (WORLD_ZERO_STYLE §4a).
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: rubric glyph.
+        fontSize: 11,
+        lineHeight: 1,
+      }}
+    >
+      {glyph}
+    </span>
+  )
+}
+
+export default function EphemeristsDuelRail({
+  accent,
+  soft,
+  maxWidth,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const sheet: CSSProperties = {
+    maxWidth,
+    margin: 'var(--space-lg) 0',
+    position: 'relative',
+    overflow: 'hidden',
+    background: VELLUM,
+    border: HAIRLINE_FAINT,
+    // The opponent's colour rides the left edge, thinner than the other skins:
+    // 4px is already loud on a sheet whose every other line is 1px.
+    borderLeft: `4px solid ${accent}`,
+    fontFamily: SERIF,
+    color: TEXT,
+    // No `fontSize` (#769): the slots own their size, the frame owns none.
+  }
+
+  return (
+    <div style={sheet}>
+      <Foxing opacity={0.4} />
+
+      {/* Content sits above the foxing, which is a blended overlay at z-index 1. */}
+      <div style={{ position: 'relative', zIndex: 2 }}>
+        {/* Header: opponent wash, ruled off with the double rule. */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 'var(--space-sm)',
+            flexWrap: 'wrap',
+            padding: 'var(--space-sm) var(--space-lg)',
+            background: soft,
+            borderBottom: `1px solid color-mix(in srgb, ${OCHRE} 60%, transparent)`,
+            boxShadow: DOUBLE_RULE,
+            fontFamily: DISPLAY,
+            letterSpacing: '0.06em',
+          }}
+        >
+          <Rubric />
+          {headline}
+        </div>
+
+        <div style={{ padding: 'var(--space-md) var(--space-lg)' }}>
+          {/* Settled-only tally: ruled, never boxed-and-filled. Lighter vellum
+              than the sheet, so it reads as a cell drawn on the page. */}
+          {tally && (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                padding: 'var(--space-sm) var(--space-md)',
+                // A shade OFF the sheet, mixed toward the text ink rather than
+                // toward literal white: `--eph-vellum-text` flips to parchment
+                // in dark, so the cell stays legibly distinct in both themes
+                // instead of blazing white on the tobacco stock.
+                background: `color-mix(in srgb, ${VELLUM} 92%, ${TEXT})`,
+                borderTop: HAIRLINE,
+                borderBottom: HAIRLINE,
+                fontFamily: DISPLAY,
+                letterSpacing: '0.08em',
+              }}
+            >
+              {tally}
+            </div>
+          )}
+
+          {/* Settled-only note as a marginal gloss: an accent wash ruled ochre
+              above and blue-ink below, led by a scribe's sigil. Deliberately
+              NOT a pulsing dot — the Ephemerists do not blink. */}
+          {note && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 'var(--space-sm)',
+                marginTop: tally ? 'var(--space-sm)' : 0,
+                padding: 'var(--space-xs) var(--space-md)',
+                background: soft,
+                borderTop: `1px solid color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+                borderBottom: `1px solid color-mix(in srgb, ${LAPIS} 45%, transparent)`,
+                fontStyle: 'italic',
+              }}
+            >
+              <Rubric glyph="❧" />
+              <div style={{ flex: '1 1 0', minWidth: 0 }}>{note}</div>
+            </div>
+          )}
+
+          {/* The ledger band: roster, next step and stakes, on the shadowed
+              verso stock. Opened by a rubric divider — the mock's lettered
+              rubric minus its invented copy. */}
+          {body && (
+            <>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--space-sm)',
+                  marginTop: 'var(--space-md)',
+                }}
+              >
+                <Rubric />
+                <span
+                  aria-hidden
+                  style={{
+                    flex: '1 1 0',
+                    height: 1,
+                    background: `color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+                    boxShadow: DOUBLE_RULE,
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  marginTop: 'var(--space-sm)',
+                  padding: 'var(--space-md)',
+                  background: VELLUM_DEEP,
+                  border: HAIRLINE_FAINT,
+                }}
+              >
+                {body}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/duelRails/EphemeristsMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EphemeristsMobileDuelRail.tsx
@@ -1,0 +1,176 @@
+/**
+ * Ephemerists MOBILE duel rail (#724) — the same ledger leaf, thumbed down.
+ *
+ * Two changes from the desktop sheet, both forced by phone width:
+ *  - the header stacks the rubric mark and the headline into one wrapping row
+ *    with tighter side margins (a Cinzel opponent name and a rule on one narrow
+ *    line otherwise breaks mid-word);
+ *  - the settled tally sits centred on its own ruled band, which is where a
+ *    scoreboard belongs when there is no second column to hold it.
+ *
+ * Single-column throughout — SPEC-faction-ui-profile §1a forbids a fixed-px
+ * grid on the mobile path, and nothing here wants one.
+ *
+ * Same contract and the same restraint as the desktop skin: every slot arrives
+ * pre-rendered, `body` is `null` for `declined`/`forfeited`, `tally`/`note` are
+ * `null` outside `settled`, and no container sets a `fontSize` (#769).
+ *
+ * `maxWidth` is deliberately ignored: the rail is full-bleed inside the phone
+ * column, so the desktop archetype-width map has nothing to line up with.
+ */
+import type { CSSProperties } from 'react'
+import { Foxing } from '../../../components/cards/ephemeristsAtoms'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const VELLUM = 'var(--eph-vellum)'
+const VELLUM_DEEP = 'var(--eph-vellum-deep)'
+const TEXT = 'var(--eph-vellum-text)'
+const RUBRIC = 'var(--eph-rubric)'
+const OCHRE = 'var(--eph-gold)'
+const LAPIS = 'var(--eph-lapis)'
+const DISPLAY = 'var(--eph-display)'
+const SERIF = 'var(--eph-serif)'
+
+const HAIRLINE = `1px solid color-mix(in srgb, ${TEXT} 22%, transparent)`
+const HAIRLINE_FAINT = `1px solid color-mix(in srgb, ${TEXT} 12%, transparent)`
+const DOUBLE_RULE = `0 2px 0 -1px color-mix(in srgb, ${LAPIS} 45%, transparent)`
+
+/** The rubric mark — a scribe's sigil used as an icon. Not text. */
+function Rubric({ glyph = '✧' }: { glyph?: string }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        color: RUBRIC,
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: rubric glyph, sized to the rule it leads.
+        fontSize: 11,
+        lineHeight: 1,
+      }}
+    >
+      {glyph}
+    </span>
+  )
+}
+
+export default function EphemeristsMobileDuelRail({
+  accent,
+  soft,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const sheet: CSSProperties = {
+    margin: 'var(--space-md) 0',
+    position: 'relative',
+    overflow: 'hidden',
+    background: VELLUM,
+    border: HAIRLINE_FAINT,
+    borderLeft: `4px solid ${accent}`,
+    fontFamily: SERIF,
+    color: TEXT,
+    // No `fontSize` (#769).
+  }
+
+  return (
+    <div style={sheet}>
+      <Foxing opacity={0.4} />
+
+      <div style={{ position: 'relative', zIndex: 2 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 'var(--space-sm)',
+            flexWrap: 'wrap',
+            padding: 'var(--space-sm) var(--space-md)',
+            background: soft,
+            borderBottom: `1px solid color-mix(in srgb, ${OCHRE} 60%, transparent)`,
+            boxShadow: DOUBLE_RULE,
+            fontFamily: DISPLAY,
+            letterSpacing: '0.05em',
+          }}
+        >
+          <Rubric />
+          {headline}
+        </div>
+
+        <div style={{ padding: 'var(--space-md)' }}>
+          {tally && (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                padding: 'var(--space-sm)',
+                // Mixed toward the text ink, not toward white: `--eph-vellum-text`
+                // flips to parchment in dark, so the cell stays distinct in both.
+                background: `color-mix(in srgb, ${VELLUM} 92%, ${TEXT})`,
+                borderTop: HAIRLINE,
+                borderBottom: HAIRLINE,
+                fontFamily: DISPLAY,
+                letterSpacing: '0.08em',
+              }}
+            >
+              {tally}
+            </div>
+          )}
+
+          {/* Marginal gloss — ruled ochre above, blue ink below, led by a
+              scribe's sigil. Not a pulsing dot; this faction does not blink. */}
+          {note && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 'var(--space-sm)',
+                marginTop: tally ? 'var(--space-sm)' : 0,
+                padding: 'var(--space-xs) var(--space-sm)',
+                background: soft,
+                borderTop: `1px solid color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+                borderBottom: `1px solid color-mix(in srgb, ${LAPIS} 45%, transparent)`,
+                fontStyle: 'italic',
+              }}
+            >
+              <Rubric glyph="❧" />
+              <div style={{ flex: '1 1 0', minWidth: 0 }}>{note}</div>
+            </div>
+          )}
+
+          {body && (
+            <>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--space-sm)',
+                  marginTop: 'var(--space-md)',
+                }}
+              >
+                <Rubric />
+                <span
+                  aria-hidden
+                  style={{
+                    flex: '1 1 0',
+                    height: 1,
+                    background: `color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+                    boxShadow: DOUBLE_RULE,
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  marginTop: 'var(--space-sm)',
+                  padding: 'var(--space-md)',
+                  background: VELLUM_DEEP,
+                  border: HAIRLINE_FAINT,
+                }}
+              >
+                {body}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Ephemerists duel skins: the four surfaces (desktop + mobile rail, desktop + mobile seal-confirm), plus one cascade fix the skin needed.

Closes #724

## What landed

Four new skins, registered as **thunks** on `frontend/src/factions/ephemerists.ts` (`duelSeal`, `duelRail`, `mobileDuelSeal`, `mobileDuelRail`). The old four registries named in the issue body no longer exist; registration is the one manifest.

The design reads as an **antiquarian manuscript**: aged vellum, nothing hard-bordered, every division a 1px rule. The header carries the manuscript **double rule** — an ochre hairline with a blue-ink rule ruled 2px under it, drawn as a `box-shadow` so the second line costs no element and never touches layout. An age-foxing overlay blends over the whole sheet with content lifted above it at `z-index: 2`. The settled note is a **marginal gloss** led by a `❧` sigil — not a pulsing dot; this faction does not blink.

All colours are the existing `--eph-*` token block. **No new colour variables.** One structural choice worth naming: hairlines mix from `--eph-vellum-text`, not `--eph-ink`. Ink stays dark in both themes while vellum-text flips to parchment, so an ink-based rule is invisible on the dark tobacco vellum. The tally cell is likewise mixed *toward the text ink* rather than toward white, so it stays a distinct shade in both themes instead of blazing white on dark stock.

## The dark-mode question, answered explicitly

Foxing is a **stain**: it darkens light vellum, so `mix-blend-mode: multiply` is the physically right operator — and it was hardcoded inline on the shared `Foxing` atom. On the dark theme `--eph-vellum` flips to a near-black tobacco, where multiply has essentially nothing left to remove: the blotches vanish, and where they survive they read as mud.

Dark-theme foxing is an age **bloom** instead — the same four blotches *lightening* the sheet. So the operator flips to `screen`, via a new `.eph-foxing` class in `index.css` under the `[data-theme="dark"]` cascade. Not a `dark ? 'multiply' : 'screen'` ternary. This is a **two-line CSS addition plus a one-line atom change**, and it improves every existing Ephemerists vellum surface in dark mode (praxis detail, feed frame, cards) — not just the duel skins.

## Contract compliance

- **Rails are pure frames.** `headline` / `tally` / `note` / `body` arrive already rendered; nothing is recomputed, no status re-derived, no string changed. `body === null` for `declined`/`forfeited` is survived (the ledger simply ends after the header — the correct empty state, no substitute roster). `tally`/`note` reserve no height outside `settled`.
- **No `fontSize` on any container** (#769). `fontFamily` *is* set — that is a skin's to own (§4a). The slot-size guard in `duelSkinSlots.test.tsx` passes for all four.
- **Seals render both modes** (#751). `useDuelSealCopy` owns heading, body, note, confirm label and danger tone; nothing is re-derived. `StakesTiles` / `RaceRoster` / `SealActions` all composed in both modes.
- **Copy is catalog-only.** Every string via `t()` from `praxis.json`.

## Three places the mock lost to the contract

1. **The rail eyebrow "CONTRA" is not built.** That is *copy*, and duel copy is faction-neutral by decision (#718) — there is no such key, and inventing a Latin eyebrow for one faction reintroduces the per-faction voice #718 declined. The eyebrow is the rubric glyph alone: ornament, not a word.
2. **The mock's ruled roster lines and its "WHAT IS AT STAKE" rubric sit inside the opaque `body` node**, which a rail skin cannot reach. The ledger treatment is applied to the body band as a whole and the rubric becomes an undecorated ruled divider above it. In the *dialogs*, where slots are composed by hand, the rubric is lettered — using the shipped `duelStakes.heading`, not a new key.
3. **The tally is one node carrying both figures**, so it gets one ruled cell rather than the mock's two. Splitting it would mean recomputing.

One accessibility deviation in the forfeit cost panel: the mock puts the warning itself in faded red on inked stock. `--eph-rubric` on `--eph-ink` is roughly 2.5:1, and this is the one sentence a player must not miss. The red carries the **panel** — its border, its left rule, its `❦` mark — and the warning is set in parchment.

## What to eyeball

Visual QA is **outstanding**: I cannot screenshot (no dev stack, Browser pane renderer times out). Verified via `tsc --noEmit`, `vitest` (1006 pass / 105 files), `eslint` (clean) and `vite build`.

Per surface, in **light and dark**:

**Rail — all five states**
- `pending` — header + body band; stakes collapsed to the single solo-fallback line by `StakesTiles` (not by this skin); no tally cell, no gloss.
- `active` — same, with the roster and next-step line in the band.
- `declined` — `body === null`. Header only. Confirm the sheet ends cleanly and does not leave an empty ruled band.
- `forfeited` — same empty-body shape.
- `settled` — the ruled tally cell, then the `❧` marginal gloss, then the band. Confirm the gloss's ochre-above / blue-ink-below rules read as two different inks and not as one grey line.

**Both seal dialogs × both modes**
- `submit` on an `active` duel with the opponent uncast: the free-reopen note should render as a gloss.
- `submit` on `pending`: no note, stakes collapsed to one line.
- `forfeit` on a `settled` duel: the inked cost panel, red rule and `❦` mark, parchment warning; the destructive confirm button.

**Specifically the foxing blend in dark mode.** This is the change most likely to look wrong: check the four blotches on the rail sheet, both dialogs, *and* the pre-existing surfaces the atom feeds (Ephemerists praxis detail, feed frame). They should read as faint age-bloom lightening the tobacco stock — visible but not glowing, and never grey mud. If `screen` reads too hot, the dial is the `opacity` each caller passes (currently `0.4` on the new surfaces, `0.45`/`0.5` on the old ones), not the blend mode.

**Also worth a glance:** the double rule at phone width, where the Cinzel opponent name wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
