### PR TITLE
fix(db): drop legacy faction.name/description — unblock prod deploys

### DIFF
--- a/backend/alembic/versions/0006_faction_drop_name_description.py
+++ b/backend/alembic/versions/0006_faction_drop_name_description.py
@@ -1,0 +1,35 @@
+"""Drop the legacy faction.name / faction.description columns (ADR-0038).
+
+ADR-0038 moved faction prose to the frontend locale catalog and removed both
+columns from the model — but no migration ever dropped them from databases that
+predate the 0001 squash. The squash builds tables via ``metadata.create_all``,
+which skips tables that already exist, so deployed DBs kept a NOT NULL ``name``
+column the ORM no longer writes. Every existing row already had a name, so this
+stayed invisible until Cozy Coven (#810) inserted a brand-new slug and hit a
+NotNullViolation in ``seed.py``.
+
+Idempotent: fresh DBs built from 0001 never had these columns.
+
+Revision ID: 0006_faction_drop_name_description
+Revises: 0005_character_stats_level_jump
+Create Date: 2026-07-19
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0006_faction_drop_name_description"
+down_revision: Union[str, None] = "0005_character_stats_level_jump"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE faction DROP COLUMN IF EXISTS name")
+    op.execute("ALTER TABLE faction DROP COLUMN IF EXISTS description")
+
+
+def downgrade() -> None:
+    # ponytail: prose lives in the locale catalog now — restore the shape, not the data.
+    op.execute("ALTER TABLE faction ADD COLUMN IF NOT EXISTS name VARCHAR")
+    op.execute("ALTER TABLE faction ADD COLUMN IF NOT EXISTS description VARCHAR")

--- a/backend/alembic/versions/0006_faction_drop_prose.py
+++ b/backend/alembic/versions/0006_faction_drop_prose.py
@@ -10,7 +10,7 @@ NotNullViolation in ``seed.py``.
 
 Idempotent: fresh DBs built from 0001 never had these columns.
 
-Revision ID: 0006_faction_drop_name_description
+Revision ID: 0006_faction_drop_prose
 Revises: 0005_character_stats_level_jump
 Create Date: 2026-07-19
 """
@@ -18,7 +18,7 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "0006_faction_drop_name_description"
+revision: str = "0006_faction_drop_prose"
 down_revision: Union[str, None] = "0005_character_stats_level_jump"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/tests/test_migration_revision_ids.py
+++ b/backend/tests/test_migration_revision_ids.py
@@ -1,0 +1,27 @@
+"""Guard: every Alembic revision id fits `alembic_version.version_num`.
+
+That column is varchar(32). A longer id passes every local check and only dies
+mid-`alembic upgrade` on the UPDATE that records it — after the migration's DDL
+has already run. This has cost two round trips (e658382, #817); the assert is
+cheaper than a third.
+"""
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+VERSION_NUM_MAX_LENGTH = 32
+_ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
+
+
+def test_revision_ids_fit_version_num_column() -> None:
+    script = ScriptDirectory.from_config(Config(str(_ALEMBIC_INI)))
+    too_long = {
+        revision.revision
+        for revision in script.walk_revisions()
+        if len(revision.revision) > VERSION_NUM_MAX_LENGTH
+    }
+    assert not too_long, (
+        f"revision ids exceed alembic_version.version_num varchar({VERSION_NUM_MAX_LENGTH}): "
+        f"{sorted(too_long)}"
+    )


### PR DESCRIPTION
## What broke

The last three deploys failed. One bug, cascading into a restart loop.

**The bug** (02:16 log): `seed.py` inserts `Faction(slug=…, status=…)`. ADR-0038 (PR #545) removed `name`/`description` from the model, but **no migration ever dropped them from deployed databases**. `0001_squashed` builds tables with `Base.metadata.create_all`, which skips tables that already exist — so any DB predating the squash still carries a `NOT NULL` `faction.name` the ORM no longer writes.

Invisible until now because every existing faction row already had a name. Cozy Coven (#810) inserted a *brand-new* slug:

```
NotNullViolationError: null value in column "name" of relation "faction"
Failing row contains (coven, null, , visible, …)
```

**The loop** (02:19–02:31): migration `0005` (from #813) committed *before* `seed.py` crashed. Render rolled back to the pre-`0005` image, whose `check_db_stamp.py` doesn't recognise `0005_character_stats_level_jump` → exits 1 → never binds a port → `Port scan timeout`. Every restart repeats it.

The stamp check is doing its job — it's reporting a genuine code/DB fork, not a squash. **Do not run `reset_db.sh`** as its error message suggests; the stamp isn't orphaned.

## The fix

Migration `0006` drops both stale columns. `IF EXISTS`, so fresh DBs built from `0001` are unaffected and CI stays green.

Deploying this clears the stamp check on its own (the branch contains `0005`), then `0006` unblocks the seed.

## Not covered

Any *other* model column removed since the 2026-06-23 squash has the same blind spot — `create_all` never alters an existing table. Worth one audit pass; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
