### PR TITLE
feat(praxis): expose scoring breakdown on PraxisCardOut (ADR-0047, #819)

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -44,6 +44,7 @@ from services.praxis import (
     _build_invite_out,
     _require_member,
     apply_metatask,
+    author_contributions_for,
     build_praxis_card_out,
     build_praxis_out,
     can_view_praxis,
@@ -155,9 +156,17 @@ async def list_praxes_route(
         if viewer
         else {}
     )
+    # Score breakdown (ADR-0047): one scoring pass per distinct author for the
+    # whole page — not per card. Grouped by author because the breakdown is the
+    # AUTHOR's banked points, not the viewer's.
+    author_contributions = await author_contributions_for(praxes, session)
     return [
         await build_praxis_card_out(
-            praxis, session, crowned_ids=crowned, viewer_votes=viewer_votes
+            praxis,
+            session,
+            crowned_ids=crowned,
+            viewer_votes=viewer_votes,
+            author_contributions=author_contributions,
         )
         for praxis in praxes
     ]

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -94,6 +94,16 @@ class PraxisCardOut(BaseModel):
     submit_proposed_at: Optional[datetime] = None  # collab pending-publish chip (#521, ADR-0012)
     member_count: int
     score: float
+    # Scoring breakdown for the score stamp (ADR-0047). Computed for the praxis
+    # AUTHOR (created_by), not the viewer — the card shows the points the praxis
+    # banked for whoever made it. ``display_multiplier`` is the single resolved
+    # multiplier: faction_mult for solo, faction×duel for a duel side, and None
+    # for collab (no single multiplier → the stamp collapses to Merit).
+    base_points: int = 0
+    metatask_points: int = 0
+    display_multiplier: Optional[float] = None
+    points_from_votes: int = 0
+    total: float = 0.0
     voter_count: int = 0
     is_top_for_task: bool = False  # Task Crown: top submitted praxis for its task (ADR-0028)
     task_faction_slug: Optional[str] = None

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -29,6 +29,7 @@ from models.praxis import (
     PraxisType,
 )
 from models.era import Era
+from models.character_stats import CharacterStats
 from models.task import Task, TaskStatus, TaskType
 from models.vote import Vote
 from schemas.task import TaskOut
@@ -42,6 +43,7 @@ from schemas.praxis import (
 )
 from services import collab_consensus
 from services.character_stats import recalculate_character_stats
+from services.praxis_scoring import Contribution, compute_contributions
 from services.faction_service import faction_permits
 from services.era import get_current_era_row, get_or_create_stats
 from services.level_jump import available_level_reach, consume_level_jump
@@ -247,6 +249,108 @@ async def build_praxis_out(
     )
 
 
+async def author_contributions_for(
+    praxes: list[Praxis],
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> dict[int, Contribution]:
+    """Scoring breakdown for each praxis, computed for its AUTHOR (ADR-0047).
+
+    The card's score stamp shows the points the praxis banked for whoever made
+    it, so the scoring subject is ``praxis.created_by`` — not the viewer. This
+    differs from ``compute_contributions``'s usual per-viewer use (ADR-0014).
+
+    Praxes are grouped by author so a feed makes O(distinct authors) scoring
+    passes, not O(praxes) — ``compute_contributions`` applies a single
+    character's faction/level to the whole batch it is handed, so one call per
+    author is required. List routes precompute this once and hand it to
+    :func:`build_praxis_card_out` via ``author_contributions``.
+    """
+    if not praxes:
+        return {}
+
+    era_row = await get_current_era_row(session)
+
+    author_ids = {p.created_by_id for p in praxes}
+    authors_result = await session.execute(
+        select(Character).where(Character.id.in_(author_ids))
+    )
+    authors_by_id: dict[int, Character] = {c.id: c for c in authors_result.scalars()}
+
+    # Author level gates metatask points (compute_contributions passes it through
+    # to get_meta_task_points_bulk). One bulk fetch, not one per author.
+    levels_result = await session.execute(
+        select(CharacterStats.character_id, CharacterStats.level).where(
+            CharacterStats.character_id.in_(author_ids),
+            CharacterStats.era_id == era_row.id,
+        )
+    )
+    level_by_author: dict[int, int] = {cid: lvl for cid, lvl in levels_result.all()}
+
+    praxes_by_author: dict[int, list[Praxis]] = {}
+    for praxis in praxes:
+        praxes_by_author.setdefault(praxis.created_by_id, []).append(praxis)
+
+    contributions: dict[int, Contribution] = {}
+    for author_id, author_praxes in praxes_by_author.items():
+        author = authors_by_id.get(author_id)
+        if author is None:
+            continue
+        contributions.update(
+            await compute_contributions(
+                author_praxes,
+                author,
+                era,
+                session,
+                character_level=level_by_author.get(author_id, 0),
+            )
+        )
+    return contributions
+
+
+def _resolve_card_scoring(
+    praxis: Praxis, contribution: Optional[Contribution], task_point_value: int, tally_votes_points: int
+) -> tuple[int, int, Optional[float], int, float]:
+    """Resolve the score-stamp fields from a Contribution (ADR-0047).
+
+    Returns ``(base_points, metatask_points, display_multiplier, points_from_votes,
+    total)``. ``display_multiplier`` is the single value the stamp renders:
+    faction_mult for solo, faction×duel combined for a duel side, and ``None``
+    for collab (members span factions → no single multiplier → stamp collapses
+    to Merit = base + votes).
+    """
+    if contribution is None:
+        # Defensive fallback (author missing / unscoreable): Merit only.
+        display = None if praxis.type == PraxisType.collab else 1.0
+        return (
+            task_point_value,
+            0,
+            display,
+            tally_votes_points,
+            float(task_point_value + tally_votes_points),
+        )
+
+    if praxis.type == PraxisType.collab:
+        # No single multiplier exists (ADR-0047 §Decision): collapse to Merit.
+        return (
+            contribution.base_points,
+            contribution.metatask_points,
+            None,
+            contribution.points_from_votes,
+            float(contribution.base_points + contribution.points_from_votes),
+        )
+
+    # Solo or duel side: one combined multiplier (duel_multiplier is 1.0 for a
+    # plain solo, so faction×duel reduces to faction for solo).
+    return (
+        contribution.base_points,
+        contribution.metatask_points,
+        contribution.faction_multiplier * contribution.duel_multiplier,
+        contribution.points_from_votes,
+        contribution.total,
+    )
+
+
 async def build_praxis_card_out(
     praxis: Praxis,
     session: AsyncSession,
@@ -254,10 +358,15 @@ async def build_praxis_card_out(
     *,
     crowned_ids: Optional[set[int]] = None,
     viewer_votes: Optional[dict[int, ViewerVote]] = None,
+    author_contributions: Optional[dict[int, Contribution]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
 
-    score = Merit = task base + points_from_votes (viewer-independent; ADR-0014).
+    ``score`` stays Merit = task base + points_from_votes (viewer-independent;
+    ADR-0014) to preserve the current frontend's vote-derivation until the
+    redesign reads ``total``. The score stamp reads the explicit breakdown
+    fields (``base_points``/``metatask_points``/``display_multiplier``/
+    ``points_from_votes``/``total``), computed for the praxis AUTHOR per ADR-0047.
 
     ``crowned_ids`` are the Task Crown holders (ADR-0028); list routes
     precompute them once via :func:`~services.vote_tally.crowned_praxis_ids`
@@ -268,6 +377,11 @@ async def build_praxis_card_out(
     :func:`~services.vote_tally.viewer_votes_for` so neither the viewer's own-star
     highlight nor the account-mate marker becomes a per-card query. ``None``
     (anonymous viewer) leaves both ``viewer_vote`` and ``voted_by_name`` unset.
+
+    ``author_contributions`` maps praxis id → the author's :class:`Contribution`;
+    list routes precompute it once via :func:`author_contributions_for` so the
+    score breakdown is not re-derived per card. When absent, this builder scores
+    the single praxis itself (single-card callers).
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -279,6 +393,21 @@ async def build_praxis_card_out(
     tally_map = await tally_votes([praxis.id], session)
     tally = get_tally(tally_map, praxis.id)
     score = float(task_point_value + tally.points_from_votes)
+
+    # Score breakdown (ADR-0047), computed for the AUTHOR. Reuse the precomputed
+    # map when the list route supplies it; otherwise score this praxis alone.
+    contribution = author_contributions.get(praxis.id) if author_contributions else None
+    if contribution is None:
+        contribution = (
+            await author_contributions_for([praxis], session, era)
+        ).get(praxis.id)
+    (
+        base_points,
+        metatask_points,
+        display_multiplier,
+        points_from_votes,
+        total,
+    ) = _resolve_card_scoring(praxis, contribution, task_point_value, tally.points_from_votes)
 
     # Task Crown (ADR-0028): top submitted praxis for this task, computed live.
     if crowned_ids is None:
@@ -302,6 +431,11 @@ async def build_praxis_card_out(
         submit_proposed_at=praxis.submit_proposed_at,
         member_count=len(praxis.members),
         score=score,
+        base_points=base_points,
+        metatask_points=metatask_points,
+        display_multiplier=display_multiplier,
+        points_from_votes=points_from_votes,
+        total=total,
         voter_count=tally.voter_count,
         is_top_for_task=praxis.id in crowned_ids,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
@@ -1627,6 +1761,7 @@ __all__ = [
     "active_member_task_ids_subquery",
     "allowed_praxis_modes",
     "apply_metatask",
+    "author_contributions_for",
     "build_praxis_out",
     "build_praxis_card_out",
     "cancel_pending_publish_on_edit",

--- a/backend/tests/integration/test_praxis_card_breakdown.py
+++ b/backend/tests/integration/test_praxis_card_breakdown.py
@@ -1,0 +1,336 @@
+"""Integration tests for the PraxisCardOut scoring breakdown (ADR-0047, #819).
+
+``build_praxis_card_out`` surfaces the per-praxis scoring breakdown
+(``base_points``/``metatask_points``/``display_multiplier``/
+``points_from_votes``/``total``) computed for the praxis AUTHOR, so the
+frontend score stamp can render ``base × mult (+meta) + votes = total`` without
+re-deriving the formula.
+
+Display-multiplier rules (ADR-0047):
+- solo → faction_multiplier
+- duel → faction_multiplier × duel_multiplier combined into one value
+- collab → None (stamp collapses to Merit = base + votes)
+
+``score`` stays Merit for every type (unchanged from ADR-0014); ``total`` is the
+new headline the redesign reads.
+"""
+
+import dataclasses
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.duel import Duel, DuelStatus
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from models.vote import Vote
+from services.praxis import build_praxis_card_out
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _era_with_wow_own_modifier(value: float):
+    """CURRENT_ERA with WOW's solo own_task_modifier overridden.
+
+    Era 1 deliberately flattens every solo multiplier to 1.0 (#452), so a
+    "solo mult != 1" case is unreachable from live config. This override
+    exercises the resolution path — that display_multiplier reflects the
+    faction multiplier rather than being pinned to 1.0 — without depending on a
+    future era's tuning. The card builder reads ``era.*``, so this flows through.
+    """
+    boosted = dataclasses.replace(
+        CURRENT_ERA.factions["wow"], own_task_modifier=value
+    )
+    factions = dict(CURRENT_ERA.factions)
+    factions["wow"] = boosted
+    return dataclasses.replace(CURRENT_ERA, factions=factions)
+
+
+async def _load_card(session: AsyncSession, praxis_id: int, era=CURRENT_ERA):
+    """Reload a praxis with the relationships the card builder needs (lazy=raise)."""
+    result = await session.execute(
+        select(Praxis)
+        .where(Praxis.id == praxis_id)
+        .options(
+            selectinload(Praxis.task),
+            selectinload(Praxis.created_by),
+            selectinload(Praxis.members),
+            selectinload(Praxis.media_items),
+        )
+    )
+    praxis = result.scalar_one()
+    return await build_praxis_card_out(praxis, session, era=era)
+
+
+async def _cast_vote(
+    session: AsyncSession, praxis: Praxis, voter: Character, value: int
+) -> None:
+    """Direct Vote insert — bypasses the service-layer budget/anti-vote checks."""
+    session.add(
+        Vote(
+            praxis_id=praxis.id,
+            voter_character_id=voter.id,
+            voter_account_id=voter.account_id,
+            value=value,
+        )
+    )
+    await session.flush()
+
+
+async def _make_character(
+    session: AsyncSession,
+    era: Era,
+    *,
+    faction_slug: str,
+    username: str,
+    email: str,
+    level: int = 0,
+) -> Character:
+    account = Account(email=email)
+    session.add(account)
+    await session.flush()
+    character = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username,
+        faction_slug=faction_slug,
+    )
+    session.add(character)
+    await session.flush()
+    session.add(
+        CharacterStats(
+            character_id=character.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=level,
+            votes_spent_this_era=0,
+        )
+    )
+    await session.flush()
+    return character
+
+
+async def _ensure_faction(session: AsyncSession, slug: str) -> None:
+    existing = await session.execute(select(Faction).where(Faction.slug == slug))
+    if existing.scalar_one_or_none() is None:
+        session.add(Faction(slug=slug, status=FactionStatus.visible))
+        await session.flush()
+
+
+async def _make_task(
+    session: AsyncSession, creator: Character, *, faction_slug: str, points: int
+) -> Task:
+    task = Task(
+        title=f"{faction_slug} task",
+        description="proof",
+        point_value=points,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=creator.id,
+        primary_faction_slug=faction_slug,
+    )
+    session.add(task)
+    await session.flush()
+    return task
+
+
+async def _make_solo(
+    session: AsyncSession, task: Task, author: Character
+) -> Praxis:
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=author.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title="solo",
+        body_text="proof",
+    )
+    session.add(praxis)
+    await session.flush()
+    session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id))
+    await session.flush()
+    return praxis
+
+
+# ---------------------------------------------------------------------------
+# solo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_solo_multiplier_not_one_surfaces_faction_modifier(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """Solo with faction_multiplier != 1.0 → display_multiplier = that modifier.
+
+    Uses an era override (WOW own_task_modifier = 1.1) because live Era 1
+    flattens all solo multipliers to 1.0 (#452). Proves the resolved
+    display_multiplier is the faction multiplier, not a hardcoded 1.0.
+    """
+    custom_era = _era_with_wow_own_modifier(1.1)
+    await _ensure_faction(db_session, "wow")
+    author = await _make_character(
+        db_session, era, faction_slug="wow", username="wowauthor", email="wow@x.com"
+    )
+    voter = await _make_character(
+        db_session, era, faction_slug="ua", username="wowvoter", email="wowvoter@x.com"
+    )
+    task = await _make_task(db_session, author, faction_slug="wow", points=10)
+    praxis = await _make_solo(db_session, task, author)
+    await _cast_vote(db_session, praxis, voter, 4)
+
+    card = await _load_card(db_session, praxis.id, era=custom_era)
+
+    assert card.base_points == 10
+    assert card.metatask_points == 0
+    assert card.display_multiplier == pytest.approx(1.1)
+    assert card.points_from_votes == 4
+    # total = (10 + 0) × 1.1 × 1.0 + 4 = 15.0
+    assert card.total == pytest.approx(15.0)
+    # score stays Merit = base + votes (unchanged; ADR-0014)
+    assert card.score == pytest.approx(14.0)
+
+
+@pytest.mark.asyncio
+async def test_solo_multiplier_one_ua_own_task(
+    db_session: AsyncSession, era: Era, faction_ua: Faction, character: Character
+):
+    """UA author on a UA task → display_multiplier = 1.0 (frontend hides the row)."""
+    voter = await _make_character(
+        db_session, era, faction_slug="ua", username="uavoter", email="uavoter@x.com"
+    )
+    task = await _make_task(db_session, character, faction_slug="ua", points=10)
+    praxis = await _make_solo(db_session, task, character)
+    await _cast_vote(db_session, praxis, voter, 4)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert card.base_points == 10
+    assert card.metatask_points == 0
+    assert card.display_multiplier == pytest.approx(1.0)
+    assert card.points_from_votes == 4
+    # total = 10 × 1.0 + 4 = 14.0, equal to Merit here
+    assert card.total == pytest.approx(14.0)
+    assert card.score == pytest.approx(14.0)
+
+
+# ---------------------------------------------------------------------------
+# collab
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collab_multi_faction_multiplier_null_total_is_merit(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """Multi-faction collab → display_multiplier is None, total = Merit (base+votes)."""
+    await _ensure_faction(db_session, "wow")
+    author = await _make_character(
+        db_session, era, faction_slug="wow", username="collabwow", email="cw@x.com"
+    )
+    member = await _make_character(
+        db_session, era, faction_slug="ua", username="collabua", email="cu@x.com"
+    )
+    voter = await _make_character(
+        db_session, era, faction_slug="ua", username="collabvoter", email="cv@x.com"
+    )
+    task = await _make_task(db_session, author, faction_slug="ua", points=10)
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=author.id,
+        type=PraxisType.collab,
+        status=PraxisStatus.submitted,
+        title="collab",
+        body_text="proof",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            PraxisMember(praxis_id=praxis.id, character_id=author.id),
+            PraxisMember(praxis_id=praxis.id, character_id=member.id),
+        ]
+    )
+    await db_session.flush()
+    await _cast_vote(db_session, praxis, voter, 3)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert card.base_points == 10
+    assert card.metatask_points == 0
+    assert card.display_multiplier is None
+    assert card.points_from_votes == 3
+    # Merit = 10 + 3 = 13.0 (no multiplier)
+    assert card.total == pytest.approx(13.0)
+    assert card.score == pytest.approx(13.0)
+
+
+# ---------------------------------------------------------------------------
+# duel — each side its own resolved total (ADR-0011 / ADR-0047)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duel_winner_and_loser_resolved_totals(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """Duel sides show combined faction×duel multiplier; winner boosted, loser reduced.
+
+    UA: own_task_modifier = 1.0, duel_win_modifier = 1.5, duel_loss_modifier = 0.5.
+    """
+    challenger = await _make_character(
+        db_session, era, faction_slug="ua", username="challenger", email="ch@x.com"
+    )
+    opponent = await _make_character(
+        db_session, era, faction_slug="ua", username="opponent", email="op@x.com"
+    )
+    voter = await _make_character(
+        db_session, era, faction_slug="ua", username="duelvoter", email="dv@x.com"
+    )
+    task = await _make_task(db_session, challenger, faction_slug="ua", points=10)
+    challenger_praxis = await _make_solo(db_session, task, challenger)
+    opponent_praxis = await _make_solo(db_session, task, opponent)
+
+    # Non-participant votes: challenger wins (5 > 2).
+    await _cast_vote(db_session, challenger_praxis, voter, 5)
+    await _cast_vote(db_session, opponent_praxis, voter, 2)
+
+    db_session.add(
+        Duel(
+            task_id=task.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=opponent.id,
+            opponent_praxis_id=opponent_praxis.id,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.flush()
+
+    winner_card = await _load_card(db_session, challenger_praxis.id)
+    loser_card = await _load_card(db_session, opponent_praxis.id)
+
+    # Winner: faction 1.0 × duel_win 1.5 = 1.5; total = 10 × 1.5 + 5 = 20.0
+    assert winner_card.base_points == 10
+    assert winner_card.metatask_points == 0
+    assert winner_card.display_multiplier == pytest.approx(1.5)
+    assert winner_card.points_from_votes == 5
+    assert winner_card.total == pytest.approx(20.0)
+
+    # Loser: faction 1.0 × duel_loss 0.5 = 0.5; total = 10 × 0.5 + 2 = 7.0
+    assert loser_card.base_points == 10
+    assert loser_card.metatask_points == 0
+    assert loser_card.display_multiplier == pytest.approx(0.5)
+    assert loser_card.points_from_votes == 2
+    assert loser_card.total == pytest.approx(7.0)


### PR DESCRIPTION
Closes #819

## What this does

Exposes the per-praxis scoring **breakdown** on `PraxisCardOut` so the frontend score stamp can render `base × mult (+meta) + votes = total` without re-deriving the formula (ADR-0047).

New fields on `PraxisCardOut`:
- `base_points: int`
- `metatask_points: int`
- `display_multiplier: Optional[float]` (nullable)
- `points_from_votes: int`
- `total: float`

The scoring subject is the praxis **AUTHOR** (`created_by`), not the viewer — the card shows the points the praxis banked for whoever made it. Values come from the existing `compute_contributions` / `Contribution` path (`services/praxis_scoring.py`); the formula is not re-implemented.

### `display_multiplier` resolution (server-side, per ADR-0047)
- **solo** → `faction_multiplier`
- **duel** → `faction_multiplier × duel_multiplier` combined into one value (each side its own resolved total; `compute_contributions` already computes the correct side). Since `duel_multiplier` is `1.0` for a plain solo, one expression `faction × duel` covers both.
- **collab** → `null` (members span factions → no single multiplier → stamp collapses to Merit)

### `total` semantics
- solo/duel → full `Contribution.total`
- collab → Merit = `base_points + points_from_votes` (no multiplier)

### What I did with `score` (and why)
**Kept `score` = Merit for every type** (unchanged from ADR-0014). Rationale:
- `score` is **not** a backend sort key. The `GET /praxes` feed orders by `Praxis.submitted_at` (`PraxisSort`), never by `score`, so changing `score` would not affect ordering — but there was no need to touch it.
- The **current** frontend derives vote points by subtraction (`praxisCard/shared.tsx`: `votePoints = score - base`) assuming `score = Merit`. Flipping `score` to the multiplied total now would silently break that derivation on solo/duel cards **before** the redesign (#820/#821) lands. Per the issue's escape hatch, I kept `score` = Merit and put the computed total in the new explicit `total` field, which the redesign reads for the headline. No behavior change for existing consumers; the breakdown is purely additive.

### Performance
`build_praxis_card_out` runs once per card, so a naive per-card author-scoring pass would be an N+1 (~6 queries/card). Instead the list route precomputes `author_contributions_for(praxes, session)` **once per page**, grouped by distinct author (O(authors) scoring passes, not O(praxes)), and hands the map to the card builder — mirroring the existing `crowned_ids` / `viewer_votes` precompute pattern. Single-card callers (no map supplied) fall back to scoring the one praxis.

## Tests

New: `backend/tests/integration/test_praxis_card_breakdown.py`
- solo, `display_multiplier` != 1 (via an era override — see note below) → asserts `1.1`, `total = 15.0`
- solo, `display_multiplier` == 1 (live UA config) → asserts `1.0`, `total = 14.0` (row would hide)
- collab, multi-faction → `display_multiplier is None`, `total = Merit = 13.0`
- duel winner (boosted) → combined `1.5`, `total = 20.0`
- duel loser (reduced) → combined `0.5`, `total = 7.0`

**Config note (not a spec contradiction):** live Era 1 deliberately flattens **every solo multiplier** to `1.0` (#452 — `own_task_modifier`/`other_task_modifier` all `1.0`; only Coven's *collab* modifier and duel win/loss are non-identity). So a "solo mult != 1" case is unreachable from live config. The solo mult != 1 test therefore passes a custom `era` (WOW `own_task_modifier = 1.1`) to prove the resolution surfaces the faction multiplier rather than pinning it to `1.0`. The duel tests exercise mult != 1 with **live** config.

```
TEST_DATABASE_URL=postgresql+asyncpg://.../wz819_test pytest
```
Result: **682 passed** (full backend suite). New file: 4 passed. CI job `test` = pytest.

## What to eyeball
Backend only — **no visual QA applies**. Inspect these API responses' new fields:
- `GET /praxes?type=solo` — `display_multiplier` (1.0 in live Era 1), `base_points`, `points_from_votes`, `total`, and `score` still = Merit
- `GET /praxes?type=collab` — `display_multiplier: null`, `total` == Merit == `base + votes`
- A duel side's card — combined `display_multiplier` (1.5 winner / 0.5 loser with UA), `total` = that side's resolved total
