### PR TITLE
Point Singularity praxis detail at the token that exists (#806)

### DIFF
--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -41,7 +41,7 @@ function Sprockets({ position }: { position: 'top' | 'bottom' }) {
         justifyContent: 'space-between',
         alignItems: 'center',
         padding: 'var(--space-xs) var(--space-md)',
-        background: 'color-mix(in srgb, var(--faction-singularity-muted) 10%, transparent)',
+        background: 'color-mix(in srgb, var(--faction-singularity-card-muted) 10%, transparent)',
         ...border,
       }}
     >
@@ -53,7 +53,7 @@ function Sprockets({ position }: { position: 'top' | 'bottom' }) {
             height: 7,
             borderRadius: '50%',
             background: 'var(--faction-singularity-card-bg)',
-            border: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 45%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--faction-singularity-card-muted) 45%, transparent)',
           }}
         />
       ))}
@@ -81,7 +81,7 @@ function SgDivider({ label }: { label: string }) {
         style={{
           flex: 1,
           height: 1,
-          background: 'color-mix(in srgb, var(--faction-singularity-muted) 28%, transparent)',
+          background: 'color-mix(in srgb, var(--faction-singularity-card-muted) 28%, transparent)',
         }}
       />
     </div>
@@ -112,7 +112,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
         background: 'var(--faction-singularity-card-bg)',
         border: '1px solid var(--faction-singularity-border-hard)',
         boxShadow:
-          '0 0 0 1px color-mix(in srgb, var(--faction-singularity-muted) 12%, transparent), 0 0 40px -20px color-mix(in srgb, var(--faction-singularity-card-accent) 30%, transparent)',
+          '0 0 0 1px color-mix(in srgb, var(--faction-singularity-card-muted) 12%, transparent), 0 0 40px -20px color-mix(in srgb, var(--faction-singularity-card-accent) 30%, transparent)',
         overflow: 'hidden',
         padding: 0,
       }}
@@ -143,7 +143,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
             gap: 'var(--space-md)',
             flexWrap: 'wrap',
             padding: 'var(--space-md) var(--space-xl)',
-            borderBottom: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 28%, transparent)',
+            borderBottom: '1px solid color-mix(in srgb, var(--faction-singularity-card-muted) 28%, transparent)',
             background: 'color-mix(in srgb, var(--faction-singularity-card-accent) 3%, transparent)',
           }}
         >
@@ -152,7 +152,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
               fontSize: 'var(--text-sm)',
               letterSpacing: '0.22em',
               textTransform: 'uppercase',
-              color: 'var(--faction-singularity-muted)',
+              color: 'var(--faction-singularity-card-muted)',
             }}
           >
             {t('detail.singularity.sealedProtocol')}
@@ -161,7 +161,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
             style={{
               fontSize: 'var(--text-xs)',
               letterSpacing: '0.12em',
-              color: 'color-mix(in srgb, var(--faction-singularity-muted) 55%, transparent)',
+              color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 55%, transparent)',
             }}
           >
             {t('detail.singularity.signalTrace', { date: formatTimestamp(sealedDate) })}
@@ -203,8 +203,8 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
               style={{
                 fontSize: 'var(--text-xs)',
                 padding: 'var(--space-xs) var(--space-md)',
-                border: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 40%, transparent)',
-                color: 'color-mix(in srgb, var(--faction-singularity-muted) 80%, transparent)',
+                border: '1px solid color-mix(in srgb, var(--faction-singularity-card-muted) 40%, transparent)',
+                color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 80%, transparent)',
                 letterSpacing: '0.14em',
               }}
             >
@@ -221,19 +221,19 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
             >
               {t('detail.singularity.re', { task: praxis.task_title })}
             </Link>
-            <span style={{ color: 'color-mix(in srgb, var(--faction-singularity-muted) 35%, transparent)', fontSize: 'var(--text-xs)' }}>·</span>
+            <span style={{ color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 35%, transparent)', fontSize: 'var(--text-xs)' }}>·</span>
             <span
               style={{
                 fontSize: 'var(--text-xs)',
                 letterSpacing: '0.1em',
-                color: 'color-mix(in srgb, var(--faction-singularity-muted) 60%, transparent)',
+                color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 60%, transparent)',
               }}
             >
               {t('detail.singularity.gradeCredits', { grade, points: praxis.task_point_value })}
             </span>
             {praxis.moderation_status === 'flagged' && (
               <>
-                <span style={{ color: 'color-mix(in srgb, var(--faction-singularity-muted) 35%, transparent)', fontSize: 'var(--text-xs)' }}>·</span>
+                <span style={{ color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 35%, transparent)', fontSize: 'var(--text-xs)' }}>·</span>
                 <span
                   style={{
                     fontSize: 'var(--text-xs)',
@@ -257,7 +257,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
                 fontSize: 'var(--text-xs)',
                 letterSpacing: '0.2em',
                 marginBottom: 'var(--space-sm)',
-                color: 'color-mix(in srgb, var(--faction-singularity-muted) 55%, transparent)',
+                color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 55%, transparent)',
               }}
             >
               {t('detail.singularity.output')}
@@ -300,7 +300,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
               gap: 'var(--space-md)',
               paddingBottom: 'var(--space-lg)',
               marginBottom: 'var(--space-sm)',
-              borderBottom: '1px dashed color-mix(in srgb, var(--faction-singularity-muted) 28%, transparent)',
+              borderBottom: '1px dashed color-mix(in srgb, var(--faction-singularity-card-muted) 28%, transparent)',
             }}
           >
             <Link to={`/characters/${praxis.created_by_id}`}>
@@ -315,7 +315,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
                   justifyContent: 'center',
                   fontSize: 'var(--text-base)',
                   letterSpacing: '0.06em',
-                  color: 'var(--faction-singularity-muted)',
+                  color: 'var(--faction-singularity-card-muted)',
                   background: `color-mix(in srgb, ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')} 20%, var(--faction-singularity-card-bg))`,
                   border: `1px solid ${factionCssVar(praxis.created_by_faction_slug, 'card-accent')}`,
                 }}
@@ -337,7 +337,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
                 style={{
                   fontSize: 'var(--text-xs)',
                   letterSpacing: '0.06em',
-                  color: 'color-mix(in srgb, var(--faction-singularity-muted) 50%, transparent)',
+                  color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 50%, transparent)',
                 }}
               >
                 {t('detail.singularity.instanceLabel', { instance: instance.toLowerCase() })}
@@ -353,7 +353,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
                   fontSize: 'var(--text-xs)',
                   letterSpacing: '0.12em',
                   marginTop: 'var(--space-xs)',
-                  color: 'color-mix(in srgb, var(--faction-singularity-muted) 50%, transparent)',
+                  color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 50%, transparent)',
                 }}
               >
                 {t('detail.singularity.baseCredits')}
@@ -385,8 +385,8 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
               />
               <div
                 style={{
-                  border: '1px solid color-mix(in srgb, var(--faction-singularity-muted) 30%, transparent)',
-                  background: 'color-mix(in srgb, var(--faction-singularity-muted) 6%, transparent)',
+                  border: '1px solid color-mix(in srgb, var(--faction-singularity-card-muted) 30%, transparent)',
+                  background: 'color-mix(in srgb, var(--faction-singularity-card-muted) 6%, transparent)',
                   padding: 'var(--space-md)',
                 }}
               >
@@ -403,7 +403,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
                 state={state}
                 align="right"
                 accent="var(--faction-singularity-card-accent)"
-                muted="color-mix(in srgb, var(--faction-singularity-muted) 55%, transparent)"
+                muted="color-mix(in srgb, var(--faction-singularity-card-muted) 55%, transparent)"
               />
             </div>
             <VoteUI

--- a/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
+++ b/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+import { readThemes } from "./cssVars";
+
 /**
  * Guard for the "looks tokenized, is not" failure class (#806).
  *
@@ -19,7 +21,12 @@ const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".css"];
 function collectSourceFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = join(directory, entry.name);
-    if (entry.isDirectory()) return collectSourceFiles(path);
+    // Tests never render; they quote token names as prose and fixtures.
+    // (This file's own docstring trips the guard otherwise — which is a
+    // pleasant demonstration that the guard works.)
+    if (entry.isDirectory()) {
+      return entry.name === "__tests__" ? [] : collectSourceFiles(path);
+    }
     return SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))
       ? [path]
       : [];
@@ -31,9 +38,13 @@ function matchAll(text: string, pattern: RegExp): string[] {
 }
 
 describe("faction CSS custom properties (#806)", () => {
-  const stylesheet = readFileSync(join(SRC_DIR, "index.css"), "utf-8");
+  // readThemes strips comments and reads both theme blocks, so a token merely
+  // *mentioned* in a comment never counts as declared.
+  const themes = readThemes(readFileSync(join(SRC_DIR, "index.css"), "utf-8"));
   const declared = new Set(
-    matchAll(stylesheet, /(--faction-[A-Za-z0-9-]+)\s*:/g),
+    [...themes.light.keys(), ...themes.dark.keys()].filter((name) =>
+      name.startsWith("--faction-"),
+    ),
   );
 
   it("declares faction tokens in index.css at all (sanity check on the parse)", () => {

--- a/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
+++ b/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guard for the "looks tokenized, is not" failure class (#806).
+ *
+ * `var(--faction-does-not-exist)` passes tsc, eslint and the no-raw-style-values
+ * ratchet — a var() reference looks correctly tokenized to every check we run.
+ * At runtime the undefined custom property makes the whole declaration invalid
+ * (a color-mix() containing it resolves to nothing), so the chrome silently
+ * renders with no colour. Only a name-set comparison can catch it.
+ */
+
+const SRC_DIR = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".css"];
+
+function collectSourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(path);
+    return SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))
+      ? [path]
+      : [];
+  });
+}
+
+function matchAll(text: string, pattern: RegExp): string[] {
+  return [...text.matchAll(pattern)].map((match) => match[1]);
+}
+
+describe("faction CSS custom properties (#806)", () => {
+  const stylesheet = readFileSync(join(SRC_DIR, "index.css"), "utf-8");
+  const declared = new Set(
+    matchAll(stylesheet, /(--faction-[A-Za-z0-9-]+)\s*:/g),
+  );
+
+  it("declares faction tokens in index.css at all (sanity check on the parse)", () => {
+    expect(declared.size).toBeGreaterThan(50);
+    expect(declared.has("--faction-singularity-card-muted")).toBe(true);
+  });
+
+  it("has no var(--faction-*) reference pointing at an undeclared token", () => {
+    const orphans: string[] = [];
+
+    for (const file of collectSourceFiles(SRC_DIR)) {
+      const source = readFileSync(file, "utf-8");
+      for (const token of matchAll(
+        source,
+        /var\(\s*(--faction-[A-Za-z0-9-]+)/g,
+      )) {
+        if (!declared.has(token)) {
+          orphans.push(`${token} referenced in ${file}`);
+        }
+      }
+    }
+
+    expect(orphans).toEqual([]);
+  });
+});


### PR DESCRIPTION
`SingularityPraxisDetail.tsx` referenced `var(--faction-singularity-muted)` **20 times**. That token is never declared. The real name is `--faction-singularity-card-muted` (`#60a5fa`), declared in both theme blocks of `index.css`.

Every use sits inside a `color-mix()`, so the undefined custom property made the function invalid and the whole declaration was dropped — silently. `tsc`, `eslint` and the `no-raw-style-values` ratchet all pass on an undefined token, because a `var()` reference looks correctly tokenized to every gate we run.

## Changes

- Renamed all 20 references. Mechanical; no other change to the component.
- Added `frontend/src/utils/__tests__/factionTokensDeclared.test.ts` — every `var(--faction-*)` referenced under `frontend/src` must be declared in `index.css`.

## Sweep result (issue ask #2)

Extracted every `var(--faction-…)` reference in `frontend/src` and diffed against the names declared in `index.css`: **102 distinct tokens referenced, 112 declared.**

**`--faction-singularity-muted` was the only orphan in the entire frontend.** No other instance of this bug exists today — which is the useful negative result the issue asked for. (The 10 declared-but-unreferenced tokens are not a defect; an unused token renders nothing wrong.)

## On the test

The guard is static — a name-set comparison, which fits the `renderToStaticMarkup`-only harness. A "does it render blue" test does not.

Two things worth noting:

- It is **verified to catch the real bug**: reintroducing one bad reference makes it fail with `--faction-singularity-muted referenced in …`, then passes again once reverted.
- It caught its own docstring on the first run (the comment contains an illustrative `var(--faction-…)`), so `__tests__` is excluded from the reference scan. Declared-set parsing reuses the existing `cssVars.readThemes` helper rather than a bare regex, so a token merely *mentioned* in a CSS comment never counts as declared.

## What to eyeball

**The Singularity praxis-detail page.** This chrome is currently rendering with **no colour at all**, so the proof is that it *appears* — not that it compiles:

- the **sprocket strip**
- the **sprocket-hole borders**
- the **section-divider rules**
- the **outer box-shadow**

Both themes (Singularity is always dark, but the token is declared per-theme).

**Visual QA is outstanding** — I cannot screenshot in this environment and there is no dev stack running. Verified only via tests, `tsc`, `eslint` and `vite build`.

## Verification

- `vitest run` — 1066 tests / 106 files pass
- `eslint` on both touched files — clean
- `vite build` — succeeds
- `tsc --noEmit` — the only errors are the known stale-junction `Cannot find module 'node:fs'/'node:url'` false alarm (PR #675); the untouched, already-green `factionContrast.test.ts` reports the same, confirming it is environmental

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)