### PR TITLE
Cozy Coven: the eighth faction, from Warriors of Whimsy's aesthetic (#784)

### DIFF
--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -58,6 +58,22 @@ ERA_1_FACTIONS = {
         duel_win_modifier=1.5,
         duel_loss_modifier=0.5,
     ),
+    # Cozy Coven (#784) — the eighth faction. It inherits Warriors of Whimsy's
+    # lo-fi pink `.exe` AESTHETIC only; the modifiers below are the Era 1
+    # baseline, deliberately NOT wow's +10% own/collab pair above. Whether Cozy
+    # Coven should carry that bonus is a game-balance decision for the owner, not
+    # a consequence of the visual move, so it starts flat and is flagged rather
+    # than inherited silently.
+    "coven": FactionConfig(
+        slug="coven",
+        can_always_rejoin=False,
+        own_task_modifier=1.0,
+        other_task_modifier=1.0,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
+    ),
     "ephemerists": FactionConfig(
         slug="ephemerists",
         can_always_rejoin=False,

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -40,6 +40,32 @@ from models.task import Task, TaskStatus, TaskType
 HIDDEN_FACTION_SLUGS = frozenset({"aged_out", "na"})
 
 
+async def upsert_era_factions(session, era) -> int:
+    """Give every faction in the era config a `Faction` row, and return how many
+    were added.
+
+    The `Faction` table is a thin display mirror of the era config — slug plus
+    status, no rules (ADR-0038) — so this is idempotent and safe to run against
+    an already-seeded database. That matters because factions are added between
+    seeds: `Faction.slug` is a plain string primary key and `character.
+    faction_slug` a plain string foreign key, so a new faction needs a row here
+    and never an Alembic migration.
+    """
+    added = 0
+    for slug in era.factions:
+        existing = await session.execute(
+            select(Faction).where(Faction.slug == slug)
+        )
+        if existing.scalar_one_or_none() is None:
+            status = FactionStatus.hidden if slug in HIDDEN_FACTION_SLUGS else FactionStatus.visible
+            # ADR-0038: the row is slug + status only; name/description prose
+            # lives in frontend/src/locales/en/factions.json.
+            session.add(Faction(slug=slug, status=status))
+            added += 1
+    await session.flush()
+    return added
+
+
 # ---------------------------------------------------------------------------
 # Dev-only demo content
 # ---------------------------------------------------------------------------
@@ -156,6 +182,15 @@ async def seed(env: str, yes: bool) -> None:
 
         if pixie_acc and task_count > 0:
             print("Database already fully seeded (pixie account + tasks exist).")
+            # A faction added to the era config AFTER a database was seeded would
+            # otherwise never get its row: this branch used to return before
+            # Phase 1 ran (#784, Cozy Coven). The Faction table is a thin display
+            # mirror of the era config, so topping it up is always safe and needs
+            # no migration.
+            new_factions = await upsert_era_factions(session, era)
+            if new_factions > 0:
+                await session.commit()
+                print(f"  >Factions ({new_factions} new)")
             if env == "dev":
                 await seed_dev_demo(session)  # idempotent — tops up demo content
             await engine.dispose()
@@ -166,21 +201,7 @@ async def seed(env: str, yes: bool) -> None:
         # ------------------------------------------------------------------
         # Phase 1: Factions (from era config, upsert)
         # ------------------------------------------------------------------
-        faction_count = 0
-        for slug, faction_config in era.factions.items():
-            existing = await session.execute(
-                select(Faction).where(Faction.slug == slug)
-            )
-            if existing.scalar_one_or_none() is None:
-                status = FactionStatus.hidden if slug in HIDDEN_FACTION_SLUGS else FactionStatus.visible
-                # ADR-0038: the row is slug + status only; name/description prose
-                # lives in frontend/src/locales/en/factions.json.
-                session.add(Faction(
-                    slug=slug,
-                    status=status,
-                ))
-                faction_count += 1
-        await session.flush()
+        faction_count = await upsert_era_factions(session, era)
         if faction_count > 0:
             print(f"  >Factions ({faction_count} new)")
         else:

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -227,7 +227,7 @@ const wowScrapDeep: CSSProperties = {
   left: -4,
   right: -4,
   height: 24,
-  background: "var(--faction-wow-scrap-deep)",
+  background: "var(--faction-coven-scrap-deep)",
   border: "1.5px solid rgba(0,0,0,0.12)",
   transform: "rotate(-4deg)",
   borderRadius: 1,
@@ -239,7 +239,7 @@ const wowScrapMid: CSSProperties = {
   left: -2,
   right: -2,
   height: 36,
-  background: "var(--faction-wow-scrap-mid)",
+  background: "var(--faction-coven-scrap-mid)",
   border: "1.5px solid rgba(0,0,0,0.12)",
   transform: "rotate(3deg)",
   borderRadius: 1,
@@ -252,7 +252,7 @@ const wowTape: CSSProperties = {
   transform: "translateX(-50%) rotate(-1deg)",
   width: 48,
   height: 14,
-  background: "var(--faction-wow-tape)",
+  background: "var(--faction-coven-tape)",
   borderRadius: 1,
 };
 
@@ -270,12 +270,12 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
       <div
         style={{
           position: "relative",
-          background: factionCssVar("wow", "card-bg"),
+          background: factionCssVar("coven", "card-bg"),
           border: "1.5px solid rgba(0,0,0,0.12)",
           transform: "rotate(-2deg)",
           padding: "var(--space-xl) var(--space-lg) var(--space-lg)",
           fontFamily: "'Courier Prime', monospace",
-          color: factionCssVar("wow", "card-text"),
+          color: factionCssVar("coven", "card-text"),
           zIndex: 2,
           transition: "background 150ms, color 150ms",
           boxSizing: "border-box",
@@ -285,9 +285,9 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
-          tint={factionCssVar("wow", "card-accent")}
-          muted={factionCssVar("wow", "card-muted")}
-          paper={factionCssVar("wow", "card-bg")}
+          tint={factionCssVar("coven", "card-accent")}
+          muted={factionCssVar("coven", "card-muted")}
+          paper={factionCssVar("coven", "card-bg")}
           showCrown={showCrown}
         />
       </div>

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -220,7 +220,7 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
   );
 }
 
-/** The two offset scrap layers behind the WOW card, plus its tape. Static (#586). */
+/** The two offset scrap layers behind the COVEN card, plus its tape. Static (#586). */
 const wowScrapDeep: CSSProperties = {
   position: "absolute",
   top: 10,
@@ -256,7 +256,7 @@ const wowTape: CSSProperties = {
   borderRadius: 1,
 };
 
-export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
       style={{

--- a/frontend/src/components/__tests__/credentialCard.test.tsx
+++ b/frontend/src/components/__tests__/credentialCard.test.tsx
@@ -15,7 +15,7 @@ describe('CredentialCard', () => {
     expect(html).toContain('--faction-coven-card-bg')
     expect(html).toContain('Marlow Quill')
     expect(html).toContain('@marlowquill')
-    expect(html).toContain('Warriors of Whimsy') // faction pill label
+    expect(html).toContain('Cozy Coven') // faction pill label
     expect(html).toContain('42')
   })
 

--- a/frontend/src/components/__tests__/credentialCard.test.tsx
+++ b/frontend/src/components/__tests__/credentialCard.test.tsx
@@ -10,9 +10,9 @@ import CredentialCard from '../CredentialCard'
 describe('CredentialCard', () => {
   it('skins to the faction token set and shows the faction pill', () => {
     const html = renderToStaticMarkup(
-      <CredentialCard displayName="Marlow Quill" handle="marlowquill" bio="x" factionSlug="wow" level={3} score={42} />,
+      <CredentialCard displayName="Marlow Quill" handle="marlowquill" bio="x" factionSlug="coven" level={3} score={42} />,
     )
-    expect(html).toContain('--faction-wow-card-bg')
+    expect(html).toContain('--faction-coven-card-bg')
     expect(html).toContain('Marlow Quill')
     expect(html).toContain('@marlowquill')
     expect(html).toContain('Warriors of Whimsy') // faction pill label

--- a/frontend/src/components/__tests__/factionFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/factionFeedFrame.test.tsx
@@ -22,7 +22,7 @@ const CARD = <span>card-body</span>;
 const DESIGNED_FACTIONS = [
   "everymen",
   "ephemerists",
-  "wow",
+  "coven",
   "snide",
   "singularity",
   "ua",

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -17,10 +17,10 @@ function item(type: string, payload: Record<string, unknown>): ActivityFeedItem 
     type,
     timestamp: '2026-01-01T00:00:00Z',
     actor_display_name: 'Ada',
-    actor_faction_slug: 'wow',
+    actor_faction_slug: 'coven',
     actor_avatar_url: null,
     payload,
-    context_faction_slug: 'wow',
+    context_faction_slug: 'coven',
   }
 }
 
@@ -61,7 +61,7 @@ describe('normalizeFeedItem', () => {
       item('foe_taunt', {
         from_character_id: 9,
         taunt_id: 9,
-        faction_slug: 'wow',
+        faction_slug: 'coven',
         trigger_type: 'score_overtake',
         from_name: 'Ada',
         to_name: 'Bo',

--- a/frontend/src/components/__tests__/voteReframes.test.tsx
+++ b/frontend/src/components/__tests__/voteReframes.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../auth/AuthContext', () => ({
 const REGISTERED_SLUGS = [
   'ephemerists',
   'everymen',
-  'wow',
+  'coven',
   'snide',
   'singularity',
   'ua',

--- a/frontend/src/components/avatar/CovenAvatar.tsx
+++ b/frontend/src/components/avatar/CovenAvatar.tsx
@@ -22,13 +22,13 @@ export default function CovenAvatar({ character, size }: FactionAvatarProps) {
       character={character}
       size={size}
       circle={{
-        borderColor: 'var(--faction-wow-win-border)',
-        bg: 'var(--faction-wow-notepad-bg)',
-        textColor: 'var(--faction-wow-card-text)',
-        fontFamily: 'var(--faction-wow-card-font)',
+        borderColor: 'var(--faction-coven-win-border)',
+        bg: 'var(--faction-coven-notepad-bg)',
+        textColor: 'var(--faction-coven-card-text)',
+        fontFamily: 'var(--faction-coven-card-font)',
       }}
-      badgeBg="var(--faction-wow)"
-      badgeRing="var(--faction-wow-notepad-bg)"
+      badgeBg="var(--faction-coven)"
+      badgeRing="var(--faction-coven-notepad-bg)"
       glyph={(s, color) => <MoonGlyph size={s} color={color} />}
     />
   )

--- a/frontend/src/components/avatar/CovenAvatar.tsx
+++ b/frontend/src/components/avatar/CovenAvatar.tsx
@@ -16,7 +16,7 @@ function MoonGlyph({ size, color }: { size: number; color: string }) {
  * Warriors of Whimsy avatar — the standard circle with a pink "coven" moon membership
  * badge clipped to the lower-right.
  */
-export default function WowAvatar({ character, size }: FactionAvatarProps) {
+export default function CovenAvatar({ character, size }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}

--- a/frontend/src/components/backdrop/CovenBackdrop.tsx
+++ b/frontend/src/components/backdrop/CovenBackdrop.tsx
@@ -1,8 +1,8 @@
 /**
  * Warriors of Whimsy full-page backdrop — a lo-fi pastel "desktop": soft pink field with a
- * dotted grid and a gentle corner glow. Theme-aware via the `.wow-backdrop`
+ * dotted grid and a gentle corner glow. Theme-aware via the `.coven-backdrop`
  * rule in index.css. Fixed behind page content at z-index 0.
  */
 export default function CovenBackdrop() {
-  return <div className="wow-backdrop" aria-hidden="true" />
+  return <div className="coven-backdrop" aria-hidden="true" />
 }

--- a/frontend/src/components/backdrop/CovenBackdrop.tsx
+++ b/frontend/src/components/backdrop/CovenBackdrop.tsx
@@ -3,6 +3,6 @@
  * dotted grid and a gentle corner glow. Theme-aware via the `.wow-backdrop`
  * rule in index.css. Fixed behind page content at z-index 0.
  */
-export default function WowBackdrop() {
+export default function CovenBackdrop() {
   return <div className="wow-backdrop" aria-hidden="true" />
 }

--- a/frontend/src/components/cards/CovenFactionHero.tsx
+++ b/frontend/src/components/cards/CovenFactionHero.tsx
@@ -104,9 +104,9 @@ export default function CovenFactionHero({
   // ponytail: three real counts. seasonRank / total-points-won aren't sourced yet
   // (no leaderboard/aggregate endpoint) — add charms when they are.
   const statTags = [
-    { value: members, label: i18n.t("feed:factionHero.wow.stats.members"), color: PINK, rot: "-3deg" },
-    { value: tasks, label: i18n.t("feed:factionHero.wow.stats.tasks"), color: IVY, rot: "2.5deg" },
-    { value: praxes, label: i18n.t("feed:factionHero.wow.stats.praxes"), color: ACCENT, rot: "-2deg" },
+    { value: members, label: i18n.t("feed:factionHero.coven.stats.members"), color: PINK, rot: "-3deg" },
+    { value: tasks, label: i18n.t("feed:factionHero.coven.stats.tasks"), color: IVY, rot: "2.5deg" },
+    { value: praxes, label: i18n.t("feed:factionHero.coven.stats.praxes"), color: ACCENT, rot: "-2deg" },
   ];
 
   return (
@@ -159,7 +159,7 @@ export default function CovenFactionHero({
                 marginBottom: "var(--space-xs)",
               }}
             >
-              {i18n.t("feed:factionHero.wow.eyebrow")}
+              {i18n.t("feed:factionHero.coven.eyebrow")}
             </div>
             <h1
               style={{
@@ -176,7 +176,7 @@ export default function CovenFactionHero({
               {name}
             </h1>
             <div style={{ fontFamily: SCRIPT, fontSize: "var(--text-title)", color: PINK, marginTop: "var(--space-xs)" }}>
-              {i18n.t("feed:factionHero.wow.motto")}
+              {i18n.t("feed:factionHero.coven.motto")}
             </div>
             <p
               className="content-text"
@@ -188,7 +188,7 @@ export default function CovenFactionHero({
                 margin: "var(--space-sm) 0 0",
               }}
             >
-              {description ?? i18n.t("feed:factionHero.wow.descriptionFallback")}
+              {description ?? i18n.t("feed:factionHero.coven.descriptionFallback")}
             </p>
           </div>
 

--- a/frontend/src/components/cards/CovenFactionHero.tsx
+++ b/frontend/src/components/cards/CovenFactionHero.tsx
@@ -9,7 +9,7 @@ import i18n from "../../i18n";
  * in a SIDE column (never a full-width band). Two pushpins tack the banner down.
  * Ported from the WoW design kit; conforms to {@link FactionHeroProps}.
  *
- * Theme-aware through the cascade: every colour resolves to a --faction-wow-*
+ * Theme-aware through the cascade: every colour resolves to a --faction-coven-*
  * token (which already carries light + dark values), so the board never mutates
  * the global theme. The script face is the WoW card-font token (Caveat); body
  * copy uses --font-body, matching CovenTaskCard / the WoW PraxisCard branch.
@@ -18,25 +18,25 @@ import i18n from "../../i18n";
  * Motto is a faction constant (not a backend field).
  */
 
-// Token shorthands — every value resolves to a --faction-wow-* var.
-const PINK = "var(--faction-wow)";
-const CARD_BG = "var(--faction-wow-card-bg)";
-const INK = "var(--faction-wow-card-text)";
-const ACCENT = "var(--faction-wow-card-accent)";
-const MUTED = "var(--faction-wow-card-muted)";
-const NOTEPAD = "var(--faction-wow-notepad-bg)";
-const WIN_BORDER = "var(--faction-wow-win-border)";
-const TITLE_TO = "var(--faction-wow-title-to)";
-const IVY = "var(--faction-wow-ivy)";
-const IVY_LEAF = "var(--faction-wow-ivy-leaf)";
-const DOT = "var(--faction-wow-dot)";
+// Token shorthands — every value resolves to a --faction-coven-* var.
+const PINK = "var(--faction-coven)";
+const CARD_BG = "var(--faction-coven-card-bg)";
+const INK = "var(--faction-coven-card-text)";
+const ACCENT = "var(--faction-coven-card-accent)";
+const MUTED = "var(--faction-coven-card-muted)";
+const NOTEPAD = "var(--faction-coven-notepad-bg)";
+const WIN_BORDER = "var(--faction-coven-win-border)";
+const TITLE_TO = "var(--faction-coven-title-to)";
+const IVY = "var(--faction-coven-ivy)";
+const IVY_LEAF = "var(--faction-coven-ivy-leaf)";
+const DOT = "var(--faction-coven-dot)";
 
-const SCRIPT = "var(--faction-wow-card-font)";
+const SCRIPT = "var(--faction-coven-card-font)";
 const BODY = "var(--font-body)";
 
 // The board's board-brown shadow has no dedicated token; the WoW atoms use a raw
 // warm-brown rgba for their pinned-paper drop shadows. Reuse the same value.
-// ponytail: no --faction-wow-board-shadow token exists; matching the atoms' rgba.
+// ponytail: no --faction-coven-board-shadow token exists; matching the atoms' rgba.
 const BOARD_SHADOW = "rgba(80,50,30,0.3)";
 
 /** Tiny four-point sparkle — same glyph the WoW task/window chrome uses. */

--- a/frontend/src/components/cards/CovenFactionHero.tsx
+++ b/frontend/src/components/cards/CovenFactionHero.tsx
@@ -12,7 +12,7 @@ import i18n from "../../i18n";
  * Theme-aware through the cascade: every colour resolves to a --faction-wow-*
  * token (which already carries light + dark values), so the board never mutates
  * the global theme. The script face is the WoW card-font token (Caveat); body
- * copy uses --font-body, matching WowTaskCard / the WoW PraxisCard branch.
+ * copy uses --font-body, matching CovenTaskCard / the WoW PraxisCard branch.
  *
  * The page passes raw counts; the faction labels them in its own whimsy voice.
  * Motto is a faction constant (not a backend field).
@@ -93,7 +93,7 @@ function Pushpin({ color, style }: { color: string; style?: CSSProperties }) {
   );
 }
 
-export default function WowFactionHero({
+export default function CovenFactionHero({
   name,
   description,
   members,

--- a/frontend/src/components/cards/CovenSigil.tsx
+++ b/frontend/src/components/cards/CovenSigil.tsx
@@ -3,11 +3,11 @@
  *
  * The single canonical COVEN emblem, drawn once and reused everywhere the sparkle
  * appears (faction-select tile, the wow.exe title bar, mobile praxis card).
- * Colors come from the --faction-wow token by default — never hardcode hex.
+ * Colors come from the --faction-coven token by default — never hardcode hex.
  */
 export function CovenSigil({
   size = 22,
-  color = "var(--faction-wow)",
+  color = "var(--faction-coven)",
 }: {
   size?: number;
   color?: string;

--- a/frontend/src/components/cards/CovenSigil.tsx
+++ b/frontend/src/components/cards/CovenSigil.tsx
@@ -1,11 +1,11 @@
 /**
- * WowSigil — the Warriors of Whimsy four-point sparkle, the faction's only mark.
+ * CovenSigil — the Warriors of Whimsy four-point sparkle, the faction's only mark.
  *
- * The single canonical WOW emblem, drawn once and reused everywhere the sparkle
+ * The single canonical COVEN emblem, drawn once and reused everywhere the sparkle
  * appears (faction-select tile, the wow.exe title bar, mobile praxis card).
  * Colors come from the --faction-wow token by default — never hardcode hex.
  */
-export function WowSigil({
+export function CovenSigil({
   size = 22,
   color = "var(--faction-wow)",
 }: {

--- a/frontend/src/components/cards/CovenTaskCard.tsx
+++ b/frontend/src/components/cards/CovenTaskCard.tsx
@@ -49,7 +49,7 @@ function WindowDot({ color }: { color: string }) {
   );
 }
 
-export default function WowTaskCard({
+export default function CovenTaskCard({
   task,
   displayPoints,
   onSignup,

--- a/frontend/src/components/cards/CovenTaskCard.tsx
+++ b/frontend/src/components/cards/CovenTaskCard.tsx
@@ -62,7 +62,7 @@ export default function CovenTaskCard({
         flex: "0 1 196px",
         borderRadius: 12,
         overflow: "hidden",
-        border: "2px solid var(--faction-wow-win-border)",
+        border: "2px solid var(--faction-coven-win-border)",
         fontFamily: "var(--font-body)",
         transition: "border-color 150ms",
       }}
@@ -75,8 +75,8 @@ export default function CovenTaskCard({
           gap: "var(--space-sm)",
           padding: "var(--space-sm) var(--space-sm)",
           background:
-            "linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))",
-          borderBottom: "2px solid var(--faction-wow-win-border)",
+            "linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))",
+          borderBottom: "2px solid var(--faction-coven-win-border)",
         }}
       >
         <div style={{ display: "flex", gap: "var(--space-xs)" }}>
@@ -91,10 +91,10 @@ export default function CovenTaskCard({
             gap: "var(--space-xs)",
             fontSize: "var(--text-base)",
             letterSpacing: "0.03em",
-            color: "var(--faction-wow-title-text)",
+            color: "var(--faction-coven-title-text)",
           }}
         >
-          <Sparkle size={9} color="var(--faction-wow-title-text)" />
+          <Sparkle size={9} color="var(--faction-coven-title-text)" />
           {i18n.t("feed:taskCard.wow.windowTitle")}
         </span>
         <span
@@ -103,7 +103,7 @@ export default function CovenTaskCard({
             fontSize: "var(--text-base)",
             opacity: 0.75,
             letterSpacing: "1.5px",
-            color: "var(--faction-wow-title-text)",
+            color: "var(--faction-coven-title-text)",
           }}
         >
           ▭ ✕
@@ -115,9 +115,9 @@ export default function CovenTaskCard({
         style={
           {
             padding: "var(--space-md) var(--space-md) var(--space-md)",
-            background: "var(--faction-wow-body-bg)",
+            background: "var(--faction-coven-body-bg)",
             backgroundImage:
-              "radial-gradient(var(--faction-wow-dot) 1.4px, transparent 1.4px)",
+              "radial-gradient(var(--faction-coven-dot) 1.4px, transparent 1.4px)",
             backgroundSize: "13px 13px",
           } as React.CSSProperties
         }
@@ -125,8 +125,8 @@ export default function CovenTaskCard({
         {/* notepad panel */}
         <div
           style={{
-            background: "var(--faction-wow-notepad-bg)",
-            border: "1.5px solid var(--faction-wow-notepad-border)",
+            background: "var(--faction-coven-notepad-bg)",
+            border: "1.5px solid var(--faction-coven-notepad-border)",
             borderRadius: 7,
             padding: "var(--space-sm) var(--space-md)",
             marginBottom: "var(--space-md)",
@@ -134,7 +134,7 @@ export default function CovenTaskCard({
         >
           <div
             className="card-meta"
-            style={{ color: "var(--faction-wow-card-accent)" }}
+            style={{ color: "var(--faction-coven-card-accent)" }}
           >
             {i18n.t("feed:taskCard.wow.questMeta", { points: displayPoints })}
           </div>
@@ -146,11 +146,11 @@ export default function CovenTaskCard({
             <div
               className="content-title"
               style={{
-                fontFamily: "var(--faction-wow-card-font)",
+                fontFamily: "var(--faction-coven-card-font)",
                 fontWeight: 700,
                 lineHeight: 1.05,
                 marginBottom: "var(--space-xs)",
-                color: "var(--faction-wow-card-text)",
+                color: "var(--faction-coven-card-text)",
                 overflowWrap: "anywhere",
               }}
             >
@@ -161,7 +161,7 @@ export default function CovenTaskCard({
           {task.description && (
             <div
               className="card-description"
-              style={{ color: "var(--faction-wow-card-muted)" }}
+              style={{ color: "var(--faction-coven-card-muted)" }}
             >
               {task.description}
             </div>
@@ -180,14 +180,14 @@ export default function CovenTaskCard({
 
         {/* status row */}
         <div className="card-footer">
-          <LevelGem level={task.level_required} factionSlug="wow" />
+          <LevelGem level={task.level_required} factionSlug="coven" />
           {/* Points shown as a ◆ corner-counter — a badge/counter, so it stays
               label-tier per the role vocabulary (§4), not a plain score number. */}
           <span
             style={{
               fontSize: "var(--text-sm)",
               letterSpacing: "0.1em",
-              color: "var(--faction-wow-card-accent)",
+              color: "var(--faction-coven-card-accent)",
             }}
           >
             ◆ {i18n.t("feed:taskCard.wow.points", { points: displayPoints })}

--- a/frontend/src/components/cards/CovenTaskCard.tsx
+++ b/frontend/src/components/cards/CovenTaskCard.tsx
@@ -95,7 +95,7 @@ export default function CovenTaskCard({
           }}
         >
           <Sparkle size={9} color="var(--faction-coven-title-text)" />
-          {i18n.t("feed:taskCard.wow.windowTitle")}
+          {i18n.t("feed:taskCard.coven.windowTitle")}
         </span>
         <span
           style={{
@@ -136,7 +136,7 @@ export default function CovenTaskCard({
             className="card-meta"
             style={{ color: "var(--faction-coven-card-accent)" }}
           >
-            {i18n.t("feed:taskCard.wow.questMeta", { points: displayPoints })}
+            {i18n.t("feed:taskCard.coven.questMeta", { points: displayPoints })}
           </div>
 
           <Link
@@ -174,7 +174,7 @@ export default function CovenTaskCard({
             className="btn-primary"
             style={{ fontSize: "var(--text-xs)", padding: "var(--space-xs) var(--space-sm)", marginBottom: "var(--space-sm)" }}
           >
-            {i18n.t("feed:taskCard.wow.signup")}
+            {i18n.t("feed:taskCard.coven.signup")}
           </button>
         )}
 
@@ -190,7 +190,7 @@ export default function CovenTaskCard({
               color: "var(--faction-coven-card-accent)",
             }}
           >
-            ◆ {i18n.t("feed:taskCard.wow.points", { points: displayPoints })}
+            ◆ {i18n.t("feed:taskCard.coven.points", { points: displayPoints })}
           </span>
         </div>
       </div>

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -293,7 +293,7 @@ export function CovenCard({
               letterSpacing: "0.03em",
             }}
           >
-            <CovenSigil size={10} color={titleText} /> {i18n.t("feed:identity.wow.windowTitle")}
+            <CovenSigil size={10} color={titleText} /> {i18n.t("feed:identity.coven.windowTitle")}
           </span>
           <span
             style={{
@@ -361,7 +361,7 @@ export function CovenCard({
                 marginBottom: "var(--space-xs)",
               }}
             >
-              <StatusBadge status={status} slug="wow" />
+              <StatusBadge status={status} slug="coven" />
             </div>
             <div
               style={{

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -213,7 +213,7 @@ export function CovenCard({
 }: FactionCardProps) {
   const fullDesc = factionDescription(faction.slug);
   const desc = fullDesc.slice(0, 100) + (fullDesc.length > 100 ? "…" : "");
-  const titleText = "var(--faction-wow-title-text)";
+  const titleText = "var(--faction-coven-title-text)";
   return (
     <div
       style={
@@ -232,7 +232,7 @@ export function CovenCard({
             position: "relative",
             borderRadius: 12,
             overflow: "hidden",
-            border: "2px solid var(--faction-wow-win-border)",
+            border: "2px solid var(--faction-coven-win-border)",
             transition: "background 150ms, color 150ms",
             boxSizing: "border-box",
           } as React.CSSProperties
@@ -248,8 +248,8 @@ export function CovenCard({
               // eslint-disable-next-line local/no-raw-style-values -- ornament: inset of the drawn window title bar; rounding reflows the chrome.
               padding: "7px 11px",
               background:
-                "linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))",
-              borderBottom: "2px solid var(--faction-wow-win-border)",
+                "linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))",
+              borderBottom: "2px solid var(--faction-coven-win-border)",
             } as React.CSSProperties
           }
         >
@@ -314,9 +314,9 @@ export function CovenCard({
             {
               position: "relative",
               padding: "var(--space-lg) var(--space-lg) var(--space-md)",
-              background: "var(--faction-wow-body-bg)",
+              background: "var(--faction-coven-body-bg)",
               backgroundImage:
-                "radial-gradient(var(--faction-wow-dot) 1.4px, transparent 1.4px)",
+                "radial-gradient(var(--faction-coven-dot) 1.4px, transparent 1.4px)",
               backgroundSize: "13px 13px",
             } as React.CSSProperties
           }
@@ -333,8 +333,8 @@ export function CovenCard({
             }}
           >
             <CovenIvySticker
-              stem="var(--faction-wow-ivy)"
-              leaf="var(--faction-wow-ivy-leaf)"
+              stem="var(--faction-coven-ivy)"
+              leaf="var(--faction-coven-ivy-leaf)"
             />
           </span>
           {invitationNote && (
@@ -346,8 +346,8 @@ export function CovenCard({
               {
                 position: "relative",
                 zIndex: 2,
-                background: "var(--faction-wow-notepad-bg)",
-                border: "1.5px solid var(--faction-wow-notepad-border)",
+                background: "var(--faction-coven-notepad-bg)",
+                border: "1.5px solid var(--faction-coven-notepad-border)",
                 borderRadius: 7,
                 padding: "var(--space-md)",
                 marginBottom: "var(--space-md)",
@@ -357,7 +357,7 @@ export function CovenCard({
             <div
               className="card-meta"
               style={{
-                color: factionCssVar("wow", "card-accent"),
+                color: factionCssVar("coven", "card-accent"),
                 marginBottom: "var(--space-xs)",
               }}
             >
@@ -365,12 +365,12 @@ export function CovenCard({
             </div>
             <div
               style={{
-                fontFamily: factionCssVar("wow", "card-font"),
+                fontFamily: factionCssVar("coven", "card-font"),
                 // eslint-disable-next-line local/no-raw-style-values -- ornament: faction name in Caveat at notepad-headline size — the archetype's voice
                 fontSize: 26,
                 fontWeight: 700,
                 lineHeight: 1.05,
-                color: factionCssVar("wow", "card-text"),
+                color: factionCssVar("coven", "card-text"),
                 marginBottom: "var(--space-xs)",
               }}
             >
@@ -381,7 +381,7 @@ export function CovenCard({
                 className="card-description"
                 style={{
                   lineHeight: 1.5,
-                  color: factionCssVar("wow", "card-muted"),
+                  color: factionCssVar("coven", "card-muted"),
                 }}
               >
                 {desc}

--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -5,7 +5,7 @@ import { pickVariant } from "../../utils/factionDispatch";
 import { surfaceMap } from "../../factions";
 import SnideMasthead from "./SnideMasthead";
 import { EphSeal, LapisLastWord } from "./ephemeristsAtoms";
-import { WowSigil } from "./WowSigil";
+import { CovenSigil } from "./CovenSigil";
 
 /**
  * FactionCard — faction-archetype switcher.
@@ -184,7 +184,7 @@ export function UaCard({
 // ─── Warriors of Whimsy ".exe" window atoms ──────────────────────────────────────────────
 
 /** A tiny white die-cut ivy sticker peeking off the window corner. */
-function WowIvySticker({
+function CovenIvySticker({
   stem,
   leaf,
 }: {
@@ -206,7 +206,7 @@ function WowIvySticker({
   );
 }
 
-export function WowCard({
+export function CovenCard({
   faction,
   status,
   invitationNote,
@@ -293,7 +293,7 @@ export function WowCard({
               letterSpacing: "0.03em",
             }}
           >
-            <WowSigil size={10} color={titleText} /> {i18n.t("feed:identity.wow.windowTitle")}
+            <CovenSigil size={10} color={titleText} /> {i18n.t("feed:identity.wow.windowTitle")}
           </span>
           <span
             style={{
@@ -332,7 +332,7 @@ export function WowCard({
               pointerEvents: "none",
             }}
           >
-            <WowIvySticker
+            <CovenIvySticker
               stem="var(--faction-wow-ivy)"
               leaf="var(--faction-wow-ivy-leaf)"
             />

--- a/frontend/src/components/cards/FactionSelectCard.tsx
+++ b/frontend/src/components/cards/FactionSelectCard.tsx
@@ -89,7 +89,7 @@ export function UaSelectCard({ state = "locked", members, onVisit }: Omit<Factio
 }
 
 export function COVENSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
-  const status = i18n.t(`feed:factionSelect.wow.status.${state}` as const);
+  const status = i18n.t(`feed:factionSelect.coven.status.${state}` as const);
   return (
     <div style={{
       width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
@@ -104,31 +104,31 @@ export function COVENSelectCard({ state = "locked", members, onVisit }: Omit<Fac
         <span style={{ display: "flex", gap: 6 }}>
           {["#f6c75e", "#7fc59e", "#ec5f99"].map((color) => <i key={color} style={{ width: 11, height: 11, borderRadius: "50%", background: color, border: "1px solid rgba(0,0,0,0.15)" }} />)}
         </span>
-        <span style={{ fontSize: "var(--text-lg)", color: "var(--gestalt-title-text)", letterSpacing: "0.02em" }}>{i18n.t("feed:identity.wow.windowTitle")}</span>
+        <span style={{ fontSize: "var(--text-lg)", color: "var(--gestalt-title-text)", letterSpacing: "0.02em" }}>{i18n.t("feed:identity.coven.windowTitle")}</span>
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ▢ ✕ are drawn window-chrome glyphs used as icons, not text */}
         <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--gestalt-title-text)", opacity: 0.7 }}>▢ ✕</span>
       </div>
       <div style={{ flex: 1, padding: "var(--space-lg) var(--space-xl) 0", position: "relative" }}>
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: hand-script faction name, the whimsy.exe window's display type */}
         <div style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 27, lineHeight: 1.1, color: "var(--gestalt-ink)", whiteSpace: "nowrap" }}>
-          <span style={{ display: "inline-block", verticalAlign: "-3px", marginRight: "var(--space-sm)" }}><CovenSigil size={18} color="var(--faction-coven)" /></span>{i18n.t("feed:factionSelect.wow.name")}
+          <span style={{ display: "inline-block", verticalAlign: "-3px", marginRight: "var(--space-sm)" }}><CovenSigil size={18} color="var(--faction-coven)" /></span>{i18n.t("feed:factionSelect.coven.name")}
         </div>
         <p className="content-text" style={{ margin: "var(--space-md) 0 0", lineHeight: 1.6, color: "var(--gestalt-ink-soft)" }}>
-          {i18n.t("feed:factionSelect.wow.blurb")}
+          {i18n.t("feed:factionSelect.coven.blurb")}
         </p>
       </div>
       <div style={{ padding: "0 var(--space-xl) var(--space-lg)" }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-md)", marginBottom: "var(--space-md)" }}>
           {/* eslint-disable-next-line local/no-raw-style-values -- ornament: inset of the rotated status sticker; rounding reflows the sticker. */}
           <div style={{ transform: "rotate(-1.5deg)", background: "var(--gestalt-pink-lt)", color: "var(--gestalt-ink)", fontSize: "var(--text-md)", padding: "5px 10px", borderRadius: 4 }}>{status}</div>
-          {members != null && <div style={{ flexShrink: 0, fontSize: "var(--text-sm)", letterSpacing: "0.04em", color: "var(--gestalt-label)" }}>{i18n.t("feed:factionSelect.wow.members", { count: members })}</div>}
+          {members != null && <div style={{ flexShrink: 0, fontSize: "var(--text-sm)", letterSpacing: "0.04em", color: "var(--gestalt-label)" }}>{i18n.t("feed:factionSelect.coven.members", { count: members })}</div>}
         </div>
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer",
           border: "1.5px solid var(--gestalt-pink)", borderRadius: 7, background: "var(--gestalt-pink)", color: "#fff",
           // eslint-disable-next-line local/no-raw-style-values -- ornament: CTA is set in the faction's hand-script at display size; a label token would flatten the archetype (§270)
           fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 21, padding: "var(--space-sm) var(--space-lg)",
-        }}>{i18n.t("feed:factionSelect.wow.cta")}</button>
+        }}>{i18n.t("feed:factionSelect.coven.cta")}</button>
       </div>
     </div>
   );
@@ -374,7 +374,7 @@ export function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit
 // change (these two slugs are not in FACTION_ALIASES), so it is left alone here
 // and tracked as follow-up.
 const LEGACY_SLUG: Record<string, string> = {
-  gestalt: "wow",
+  gestalt: "coven",
   journeymen: "ephemerists",
 };
 

--- a/frontend/src/components/cards/FactionSelectCard.tsx
+++ b/frontend/src/components/cards/FactionSelectCard.tsx
@@ -2,7 +2,7 @@ import i18n from "../../i18n";
 import { pickVariant } from "../../utils/factionDispatch";
 import { surfaceMap } from "../../factions";
 import { UaSigil } from "./UaSigil";
-import { WowSigil } from "./WowSigil";
+import { CovenSigil } from "./CovenSigil";
 import { SnideSigil } from "../snide/snideAtoms";
 import { EphemeristsSigil } from "./ephemeristsAtoms";
 import { SingularitySigil } from "./SingularitySigil";
@@ -88,7 +88,7 @@ export function UaSelectCard({ state = "locked", members, onVisit }: Omit<Factio
   );
 }
 
-export function WOWSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
+export function COVENSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.wow.status.${state}` as const);
   return (
     <div style={{
@@ -111,7 +111,7 @@ export function WOWSelectCard({ state = "locked", members, onVisit }: Omit<Facti
       <div style={{ flex: 1, padding: "var(--space-lg) var(--space-xl) 0", position: "relative" }}>
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: hand-script faction name, the whimsy.exe window's display type */}
         <div style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 27, lineHeight: 1.1, color: "var(--gestalt-ink)", whiteSpace: "nowrap" }}>
-          <span style={{ display: "inline-block", verticalAlign: "-3px", marginRight: "var(--space-sm)" }}><WowSigil size={18} color="var(--faction-wow)" /></span>{i18n.t("feed:factionSelect.wow.name")}
+          <span style={{ display: "inline-block", verticalAlign: "-3px", marginRight: "var(--space-sm)" }}><CovenSigil size={18} color="var(--faction-wow)" /></span>{i18n.t("feed:factionSelect.wow.name")}
         </div>
         <p className="content-text" style={{ margin: "var(--space-md) 0 0", lineHeight: 1.6, color: "var(--gestalt-ink-soft)" }}>
           {i18n.t("feed:factionSelect.wow.blurb")}

--- a/frontend/src/components/cards/FactionSelectCard.tsx
+++ b/frontend/src/components/cards/FactionSelectCard.tsx
@@ -111,7 +111,7 @@ export function COVENSelectCard({ state = "locked", members, onVisit }: Omit<Fac
       <div style={{ flex: 1, padding: "var(--space-lg) var(--space-xl) 0", position: "relative" }}>
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: hand-script faction name, the whimsy.exe window's display type */}
         <div style={{ fontFamily: "var(--font-faction-script)", fontWeight: 700, fontSize: 27, lineHeight: 1.1, color: "var(--gestalt-ink)", whiteSpace: "nowrap" }}>
-          <span style={{ display: "inline-block", verticalAlign: "-3px", marginRight: "var(--space-sm)" }}><CovenSigil size={18} color="var(--faction-wow)" /></span>{i18n.t("feed:factionSelect.wow.name")}
+          <span style={{ display: "inline-block", verticalAlign: "-3px", marginRight: "var(--space-sm)" }}><CovenSigil size={18} color="var(--faction-coven)" /></span>{i18n.t("feed:factionSelect.wow.name")}
         </div>
         <p className="content-text" style={{ margin: "var(--space-md) 0 0", lineHeight: 1.6, color: "var(--gestalt-ink-soft)" }}>
           {i18n.t("feed:factionSelect.wow.blurb")}

--- a/frontend/src/components/collab/__tests__/collabCopy.test.ts
+++ b/frontend/src/components/collab/__tests__/collabCopy.test.ts
@@ -19,7 +19,7 @@ const FACTION_SLUGS = [
   'snide',
   'singularity',
   'ua',
-  'wow',
+  'coven',
   'albescent',
 ] as const
 
@@ -27,8 +27,8 @@ const SHARED_KEYS = Object.keys(forms.editPraxis.collab) as CollabCopyKey[]
 
 describe('collabCopy — faction override resolution', () => {
   it('resolves a faction override when one exists', () => {
-    // wow keeps the witch-walk diction; everymen files a work report.
-    expect(collabCopy('wow', 'pillWeaving')).toBe('still walking')
+    // coven keeps the witch-walk diction; everymen files a work report.
+    expect(collabCopy('coven', 'pillWeaving')).toBe('still walking')
     expect(collabCopy('everymen', 'pillWeaving')).toBe('still on the clock')
     expect(collabCopy('singularity', 'pillWeaving')).toBe('pending')
   })

--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -34,7 +34,7 @@ function Window({ title, children }: { title: string; children: React.ReactNode 
   )
 }
 
-export default function WowComment(props: CommentProps) {
+export default function CovenComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props

--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -71,7 +71,7 @@ export default function CovenComment(props: CommentProps) {
             <span>
               {' · '}
               {formatCommentTime(slug, comment.created_at)}
-              {comment.is_edited ? ` · ${t('comments.wow.edited')}` : ''}
+              {comment.is_edited ? ` · ${t('comments.coven.edited')}` : ''}
             </span>
             <OwnerControls owner={owner} />
             <CommentFlagControl comment={comment} />

--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -8,7 +8,7 @@ import { CommentFlagControl } from '../FlagControl'
 
 /**
  * Warriors of Whimsy — `{handle}.exe` (ADR-0018). Reuses the task-card window
- * chrome verbatim (--faction-wow-win-border / title gradient / dotted body),
+ * chrome verbatim (--faction-coven-win-border / title gradient / dotted body),
  * retitled to the author's handle. Handwritten Caveat body.
  */
 function Dot({ color }: { color: string }) {
@@ -17,17 +17,17 @@ function Dot({ color }: { color: string }) {
 
 function Window({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div style={{ border: '2px solid var(--faction-wow-win-border)', borderRadius: 11, overflow: 'hidden' }}>
-      <div style={{ display: 'flex', alignItems: 'center', padding: 'var(--space-sm) var(--space-md)', background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))', borderBottom: '2px solid var(--faction-wow-win-border)',
+    <div style={{ border: '2px solid var(--faction-coven-win-border)', borderRadius: 11, overflow: 'hidden' }}>
+      <div style={{ display: 'flex', alignItems: 'center', padding: 'var(--space-sm) var(--space-md)', background: 'linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))', borderBottom: '2px solid var(--faction-coven-win-border)',
         // eslint-disable-next-line local/no-raw-style-values -- ornament: rhythm of the three drawn traffic-light dots, not layout spacing
         gap: 7 }}>
         <Dot color="#fb7aa8" /><Dot color="#f6c75e" /><Dot color="#86cfa6" />
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: window title bar + close glyphs, part of the desktop-window illustration */}
-        <span style={{ fontSize: 10, letterSpacing: '0.03em', color: 'var(--faction-wow-title-text)', marginLeft: 2 }}>✦ {title}</span>
+        <span style={{ fontSize: 10, letterSpacing: '0.03em', color: 'var(--faction-coven-title-text)', marginLeft: 2 }}>✦ {title}</span>
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the ▭ ✕ window glyphs are drawn chrome, not typeset copy */}
-        <span style={{ marginLeft: 'auto', fontSize: 10, opacity: 0.8, letterSpacing: '1.5px', color: 'var(--faction-wow-title-text)' }}>▭ ✕</span>
+        <span style={{ marginLeft: 'auto', fontSize: 10, opacity: 0.8, letterSpacing: '1.5px', color: 'var(--faction-coven-title-text)' }}>▭ ✕</span>
       </div>
-      <div style={{ padding: 'var(--space-md) var(--space-lg)', background: 'var(--faction-wow-body-bg)', backgroundImage: 'radial-gradient(var(--faction-wow-dot) 1.4px, transparent 1.4px)', backgroundSize: '13px 13px' }}>
+      <div style={{ padding: 'var(--space-md) var(--space-lg)', background: 'var(--faction-coven-body-bg)', backgroundImage: 'radial-gradient(var(--faction-coven-dot) 1.4px, transparent 1.4px)', backgroundSize: '13px 13px' }}>
         {children}
       </div>
     </div>
@@ -43,7 +43,7 @@ export default function CovenComment(props: CommentProps) {
         <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
           <FactionAvatar character={character} size="sm" />
           <div style={{ flex: 1 }}>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-wow-card-accent)" bg="var(--faction-wow-notepad-bg)" text="var(--faction-wow-card-text)" />
+            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-coven-card-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
           </div>
         </div>
       </Window>
@@ -57,14 +57,14 @@ export default function CovenComment(props: CommentProps) {
       <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
         <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontFamily: 'var(--faction-wow-card-font)', fontSize: 'var(--text-content)', lineHeight: 1.25, color: 'var(--faction-wow-card-text)' }}>
+          <div style={{ fontFamily: 'var(--faction-coven-card-font)', fontSize: 'var(--text-content)', lineHeight: 1.25, color: 'var(--faction-coven-card-text)' }}>
             {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-wow-card-accent)" bg="var(--faction-wow-notepad-bg)" text="var(--faction-wow-card-text)" />
+              <CommentEditor owner={owner} accent="var(--faction-coven-card-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
             ) : (
-              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-wow-card-accent)" />
+              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-coven-card-accent)" />
             )}
           </div>
-          <div style={{ marginTop: 'var(--space-sm)', fontSize: 'var(--text-md)', color: 'var(--faction-wow-card-accent)', letterSpacing: '0.04em', display: 'inline-flex', alignItems: 'baseline', flexWrap: 'wrap', gap: 'var(--space-sm)' }}>
+          <div style={{ marginTop: 'var(--space-sm)', fontSize: 'var(--text-md)', color: 'var(--faction-coven-card-accent)', letterSpacing: '0.04em', display: 'inline-flex', alignItems: 'baseline', flexWrap: 'wrap', gap: 'var(--space-sm)' }}>
             <Link to={`/characters/${comment.author.id}`} style={{ color: 'inherit', textDecoration: 'none' }}>
               @{comment.author.username}
             </Link>

--- a/frontend/src/components/duel/CovenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenDuelSealConfirm.tsx
@@ -3,7 +3,7 @@
  *
  * The Default dialog's content, re-hung inside a centred `wow.exe` window:
  * traffic-light title bar, dotted board, notepad scrap for the stakes and the
- * roster, lo-fi pink confirm. Same beat, Wow's hand.
+ * roster, lo-fi pink confirm. Same beat, Coven's hand.
  *
  * Pure frame. `StakesTiles` computes the win/lose figures from `useGameConfig()`
  * and the viewer's own faction (Snide's 0.0× lose falls out by construction),
@@ -11,7 +11,7 @@
  * the same one the Default skin makes. Nothing here recomputes or drops any of it.
  *
  * The design's hardcoded `+90 / +30` and `0.5×` are deliberately absent: those
- * are Wow's live numbers and the slot owns them. So is 2c's "can't edit while the
+ * are Coven's live numbers and the slot owns them. So is 2c's "can't edit while the
  * duel runs" — during `active` the reopen is free, and #718's `reopenNote` says so.
  *
  * Copy is faction-neutral by decision (#718): the design's witch voice is tone
@@ -51,7 +51,7 @@ function Sparkle({ size, color }: { size: number; color: string }) {
   )
 }
 
-export default function WowDuelSealConfirm({
+export default function CovenDuelSealConfirm({
   duel,
   viewerCharacterId,
   taskPointValue,
@@ -64,7 +64,7 @@ export default function WowDuelSealConfirm({
   const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
 
   // Opponent tokens, same rule as the Default dialog and the rail: the foreign
-  // duelist looks foreign even inside Wow's window.
+  // duelist looks foreign even inside Coven's window.
   const accent = factionCssVar(foe.faction_slug, 'card-accent')
   const theme: DuelSlotTheme = { accent, muted: CARD_MUTED, bodyFont: 'var(--font-body)' }
 
@@ -129,7 +129,7 @@ export default function WowDuelSealConfirm({
           </p>
 
           {/* The free-reopen half of the truth — same condition as the Default
-              skin, because it is the same fact, not a Wow flourish. A forfeit
+              skin, because it is the same fact, not a Coven flourish. A forfeit
               has no such note, and `copy.note` is null there. */}
           {copy.note && (
             <p
@@ -175,7 +175,7 @@ export default function WowDuelSealConfirm({
             />
           </div>
           {/* ponytail: SealActions keeps its shared btn-outline / btn-primary
-              pair rather than growing a Wow gradient-button skin slot. The
+              pair rather than growing a Coven gradient-button skin slot. The
               global [Cancel] … [Submit] order (#646) is worth more here than a
               pink button, and adding a skin prop would be foundation work. */}
         </div>

--- a/frontend/src/components/duel/CovenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenDuelSealConfirm.tsx
@@ -28,17 +28,17 @@ import {
 } from './shared'
 import type { DuelSealConfirmProps } from './DuelSealConfirm'
 
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const TITLE_FROM = 'var(--faction-wow-title-from)'
-const TITLE_TO = 'var(--faction-wow-title-to)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const DOT = 'var(--faction-wow-dot)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const SCRIPT = 'var(--faction-wow-card-font)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const TITLE_FROM = 'var(--faction-coven-title-from)'
+const TITLE_TO = 'var(--faction-coven-title-to)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const DOT = 'var(--faction-coven-dot)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const SCRIPT = 'var(--faction-coven-card-font)'
 
 function Sparkle({ size, color }: { size: number; color: string }) {
   return (

--- a/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
@@ -51,7 +51,7 @@ function SheetHandle({ color }: { color: string }) {
   )
 }
 
-export default function WowMobileDuelSealConfirm({
+export default function CovenMobileDuelSealConfirm({
   duel,
   viewerCharacterId,
   taskPointValue,

--- a/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
@@ -21,17 +21,17 @@ import {
 } from './shared'
 import type { DuelSealConfirmProps } from './DuelSealConfirm'
 
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const TITLE_FROM = 'var(--faction-wow-title-from)'
-const TITLE_TO = 'var(--faction-wow-title-to)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const DOT = 'var(--faction-wow-dot)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const SCRIPT = 'var(--faction-wow-card-font)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const TITLE_FROM = 'var(--faction-coven-title-from)'
+const TITLE_TO = 'var(--faction-coven-title-to)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const DOT = 'var(--faction-coven-dot)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const SCRIPT = 'var(--faction-coven-card-font)'
 
 /** The sheet's grab handle, standing in for the desktop window's traffic lights. */
 function SheetHandle({ color }: { color: string }) {

--- a/frontend/src/components/duel/DuelSealConfirm.tsx
+++ b/frontend/src/components/duel/DuelSealConfirm.tsx
@@ -19,7 +19,7 @@
  * the EditPraxis dispatcher, so all 16 composer surfaces inherit it.
  *
  * The Default skin below is the only one this issue ships; the manifest seam
- * exists so per-faction skins (#720 for Wow, one issue per faction after) are a
+ * exists so per-faction skins (#720 for Coven, one issue per faction after) are a
  * `duelSeal` / `mobileDuelSeal` row and nothing else. Skins own the FRAME only —
  * every figure and every branch lives in `duel/shared.tsx`.
  *

--- a/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
@@ -216,7 +216,7 @@ export default function SingularityDuelSealConfirm({
           </div>
           {/* ponytail: SealActions keeps the shared btn-outline / btn-primary
               pair rather than growing a terminal-button skin slot, on the same
-              reasoning WowDuelSealConfirm recorded — the global
+              reasoning CovenDuelSealConfirm recorded — the global
               [Cancel] … [Submit] order (#646) is worth more than a bracketed
               `[ SEAL ]`, and a skin prop on the shared component is foundation
               work, not a skin change. */}

--- a/frontend/src/components/duel/SingularityMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SingularityMobileDuelSealConfirm.tsx
@@ -1,7 +1,7 @@
 /**
  * Singularity MOBILE duel seal-confirm (#723).
  *
- * The desktop dialog thumbed down. Where Wow's phone skin is a bottom sheet
+ * The desktop dialog thumbed down. Where Coven's phone skin is a bottom sheet
  * pinned to a rounded edge over the page, Singularity takes the whole screen:
  * the phone IS the terminal. That also answers the light-mode question for the
  * mobile path — the ground is the faction's own always-dark token rather than

--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -4,7 +4,7 @@
  *
  * A skin owns the FRAME and may arrange the slots however its faction likes; it
  * may never DROP one and may never recompute one. Both registries are walked
- * (plus their Default fallback), so the faction skins that follow Wow fail here
+ * (plus their Default fallback), so the faction skins that follow Coven fail here
  * the moment one of them loses a slot.
  *
  * Two registries, two techniques:
@@ -144,7 +144,7 @@ describe('duel seal skins render every slot', () => {
    * irreversible consequence (the forfeit mode added in #751). This is the
    * #769 guard, ported to the seal surface as that issue asked.
    *
-   * Both Wow seal skins carried the matching defect on their note, as #800
+   * Both Coven seal skins carried the matching defect on their note, as #800
    * named. Writing this guard against every registered skin (not just the
    * two named ones) also caught the same defect, previously unreported, on
    * both Snide seal skins — fixed alongside the named ones so the guard

--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -31,7 +31,7 @@ function Sparkle({ size }: { size: number }) {
   )
 }
 
-export default function WowFeedFrame({ children }: { children: ReactNode }) {
+export default function CovenFeedFrame({ children }: { children: ReactNode }) {
   return (
     <div
       style={{

--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -10,14 +10,14 @@ import i18n from '../../i18n'
  * not a reimplementation of the card. Flips with the theme via the WoW tokens.
  */
 
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const TITLE_FROM = 'var(--faction-wow-title-from)'
-const TITLE_TO = 'var(--faction-wow-title-to)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const SCRIPT = 'var(--faction-wow-card-font)'
-const PINK = 'var(--faction-wow)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const TITLE_FROM = 'var(--faction-coven-title-from)'
+const TITLE_TO = 'var(--faction-coven-title-to)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const SCRIPT = 'var(--faction-coven-card-font)'
+const PINK = 'var(--faction-coven)'
 
 /** The four-point sparkle charm — WoW's signature window flourish. */
 function Sparkle({ size }: { size: number }) {
@@ -55,9 +55,9 @@ export default function CovenFeedFrame({ children }: { children: ReactNode }) {
         }}
       >
         {[
-          'var(--faction-wow-scrap-deep)',
-          'var(--faction-wow-tape)',
-          'var(--faction-wow-ivy-leaf)',
+          'var(--faction-coven-scrap-deep)',
+          'var(--faction-coven-tape)',
+          'var(--faction-coven-ivy-leaf)',
         ].map((lightColor) => (
           <span
             key={lightColor}

--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -83,7 +83,7 @@ export default function CovenFeedFrame({ children }: { children: ReactNode }) {
             color: TITLE_TEXT,
           }}
         >
-          {i18n.t('feed:identity.wow.windowTitle')}
+          {i18n.t('feed:identity.coven.windowTitle')}
           <Sparkle size={12} />
         </span>
       </div>

--- a/frontend/src/components/home/ActivityTicker.tsx
+++ b/frontend/src/components/home/ActivityTicker.tsx
@@ -152,14 +152,14 @@ export default function ActivityTicker() {
       >
         <div
           className="eyebrow"
-          style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', color: 'var(--faction-wow)' }}
+          style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', color: 'var(--faction-coven)' }}
         >
           <span
             style={{
               width: 7,
               height: 7,
               borderRadius: '50%',
-              background: 'var(--faction-wow)',
+              background: 'var(--faction-coven)',
               display: 'inline-block',
               animation: 'wz-blink 1.4s ease-in-out infinite',
             }}

--- a/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
@@ -74,7 +74,7 @@ export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
           }}
         >
           <CovenSigil size={11} color={accent} />
-          {i18n.t('feed:identity.wow.windowTitle')}
+          {i18n.t('feed:identity.coven.windowTitle')}
         </div>
         <MobilePraxisBody praxis={praxis} theme={theme} />
       </div>

--- a/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
@@ -7,17 +7,17 @@ import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 /**
  * Warriors of Whimsy MOBILE praxis card (#573) — a taped scrap of the proof
  * board: a torn pink strip peeking behind the tilted notepad, a strip of tape,
- * sparkle marks. Mirrors the desktop COVEN praxis frame; --faction-wow-* tokens,
+ * sparkle marks. Mirrors the desktop COVEN praxis frame; --faction-coven-* tokens,
  * always-light.
  */
 export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
-  const accent = factionCssVar('wow', 'card-accent')
+  const accent = factionCssVar('coven', 'card-accent')
   const theme: MobileSlotTheme = {
-    ink: factionCssVar('wow', 'card-text'),
-    muted: factionCssVar('wow', 'card-muted'),
+    ink: factionCssVar('coven', 'card-text'),
+    muted: factionCssVar('coven', 'card-muted'),
     accent,
-    paper: factionCssVar('wow', 'card-bg'),
-    displayFont: 'var(--faction-wow-card-font)',
+    paper: factionCssVar('coven', 'card-bg'),
+    displayFont: 'var(--faction-coven-card-font)',
     bodyFont: "'Courier Prime', monospace",
   }
   return (
@@ -34,7 +34,7 @@ export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
           left: -3,
           right: -3,
           height: 26,
-          background: 'var(--faction-wow-scrap-mid)',
+          background: 'var(--faction-coven-scrap-mid)',
           border: '1.5px solid rgba(0,0,0,0.12)',
           transform: 'rotate(-3deg)',
         }}
@@ -42,7 +42,7 @@ export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
       <div
         style={{
           position: 'relative',
-          background: factionCssVar('wow', 'card-bg'),
+          background: factionCssVar('coven', 'card-bg'),
           border: '1.5px solid rgba(0,0,0,0.12)',
           padding: 'var(--space-lg) var(--space-lg) var(--space-md)',
           zIndex: 2,
@@ -56,7 +56,7 @@ export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
             transform: 'translateX(-50%) rotate(-2deg)',
             width: 54,
             height: 14,
-            background: 'var(--faction-wow-tape)',
+            background: 'var(--faction-coven-tape)',
             borderRadius: 1,
           }}
         />

--- a/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
@@ -1,16 +1,16 @@
 import type { PraxisCardOut } from '../../../api/praxis'
 import { factionCssVar } from '../../../utils/factions'
-import { WowSigil } from '../../cards/WowSigil'
+import { CovenSigil } from '../../cards/CovenSigil'
 import i18n from '../../../i18n'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
  * Warriors of Whimsy MOBILE praxis card (#573) — a taped scrap of the proof
  * board: a torn pink strip peeking behind the tilted notepad, a strip of tape,
- * sparkle marks. Mirrors the desktop WOW praxis frame; --faction-wow-* tokens,
+ * sparkle marks. Mirrors the desktop COVEN praxis frame; --faction-wow-* tokens,
  * always-light.
  */
-export default function WowMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   const accent = factionCssVar('wow', 'card-accent')
   const theme: MobileSlotTheme = {
     ink: factionCssVar('wow', 'card-text'),
@@ -73,7 +73,7 @@ export default function WowMobilePraxisCard({ praxis }: { praxis: PraxisCardOut 
             color: accent,
           }}
         >
-          <WowSigil size={11} color={accent} />
+          <CovenSigil size={11} color={accent} />
           {i18n.t('feed:identity.wow.windowTitle')}
         </div>
         <MobilePraxisBody praxis={praxis} theme={theme} />

--- a/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
+++ b/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
@@ -10,7 +10,7 @@ import { pickVariant } from '../../../../utils/factionDispatch'
 import { surfaceMap } from '../../../../factions'
 import DefaultMobilePraxisCard from '../DefaultMobilePraxisCard'
 import UaMobilePraxisCard from '../UaMobilePraxisCard'
-import WowMobilePraxisCard from '../WowMobilePraxisCard'
+import CovenMobilePraxisCard from '../CovenMobilePraxisCard'
 import SnideMobilePraxisCard from '../SnideMobilePraxisCard'
 import EphemeristsMobilePraxisCard from '../EphemeristsMobilePraxisCard'
 import SingularityMobilePraxisCard from '../SingularityMobilePraxisCard'
@@ -18,7 +18,7 @@ import EverymenMobilePraxisCard from '../EverymenMobilePraxisCard'
 
 const CARD_BY_SLUG = {
   ua: UaMobilePraxisCard,
-  wow: WowMobilePraxisCard,
+  wow: CovenMobilePraxisCard,
   snide: SnideMobilePraxisCard,
   ephemerists: EphemeristsMobilePraxisCard,
   singularity: SingularityMobilePraxisCard,

--- a/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
+++ b/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
@@ -18,7 +18,7 @@ import EverymenMobilePraxisCard from '../EverymenMobilePraxisCard'
 
 const CARD_BY_SLUG = {
   ua: UaMobilePraxisCard,
-  wow: CovenMobilePraxisCard,
+  coven: CovenMobilePraxisCard,
   snide: SnideMobilePraxisCard,
   ephemerists: EphemeristsMobilePraxisCard,
   singularity: SingularityMobilePraxisCard,

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -42,7 +42,7 @@ function HeartGlyph({ filled, color, size = 30 }: { filled: boolean; color: stri
   )
 }
 
-export default function WowVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
+export default function CovenVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
 

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -34,7 +34,7 @@ function HeartGlyph({ filled, color, size = 30 }: { filled: boolean; color: stri
       <path
         d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
         fill={filled ? color : 'none'}
-        stroke={filled ? '#fff' : 'var(--faction-wow-border)'}
+        stroke={filled ? '#fff' : 'var(--faction-coven-border)'}
         strokeWidth={filled ? 2.2 : 2}
         strokeLinejoin="round"
       />
@@ -75,9 +75,9 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
                   cursor: saving ? 'default' : 'pointer',
                   padding: 0,
                   borderRadius: 9,
-                  border: `1.5px solid ${filled ? 'var(--faction-wow)' : 'var(--faction-wow-border)'}`,
-                  background: filled ? 'var(--faction-wow-notepad-bg)' : 'transparent',
-                  boxShadow: filled ? '0 3px 7px var(--faction-wow-light)' : 'none',
+                  border: `1.5px solid ${filled ? 'var(--faction-coven)' : 'var(--faction-coven-border)'}`,
+                  background: filled ? 'var(--faction-coven-notepad-bg)' : 'transparent',
+                  boxShadow: filled ? '0 3px 7px var(--faction-coven-light)' : 'none',
                   transform: active ? 'scale(1.08)' : 'none',
                   transition: 'all 120ms',
                 } as React.CSSProperties}
@@ -90,7 +90,7 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
                   fontSize: 'var(--text-xs)',
                   textTransform: 'uppercase',
                   letterSpacing: '0.04em',
-                  color: filled ? fill : 'var(--faction-wow-card-muted)',
+                  color: filled ? fill : 'var(--faction-coven-card-muted)',
                   maxWidth: HEART_TILE + 2,
                   textAlign: 'center',
                   lineHeight: 1.2,
@@ -109,9 +109,9 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
         totalVotes={totalVotes}
         error={error}
         theme={{
-          muted: 'var(--faction-wow-card-muted)',
-          accent: 'var(--faction-wow)',
-          accentFont: 'var(--faction-wow-card-font)',
+          muted: 'var(--faction-coven-card-muted)',
+          accent: 'var(--faction-coven)',
+          accentFont: 'var(--faction-coven-card-font)',
           errorColor: 'var(--color-danger)',
         }}
       />

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -25,7 +25,7 @@ const HEART_FILLS: Record<number, string> = {
 
 const HEART_TILE = 40
 
-const TIERS = VOTE_REFRAMES['wow'].tiers
+const TIERS = VOTE_REFRAMES['coven'].tiers
 
 /** Inline heart glyph — filled (ramp color) or outline-only when empty. */
 function HeartGlyph({ filled, color, size = 30 }: { filled: boolean; color: string; size?: number }) {
@@ -65,7 +65,7 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
               <button
                 disabled={saving}
                 onClick={() => void vote(tier.value)}
-                aria-label={t('chrome.wow.rateAria', { value: tier.value, label: tier.label })}
+                aria-label={t('chrome.coven.rateAria', { value: tier.value, label: tier.label })}
                 style={{
                   width: HEART_TILE,
                   height: HEART_TILE,

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -38,13 +38,13 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
       { value: 5, label: i18n.t('votes:everymen.legendary') },
     ],
   },
-  wow: {
+  coven: {
     tiers: [
-      { value: 1, label: i18n.t('votes:wow.a-start') },
-      { value: 2, label: i18n.t('votes:wow.solid') },
-      { value: 3, label: i18n.t('votes:wow.good') },
-      { value: 4, label: i18n.t('votes:wow.excellent') },
-      { value: 5, label: i18n.t('votes:wow.legendary') },
+      { value: 1, label: i18n.t('votes:coven.a-start') },
+      { value: 2, label: i18n.t('votes:coven.solid') },
+      { value: 3, label: i18n.t('votes:coven.good') },
+      { value: 4, label: i18n.t('votes:coven.excellent') },
+      { value: 5, label: i18n.t('votes:coven.legendary') },
     ],
   },
   snide: {

--- a/frontend/src/factions/__tests__/addAFaction.test.tsx
+++ b/frontend/src/factions/__tests__/addAFaction.test.tsx
@@ -88,7 +88,7 @@ const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
 /** Slug-keyed literal whose value is a component reference, e.g. `ua: UaCard`. */
 const REGISTRY_ROW =
-  /^\s*(ua|wow|snide|ephemerists|singularity|everymen|albescent)\s*:\s*[A-Z]\w*\s*,?\s*$/gm
+  /^\s*(ua|wow|coven|snide|ephemerists|singularity|everymen|albescent)\s*:\s*[A-Z]\w*\s*,?\s*$/gm
 
 /**
  * Files allowed to map faction slugs to capitalised values.

--- a/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
+++ b/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Warriors of Whimsy's interim state (#784).
+ *
+ * Its lo-fi pink `.exe` identity moved wholesale to Cozy Coven, so `wow` now
+ * registers no manifest and no theme. That is intended — a clean slate for the
+ * gold redesign — but it opens a specific, quiet failure mode.
+ *
+ * The dangerous failure is NOT a crash. A faction that renders `Default` looks
+ * fine. The failure is `factionName()` falling through to `names.na` and
+ * silently labelling a real, populated, joinable faction "Unaffiliated" for
+ * however long the redesign takes. Nothing else in the suite would notice:
+ * there is no type error, no thrown key, no visual diff a build can see. So
+ * this file asserts both halves together — falls back everywhere AND still has
+ * words — because it is their combination that means "clean slate" rather than
+ * "broken faction".
+ *
+ * DELETE THIS FILE when the gold identity ships and `wow` has a manifest again.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+
+import { FACTION_MANIFESTS, surfaceMap, SURFACE_KEYS } from '..'
+import type { FactionSurface } from '..'
+import { pickVariant } from '../../utils/factionDispatch'
+import {
+  factionCssVar,
+  factionColor,
+  factionDescription,
+  factionName,
+  isKnownFaction,
+} from '../../utils/factions'
+
+function Sentinel() {
+  return <div>default-sentinel</div>
+}
+
+describe('wow falls back to Default on every surface', () => {
+  it('registers no manifest at all', () => {
+    expect(FACTION_MANIFESTS.map((manifest) => manifest.slug)).not.toContain('wow')
+  })
+
+  for (const surface of SURFACE_KEYS) {
+    it(`claims nothing on the ${surface} surface, so it gets the fallback`, () => {
+      const map = surfaceMap(surface as FactionSurface)
+
+      // Unclaimed: no bespoke component is registered for the slug...
+      expect(map['wow'], `${surface} should be unclaimed by wow`).toBeUndefined()
+
+      // ...so the dispatcher hands back the caller's Default, and it renders.
+      const Resolved = pickVariant(map as Record<string, typeof Sentinel>, 'wow', Sentinel)
+      expect(Resolved).toBe(Sentinel)
+      expect(renderToStaticMarkup(<Resolved />)).toContain('default-sentinel')
+    })
+  }
+
+  it('reads the neutral theme rather than a token that no longer exists', () => {
+    // --faction-wow-* moved to --faction-coven-*. Resolving anywhere else would
+    // emit a var() naming a declaration that is not in index.css: valid CSS,
+    // lints clean, renders as nothing.
+    expect(factionCssVar('wow')).toBe('var(--faction-default)')
+    expect(factionCssVar('wow', 'card-bg')).toBe('var(--faction-default-card-bg)')
+    expect(isKnownFaction('wow')).toBe(false)
+    expect(factionColor('wow')).toBe(factionColor('na'))
+  })
+})
+
+describe('wow still reads as a real faction', () => {
+  it('resolves its own name, NOT the Unaffiliated fallback', () => {
+    expect(factionName('wow')).toBe('Warriors of Whimsy')
+    expect(factionName('wow')).not.toBe(factionName('na'))
+  })
+
+  it('resolves its own description, NOT the empty-description fallback', () => {
+    const description = factionDescription('wow')
+    expect(description).not.toBe(factionDescription('na'))
+    expect(description).not.toBe(factionDescription('definitely_not_a_faction'))
+    expect(description.length).toBeGreaterThan(0)
+  })
+
+  it('is distinguishable from Cozy Coven, which took its aesthetic', () => {
+    // The rename is only sound if the two slugs are genuinely separate
+    // identities. If these ever collide, one of them has swallowed the other.
+    expect(factionName('coven')).not.toBe(factionName('wow'))
+    expect(factionDescription('coven')).not.toBe(factionDescription('wow'))
+  })
+})

--- a/frontend/src/factions/coven.ts
+++ b/frontend/src/factions/coven.ts
@@ -1,5 +1,5 @@
 /**
- * wow — the surfaces this faction overrides (#782).
+ * coven — the surfaces this faction overrides (#782).
  *
  * Override-only: any surface absent here renders that surface's `Default*`
  * archetype via `pickVariant`. Adding a surface is one line; no dispatcher is
@@ -38,8 +38,8 @@ import { CovenSigil } from '../components/cards/CovenSigil'
 import { CovenCard } from '../components/cards/FactionCard'
 import { COVENSelectCard } from '../components/cards/FactionSelectCard'
 
-export const WOW_MANIFEST: FactionManifest = {
-  slug: 'wow',
+export const COVEN_MANIFEST: FactionManifest = {
+  slug: 'coven',
 
   factionCard: () => CovenCard,
   factionSelectCard: () => COVENSelectCard,

--- a/frontend/src/factions/index.ts
+++ b/frontend/src/factions/index.ts
@@ -28,12 +28,12 @@
 import type { FactionManifest, FactionSurface } from './manifest'
 
 import { ALBESCENT_MANIFEST } from './albescent'
+import { COVEN_MANIFEST } from './coven'
 import { EPHEMERISTS_MANIFEST } from './ephemerists'
 import { EVERYMEN_MANIFEST } from './everymen'
 import { SINGULARITY_MANIFEST } from './singularity'
 import { SNIDE_MANIFEST } from './snide'
 import { UA_MANIFEST } from './ua'
-import { WOW_MANIFEST } from './wow'
 
 export type { FactionManifest, FactionSurface } from './manifest'
 export { SURFACE_KEYS } from './manifest'
@@ -43,6 +43,14 @@ export { SURFACE_KEYS } from './manifest'
  * consumer that iterates gets the house order for free. `na` / unaffiliated is a
  * state rather than a faction and deliberately has no manifest: it falls through
  * to the neutral `Default*` skins everywhere (ADR-0039).
+ *
+ * `wow` has no manifest either, for a different reason (#784): Warriors of
+ * Whimsy's lo-fi pink `.exe` identity moved wholesale to Cozy Coven, and its
+ * replacement gold identity is a sibling issue. Registering nothing is exactly
+ * what the override-only contract wants in the meantime — every surface hands
+ * `wow` its `Default*` archetype, which is a clean slate rather than a gap. Its
+ * name and description still resolve from the catalog, so it reads as a real
+ * faction throughout; `wowRendersDefault.test.tsx` pins both halves of that.
  */
 export const FACTION_MANIFESTS: readonly FactionManifest[] = [
   EVERYMEN_MANIFEST,
@@ -51,7 +59,7 @@ export const FACTION_MANIFESTS: readonly FactionManifest[] = [
   EPHEMERISTS_MANIFEST,
   SINGULARITY_MANIFEST,
   ALBESCENT_MANIFEST,
-  WOW_MANIFEST,
+  COVEN_MANIFEST,
 ]
 
 /** A slug-keyed map of one surface, in the shape `pickVariant` consumes. */

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -10,62 +10,62 @@
  */
 import type { FactionManifest } from './manifest'
 
-import WowAvatar from '../components/avatar/WowAvatar'
-import WowBackdrop from '../components/backdrop/WowBackdrop'
-import WowComment from '../components/comments/voices/WowComment'
-import WowDuelRail from '../pages/praxisDetail/duelRails/WowDuelRail'
-import WowDuelSealConfirm from '../components/duel/WowDuelSealConfirm'
-import WowEditPraxis from '../pages/editPraxis/archetypes/WowEditPraxis'
-import WowFactionBody from '../pages/factionDetail/archetypes/WowFactionBody'
-import WowFactionHero from '../components/cards/WowFactionHero'
-import WowFactionPage from '../pages/factionDetail/mobileArchetypes/WowFactionPage'
-import WowFeedFrame from '../components/feed/WowFeedFrame'
-import WowFieldDesk from '../pages/fieldDesk/mobileArchetypes/WowFieldDesk'
-import WowMobileDuelRail from '../pages/praxisDetail/duelRails/WowMobileDuelRail'
-import WowMobileDuelSealConfirm from '../components/duel/WowMobileDuelSealConfirm'
-import WowMobileEditPraxis from '../pages/editPraxis/mobileArchetypes/WowEditPraxis'
-import WowMobilePraxisCard from '../components/praxisCard/mobile/WowMobilePraxisCard'
-import WowMobilePraxisDetail from '../pages/praxisDetail/mobileArchetypes/WowPraxisDetail'
-import WowMobileTaskCard from '../pages/tasks/mobileArchetypes/cards/WowMobileTaskCard'
-import WowMobileTaskDetail from '../pages/taskDetail/mobileArchetypes/WowTaskDetail'
-import WowPraxisDetail from '../pages/praxisDetail/archetypes/WowPraxisDetail'
-import WowProfileBody from '../pages/characterProfile/archetypes/WowProfileBody'
-import WowTaskCard from '../components/cards/WowTaskCard'
-import WowTaskDetail from '../pages/taskDetail/archetypes/WowTaskDetail'
-import WowVote from '../components/vote/WowVote'
-import { WowPraxisCard } from '../components/PraxisCard'
-import { WowSigil } from '../components/cards/WowSigil'
-import { WowCard } from '../components/cards/FactionCard'
-import { WOWSelectCard } from '../components/cards/FactionSelectCard'
+import CovenAvatar from '../components/avatar/CovenAvatar'
+import CovenBackdrop from '../components/backdrop/CovenBackdrop'
+import CovenComment from '../components/comments/voices/CovenComment'
+import CovenDuelRail from '../pages/praxisDetail/duelRails/CovenDuelRail'
+import CovenDuelSealConfirm from '../components/duel/CovenDuelSealConfirm'
+import CovenEditPraxis from '../pages/editPraxis/archetypes/CovenEditPraxis'
+import CovenFactionBody from '../pages/factionDetail/archetypes/CovenFactionBody'
+import CovenFactionHero from '../components/cards/CovenFactionHero'
+import CovenFactionPage from '../pages/factionDetail/mobileArchetypes/CovenFactionPage'
+import CovenFeedFrame from '../components/feed/CovenFeedFrame'
+import CovenFieldDesk from '../pages/fieldDesk/mobileArchetypes/CovenFieldDesk'
+import CovenMobileDuelRail from '../pages/praxisDetail/duelRails/CovenMobileDuelRail'
+import CovenMobileDuelSealConfirm from '../components/duel/CovenMobileDuelSealConfirm'
+import CovenMobileEditPraxis from '../pages/editPraxis/mobileArchetypes/CovenEditPraxis'
+import CovenMobilePraxisCard from '../components/praxisCard/mobile/CovenMobilePraxisCard'
+import CovenMobilePraxisDetail from '../pages/praxisDetail/mobileArchetypes/CovenPraxisDetail'
+import CovenMobileTaskCard from '../pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard'
+import CovenMobileTaskDetail from '../pages/taskDetail/mobileArchetypes/CovenTaskDetail'
+import CovenPraxisDetail from '../pages/praxisDetail/archetypes/CovenPraxisDetail'
+import CovenProfileBody from '../pages/characterProfile/archetypes/CovenProfileBody'
+import CovenTaskCard from '../components/cards/CovenTaskCard'
+import CovenTaskDetail from '../pages/taskDetail/archetypes/CovenTaskDetail'
+import CovenVote from '../components/vote/CovenVote'
+import { CovenPraxisCard } from '../components/PraxisCard'
+import { CovenSigil } from '../components/cards/CovenSigil'
+import { CovenCard } from '../components/cards/FactionCard'
+import { COVENSelectCard } from '../components/cards/FactionSelectCard'
 
 export const WOW_MANIFEST: FactionManifest = {
   slug: 'wow',
 
-  factionCard: () => WowCard,
-  factionSelectCard: () => WOWSelectCard,
-  taskCard: () => WowTaskCard,
-  praxisCard: () => WowPraxisCard,
-  avatar: () => WowAvatar,
-  backdrop: () => WowBackdrop,
-  sigil: () => WowSigil,
-  comment: () => WowComment,
-  feedFrame: () => WowFeedFrame,
-  vote: () => WowVote,
-  taskDetail: () => WowTaskDetail,
-  praxisDetail: () => WowPraxisDetail,
-  editPraxis: () => WowEditPraxis,
-  factionHero: () => WowFactionHero,
-  factionBody: () => WowFactionBody,
-  profileBody: () => WowProfileBody,
-  duelSeal: () => WowDuelSealConfirm,
-  duelRail: () => WowDuelRail,
-  mobileTaskCard: () => WowMobileTaskCard,
-  mobilePraxisCard: () => WowMobilePraxisCard,
-  mobileTaskDetail: () => WowMobileTaskDetail,
-  mobilePraxisDetail: () => WowMobilePraxisDetail,
-  mobileEditPraxis: () => WowMobileEditPraxis,
-  mobileFactionPage: () => WowFactionPage,
-  mobileFieldDesk: () => WowFieldDesk,
-  mobileDuelSeal: () => WowMobileDuelSealConfirm,
-  mobileDuelRail: () => WowMobileDuelRail,
+  factionCard: () => CovenCard,
+  factionSelectCard: () => COVENSelectCard,
+  taskCard: () => CovenTaskCard,
+  praxisCard: () => CovenPraxisCard,
+  avatar: () => CovenAvatar,
+  backdrop: () => CovenBackdrop,
+  sigil: () => CovenSigil,
+  comment: () => CovenComment,
+  feedFrame: () => CovenFeedFrame,
+  vote: () => CovenVote,
+  taskDetail: () => CovenTaskDetail,
+  praxisDetail: () => CovenPraxisDetail,
+  editPraxis: () => CovenEditPraxis,
+  factionHero: () => CovenFactionHero,
+  factionBody: () => CovenFactionBody,
+  profileBody: () => CovenProfileBody,
+  duelSeal: () => CovenDuelSealConfirm,
+  duelRail: () => CovenDuelRail,
+  mobileTaskCard: () => CovenMobileTaskCard,
+  mobilePraxisCard: () => CovenMobilePraxisCard,
+  mobileTaskDetail: () => CovenMobileTaskDetail,
+  mobilePraxisDetail: () => CovenMobilePraxisDetail,
+  mobileEditPraxis: () => CovenMobileEditPraxis,
+  mobileFactionPage: () => CovenFactionPage,
+  mobileFieldDesk: () => CovenFieldDesk,
+  mobileDuelSeal: () => CovenMobileDuelSealConfirm,
+  mobileDuelRail: () => CovenMobileDuelRail,
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,7 +42,7 @@
 
   /* ── Faction primary colors (rainbow palette) ── */
   --faction-ua: var(--ua-orange); /* burnt amber — gilt salon (#240) */
-  --faction-wow: #ec5f99; /* redesign pink */
+  --faction-coven: #ec5f99; /* redesign pink */
   --faction-snide: #6fae00; /* acid green (deep — legible on light chrome) */
   --faction-ephemerists: #1d6e72; /* lapis-verdigris — Ephemerists reskin of the teal slot */
   --faction-singularity: #2563eb; /* blue */
@@ -56,56 +56,56 @@
      omitted there inherit these :root values through the cascade. */
   --faction-ua-on-fill: #ffffff; /* #c2541f — 4.58:1 */
   --faction-everymen-on-fill: #ffffff; /* #c1272d — 5.84:1 */
-  --faction-wow-on-fill: #14110b; /* #ec5f99 — white only 3.15:1; ink 5.98:1 */
+  --faction-coven-on-fill: #14110b; /* #ec5f99 — white only 3.15:1; ink 5.98:1 */
   --faction-snide-on-fill: #14110b; /* #6fae00 — white only 2.72:1; ink 6.93:1 */
   --faction-ephemerists-on-fill: #ffffff; /* #1d6e72 — 5.96:1 */
   --faction-singularity-on-fill: #ffffff; /* #2563eb — 5.17:1 */
 
   /* ── Faction tints (backgrounds, highlights) ── */
   --faction-ua-light: rgba(194, 84, 31, 0.08);
-  --faction-wow-light: rgba(236, 95, 153, 0.1);
+  --faction-coven-light: rgba(236, 95, 153, 0.1);
   --faction-snide-light: rgba(182, 255, 46, 0.16);
   --faction-ephemerists-light: rgba(29, 110, 114, 0.1);
   --faction-singularity-light: rgba(37, 99, 235, 0.1);
 
   /* ── Faction borders ── */
   --faction-ua-border: rgba(194, 84, 31, 0.3);
-  --faction-wow-border: rgba(236, 95, 153, 0.3);
+  --faction-coven-border: rgba(236, 95, 153, 0.3);
   --faction-snide-border: rgba(111, 174, 0, 0.45);
   --faction-ephemerists-border: rgba(29, 110, 114, 0.35);
   --faction-singularity-border: rgba(37, 99, 235, 0.35);
 
   /* ── Faction card backgrounds (light mode) ── */
   --faction-ua-card-bg: var(--ua-paper); /* parchment sheet */
-  --faction-wow-card-bg: #fdeef3; /* blush collage */
+  --faction-coven-card-bg: #fdeef3; /* blush collage */
   --faction-snide-card-bg: #14110b; /* photocopier ink (dark-in-light, Singularity precedent) */
   --faction-ephemerists-card-bg: var(--eph-vellum); /* Ephemerists: aged manuscript stock */
   --faction-singularity-card-bg: #050f08; /* terminal black */
 
   /* ── Faction card text (light mode) ── */
   --faction-ua-card-text: var(--ua-ink);
-  --faction-wow-card-text: #581c39;
+  --faction-coven-card-text: #581c39;
   --faction-snide-card-text: #f4f1e8; /* warm xerox paper on ink */
   --faction-ephemerists-card-text: var(--eph-vellum-text);
   --faction-singularity-card-text: #4ade80;
 
   /* ── Faction card accents (light mode) ── */
   --faction-ua-card-accent: var(--ua-orange);
-  --faction-wow-card-accent: #ec5f99;
+  --faction-coven-card-accent: #ec5f99;
   --faction-snide-card-accent: #b6ff2e; /* toxic acid */
   --faction-ephemerists-card-accent: var(--eph-rubric);
   --faction-singularity-card-accent: #4ade80; /* terminal green */
 
   /* ── Faction card secondary text (descriptions, metadata) ── */
   --faction-ua-card-muted: var(--ua-sub);
-  --faction-wow-card-muted: #831843;
+  --faction-coven-card-muted: #831843;
   --faction-snide-card-muted: #d8d6c8; /* faded newsprint grey on ink */
   --faction-ephemerists-card-muted: var(--eph-muted);
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
 
   /* ── Faction headline fonts (per-faction display) ── */
   --faction-ua-card-font: var(--font-faction-old);
-  --faction-wow-card-font: var(--font-faction-script);
+  --faction-coven-card-font: var(--font-faction-script);
   --faction-snide-card-font: var(--font-faction-marker);
   --faction-ephemerists-card-font: var(--eph-display);
   --faction-singularity-card-font: var(--font-faction-terminal);
@@ -210,21 +210,21 @@
   --ua-gilt: linear-gradient(135deg, #eec06a 0%, #9c6a1a 24%, #f0c878 50%, #9c6a1a 76%, #dd9322 100%);
 
   /* ── Warriors of Whimsy collage scrap layers (legacy — kept for back-compat) ── */
-  --faction-wow-scrap-deep: #fbcfe0;
-  --faction-wow-scrap-mid: #fce7ef;
-  --faction-wow-tape: rgba(250, 230, 130, 0.7);
+  --faction-coven-scrap-deep: #fbcfe0;
+  --faction-coven-scrap-mid: #fce7ef;
+  --faction-coven-tape: rgba(250, 230, 130, 0.7);
 
   /* ── Warriors of Whimsy lo-fi ".exe" window chrome (redesign) ── */
-  --faction-wow-win-border: #e487b5;
-  --faction-wow-title-from: #fbcfe2;
-  --faction-wow-title-to: #f3a6cb;
-  --faction-wow-title-text: #8e2f5c;
-  --faction-wow-body-bg: #fdeef6;
-  --faction-wow-notepad-bg: #fffdfa;
-  --faction-wow-notepad-border: #f3b6d2;
-  --faction-wow-dot: rgba(214, 90, 150, 0.2);
-  --faction-wow-ivy: #7cbf99;
-  --faction-wow-ivy-leaf: #9ad3b1;
+  --faction-coven-win-border: #e487b5;
+  --faction-coven-title-from: #fbcfe2;
+  --faction-coven-title-to: #f3a6cb;
+  --faction-coven-title-text: #8e2f5c;
+  --faction-coven-body-bg: #fdeef6;
+  --faction-coven-notepad-bg: #fffdfa;
+  --faction-coven-notepad-border: #f3b6d2;
+  --faction-coven-dot: rgba(214, 90, 150, 0.2);
+  --faction-coven-ivy: #7cbf99;
+  --faction-coven-ivy-leaf: #9ad3b1;
 
   /* ══ Everymen — the rainbow's missing red (union/WW2 poster) ══
      Constants (cream/gold/ink) keep their role in both themes; the paper
@@ -422,7 +422,7 @@
 
   /* ── Faction primary colors (dark — brightened rainbow) ── */
   --faction-ua: var(--ua-orange); /* always-light salon — never dims (#240) */
-  --faction-wow: #f472b6; /* magenta */
+  --faction-coven: #f472b6; /* magenta */
   --faction-snide: #b6ff2e; /* acid green (bright — pops on dark) */
   --faction-ephemerists: #3aa0a4; /* lapis-verdigris lifted for dark — Ephemerists */
   --faction-singularity: #60a5fa; /* blue */
@@ -437,40 +437,40 @@
 
   /* ── Faction tints (dark) ── */
   --faction-ua-light: rgba(194, 84, 31, 0.08);
-  --faction-wow-light: rgba(244, 114, 182, 0.08);
+  --faction-coven-light: rgba(244, 114, 182, 0.08);
   --faction-snide-light: rgba(182, 255, 46, 0.12);
   --faction-ephemerists-light: rgba(58, 160, 164, 0.1);
   --faction-singularity-light: rgba(96, 165, 250, 0.1);
 
   /* ── Faction borders (dark) ── */
   --faction-ua-border: rgba(194, 84, 31, 0.3);
-  --faction-wow-border: rgba(244, 114, 182, 0.25);
+  --faction-coven-border: rgba(244, 114, 182, 0.25);
   --faction-snide-border: rgba(182, 255, 46, 0.3);
   --faction-ephemerists-border: rgba(58, 160, 164, 0.35);
   --faction-singularity-border: rgba(96, 165, 250, 0.25);
 
   /* ── Faction card backgrounds (dark mode) ── */
   --faction-ua-card-bg: var(--ua-paper); /* salon never dims (#240) */
-  --faction-wow-card-bg: #2a0d1c;
+  --faction-coven-card-bg: #2a0d1c;
   --faction-snide-card-bg: #0c0a07; /* deeper ink */
   /* ephemerists card-bg inherits the :root var(--eph-vellum) rebind (flips below) */
   --faction-singularity-card-bg: #050f08;
 
   /* ── Faction card text (dark mode) ── */
   --faction-ua-card-text: var(--ua-ink);
-  --faction-wow-card-text: #fbcfe0;
+  --faction-coven-card-text: #fbcfe0;
   --faction-snide-card-text: #f4f1e8;
   --faction-singularity-card-text: #4ade80;
 
   /* ── Faction card accents (dark mode) ── */
   --faction-ua-card-accent: var(--ua-orange);
-  --faction-wow-card-accent: #f472b6;
+  --faction-coven-card-accent: #f472b6;
   --faction-snide-card-accent: #b6ff2e;
   --faction-singularity-card-accent: #4ade80; /* terminal green */
 
   /* ── Faction card secondary text (dark mode) ── */
   --faction-ua-card-muted: var(--ua-sub);
-  --faction-wow-card-muted: #dd719c;
+  --faction-coven-card-muted: #dd719c;
   --faction-snide-card-muted: #cfcdbf;
   /* SNIDE flyposted wall flips to concrete-at-night */
   --faction-snide-wall: #141310;
@@ -511,21 +511,21 @@
   --eph-field-deep: #0a1d2a;
 
   /* ── Warriors of Whimsy collage scrap layers (dark) ── */
-  --faction-wow-scrap-deep: #091209;
-  --faction-wow-scrap-mid: #0d1a10;
-  --faction-wow-tape: rgba(250, 230, 130, 0.12);
+  --faction-coven-scrap-deep: #091209;
+  --faction-coven-scrap-mid: #0d1a10;
+  --faction-coven-tape: rgba(250, 230, 130, 0.12);
 
   /* ── Warriors of Whimsy ".exe" window chrome (dark) ── */
-  --faction-wow-win-border: #f472b6;
-  --faction-wow-title-from: #5e2a46;
-  --faction-wow-title-to: #41203a;
-  --faction-wow-title-text: #fbd6e8;
-  --faction-wow-body-bg: #2a0d1c;
-  --faction-wow-notepad-bg: #39152a;
-  --faction-wow-notepad-border: #7a3358;
-  --faction-wow-dot: rgba(244, 114, 182, 0.16);
-  --faction-wow-ivy: #5fa882;
-  --faction-wow-ivy-leaf: #7fc59e;
+  --faction-coven-win-border: #f472b6;
+  --faction-coven-title-from: #5e2a46;
+  --faction-coven-title-to: #41203a;
+  --faction-coven-title-text: #fbd6e8;
+  --faction-coven-body-bg: #2a0d1c;
+  --faction-coven-notepad-bg: #39152a;
+  --faction-coven-notepad-border: #7a3358;
+  --faction-coven-dot: rgba(244, 114, 182, 0.16);
+  --faction-coven-ivy: #5fa882;
+  --faction-coven-ivy-leaf: #7fc59e;
 
   /* ── Watercolor splash opacities (dimmer in dark) ── */
   --wc-opacity-blob: 0.15;
@@ -593,24 +593,24 @@
   background: radial-gradient(120% 90% at 50% 8%, transparent 40%, color-mix(in srgb, var(--everymen-paper-deep) 55%, transparent));
 }
 
-/* ══ Warriors of Whimsy lo-fi desktop backdrop (faction-context pages; theme-aware) ══ */
-.wow-backdrop {
+/* ══ Cozy Coven lo-fi desktop backdrop (faction-context pages; theme-aware) ══ */
+.coven-backdrop {
   position: fixed;
   inset: 0;
   z-index: 0;
   pointer-events: none;
-  background-color: var(--faction-wow-body-bg);
+  background-color: var(--faction-coven-body-bg);
   background-image:
-    radial-gradient(46% 36% at 0% 0%, color-mix(in srgb, var(--faction-wow) 12%, transparent), transparent 70%),
-    radial-gradient(50% 40% at 100% 100%, color-mix(in srgb, var(--faction-wow-ivy) 12%, transparent), transparent 70%),
-    radial-gradient(var(--faction-wow-dot) 1.4px, transparent 1.6px);
+    radial-gradient(46% 36% at 0% 0%, color-mix(in srgb, var(--faction-coven) 12%, transparent), transparent 70%),
+    radial-gradient(50% 40% at 100% 100%, color-mix(in srgb, var(--faction-coven-ivy) 12%, transparent), transparent 70%),
+    radial-gradient(var(--faction-coven-dot) 1.4px, transparent 1.6px);
   background-size: 100% 100%, 100% 100%, 14px 14px;
 }
-.wow-backdrop::after {
+.coven-backdrop::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(120% 95% at 50% 0%, transparent 45%, color-mix(in srgb, var(--faction-wow-body-bg) 70%, transparent));
+  background: radial-gradient(120% 95% at 50% 0%, transparent 45%, color-mix(in srgb, var(--faction-coven-body-bg) 70%, transparent));
 }
 
 /* ══ S.N.I.D.E. flyposted-wall backdrop (faction-context pages; theme-aware) ══ */

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -16,7 +16,7 @@ import { findDuplicateJsonKeys } from './findDuplicateJsonKeys'
 const FACTION_SLUGS = [
   'ephemerists',
   'everymen',
-  'wow',
+  'coven',
   'snide',
   'singularity',
   'ua',

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -165,7 +165,7 @@
       "pending_one": "{{count}} pending request",
       "pending_other": "{{count}} pending requests",
       "browseTasks": "Browse Tasks",
-      "wow": {
+      "coven": {
         "charWindow": "you",
         "questsWindow": "quests",
         "charEyebrow": "you",

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -2,6 +2,7 @@
   "names": {
     "ua": "UA",
     "snide": "S.N.I.D.E.",
+    "coven": "Cozy Coven",
     "wow": "Warriors of Whimsy",
     "ephemerists": "The Ephemerists",
     "everymen": "Everymen",
@@ -12,6 +13,7 @@
   "descriptions": {
     "ua": "The Gilt Salon — a regal academy. Full points on all tasks.",
     "snide": "Specialists in one-on-one competition. Bonus points for winning duels.",
+    "coven": "A soft-lit circle of makers. Full points on every task.",
     "wow": "Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
     "ephemerists": "Wanderers who set down fleeting truths before the road moves on. Task Vision — access to select retired tasks.",
     "everymen": "No inner circle, no waiting to be chosen. Reliable hands who do the work in front of them and finish what they start.",
@@ -464,7 +466,7 @@
       }
     }
   },
-  "wow": {
+  "coven": {
     "manifesto": {
       "heading": "the manifesto ✦",
       "empty": "No manifesto scribbled yet."

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -110,7 +110,7 @@
     "ephemerists": {
       "wordmark": "THE EPHEMERISTS"
     },
-    "wow": {
+    "coven": {
       "windowTitle": "whimsy.exe"
     },
     "singularity": {
@@ -170,7 +170,7 @@
       "pointsLine": "UA · {{points}} pts",
       "signup": "Matriculate"
     },
-    "wow": {
+    "coven": {
       "windowTitle": "wow.exe",
       "questMeta": "new quest · {{points}} pts",
       "signup": "sign up",
@@ -270,7 +270,7 @@
         "praxes": "acquisitions"
       }
     },
-    "wow": {
+    "coven": {
       "eyebrow": "World Zero · Faction · est. MMXXI",
       "motto": "make it weird, make it matter",
       "descriptionFallback": "Nobody said the work couldn't be fun. Cast something.",
@@ -296,7 +296,7 @@
       "members_other": "{{count}} residents",
       "cta": "Enter the Salon →"
     },
-    "wow": {
+    "coven": {
       "name": "Warriors of Whimsy",
       "blurb": "A little magic, a lot of mischief. World Zero’s coven for the soft and the strange — take a quest, cast a small spell, let the circle cheer.",
       "status": {

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -488,7 +488,7 @@
       "publishBusy": "hanging…",
       "dropLabel": "Withdraw Work"
     },
-    "wow": {
+    "coven": {
       "collab": {
         "castStatus": "{{cast}} of {{total}} have cast",
         "pillCast": "cast",
@@ -598,6 +598,7 @@
     "factionDescriptor": {
       "na": "Anyone",
       "ua": "Academy",
+      "coven": "Circle",
       "wow": "Collective",
       "everymen": "Mobilize",
       "snide": "Mischief",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -315,7 +315,7 @@
         "appraise": "call the job"
       }
     },
-    "wow": {
+    "coven": {
       "mode": {
         "collab": "cast together",
         "solo": "filed solo"
@@ -396,7 +396,7 @@
       "masthead": "EVERYMEN · DISPATCH FROM THE FLOOR",
       "edited": "revised"
     },
-    "wow": {
+    "coven": {
       "edited": "edited"
     },
     "snide": {

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -158,7 +158,7 @@
     "bestInHall": "BEST IN HALL",
     "viewAll": "View all {{count}} reports →"
   },
-  "wow": {
+  "coven": {
     "breadcrumb": "Tasks",
     "faction": "Warriors of Whimsy",
     "window": "quest.exe",

--- a/frontend/src/locales/en/taunts.json
+++ b/frontend/src/locales/en/taunts.json
@@ -27,7 +27,7 @@
       "{{from_name}} finished what {{to_name}} couldn't start."
     ]
   },
-  "wow": {
+  "coven": {
     "score_overtake": [
       "The collective lifts {{from_name}} above {{to_name}}. Together, always.",
       "{{from_name}} rose past {{to_name}}. The whole is greater than the parts."

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -13,7 +13,7 @@
     "excellent": "excellent",
     "legendary": "legendary"
   },
-  "wow": {
+  "coven": {
     "a-start": "a start",
     "solid": "solid",
     "good": "good",
@@ -56,7 +56,7 @@
     "everymen": {
       "rateAria": "Rate {{value}} — {{label}}"
     },
-    "wow": {
+    "coven": {
       "rateAria": "Rate {{value}} — {{label}}"
     },
     "snide": {

--- a/frontend/src/pages/characterProfile/FactionProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/FactionProfileBody.tsx
@@ -16,7 +16,7 @@
  * below and its players adopt the bespoke skin with no other change (#460):
  *
  *   ua:          UaProfileBody,
- *   wow:         WowProfileBody,
+ *   wow:         CovenProfileBody,
  *   snide:       SnideProfileBody,
  *   ephemerists: EphemeristsProfileBody,
  *   singularity: SingularityProfileBody,

--- a/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
@@ -64,7 +64,7 @@ describe("FactionProfileBody dispatch", () => {
     // member's profile IS the default one. That is the point — a profile is
     // exactly where a secret society would give itself away.
     expect(Object.keys(surfaceMap("profileBody")).sort()).toEqual(
-      ["ephemerists", "everymen", "singularity", "snide", "ua", "wow"].sort(),
+      ["ephemerists", "everymen", "singularity", "snide", "ua", "coven"].sort(),
     );
   });
 
@@ -96,7 +96,7 @@ describe("FactionProfileBody dispatch", () => {
   it("renders a profile for every faction slug (bespoke skin or default)", () => {
     for (const slug of [
       "ua",
-      "wow",
+      "coven",
       "snide",
       "ephemerists",
       "singularity",

--- a/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
@@ -1,8 +1,8 @@
 /**
- * WowProfileBody — Warriors of Whimsy scrapbook player-profile skin (#460).
+ * CovenProfileBody — Warriors of Whimsy scrapbook player-profile skin (#460).
  * Ported from docs/design/profile/templates/Warriors of Whimsy Profile.dc.html:
  * a cork-board mat with push-pin dots, slight tilts, washi-tape strips, and an
- * ".exe window" progression panel. WOW follows the global light/dark cascade —
+ * ".exe window" progression panel. COVEN follows the global light/dark cascade —
  * it reads --faction-wow-* / --faction-wow-card-* tokens (which flip with the
  * theme) and never pins a fixed data-theme.
  *
@@ -173,6 +173,6 @@ const kit: ProfileKit = {
   ),
 }
 
-export default function WowProfileBody(props: ProfileBodyProps) {
+export default function CovenProfileBody(props: ProfileBodyProps) {
   return <ProfileSkin props={props} kit={kit} />
 }

--- a/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
@@ -3,26 +3,26 @@
  * Ported from docs/design/profile/templates/Warriors of Whimsy Profile.dc.html:
  * a cork-board mat with push-pin dots, slight tilts, washi-tape strips, and an
  * ".exe window" progression panel. COVEN follows the global light/dark cascade —
- * it reads --faction-wow-* / --faction-wow-card-* tokens (which flip with the
+ * it reads --faction-coven-* / --faction-coven-card-* tokens (which flip with the
  * theme) and never pins a fixed data-theme.
  *
  * Structure is DefaultProfileBody's locked spine via ProfileSkin. No hardcoded
- * hex — colours via --faction-wow-* vars.
+ * hex — colours via --faction-coven-* vars.
  */
 import type { ReactNode } from 'react'
 
 import type { ProfileBodyProps } from '../FactionProfileBody'
 import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
 
-const INK = 'var(--faction-wow-card-text)'
-const MUTED = 'var(--faction-wow-card-muted)'
-const ACCENT = 'var(--faction-wow-card-accent)'
-const SURFACE = 'var(--faction-wow-notepad-bg)'
-const BORDER = 'var(--faction-wow-win-border)'
-const MAT = 'var(--faction-wow-light)'
+const INK = 'var(--faction-coven-card-text)'
+const MUTED = 'var(--faction-coven-card-muted)'
+const ACCENT = 'var(--faction-coven-card-accent)'
+const SURFACE = 'var(--faction-coven-notepad-bg)'
+const BORDER = 'var(--faction-coven-win-border)'
+const MAT = 'var(--faction-coven-light)'
 const DISPLAY = 'var(--font-faction-script)' // Caveat
 const EYEBROW = 'var(--font-body)'
-const BAR = 'linear-gradient(90deg, var(--faction-wow-title-from), var(--faction-wow-card-accent))'
+const BAR = 'linear-gradient(90deg, var(--faction-coven-title-from), var(--faction-coven-card-accent))'
 
 function Pin({ left, right }: { left?: number; right?: number }) {
   return (
@@ -52,7 +52,7 @@ function heading(title: string, eyebrow: string): ReactNode {
           fontFamily: DISPLAY,
           fontSize: 'var(--text-heading)',
           color: ACCENT,
-          background: 'var(--faction-wow-tape)',
+          background: 'var(--faction-coven-tape)',
           padding: 'var(--space-xs) var(--space-md)',
           transform: 'rotate(-1.5deg)',
           display: 'inline-block',
@@ -66,9 +66,9 @@ function heading(title: string, eyebrow: string): ReactNode {
 }
 
 const kit: ProfileKit = {
-  slug: 'wow',
+  slug: 'coven',
   pageBackground: MAT,
-  pageOverlay: 'radial-gradient(var(--faction-wow-dot) 1px, transparent 1px)',
+  pageOverlay: 'radial-gradient(var(--faction-coven-dot) 1px, transparent 1px)',
   ink: INK,
   muted: MUTED,
   accent: ACCENT,
@@ -77,7 +77,7 @@ const kit: ProfileKit = {
   displayFont: DISPLAY,
   eyebrowFont: EYEBROW,
   headerStyle: {
-    background: 'var(--faction-wow-notepad-bg)',
+    background: 'var(--faction-coven-notepad-bg)',
     border: `1px solid ${BORDER}`,
     borderRadius: 16,
     padding: 'var(--space-2xl)',
@@ -111,7 +111,7 @@ const kit: ProfileKit = {
   },
   ringLabel: 'lvl',
   barFill: BAR,
-  barTrack: 'var(--faction-wow-notepad-border)',
+  barTrack: 'var(--faction-coven-notepad-border)',
   nextLevelLabel: (next) => `next · lvl ${next}`,
   sectionHeading: heading,
   praxisEyebrow: (name) => `sealed by ${name}`,
@@ -149,7 +149,7 @@ const kit: ProfileKit = {
     <BadgeRow
       badge={badge}
       last={last}
-      dividerColor="var(--faction-wow-notepad-border)"
+      dividerColor="var(--faction-coven-notepad-border)"
       nameStyle={{ fontFamily: DISPLAY, color: INK, lineHeight: 1.15 }}
       medallion={(glyph) => (
         <span
@@ -158,7 +158,7 @@ const kit: ProfileKit = {
             width: 34,
             height: 34,
             borderRadius: '50%',
-            background: 'radial-gradient(circle at 30% 30%, var(--faction-wow-scrap-mid), var(--faction-wow-scrap-deep))',
+            background: 'radial-gradient(circle at 30% 30%, var(--faction-coven-scrap-mid), var(--faction-coven-scrap-deep))',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -185,7 +185,7 @@ function Ivy({
   );
 }
 
-export default function WowEditPraxis({ state }: Props) {
+export default function CovenEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
   const praxis = state.praxis!;
   const task = state.task;

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -198,23 +198,23 @@ export default function CovenEditPraxis({ state }: Props) {
     desc: t(`editPraxis.wow.mode.${key}.desc`),
   }));
 
-  const pink = factionCssVar("wow");
-  const pinkDeep = factionCssVar("wow", "card-accent");
-  const ink = factionCssVar("wow", "card-text");
-  const muted = factionCssVar("wow", "card-muted");
-  const lightBg = factionCssVar("wow", "light");
-  const cardFont = factionCssVar("wow", "card-font");
+  const pink = factionCssVar("coven");
+  const pinkDeep = factionCssVar("coven", "card-accent");
+  const ink = factionCssVar("coven", "card-text");
+  const muted = factionCssVar("coven", "card-muted");
+  const lightBg = factionCssVar("coven", "light");
+  const cardFont = factionCssVar("coven", "card-font");
 
-  const winBorder = factionCssVar("wow", "win-border");
-  const titleFrom = factionCssVar("wow", "title-from");
-  const titleTo = factionCssVar("wow", "title-to");
-  const titleText = factionCssVar("wow", "title-text");
-  const bodyBg = factionCssVar("wow", "body-bg");
-  const notepadBg = factionCssVar("wow", "notepad-bg");
-  const notepadBorder = factionCssVar("wow", "notepad-border");
-  const dot = factionCssVar("wow", "dot");
-  const ivy = factionCssVar("wow", "ivy");
-  const ivyLeaf = factionCssVar("wow", "ivy-leaf");
+  const winBorder = factionCssVar("coven", "win-border");
+  const titleFrom = factionCssVar("coven", "title-from");
+  const titleTo = factionCssVar("coven", "title-to");
+  const titleText = factionCssVar("coven", "title-text");
+  const bodyBg = factionCssVar("coven", "body-bg");
+  const notepadBg = factionCssVar("coven", "notepad-bg");
+  const notepadBorder = factionCssVar("coven", "notepad-border");
+  const dot = factionCssVar("coven", "dot");
+  const ivy = factionCssVar("coven", "ivy");
+  const ivyLeaf = factionCssVar("coven", "ivy-leaf");
 
   const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
 

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -194,8 +194,8 @@ export default function CovenEditPraxis({ state }: Props) {
     ["solo", "collab", "duel"] as const
   ).map((key) => ({
     key,
-    label: t(`editPraxis.wow.mode.${key}.label`),
-    desc: t(`editPraxis.wow.mode.${key}.desc`),
+    label: t(`editPraxis.coven.mode.${key}.label`),
+    desc: t(`editPraxis.coven.mode.${key}.desc`),
   }));
 
   const pink = factionCssVar("coven");
@@ -332,7 +332,7 @@ export default function CovenEditPraxis({ state }: Props) {
               }}
             >
               <Sparkle size={11} color={titleText} />{" "}
-              {t("editPraxis.wow.windowTitle")}
+              {t("editPraxis.coven.windowTitle")}
             </span>
             <span
               style={{
@@ -371,14 +371,14 @@ export default function CovenEditPraxis({ state }: Props) {
                 gap: "var(--space-sm)",
               }}
             >
-              {t("editPraxis.wow.pageTitle")}
+              {t("editPraxis.coven.pageTitle")}
               <StarSticker size={26} color="#f47aa6" />
             </div>
 
             {/* Task — notepad scrap */}
             <div style={{ ...notepadPanel, marginBottom: "var(--space-xl)" }}>
               <span style={{ ...eyebrowStyle, marginBottom: "var(--space-xs)" }}>
-                {t("editPraxis.wow.taskRefLabel")}
+                {t("editPraxis.coven.taskRefLabel")}
               </span>
               <div
                 style={{
@@ -405,7 +405,7 @@ export default function CovenEditPraxis({ state }: Props) {
             {!state.controlsLocked && (
               <div style={{ marginBottom: "var(--space-xl)" }}>
                 <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                  {t("editPraxis.wow.modeLabel")}
+                  {t("editPraxis.coven.modeLabel")}
                 </span>
                 <ModePicker
                   state={state}
@@ -468,8 +468,8 @@ export default function CovenEditPraxis({ state }: Props) {
                 >
                   <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
                     {state.duelMode
-                      ? t("editPraxis.wow.inviteLabelDuel")
-                      : t("editPraxis.wow.inviteLabel")}
+                      ? t("editPraxis.coven.inviteLabelDuel")
+                      : t("editPraxis.coven.inviteLabel")}
                   </span>
                   <InviteSearch
                     state={state}
@@ -481,7 +481,7 @@ export default function CovenEditPraxis({ state }: Props) {
                       pillBg: lightBg,
                       acceptedBg: pink,
                       acceptedColor: "var(--color-text-on-accent)",
-                      placeholder: t("editPraxis.wow.invitePlaceholder"),
+                      placeholder: t("editPraxis.coven.invitePlaceholder"),
                     }}
                   />
                 </div>
@@ -490,12 +490,12 @@ export default function CovenEditPraxis({ state }: Props) {
             {/* Title — notepad panel */}
             <div style={{ ...notepadPanel, marginBottom: "var(--space-lg)" }}>
               <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                {t("editPraxis.wow.titleLabel")}
+                {t("editPraxis.coven.titleLabel")}
               </span>
               <TitleField
                 state={state}
                 skin={{
-                  placeholder: t("editPraxis.wow.titlePlaceholder"),
+                  placeholder: t("editPraxis.coven.titlePlaceholder"),
                   inputStyle: {
                     width: "100%",
                     fontFamily: cardFont,
@@ -519,10 +519,10 @@ export default function CovenEditPraxis({ state }: Props) {
                 <TitleCounter length={state.title.length} color={muted} />
                 <span style={{ ...eyebrowStyle, color: muted, fontSize: "var(--text-xs)" }}>
                   {state.autosaveAt
-                    ? t("editPraxis.wow.autosaveSaved", {
+                    ? t("editPraxis.coven.autosaveSaved", {
                         ago: formatAutosave(state.autosaveAt),
                       })
-                    : t("editPraxis.wow.autosaveUnsaved")}
+                    : t("editPraxis.coven.autosaveUnsaved")}
                 </span>
               </div>
             </div>
@@ -530,13 +530,13 @@ export default function CovenEditPraxis({ state }: Props) {
             {/* Body — notepad panel */}
             <div style={{ ...notepadPanel, marginBottom: "var(--space-lg)" }}>
               <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                {t("editPraxis.wow.bodyLabel", { words: state.wordCount })}
+                {t("editPraxis.coven.bodyLabel", { words: state.wordCount })}
               </span>
               <BodyTextarea
                 state={state}
                 skin={{
                   rows: 12,
-                  placeholder: t("editPraxis.wow.bodyPlaceholder"),
+                  placeholder: t("editPraxis.coven.bodyPlaceholder"),
                   textareaStyle: {
                     width: "100%",
                     fontFamily: "var(--font-body)",
@@ -564,7 +564,7 @@ export default function CovenEditPraxis({ state }: Props) {
                   },
                   label: (
                     <span style={{ ...eyebrowStyle, marginBottom: "var(--space-xs)" }}>
-                      {t("editPraxis.wow.previewLabel")}
+                      {t("editPraxis.coven.previewLabel")}
                     </span>
                   ),
                   markdownStyle: {
@@ -579,7 +579,7 @@ export default function CovenEditPraxis({ state }: Props) {
             {/* Media — notepad panel */}
             <div style={{ ...notepadPanel, marginBottom: "var(--space-lg)" }}>
               <span style={{ ...eyebrowStyle, marginBottom: "var(--space-md)" }}>
-                {t("editPraxis.wow.filesLabel", {
+                {t("editPraxis.coven.filesLabel", {
                   pasted: state.media.length,
                 })}
               </span>
@@ -644,8 +644,8 @@ export default function CovenEditPraxis({ state }: Props) {
                       flexDirection: "column",
                       gap: "var(--space-xs)",
                     },
-                    buttonLabel: t("editPraxis.wow.fileButton"),
-                    helperText: t("editPraxis.wow.fileHelper"),
+                    buttonLabel: t("editPraxis.coven.fileButton"),
+                    helperText: t("editPraxis.coven.fileHelper"),
                     helperStyle: {
                       fontSize: "var(--text-sm)",
                       color: muted,
@@ -666,7 +666,7 @@ export default function CovenEditPraxis({ state }: Props) {
                 }}
               >
                 <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                  {t("editPraxis.wow.metatasksLabel")}
+                  {t("editPraxis.coven.metatasksLabel")}
                 </span>
                 <MetatasksList
                   state={state}
@@ -706,7 +706,7 @@ export default function CovenEditPraxis({ state }: Props) {
               <DropButton
                 state={state}
                 skin={{
-                  label: t("editPraxis.wow.dropLabel"),
+                  label: t("editPraxis.coven.dropLabel"),
                   style: {
                     background: "transparent",
                     color: muted,
@@ -725,8 +725,8 @@ export default function CovenEditPraxis({ state }: Props) {
                   ornament: (
                     <Sparkle size={12} color="var(--color-text-on-accent)" />
                   ),
-                  idleLabel: t("editPraxis.wow.publishIdle"),
-                  busyLabel: t("editPraxis.wow.publishBusy"),
+                  idleLabel: t("editPraxis.coven.publishIdle"),
+                  busyLabel: t("editPraxis.coven.publishBusy"),
                   style: {
                     display: "inline-flex",
                     alignItems: "center",

--- a/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
@@ -4,7 +4,7 @@
  * (Write/Preview toggle, fluid media grid, sticky submit bar) dressed in the
  * pink window chrome: dotted board, notepad panels, sparkle-titled bars.
  * Ported from the Field Kit `wow-treatment` composer; grounds on the
- * `--faction-wow-*` tokens already in index.css (the set CovenFieldDesk /
+ * `--faction-coven-*` tokens already in index.css (the set CovenFieldDesk /
  * CovenEditPraxis desktop use). Consumes `useEditPraxis` verbatim — no editor,
  * upload, or submit logic lives here. Presentation-only.
  */
@@ -29,17 +29,17 @@ import {
 import type { EditPraxisState } from "../useEditPraxis";
 import { MobileStickyBar, SegToggle, type ComposerTab } from "./shared";
 
-const PINK = "var(--faction-wow)";
-const PINK_DEEP = "var(--faction-wow-card-accent)";
-const TITLE_TEXT = "var(--faction-wow-title-text)";
-const CARD_TEXT = "var(--faction-wow-card-text)";
-const CARD_MUTED = "var(--faction-wow-card-muted)";
-const WIN_BORDER = "var(--faction-wow-win-border)";
-const NOTEPAD_BG = "var(--faction-wow-notepad-bg)";
-const NOTEPAD_BORDER = "var(--faction-wow-notepad-border)";
-const BODY_BG = "var(--faction-wow-body-bg)";
-const DOT = "var(--faction-wow-dot)";
-const SCRIPT = "var(--faction-wow-card-font)";
+const PINK = "var(--faction-coven)";
+const PINK_DEEP = "var(--faction-coven-card-accent)";
+const TITLE_TEXT = "var(--faction-coven-title-text)";
+const CARD_TEXT = "var(--faction-coven-card-text)";
+const CARD_MUTED = "var(--faction-coven-card-muted)";
+const WIN_BORDER = "var(--faction-coven-win-border)";
+const NOTEPAD_BG = "var(--faction-coven-notepad-bg)";
+const NOTEPAD_BORDER = "var(--faction-coven-notepad-border)";
+const BODY_BG = "var(--faction-coven-body-bg)";
+const DOT = "var(--faction-coven-dot)";
+const SCRIPT = "var(--faction-coven-card-font)";
 const BODY = "var(--font-body)";
 const ON_ACCENT = "var(--color-text-on-accent)";
 
@@ -89,14 +89,14 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
           gap: "var(--space-sm)",
           padding: "var(--space-sm) var(--space-md)",
           background:
-            "linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))",
+            "linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))",
           borderBottom: `2px solid ${WIN_BORDER}`,
         }}
       >
         {[
-          "var(--faction-wow-scrap-deep)",
-          "var(--faction-wow-tape)",
-          "var(--faction-wow-ivy-leaf)",
+          "var(--faction-coven-scrap-deep)",
+          "var(--faction-coven-tape)",
+          "var(--faction-coven-ivy-leaf)",
         ].map((color) => (
           <span
             key={color}
@@ -155,7 +155,7 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
 
   return (
     <div
-      data-skin="wow"
+      data-skin="coven"
       style={{
         display: "flex",
         flexDirection: "column",

--- a/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
@@ -4,8 +4,8 @@
  * (Write/Preview toggle, fluid media grid, sticky submit bar) dressed in the
  * pink window chrome: dotted board, notepad panels, sparkle-titled bars.
  * Ported from the Field Kit `wow-treatment` composer; grounds on the
- * `--faction-wow-*` tokens already in index.css (the set WowFieldDesk /
- * WowEditPraxis desktop use). Consumes `useEditPraxis` verbatim — no editor,
+ * `--faction-wow-*` tokens already in index.css (the set CovenFieldDesk /
+ * CovenEditPraxis desktop use). Consumes `useEditPraxis` verbatim — no editor,
  * upload, or submit logic lives here. Presentation-only.
  */
 import { useState } from "react";
@@ -147,7 +147,7 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
   );
 }
 
-export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
+export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
   const { t } = useTranslation("forms");
   const [tab, setTab] = useState<ComposerTab>("write");
   const praxis = state.praxis!;
@@ -442,7 +442,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
   );
 }
 
-/** Fluid 3-column media grid in the WOW notepad idiom. */
+/** Fluid 3-column media grid in the COVEN notepad idiom. */
 function MediaGrid({
   state,
   readOnly = false,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
@@ -181,15 +181,15 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
               gap: "var(--space-sm)",
             }}
           >
-            {t("editPraxis.wow.pageTitle")}
+            {t("editPraxis.coven.pageTitle")}
             <Sparkle size={16} color={PINK} />
           </h1>
           <span style={{ ...eyebrow, color: CARD_MUTED, marginLeft: "auto" }}>
             {state.autosaveAt
-              ? t("editPraxis.wow.autosaveSaved", {
+              ? t("editPraxis.coven.autosaveSaved", {
                   ago: formatAutosave(state.autosaveAt),
                 })
-              : t("editPraxis.wow.autosaveUnsaved")}
+              : t("editPraxis.coven.autosaveUnsaved")}
           </span>
         </div>
 
@@ -235,7 +235,7 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
           borderRadius: 12,
         }}
       >
-        <span style={eyebrow}>{t("editPraxis.wow.taskRefLabel")}</span>
+        <span style={eyebrow}>{t("editPraxis.coven.taskRefLabel")}</span>
         <span
           style={{
             fontFamily: SCRIPT,
@@ -256,11 +256,11 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
 
       {tab === "write" ? (
         <>
-          <Window title={t("editPraxis.wow.titleLabel")}>
+          <Window title={t("editPraxis.coven.titleLabel")}>
             <TitleField
               state={state}
               skin={{
-                placeholder: t("editPraxis.wow.titlePlaceholder"),
+                placeholder: t("editPraxis.coven.titlePlaceholder"),
                 inputStyle: {
                   width: "100%",
                   fontFamily: SCRIPT,
@@ -276,12 +276,12 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
             />
           </Window>
 
-          <Window title={t("editPraxis.wow.bodyLabel", { words: state.wordCount })}>
+          <Window title={t("editPraxis.coven.bodyLabel", { words: state.wordCount })}>
             <BodyTextarea
               state={state}
               skin={{
                 rows: 10,
-                placeholder: t("editPraxis.wow.bodyPlaceholder"),
+                placeholder: t("editPraxis.coven.bodyPlaceholder"),
                 textareaStyle: {
                   width: "100%",
                   fontFamily: BODY,
@@ -303,8 +303,8 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
             <Window
               title={
                 state.duelMode
-                  ? t("editPraxis.wow.inviteLabelDuel")
-                  : t("editPraxis.wow.inviteLabel")
+                  ? t("editPraxis.coven.inviteLabelDuel")
+                  : t("editPraxis.coven.inviteLabel")
               }
             >
               <InviteSearch
@@ -316,18 +316,18 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
                   inputBorder: `1.5px solid ${NOTEPAD_BORDER}`,
                   acceptedBg: PINK,
                   acceptedColor: ON_ACCENT,
-                  placeholder: t("editPraxis.wow.invitePlaceholder"),
+                  placeholder: t("editPraxis.coven.invitePlaceholder"),
                 }}
               />
             </Window>
           )}
 
-          <Window title={t("editPraxis.wow.filesLabel", { pasted: state.media.length })}>
+          <Window title={t("editPraxis.coven.filesLabel", { pasted: state.media.length })}>
             <MediaGrid state={state} />
           </Window>
 
           {state.showMetatasks && (
-            <Window title={t("editPraxis.wow.metatasksLabel")}>
+            <Window title={t("editPraxis.coven.metatasksLabel")}>
               <MetatasksList
                 state={state}
                 skin={{
@@ -352,7 +352,7 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
           )}
         </>
       ) : (
-        <Window title={t("editPraxis.wow.previewLabel")}>
+        <Window title={t("editPraxis.coven.previewLabel")}>
           <div
             style={{
               fontFamily: SCRIPT,
@@ -361,7 +361,7 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
               marginBottom: "var(--space-sm)",
             }}
           >
-            {state.title || t("editPraxis.wow.titlePlaceholder")}
+            {state.title || t("editPraxis.coven.titlePlaceholder")}
           </div>
           {state.media.length > 0 && (
             <div style={{ marginBottom: "var(--space-md)" }}>
@@ -398,7 +398,7 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
           <DropButton
             state={state}
             skin={{
-              label: t("editPraxis.wow.dropLabel"),
+              label: t("editPraxis.coven.dropLabel"),
               style: {
                 background: "transparent",
                 border: "none",
@@ -415,8 +415,8 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
           state={state}
           skin={{
             ornament: <Sparkle size={13} color={ON_ACCENT} />,
-            idleLabel: t("editPraxis.wow.publishIdle"),
-            busyLabel: t("editPraxis.wow.publishBusy"),
+            idleLabel: t("editPraxis.coven.publishIdle"),
+            busyLabel: t("editPraxis.coven.publishBusy"),
             style: {
               flex: 1,
               display: "inline-flex",
@@ -541,7 +541,7 @@ function MediaGrid({
               fontWeight: 700,
               color: PINK,
             },
-            buttonLabel: t("editPraxis.wow.fileButton"),
+            buttonLabel: t("editPraxis.coven.fileButton"),
           }}
         />
       )}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -136,7 +136,7 @@ function render(slug: string | null): string {
 describe("edit-praxis form-factor dispatch", () => {
   it("renders the COVEN bespoke composer on mobile for a COVEN task", () => {
     mocks.formFactor = "mobile";
-    expect(render("wow")).toContain('data-skin="coven"');
+    expect(render("coven")).toContain('data-skin="coven"');
   });
 
   it("renders the SNIDE bespoke composer on mobile for a SNIDE task", () => {
@@ -153,9 +153,11 @@ describe("edit-praxis form-factor dispatch", () => {
 
   it("renders the desktop archetype on desktop (skin dispatch untouched)", () => {
     mocks.formFactor = "desktop";
-    const html = render("wow");
+    const html = render("coven");
     expect(html).not.toContain("data-skin=");
-    // wow.exe desktop window chrome, not the mobile skin.
+    // The literal "wow.exe" window chrome, not the mobile skin. The window
+    // title is COPY, and Cozy Coven's display naming is deliberately deferred
+    // (#784) — the aesthetic moved pixel-identical, wording included.
     expect(html).toContain("wow.exe");
   });
 });
@@ -163,7 +165,7 @@ describe("edit-praxis form-factor dispatch", () => {
 describe("mobile composer content slots", () => {
   for (const [label, slug] of [
     ["Default", "na"],
-    ["COVEN", "wow"],
+    ["COVEN", "coven"],
     ["SNIDE", "snide"],
   ] as const) {
     it(`${label} mobile composer renders body editor + media-add + submit`, () => {

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -2,7 +2,7 @@
  * Edit-praxis form-factor dispatch (#498) — the composer twin of the TaskDetail
  * / FieldDesk mobile-dispatch seams. Renders <EditPraxis /> with useFormFactor
  * mocked and useEditPraxis stubbed, and pins:
- *   - phone + the WOW pilot → its bespoke mobile composer (data-skin="wow"),
+ *   - phone + the COVEN pilot → its bespoke mobile composer (data-skin="wow"),
  *   - phone + an unregistered faction → the Default mobile composer,
  *   - desktop → the existing desktop archetype (skin dispatch untouched).
  * It also asserts each mobile skin surfaces the body editor, media-add, and
@@ -134,7 +134,7 @@ function render(slug: string | null): string {
 }
 
 describe("edit-praxis form-factor dispatch", () => {
-  it("renders the WOW bespoke composer on mobile for a WOW task", () => {
+  it("renders the COVEN bespoke composer on mobile for a COVEN task", () => {
     mocks.formFactor = "mobile";
     expect(render("wow")).toContain('data-skin="wow"');
   });
@@ -163,7 +163,7 @@ describe("edit-praxis form-factor dispatch", () => {
 describe("mobile composer content slots", () => {
   for (const [label, slug] of [
     ["Default", "na"],
-    ["WOW", "wow"],
+    ["COVEN", "wow"],
     ["SNIDE", "snide"],
   ] as const) {
     it(`${label} mobile composer renders body editor + media-add + submit`, () => {

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -2,7 +2,7 @@
  * Edit-praxis form-factor dispatch (#498) — the composer twin of the TaskDetail
  * / FieldDesk mobile-dispatch seams. Renders <EditPraxis /> with useFormFactor
  * mocked and useEditPraxis stubbed, and pins:
- *   - phone + the COVEN pilot → its bespoke mobile composer (data-skin="wow"),
+ *   - phone + the COVEN pilot → its bespoke mobile composer (data-skin="coven"),
  *   - phone + an unregistered faction → the Default mobile composer,
  *   - desktop → the existing desktop archetype (skin dispatch untouched).
  * It also asserts each mobile skin surfaces the body editor, media-add, and
@@ -136,7 +136,7 @@ function render(slug: string | null): string {
 describe("edit-praxis form-factor dispatch", () => {
   it("renders the COVEN bespoke composer on mobile for a COVEN task", () => {
     mocks.formFactor = "mobile";
-    expect(render("wow")).toContain('data-skin="wow"');
+    expect(render("wow")).toContain('data-skin="coven"');
   });
 
   it("renders the SNIDE bespoke composer on mobile for a SNIDE task", () => {
@@ -148,7 +148,7 @@ describe("edit-praxis form-factor dispatch", () => {
     mocks.formFactor = "mobile";
     const html = render("na");
     expect(html).toContain('data-skin="default"');
-    expect(html).not.toContain('data-skin="wow"');
+    expect(html).not.toContain('data-skin="coven"');
   });
 
   it("renders the desktop archetype on desktop (skin dispatch untouched)", () => {

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -32,7 +32,7 @@ vi.mock("../../archetypes/controls", async (importActual) => {
 });
 
 import DefaultMobileEditPraxis from "../DefaultEditPraxis";
-import WowMobileEditPraxis from "../WowEditPraxis";
+import CovenMobileEditPraxis from "../CovenEditPraxis";
 
 const praxis = {
   id: 55,
@@ -128,7 +128,7 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
 describe("mobile composer submit wiring", () => {
   for (const [label, Skin] of [
     ["Default", DefaultMobileEditPraxis],
-    ["WOW", WowMobileEditPraxis],
+    ["COVEN", CovenMobileEditPraxis],
   ] as const) {
     it(`${label} hands the submit control the hook's publish handler`, () => {
       captured.state = null;

--- a/frontend/src/pages/editPraxis/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/shared.tsx
@@ -1,6 +1,6 @@
 /**
  * Shared mobile-composer primitives (#498). The two phone skins (Default + the
- * WOW pilot) diverge visually but share three load-bearing behaviours: the
+ * COVEN pilot) diverge visually but share three load-bearing behaviours: the
  * Write/Preview segmented toggle, the fluid media grid, and the sticky submit
  * bar that must ride above the fixed MobileTabBar (and, on a phone, the
  * on-screen keyboard). Kept here so both skins stay thin and neither

--- a/frontend/src/pages/factionDetail/__tests__/covenMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/covenMobileDispatch.test.tsx
@@ -12,7 +12,7 @@ import CovenFactionPage from '../mobileArchetypes/CovenFactionPage'
 
 describe('mobile faction-page COVEN dispatch', () => {
   it('mobile + the COVEN faction resolves to the bespoke COVEN page', () => {
-    expect(pickVariant(surfaceMap('mobileFactionPage'), 'wow', DefaultFactionPage)).toBe(CovenFactionPage)
+    expect(pickVariant(surfaceMap('mobileFactionPage'), 'coven', DefaultFactionPage)).toBe(CovenFactionPage)
   })
 
   it('every other faction falls through to the Default mobile page', () => {

--- a/frontend/src/pages/factionDetail/__tests__/covenMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/covenMobileDispatch.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Mobile faction-page WOW dispatch (#531). Asserts the mobile registry resolves
+ * Mobile faction-page COVEN dispatch (#531). Asserts the mobile registry resolves
  * the `wow` faction to the scrapbook coven page skin, and that every other
  * faction (and null) falls through to the single-column DefaultFactionPage.
  * Mirrors the other surfaces' wow-dispatch tests.
@@ -8,11 +8,11 @@ import { describe, it, expect } from 'vitest'
 import { pickVariant } from '../../../utils/factionDispatch'
 import { surfaceMap } from '../../../factions'
 import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
-import WowFactionPage from '../mobileArchetypes/WowFactionPage'
+import CovenFactionPage from '../mobileArchetypes/CovenFactionPage'
 
-describe('mobile faction-page WOW dispatch', () => {
-  it('mobile + the WOW faction resolves to the bespoke WOW page', () => {
-    expect(pickVariant(surfaceMap('mobileFactionPage'), 'wow', DefaultFactionPage)).toBe(WowFactionPage)
+describe('mobile faction-page COVEN dispatch', () => {
+  it('mobile + the COVEN faction resolves to the bespoke COVEN page', () => {
+    expect(pickVariant(surfaceMap('mobileFactionPage'), 'wow', DefaultFactionPage)).toBe(CovenFactionPage)
   })
 
   it('every other faction falls through to the Default mobile page', () => {

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -12,7 +12,7 @@ import type { FactionDetailState } from "../useFactionDetail";
 /**
  * Warriors of Whimsy faction-body — the whimsy.exe cork-memo-board skin of the
  * standardized six-section spine (② About, ③ join.exe, ④ Tasks, ⑤ Praxis,
- * ⑥ Members). Section ① (hero + side stat charms) is WowFactionHero, above.
+ * ⑥ Members). Section ① (hero + side stat charms) is CovenFactionHero, above.
  *
  * Same shape as EverymenFactionBody / UaFactionBody — Tasks/Praxis reuse the
  * app-wide per-faction cards (TaskCard / PraxisCard already dispatch to the WoW
@@ -23,7 +23,7 @@ import type { FactionDetailState } from "../useFactionDetail";
  *
  * Every colour resolves to a --faction-wow-* token (dark-mode-aware via the
  * cascade). The script face is the WoW card-font token (Caveat); body copy uses
- * --font-body, matching WowTaskCard and the WoW PraxisCard branch.
+ * --font-body, matching CovenTaskCard and the WoW PraxisCard branch.
  */
 
 const PINK = "var(--faction-wow)";
@@ -166,7 +166,7 @@ function Avatar({ name, size }: { name: string; size: number }) {
   );
 }
 
-export default function WowFactionBody({ state }: { state: FactionDetailState }) {
+export default function CovenFactionBody({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation("factions");
   const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } = state;
   const [confirming, setConfirming] = useState(false);

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -214,7 +214,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                 marginBottom: "var(--space-md)",
               }}
             >
-              {t("wow.manifesto.heading")}
+              {t("coven.manifesto.heading")}
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
               {paragraphs.length ? (
@@ -225,7 +225,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                 ))
               ) : (
                 <p className="content-text" style={{ fontFamily: BODY, lineHeight: 1.85, color: MUTED, margin: 0 }}>
-                  {t("wow.manifesto.empty")}
+                  {t("coven.manifesto.empty")}
                 </p>
               )}
             </div>
@@ -234,10 +234,10 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
 
         {/* ④ TASKS */}
         <div>
-          <SectionHeading>{t("wow.tasks.heading")}</SectionHeading>
-          <Kicker>{t("wow.tasks.kicker")}</Kicker>
+          <SectionHeading>{t("coven.tasks.heading")}</SectionHeading>
+          <Kicker>{t("coven.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
-            <p className="content-text" style={{ fontFamily: BODY, color: MUTED, marginTop: "var(--space-md)" }}>{t("wow.tasks.empty")}</p>
+            <p className="content-text" style={{ fontFamily: BODY, color: MUTED, marginTop: "var(--space-md)" }}>{t("coven.tasks.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-xl)", alignItems: "flex-start", marginTop: "var(--space-lg)" }}>
               {tasks.map((task) => (
@@ -258,10 +258,10 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
 
         {/* ⑤ PRAXIS */}
         <div>
-          <SectionHeading>{t("wow.praxis.heading")}</SectionHeading>
-          <Kicker>{t("wow.praxis.kicker")}</Kicker>
+          <SectionHeading>{t("coven.praxis.heading")}</SectionHeading>
+          <Kicker>{t("coven.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
-            <p className="content-text" style={{ fontFamily: BODY, color: MUTED, marginTop: "var(--space-md)" }}>{t("wow.praxis.empty")}</p>
+            <p className="content-text" style={{ fontFamily: BODY, color: MUTED, marginTop: "var(--space-md)" }}>{t("coven.praxis.empty")}</p>
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-xl)", alignItems: "flex-start", marginTop: "var(--space-lg)" }}>
               {recentPraxis.map((praxis) => (
@@ -309,7 +309,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                   <span style={{ width: 9, height: 9, borderRadius: "50%", background: ACCENT }} />
                   <span style={{ width: 9, height: 9, borderRadius: "50%", background: IVY_LEAF }} />
                 </span>
-                <span style={{ marginLeft: "auto", fontFamily: BODY, fontSize: "var(--text-base)", color: TITLE_TEXT }}>{t("wow.join.windowTitle")}</span>
+                <span style={{ marginLeft: "auto", fontFamily: BODY, fontSize: "var(--text-base)", color: TITLE_TEXT }}>{t("coven.join.windowTitle")}</span>
               </div>
 
               <div style={{ background: NOTEPAD, padding: "var(--space-lg)" }}>
@@ -328,10 +328,10 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                         lineHeight: 1,
                       }}
                     >
-                      {t("wow.join.memberTitle")}
+                      {t("coven.join.memberTitle")}
                     </div>
                     <div style={{ fontFamily: BODY, fontSize: "var(--text-md)", color: MUTED, marginTop: "var(--space-sm)" }}>
-                      <Trans t={t} i18nKey="wow.join.memberStanding">
+                      <Trans t={t} i18nKey="coven.join.memberStanding">
                         Standing · <b style={{ color: ACCENT }}>coven witch</b>
                       </Trans>
                     </div>
@@ -351,10 +351,10 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                         marginBottom: "var(--space-sm)",
                       }}
                     >
-                      {t("wow.join.eligibleTitle")}
+                      {t("coven.join.eligibleTitle")}
                     </div>
                     <div className="content-text" style={{ fontFamily: BODY, lineHeight: 1.55, color: MUTED, marginBottom: "var(--space-lg)" }}>
-                      {t("wow.join.eligibleBody")}
+                      {t("coven.join.eligibleBody")}
                     </div>
                     <button
                       onClick={() => setConfirming(true)}
@@ -374,7 +374,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                         cursor: "pointer",
                       }}
                     >
-                      {t("wow.join.joinButton")}
+                      {t("coven.join.joinButton")}
                     </button>
                   </div>
                 )}
@@ -413,8 +413,8 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                         }}
                       >
                         {membership.joining
-                          ? t("wow.join.joining")
-                          : t("wow.join.confirmButton")}
+                          ? t("coven.join.joining")
+                          : t("coven.join.confirmButton")}
                       </button>
                       <button
                         onClick={() => setConfirming(false)}
@@ -455,11 +455,11 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                           lineHeight: 1.2,
                         }}
                       >
-                        {t("wow.join.gateTitle")}
+                        {t("coven.join.gateTitle")}
                       </span>
                     </div>
                     <div className="content-text" style={{ fontFamily: BODY, lineHeight: 1.55, color: MUTED }}>
-                      {t("wow.join.gateBody", { faction: factionName(faction.slug) })}
+                      {t("coven.join.gateBody", { faction: factionName(faction.slug) })}
                     </div>
                   </div>
                 )}
@@ -501,7 +501,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                 {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the polaroid's caption chin, sized with the mat above. */}
                 <div style={{ padding: "8px 4px 14px", textAlign: "center" }}>
                   <div style={{ fontFamily: BODY, fontSize: "var(--text-xs)", letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
-                    {t("wow.spotlight.label")}
+                    {t("coven.spotlight.label")}
                   </div>
                   <div
                     style={{
@@ -516,7 +516,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                     {spot.display_name}
                   </div>
                   <div style={{ fontFamily: BODY, fontSize: "var(--text-sm)", color: INK, marginTop: "var(--space-xs)" }}>
-                    {t("wow.spotlight.stat", {
+                    {t("coven.spotlight.stat", {
                       level: spot.level,
                       score: spot.all_time_score.toLocaleString(),
                     })}
@@ -549,12 +549,12 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                   marginBottom: "var(--space-sm)",
                 }}
               >
-                {t("wow.roster.heading")}
+                {t("coven.roster.heading")}
               </div>
               {roster.length === 0 ? (
                 <p className="content-text" style={{ fontFamily: BODY, color: MUTED }}>
                   {spot
-                    ? t("wow.roster.emptyWithSpotlight")
+                    ? t("coven.roster.emptyWithSpotlight")
                     : t("detail.membersEmpty")}
                 </p>
               ) : (
@@ -582,7 +582,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                       {m.display_name}
                     </span>
                     <span style={{ fontFamily: BODY, fontSize: "var(--text-sm)", color: ACCENT }}>
-                      {t("wow.roster.level", { level: m.level })}
+                      {t("coven.roster.level", { level: m.level })}
                     </span>
                   </Link>
                 ))

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -21,37 +21,37 @@ import type { FactionDetailState } from "../useFactionDetail";
  * Witch-of-the-week polaroid + coven roster, and the FDL laurel on the single
  * top-scoring praxis.
  *
- * Every colour resolves to a --faction-wow-* token (dark-mode-aware via the
+ * Every colour resolves to a --faction-coven-* token (dark-mode-aware via the
  * cascade). The script face is the WoW card-font token (Caveat); body copy uses
  * --font-body, matching CovenTaskCard and the WoW PraxisCard branch.
  */
 
-const PINK = "var(--faction-wow)";
-const CARD_BG = "var(--faction-wow-card-bg)";
-const INK = "var(--faction-wow-card-text)";
-const ACCENT = "var(--faction-wow-card-accent)";
-const MUTED = "var(--faction-wow-card-muted)";
-const NOTEPAD = "var(--faction-wow-notepad-bg)";
-const NOTEPAD_BORDER = "var(--faction-wow-notepad-border)";
-const WIN_BORDER = "var(--faction-wow-win-border)";
-const TITLE_FROM = "var(--faction-wow-title-from)";
-const TITLE_TO = "var(--faction-wow-title-to)";
-const TITLE_TEXT = "var(--faction-wow-title-text)";
-const TAPE = "var(--faction-wow-tape)";
-const IVY = "var(--faction-wow-ivy)";
-const IVY_LEAF = "var(--faction-wow-ivy-leaf)";
+const PINK = "var(--faction-coven)";
+const CARD_BG = "var(--faction-coven-card-bg)";
+const INK = "var(--faction-coven-card-text)";
+const ACCENT = "var(--faction-coven-card-accent)";
+const MUTED = "var(--faction-coven-card-muted)";
+const NOTEPAD = "var(--faction-coven-notepad-bg)";
+const NOTEPAD_BORDER = "var(--faction-coven-notepad-border)";
+const WIN_BORDER = "var(--faction-coven-win-border)";
+const TITLE_FROM = "var(--faction-coven-title-from)";
+const TITLE_TO = "var(--faction-coven-title-to)";
+const TITLE_TEXT = "var(--faction-coven-title-text)";
+const TAPE = "var(--faction-coven-tape)";
+const IVY = "var(--faction-coven-ivy)";
+const IVY_LEAF = "var(--faction-coven-ivy-leaf)";
 
-const SCRIPT = "var(--faction-wow-card-font)";
+const SCRIPT = "var(--faction-coven-card-font)";
 const BODY = "var(--font-body)";
 
 // The board's warm-brown drop shadow + the index card's ruling have no dedicated
 // tokens; the WoW atoms hardcode the same warm rgba pair for their pinned paper.
 // Reuse them so this skin matches the atoms exactly.
-// ponytail: no --faction-wow-board-shadow / -rule token exists yet.
+// ponytail: no --faction-coven-board-shadow / -rule token exists yet.
 const BOARD_SHADOW = "rgba(80,50,30,0.28)";
 const PIN_SHADOW = "rgba(80,50,30,0.4)";
 // Faint hairline for a card edge — a muted mix of the notepad border.
-const HAIRLINE = "color-mix(in srgb, var(--faction-wow-notepad-border) 55%, transparent)";
+const HAIRLINE = "color-mix(in srgb, var(--faction-coven-notepad-border) 55%, transparent)";
 
 /** Tiny four-point sparkle — the WoW chrome's signature glyph. */
 function Sparkle({ size = 12, color = "currentColor" }: { size?: number; color?: string }) {

--- a/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
@@ -14,7 +14,7 @@ import type { FactionDetailState } from '../useFactionDetail'
  * via `state.membership`, ADR-0019) — only the dress changes: a pink scrapbook
  * "wow.exe" window hero on a dotted board, Caveat script, sparkle accents, rose
  * accent. Grounds on the `--faction-wow-*` window tokens already in index.css (the
- * set the WOW pilots use); always-light. Reuses the shared `mobile.*` faction copy
+ * set the COVEN pilots use); always-light. Reuses the shared `mobile.*` faction copy
  * so the slot contract holds. Presentation-only — all data + the join handler
  * arrive via {@link FactionDetailState}.
  */
@@ -120,7 +120,7 @@ const cancelButton: CSSProperties = {
   cursor: 'pointer',
 }
 
-export default function WowFactionPage({ state }: { state: FactionDetailState }) {
+export default function CovenFactionPage({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation('factions')
   const { faction, members, tasks, recentPraxis, membership } = state
   const [confirming, setConfirming] = useState(false)

--- a/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
@@ -13,7 +13,7 @@ import type { FactionDetailState } from '../useFactionDetail'
  * member/task counts, top members, recent praxis, and the invite-gated Join model
  * via `state.membership`, ADR-0019) — only the dress changes: a pink scrapbook
  * "wow.exe" window hero on a dotted board, Caveat script, sparkle accents, rose
- * accent. Grounds on the `--faction-wow-*` window tokens already in index.css (the
+ * accent. Grounds on the `--faction-coven-*` window tokens already in index.css (the
  * set the COVEN pilots use); always-light. Reuses the shared `mobile.*` faction copy
  * so the slot contract holds. Presentation-only — all data + the join handler
  * arrive via {@link FactionDetailState}.
@@ -21,17 +21,17 @@ import type { FactionDetailState } from '../useFactionDetail'
 
 const NA_SLUG = 'na'
 
-const PINK = 'var(--faction-wow)'
-const PINK_DEEP = 'var(--faction-wow-card-accent)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const DOT = 'var(--faction-wow-dot)'
-const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const PINK = 'var(--faction-coven)'
+const PINK_DEEP = 'var(--faction-coven-card-accent)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const DOT = 'var(--faction-coven-dot)'
+const SCRIPT = 'var(--faction-coven-card-font)' // Caveat
 const BODY = 'var(--font-body)' // Courier Prime
 const ON_ACCENT = 'var(--color-text-on-accent)'
 
@@ -58,7 +58,7 @@ function Avatar({ name, size }: { name: string; size: number }) {
         width: size,
         height: size,
         borderRadius: '50%',
-        background: `linear-gradient(150deg, var(--faction-wow-title-from), ${PINK})`,
+        background: `linear-gradient(150deg, var(--faction-coven-title-from), ${PINK})`,
         border: `1.5px solid ${WIN_BORDER}`,
         display: 'flex',
         alignItems: 'center',
@@ -134,7 +134,7 @@ export default function CovenFactionPage({ state }: { state: FactionDetailState 
 
   return (
     <div
-      data-skin="wow"
+      data-skin="coven"
       className="py-4"
       style={{
         fontFamily: BODY,
@@ -164,11 +164,11 @@ export default function CovenFactionPage({ state }: { state: FactionDetailState 
             alignItems: 'center',
             gap: 'var(--space-sm)',
             padding: 'var(--space-sm) var(--space-md)',
-            background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+            background: 'linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))',
             borderBottom: `2px solid ${WIN_BORDER}`,
           }}
         >
-          {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+          {['var(--faction-coven-scrap-deep)', 'var(--faction-coven-tape)', 'var(--faction-coven-ivy-leaf)'].map((c) => (
             <span key={c} style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }} />
           ))}
           <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 'var(--space-xs)', fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}>
@@ -179,7 +179,7 @@ export default function CovenFactionPage({ state }: { state: FactionDetailState 
         <div
           style={{
             padding: 'var(--space-xl) var(--space-lg) var(--space-xl)',
-            background: 'linear-gradient(160deg, var(--faction-wow-title-from), var(--faction-wow-card-muted) 60%, var(--faction-wow))',
+            background: 'linear-gradient(160deg, var(--faction-coven-title-from), var(--faction-coven-card-muted) 60%, var(--faction-coven))',
             color: TITLE_TEXT,
           }}
         >

--- a/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
@@ -173,7 +173,7 @@ export default function CovenFactionPage({ state }: { state: FactionDetailState 
           ))}
           <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 'var(--space-xs)', fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}>
             <Sparkle size={11} color={TITLE_TEXT} />
-            {t('wow.mobile.eyebrow')}
+            {t('coven.mobile.eyebrow')}
           </span>
         </div>
         <div

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -86,7 +86,7 @@ function render(): string {
 }
 
 describe('FieldDesk form-factor dispatch', () => {
-  it('renders the WOW bespoke home skin on mobile for a WOW life', () => {
+  it('renders the COVEN bespoke home skin on mobile for a COVEN life', () => {
     mocks.formFactor = 'mobile'
     mocks.user = currentUser('wow')
     expect(render()).toContain('data-skin="wow"')

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -89,7 +89,7 @@ describe('FieldDesk form-factor dispatch', () => {
   it('renders the COVEN bespoke home skin on mobile for a COVEN life', () => {
     mocks.formFactor = 'mobile'
     mocks.user = currentUser('wow')
-    expect(render()).toContain('data-skin="wow"')
+    expect(render()).toContain('data-skin="coven"')
   })
 
   it('renders the SNIDE bespoke home skin on mobile for a SNIDE life', () => {
@@ -103,7 +103,7 @@ describe('FieldDesk form-factor dispatch', () => {
     mocks.user = currentUser('na')
     const html = render()
     expect(html).toContain('data-skin="default"')
-    expect(html).not.toContain('data-skin="wow"')
+    expect(html).not.toContain('data-skin="coven"')
   })
 
   it('renders the desktop roster on desktop (skin dispatch untouched)', () => {

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -88,7 +88,7 @@ function render(): string {
 describe('FieldDesk form-factor dispatch', () => {
   it('renders the COVEN bespoke home skin on mobile for a COVEN life', () => {
     mocks.formFactor = 'mobile'
-    mocks.user = currentUser('wow')
+    mocks.user = currentUser('coven')
     expect(render()).toContain('data-skin="coven"')
   })
 
@@ -108,7 +108,7 @@ describe('FieldDesk form-factor dispatch', () => {
 
   it('renders the desktop roster on desktop (skin dispatch untouched)', () => {
     mocks.formFactor = 'desktop'
-    mocks.user = currentUser('wow')
+    mocks.user = currentUser('coven')
     const html = render()
     expect(html).not.toContain('data-skin=')
     expect(html.replace(/<[^>]*>/g, '')).toContain('Whose shoes today?')

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -13,7 +13,7 @@ import type { FieldDeskHomeState } from '../useFieldDeskHome'
  * mobile home — character header, stat tiles, active-tasks list, primary
  * actions — only the dress changes. Ported from the Field Kit `wow-treatment`
  * §02 home; grounds entirely on the `--faction-wow-*` window tokens already in
- * index.css (same set WowTaskDetail uses). Presentation-only.
+ * index.css (same set CovenTaskDetail uses). Presentation-only.
  */
 
 const PINK = 'var(--faction-wow)'
@@ -130,7 +130,7 @@ const ghostButton: CSSProperties = {
   textDecoration: 'none',
 }
 
-export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
+export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
   const { character, eraName, votesReceived, activeTasks, pendingCount, canProposeTask } = state
 

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -163,10 +163,10 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
       </header>
 
       {/* ── Character window ── */}
-      <Window title={t('fieldDesk.home.wow.charWindow')}>
+      <Window title={t('fieldDesk.home.coven.charWindow')}>
         <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-md)' }}>
           <span className="eyebrow" style={{ color: CARD_MUTED }}>
-            {t('fieldDesk.home.wow.charEyebrow')}
+            {t('fieldDesk.home.coven.charEyebrow')}
           </span>
           <Link
             to={`/characters/${character.id}/edit`}
@@ -288,11 +288,11 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
       )}
 
       {/* ── Quests window ── */}
-      <Window title={t('fieldDesk.home.wow.questsWindow')}>
+      <Window title={t('fieldDesk.home.coven.questsWindow')}>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-sm)' }}>
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-xs)', fontFamily: SCRIPT, fontSize: 'var(--text-content)', color: TITLE_TEXT }}>
             <Sparkle size={12} color={PINK} />
-            {t('fieldDesk.home.wow.questsHeading')}
+            {t('fieldDesk.home.coven.questsHeading')}
           </span>
           <span style={{ flex: 1, height: 2, background: `repeating-linear-gradient(90deg, ${PINK} 0 8px, transparent 8px 14px)` }} />
           <Link to="/tasks" className="eyebrow" style={{ color: PINK, textDecoration: 'none' }}>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -12,20 +12,20 @@ import type { FieldDeskHomeState } from '../useFieldDeskHome'
  * inner notepad), taped to a rose board. Same content slots as the Default
  * mobile home — character header, stat tiles, active-tasks list, primary
  * actions — only the dress changes. Ported from the Field Kit `wow-treatment`
- * §02 home; grounds entirely on the `--faction-wow-*` window tokens already in
+ * §02 home; grounds entirely on the `--faction-coven-*` window tokens already in
  * index.css (same set CovenTaskDetail uses). Presentation-only.
  */
 
-const PINK = 'var(--faction-wow)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const DOT = 'var(--faction-wow-dot)'
-const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const PINK = 'var(--faction-coven)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const DOT = 'var(--faction-coven-dot)'
+const SCRIPT = 'var(--faction-coven-card-font)' // Caveat
 const BODY = 'var(--font-body)' // Courier Prime
 const ON_ACCENT = 'var(--color-text-on-accent)'
 
@@ -59,11 +59,11 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
           alignItems: 'center',
           gap: 'var(--space-sm)',
           padding: 'var(--space-sm) var(--space-md)',
-          background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+          background: 'linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))',
           borderBottom: `2px solid ${WIN_BORDER}`,
         }}
       >
-        {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+        {['var(--faction-coven-scrap-deep)', 'var(--faction-coven-tape)', 'var(--faction-coven-ivy-leaf)'].map((c) => (
           <span
             key={c}
             style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }}
@@ -108,7 +108,7 @@ const pinkButton: CSSProperties = {
   borderRadius: 14,
   color: ON_ACCENT,
   border: `1.5px solid ${WIN_BORDER}`,
-  background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+  background: `linear-gradient(180deg, ${PINK}, var(--faction-coven-card-muted))`,
   textDecoration: 'none',
 }
 
@@ -142,7 +142,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
 
   return (
     <div
-      data-skin="wow"
+      data-skin="coven"
       className="page"
       style={{
         display: 'flex',
@@ -200,7 +200,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
               <span
                 className="flex w-full h-full items-center justify-center rounded-full"
                 style={{
-                  background: 'radial-gradient(circle at 35% 28%, var(--faction-wow-title-from), var(--faction-wow))',
+                  background: 'radial-gradient(circle at 35% 28%, var(--faction-coven-title-from), var(--faction-coven))',
                   fontFamily: SCRIPT,
                   // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 56px medallion, not text
                   fontSize: 24,
@@ -247,7 +247,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
               style={{
                 flex: '1 1 0',
                 minWidth: 0,
-                background: 'var(--faction-wow-scrap-mid)',
+                background: 'var(--faction-coven-scrap-mid)',
                 border: `1px solid ${NOTEPAD_BORDER}`,
                 borderRadius: 12,
                 padding: 'var(--space-md) var(--space-sm)',

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -54,7 +54,7 @@ import {
  */
 const RAIL_WIDTH_BY_SLUG: Record<string, string> = {
   everymen: "46rem", // EverymenPraxisDetail
-  wow: "720px", // WowPraxisDetail
+  wow: "720px", // CovenPraxisDetail
 };
 const DEFAULT_RAIL_WIDTH = "42rem";
 

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -54,7 +54,7 @@ import {
  */
 const RAIL_WIDTH_BY_SLUG: Record<string, string> = {
   everymen: "46rem", // EverymenPraxisDetail
-  wow: "720px", // CovenPraxisDetail
+  coven: "720px", // CovenPraxisDetail
 };
 const DEFAULT_RAIL_WIDTH = "42rem";
 

--- a/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Mobile praxis-read content-slot invariant — the mobile twin of
- * archetypeSlots.test. Walks surfaceMap('mobilePraxisDetail') (the WOW pilot) plus the
+ * archetypeSlots.test. Walks surfaceMap('mobilePraxisDetail') (the COVEN pilot) plus the
  * Default mobile skin and asserts each still emits the invariant CONTENT slots:
  * the finding title, the account body, the re-task link, and the author byline.
  * The shared Task Crown banner is checked separately. Rendered to static markup

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -40,8 +40,8 @@ const ON_ACCENT = 'var(--color-text-on-accent)'
 /** Party-voiced label for the filing mode. A duel side is a solo praxis
  * (ADR-0011) — its duel context is shown by the shared DuelCrossLink, not here. */
 function modeVoice(type: string, t: TFunction<'praxis'>): string {
-  if (type === 'collab') return t('detail.wow.mode.collab')
-  return t('detail.wow.mode.solo')
+  if (type === 'collab') return t('detail.coven.mode.collab')
+  return t('detail.coven.mode.solo')
 }
 
 /** Sparkle charm — the kit's signature four-point star. */
@@ -164,7 +164,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
             boxShadow: `0 14px 34px color-mix(in srgb, ${PINK} 30%, transparent)`,
           }}
         >
-          <TitleBar name={t('detail.wow.windows.praxis')} />
+          <TitleBar name={t('detail.coven.windows.praxis')} />
 
           {/* desktop body — dotted grid */}
           <div
@@ -200,18 +200,18 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                   boxShadow: `0 3px 8px var(--faction-coven-light)`,
                 }}
               >
-                <Sparkle size={10} color={ON_ACCENT} /> {t('detail.wow.sealed')}
+                <Sparkle size={10} color={ON_ACCENT} /> {t('detail.coven.sealed')}
               </span>
               <span style={pill}>{modeVoice(praxis.type, t)}</span>
               <span style={{ fontSize: 'var(--text-sm)', color: CARD_MUTED, letterSpacing: '0.04em' }}>
-                {t('detail.wow.re')}{' '}
+                {t('detail.coven.re')}{' '}
                 <Link
                   to={`/tasks/${praxis.task_id}`}
                   style={{ color: TITLE_TEXT, fontWeight: 700, textDecoration: 'none' }}
                 >
                   {praxis.task_title}
                 </Link>{' '}
-                {t('detail.wow.lvlSealed', { level: praxis.task_level_required, date: formatTimestamp(sealedDate) })}
+                {t('detail.coven.lvlSealed', { level: praxis.task_level_required, date: formatTimestamp(sealedDate) })}
               </span>
               {praxis.moderation_status === 'flagged' && (
                 <span
@@ -222,7 +222,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                     background: 'transparent',
                   }}
                 >
-                  {t('detail.wow.flagged')}
+                  {t('detail.coven.flagged')}
                 </span>
               )}
             </div>
@@ -237,7 +237,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                 marginBottom: 'var(--space-sm)',
               }}
             >
-              {t('detail.wow.theFinding')}
+              {t('detail.coven.theFinding')}
             </div>
             <h1
               style={{
@@ -250,7 +250,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                 overflowWrap: 'anywhere',
               }}
             >
-              {praxis.title ?? t('detail.wow.untitled')}
+              {praxis.title ?? t('detail.coven.untitled')}
             </h1>
 
             {/* ── Owner actions (invariant) ── */}
@@ -303,7 +303,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                 <div
                   style={{ fontSize: 'var(--text-sm)', color: CARD_MUTED, letterSpacing: '0.06em', marginTop: 'var(--space-xs)' }}
                 >
-                  {t('detail.wow.witchWhoCast')}
+                  {t('detail.coven.witchWhoCast')}
                 </div>
               </div>
               <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
@@ -319,7 +319,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                     marginTop: 'var(--space-xs)',
                   }}
                 >
-                  {t('detail.wow.basePoints')}
+                  {t('detail.coven.basePoints')}
                 </div>
               </div>
             </div>
@@ -327,7 +327,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
             {/* ── 3 · the account (body text) ── */}
             {praxis.body_text && (
               <>
-                <Divider label={t('detail.wow.whatIDid')} />
+                <Divider label={t('detail.coven.whatIDid')} />
                 <MarkdownPreview
                   source={praxis.body_text}
                   className="markdown-preview content-text"
@@ -340,7 +340,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
             {praxis.media_items.length > 0 && (
               <>
                 <Divider
-                  label={t('detail.wow.keepsakes', { count: praxis.media_items.length })}
+                  label={t('detail.coven.keepsakes', { count: praxis.media_items.length })}
                 />
                 <div
                   style={{
@@ -350,7 +350,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                     boxShadow: `0 6px 16px color-mix(in srgb, ${PINK} 18%, transparent)`,
                   }}
                 >
-                  <TitleBar name={t('detail.wow.windows.keepsakes')} />
+                  <TitleBar name={t('detail.coven.windows.keepsakes')} />
                   <div
                     style={{
                       padding: 'var(--space-md)',
@@ -376,7 +376,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
             boxShadow: `0 10px 26px color-mix(in srgb, ${PINK} 26%, transparent)`,
           }}
         >
-          <TitleBar name={t('detail.wow.windows.hearts')} />
+          <TitleBar name={t('detail.coven.windows.hearts')} />
           <div
             style={{
               padding: 'var(--space-xl) var(--space-xl) var(--space-xl)',
@@ -405,7 +405,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                   color: TITLE_TEXT,
                 }}
               >
-                <Sparkle size={14} color={PINK} /> {t('detail.wow.sendLove')}
+                <Sparkle size={14} color={PINK} /> {t('detail.coven.sendLove')}
               </span>
               <PraxisScoreBreakdown state={state} align="right" accent={PINK} muted={CARD_MUTED} font={SCRIPT} />
             </div>

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -8,7 +8,7 @@
  *
  * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
  * the shared module — this archetype owns only presentation. WoW flips with the
- * theme normally, so every color reads from --faction-wow* tokens (light + dark
+ * theme normally, so every color reads from --faction-coven* tokens (light + dark
  * already defined in index.css). No document-theme mutation, no hardcoded hex.
  * The author byline themes to the AUTHOR's faction, not the task's.
  */
@@ -25,15 +25,15 @@ import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBloc
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 // ── whimsy.exe token vocabulary (same as CovenTaskDetail) ──────────────────────
-const PINK = 'var(--faction-wow)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const DOT = 'var(--faction-wow-dot)'
-const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const PINK = 'var(--faction-coven)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const DOT = 'var(--faction-coven-dot)'
+const SCRIPT = 'var(--faction-coven-card-font)' // Caveat
 const BODY = 'var(--font-body)' // Courier Prime
 const ON_ACCENT = 'var(--color-text-on-accent)'
 
@@ -60,7 +60,7 @@ function Sparkle({ size, color, style }: { size: number; color: string; style?: 
 function Divider({ label }: { label: string }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', margin: 'var(--space-xl) 0 var(--space-lg)' }}>
-      <span style={{ flex: 1, height: 0, borderTop: `2px dotted var(--faction-wow-border)` }} />
+      <span style={{ flex: 1, height: 0, borderTop: `2px dotted var(--faction-coven-border)` }} />
       <span
         style={{
           display: 'inline-flex',
@@ -76,7 +76,7 @@ function Divider({ label }: { label: string }) {
       >
         <Sparkle size={9} color={PINK} /> {label}
       </span>
-      <span style={{ flex: 1, height: 0, borderTop: `2px dotted var(--faction-wow-border)` }} />
+      <span style={{ flex: 1, height: 0, borderTop: `2px dotted var(--faction-coven-border)` }} />
     </div>
   )
 }
@@ -90,11 +90,11 @@ function TitleBar({ name }: { name: string }) {
         alignItems: 'center',
         gap: 'var(--space-sm)',
         padding: 'var(--space-sm) var(--space-lg)',
-        background: `linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))`,
+        background: `linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))`,
         borderBottom: `2px solid ${WIN_BORDER}`,
       }}
     >
-      {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((lightColor) => (
+      {['var(--faction-coven-scrap-deep)', 'var(--faction-coven-tape)', 'var(--faction-coven-ivy-leaf)'].map((lightColor) => (
         <span
           key={lightColor}
           style={{
@@ -141,9 +141,9 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
     textTransform: 'uppercase',
     padding: 'var(--space-xs) var(--space-md)',
     borderRadius: 20,
-    background: 'var(--faction-wow-light)',
+    background: 'var(--faction-coven-light)',
     color: CARD_TEXT,
-    border: `1px solid var(--faction-wow-border)`,
+    border: `1px solid var(--faction-coven-border)`,
     whiteSpace: 'nowrap',
   }
 
@@ -178,7 +178,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
           >
             <Sparkle
               size={20}
-              color="var(--faction-wow-tape)"
+              color="var(--faction-coven-tape)"
               style={{ position: 'absolute', top: 18, right: 22, transform: 'rotate(10deg)' }}
             />
 
@@ -197,7 +197,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                   padding: 'var(--space-xs) var(--space-md)',
                   borderRadius: 20,
                   fontWeight: 700,
-                  boxShadow: `0 3px 8px var(--faction-wow-light)`,
+                  boxShadow: `0 3px 8px var(--faction-coven-light)`,
                 }}
               >
                 <Sparkle size={10} color={ON_ACCENT} /> {t('detail.wow.sealed')}
@@ -266,7 +266,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                 gap: 'var(--space-md)',
                 paddingTop: 'var(--space-lg)',
                 marginTop: 'var(--space-lg)',
-                borderTop: `2px dotted var(--faction-wow-border)`,
+                borderTop: `2px dotted var(--faction-coven-border)`,
               }}
             >
               <Link to={`/characters/${praxis.created_by_id}`} style={{ flexShrink: 0 }}>

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -24,7 +24,7 @@ import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
-// ── whimsy.exe token vocabulary (same as WowTaskDetail) ──────────────────────
+// ── whimsy.exe token vocabulary (same as CovenTaskDetail) ──────────────────────
 const PINK = 'var(--faction-wow)'
 const TITLE_TEXT = 'var(--faction-wow-title-text)'
 const CARD_TEXT = 'var(--faction-wow-card-text)'
@@ -124,7 +124,7 @@ function TitleBar({ name }: { name: string }) {
   )
 }
 
-export default function WowPraxisDetail({ state }: { state: PraxisDetailState }) {
+export default function CovenPraxisDetail({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
   const { praxis } = state
   if (!praxis) return null

--- a/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
@@ -14,10 +14,10 @@
  * rail keeps its existing mount above the archetype; no praxis-detail surface
  * has a two-column layout and mobile forbids one outright).
  *
- * Tokens are the `--faction-wow-*` set WowEditPraxis / WowPraxisDetail already
+ * Tokens are the `--faction-wow-*` set CovenEditPraxis / CovenPraxisDetail already
  * use — no new variables. `accent`/`soft` still arrive from the OPPONENT's
  * faction and are spent on the edge that faces them, so a foreign duelist keeps
- * tinting the window even inside Wow chrome.
+ * tinting the window even inside Coven chrome.
  */
 import type { CSSProperties } from 'react'
 import type { DuelRailSkinProps } from '../DuelCrossLink'
@@ -33,7 +33,7 @@ const DOT = 'var(--faction-wow-dot)'
 const CARD_TEXT = 'var(--faction-wow-card-text)'
 const SCRIPT = 'var(--faction-wow-card-font)'
 
-/** The kit's four-point sparkle, the window-title ornament on every Wow surface. */
+/** The kit's four-point sparkle, the window-title ornament on every Coven surface. */
 function Sparkle({ size, color }: { size: number; color: string }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden>
@@ -45,7 +45,7 @@ function Sparkle({ size, color }: { size: number; color: string }) {
   )
 }
 
-export default function WowDuelRail({
+export default function CovenDuelRail({
   accent,
   maxWidth,
   headline,
@@ -58,7 +58,7 @@ export default function WowDuelRail({
     margin: 'var(--space-lg) 0',
     borderRadius: 12,
     overflow: 'hidden',
-    // The opponent's colour rides the left edge; the rest of the window is Wow's.
+    // The opponent's colour rides the left edge; the rest of the window is Coven's.
     border: `2px solid ${WIN_BORDER}`,
     borderLeft: `4px solid ${accent}`,
     boxShadow: `0 10px 24px color-mix(in srgb, ${accent} 20%, transparent)`,
@@ -71,7 +71,7 @@ export default function WowDuelRail({
   return (
     <div style={shell}>
       {/* title bar — headline left, live tally right, exactly the .exe chrome
-          WowEditPraxis and WowPraxisDetail already wear */}
+          CovenEditPraxis and CovenPraxisDetail already wear */}
       <div
         style={{
           display: 'flex',
@@ -118,7 +118,7 @@ export default function WowDuelRail({
             board renders as a bare dotted strip under the title bar. That is the
             correct empty state — there is no race left — and it costs no branch
             here, so no bespoke "duel is over" ornament is drawn for it.
-            ponytail: the design's soft `background: soft` wash is dropped; Wow's
+            ponytail: the design's soft `background: soft` wash is dropped; Coven's
             own BODY_BG already reads as a tinted surface and layering the
             opponent's wash under the dot grid muddied both. */}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
@@ -14,7 +14,7 @@
  * rail keeps its existing mount above the archetype; no praxis-detail surface
  * has a two-column layout and mobile forbids one outright).
  *
- * Tokens are the `--faction-wow-*` set CovenEditPraxis / CovenPraxisDetail already
+ * Tokens are the `--faction-coven-*` set CovenEditPraxis / CovenPraxisDetail already
  * use — no new variables. `accent`/`soft` still arrive from the OPPONENT's
  * faction and are spent on the edge that faces them, so a foreign duelist keeps
  * tinting the window even inside Coven chrome.
@@ -22,16 +22,16 @@
 import type { CSSProperties } from 'react'
 import type { DuelRailSkinProps } from '../DuelCrossLink'
 
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const TITLE_FROM = 'var(--faction-wow-title-from)'
-const TITLE_TO = 'var(--faction-wow-title-to)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const DOT = 'var(--faction-wow-dot)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const SCRIPT = 'var(--faction-wow-card-font)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const TITLE_FROM = 'var(--faction-coven-title-from)'
+const TITLE_TO = 'var(--faction-coven-title-to)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const DOT = 'var(--faction-coven-dot)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const SCRIPT = 'var(--faction-coven-card-font)'
 
 /** The kit's four-point sparkle, the window-title ornament on every Coven surface. */
 function Sparkle({ size, color }: { size: number; color: string }) {

--- a/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
@@ -50,7 +50,7 @@ function TitleDots() {
   )
 }
 
-export default function WowMobileDuelRail({
+export default function CovenMobileDuelRail({
   accent,
   headline,
   tally,

--- a/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
@@ -14,23 +14,23 @@
 import type { CSSProperties } from 'react'
 import type { DuelRailSkinProps } from '../DuelCrossLink'
 
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const TITLE_FROM = 'var(--faction-wow-title-from)'
-const TITLE_TO = 'var(--faction-wow-title-to)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const DOT = 'var(--faction-wow-dot)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const SCRIPT = 'var(--faction-wow-card-font)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const TITLE_FROM = 'var(--faction-coven-title-from)'
+const TITLE_TO = 'var(--faction-coven-title-to)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const DOT = 'var(--faction-coven-dot)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const SCRIPT = 'var(--faction-coven-card-font)'
 
 /** The phone window's three traffic lights — smaller than the desktop set. */
 function TitleDots() {
   const colors = [
-    'var(--faction-wow-scrap-deep)',
-    'var(--faction-wow-tape)',
-    'var(--faction-wow-ivy-leaf)',
+    'var(--faction-coven-scrap-deep)',
+    'var(--faction-coven-tape)',
+    'var(--faction-coven-ivy-leaf)',
   ]
   return (
     <span style={{ display: 'flex', gap: 'var(--space-xs)' }} aria-hidden>

--- a/frontend/src/pages/praxisDetail/duelRails/EverymenMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EverymenMobileDuelRail.tsx
@@ -34,7 +34,7 @@ export default function EverymenMobileDuelRail({
 }: DuelRailSkinProps) {
   // ponytail: `maxWidth` is intentionally ignored. The rail is full-bleed inside
   // the phone column, so the desktop archetype-width map has nothing to line up
-  // with here — the same call WowMobileDuelRail makes.
+  // with here — the same call CovenMobileDuelRail makes.
   const shell: CSSProperties = {
     margin: 'var(--space-md) 0',
     background: PAPER,

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
@@ -5,7 +5,7 @@
  * account body, and a big thumb-sized star caster. Single-column; ported from
  * the Field Kit `wow-treatment` §05 praxis detail. Renders the same invariant
  * CONTENT + behavior slots as every archetype (shared module) — only the dress
- * changes. Grounds on the `--faction-wow-*` tokens already in index.css (same
+ * changes. Grounds on the `--faction-coven-*` tokens already in index.css (same
  * set CovenPraxisDetail / CovenFieldDesk use). Presentation-only.
  */
 import type { CSSProperties, ReactNode } from 'react'
@@ -27,16 +27,16 @@ import {
 } from '../shared'
 import { MobileStarVote } from './shared'
 
-const PINK = 'var(--faction-wow)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const DOT = 'var(--faction-wow-dot)'
-const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const PINK = 'var(--faction-coven)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const DOT = 'var(--faction-coven-dot)'
+const SCRIPT = 'var(--faction-coven-card-font)' // Caveat
 const BODY = 'var(--font-body)' // Courier Prime
 const ON_ACCENT = 'var(--color-text-on-accent)'
 
@@ -69,11 +69,11 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
           alignItems: 'center',
           gap: 'var(--space-sm)',
           padding: 'var(--space-sm) var(--space-md)',
-          background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+          background: 'linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))',
           borderBottom: `2px solid ${WIN_BORDER}`,
         }}
       >
-        {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+        {['var(--faction-coven-scrap-deep)', 'var(--faction-coven-tape)', 'var(--faction-coven-ivy-leaf)'].map((c) => (
           <span
             key={c}
             style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }}
@@ -112,7 +112,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
 
   return (
     <div
-      data-skin="wow"
+      data-skin="coven"
       className="page"
       style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: BODY, color: CARD_TEXT, background: BODY_BG }}
     >
@@ -128,7 +128,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
             style={{
               width: 40,
               height: 40,
-              background: `linear-gradient(150deg, ${PINK}, var(--faction-wow-card-muted))`,
+              background: `linear-gradient(150deg, ${PINK}, var(--faction-coven-card-muted))`,
               border: `1.5px solid ${WIN_BORDER}`,
               color: ON_ACCENT,
               fontFamily: SCRIPT,

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
@@ -152,7 +152,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
 
       {/* praxis.exe window — full media inside */}
       {praxis.media_items.length > 0 && (
-        <Window title={t('detail.wow.windows.keepsakes')}>
+        <Window title={t('detail.coven.windows.keepsakes')}>
           <MediaGallery media={praxis.media_items} layout="grid" />
         </Window>
       )}
@@ -160,10 +160,10 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
       {/* Finding headline */}
       <div>
         <div style={{ fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '0.2em', color: CARD_MUTED, marginBottom: 'var(--space-xs)' }}>
-          {t('detail.wow.theFinding')}
+          {t('detail.coven.theFinding')}
         </div>
         <h1 style={{ fontFamily: SCRIPT, fontWeight: 700, fontSize: 'var(--text-heading)', lineHeight: 1.12, margin: 0, color: TITLE_TEXT, overflowWrap: 'anywhere' }}>
-          {praxis.title ?? t('detail.wow.untitled')}
+          {praxis.title ?? t('detail.coven.untitled')}
         </h1>
       </div>
 
@@ -172,11 +172,11 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
 
       {/* re: task link */}
       <div style={{ fontSize: 'var(--text-sm)', color: CARD_MUTED, letterSpacing: '0.04em' }}>
-        {t('detail.wow.re')}{' '}
+        {t('detail.coven.re')}{' '}
         <Link to={`/tasks/${praxis.task_id}`} style={{ color: TITLE_TEXT, fontWeight: 700, textDecoration: 'none' }}>
           {praxis.task_title}
         </Link>{' '}
-        {t('detail.wow.lvlSealed', { level: praxis.task_level_required, date: formatTimestamp(sealedDate) })}
+        {t('detail.coven.lvlSealed', { level: praxis.task_level_required, date: formatTimestamp(sealedDate) })}
       </div>
 
       {/* Account body */}
@@ -189,13 +189,13 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
       )}
 
       {/* hearts.exe — the touch star caster */}
-      <Window title={t('detail.wow.windows.hearts')}>
+      <Window title={t('detail.coven.windows.hearts')}>
         <div
           className="flex items-center justify-center gap-2 content-title"
           style={{ marginBottom: 'var(--space-md)', fontFamily: SCRIPT, color: TITLE_TEXT }}
         >
           <Sparkle size={13} color={PINK} />
-          {t('detail.wow.sendLove')}
+          {t('detail.coven.sendLove')}
         </div>
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={PINK} font={SCRIPT} />

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
@@ -6,7 +6,7 @@
  * the Field Kit `wow-treatment` §05 praxis detail. Renders the same invariant
  * CONTENT + behavior slots as every archetype (shared module) — only the dress
  * changes. Grounds on the `--faction-wow-*` tokens already in index.css (same
- * set WowPraxisDetail / WowFieldDesk use). Presentation-only.
+ * set CovenPraxisDetail / CovenFieldDesk use). Presentation-only.
  */
 import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
@@ -102,7 +102,7 @@ function Window({ title, children }: { title: string; children: ReactNode }) {
   )
 }
 
-export default function WowPraxisDetail({ state }: { state: PraxisDetailState }) {
+export default function CovenPraxisDetail({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
   const { praxis } = state
   if (!praxis) return null

--- a/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
@@ -85,7 +85,7 @@ describe('propose task — unaffiliated option', () => {
 
     const affiliated = render({
       canProposeMetatask: true,
-      factionSlug: 'wow',
+      factionSlug: 'coven',
     }).replace(/<[^>]*>/g, '')
     expect(affiliated).toContain('applies as a bonus to all')
   })

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -111,6 +111,7 @@ const knownPennantFillStyle = (slug: string): CSSProperties => ({
 const FACTION_DESCRIPTOR_KEY = {
   na: "proposeTask.factionDescriptor.na",
   ua: "proposeTask.factionDescriptor.ua",
+  coven: "proposeTask.factionDescriptor.coven",
   wow: "proposeTask.factionDescriptor.wow",
   everymen: "proposeTask.factionDescriptor.everymen",
   snide: "proposeTask.factionDescriptor.snide",

--- a/frontend/src/pages/taskDetail/__tests__/covenDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenDispatch.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Mobile task-detail WOW dispatch (#531). Asserts the mobile registry resolves a
+ * Mobile task-detail COVEN dispatch (#531). Asserts the mobile registry resolves a
  * `wow` task to the quest.exe scrapbook skin, that other factions fall through to
  * the Default mobile detail, and that the desktop archetype is untouched.
  */
@@ -7,13 +7,13 @@ import { describe, it, expect } from "vitest";
 import { pickVariant } from "../../../utils/factionDispatch";
 import { surfaceMap } from "../../../factions";
 import DefaultMobileTaskDetail from "../mobileArchetypes/DefaultTaskDetail";
-import WowMobileTaskDetail from "../mobileArchetypes/WowTaskDetail";
-import WowDesktopTaskDetail from "../archetypes/WowTaskDetail";
+import CovenMobileTaskDetail from "../mobileArchetypes/CovenTaskDetail";
+import CovenDesktopTaskDetail from "../archetypes/CovenTaskDetail";
 
-describe("mobile task-detail WOW dispatch", () => {
-  it("mobile + a WOW task resolves to the bespoke WOW mobile skin", () => {
+describe("mobile task-detail COVEN dispatch", () => {
+  it("mobile + a COVEN task resolves to the bespoke COVEN mobile skin", () => {
     expect(pickVariant(surfaceMap('mobileTaskDetail'), "wow", DefaultMobileTaskDetail)).toBe(
-      WowMobileTaskDetail,
+      CovenMobileTaskDetail,
     );
   });
 
@@ -25,9 +25,9 @@ describe("mobile task-detail WOW dispatch", () => {
     }
   });
 
-  it("desktop keeps its own WOW archetype, never the mobile skin", () => {
+  it("desktop keeps its own COVEN archetype, never the mobile skin", () => {
     const desktop = pickVariant(surfaceMap('taskDetail'), "wow", DefaultMobileTaskDetail);
-    expect(desktop).toBe(WowDesktopTaskDetail);
-    expect(desktop).not.toBe(WowMobileTaskDetail);
+    expect(desktop).toBe(CovenDesktopTaskDetail);
+    expect(desktop).not.toBe(CovenMobileTaskDetail);
   });
 });

--- a/frontend/src/pages/taskDetail/__tests__/covenDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenDispatch.test.tsx
@@ -12,7 +12,7 @@ import CovenDesktopTaskDetail from "../archetypes/CovenTaskDetail";
 
 describe("mobile task-detail COVEN dispatch", () => {
   it("mobile + a COVEN task resolves to the bespoke COVEN mobile skin", () => {
-    expect(pickVariant(surfaceMap('mobileTaskDetail'), "wow", DefaultMobileTaskDetail)).toBe(
+    expect(pickVariant(surfaceMap('mobileTaskDetail'), "coven", DefaultMobileTaskDetail)).toBe(
       CovenMobileTaskDetail,
     );
   });
@@ -26,7 +26,7 @@ describe("mobile task-detail COVEN dispatch", () => {
   });
 
   it("desktop keeps its own COVEN archetype, never the mobile skin", () => {
-    const desktop = pickVariant(surfaceMap('taskDetail'), "wow", DefaultMobileTaskDetail);
+    const desktop = pickVariant(surfaceMap('taskDetail'), "coven", DefaultMobileTaskDetail);
     expect(desktop).toBe(CovenDesktopTaskDetail);
     expect(desktop).not.toBe(CovenMobileTaskDetail);
   });

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -20,15 +20,15 @@ import type { TaskDetailState } from "../useTaskDetail";
  * <PraxisCard> and the shared state replace them.
  */
 
-const PINK = "var(--faction-wow)";
-const TITLE_TEXT = "var(--faction-wow-title-text)";
-const CARD_TEXT = "var(--faction-wow-card-text)";
-const CARD_MUTED = "var(--faction-wow-card-muted)";
-const WIN_BORDER = "var(--faction-wow-win-border)";
-const NOTEPAD_BG = "var(--faction-wow-notepad-bg)";
-const NOTEPAD_BORDER = "var(--faction-wow-notepad-border)";
-const DOT = "var(--faction-wow-dot)";
-const SCRIPT = "var(--faction-wow-card-font)"; // Caveat
+const PINK = "var(--faction-coven)";
+const TITLE_TEXT = "var(--faction-coven-title-text)";
+const CARD_TEXT = "var(--faction-coven-card-text)";
+const CARD_MUTED = "var(--faction-coven-card-muted)";
+const WIN_BORDER = "var(--faction-coven-win-border)";
+const NOTEPAD_BG = "var(--faction-coven-notepad-bg)";
+const NOTEPAD_BORDER = "var(--faction-coven-notepad-border)";
+const DOT = "var(--faction-coven-dot)";
+const SCRIPT = "var(--faction-coven-card-font)"; // Caveat
 const BODY = "var(--font-body)"; // Courier Prime
 const ACCENT = "var(--font-accent)"; // Bebas Neue
 const ON_ACCENT = "var(--color-text-on-accent)";
@@ -104,7 +104,7 @@ function PartyRow({
     >
       {signups.map((m, index) => {
         const rel = relationOf(m.character_id, friends, foes);
-        const relColor = rel === "friend" ? PINK : "var(--faction-wow-ivy)";
+        const relColor = rel === "friend" ? PINK : "var(--faction-coven-ivy)";
         return (
           <Link
             key={m.character_id}
@@ -227,9 +227,9 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
     textTransform: "uppercase",
     padding: "var(--space-sm) var(--space-lg)",
     borderRadius: 20,
-    background: "var(--faction-wow-light)",
+    background: "var(--faction-coven-light)",
     color: CARD_TEXT,
-    border: `1.5px solid var(--faction-wow-border)`,
+    border: `1.5px solid var(--faction-coven-border)`,
   };
 
   return (
@@ -273,11 +273,11 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
               alignItems: "center",
               gap: "var(--space-sm)",
               padding: "var(--space-sm) var(--space-lg)",
-              background: `linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))`,
+              background: `linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))`,
               borderBottom: `2px solid ${WIN_BORDER}`,
             }}
           >
-            {["var(--faction-wow-scrap-deep)", "var(--faction-wow-tape)", "var(--faction-wow-ivy-leaf)"].map(
+            {["var(--faction-coven-scrap-deep)", "var(--faction-coven-tape)", "var(--faction-coven-ivy-leaf)"].map(
               (lightColor) => (
                 <span
                   key={lightColor}
@@ -316,7 +316,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           >
             <Sparkle
               size={22}
-              color="var(--faction-wow-tape)"
+              color="var(--faction-coven-tape)"
               style={{
                 position: "absolute",
                 top: 18,
@@ -413,7 +413,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 borderRadius: 12,
                 background: NOTEPAD_BG,
                 padding: "var(--space-lg) var(--space-xl)",
-                boxShadow: `4px 4px 0 var(--faction-wow-scrap-deep)`,
+                boxShadow: `4px 4px 0 var(--faction-coven-scrap-deep)`,
               }}
             >
               <button
@@ -428,7 +428,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                   padding: "var(--space-md) var(--space-xl)",
                   border: `1.5px solid ${WIN_BORDER}`,
                   borderRadius: 10,
-                  background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+                  background: `linear-gradient(180deg, ${PINK}, var(--faction-coven-card-muted))`,
                   boxShadow: `0 4px 10px color-mix(in srgb, ${PINK} 35%, transparent)`,
                 }}
               >
@@ -486,7 +486,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 padding: "var(--space-md) var(--space-xl)",
                 border: `1.5px solid ${WIN_BORDER}`,
                 borderRadius: 10,
-                background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+                background: `linear-gradient(180deg, ${PINK}, var(--faction-coven-card-muted))`,
                 textDecoration: "none",
               }}
             >
@@ -523,7 +523,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 padding: "var(--space-md) var(--space-xl)",
                 border: `1.5px solid ${WIN_BORDER}`,
                 borderRadius: 10,
-                background: `linear-gradient(180deg, ${PINK}, var(--faction-wow-card-muted))`,
+                background: `linear-gradient(180deg, ${PINK}, var(--faction-coven-card-muted))`,
                 textDecoration: "none",
               }}
             >
@@ -706,7 +706,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                           fontSize: "var(--text-content)",
                           padding: "var(--space-xs) var(--space-lg)",
                           borderRadius: 14,
-                          boxShadow: `2px 3px 0 var(--faction-wow-scrap-deep)`,
+                          boxShadow: `2px 3px 0 var(--faction-coven-scrap-deep)`,
                         }}
                       >
                         <span style={{ fontSize: "var(--text-lg)", lineHeight: 1 }}>⚜</span>{" "}

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -181,7 +181,7 @@ function PartyRow({
   );
 }
 
-export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
+export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
   const { t } = useTranslation("tasks");
   const {
     task,

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -175,7 +175,7 @@ function PartyRow({
           marginLeft: "var(--space-sm)",
         }}
       >
-        {t("wow.inTheParty")}
+        {t("coven.inTheParty")}
       </span>
     </div>
   );
@@ -245,11 +245,11 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
         }}
       >
         <Link to="/tasks" style={{ color: PINK, textDecoration: "none" }}>
-          {t("wow.breadcrumb")}
+          {t("coven.breadcrumb")}
         </Link>
         <span style={{ opacity: 0.5, margin: "0 var(--space-sm)" }}>›</span>
         <span style={{ fontFamily: SCRIPT, fontSize: "var(--text-content)" }}>
-          {t("wow.faction")}
+          {t("coven.faction")}
         </span>
         <span style={{ opacity: 0.5, margin: "0 var(--space-sm)" }}>›</span>
         <span style={{ color: PINK }}>{task.title}</span>
@@ -300,7 +300,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 textShadow: `1px 1px 0 ${TITLE_TEXT}`,
               }}
             >
-              {t("wow.window")}
+              {t("coven.window")}
             </span>
           </div>
 
@@ -343,7 +343,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 marginBottom: "var(--space-sm)",
               }}
             >
-              {task.status === "active" ? t("wow.statusOpen") : task.status}
+              {task.status === "active" ? t("coven.statusOpen") : task.status}
             </div>
             <div
               className="content-title"
@@ -367,7 +367,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             >
               <span style={pill}>
                 <Sparkle size={11} color={PINK} />{" "}
-                {t("wow.level", { level: task.level_required })}
+                {t("coven.level", { level: task.level_required })}
               </span>
               <span
                 className="content-title"
@@ -388,10 +388,10 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                     strokeLinejoin="round"
                   />
                 </svg>
-                {t("wow.sparks", { points: modifiedPoints })}
+                {t("coven.sparks", { points: modifiedPoints })}
               </span>
               <span style={pill}>
-                {t("wow.onView", {
+                {t("coven.onView", {
                   signups: signups.length,
                   completed: submissions.length,
                 })}
@@ -432,10 +432,10 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                   boxShadow: `0 4px 10px color-mix(in srgb, ${PINK} 35%, transparent)`,
                 }}
               >
-                {t("wow.signup.cta", { points: modifiedPoints })}
+                {t("coven.signup.cta", { points: modifiedPoints })}
               </button>
               <div className="content-text" style={{ fontFamily: SCRIPT, color: PINK }}>
-                {t("wow.signup.note")}
+                {t("coven.signup.note")}
               </div>
               <div
                 style={{
@@ -447,10 +447,10 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 }}
               >
                 <div>
-                  {t("wow.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
+                  {t("coven.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
                 </div>
                 <div>
-                  {t("wow.signup.levelRequired", { level: task.level_required })}
+                  {t("coven.signup.levelRequired", { level: task.level_required })}
                 </div>
               </div>
             </div>
@@ -473,7 +473,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             }}
           >
             <span className="content-text" style={{ fontFamily: SCRIPT, color: TITLE_TEXT }}>
-              {t("wow.submitted.text")}
+              {t("coven.submitted.text")}
             </span>
             <Link
               to={`/praxes/${mySubmission.id}/edit`}
@@ -490,7 +490,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 textDecoration: "none",
               }}
             >
-              {t("wow.submitted.edit")}
+              {t("coven.submitted.edit")}
             </Link>
           </div>
         )}
@@ -510,7 +510,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             }}
           >
             <span className="content-text" style={{ fontFamily: SCRIPT, color: TITLE_TEXT }}>
-              {t("wow.inProgress.text")}
+              {t("coven.inProgress.text")}
             </span>
             <Link
               to={`/praxes/${inProgressPraxisId}/edit`}
@@ -527,7 +527,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 textDecoration: "none",
               }}
             >
-              {t("wow.inProgress.continue")}
+              {t("coven.inProgress.continue")}
             </Link>
             <button
               onClick={handleDrop}
@@ -540,7 +540,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 color: CARD_MUTED,
               }}
             >
-              {t("wow.inProgress.drop")}
+              {t("coven.inProgress.drop")}
             </button>
           </div>
         )}
@@ -548,14 +548,14 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
         {/* ── The party so far (signups) ── */}
         {signups.length > 0 && (
           <section>
-            <SectionHead>{t("wow.partyHeading")}</SectionHead>
+            <SectionHead>{t("coven.partyHeading")}</SectionHead>
             <PartyRow signups={signups} friends={friends} foes={foes} />
           </section>
         )}
 
         {/* ── What we're asking (description) ── */}
         <section>
-          <SectionHead>{t("wow.askingHeading")}</SectionHead>
+          <SectionHead>{t("coven.askingHeading")}</SectionHead>
           <div
             style={{
               border: `2px solid ${NOTEPAD_BORDER}`,
@@ -575,14 +575,14 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                 whiteSpace: "pre-wrap",
               }}
             >
-              {task.description || t("wow.askingEmpty")}
+              {task.description || t("coven.askingEmpty")}
             </p>
           </div>
         </section>
 
         {/* ── The love so far (vote aggregate) ── */}
         <section>
-          <SectionHead>{t("wow.loveHeading")}</SectionHead>
+          <SectionHead>{t("coven.loveHeading")}</SectionHead>
           {voteCount > 0 ? (
             <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)" }}>
               <span
@@ -603,16 +603,16 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                     color: TITLE_TEXT,
                   }}
                 >
-                  {t("wow.love.top")}
+                  {t("coven.love.top")}
                 </div>
                 <div style={{ fontSize: "var(--text-base)", color: CARD_MUTED }}>
-                  {t("wow.love.adored", { count: voteCount })}
+                  {t("coven.love.adored", { count: voteCount })}
                 </div>
               </div>
             </div>
           ) : (
             <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK }}>
-              {t("wow.love.none")}
+              {t("coven.love.none")}
             </p>
           )}
         </section>
@@ -640,7 +640,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                   whiteSpace: "nowrap",
                 }}
               >
-                {t("wow.spellsHeading", { count: submissions.length })}
+                {t("coven.spellsHeading", { count: submissions.length })}
               </h2>
             </div>
             <div style={{ display: "flex", gap: 0 }}>
@@ -664,8 +664,8 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                     }}
                   >
                     {sort === "score"
-                      ? t("wow.sort.mostLoved")
-                      : t("wow.sort.recent")}
+                      ? t("coven.sort.mostLoved")
+                      : t("coven.sort.recent")}
                   </button>
                 );
               })}
@@ -674,7 +674,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
 
           {sortedSubmissions.length === 0 ? (
             <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK }}>
-              {t("wow.empty")}
+              {t("coven.empty")}
             </p>
           ) : (
             <>
@@ -710,7 +710,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                         }}
                       >
                         <span style={{ fontSize: "var(--text-lg)", lineHeight: 1 }}>⚜</span>{" "}
-                        {t("wow.mostLoved")}
+                        {t("coven.mostLoved")}
                       </div>
                     )}
                     <PraxisCard praxis={s} />
@@ -728,7 +728,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                       textDecoration: "none",
                     }}
                   >
-                    {t("wow.viewAll", { count: submissions.length })}
+                    {t("coven.viewAll", { count: submissions.length })}
                   </Link>
                 </div>
               )}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
@@ -12,21 +12,21 @@ import type { TaskDetailState } from '../useTaskDetail'
  * we're asking" brief, the love-so-far aggregate, the spells cast (completions),
  * and a sparkle-stamped **sticky action bar** ("join the party") pinned above the
  * tab bar. Single-column, no fixed-px grid. Reuses the same {@link TaskDetailState},
- * the shared mobile sticky bar, and the `wow.*` copy + `--faction-wow-*` tokens as
+ * the shared mobile sticky bar, and the `wow.*` copy + `--faction-coven-*` tokens as
  * the desktop archetype and the other COVEN pilots. Always-light: COVEN is native-light.
  */
 
-const PINK = 'var(--faction-wow)'
-const PINK_DEEP = 'var(--faction-wow-card-accent)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const CARD_TEXT = 'var(--faction-wow-card-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const DOT = 'var(--faction-wow-dot)'
-const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const PINK = 'var(--faction-coven)'
+const PINK_DEEP = 'var(--faction-coven-card-accent)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const CARD_TEXT = 'var(--faction-coven-card-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const DOT = 'var(--faction-coven-dot)'
+const SCRIPT = 'var(--faction-coven-card-font)' // Caveat
 const BODY = 'var(--font-body)' // Courier Prime
 const ON_ACCENT = 'var(--color-text-on-accent)'
 
@@ -86,7 +86,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
 
   return (
     <div
-      data-skin="wow"
+      data-skin="coven"
       className="py-4"
       style={{
         fontFamily: BODY,
@@ -125,11 +125,11 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             alignItems: 'center',
             gap: "var(--space-sm)",
             padding: "var(--space-sm) var(--space-md)",
-            background: 'linear-gradient(180deg, var(--faction-wow-title-from), var(--faction-wow-title-to))',
+            background: 'linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))',
             borderBottom: `2px solid ${WIN_BORDER}`,
           }}
         >
-          {['var(--faction-wow-scrap-deep)', 'var(--faction-wow-tape)', 'var(--faction-wow-ivy-leaf)'].map((c) => (
+          {['var(--faction-coven-scrap-deep)', 'var(--faction-coven-tape)', 'var(--faction-coven-ivy-leaf)'].map((c) => (
             <span key={c} style={{ width: 9, height: 9, borderRadius: '50%', background: c, border: '1.2px solid rgba(255,255,255,0.7)' }} />
           ))}
           <span style={{ marginLeft: "auto", display: 'inline-flex', alignItems: 'center', gap: "var(--space-xs)", fontFamily: SCRIPT, fontSize: "var(--text-content)", color: TITLE_TEXT }}>
@@ -249,7 +249,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                         fontSize: "var(--text-xl)",
                         padding: "var(--space-xs) var(--space-lg)",
                         borderRadius: 14,
-                        boxShadow: '2px 3px 0 var(--faction-wow-scrap-deep)',
+                        boxShadow: '2px 3px 0 var(--faction-coven-scrap-deep)',
                       }}
                     >
                       <span style={{ fontSize: "var(--text-lg)", lineHeight: 1 }}>⚜</span>
@@ -275,7 +275,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
       {canSignUp && (
         <MobileStickyBar>
           {signupError && (
-            <div style={{ fontFamily: BODY, fontSize: "var(--text-lg)", color: 'var(--color-danger)', padding: "var(--space-sm) var(--space-md)", background: 'var(--faction-wow-light)', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9 }}>
+            <div style={{ fontFamily: BODY, fontSize: "var(--text-lg)", color: 'var(--color-danger)', padding: "var(--space-sm) var(--space-md)", background: 'var(--faction-coven-light)', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9 }}>
               {signupError}
             </div>
           )}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
@@ -103,7 +103,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
       {/* Breadcrumb */}
       <nav className="mb-3" style={{ fontSize: "var(--text-sm)", letterSpacing: '0.12em', textTransform: 'uppercase', color: CARD_MUTED }}>
         <Link to="/tasks" style={{ color: PINK_DEEP, textDecoration: 'none' }}>
-          {t('wow.breadcrumb')}
+          {t('coven.breadcrumb')}
         </Link>
         <span aria-hidden style={{ margin: "0 var(--space-sm)", color: PINK }}>›</span>
         <span style={{ fontFamily: SCRIPT, fontSize: "var(--text-xl)", color: TITLE_TEXT }}>{task.title}</span>
@@ -134,7 +134,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           ))}
           <span style={{ marginLeft: "auto", display: 'inline-flex', alignItems: 'center', gap: "var(--space-xs)", fontFamily: SCRIPT, fontSize: "var(--text-content)", color: TITLE_TEXT }}>
             <Sparkle size={11} color={TITLE_TEXT} />
-            {t('wow.window')}
+            {t('coven.window')}
           </span>
         </div>
         <div
@@ -148,7 +148,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
         >
           <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: "var(--space-lg) var(--space-lg) var(--space-xl)" }}>
             <div style={{ fontSize: "var(--text-sm)", letterSpacing: '0.16em', textTransform: 'uppercase', color: CARD_MUTED, marginBottom: "var(--space-sm)" }}>
-              {task.status === 'active' ? t('wow.statusOpen') : task.status}
+              {task.status === 'active' ? t('coven.statusOpen') : task.status}
             </div>
             <h1 className="content-title" style={{ fontFamily: SCRIPT, lineHeight: 0.95, color: TITLE_TEXT, margin: "0 0 var(--space-lg)", overflowWrap: 'anywhere' }}>
               {task.title}
@@ -156,10 +156,10 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             <div className="flex items-center gap-2 flex-wrap">
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: "var(--space-sm)", fontSize: "var(--text-base)", letterSpacing: '0.06em', textTransform: 'uppercase', color: CARD_TEXT, background: BODY_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 999, padding: "var(--space-sm) var(--space-md)" }}>
                 <Sparkle size={10} color={PINK} />
-                {t('wow.level', { level: task.level_required })}
+                {t('coven.level', { level: task.level_required })}
               </span>
               <span className="content-title" style={{ display: 'inline-flex', alignItems: 'center', gap: "var(--space-sm)", fontFamily: SCRIPT, color: PINK }}>
-                {t('wow.sparks', { points: modifiedPoints })}
+                {t('coven.sparks', { points: modifiedPoints })}
               </span>
             </div>
           </div>
@@ -168,34 +168,34 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
 
       {/* What we're asking — brief */}
       <section style={{ marginBottom: "var(--space-xl)" }}>
-        <SectionHead title={t('wow.askingHeading')} />
+        <SectionHead title={t('coven.askingHeading')} />
         <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: "var(--space-lg) var(--space-lg)" }}>
           <p className="content-text" style={{ fontFamily: BODY, lineHeight: 1.75, color: task.description ? CARD_TEXT : CARD_MUTED, margin: 0, whiteSpace: 'pre-wrap' }}>
-            {task.description || t('wow.askingEmpty')}
+            {task.description || t('coven.askingEmpty')}
           </p>
         </div>
       </section>
 
       {/* The love so far — read-only aggregate */}
       <section style={{ marginBottom: "var(--space-xl)" }}>
-        <SectionHead title={t('wow.loveHeading')} />
+        <SectionHead title={t('coven.loveHeading')} />
         {voteCount > 0 ? (
           <div style={{ display: 'flex', alignItems: 'flex-end', gap: "var(--space-md)" }}>
             <span className="content-title" style={{ fontFamily: SCRIPT, lineHeight: 0.8, color: PINK }}>{topScore}</span>
             <div style={{ paddingBottom: "var(--space-xs)" }}>
-              <div className="content-text" style={{ fontFamily: SCRIPT, color: TITLE_TEXT }}>{t('wow.love.top')}</div>
-              <div style={{ fontSize: "var(--text-base)", color: CARD_MUTED, marginTop: "var(--space-xs)" }}>{t('wow.love.adored', { count: voteCount })}</div>
+              <div className="content-text" style={{ fontFamily: SCRIPT, color: TITLE_TEXT }}>{t('coven.love.top')}</div>
+              <div style={{ fontSize: "var(--text-base)", color: CARD_MUTED, marginTop: "var(--space-xs)" }}>{t('coven.love.adored', { count: voteCount })}</div>
             </div>
           </div>
         ) : (
-          <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK, margin: 0 }}>{t('wow.love.none')}</p>
+          <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK, margin: 0 }}>{t('coven.love.none')}</p>
         )}
       </section>
 
       {/* Spells cast (completions) */}
       <section>
         <SectionHead
-          title={t('wow.spellsHeading', { count: submissions.length })}
+          title={t('coven.spellsHeading', { count: submissions.length })}
           trailing={
             <div style={{ display: 'flex' }}>
               {(['score', 'recent'] as const).map((sort) => {
@@ -217,7 +217,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                       cursor: 'pointer',
                     }}
                   >
-                    {sort === 'score' ? t('wow.sort.mostLoved') : t('wow.sort.recent')}
+                    {sort === 'score' ? t('coven.sort.mostLoved') : t('coven.sort.recent')}
                   </button>
                 )
               })}
@@ -225,7 +225,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           }
         />
         {sortedSubmissions.length === 0 ? (
-          <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK, margin: 0 }}>{t('wow.empty')}</p>
+          <p className="content-text" style={{ fontFamily: SCRIPT, color: PINK, margin: 0 }}>{t('coven.empty')}</p>
         ) : (
           <>
             <div className="flex flex-col gap-4">
@@ -253,7 +253,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                       }}
                     >
                       <span style={{ fontSize: "var(--text-lg)", lineHeight: 1 }}>⚜</span>
-                      {t('wow.mostLoved')}
+                      {t('coven.mostLoved')}
                     </div>
                   )}
                   <PraxisCard praxis={s} />
@@ -263,7 +263,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             {submissions.length > 4 && (
               <div style={{ marginTop: "var(--space-lg)" }}>
                 <Link to={`/praxes?task_id=${task.id}`} className="content-text" style={{ fontFamily: SCRIPT, color: PINK, textDecoration: 'none' }}>
-                  {t('wow.viewAll', { count: submissions.length })}
+                  {t('coven.viewAll', { count: submissions.length })}
                 </Link>
               </div>
             )}
@@ -301,22 +301,22 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             }}
           >
             <Sparkle size={13} color={ON_ACCENT} />
-            {t('wow.signup.cta', { points: modifiedPoints })}
+            {t('coven.signup.cta', { points: modifiedPoints })}
           </button>
           <MobileStickyCaption color={CARD_MUTED}>
-            {t('wow.signup.slots', { open: slotsOpen, max: maxTaskSlots })}
+            {t('coven.signup.slots', { open: slotsOpen, max: maxTaskSlots })}
           </MobileStickyCaption>
         </MobileStickyBar>
       )}
 
       {mySubmission && (
         <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <span className="content-text" style={{ fontFamily: SCRIPT, color: PINK, flex: 1 }}>{t('wow.submitted.text')}</span>
+          <span className="content-text" style={{ fontFamily: SCRIPT, color: PINK, flex: 1 }}>{t('coven.submitted.text')}</span>
           <Link
             to={`/praxes/${mySubmission.id}/edit`}
             style={{ fontFamily: BODY, fontSize: "var(--text-base)", letterSpacing: '0.12em', textTransform: 'uppercase', padding: "var(--space-md) var(--space-lg)", color: ON_ACCENT, background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`, border: `1.5px solid ${PINK_DEEP}`, borderRadius: 12, textDecoration: 'none' }}
           >
-            {t('wow.submitted.edit')}
+            {t('coven.submitted.edit')}
           </Link>
         </MobileStickyBar>
       )}
@@ -327,13 +327,13 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             onClick={handleDrop}
             style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: SCRIPT, fontSize: "var(--text-content)", color: CARD_MUTED }}
           >
-            {t('wow.inProgress.drop')}
+            {t('coven.inProgress.drop')}
           </button>
           <Link
             to={`/praxes/${inProgressPraxisId}/edit`}
             style={{ marginLeft: "auto", fontFamily: BODY, fontSize: "var(--text-md)", letterSpacing: '0.12em', textTransform: 'uppercase', padding: "var(--space-md) var(--space-xl)", color: ON_ACCENT, background: `linear-gradient(180deg, ${PINK}, ${PINK_DEEP})`, border: `1.5px solid ${PINK_DEEP}`, borderRadius: 14, textDecoration: 'none' }}
           >
-            {t('wow.inProgress.continue')}
+            {t('coven.inProgress.continue')}
           </Link>
         </MobileStickyBar>
       )}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
@@ -13,7 +13,7 @@ import type { TaskDetailState } from '../useTaskDetail'
  * and a sparkle-stamped **sticky action bar** ("join the party") pinned above the
  * tab bar. Single-column, no fixed-px grid. Reuses the same {@link TaskDetailState},
  * the shared mobile sticky bar, and the `wow.*` copy + `--faction-wow-*` tokens as
- * the desktop archetype and the other WOW pilots. Always-light: WOW is native-light.
+ * the desktop archetype and the other COVEN pilots. Always-light: COVEN is native-light.
  */
 
 const PINK = 'var(--faction-wow)'
@@ -56,7 +56,7 @@ function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode 
   )
 }
 
-export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
+export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
   const { t } = useTranslation('tasks')
   const {
     task,

--- a/frontend/src/pages/tasks/mobileArchetypes/__tests__/mobileTaskCardDispatch.test.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/__tests__/mobileTaskCardDispatch.test.tsx
@@ -10,7 +10,7 @@ import { pickVariant } from '../../../../utils/factionDispatch'
 import { surfaceMap } from '../../../../factions'
 import DefaultMobileTaskCard from '../cards/DefaultMobileTaskCard'
 import UaMobileTaskCard from '../cards/UaMobileTaskCard'
-import WowMobileTaskCard from '../cards/WowMobileTaskCard'
+import CovenMobileTaskCard from '../cards/CovenMobileTaskCard'
 import SnideMobileTaskCard from '../cards/SnideMobileTaskCard'
 import EverymenMobileTaskCard from '../cards/EverymenMobileTaskCard'
 import SingularityMobileTaskCard from '../cards/SingularityMobileTaskCard'
@@ -18,7 +18,7 @@ import EphemeristsMobileTaskCard from '../cards/EphemeristsMobileTaskCard'
 
 const CARD_BY_SLUG = {
   ua: UaMobileTaskCard,
-  wow: WowMobileTaskCard,
+  wow: CovenMobileTaskCard,
   snide: SnideMobileTaskCard,
   everymen: EverymenMobileTaskCard,
   singularity: SingularityMobileTaskCard,

--- a/frontend/src/pages/tasks/mobileArchetypes/__tests__/mobileTaskCardDispatch.test.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/__tests__/mobileTaskCardDispatch.test.tsx
@@ -18,7 +18,7 @@ import EphemeristsMobileTaskCard from '../cards/EphemeristsMobileTaskCard'
 
 const CARD_BY_SLUG = {
   ua: UaMobileTaskCard,
-  wow: CovenMobileTaskCard,
+  coven: CovenMobileTaskCard,
   snide: SnideMobileTaskCard,
   everymen: EverymenMobileTaskCard,
   singularity: SingularityMobileTaskCard,

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
@@ -63,7 +63,7 @@ export default function CovenMobileTaskCard({ task, points }: { task: TaskOut; p
         <div style={{ background: NOTEPAD_BG, border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9, padding: 'var(--space-md) var(--space-lg)', display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-sm)', fontSize: 'var(--text-sm)', letterSpacing: '0.14em', textTransform: 'uppercase', color }}>
             <Sparkle size={10} color={color} />
-            {t('wow.mobile.cardMeta', { faction: factionName(task.primary_faction_slug), points })}
+            {t('coven.mobile.cardMeta', { faction: factionName(task.primary_faction_slug), points })}
           </span>
 
           <h2 className="content-title" style={{ fontFamily: SCRIPT, lineHeight: 1.05, color: TITLE_TEXT, margin: 0, overflowWrap: 'anywhere' }}>

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
@@ -37,7 +37,7 @@ function Sparkle({ size, color, style }: { size: number; color: string; style?: 
 }
 
 /** A pink scrapbook quest sticker-card: dotted board + inner notepad. */
-export default function WowMobileTaskCard({ task, points }: { task: TaskOut; points: number }) {
+export default function CovenMobileTaskCard({ task, points }: { task: TaskOut; points: number }) {
   const { t } = useTranslation('tasks')
   const color = factionCssVar(task.primary_faction_slug)
   return (

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
@@ -9,19 +9,19 @@ import { MobileTaskDescription } from './shared'
  * Warriors of Whimsy MOBILE task card (#531/#565) — a pink scrapbook "quest"
  * sticker-card: dotted board, inner notepad, sparkle accents, Caveat title.
  * Reads `task.primary_faction_slug` for its own faction tint. Grounds on the
- * `--faction-wow-*` window tokens; always-light. Presentation-only.
+ * `--faction-coven-*` window tokens; always-light. Presentation-only.
  */
 
-const PINK = 'var(--faction-wow)'
-const PINK_DEEP = 'var(--faction-wow-card-accent)'
-const TITLE_TEXT = 'var(--faction-wow-title-text)'
-const CARD_MUTED = 'var(--faction-wow-card-muted)'
-const WIN_BORDER = 'var(--faction-wow-win-border)'
-const NOTEPAD_BG = 'var(--faction-wow-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-wow-notepad-border)'
-const BODY_BG = 'var(--faction-wow-body-bg)'
-const DOT = 'var(--faction-wow-dot)'
-const SCRIPT = 'var(--faction-wow-card-font)' // Caveat
+const PINK = 'var(--faction-coven)'
+const PINK_DEEP = 'var(--faction-coven-card-accent)'
+const TITLE_TEXT = 'var(--faction-coven-title-text)'
+const CARD_MUTED = 'var(--faction-coven-card-muted)'
+const WIN_BORDER = 'var(--faction-coven-win-border)'
+const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
+const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
+const BODY_BG = 'var(--faction-coven-body-bg)'
+const DOT = 'var(--faction-coven-dot)'
+const SCRIPT = 'var(--faction-coven-card-font)' // Caveat
 const BODY = 'var(--font-body)' // Courier Prime
 
 /** The kit's four-point sparkle. */

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -2,7 +2,7 @@
  * Mobile Updates = a MIXED, multi-faction stream (#532), not seven per-faction
  * screens. Renders MobileUpdates with a feed whose items carry DIFFERENT
  * `context_faction_slug` values and proves each card keeps its OWN faction frame
- * (distinct WOW / UA / SNIDE chrome coexisting in one render) — never one
+ * (distinct COVEN / UA / SNIDE chrome coexisting in one render) — never one
  * uniform tint. Reuses the shared FeedCardRouter + normalizeFeedItem path.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -62,14 +62,14 @@ describe('mobile Updates mixed multi-faction stream', () => {
     expect(html).toContain('data-feed="mobile"')
   })
 
-  it('keeps each card in its OWN faction frame — WOW + UA chrome coexist', () => {
+  it('keeps each card in its OWN faction frame — COVEN + UA chrome coexist', () => {
     const { text, html } = render(baseState({ items }))
     // Distinct per-faction frame markers appearing TOGETHER in one render
     // prove a mixed stream, not one uniform tint.
-    expect(text, 'WOW window chrome').toContain('whimsy.exe')
+    expect(text, 'COVEN window chrome').toContain('whimsy.exe')
     expect(text, 'UA salon masthead').toContain('University of Asthmatics')
     expect(html, 'SNIDE dossier tokens').toContain('--faction-snide')
-    expect(html, 'WOW scrapbook tokens').toContain('--faction-wow')
+    expect(html, 'COVEN scrapbook tokens').toContain('--faction-wow')
   })
 
   it('renders every card body (the shared FeedRowContent rows)', () => {

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -52,7 +52,7 @@ function render(state: UpdatesState): { html: string; text: string } {
 
 describe('mobile Updates mixed multi-faction stream', () => {
   const items = [
-    completion('wow', 1, 'Cast a small spell'),
+    completion('coven', 1, 'Cast a small spell'),
     completion('ua', 2, 'Hang the canvas'),
     completion('snide', 3, 'Map the boring'),
   ]

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -69,7 +69,7 @@ describe('mobile Updates mixed multi-faction stream', () => {
     expect(text, 'COVEN window chrome').toContain('whimsy.exe')
     expect(text, 'UA salon masthead').toContain('University of Asthmatics')
     expect(html, 'SNIDE dossier tokens').toContain('--faction-snide')
-    expect(html, 'COVEN scrapbook tokens').toContain('--faction-wow')
+    expect(html, 'COVEN scrapbook tokens').toContain('--faction-coven')
   })
 
   it('renders every card body (the shared FeedRowContent rows)', () => {

--- a/frontend/src/utils/__tests__/commentTime.test.ts
+++ b/frontend/src/utils/__tests__/commentTime.test.ts
@@ -12,8 +12,8 @@ describe('formatCommentTime — per-faction dialects', () => {
   })
 
   it('wow is terse', () => {
-    expect(formatCommentTime('wow', ago(3 * 60), NOW)).toBe('3h')
-    expect(formatCommentTime('wow', ago(5), NOW)).toBe('5m')
+    expect(formatCommentTime('coven', ago(3 * 60), NOW)).toBe('3h')
+    expect(formatCommentTime('coven', ago(5), NOW)).toBe('5m')
   })
 
   it('snide zero-pads hours and shouts', () => {

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -41,7 +41,7 @@ const BOTH_THEMES: Theme[] = ["light", "dark"];
 const CARD_KEYS = [
   "ua",
   "everymen",
-  "wow",
+  "coven",
   "snide",
   "ephemerists",
   "singularity",
@@ -167,7 +167,7 @@ const BASELINE: Record<string, { ratio: number; issue: number }> = {
   // Card accents used as metadata text (§3: "metadata / decorative accent").
   "light | ua card accent": { ratio: 4.27, issue: 651 },
   "light | everymen card accent": { ratio: 4.49, issue: 651 },
-  "light | wow card accent": { ratio: 2.81, issue: 651 },
+  "light | coven card accent": { ratio: 2.81, issue: 651 },
   "dark | ua card accent": { ratio: 4.27, issue: 651 },
   "dark | everymen card accent": { ratio: 4.16, issue: 651 },
   "dark | ephemerists card accent": { ratio: 3.72, issue: 651 },

--- a/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
+++ b/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
@@ -9,7 +9,7 @@ import {
 describe("sortFactionsByRainbowOrder", () => {
   it("orders known factions into canonical rainbow order", () => {
     const shuffled = [
-      { slug: "wow" },
+      { slug: "coven" },
       { slug: "singularity" },
       { slug: "everymen" },
       { slug: "ephemerists" },
@@ -25,31 +25,31 @@ describe("sortFactionsByRainbowOrder", () => {
     // Albescent is registered but not themed, so it sorts with the unknowns
     // rather than claiming a slot in the spectrum. See the leak suite below.
     expect(
-      sortFactionsByRainbowOrder([{ slug: "albescent" }, { slug: "wow" }]).map(
+      sortFactionsByRainbowOrder([{ slug: "albescent" }, { slug: "coven" }]).map(
         (f) => f.slug,
       ),
-    ).toEqual(["wow", "albescent"]);
+    ).toEqual(["coven", "albescent"]);
   });
 
   it("sorts unknown slugs last, preserving their relative order", () => {
     const factions = [
       { slug: "mystery_b" },
-      { slug: "wow" },
+      { slug: "coven" },
       { slug: "mystery_a" },
       { slug: "everymen" },
     ];
     expect(sortFactionsByRainbowOrder(factions).map((f) => f.slug)).toEqual([
       "everymen",
-      "wow",
+      "coven",
       "mystery_b",
       "mystery_a",
     ]);
   });
 
   it("does not mutate the input array", () => {
-    const factions = [{ slug: "wow" }, { slug: "everymen" }];
+    const factions = [{ slug: "coven" }, { slug: "everymen" }];
     sortFactionsByRainbowOrder(factions);
-    expect(factions.map((f) => f.slug)).toEqual(["wow", "everymen"]);
+    expect(factions.map((f) => f.slug)).toEqual(["coven", "everymen"]);
   });
 });
 
@@ -113,9 +113,9 @@ describe("factionFill (#636 / ADR-0039)", () => {
   });
 
   it("pairs a real faction fill with its on-fill AA ink for a pill (#649)", () => {
-    expect(factionFill("wow", "pill")).toEqual({
-      background: "var(--faction-wow)",
-      color: "var(--faction-wow-on-fill)",
+    expect(factionFill("coven", "pill")).toEqual({
+      background: "var(--faction-coven)",
+      color: "var(--faction-coven-on-fill)",
     });
   });
 });
@@ -140,15 +140,21 @@ describe("FACTION_RAINBOW_ORDER does not leak Albescent (#783, ADR-0027)", () =>
     expect(JSON.stringify(fills)).not.toContain("albescent");
   });
 
-  it("still carries every faction that is publicly visible", () => {
+  it("still carries every faction that is publicly visible AND themed", () => {
     // Guards the opposite mistake: closing the leak by emptying the spectrum.
+    //
+    // `wow` is the one publicly-visible faction absent here, and only until its
+    // redesign ships (#784). Cozy Coven took the pink block, so `wow` resolves
+    // to `default` — putting it back now would paint a grey stop mid-rainbow,
+    // the same defect Albescent was removed to fix. It rejoins between "ua" and
+    // "snide" once it has a gold block of its own.
     expect([...FACTION_RAINBOW_ORDER].sort()).toEqual([
+      "coven",
       "ephemerists",
       "everymen",
       "singularity",
       "snide",
       "ua",
-      "wow",
     ]);
   });
 });

--- a/frontend/src/utils/__tests__/isKnownFaction.test.ts
+++ b/frontend/src/utils/__tests__/isKnownFaction.test.ts
@@ -30,13 +30,27 @@ describe("isKnownFaction", () => {
     for (const slug of [
       "ua",
       "everymen",
-      "wow",
+      "coven",
       "snide",
       "ephemerists",
       "singularity",
     ]) {
       expect(isKnownFaction(slug), `${slug} should be known`).toBe(true);
     }
+  });
+
+  /**
+   * The THIRD inhabitant of the unthemed side (#784), and the only temporary
+   * one. `na` is not a faction; `albescent` is a faction that hides. `wow` is
+   * a faction that is merely mid-redesign: its lo-fi pink `.exe` block became
+   * --faction-coven-* when the aesthetic moved to Cozy Coven, and its gold
+   * replacement is a sibling issue. Until that lands there is no
+   * --faction-wow-* block to point at, so CSS_KEY maps it to `default` and the
+   * predicate reports it unknown. Delete this test when the gold block ships.
+   */
+  it("returns false for `wow` — themeless while its redesign is pending", () => {
+    expect(isKnownFaction("wow")).toBe(false);
+    expect(factionCssVar("wow")).toBe("var(--faction-default)");
   });
 
   it("returns false for an unregistered slug", () => {

--- a/frontend/src/utils/commentTime.ts
+++ b/frontend/src/utils/commentTime.ts
@@ -41,7 +41,7 @@ function relative(d: TimeDelta): string {
   return 'just now'
 }
 
-/** Terse relative time (wow / singularity terminal). */
+/** Terse relative time (coven / singularity terminal). */
 function terse(d: TimeDelta): string {
   if (d.days >= 1) return `${d.days}d`
   if (d.hours >= 1) return `${d.hours}h`
@@ -60,7 +60,7 @@ export function formatCommentTime(
 ): string {
   const d = timeDelta(iso, now)
   switch (slug) {
-    case 'wow':
+    case 'coven':
       return terse(d)
     case 'snide':
       return `${String(d.hours).padStart(3, '0')}H AGO`

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -37,8 +37,12 @@ export interface FactionConfig {
 const FACTION_FALLBACKS: Record<string, FactionConfig> = {
   ua: { slug: "ua", color: "#c2541f" },
   everymen: { slug: "everymen", color: "#c1272d" },
-  wow: { slug: "wow", color: "#ec5f99" },
+  coven: { slug: "coven", color: "#ec5f99" },
   snide: { slug: "snide", color: "#6fae00" },
+  // `wow` is deliberately absent (#784). The pink above WAS its colour; the
+  // whole --faction-wow-* block moved to `coven` with the aesthetic, and
+  // Warriors of Whimsy's replacement gold identity is a sibling issue. Until
+  // that ships, factionColor('wow') hands back the same neutral grey as `na`.
   ephemerists: { slug: "ephemerists", color: "#1d6e72" },
   singularity: { slug: "singularity", color: "#2563eb" },
   // `albescent` is deliberately absent (#783). It was first-class here (#232)
@@ -68,8 +72,16 @@ export const FACTION_ALIASES: Record<string, string> = {};
 const CSS_KEY: Record<string, string> = {
   ua: "ua",
   everymen: "everymen",
-  wow: "wow",
+  coven: "coven",
   snide: "snide",
+  // Warriors of Whimsy is themeless in the interim (#784), so it points at
+  // `default` exactly like `albescent` below — but for a THIRD reason again:
+  // not secrecy, not statelessness, just a gap. Its lo-fi pink `.exe` block
+  // became --faction-coven-*, and its gold replacement is a sibling issue.
+  // Pointing it anywhere else would name a token that does not exist: that
+  // lints clean and renders broken. When the gold block ships this flips back
+  // to `wow: "wow"` and `wow` rejoins FACTION_RAINBOW_ORDER.
+  wow: "default",
   ephemerists: "ephemerists",
   singularity: "singularity",
   // Albescent is registered but NOT themed (#783). It is a secret society
@@ -284,7 +296,17 @@ export const FACTION_RAINBOW_ORDER: readonly string[] = [
   "snide",
   "ephemerists",
   "singularity",
-  "wow",
+  // Cozy Coven takes the pink slot, because it took the pink (#784). Warriors
+  // of Whimsy is NOT here in the interim: the array is a spectrum, every
+  // consumer paints straight off it, and `wow` currently resolves to `default`
+  // — a grey stop mid-rainbow on the Leaderboard and DefaultPlayers bars and a
+  // grey petal in Meadow's bloom. That is the same shape of defect #783 removed
+  // Albescent to fix, so an unthemed slug stays out on the same principle.
+  //
+  // #784 anticipated `wow` sitting near gold once it is gold. That is the
+  // sibling redesign's job — it ships the --faction-wow-* block and this slug
+  // rejoins between "ua" and "snide", taking the order to seven.
+  "coven",
 ];
 
 /**


### PR DESCRIPTION
Cozy Coven becomes the eighth faction, inheriting Warriors of Whimsy's lo-fi pink `.exe` aesthetic wholesale. Warriors of Whimsy keeps its slug, registers nothing, and falls back to `Default` everywhere on a clean slate for its gold redesign.

A rename, not a rebuild. No character data migrates, and no Alembic migration exists — `Faction.slug` is a plain string PK, so registering a faction is an era-config entry plus a seed row.

Closes #784

## Two things need your decision

**1. Cozy Coven's modifiers start at the Era 1 baseline — game-balance question for you.**
Warriors of Whimsy carries `own_task_modifier` / `collab_own_modifier` of `1.1`. Per the issue's decision doc I did **not** copy those over silently: Cozy Coven starts flat (1.0 / 1.0, duel 1.5 / 0.5). Whether the bonus should follow the aesthetic is yours to call. `wow` keeps its 1.1 pair untouched.

**2. `FACTION_RAINBOW_ORDER` stays at SIX, not seven — this diverges from the issue text.**
Step 7 anticipated `wow` sitting near gold while `coven` takes the pink slot. But `wow` has no colour yet — its entire token block moved to `coven`, and its gold block is the sibling issue. A slug resolving to `default` in that array paints a **grey stop mid-rainbow** on the Leaderboard and DefaultPlayers stripe bars and a grey petal in Meadow's bloom — precisely the defect #783 removed Albescent to fix. So `coven` takes the pink slot and `wow` steps out until it is gold, at which point it rejoins between `ua` and `snide` and the order becomes seven. Meadow therefore still paints **6 petals**, not 7. Say the word if you'd rather see wow in there greyed.

## Was adding a faction actually cheap? Mostly.

The issue asked for this signal explicitly. Registering Cozy Coven was **one manifest file plus one index line** — no dispatcher was touched, and all 27 surfaces picked it up automatically. The slot-contract suites adopted it with zero edits, exactly as #782 promised.

Three things cost more than that, none of them a manifest defect:
- `addAFaction.test.tsx`'s `REGISTRY_ROW` regex **hardcodes the slug alternation**. Without adding `coven` there, the "no surface-owned registry" guard silently stops covering the new faction. Worth making that regex derive from `FACTION_MANIFESTS` — flagging on #782 rather than fixing here.
- The seed's "already fully seeded" branch **returned before the faction upsert ran**, so a faction added after a DB was seeded never got its row. Fixed here (`upsert_era_factions`), no migration.
- The copy catalogs and a handful of slug-keyed maps (`voteReframes`, `commentTime`, `DuelCrossLink`, `FACTION_DESCRIPTOR_KEY`) are per-slug by nature — expected cost, not a seam problem.

Also: the issue says to update `factionContrast.test.ts`'s `ARCHETYPE_PAIRS`. The wow rows are actually in `CARD_KEYS`. `ARCHETYPE_PAIRS` is unchanged at 21 rows and the suite still runs **98 tests** — the count did not drop.

## Commit shape

Commits 3 and 5 are deliberately separate. `048b414` is the mechanical 26-file `git mv` (155 insertions / 155 deletions, symmetric, no visual effect). `3cbe151` is the one-line manifest repoint where the visual swap actually happens — a visual regression bisects there, not into the rename.

## Verification

`pytest` 190 unit + 443 integration pass (on a dedicated `wz784_test` DB). Frontend: `tsc --noEmit`, `eslint`, `vite build` all clean; **1057 vitest tests pass**, including a new `wowRendersDefault.test.tsx`.

That new file asserts both halves of wow's interim state together, because only the combination means "clean slate" rather than "broken faction": it claims no surface (27 assertions, one per `SURFACE_KEYS` entry, each rendering the fallback) **and** still resolves `Warriors of Whimsy` rather than falling through to `names.na`. The dangerous failure here was never a crash — it was a real, joinable faction quietly labelled "Unaffiliated" for the whole redesign window, invisible to types, builds and visual diffs alike.

**Visual QA is outstanding** — I cannot screenshot in this environment and there is no dev stack, so everything below is verified by tests and build only.

## What to eyeball

1. **A `coven` character's surfaces** — must be **pixel-identical** to today's Warriors of Whimsy: notepad chrome, tape, ivy, scraps, Caveat headline, pink `.exe` window bars. Token *values* are untouched; only the names changed. Check both light and dark.
2. **A `wow` character's surfaces** — clean `Default` everywhere, and crucially the faction pill/name reads **"Warriors of Whimsy"**, never "Unaffiliated".
3. **The Meadow petal ring** — expect **6 petals** (see decision 2 above), no two adjacent petals sharing a hue.
4. **The faction stripe bars** on Leaderboard and mobile `DefaultPlayers` — six stops, no grey gap where wow used to sit.

## Deliberately unchanged

- Copy **values**, including the literal `wow.exe` window chrome. The issue defers Cozy Coven's display naming to a separate one-string change, and "pixel-identical" covers wording.
- The Era 1 **tasks** with `faction_slug="wow"` stay with Warriors of Whimsy. Cozy Coven starts with no members and no tasks; the issue is silent on moving them, so I didn't.
- `.design-sync/previews/Wow*.tsx` — vendored design records, not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
