### PR TITLE
Singularity duel skins: the cold green-on-black terminal (#723)

### DIFF
--- a/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
@@ -1,0 +1,229 @@
+/**
+ * Singularity DESKTOP duel seal-confirm (#723).
+ *
+ * The Default dialog's content re-hung inside the faction's cold green-on-black
+ * terminal: near-black ground lifted by two large soft radial glows (phosphor
+ * green from the top-left, brand blue from the top-right), a scanline wash,
+ * hairline low-opacity green borders at a small radius, and the monospace
+ * terminal face throughout. Where Everymen stamps a hard 2px rectangle,
+ * Singularity reads as translucent green-tinted glass.
+ *
+ * The signature ornament — the blinking block cursor — is used ONCE, on the
+ * prompt line that carries the heading. Scattering it turns a terminal into a
+ * christmas tree. The `$ ` prompt and `// ` comment markers are punctuation
+ * around catalog strings, exactly as `SingularityTaskCard` renders `"> "` before
+ * a task title: voice, not copy.
+ *
+ * Pure frame. `StakesTiles` computes every figure from `useGameConfig()` and the
+ * viewer's own faction (Snide's 0.0× lose falls out by construction),
+ * `RaceRoster` reads `is_submitted`, and `useDuelSealCopy` owns the entire
+ * submit/forfeit mode branch (#751) — heading, body, note, confirm label and the
+ * destructive tone. Nothing here re-derives or drops any of it.
+ *
+ * Copy is faction-neutral by decision (#718) and comes only from `praxis.json`.
+ * The design canvas's terminal voice is tone reference, not strings, and its
+ * annotated "1.5× / 0.5×" is deliberately absent — those are per-faction values
+ * the slot owns.
+ *
+ * ALWAYS-DARK. The `--faction-singularity-*` tokens hold identical terminal
+ * values in both themes (the precedent every Singularity surface follows since
+ * `SingularityTaskCard`), so this dialog is a terminal in light mode too. The
+ * one thing light mode changes is what surrounds it, and the overlay below is
+ * an explicit near-black scrim rather than the theme's, so the panel never
+ * floats on a white page.
+ */
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const GROUND = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const PHOSPHOR_DIM = 'var(--faction-singularity-phosphor-dim)'
+const BRAND_BLUE = 'var(--faction-singularity-card-muted)'
+const TERMINAL = 'var(--faction-singularity-card-font)'
+
+/** Hairline rules and panel edges: the accent at low opacity, never a solid. */
+const HAIRLINE = `color-mix(in srgb, ${PHOSPHOR} 22%, transparent)`
+/** Translucent green glass — the inner panel that holds the slots. */
+const GLASS = `color-mix(in srgb, ${PHOSPHOR} 5%, transparent)`
+
+/**
+ * The two soft radial glows plus the scanline wash, as one background stack.
+ * Both glows sit at very low opacity — they lift the black, they do not tint it.
+ */
+const TERMINAL_GROUND = {
+  background: GROUND,
+  backgroundImage: [
+    `radial-gradient(60% 60% at 0% 0%, color-mix(in srgb, ${PHOSPHOR} 14%, transparent), transparent 70%)`,
+    `radial-gradient(55% 55% at 100% 0%, color-mix(in srgb, ${BRAND_BLUE} 12%, transparent), transparent 70%)`,
+    'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.02) 2px, rgba(74,222,128,0.02) 4px)',
+  ].join(', '),
+}
+
+/**
+ * The blinking block cursor — solid phosphor, `step-end`, used once per surface.
+ * `sg-cursor` exists so the reduced-motion guard in the stylesheet below can
+ * reach it; an inline style cannot carry a media query.
+ */
+function BlockCursor() {
+  return (
+    <span
+      aria-hidden
+      className="sg-cursor"
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 16,
+        background: PHOSPHOR,
+        marginLeft: 'var(--space-xs)',
+        verticalAlign: 'text-bottom',
+      }}
+    />
+  )
+}
+
+/** Blink + its reduced-motion opt-out. Duplicate declarations are idempotent. */
+const CURSOR_CSS =
+  '@keyframes blink { 50% { opacity: 0; } }' +
+  '.sg-cursor { animation: blink 1.05s step-end infinite; }' +
+  '@media (prefers-reduced-motion: reduce) { .sg-cursor { animation: none; } }'
+
+export default function SingularityDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  // Opponent tokens, same rule as the Default dialog and the rail: on a terminal
+  // the foreign duelist's colour is the one variable that isn't phosphor, which
+  // is precisely why it gets the left edge and the cast glow.
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: PHOSPHOR_DIM, bodyFont: TERMINAL }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{
+        padding: 'var(--space-lg)',
+        // Explicit near-black, not the theme's scrim: the panel is always-dark,
+        // so a light-mode page must not show through around it.
+        background: 'radial-gradient(circle, rgba(2,8,4,0.72), rgba(2,8,4,0.9))',
+      }}
+    >
+      <div
+        className="w-full max-w-[460px]"
+        style={{
+          ...TERMINAL_GROUND,
+          borderRadius: 6,
+          overflow: 'hidden',
+          border: `1px solid ${HAIRLINE}`,
+          borderLeft: `3px solid ${accent}`,
+          boxShadow: `0 0 44px -18px color-mix(in srgb, ${accent} 55%, transparent)`,
+          color: PHOSPHOR_DIM,
+          fontFamily: TERMINAL,
+        }}
+      >
+        <div style={{ padding: 'var(--space-lg)' }}>
+          {/* Prompt line — `$` sigil, the heading, and the one blinking cursor. */}
+          <h2
+            style={{
+              fontSize: 'var(--text-title)',
+              color: PHOSPHOR,
+              letterSpacing: '0.02em',
+              ...(copy.danger ? { color: 'var(--color-danger)' } : {}),
+            }}
+          >
+            <span aria-hidden style={{ color: BRAND_BLUE }}>{'$ '}</span>
+            {copy.heading}
+            <BlockCursor />
+          </h2>
+
+          <div
+            aria-hidden
+            style={{ height: 1, background: HAIRLINE, margin: 'var(--space-md) 0' }}
+          />
+
+          <p
+            className="content-text"
+            style={{
+              lineHeight: 1.55,
+              color: copy.danger ? 'var(--color-danger)' : PHOSPHOR_DIM,
+            }}
+          >
+            {copy.body}
+          </p>
+
+          {/* The free-reopen half of the truth — the same condition the Default
+              skin uses, because it is a fact about the duel, not a flourish.
+              `copy.note` is null in forfeit mode; there is nothing reassuring
+              left to say, and that silence is the design. */}
+          {copy.note && (
+            <p
+              className="content-text"
+              style={{ marginTop: 'var(--space-sm)', color: 'var(--color-success)' }}
+            >
+              <span aria-hidden>{'// '}</span>
+              {copy.note}
+            </p>
+          )}
+
+          {/* Green glass panel: the stakes pair and the cast roster. */}
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              background: GLASS,
+              border: `1px solid ${HAIRLINE}`,
+              borderRadius: 3,
+              padding: 'var(--space-md)',
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+
+          <div style={{ marginTop: 'var(--space-lg)' }}>
+            <SealActions
+              onConfirm={onConfirm}
+              onCancel={onCancel}
+              busy={busy}
+              confirmLabel={copy.confirmLabel}
+              danger={copy.danger}
+              theme={theme}
+            />
+          </div>
+          {/* ponytail: SealActions keeps the shared btn-outline / btn-primary
+              pair rather than growing a terminal-button skin slot, on the same
+              reasoning WowDuelSealConfirm recorded — the global
+              [Cancel] … [Submit] order (#646) is worth more than a bracketed
+              `[ SEAL ]`, and a skin prop on the shared component is foundation
+              work, not a skin change. */}
+        </div>
+      </div>
+
+      <style>{CURSOR_CSS}</style>
+    </div>
+  )
+}

--- a/frontend/src/components/duel/SingularityMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SingularityMobileDuelSealConfirm.tsx
@@ -1,0 +1,178 @@
+/**
+ * Singularity MOBILE duel seal-confirm (#723).
+ *
+ * The desktop dialog thumbed down. Where Wow's phone skin is a bottom sheet
+ * pinned to a rounded edge over the page, Singularity takes the whole screen:
+ * the phone IS the terminal. That also answers the light-mode question for the
+ * mobile path — the ground is the faction's own always-dark token rather than
+ * `--color-bg-page`, so a Singularity member in light mode gets a terminal, not
+ * a terminal panel floating on white.
+ *
+ * Single column throughout (SPEC-faction-ui-profile §1a — no fixed-px grid on
+ * the mobile path), actions last so the thumb lands on them, and the one
+ * blinking cursor kept on the prompt line.
+ *
+ * Pure frame, same contract as the desktop skin: `StakesTiles` / `RaceRoster`
+ * own every figure and `useDuelSealCopy` owns the whole submit/forfeit branch
+ * (#751). Copy is `praxis.json` only — faction-neutral by decision (#718).
+ */
+import { factionCssVar } from '../../utils/factions'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const GROUND = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const PHOSPHOR_DIM = 'var(--faction-singularity-phosphor-dim)'
+const BRAND_BLUE = 'var(--faction-singularity-card-muted)'
+const TERMINAL = 'var(--faction-singularity-card-font)'
+
+const HAIRLINE = `color-mix(in srgb, ${PHOSPHOR} 22%, transparent)`
+const GLASS = `color-mix(in srgb, ${PHOSPHOR} 5%, transparent)`
+
+/** Same ground stack as the desktop dialog; the glows anchor to the screen here. */
+const TERMINAL_GROUND = {
+  background: GROUND,
+  backgroundImage: [
+    `radial-gradient(70% 40% at 0% 0%, color-mix(in srgb, ${PHOSPHOR} 15%, transparent), transparent 70%)`,
+    `radial-gradient(65% 35% at 100% 0%, color-mix(in srgb, ${BRAND_BLUE} 13%, transparent), transparent 70%)`,
+    'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.02) 2px, rgba(74,222,128,0.02) 4px)',
+  ].join(', '),
+}
+
+/** The one blinking block cursor; `sg-cursor` carries the reduced-motion guard. */
+function BlockCursor() {
+  return (
+    <span
+      aria-hidden
+      className="sg-cursor"
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 16,
+        background: PHOSPHOR,
+        marginLeft: 'var(--space-xs)',
+        verticalAlign: 'text-bottom',
+      }}
+    />
+  )
+}
+
+/** Blink + its reduced-motion opt-out. Duplicate declarations are idempotent. */
+const CURSOR_CSS =
+  '@keyframes blink { 50% { opacity: 0; } }' +
+  '.sg-cursor { animation: blink 1.05s step-end infinite; }' +
+  '@media (prefers-reduced-motion: reduce) { .sg-cursor { animation: none; } }'
+
+export default function SingularityMobileDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: PHOSPHOR_DIM, bodyFont: TERMINAL }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex flex-col justify-end overflow-y-auto"
+      style={{
+        ...TERMINAL_GROUND,
+        color: PHOSPHOR_DIM,
+        fontFamily: TERMINAL,
+        // The opponent still owns the edge that faces them, full-height here.
+        borderLeft: `3px solid ${accent}`,
+      }}
+    >
+      <div style={{ padding: 'var(--space-lg)' }}>
+        <h2
+          style={{
+            fontSize: 'var(--text-title)',
+            color: copy.danger ? 'var(--color-danger)' : PHOSPHOR,
+            letterSpacing: '0.02em',
+          }}
+        >
+          <span aria-hidden style={{ color: BRAND_BLUE }}>{'$ '}</span>
+          {copy.heading}
+          <BlockCursor />
+        </h2>
+
+        <div
+          aria-hidden
+          style={{ height: 1, background: HAIRLINE, margin: 'var(--space-md) 0' }}
+        />
+
+        <p
+          className="content-text"
+          style={{
+            lineHeight: 1.55,
+            color: copy.danger ? 'var(--color-danger)' : PHOSPHOR_DIM,
+          }}
+        >
+          {copy.body}
+        </p>
+
+        {copy.note && (
+          <p
+            className="content-text"
+            style={{ marginTop: 'var(--space-sm)', color: 'var(--color-success)' }}
+          >
+            <span aria-hidden>{'// '}</span>
+            {copy.note}
+          </p>
+        )}
+
+        <div
+          style={{
+            marginTop: 'var(--space-md)',
+            background: GLASS,
+            border: `1px solid ${HAIRLINE}`,
+            borderRadius: 3,
+            padding: 'var(--space-md)',
+          }}
+        >
+          <StakesTiles
+            viewerFactionSlug={me.faction_slug}
+            opponentFactionSlug={foe.faction_slug}
+            opponentName={foe.display_name}
+            taskPointValue={taskPointValue}
+            status={duel.status}
+            theme={theme}
+          />
+          <RaceRoster me={me} foe={foe} theme={theme} />
+        </div>
+
+        {/* ponytail: actions keep the shared SealActions pair — thumb-sized
+            terminal buttons would need a skin slot on the shared component,
+            which is foundation work, not a skin change. */}
+        <div style={{ marginTop: 'var(--space-lg)' }}>
+          <SealActions
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            busy={busy}
+            confirmLabel={copy.confirmLabel}
+            danger={copy.danger}
+            theme={theme}
+          />
+        </div>
+      </div>
+
+      <style>{CURSOR_CSS}</style>
+    </div>
+  )
+}

--- a/frontend/src/factions/singularity.ts
+++ b/frontend/src/factions/singularity.ts
@@ -13,12 +13,16 @@ import type { FactionManifest } from './manifest'
 import SingularityAvatar from '../components/avatar/SingularityAvatar'
 import SingularityBackdrop from '../components/backdrop/SingularityBackdrop'
 import SingularityComment from '../components/comments/voices/SingularityComment'
+import SingularityDuelRail from '../pages/praxisDetail/duelRails/SingularityDuelRail'
+import SingularityDuelSealConfirm from '../components/duel/SingularityDuelSealConfirm'
 import SingularityEditPraxis from '../pages/editPraxis/archetypes/SingularityEditPraxis'
 import SingularityFactionBody from '../pages/factionDetail/archetypes/SingularityFactionBody'
 import SingularityFactionHero from '../components/cards/SingularityFactionHero'
 import SingularityFactionPage from '../pages/factionDetail/mobileArchetypes/SingularityFactionPage'
 import SingularityFeedFrame from '../components/feed/SingularityFeedFrame'
 import SingularityHome from '../pages/fieldDesk/mobileArchetypes/SingularityHome'
+import SingularityMobileDuelRail from '../pages/praxisDetail/duelRails/SingularityMobileDuelRail'
+import SingularityMobileDuelSealConfirm from '../components/duel/SingularityMobileDuelSealConfirm'
 import SingularityMobileEditPraxis from '../pages/editPraxis/mobileArchetypes/SingularityComposer'
 import SingularityMobilePraxisCard from '../components/praxisCard/mobile/SingularityMobilePraxisCard'
 import SingularityMobilePraxisDetail from '../pages/praxisDetail/mobileArchetypes/SingularityPraxisDetail'
@@ -53,6 +57,8 @@ export const SINGULARITY_MANIFEST: FactionManifest = {
   factionHero: () => SingularityFactionHero,
   factionBody: () => SingularityFactionBody,
   profileBody: () => SingularityProfileBody,
+  duelSeal: () => SingularityDuelSealConfirm,
+  duelRail: () => SingularityDuelRail,
   mobileTaskCard: () => SingularityMobileTaskCard,
   mobilePraxisCard: () => SingularityMobilePraxisCard,
   mobileTaskDetail: () => SingularityMobileTaskDetail,
@@ -60,4 +66,6 @@ export const SINGULARITY_MANIFEST: FactionManifest = {
   mobileEditPraxis: () => SingularityMobileEditPraxis,
   mobileFactionPage: () => SingularityFactionPage,
   mobileFieldDesk: () => SingularityHome,
+  mobileDuelSeal: () => SingularityMobileDuelSealConfirm,
+  mobileDuelRail: () => SingularityMobileDuelRail,
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -157,6 +157,16 @@
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;
 
+  /* Dim sage phosphor (#723) — the SECOND green. `card-text` and `card-accent`
+     are the same bright #4ade80, so a Singularity surface had one weight of
+     green and reached for `color-mix(… accent N%, transparent)` whenever it
+     wanted a quieter one. That is fine for a hairline rule and wrong for body
+     copy: translucent text has no fixed contrast ratio (#651). This is a SOLID
+     dim green, 7.25:1 on --faction-singularity-card-bg, so prose can sit below
+     the accent without sitting below AA. Terminal tokens are theme-invariant
+     (Singularity is always-dark), so this one value serves both themes. */
+  --faction-singularity-phosphor-dim: #7ba98a;
+
   /* ══ Ephemerists illuminated-codex palette (the ephemerists slot) ══
      The card contract above rebinds to these. CONSTANTS (gold/rubric/
      lapis/verdigris/ink) keep their role in both themes; the VELLUM

--- a/frontend/src/pages/praxisDetail/duelRails/SingularityDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SingularityDuelRail.tsx
@@ -1,0 +1,156 @@
+/**
+ * Singularity DESKTOP duel rail (#723) — the duel context as a terminal readout
+ * docked above the praxis.
+ *
+ * Pure frame. Every slot arrives pre-rendered from `DuelCrossLink`: the
+ * forfeited-pre-empts-status check, the per-`DuelStatus` branch table and the
+ * slot composition inside `body` all live above this file. This one decides
+ * only where the phosphor goes. It cannot recompute a figure or re-derive a
+ * status, and it must never drop a slot.
+ *
+ * Chrome: near-black ground lifted by two soft radial glows (green top-left,
+ * brand blue top-right) under a scanline wash; hairline low-opacity green
+ * borders at a small radius; the monospace terminal face. The `$ ` prompt
+ * marker is punctuation, the same voice `SingularityTaskCard` speaks with `"> "`
+ * — no invented copy, no locale keys.
+ *
+ * The opponent's accent is the one non-phosphor colour on the surface, which is
+ * the whole point of the skin: it rides the left edge and casts the glow, so a
+ * foreign duelist reads as a foreign variable on the terminal.
+ *
+ * Contract notes the design canvas gets wrong and this file follows the CODE on:
+ *  - `body` is `null` for `declined` and `forfeited` — there is no race left, so
+ *    the readout is a bare header. No substitute roster is drawn.
+ *  - `tally` and `note` are `null` outside `settled`, so neither reserves height.
+ *  - Stakes collapse to one line while `pending`; `StakesTiles` already does that
+ *    inside `body`, and this file must not re-implement the hiding.
+ *
+ * NO `fontSize` on the wrapper (#769). The slots size themselves; a wrapper size
+ * overrides all of them at once. A skin owns font, colour and ornament, never
+ * type size (WORLD_ZERO_STYLE §4a).
+ *
+ * ALWAYS-DARK: the `--faction-singularity-*` tokens hold identical terminal
+ * values in both themes, so this rail is a terminal in light mode too — the
+ * precedent every Singularity surface has followed since `SingularityTaskCard`.
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const GROUND = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const PHOSPHOR_DIM = 'var(--faction-singularity-phosphor-dim)'
+const BRAND_BLUE = 'var(--faction-singularity-card-muted)'
+const TERMINAL = 'var(--faction-singularity-card-font)'
+
+const HAIRLINE = `color-mix(in srgb, ${PHOSPHOR} 22%, transparent)`
+const GLASS = `color-mix(in srgb, ${PHOSPHOR} 5%, transparent)`
+
+/**
+ * The signature blinking block cursor, used ONCE per surface — here on the
+ * state headline, the rail's only heading. `sg-cursor` exists so the
+ * reduced-motion guard in the stylesheet below can reach it; an inline style
+ * cannot carry a media query.
+ */
+function BlockCursor() {
+  return (
+    <span
+      aria-hidden
+      className="sg-cursor"
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 14,
+        background: PHOSPHOR,
+        marginLeft: 'var(--space-xs)',
+        verticalAlign: 'text-bottom',
+      }}
+    />
+  )
+}
+
+/** Blink + its reduced-motion opt-out. Duplicate declarations are idempotent. */
+const CURSOR_CSS =
+  '@keyframes blink { 50% { opacity: 0; } }' +
+  '.sg-cursor { animation: blink 1.05s step-end infinite; }' +
+  '@media (prefers-reduced-motion: reduce) { .sg-cursor { animation: none; } }'
+
+export default function SingularityDuelRail({
+  accent,
+  maxWidth,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const shell: CSSProperties = {
+    maxWidth,
+    margin: 'var(--space-lg) 0',
+    borderRadius: 6,
+    overflow: 'hidden',
+    border: `1px solid ${HAIRLINE}`,
+    borderLeft: `3px solid ${accent}`,
+    boxShadow: `0 0 34px -18px color-mix(in srgb, ${accent} 55%, transparent)`,
+    background: GROUND,
+    backgroundImage: [
+      `radial-gradient(60% 70% at 0% 0%, color-mix(in srgb, ${PHOSPHOR} 14%, transparent), transparent 70%)`,
+      `radial-gradient(55% 65% at 100% 0%, color-mix(in srgb, ${BRAND_BLUE} 12%, transparent), transparent 70%)`,
+      'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.02) 2px, rgba(74,222,128,0.02) 4px)',
+    ].join(', '),
+    fontFamily: TERMINAL,
+    // No `fontSize` here (#769) — see the header note.
+    color: PHOSPHOR_DIM,
+  }
+
+  return (
+    <div style={shell}>
+      {/* Prompt line: `$` sigil, the state headline, the live tally on the right. */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-md) var(--space-lg)',
+          borderBottom: `1px solid ${HAIRLINE}`,
+          flexWrap: 'wrap',
+        }}
+      >
+        {/* Content tier, on the headline's own container — the headline arrives
+            unsized, and this is a heading, not a label. */}
+        <span style={{ fontSize: 'var(--text-content)', color: PHOSPHOR }}>
+          <span aria-hidden style={{ color: BRAND_BLUE }}>{'$ '}</span>
+          {headline}
+          <BlockCursor />
+        </span>
+        {tally && (
+          <span style={{ marginLeft: 'auto', color: PHOSPHOR, fontWeight: 700 }}>{tally}</span>
+        )}
+      </div>
+
+      {/* `declined` and `forfeited` arrive with note AND body null, so the whole
+          lower block is skipped rather than padding out an empty strip. */}
+      {(note || body) && (
+      <div style={{ padding: 'var(--space-lg)' }}>
+        {note}
+        {body && (
+          <div
+            style={{
+              marginTop: note ? 'var(--space-sm)' : 0,
+              background: GLASS,
+              border: `1px solid ${HAIRLINE}`,
+              borderRadius: 3,
+              padding: 'var(--space-md)',
+            }}
+          >
+            {body}
+          </div>
+        )}
+        {/* ponytail: the readout then collapses to the prompt line alone. That
+            is the correct empty state — the duel is over — so no bespoke
+            "connection closed" ornament is drawn for it. */}
+      </div>
+      )}
+
+      <style>{CURSOR_CSS}</style>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/duelRails/SingularityMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SingularityMobileDuelRail.tsx
@@ -1,0 +1,131 @@
+/**
+ * Singularity MOBILE duel rail (#723).
+ *
+ * The desktop readout thumbed down. Two changes, both forced by phone width:
+ * the tally leaves the prompt line (a score pair and a headline on one
+ * phone-width row wrap into mush) and drops to its own centred line above the
+ * glass panel, where it reads as the scoreboard it is; and `maxWidth` is
+ * ignored, because the rail is full-bleed inside the phone column and the
+ * desktop archetype-width map has nothing to line up with here.
+ *
+ * Single column throughout — SPEC-faction-ui-profile §1a forbids a fixed-px
+ * grid on the mobile path, and this surface needs none.
+ *
+ * Pure frame, same contract as the desktop skin: every slot arrives already
+ * rendered, `body`/`tally`/`note` are legitimately null in some states, and none
+ * of the duel's arithmetic or `DuelStatus` branching is visible from here.
+ * No `fontSize` on the wrapper (#769).
+ */
+import type { CSSProperties } from 'react'
+import type { DuelRailSkinProps } from '../DuelCrossLink'
+
+const GROUND = 'var(--faction-singularity-card-bg)'
+const PHOSPHOR = 'var(--faction-singularity-card-accent)'
+const PHOSPHOR_DIM = 'var(--faction-singularity-phosphor-dim)'
+const BRAND_BLUE = 'var(--faction-singularity-card-muted)'
+const TERMINAL = 'var(--faction-singularity-card-font)'
+
+const HAIRLINE = `color-mix(in srgb, ${PHOSPHOR} 22%, transparent)`
+const GLASS = `color-mix(in srgb, ${PHOSPHOR} 5%, transparent)`
+
+/** The one blinking block cursor, on the rail's only heading. */
+function BlockCursor() {
+  return (
+    <span
+      aria-hidden
+      className="sg-cursor"
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 14,
+        background: PHOSPHOR,
+        marginLeft: 'var(--space-xs)',
+        verticalAlign: 'text-bottom',
+      }}
+    />
+  )
+}
+
+/** Blink + its reduced-motion opt-out. Duplicate declarations are idempotent. */
+const CURSOR_CSS =
+  '@keyframes blink { 50% { opacity: 0; } }' +
+  '.sg-cursor { animation: blink 1.05s step-end infinite; }' +
+  '@media (prefers-reduced-motion: reduce) { .sg-cursor { animation: none; } }'
+
+export default function SingularityMobileDuelRail({
+  accent,
+  headline,
+  tally,
+  note,
+  body,
+}: DuelRailSkinProps) {
+  const shell: CSSProperties = {
+    margin: 'var(--space-md) 0',
+    borderRadius: 9,
+    overflow: 'hidden',
+    border: `1px solid ${HAIRLINE}`,
+    borderLeft: `3px solid ${accent}`,
+    boxShadow: `0 0 26px -14px color-mix(in srgb, ${accent} 55%, transparent)`,
+    background: GROUND,
+    backgroundImage: [
+      `radial-gradient(80% 60% at 0% 0%, color-mix(in srgb, ${PHOSPHOR} 15%, transparent), transparent 70%)`,
+      `radial-gradient(75% 55% at 100% 0%, color-mix(in srgb, ${BRAND_BLUE} 13%, transparent), transparent 70%)`,
+      'repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.02) 2px, rgba(74,222,128,0.02) 4px)',
+    ].join(', '),
+    fontFamily: TERMINAL,
+    // No `fontSize` here (#769) — the slots own their size, the frame owns none.
+    color: PHOSPHOR_DIM,
+  }
+
+  return (
+    <div style={shell}>
+      <div
+        style={{
+          padding: 'var(--space-md)',
+          borderBottom: `1px solid ${HAIRLINE}`,
+        }}
+      >
+        <span style={{ fontSize: 'var(--text-content)', color: PHOSPHOR }}>
+          <span aria-hidden style={{ color: BRAND_BLUE }}>{'$ '}</span>
+          {headline}
+          <BlockCursor />
+        </span>
+      </div>
+
+      {(tally || note || body) && (
+        <div style={{ padding: 'var(--space-md)' }}>
+          {tally && (
+            <div
+              style={{
+                // The tally arrives on .content-title already (#769) — this
+                // scoreboard block contributes the phosphor and the centring.
+                color: PHOSPHOR,
+                fontWeight: 700,
+                textAlign: 'center',
+                marginBottom: 'var(--space-xs)',
+              }}
+            >
+              {tally}
+            </div>
+          )}
+          {note}
+          {body && (
+            <div
+              style={{
+                marginTop: 'var(--space-sm)',
+                background: GLASS,
+                border: `1px solid ${HAIRLINE}`,
+                borderRadius: 3,
+                padding: 'var(--space-md)',
+              }}
+            >
+              {body}
+            </div>
+          )}
+        </div>
+      )}
+
+      <style>{CURSOR_CSS}</style>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #723

Four bespoke duel surfaces for Singularity, plus one new colour token.

## What landed

| Manifest field | File |
|---|---|
| `duelSeal` | `frontend/src/components/duel/SingularityDuelSealConfirm.tsx` |
| `mobileDuelSeal` | `frontend/src/components/duel/SingularityMobileDuelSealConfirm.tsx` |
| `duelRail` | `frontend/src/pages/praxisDetail/duelRails/SingularityDuelRail.tsx` |
| `mobileDuelRail` | `frontend/src/pages/praxisDetail/duelRails/SingularityMobileDuelRail.tsx` |

Registered in `frontend/src/factions/singularity.ts` as **thunks**, per the cycle
note in `factions/manifest.ts`. The issue body's four registries
(`DUEL_SEAL_BY_SLUG` &co.) no longer exist — #782/#795 replaced them with the
per-faction manifest, which is what this uses.

## The chrome

Singularity reads as a cold green-on-black terminal: near-black ground lifted by
two large soft radial glows (phosphor green from the top-left, brand blue from
the top-right) under a scanline wash, hairline low-opacity green borders at a
small radius (3–9px), monospace terminal face throughout. The opposite of
Everymen's hard 2px stamped rectangle — translucent green-tinted glass.

The blinking block cursor is used **once per surface**, on the prompt line that
carries the heading. `$ ` and `// ` markers are punctuation around catalog
strings, the same voice `SingularityTaskCard` speaks with `"> "` — no invented
copy and no new locale keys.

The **opponent's accent is the one non-phosphor colour on the surface**, which is
the point of the skin: it rides the left edge and casts the glow, so a foreign
duelist reads as a foreign variable on the terminal.

## Design decisions worth arguing with

**One new token — `--faction-singularity-phosphor-dim: #7ba98a`.** `card-text` and
`card-accent` are both the same bright `#4ade80`, so Singularity has exactly one
weight of green and existing surfaces reach for
`color-mix(… accent N%, transparent)` whenever they want a quieter one. That is
fine for a hairline rule and wrong for body copy — translucent text has no fixed
contrast ratio (#651 doctrine). This is a solid dim sage at **7.25:1** on
`--faction-singularity-card-bg`, visibly below the accent without being below AA.
Declared in `:root` only, following `--faction-singularity-border-hard`'s
precedent: Singularity terminal tokens are theme-invariant.

**Light mode.** Singularity is an always-dark faction — its tokens hold identical
terminal values in both themes, the precedent every Singularity surface has
followed since `SingularityTaskCard`. So the skin is a terminal in light mode
too, by design. The only thing light mode actually changes is what *surrounds*
the surface, and both seal dialogs handle it without a ternary:
- desktop overlay is an explicit near-black scrim, not the theme's, so the panel
  never floats on a white page;
- the mobile dialog takes the **whole screen on the faction's own ground** rather
  than Wow's `--color-bg-page` bottom-sheet, so the phone *is* the terminal.

**Reduced motion.** The cursor's blink moved from an inline `animation` to an
`.sg-cursor` rule in the surface's own `<style>` block, so it can carry a
`prefers-reduced-motion: reduce` opt-out — an inline style cannot hold a media
query. A rail's cursor blinks for as long as you read the page, which is exactly
the case that rule exists for.

**Empty states are collapsed, not padded.** `declined` / `forfeited` arrive with
`tally`, `note` and `body` all `null`; both rails skip the lower block entirely
rather than rendering an empty padded strip. No substitute roster is invented.

## What is deliberately absent

- The canvas's annotated "1.5× win / 0.5× lose" — per-faction values `StakesTiles`
  owns; Snide's `0.0×` falls out by construction.
- Any string not in `praxis.json`. Copy is faction-neutral by decision (#718);
  `.design-sync/BRIEF-duel-surfaces.md` §4 specs copy that was never built.
- Any `fontSize` on a rail wrapper (#769). Slots own their size, frames own none.
- The mock's `state` enum — the real branching is the dispatcher's job; these
  skins only ever see already-rendered slots.

## Verification

- `tsc --noEmit` clean (only the known stale-junction `node:fs` false alarms, PR #675)
- `vite build` clean
- `eslint .` clean across the repo — the `no-raw-style-values` ratchet applies in
  full to these four new files
- `duelSkinSlots.test.tsx` **180 tests pass**; it picked the new skins up
  automatically off the manifest (21 → 31 duel-skin cases). That file was not
  edited.

**Visual QA is outstanding** — no screenshot renderer and no dev stack in this
environment, so everything above is verified by types, lint, build and tests only.

## What to eyeball

Five duel states × two modes × both themes:

| | desktop rail | mobile rail | desktop seal | mobile seal |
|---|---|---|---|---|
| `pending` | headline only + stakes collapsed to the solo-fallback **line**, no tiles, no tally | same, tally absent | body reads `bodyPending`, no reopen note | same |
| `active`, you haven't cast | roster + next-step + win/lose tiles | single column | `bodyActive` + reopen note in green | full-screen |
| `active`, you've cast | next-step flips to waiting-on-them | | reopen note present only while *they* haven't cast | |
| `settled` | tally on the right of the prompt line | tally on **its own centred line** above the glass panel | forfeit mode opens here | |
| `declined` / `forfeited` | prompt line **alone** — no empty padded strip below | same | n/a | n/a |

Then, specifically:
1. **Forfeit mode** (`mode="forfeit"`, only reachable on a settled duel): heading
   and confirm both read "Forfeit", body is `confirmPrompt` + the Snide-aware
   `cost` line in `--color-danger`, no green reassurance note, confirm button
   destructive. Nothing should say "Seal the duel?".
2. **Light mode**: toggle the theme on all four. Nothing should lighten. The
   desktop dialog's scrim should stay near-black; the mobile dialog should have
   no white gutter.
3. **The opponent's accent** on the left edge and in the glow — duel a Snide
   player (acid green) and then a UA player (burnt amber) and check the foreign
   colour actually reads as foreign against the phosphor.
4. **Contrast**: body copy at `--faction-singularity-phosphor-dim` should be
   clearly quieter than the accent-green headline but still comfortably readable
   on the terminal black.
5. **Cursor**: exactly one blinking block per surface, on the heading. Turn on
   OS reduced-motion and confirm it stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
