### PR TITLE
docs: ADR-0047/0048 for the faction praxis-card redesign

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -259,12 +259,16 @@ _Avoid_: "praxis score" as a per-praxis number with multipliers baked in (that c
 what the recalc path and the read path currently disagree on).
 
 **Merit** *(the faction-neutral praxis number)*:
-`task base + points_from_votes` — no faction/duel multiplier, **viewer-independent**. What a
-**praxis card** shows and what task submissions sort by: it compares the *work*, not whose
-faction multiplier was luckier. Distinct from **Contribution** (per-character, multiplied,
-feeds standings + the detail-page breakdown). Splitting Merit from Contribution is the
-locality win of the praxis-scoring deepening — one well-defined number per surface instead of
-one conflated `score` field computed two disagreeing ways.
+`task base + points_from_votes` — no faction/duel multiplier, **viewer-independent**. What
+task submissions sort by, and the number a **collab** praxis card shows (a collab has no single
+faction multiplier). Distinct from **Contribution** (per-character, multiplied, feeds standings
++ the detail-page breakdown). Splitting Merit from Contribution is the locality win of the
+praxis-scoring deepening — one well-defined number per surface instead of one conflated `score`
+field computed two disagreeing ways.
+_Note (ADR-0047):_ **solo** and **duel** praxis cards no longer show Merit — they show the
+computed **total** via the conditional score stamp (solo: `base × faction + votes`; duel: the
+side's own total with faction×duel combined). The multiplier/metatask rows appear only when
+non-identity. Merit remains the collab-card number and the submission sort key.
 
 **Metatask**:
 A flat-points **add-on to a praxis**, not a doable task — it has no praxis, no votes, no

--- a/docs/adr/0047-praxis-card-shows-computed-total-not-merit.md
+++ b/docs/adr/0047-praxis-card-shows-computed-total-not-merit.md
@@ -1,0 +1,78 @@
+# ADR-0047 — The praxis card shows the computed total, not Merit
+
+**Status:** Accepted
+**Date:** 2026-07-19
+**Supersedes:** the "Merit (the card number)" decision in **ADR-0014**
+**Relates to:** ADR-0014 (Contribution vs Merit), ADR-0011 (duel = two solo sides),
+the Faction Praxis Cards redesign (the "score stamp") and its per-faction issues.
+
+## Context
+
+ADR-0014 split two numbers: **Contribution** (per-character, multiplied —
+`(base + metatasks) × faction × duel + votes`) and **Merit** (`task base +
+points_from_votes`, no multiplier, viewer-independent). It ruled that the
+**praxis card** shows **Merit** — "it compares the *work*, not whose faction
+multiplier was luckier" — and reserved the multiplier math for standings and the
+**detail-page** Contribution breakdown.
+
+The Faction Praxis Cards redesign reverses that presentation choice. Its whole
+through-line is a corner **score stamp** that lays the math out on the card:
+`base 12 · ×0.80 · +4 votes · = 13.6`. The owner wants the card to show the
+points a praxis actually banked, and to show *why* via the stamp — surfacing the
+faction multiplier where it applies.
+
+ADR-0014's reason for hiding the multiplier still bites in exactly one place:
+for a **collab**, members span factions, so "the praxis's multiplier" has no
+single value (the conflated-concept problem ADR-0014 was built to avoid). The
+redesign resolves this not by hiding the multiplier everywhere, but by making
+the stamp **conditional** — it only surfaces a term when that term is
+well-defined and non-identity.
+
+## Decision
+
+`PraxisCardOut.score` and the card's headline number become the **computed
+total**, not Merit — but **only where the total is well-defined**. The card
+renders a **conditional stamp** with these rules, per praxis type:
+
+- **Solo** — full Contribution total: `(base + meta) × faction_mult + votes`.
+  - The **multiplier** row shows only when `faction_mult ≠ 1.0`.
+  - The **metatask** row shows only when `metatask_points > 0`.
+  - The **votes** row always shows (`+0` is valid).
+- **Collab** — no single multiplier exists, so the stamp **collapses to Merit**:
+  `base + votes = total`, **no multiplier row**. (This is the one case ADR-0014's
+  reasoning still governs.)
+- **Duel** — each side is its own praxis (ADR-0011). Its card shows **that
+  side's own resolved total** with the **faction and duel multipliers combined
+  into a single multiplier row** (shown when the combined value ≠ 1.0). The
+  winner's card shows the boosted amount; the loser's the reduced one.
+
+Consequence, accepted deliberately: in a mixed feed, a solo card and a collab
+card can compute "total" differently (multiplied vs Merit). That is inherent to
+the domain — the conditional rule embraces it rather than forcing one number to
+mean two things.
+
+### Backend
+
+The `Contribution` breakdown ADR-0014 already computes
+(`base_points · metatask_points · faction_multiplier · duel_multiplier ·
+points_from_votes · total`) is **exposed on `PraxisCardOut`**, with a single
+**display multiplier** field resolved server-side per the rules above (faction
+for solo; combined faction×duel for duel; **null** for collab → card hides the
+row and shows Merit). The card no longer derives vote-points by subtraction.
+
+### Display
+
+Total to **1 decimal** by default (`13.6`); a faction skin may format
+stylistically (e.g. Singularity's terminal `13.60` / `×0.80` / `+04`) — the
+underlying value is identical. Applies on both desktop (corner stamp) and mobile
+(horizontal `BASE | MULT | VOTES | TOT` strip; the MULT cell collapses out when
+not shown).
+
+## Consequences
+
+- ADR-0014's scoring model is **unchanged** — this ADR only changes what the
+  **card** renders. Contribution/Merit as concepts both survive; Merit remains
+  the collab-card number and the task-submission sort key.
+- The multiplier is now visible on solo/duel cards, so off-faction penalties and
+  duel outcomes read directly from the feed, not only the detail page.
+- Mobile and desktop share the same conditional rules and the same API fields.

--- a/docs/adr/0048-albescent-unfreezes-per-surface-as-designs-land.md
+++ b/docs/adr/0048-albescent-unfreezes-per-surface-as-designs-land.md
@@ -1,0 +1,47 @@
+# ADR-0048 — Albescent unfreezes one surface at a time, as designs land
+
+**Status:** Accepted
+**Date:** 2026-07-19
+**Amends:** **ADR-0046** (Albescent is frozen: new surfaces fall through to NA)
+**Relates to:** ADR-0027 (Albescent is a secret society), ADR-0039 (the NA/default
+identity is the rainbow), ADR-0047 (the praxis-card score stamp).
+
+## Context
+
+ADR-0046 froze Albescent — every dispatched surface falls through to the NA/Default
+skin — because "Albescent's visual direction is under reconsideration," and skins
+carry a short half-life when a look is about to change.
+
+That freeze was a *hold pending a direction*, not a permanent identity. The Faction
+Praxis Cards redesign now supplies a direction for one surface: an Albescent praxis
+card that is **near-identical to Unaffiliated (NA), with a slow rainbow drift over the
+card** — a quiet shimmer. Because NA is now the rainbow "spectrum" card (ADR-0039,
+and the redesign's new Default), Albescent already inherits the spectrum look by
+fallthrough; the drift is the only bespoke delta.
+
+The drift is on-theme for ADR-0027: a card that reads as plain unaffiliated at a
+glance but shimmers for those who know is **hiding in plain sight**. Albescent's
+design language, going forward, is "**an NA-lookalike with deliberate secret tells**"
+— the drift is the first such tell.
+
+## Decision
+
+Albescent unfreezes **per surface, as a design for that surface lands** — it is no
+longer frozen wholesale.
+
+- **Praxis card (this redesign):** build Albescent's bespoke variant = the NA/Default
+  spectrum card **plus a slow rainbow drift**. This is the first unfreeze.
+- **Every other Albescent surface stays frozen** (falls through to NA per ADR-0046)
+  until its own design lands. ADR-0046's fallthrough remains the default; this ADR
+  just carves out surfaces one at a time.
+
+## Consequences
+
+- ADR-0046's mechanism (partial registry, designed fallthrough) is intact; "frozen"
+  now means "frozen **until designed**," released surface-by-surface rather than all
+  at once.
+- Albescent gains exactly one registry row (the praxis-card manifest surface). A
+  builder must render it as **NA + drift**, not a from-scratch skin — the secret-society
+  tell depends on the NA resemblance.
+- Future Albescent surfaces follow this ADR: land a design, unfreeze that one surface,
+  keep the rest on NA.


### PR DESCRIPTION
Records the decisions from the Faction Praxis Cards grill that break with two landed ADRs, so the build issues (epic #818 → #819/#820/#821) can cite them.

## What's here
- **ADR-0047 — praxis card shows the computed total, not Merit.** The feed card gains a conditional score stamp (`base × mult (+meta) + votes = total`): solo shows the full multiplied total, collab stays Merit (no single multiplier), duel shows each side's own total with faction×duel combined. Supersedes the "Merit (the card number)" rule in ADR-0014.
- **ADR-0048 — Albescent unfreezes per-surface as designs land** (amends ADR-0046). The praxis card is the first unfreeze: NA spectrum + a slow rainbow drift, a secret-society tell.
- **CONTEXT.md** — the Merit glossary entry corrected (Merit is now the collab-card number + sort key, not "what the praxis card shows").

Docs only — no code. The build lands under #819/#820/#821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
