### PR TITLE
Warriors of Whimsy: the level-jump ability, and the WOW/Coven modifier swap

### DIFF
--- a/backend/alembic/versions/0005_character_stats_level_jump.py
+++ b/backend/alembic/versions/0005_character_stats_level_jump.py
@@ -1,0 +1,43 @@
+"""Add character_stats.level_jump_used_at_level for the faction level jump (#811).
+
+The column records the level at which a character last spent their faction's
+level-jump allowance; NULL means never spent this era. The allowance is
+available iff it differs from ``level``, so levelling up restores it and no
+reset job exists to migrate.
+
+0001_squashed builds the schema from the live ORM models, so a *fresh* DB (CI,
+local reset) already has this column and the ADD below is a no-op. An
+already-deployed DB is stamped past 0001_squashed and never re-runs it, so it
+needs the explicit ADD — hence IF NOT EXISTS, which makes this safe on fresh
+and deployed DBs alike.
+
+Nullable with no server default on purpose: "never spent" is genuinely absent
+information, not a zero, and level 0 is a real level a jump can be spent at.
+Backfilling would therefore have to invent a value; NULL says the truth.
+
+Revision ID: 0005_character_stats_level_jump
+Revises: 0004_character_faction_na
+Create Date: 2026-07-19
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_character_stats_level_jump"
+down_revision: Union[str, None] = "0004_character_faction_na"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text(
+        "ALTER TABLE character_stats "
+        "ADD COLUMN IF NOT EXISTS level_jump_used_at_level INTEGER"
+    ))
+
+
+def downgrade() -> None:
+    op.execute(sa.text(
+        "ALTER TABLE character_stats DROP COLUMN IF EXISTS level_jump_used_at_level"
+    ))

--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -51,6 +51,9 @@ from game_config import (
 #   collab_other_modifier   -- collaborative task from another faction
 #   duel_win_modifier       -- base points when you win a duel
 #   duel_loss_modifier      -- base points when you lose a duel
+#   level_jump_reach        -- levels above own level this faction may reach when
+#                              signing up, once per level. Optional, defaults to 0
+#                              (no ability). Era 1 gives wow 1; everyone else 0.
 
 ERA_N_FACTIONS = {
     # --- Required system factions (copy and customize) ---

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -48,28 +48,30 @@ ERA_1_FACTIONS = {
         duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
         duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
     ),
+    # Warriors of Whimsy (#811). Its perk is MECHANICAL, not multiplicative: the
+    # level jump below is WOW's only perk, so every modifier drops to the Era 1
+    # baseline. The +10% own/collab pair it used to carry moved to Cozy Coven.
     "wow": FactionConfig(
         slug="wow",
         can_always_rejoin=False,
-        own_task_modifier=1.1,        # +10% on solo own-faction
+        own_task_modifier=1.0,
         other_task_modifier=1.0,
-        collab_own_modifier=1.1,      # +10% on collab own-faction
+        collab_own_modifier=1.0,
         collab_other_modifier=1.0,
         duel_win_modifier=1.5,
         duel_loss_modifier=0.5,
+        level_jump_reach=1,           # once per level, claim ONE task 1 level up
     ),
-    # Cozy Coven (#784) — the eighth faction. It inherits Warriors of Whimsy's
-    # lo-fi pink `.exe` AESTHETIC only; the modifiers below are the Era 1
-    # baseline, deliberately NOT wow's +10% own/collab pair above. Whether Cozy
-    # Coven should carry that bonus is a game-balance decision for the owner, not
-    # a consequence of the visual move, so it starts flat and is flagged rather
-    # than inherited silently.
+    # Cozy Coven (#784) — the eighth faction. It inherited Warriors of Whimsy's
+    # lo-fi pink `.exe` aesthetic in #784; #811 hands it WOW's collaboration
+    # bonus too, so Coven is now the only faction in Era 1 carrying a non-1.0
+    # modifier.
     "coven": FactionConfig(
         slug="coven",
         can_always_rejoin=False,
         own_task_modifier=1.0,
         other_task_modifier=1.0,
-        collab_own_modifier=1.0,
+        collab_own_modifier=1.1,      # +10% on collab own-faction
         collab_other_modifier=1.0,
         duel_win_modifier=1.5,
         duel_loss_modifier=0.5,

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -69,6 +69,12 @@ class FactionConfig:
     collab_other_modifier: float     # collaborative other-faction task multiplier
     duel_win_modifier: float         # duel win multiplier (applied to base points)
     duel_loss_modifier: float        # duel loss multiplier (applied to base points)
+    # Levels ABOVE the character's own level that a member may reach when signing
+    # up for a task, once per level (#811). 0 = no such ability (the baseline for
+    # every faction); 1 = may claim a single task exactly one level up per level.
+    # Read via services.level_jump — never branch on a faction slug in a service.
+    # Defaulted so existing/new era files only state it where it is non-zero.
+    level_jump_reach: int = 0
 
 
 @dataclass(frozen=True)

--- a/backend/models/character_stats.py
+++ b/backend/models/character_stats.py
@@ -33,6 +33,14 @@ class CharacterStats(Base):
     votes_spent_this_era: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="0"
     )
+    # The character's level at the moment they last spent their faction's
+    # level-jump allowance (#811); NULL means never spent this era. The allowance
+    # is available iff this differs from `level`, so levelling up restores it with
+    # no reset job, and the per-(character, era) row shape clears it on era reset
+    # for free. Read/written only through services.level_jump.
+    level_jump_used_at_level: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -36,3 +36,9 @@ class CurrentUser(BaseModel):
     can_see_retired_tasks: bool = False
     can_see_pending_tasks: bool = False
     can_comment: bool = False
+    # Faction level-jump allowance (#811). reach = levels above own level this
+    # faction grants (0 = no such ability, so hide the affordance entirely);
+    # available = unspent at the current level. Neither is short-circuited by
+    # is_admin — the jump is a faction perk, not a level gate.
+    level_jump_reach: int = 0
+    level_jump_available: bool = False

--- a/backend/services/character_capabilities.py
+++ b/backend/services/character_capabilities.py
@@ -11,12 +11,17 @@ Design choices:
 - ``is_admin=True`` short-circuits every flag to True. Mirrors the existing
   ``skip_level_check`` admin escape hatch in ``services.task.propose_task``.
 - ``character_level=None`` (no active character) makes every flag False.
+- The faction level-jump fields (#811) take ``faction_slug`` and the stats row's
+  ``level_jump_used_at_level`` for the same reason — passing the two scalars
+  keeps this function pure and DB-free. The rule itself lives in
+  ``services.level_jump``, shared with the sign-up gate so they cannot drift.
 - Never imports CURRENT_ERA inside the function body — it is the default arg
   only, per CLAUDE.md config architecture rules.
 """
 from dataclasses import dataclass
 
 from game_config import CURRENT_ERA, EraConfig
+from services.level_jump import available_level_reach, faction_level_jump_reach
 
 
 @dataclass(frozen=True)
@@ -28,13 +33,35 @@ class CharacterCapabilities:
     can_see_retired_tasks: bool
     can_see_pending_tasks: bool
     can_comment: bool
+    # Faction level-jump allowance (#811). ``level_jump_reach`` is what the
+    # faction grants at all (0 for everyone without the ability), so the frontend
+    # can hide the affordance entirely rather than showing it spent forever;
+    # ``level_jump_available`` is whether it is unspent at the current level.
+    # Unlike the flags above, these are NOT short-circuited by is_admin: the jump
+    # is a faction perk, not a level gate, and an admin claiming to hold an
+    # ability their faction does not grant would be a lie in the UI.
+    level_jump_reach: int
+    level_jump_available: bool
 
 
 def compute_capabilities(
     character_level: int | None,
     is_admin: bool,
     era: EraConfig = CURRENT_ERA,
+    faction_slug: str | None = None,
+    level_jump_used_at_level: int | None = None,
 ) -> CharacterCapabilities:
+    granted_reach = faction_level_jump_reach(faction_slug, era)
+    if character_level is None:
+        jump_available = False
+    else:
+        jump_available = (
+            available_level_reach(
+                faction_slug, character_level, level_jump_used_at_level, era
+            )
+            > 0
+        )
+
     if is_admin:
         return CharacterCapabilities(
             can_propose_task=True,
@@ -43,6 +70,8 @@ def compute_capabilities(
             can_see_retired_tasks=True,
             can_see_pending_tasks=True,
             can_comment=True,
+            level_jump_reach=granted_reach,
+            level_jump_available=jump_available,
         )
 
     if character_level is None:
@@ -53,6 +82,8 @@ def compute_capabilities(
             can_see_retired_tasks=False,
             can_see_pending_tasks=False,
             can_comment=False,
+            level_jump_reach=granted_reach,
+            level_jump_available=False,
         )
 
     return CharacterCapabilities(
@@ -62,4 +93,6 @@ def compute_capabilities(
         can_see_retired_tasks=character_level >= era.level_to_see_retired_tasks,
         can_see_pending_tasks=character_level >= era.level_to_see_pending_tasks,
         can_comment=character_level >= era.comment_level_required,
+        level_jump_reach=granted_reach,
+        level_jump_available=jump_available,
     )

--- a/backend/services/current_user.py
+++ b/backend/services/current_user.py
@@ -31,6 +31,7 @@ async def build_current_user(
 
     char_out = None
     character_level: int | None = None
+    level_jump_used_at_level: int | None = None
     if character:
         stats = await load_current_era_stats(character.id, session)
         # #243: surface the active life's own current-era invitation letters so the
@@ -40,6 +41,7 @@ async def build_current_user(
         )
         char_out = build_character_out(character, stats, invitations=invitations)
         character_level = stats.level if stats else 0
+        level_jump_used_at_level = stats.level_jump_used_at_level if stats else None
 
     is_admin = await account_has_admin_role(account.id, session)
 
@@ -52,7 +54,13 @@ async def build_current_user(
         can_create_more = False
         can_albescent = False
 
-    capabilities = compute_capabilities(character_level, is_admin)
+    capabilities = compute_capabilities(
+        character_level,
+        is_admin,
+        era,
+        faction_slug=character.faction_slug if character else None,
+        level_jump_used_at_level=level_jump_used_at_level,
+    )
 
     return CurrentUser(
         account_id=account.id,

--- a/backend/services/level_jump.py
+++ b/backend/services/level_jump.py
@@ -1,0 +1,82 @@
+"""The faction level-jump allowance (#811) — one home for the whole ability.
+
+A faction may grant its members the right to reach ``level_jump_reach`` levels
+ABOVE their own when signing up for a task, once per level. Era 1 gives this to
+Warriors of Whimsy (reach 1); every other faction sits at the 0 baseline.
+
+Two rules and no more:
+
+- **Availability.** The allowance is available iff
+  ``stats.level_jump_used_at_level != stats.level``. Levelling up changes
+  ``stats.level``, which restores it — there is deliberately no counter and no
+  reset job. Stats rows are per-(character, era), so an era reset clears it too.
+- **Consumption.** Spending is recorded by stamping the *current* level. It
+  happens on sign-up and is never refunded: abandoning or deleting the praxis
+  does not give it back, otherwise it could be farmed by claiming and backing
+  out.
+
+Both callers (the sign-up gate in ``services.praxis`` and the capability flags in
+``services.character_capabilities``) read :func:`available_level_reach`, so the
+enforcement and the UI affordance cannot drift apart. Nothing here branches on a
+faction slug — the reach is a ``FactionConfig`` field read off ``era``.
+"""
+from typing import Optional
+
+from game_config import CURRENT_ERA, EraConfig
+from models.character_stats import CharacterStats
+
+
+def faction_level_jump_reach(
+    faction_slug: Optional[str],
+    era: EraConfig = CURRENT_ERA,
+) -> int:
+    """The reach this faction grants at all, ignoring whether it is spent.
+
+    Returns 0 for anonymous/unaffiliated characters and for any slug the era does
+    not define (a character carrying a slug from a previous era gets no ability
+    rather than an error).
+    """
+    if faction_slug is None:
+        return 0
+    faction_config = era.factions.get(faction_slug)
+    if faction_config is None:
+        return 0
+    return faction_config.level_jump_reach
+
+
+def is_level_jump_available(
+    character_level: int,
+    level_jump_used_at_level: Optional[int],
+) -> bool:
+    """Whether the once-per-level allowance is unspent at ``character_level``."""
+    return level_jump_used_at_level != character_level
+
+
+def available_level_reach(
+    faction_slug: Optional[str],
+    character_level: int,
+    level_jump_used_at_level: Optional[int],
+    era: EraConfig = CURRENT_ERA,
+) -> int:
+    """Levels above ``character_level`` this character may reach *right now*.
+
+    0 when the faction grants no jump or when the allowance is already spent at
+    this level. This is the number the task-level gate adds to the character's
+    level, so it is also the number the UI shows.
+    """
+    reach = faction_level_jump_reach(faction_slug, era)
+    if reach <= 0:
+        return 0
+    if not is_level_jump_available(character_level, level_jump_used_at_level):
+        return 0
+    return reach
+
+
+def consume_level_jump(stats: CharacterStats) -> None:
+    """Record the allowance as spent at the character's current level.
+
+    Idempotent within a level: stamping the same level twice is a no-op. Callers
+    must only invoke this when the claim actually *needed* the jump — see
+    :func:`services.praxis.create_praxis`.
+    """
+    stats.level_jump_used_at_level = stats.level

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -44,6 +44,7 @@ from services import collab_consensus
 from services.character_stats import recalculate_character_stats
 from services.faction_service import faction_permits
 from services.era import get_current_era_row, get_or_create_stats
+from services.level_jump import available_level_reach, consume_level_jump
 from models.duel import Duel, DuelStatus
 from services.vote_tally import crowned_praxis_ids, get_tally, tally_votes, ViewerVote
 
@@ -581,7 +582,9 @@ async def list_praxes(
     return praxes
 
 
-def meets_task_level(character_level: int, task: Task) -> bool:
+def meets_task_level(
+    character_level: int, task: Task, level_reach: int = 0
+) -> bool:
     """Whether ``character_level`` clears the task's own level bar (#292).
 
     The single home for the **task-level** gate — the "level half" that used to
@@ -590,8 +593,15 @@ def meets_task_level(character_level: int, task: Task) -> bool:
     (the faction half, #171) and from the era-config thresholds
     (collab/flag/comment/metatask-apply), which each already sit in their own
     purpose-named predicate and share a single ``era.*`` source for their value.
+
+    ``level_reach`` is the faction level-jump allowance (#811): levels above the
+    character's own that they may currently reach. It is 0 for everyone without
+    the ability and for anyone who has already spent it at this level — see
+    :func:`services.level_jump.available_level_reach`, which is the only thing
+    that should compute it. Extending the gate here (rather than per mode) is
+    what gives the ability identical behaviour across solo, collab and duel.
     """
-    return character_level >= task.level_required
+    return character_level + level_reach >= task.level_required
 
 
 class SignupDenialReason(str, Enum):
@@ -631,7 +641,10 @@ async def evaluate_signup(
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, character.id, era_row.id)
 
-    if not meets_task_level(stats.level, task):
+    level_reach = available_level_reach(
+        character.faction_slug, stats.level, stats.level_jump_used_at_level, era
+    )
+    if not meets_task_level(stats.level, task, level_reach):
         return SignupEligibility(False, SignupDenialReason.below_level)
 
     if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
@@ -735,8 +748,22 @@ async def create_praxis(
     - Character level meets task.level_required
     - Bank cap: era.max_task_signups = max concurrent in_progress praxes per character
     - Duel/collab type requires minimum level
+    - Spends the faction level-jump allowance if the claim needed it (#811)
     """
-    await _check_create_preconditions(task_id, praxis_type, character_id, session, era)
+    task = await _check_create_preconditions(
+        task_id, praxis_type, character_id, session, era
+    )
+
+    # #811: the preconditions above already allowed this claim, so if the task
+    # still sits above the character's level the only thing that let them in was
+    # the level jump — stamp it spent. Deliberately never refunded: withdrawing
+    # or deleting the praxis does not give it back, or it could be farmed by
+    # claiming and backing out.
+    era_row = await get_current_era_row(session)
+    stats = await get_or_create_stats(session, character_id, era_row.id)
+    if task.level_required > stats.level:
+        consume_level_jump(stats)
+        await session.flush()
 
     praxis = Praxis(
         task_id=task_id,
@@ -1120,6 +1147,7 @@ def is_task_eligible_for_character(
     character: Optional[Character],
     task: Task,
     character_level: int,
+    level_reach: int = 0,
 ) -> bool:
     """Return True if ``character`` is eligible to act on ``task``.
 
@@ -1139,7 +1167,9 @@ def is_task_eligible_for_character(
     if character is None:
         return False
     # Two named single-purpose gates, no bundled inline checks (#171, #292).
-    if not meets_task_level(character_level, task):
+    # ``level_reach`` (#811) is threaded through so the "eligible" affordance
+    # matches what evaluate_signup would actually allow.
+    if not meets_task_level(character_level, task, level_reach):
         return False
     if not faction_permits(character, task):
         return False

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -17,6 +17,7 @@ from services.praxis import (
     can_submit_praxis_for_task,
     is_task_eligible_for_character,
 )
+from services.level_jump import available_level_reach
 
 
 async def propose_task(
@@ -154,7 +155,12 @@ async def build_task_out_for_viewer(
     base.can_submit_praxis = await can_submit_praxis_for_task(viewer, task, session, era)
     base.allowed_modes = [m.value for m in allowed_praxis_modes(viewer, stats.level, era)]
     base.eligible_for_current_user = is_task_eligible_for_character(
-        viewer, task, stats.level
+        viewer,
+        task,
+        stats.level,
+        available_level_reach(
+            viewer.faction_slug, stats.level, stats.level_jump_used_at_level, era
+        ),
     )
     return base
 

--- a/backend/tests/integration/test_level_jump_signup.py
+++ b/backend/tests/integration/test_level_jump_signup.py
@@ -1,0 +1,189 @@
+"""#811 — the WOW level-jump allowance, end to end through the sign-up gate.
+
+The unit rule lives in tests/unit/test_level_jump.py. This file asserts the
+things only the real path can show: that the allowance is actually spent on
+sign-up, that it is never refunded, and that levelling up restores it — all via
+``evaluate_signup``/``create_praxis``, the gate every mode shares.
+"""
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.praxis import PraxisType
+from models.task import Task, TaskStatus
+from services.praxis import (
+    SignupDenialReason,
+    create_praxis,
+    delete_praxis,
+    evaluate_signup,
+)
+
+WOW = "wow"
+JUMPER_LEVEL = 3
+
+
+@pytest.fixture
+async def faction_wow(db_session: AsyncSession, faction_ua: Faction) -> Faction:
+    db_session.add(Faction(slug=WOW, status=FactionStatus.visible))
+    await db_session.commit()
+    result = await db_session.execute(select(Faction).where(Faction.slug == WOW))
+    return result.scalar_one()
+
+
+async def _set_faction_and_level(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+    faction_slug: str,
+    level: int = JUMPER_LEVEL,
+) -> CharacterStats:
+    character.faction_slug = faction_slug
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.level = level
+    await db_session.commit()
+    return stats
+
+
+async def _make_task(
+    db_session: AsyncSession, character: Character, level_required: int
+) -> Task:
+    task = Task(
+        title=f"Level {level_required} task",
+        description="",
+        point_value=10,
+        level_required=level_required,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(task)
+    await db_session.commit()
+    await db_session.refresh(task)
+    return task
+
+
+# --- the gate ---------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wow_may_sign_up_one_level_above(
+    db_session: AsyncSession, character: Character, era: Era, faction_wow: Faction
+):
+    await _set_faction_and_level(db_session, character, era, WOW)
+    task = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+
+    result = await evaluate_signup(character, task, db_session)
+    assert result.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_wow_may_never_reach_two_levels_above(
+    db_session: AsyncSession, character: Character, era: Era, faction_wow: Faction
+):
+    await _set_faction_and_level(db_session, character, era, WOW)
+    task = await _make_task(db_session, character, JUMPER_LEVEL + 2)
+
+    result = await evaluate_signup(character, task, db_session)
+    assert result.allowed is False
+    assert result.reason == SignupDenialReason.below_level
+
+
+@pytest.mark.asyncio
+async def test_non_wow_can_never_sign_up_above_their_level(
+    db_session: AsyncSession, character: Character, era: Era, faction_ua: Faction
+):
+    await _set_faction_and_level(db_session, character, era, "ua")
+    task = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+
+    result = await evaluate_signup(character, task, db_session)
+    assert result.allowed is False
+    assert result.reason == SignupDenialReason.below_level
+
+
+# --- spending it ------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_allowance_is_spent_once_and_not_twice_at_the_same_level(
+    db_session: AsyncSession, character: Character, era: Era, faction_wow: Faction
+):
+    stats = await _set_faction_and_level(db_session, character, era, WOW)
+    first = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+    second = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+
+    await create_praxis(first.id, PraxisType.solo, character.id, db_session)
+    await db_session.refresh(stats)
+    assert stats.level_jump_used_at_level == JUMPER_LEVEL
+
+    result = await evaluate_signup(character, second, db_session)
+    assert result.allowed is False
+    assert result.reason == SignupDenialReason.below_level
+
+
+@pytest.mark.asyncio
+async def test_signing_up_at_or_below_own_level_does_not_spend_it(
+    db_session: AsyncSession, character: Character, era: Era, faction_wow: Faction
+):
+    stats = await _set_faction_and_level(db_session, character, era, WOW)
+    ordinary = await _make_task(db_session, character, JUMPER_LEVEL)
+
+    await create_praxis(ordinary.id, PraxisType.solo, character.id, db_session)
+    await db_session.refresh(stats)
+    assert stats.level_jump_used_at_level is None
+
+    above = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+    assert (await evaluate_signup(character, above, db_session)).allowed is True
+
+
+@pytest.mark.asyncio
+async def test_the_allowance_returns_after_levelling_up(
+    db_session: AsyncSession, character: Character, era: Era, faction_wow: Faction
+):
+    stats = await _set_faction_and_level(db_session, character, era, WOW)
+    first = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+    await create_praxis(first.id, PraxisType.solo, character.id, db_session)
+
+    # Level up. Nothing clears the stamp — the comparison simply stops matching.
+    stats.level = JUMPER_LEVEL + 1
+    await db_session.commit()
+
+    higher = await _make_task(db_session, character, JUMPER_LEVEL + 2)
+    assert (await evaluate_signup(character, higher, db_session)).allowed is True
+
+
+@pytest.mark.asyncio
+async def test_abandoning_the_praxis_does_not_refund_the_allowance(
+    db_session: AsyncSession, character: Character, era: Era, faction_wow: Faction
+):
+    """Settled default in #811: otherwise it could be farmed by backing out."""
+    stats = await _set_faction_and_level(db_session, character, era, WOW)
+    task = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+
+    praxis = await create_praxis(task.id, PraxisType.solo, character.id, db_session)
+    await delete_praxis(praxis.id, character.id, db_session)
+    await db_session.refresh(stats)
+
+    assert stats.level_jump_used_at_level == JUMPER_LEVEL
+    retry = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+    assert (await evaluate_signup(character, retry, db_session)).allowed is False
+
+
+@pytest.mark.asyncio
+async def test_defecting_from_wow_loses_the_ability(
+    db_session: AsyncSession, character: Character, era: Era, faction_wow: Faction
+):
+    await _set_faction_and_level(db_session, character, era, WOW)
+    task = await _make_task(db_session, character, JUMPER_LEVEL + 1)
+    assert (await evaluate_signup(character, task, db_session)).allowed is True
+
+    character.faction_slug = "ua"
+    await db_session.commit()
+    assert (await evaluate_signup(character, task, db_session)).allowed is False

--- a/backend/tests/unit/test_character_capabilities.py
+++ b/backend/tests/unit/test_character_capabilities.py
@@ -85,4 +85,7 @@ def test_compute_capabilities_reads_from_era_arg() -> None:
         can_see_retired_tasks=False,
         can_see_pending_tasks=False,
         can_comment=True,
+        # No faction_slug passed, so no faction grants a jump (#811).
+        level_jump_reach=0,
+        level_jump_available=False,
     )

--- a/backend/tests/unit/test_character_capabilities.py
+++ b/backend/tests/unit/test_character_capabilities.py
@@ -89,3 +89,63 @@ def test_compute_capabilities_reads_from_era_arg() -> None:
         level_jump_reach=0,
         level_jump_available=False,
     )
+
+
+# --- faction level-jump flags (#811) ----------------------------------------
+
+
+def test_level_jump_flags_for_unspent_wow() -> None:
+    result = compute_capabilities(
+        3, is_admin=False, faction_slug="wow", level_jump_used_at_level=None
+    )
+    assert result.level_jump_reach == 1
+    assert result.level_jump_available is True
+
+
+def test_level_jump_flags_once_spent_at_this_level() -> None:
+    result = compute_capabilities(
+        3, is_admin=False, faction_slug="wow", level_jump_used_at_level=3
+    )
+    # reach stays 1 so the UI can still explain the ability rather than hiding
+    # it the moment it is used; only `available` flips.
+    assert result.level_jump_reach == 1
+    assert result.level_jump_available is False
+
+
+def test_level_jump_flags_after_levelling_up() -> None:
+    result = compute_capabilities(
+        4, is_admin=False, faction_slug="wow", level_jump_used_at_level=3
+    )
+    assert result.level_jump_available is True
+
+
+def test_level_jump_flags_absent_for_other_factions() -> None:
+    result = compute_capabilities(
+        3, is_admin=False, faction_slug="coven", level_jump_used_at_level=None
+    )
+    assert result.level_jump_reach == 0
+    assert result.level_jump_available is False
+
+
+def test_admin_does_not_get_a_level_jump_it_has_no_faction_for() -> None:
+    # is_admin short-circuits the LEVEL gates to True, but the jump is a faction
+    # perk — claiming it for a non-wow admin would be a lie in the UI.
+    result = compute_capabilities(
+        3, is_admin=True, faction_slug="ua", level_jump_used_at_level=None
+    )
+    assert result.can_propose_task is True
+    assert result.level_jump_reach == 0
+    assert result.level_jump_available is False
+
+
+def test_admin_in_wow_still_reports_its_real_allowance() -> None:
+    spent = compute_capabilities(
+        3, is_admin=True, faction_slug="wow", level_jump_used_at_level=3
+    )
+    assert spent.level_jump_reach == 1
+    assert spent.level_jump_available is False
+
+
+def test_no_active_character_has_no_level_jump() -> None:
+    result = compute_capabilities(None, is_admin=False, faction_slug="wow")
+    assert result.level_jump_available is False

--- a/backend/tests/unit/test_faction_config.py
+++ b/backend/tests/unit/test_faction_config.py
@@ -3,16 +3,48 @@
 from game_config import ERA_1
 
 
-def test_wow_solo_modifiers():
+def test_wow_modifiers_are_flat():
+    # #811: WOW's perk is the level jump, not a multiplier. Its former +10%
+    # own/collab pair moved to Cozy Coven, leaving every modifier at baseline.
     config = ERA_1.factions["wow"]
-    assert config.own_task_modifier == 1.1
+    assert config.own_task_modifier == 1.0
     assert config.other_task_modifier == 1.0
-
-
-def test_wow_collab_modifiers():
-    config = ERA_1.factions["wow"]
-    assert config.collab_own_modifier == 1.1
+    assert config.collab_own_modifier == 1.0
     assert config.collab_other_modifier == 1.0
+
+
+def test_wow_level_jump_reach():
+    # #811: once per level, a WOW member may claim ONE task exactly one level up.
+    assert ERA_1.factions["wow"].level_jump_reach == 1
+
+
+def test_coven_collab_own_bonus():
+    # #811: Cozy Coven inherits the collaboration bonus WOW gave up.
+    config = ERA_1.factions["coven"]
+    assert config.collab_own_modifier == 1.1
+    assert config.own_task_modifier == 1.0
+    assert config.collab_other_modifier == 1.0
+
+
+def test_coven_is_the_only_faction_with_a_modifier():
+    # #811 states this explicitly: after the swap, Cozy Coven's collab_own is the
+    # single non-1.0 task modifier in Era 1. Duel modifiers are a separate axis.
+    with_modifiers = {
+        slug for slug, config in ERA_1.factions.items()
+        if 1.0 != config.own_task_modifier
+        or 1.0 != config.other_task_modifier
+        or 1.0 != config.collab_own_modifier
+        or 1.0 != config.collab_other_modifier
+    }
+    assert with_modifiers == {"coven"}
+
+
+def test_level_jump_is_wow_only():
+    granted = {
+        slug for slug, config in ERA_1.factions.items()
+        if config.level_jump_reach > 0
+    }
+    assert granted == {"wow"}
 
 
 def test_snide_duel_modifiers():

--- a/backend/tests/unit/test_level_jump.py
+++ b/backend/tests/unit/test_level_jump.py
@@ -1,0 +1,95 @@
+"""Unit tests for services.level_jump — the faction level-jump allowance (#811).
+
+These cover the rule in isolation (pure, DB-free). The enforcement path that
+actually spends it lives in tests/integration/test_level_jump_signup.py.
+"""
+from dataclasses import replace
+
+import pytest
+
+from game_config import ERA_1
+from services.level_jump import (
+    available_level_reach,
+    faction_level_jump_reach,
+    is_level_jump_available,
+)
+
+
+# --- what the faction grants at all -----------------------------------------
+
+def test_wow_grants_reach_of_one() -> None:
+    assert faction_level_jump_reach("wow", ERA_1) == 1
+
+
+@pytest.mark.parametrize(
+    "slug", ["ua", "snide", "coven", "ephemerists", "everymen", "singularity",
+             "albescent", "na"],
+)
+def test_every_other_faction_grants_nothing(slug: str) -> None:
+    assert faction_level_jump_reach(slug, ERA_1) == 0
+
+
+def test_unaffiliated_none_slug_grants_nothing() -> None:
+    assert faction_level_jump_reach(None, ERA_1) == 0
+
+
+def test_slug_absent_from_the_era_grants_nothing() -> None:
+    # A character carrying a slug from a previous era must degrade to "no
+    # ability", not raise.
+    assert faction_level_jump_reach("ua_masters", ERA_1) == 0
+
+
+def test_reach_is_read_from_the_era_argument_not_the_slug() -> None:
+    """The ability is config-driven: flip the config and wow loses it."""
+    flat_wow = replace(ERA_1.factions["wow"], level_jump_reach=0)
+    generous_ua = replace(ERA_1.factions["ua"], level_jump_reach=2)
+    other_era = replace(
+        ERA_1, factions={**ERA_1.factions, "wow": flat_wow, "ua": generous_ua}
+    )
+    assert faction_level_jump_reach("wow", other_era) == 0
+    assert faction_level_jump_reach("ua", other_era) == 2
+
+
+# --- availability: the "differs from current level" rule ---------------------
+
+def test_never_spent_is_available() -> None:
+    assert is_level_jump_available(3, None) is True
+
+
+def test_spent_at_this_level_is_unavailable() -> None:
+    assert is_level_jump_available(3, 3) is False
+
+
+def test_spent_at_a_lower_level_is_available_again() -> None:
+    # This is the whole "no reset job" trick: levelling up changes the left side.
+    assert is_level_jump_available(4, 3) is True
+
+
+def test_level_zero_is_a_real_level_that_can_be_spent_at() -> None:
+    # Guards the NULL-vs-0 distinction the column deliberately preserves.
+    assert is_level_jump_available(0, None) is True
+    assert is_level_jump_available(0, 0) is False
+
+
+# --- the composed number the gate and the UI both read ----------------------
+
+def test_available_reach_for_unspent_wow() -> None:
+    assert available_level_reach("wow", 3, None, ERA_1) == 1
+
+
+def test_available_reach_is_zero_once_spent_at_this_level() -> None:
+    assert available_level_reach("wow", 3, 3, ERA_1) == 0
+
+
+def test_available_reach_returns_after_levelling_up() -> None:
+    assert available_level_reach("wow", 4, 3, ERA_1) == 1
+
+
+def test_available_reach_zero_for_a_faction_without_the_ability() -> None:
+    # Even with a pristine (never-spent) allowance, a non-wow faction gets 0.
+    assert available_level_reach("ua", 3, None, ERA_1) == 0
+
+
+def test_a_spent_stamp_on_a_faction_without_the_ability_is_still_zero() -> None:
+    # e.g. a character who used the jump as wow and then defected.
+    assert available_level_reach("ua", 4, 3, ERA_1) == 0

--- a/backend/tests/unit/test_meets_task_level.py
+++ b/backend/tests/unit/test_meets_task_level.py
@@ -25,3 +25,26 @@ def test_above_required_level_is_permitted() -> None:
 
 def test_level_zero_task_is_open_to_everyone() -> None:
     assert meets_task_level(0, _task(0)) is True
+
+
+# --- the faction level-jump term (#811) -------------------------------------
+# Extending THIS predicate is what gives the ability identical behaviour across
+# solo/collab/duel, so the arithmetic is pinned here rather than per mode.
+
+
+def test_reach_defaults_to_zero_so_the_gate_is_unchanged() -> None:
+    assert meets_task_level(2, _task(3)) is False
+
+
+def test_reach_of_one_clears_a_task_one_level_up() -> None:
+    assert meets_task_level(3, _task(4), 1) is True
+
+
+def test_reach_of_one_does_not_clear_a_task_two_levels_up() -> None:
+    # "Exactly one level, never two" — the settled default in #811.
+    assert meets_task_level(3, _task(5), 1) is False
+
+
+def test_reach_still_clears_tasks_at_or_below_own_level() -> None:
+    assert meets_task_level(3, _task(3), 1) is True
+    assert meets_task_level(3, _task(1), 1) is True

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -199,9 +199,11 @@ def test_faction_multiplier_unaffiliated_task():
 
 
 def test_faction_multiplier_own_faction():
+    # #811 flattened wow's own-task modifier to baseline; the multiplier still
+    # resolves from the faction's own config, it is just 1.0 now.
     result = compute_faction_multiplier("wow", "wow", ERA_1)
     assert result == ERA_1.factions["wow"].own_task_modifier
-    assert result == 1.1
+    assert result == 1.0
 
 
 def test_faction_multiplier_other_faction():
@@ -225,12 +227,24 @@ def test_faction_multiplier_empty_task_faction():
 
 
 def test_collab_own_faction():
+    # #811 moved the +10% collab-own bonus from wow to coven. This is the live
+    # assertion that the bonus is actually applied by the scoring path at all.
+    result = compute_faction_multiplier(
+        "coven", "coven", ERA_1,
+        collaboration_mode=COLLABORATION_MODE_COLLAB,
+    )
+    assert result == ERA_1.factions["coven"].collab_own_modifier
+    assert result == 1.1
+
+
+def test_collab_own_faction_wow_has_no_bonus():
+    # The other half of the #811 swap: wow's collab-own is plain baseline.
     result = compute_faction_multiplier(
         "wow", "wow", ERA_1,
         collaboration_mode=COLLABORATION_MODE_COLLAB,
     )
     assert result == ERA_1.factions["wow"].collab_own_modifier
-    assert result == 1.1
+    assert result == 1.0
 
 
 def test_collab_other_faction():


### PR DESCRIPTION
Gives Warriors of Whimsy its mechanical identity: **once per level, sign up for ONE task exactly one level above your own.** Also performs the modifier swap — WOW drops to full baseline, Cozy Coven gains `collab_own_modifier=1.1`.

Closes #811

## How it is built

The whole ability is one term added to the **shared** sign-up gate. `meets_task_level(character_level, task, level_reach=0)` becomes `character_level + level_reach >= task.level_required`, and `evaluate_signup` sources `level_reach` from `services/level_jump.py`. Because that gate is shared by solo/collab/duel, there are **zero per-mode branches**.

Storage is the one nullable column the issue asked for: `character_stats.level_jump_used_at_level`. Available iff it differs from `stats.level`. **No counter, no reset job** — levelling up changes the left side of the comparison, and the row is already per-(character, era) so an era reset clears it for free.

Nothing branches on a slug. `FactionConfig.level_jump_reach: int = 0` is the new field (wow=1); `services/level_jump.py` reads it off `era.*`, and a unit test flips the config to prove wow loses the ability and UA gains it.

## Defaults taken (all as stated in the issue)

- Consumed on sign-up, **never refunded** — abandoning/deleting does not give it back.
- No banking; exactly one per level; exactly one level, never two.
- Mode-specific gates (`collaboration_level_required`, `duel_level_required`) untouched.
- **One judgement call of my own:** `level_jump_*` is deliberately **not** short-circuited by `is_admin`, unlike the other capability flags. The jump is a faction perk rather than a level gate, so telling a non-WOW admin they hold it would be a lie in the UI. Flagging in case you want the usual admin-sees-all behaviour instead.

## What to eyeball

1. **The admin carve-out above** — the one place I departed from the surrounding convention.
2. **`level_jump_reach` stays non-zero once spent** (only `level_jump_available` flips), so the UI can keep explaining the ability instead of making it vanish the moment it is used. That is a copy/UX call as much as an API one.
3. **Consumption condition** in `create_praxis`: `task.level_required > stats.level`. It runs *after* preconditions pass, so "still above my level" is a sound proxy for "the jump is the only thing that let me in".
4. **`test_coven_is_the_only_faction_with_a_modifier`** encodes the issue's claim as an executable invariant across all 8 factions. It covers the four task modifiers, not duel modifiers (a separate axis where UA/Snide legitimately differ).

## Testing

`pytest --cov=. --cov-fail-under=80` on a dedicated `wz811_test` DB: **677 passed, 88.52% coverage.**

Five pre-existing tests failed on first run — all assertions on WOW's old +10% pair, all expected consequences of the swap. The live "is the collab bonus actually applied by the scoring path" assertion is repointed to Coven, with a new WOW counterpart proving it is now baseline.

New: `tests/unit/test_level_jump.py` (rule in isolation) and `tests/integration/test_level_jump_signup.py` (spend-once, no-refund-on-abandon, restored-by-levelling-up, non-WOW never clears the bar, defecting loses it).

## Migration

`0005_character_stats_level_jump`. Verified **both** paths, not just the incremental one:

- **From scratch:** fresh DB, `alembic upgrade head` through all five revisions, then confirmed the column via `\d character_stats`. `alembic check` reports no model drift.
- **Deployed-DB path:** downgraded to 0004, dropped the column to simulate a DB stamped past `0001_squashed`, re-ran `upgrade head`, confirmed the ADD landed. `IF NOT EXISTS` makes it a no-op on fresh DBs, which already get the column from `Base.metadata`.

Nullable with no server default on purpose: "never spent" is genuinely absent information, and level 0 is a real level a jump can be spent at, so a `0` backfill would be wrong. A unit test pins that distinction.

## Not done here — needs a frontend agent

Backend-only PR (my scope). The `/auth/me` seam is finished and ready to consume: `CurrentUser` now carries `level_jump_reach: int` and `level_jump_available: bool`, via the existing `character_capabilities` seam — **no new endpoint**. Still outstanding: rendering it and the i18n copy in `frontend/src/locales/en/`. Untouched by design: `factions.ts` and `index.css` (concurrent #812).

**Visual QA is outstanding** — I cannot screenshot and there is no dev stack here. Verified via tests and the migration runs only.

## Discovered, out of scope

Duel **acceptance** (`services/duel.py`, `respond_to_duel_challenge`) builds the opponent's praxis inline and never checks `task.level_required` — only `duel_level_required`, the bank cap, and active-member. So accepting a duel already lets any character onto a task above their level, regardless of faction. Pre-existing and unchanged by this PR (the jump is a no-op on a path with no level gate), but it does mean the issue's "the gate is shared by every sign-up mode" is true for *initiating* a duel (which attaches to a real `create_praxis` solo praxis) and not for *accepting* one. Worth its own issue; tightening it could break in-flight duels, so I did not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
