### PR TITLE
Duel seal dialog body text at the content floor (#800)

### DIFF
--- a/frontend/src/components/duel/DuelSealConfirm.tsx
+++ b/frontend/src/components/duel/DuelSealConfirm.tsx
@@ -120,9 +120,8 @@ export function DefaultDuelSealConfirm({
         </h2>
 
         <p
-          className="font-body"
+          className="font-body content-text"
           style={{
-            fontSize: 'var(--text-sm)',
             color: copy.danger ? 'var(--color-danger)' : 'var(--color-text-secondary)',
           }}
         >
@@ -131,8 +130,8 @@ export function DefaultDuelSealConfirm({
 
         {copy.note && (
           <p
-            className="font-body"
-            style={{ fontSize: 'var(--text-xs)', color: 'var(--color-success)' }}
+            className="font-body content-text"
+            style={{ color: 'var(--color-success)' }}
           >
             {copy.note}
           </p>

--- a/frontend/src/components/duel/SnideDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideDuelSealConfirm.tsx
@@ -155,7 +155,7 @@ export default function SnideDuelSealConfirm({
             <p
               style={{
                 marginTop: 'var(--space-sm)',
-                fontSize: 'var(--text-sm)',
+                fontSize: 'var(--text-content)',
                 color: ACID,
               }}
             >

--- a/frontend/src/components/duel/SnideMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideMobileDuelSealConfirm.tsx
@@ -121,7 +121,7 @@ export default function SnideMobileDuelSealConfirm({
             <p
               style={{
                 marginTop: 'var(--space-sm)',
-                fontSize: 'var(--text-sm)',
+                fontSize: 'var(--text-content)',
                 color: ACID,
               }}
             >

--- a/frontend/src/components/duel/WowDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowDuelSealConfirm.tsx
@@ -135,7 +135,7 @@ export default function WowDuelSealConfirm({
             <p
               style={{
                 marginTop: 'var(--space-sm)',
-                fontSize: 'var(--text-sm)',
+                fontSize: 'var(--text-content)',
                 color: 'var(--color-success)',
               }}
             >

--- a/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
@@ -130,7 +130,7 @@ export default function WowMobileDuelSealConfirm({
             <p
               style={{
                 marginTop: 'var(--space-sm)',
-                fontSize: 'var(--text-sm)',
+                fontSize: 'var(--text-content)',
                 color: 'var(--color-success)',
               }}
             >

--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -137,6 +137,46 @@ describe('duel seal skins render every slot', () => {
     expect(html).toContain('role="dialog"')
   })
 
+  /**
+   * #800: the Default dialog's body and reopen note sat at `--text-sm` (9px)
+   * and `--text-xs` (8px) — half and less than half of the 18px content floor
+   * — for text a player reads at the one duel moment with a genuinely
+   * irreversible consequence (the forfeit mode added in #751). This is the
+   * #769 guard, ported to the seal surface as that issue asked.
+   *
+   * Both Wow seal skins carried the matching defect on their note, as #800
+   * named. Writing this guard against every registered skin (not just the
+   * two named ones) also caught the same defect, previously unreported, on
+   * both Snide seal skins — fixed alongside the named ones so the guard
+   * ships green.
+   *
+   * Scoped to `<p>` tags so SealActions' buttons — legitimate `--text-sm`
+   * button chrome, same exemption the rail guard carves out — don't false-
+   * positive the check.
+   */
+  const LABEL_TIER = ['--text-xs', '--text-sm', '--text-base', '--text-md', '--text-lg']
+
+  it.each(cases)(
+    '%s does not sink body copy below the content floor in %s mode',
+    (_name, Skin, mode, duel) => {
+      const html = renderToStaticMarkup(
+        <Skin
+          duel={duel}
+          viewerCharacterId={1}
+          taskPointValue={60}
+          onConfirm={() => {}}
+          onCancel={() => {}}
+          mode={mode}
+        />,
+      )
+      const paragraphs = html.match(/<p[^>]*>/g) ?? []
+      const offenders = paragraphs.filter((tag) =>
+        LABEL_TIER.some((token) => tag.includes(`var(${token})`)),
+      )
+      expect(offenders).toEqual([])
+    },
+  )
+
   // The mode branch itself: each mode must actually SAY its own thing, so a
   // skin can't satisfy the slot walk above by hardcoding the submit copy.
   it.each(skins)('%s speaks the forfeit copy in forfeit mode', (_name, Skin) => {


### PR DESCRIPTION
Closes #800

## What changed

The duel seal/forfeit dialog's body and reopen-note text sat below the 18px content floor `WORLD_ZERO_STYLE.md` §4a establishes — `--text-sm` (9px) and `--text-xs` (8px) — for prose a player reads at the one duel moment with a genuinely irreversible consequence (the forfeit mode added in #751).

- **`DefaultDuelSealConfirm`**: body and note now use the `.content-text` role class (18px) instead of `--text-sm` / `--text-xs`.
- **`WowDuelSealConfirm` / `WowMobileDuelSealConfirm`**: note now uses `--text-content` directly, matching the body's existing convention in those files (both were already correct for body, wrong only on the note — as #800 described).
- **`SnideDuelSealConfirm` / `SnideMobileDuelSealConfirm`**: same fix on the note. This defect wasn't named in #800, but writing the guard test against every registered seal skin (not just the two the issue called out) caught it too, so it's fixed here rather than left to regress the new test.

## Test guard

Extended `duelSkinSlots.test.tsx` — the #769 Label-tier guard, previously covering only the duel rail — to the seal surface, per the issue's ask #4. It renders every registered seal skin (default + all faction skins, desktop + mobile) in both `submit` and `forfeit` mode and asserts no `<p>` tag carries an inline Label-tier `font-size`. Scoped to `<p>` tags so `SealActions`' buttons (legitimate `--text-sm` button chrome) don't false-positive.

Verified the guard actually catches the regression: reverted one of the fixes locally, confirmed the new test failed with the offending declaration named, then restored the fix.

## Test results

- `npx vitest run` — 105 test files, 1064 tests, all passing.
- `npx tsc --noEmit` — clean.
- `npx eslint` on touched files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CXj8TWhp8PG55kBP3LX6TS)_