### PR TITLE
feat(praxis): faction praxis-card redesign — chronicle recombine, WOW skin, Albescent drift, score stamp everywhere (#821)

### DIFF
--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -14,7 +14,6 @@ import {
   PraxisTaskLink,
   PraxisByline,
   PraxisVotedByMarker,
-  PraxisScoreHero,
   PraxisStats,
   PraxisExcerpt,
   PraxisModeChip,
@@ -79,8 +78,6 @@ function PraxisBody({
   paper,
   titleStyle,
   showCrown,
-  scoreStamp,
-  mediaPlaceholder,
 }: {
   praxis: PraxisCardOut;
   tint: string;
@@ -89,14 +86,6 @@ function PraxisBody({
   paper?: string;
   titleStyle?: CSSProperties;
   showCrown?: boolean;
-  /**
-   * Render the conditional {@link PraxisScoreStamp} (ADR-0047) instead of the
-   * legacy `PraxisScoreHero`. Opt-in: the spectrum Default card sets it (#820);
-   * #821 rolls it to every faction, at which point the hero retires.
-   */
-  scoreStamp?: boolean;
-  /** Show the empty-media drop-target placeholder (spectrum Default, #820). */
-  mediaPlaceholder?: boolean;
 }) {
   return (
     <>
@@ -113,26 +102,22 @@ function PraxisBody({
           <PraxisTaskLink praxis={praxis} style={{ color: muted }} />
           <PraxisExcerpt praxis={praxis} style={{ color: muted }} />
         </div>
-        {scoreStamp ? (
-          <PraxisScoreStamp
-            praxis={praxis}
-            theme={{ color: tint, border: tint, muted, paper }}
-            showCrown={showCrown}
-          />
-        ) : (
-          <PraxisScoreHero
-            praxis={praxis}
-            color={tint}
-            border={tint}
-            paper={paper}
-            showCrown={showCrown}
-          />
-        )}
+        {/*
+         * The conditional score stamp (ADR-0047) on EVERY faction (#821). It
+         * replaced the legacy `PraxisScoreHero` here — the hero survives only on
+         * the praxis-detail surfaces that have not yet migrated.
+         */}
+        <PraxisScoreStamp
+          praxis={praxis}
+          theme={{ color: tint, border: tint, muted, paper }}
+          showCrown={showCrown}
+        />
       </div>
       <PraxisStats praxis={praxis} style={{ color: muted, marginTop: "var(--space-sm)" }} />
       <PraxisModeChip praxis={praxis} />
       <PraxisRoster praxis={praxis} accent={tint} paper={paper} />
-      <PraxisMediaGallery praxis={praxis} accent={tint} paper={paper} showPlaceholder={mediaPlaceholder} />
+      {/* Every card shows the media slot — a drop target when empty (#821). */}
+      <PraxisMediaGallery praxis={praxis} accent={tint} paper={paper} showPlaceholder />
       <PraxisByline praxis={praxis} style={{ color: muted }} />
       <PraxisVotedByMarker praxis={praxis} style={{ color: muted }} />
       <PraxisVoteFooter praxis={praxis} />
@@ -603,8 +588,6 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
           muted="var(--faction-default-card-muted)"
           paper="var(--faction-default-card-bg)"
           showCrown={showCrown}
-          scoreStamp
-          mediaPlaceholder
         />
       </div>
     </div>

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -666,6 +666,24 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
   );
 }
 
+/**
+ * Albescent — the secret-society tell (#821, ADR-0048). NOT a from-scratch skin:
+ * it is the exact spectrum {@link DefaultPraxisCard} an unaffiliated player sees,
+ * with a slow rainbow DRIFT (`.alb-rainbow`) washed over the whole sheet — the
+ * one flourish that reveals the society to someone already looking. A repaint in
+ * Albescent's own colours would put it back in the spectrum and un-hide it, so
+ * this stays "NA + drift". The overlay is pointer-events:none and blends over the
+ * card; reduced-motion stills the drift (the wash remains).
+ */
+export function AlbescentPraxisCard(props: ArchetypeProps) {
+  return (
+    <div style={{ ...frameBase, position: "relative", overflow: "hidden", borderRadius: 8 }}>
+      <DefaultPraxisCard {...props} />
+      <span aria-hidden className="alb-rainbow" />
+    </div>
+  );
+}
+
 // ─── Dispatcher ───────────────────────────────────────────────────────────────
 
 export default function PraxisCard({ praxis, onModerated, showCrown = true }: Props) {

--- a/frontend/src/components/PraxisCard.tsx
+++ b/frontend/src/components/PraxisCard.tsx
@@ -224,78 +224,150 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
   );
 }
 
-/** The two offset scrap layers behind the COVEN card, plus its tape. Static (#586). */
-const wowScrapDeep: CSSProperties = {
-  position: "absolute",
-  top: 10,
-  left: -4,
-  right: -4,
-  height: 24,
-  background: "var(--faction-coven-scrap-deep)",
-  border: "1.5px solid rgba(0,0,0,0.12)",
-  transform: "rotate(-4deg)",
-  borderRadius: 1,
-};
+/**
+ * The gold/plum + WOW-yellow CHRONICLE frame (#821). A bound almanac leaf: a
+ * gradient running-head band over a vellum sheet ruled in the faction's accent.
+ * Both Cozy Coven (gold/plum) and Warriors of Whimsy (yellow) share this
+ * structure and differ only in tokens — never mix the two palettes. Frame
+ * pixel-fidelity vs. the prototype is flagged for human QA (the `.dc.html` is
+ * not reachable from here).
+ */
+interface ChronicleTheme {
+  /** Vellum sheet colour (also the Task Crown inner disc). */
+  bg: string;
+  /** Primary ink. */
+  ink: string;
+  /** Muted / secondary text. */
+  muted: string;
+  /** Accent — border, ruled hairline, score stamp. */
+  accent: string;
+  /** Running-head gradient stops + its text colour. */
+  headerFrom: string;
+  headerTo: string;
+  headerText: string;
+  /** Drop-shadow colour. */
+  shadow: string;
+  titleFont: string;
+  bodyFont: string;
+}
 
-const wowScrapMid: CSSProperties = {
-  position: "absolute",
-  top: 4,
-  left: -2,
-  right: -2,
-  height: 36,
-  background: "var(--faction-coven-scrap-mid)",
-  border: "1.5px solid rgba(0,0,0,0.12)",
-  transform: "rotate(3deg)",
-  borderRadius: 1,
-};
-
-const wowTape: CSSProperties = {
-  position: "absolute",
-  top: 5,
-  left: "50%",
-  transform: "translateX(-50%) rotate(-1deg)",
-  width: 48,
-  height: 14,
-  background: "var(--faction-coven-tape)",
-  borderRadius: 1,
-};
-
-export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+function ChroniclePraxisCard({
+  praxis,
+  adminProps,
+  showCrown,
+  masthead,
+  device,
+  theme,
+}: ArchetypeProps & {
+  masthead: string;
+  /** A small signature glyph shown left of the masthead in the running head. */
+  device: string;
+  theme: ChronicleTheme;
+}) {
   return (
     <div
       style={{
-        position: "relative",
         ...frameBase,
-        minHeight: 140,
+        position: "relative",
+        overflow: "hidden",
+        background: theme.bg,
+        color: theme.ink,
+        border: `2px solid ${theme.accent}`,
+        borderRadius: 7,
+        boxShadow: `0 12px 26px -12px ${theme.shadow}`,
+        fontFamily: theme.bodyFont,
+        transition: "background 150ms, color 150ms",
       }}
     >
-      <div style={wowScrapDeep} />
-      <div style={wowScrapMid} />
+      {/* running head — gradient band with a signature device + masthead */}
       <div
         style={{
-          position: "relative",
-          background: factionCssVar("coven", "card-bg"),
-          border: "1.5px solid rgba(0,0,0,0.12)",
-          transform: "rotate(-2deg)",
-          padding: "var(--space-xl) var(--space-lg) var(--space-lg)",
-          fontFamily: "'Courier Prime', monospace",
-          color: factionCssVar("coven", "card-text"),
-          zIndex: 2,
-          transition: "background 150ms, color 150ms",
-          boxSizing: "border-box",
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          padding: "var(--space-sm) var(--space-lg)",
+          background: `linear-gradient(90deg, ${theme.headerFrom}, ${theme.headerTo})`,
+          color: theme.headerText,
+          fontFamily: theme.titleFont,
+          fontSize: "var(--text-xs)",
+          letterSpacing: "0.16em",
+          textTransform: "uppercase",
         }}
       >
-        <div style={wowTape} />
+        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: signature dingbat sized as a glyph, not read as text */}
+        <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>
+          {device}
+        </span>
+        {masthead}
+      </div>
+      <div style={{ padding: "var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
-          tint={factionCssVar("coven", "card-accent")}
-          muted={factionCssVar("coven", "card-muted")}
-          paper={factionCssVar("coven", "card-bg")}
+          tint={theme.accent}
+          muted={theme.muted}
+          paper={theme.bg}
+          titleStyle={{ fontFamily: theme.titleFont, color: theme.ink }}
           showCrown={showCrown}
         />
       </div>
     </div>
+  );
+}
+
+/** Cozy Coven — the gold/plum chronicle (moon-phase vote widget). */
+export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+  const { t } = useTranslation("praxis");
+  return (
+    <ChroniclePraxisCard
+      praxis={praxis}
+      adminProps={adminProps}
+      showCrown={showCrown}
+      masthead={t("card.masthead.coven")}
+      device="☾"
+      theme={{
+        bg: "var(--faction-coven-chronicle-bg)",
+        ink: factionCssVar("coven", "card-text"),
+        muted: factionCssVar("coven", "card-muted"),
+        accent: "var(--faction-coven-chronicle-plum)",
+        headerFrom: "var(--faction-coven-chronicle-header-from)",
+        headerTo: "var(--faction-coven-chronicle-header-to)",
+        headerText: "var(--faction-coven-chronicle-header-text)",
+        shadow: "var(--faction-coven-chronicle-shadow)",
+        titleFont: "var(--font-faction-script)",
+        bodyFont: "'EB Garamond', serif",
+      }}
+    />
+  );
+}
+
+/**
+ * Warriors of Whimsy — the SAME chronicle structure recoloured to WOW yellow
+ * (balloon vote widget). WOW's first bespoke skin (#821, #812). Uses only
+ * `--faction-wow-*` tokens; deliberately NOT coven's gold/plum.
+ */
+export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+  const { t } = useTranslation("praxis");
+  return (
+    <ChroniclePraxisCard
+      praxis={praxis}
+      adminProps={adminProps}
+      showCrown={showCrown}
+      masthead={t("card.masthead.wow")}
+      device="✦"
+      theme={{
+        bg: "var(--faction-wow-chronicle-bg)",
+        ink: factionCssVar("wow", "card-text"),
+        muted: factionCssVar("wow", "card-muted"),
+        accent: factionCssVar("wow", "card-accent"),
+        headerFrom: "var(--faction-wow-chronicle-header-from)",
+        headerTo: "var(--faction-wow-chronicle-header-to)",
+        headerText: "var(--faction-wow-chronicle-header-text)",
+        shadow: "var(--faction-wow-chronicle-shadow)",
+        titleFont: "var(--font-display)",
+        bodyFont: "'EB Garamond', serif",
+      }}
+    />
   );
 }
 

--- a/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
@@ -1,0 +1,18 @@
+import type { PraxisCardOut } from '../../../api/praxis'
+import DefaultMobilePraxisCard from './DefaultMobilePraxisCard'
+
+/**
+ * Albescent MOBILE praxis card (#821, ADR-0048) — the mobile twin of the desktop
+ * tell: the spectrum {@link DefaultMobilePraxisCard} an unaffiliated player sees,
+ * with the slow rainbow DRIFT (`.alb-rainbow`) washed over the sheet. NOT a
+ * from-scratch skin — a repaint would un-hide the society. Every other Albescent
+ * surface still falls through to Default (#783).
+ */
+export default function AlbescentMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  return (
+    <div style={{ position: 'relative', overflow: 'hidden', borderRadius: 10 }}>
+      <DefaultMobilePraxisCard praxis={praxis} />
+      <span aria-hidden className="alb-rainbow" />
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
@@ -1,81 +1,57 @@
 import type { PraxisCardOut } from '../../../api/praxis'
+import { useTranslation } from 'react-i18next'
 import { factionCssVar } from '../../../utils/factions'
-import { CovenSigil } from '../../cards/CovenSigil'
-import i18n from '../../../i18n'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
- * Warriors of Whimsy MOBILE praxis card (#573) — a taped scrap of the proof
- * board: a torn pink strip peeking behind the tilted notepad, a strip of tape,
- * sparkle marks. Mirrors the desktop COVEN praxis frame; --faction-coven-* tokens,
- * always-light.
+ * Cozy Coven MOBILE praxis card (#821) — the gold/plum CHRONICLE: a vellum leaf
+ * with a plum→pink running-head band and a moon device. Mirrors the desktop
+ * chronicle frame; replaces the old taped-scrap collage. Single column, tokens
+ * only. Frame pixel-fidelity flagged for human QA.
  */
 export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
-  const accent = factionCssVar('coven', 'card-accent')
+  const { t } = useTranslation('praxis')
   const theme: MobileSlotTheme = {
     ink: factionCssVar('coven', 'card-text'),
     muted: factionCssVar('coven', 'card-muted'),
-    accent,
-    paper: factionCssVar('coven', 'card-bg'),
-    displayFont: 'var(--faction-coven-card-font)',
-    bodyFont: "'Courier Prime', monospace",
+    accent: 'var(--faction-coven-chronicle-plum)',
+    paper: 'var(--faction-coven-chronicle-bg)',
+    displayFont: 'var(--font-faction-script)',
+    bodyFont: "'EB Garamond', serif",
   }
   return (
     <div
       style={{
         position: 'relative',
-        paddingTop: 'var(--space-sm)',
+        overflow: 'hidden',
+        background: 'var(--faction-coven-chronicle-bg)',
+        border: '2px solid var(--faction-coven-chronicle-plum)',
+        borderRadius: 7,
+        boxShadow: '0 12px 26px -12px var(--faction-coven-chronicle-shadow)',
       }}
     >
       <div
         style={{
-          position: 'absolute',
-          top: 2,
-          left: -3,
-          right: -3,
-          height: 26,
-          background: 'var(--faction-coven-scrap-mid)',
-          border: '1.5px solid rgba(0,0,0,0.12)',
-          transform: 'rotate(-3deg)',
-        }}
-      />
-      <div
-        style={{
-          position: 'relative',
-          background: factionCssVar('coven', 'card-bg'),
-          border: '1.5px solid rgba(0,0,0,0.12)',
-          padding: 'var(--space-lg) var(--space-lg) var(--space-md)',
-          zIndex: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-sm) var(--space-lg)',
+          background:
+            'linear-gradient(90deg, var(--faction-coven-chronicle-header-from), var(--faction-coven-chronicle-header-to))',
+          color: 'var(--faction-coven-chronicle-header-text)',
+          fontFamily: 'var(--font-faction-script)',
+          fontSize: 'var(--text-sm)',
+          letterSpacing: '0.16em',
+          textTransform: 'uppercase',
         }}
       >
-        <div
-          style={{
-            position: 'absolute',
-            top: -6,
-            left: '50%',
-            transform: 'translateX(-50%) rotate(-2deg)',
-            width: 54,
-            height: 14,
-            background: 'var(--faction-coven-tape)',
-            borderRadius: 1,
-          }}
-        />
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--space-sm)',
-            marginBottom: 'var(--space-md)',
-            fontFamily: "'Courier Prime', monospace",
-            fontSize: 'var(--text-sm)',
-            letterSpacing: '0.14em',
-            textTransform: 'uppercase',
-            color: accent,
-          }}
-        >
-          <CovenSigil size={11} color={accent} />
-          {i18n.t('feed:identity.coven.windowTitle')}
-        </div>
+        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: moon dingbat sized as a glyph, not read as text */}
+        <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>
+          {'☾'}
+        </span>
+        {t('card.masthead.coven')}
+      </div>
+      <div style={{ padding: 'var(--space-lg)' }}>
         <MobilePraxisBody praxis={praxis} theme={theme} />
       </div>
     </div>

--- a/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
@@ -54,7 +54,7 @@ export default function DefaultMobilePraxisCard({ praxis }: { praxis: PraxisCard
           <DefaultSigil size={18} />
           {t('card.masthead.default')}
         </div>
-        <MobilePraxisBody praxis={praxis} theme={theme} scoreStrip mediaPlaceholder />
+        <MobilePraxisBody praxis={praxis} theme={theme} />
       </div>
     </div>
   )

--- a/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
@@ -1,0 +1,59 @@
+import type { PraxisCardOut } from '../../../api/praxis'
+import { useTranslation } from 'react-i18next'
+import { factionCssVar } from '../../../utils/factions'
+import { MobilePraxisBody, type MobileSlotTheme } from './shared'
+
+/**
+ * Warriors of Whimsy MOBILE praxis card (#821) — the SAME chronicle structure as
+ * Coven's, recoloured to WOW yellow (`--faction-wow-*`), never gold/plum. WOW's
+ * first bespoke mobile skin (#812 gave it a colour, this gives it a card).
+ * Single column, tokens only. Frame pixel-fidelity flagged for human QA.
+ */
+export default function WowMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
+  const { t } = useTranslation('praxis')
+  const theme: MobileSlotTheme = {
+    ink: factionCssVar('wow', 'card-text'),
+    muted: factionCssVar('wow', 'card-muted'),
+    accent: factionCssVar('wow', 'card-accent'),
+    paper: 'var(--faction-wow-chronicle-bg)',
+    displayFont: 'var(--font-display)',
+    bodyFont: "'EB Garamond', serif",
+  }
+  return (
+    <div
+      style={{
+        position: 'relative',
+        overflow: 'hidden',
+        background: 'var(--faction-wow-chronicle-bg)',
+        border: `2px solid ${factionCssVar('wow', 'card-accent')}`,
+        borderRadius: 7,
+        boxShadow: '0 12px 26px -12px var(--faction-wow-chronicle-shadow)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-sm) var(--space-lg)',
+          background:
+            'linear-gradient(90deg, var(--faction-wow-chronicle-header-from), var(--faction-wow-chronicle-header-to))',
+          color: 'var(--faction-wow-chronicle-header-text)',
+          fontFamily: 'var(--font-display)',
+          fontSize: 'var(--text-sm)',
+          letterSpacing: '0.16em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: star dingbat sized as a glyph, not read as text */}
+        <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>
+          ✦
+        </span>
+        {t('card.masthead.wow')}
+      </div>
+      <div style={{ padding: 'var(--space-lg)' }}>
+        <MobilePraxisBody praxis={praxis} theme={theme} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
+++ b/frontend/src/components/praxisCard/mobile/__tests__/mobilePraxisCardDispatch.test.tsx
@@ -15,6 +15,8 @@ import SnideMobilePraxisCard from '../SnideMobilePraxisCard'
 import EphemeristsMobilePraxisCard from '../EphemeristsMobilePraxisCard'
 import SingularityMobilePraxisCard from '../SingularityMobilePraxisCard'
 import EverymenMobilePraxisCard from '../EverymenMobilePraxisCard'
+import WowMobilePraxisCard from '../WowMobilePraxisCard'
+import AlbescentMobilePraxisCard from '../AlbescentMobilePraxisCard'
 
 const CARD_BY_SLUG = {
   ua: UaMobilePraxisCard,
@@ -23,6 +25,13 @@ const CARD_BY_SLUG = {
   ephemerists: EphemeristsMobilePraxisCard,
   singularity: SingularityMobilePraxisCard,
   everymen: EverymenMobilePraxisCard,
+  // WOW's first bespoke mobile card (#821) — the yellow chronicle.
+  wow: WowMobilePraxisCard,
+  // Albescent claims this surface too, but as NA + drift, not a bespoke skin
+  // (#821, ADR-0048): AlbescentMobilePraxisCard renders DefaultMobilePraxisCard
+  // with the rainbow-drift overlay. It resolves to its OWN component even though
+  // it looks like Default — see the fallthrough case below for the rest.
+  albescent: AlbescentMobilePraxisCard,
 } as const
 
 describe('mobile praxis-card per-item dispatch', () => {
@@ -32,8 +41,8 @@ describe('mobile praxis-card per-item dispatch', () => {
     })
   }
 
-  it('unregistered, factionless AND albescent praxes fall through to the Default mobile card', () => {
-    for (const slug of ['__unregistered__', 'na', 'albescent', null]) {
+  it('unregistered and factionless praxes fall through to the Default mobile card', () => {
+    for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(surfaceMap('mobilePraxisCard'), slug, DefaultMobilePraxisCard)).toBe(
         DefaultMobilePraxisCard,
       )

--- a/frontend/src/components/praxisCard/mobile/shared.tsx
+++ b/frontend/src/components/praxisCard/mobile/shared.tsx
@@ -491,19 +491,9 @@ export function MobileVoteFooter({ praxis }: { praxis: PraxisCardOut }) {
 export function MobilePraxisBody({
   praxis,
   theme,
-  scoreStrip,
-  mediaPlaceholder,
 }: {
   praxis: PraxisCardOut
   theme: MobileSlotTheme
-  /**
-   * Render the conditional {@link PraxisScoreStrip} (ADR-0047) high in the card.
-   * Opt-in: the spectrum Default card sets it (#820); #821 rolls it to every
-   * mobile faction skin.
-   */
-  scoreStrip?: boolean
-  /** Show the empty-media drop-target placeholder (spectrum Default, #820). */
-  mediaPlaceholder?: boolean
 }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
@@ -522,15 +512,15 @@ export function MobilePraxisBody({
         <MobileTitle praxis={praxis} theme={theme} />
         <MobileBody praxis={praxis} theme={theme} />
       </div>
-      {scoreStrip && (
-        <PraxisScoreStrip
-          praxis={praxis}
-          theme={{ ink: theme.ink, muted: theme.muted, accent: theme.accent }}
-        />
-      )}
+      {/* Conditional score strip (ADR-0047) on every mobile faction card (#821). */}
+      <PraxisScoreStrip
+        praxis={praxis}
+        theme={{ ink: theme.ink, muted: theme.muted, accent: theme.accent }}
+      />
       <MobileModeChip praxis={praxis} theme={theme} />
       <MobileRoster praxis={praxis} theme={theme} />
-      <MobileMediaGallery praxis={praxis} theme={theme} showPlaceholder={mediaPlaceholder} />
+      {/* Every card shows the media slot — a drop target when empty (#821). */}
+      <MobileMediaGallery praxis={praxis} theme={theme} showPlaceholder />
       <div style={{ borderTop: `1px solid ${theme.accent}`, paddingTop: 'var(--space-md)' }}>
         <MobileVotedByMarker praxis={praxis} theme={theme} />
         <MobileVoteFooter praxis={praxis} />

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -1,3 +1,4 @@
+import { useState, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
@@ -5,102 +6,217 @@ import { VoteLoginGate, VoteSummary } from './VoteShell'
 import { VOTE_REFRAMES } from './voteReframes'
 
 /**
- * Warriors of Whimsy faction vote UI — the 1-5 rating rendered as filled hearts in the
- * pink computer-witch language. Empty hearts are outline-only; filled hearts
- * climb an escalating pastel-pink ramp left-to-right, each in a soft rounded
- * stamp tile with tiny uppercase word labels.
+ * Cozy Coven vote UI (#821) — the 1-5 rating rendered as witchy MOON PHASES on a
+ * night plate. Each reached moon waxes gold toward full; the rank-5 moon gets a
+ * little face and sparkles. This is the recombination the redesign calls for: the
+ * moon-phase metaphor (the prototype's `WowVote`) lands on Coven, while the old
+ * pink hearts retire. The plate is a night surface that reads in both themes, so
+ * its inner colours do not flip — only the caption ink does.
  *
  * Plugs into the vote dispatcher via the shared {@link useVote} hook so the
- * cast/refetch logic lives in exactly one place.
+ * cast/refetch logic lives in exactly one place. All motion is a reduced-motion-
+ * gated CSS class (never inline `animation:`); a stilled plate still fills.
  */
 
-/** Escalating pink heart-fill ramp (from wow-kit.jsx voteFills). */
-const HEART_FILLS: Record<number, string> = {
-  1: '#f6b8cf',
-  2: '#f489b0',
-  3: '#ec5f99',
-  4: '#df3f86',
-  5: '#c52470',
+const R = 12
+/** SVG path for a moon lit to fraction `f` (0 = new, 1 = full). */
+function phasePath(f: number): string {
+  const rx = R * (1 - 2 * f)
+  const sweep = rx > 0 ? 0 : 1
+  return `M15 ${15 - R} A${R} ${R} 0 0 1 15 ${15 + R} A${Math.abs(rx).toFixed(2)} ${R} 0 0 ${sweep} 15 ${15 - R}Z`
 }
 
-const HEART_TILE = 40
+const SPARK_D =
+  'M12 2c.4 4.6 1.4 6.6 6 7-4.6.4-5.6 2.4-6 7-.4-4.6-1.4-6.6-6-7 4.6-.4 5.6-2.4 6-7z'
+
+/** Sparkle offsets around the rank-5 moon — ornament geometry, kept raw. */
+const SPARK_SPOTS: CSSProperties[] = [
+  { top: 0, left: -2 },
+  { top: -3, right: 0 },
+  { bottom: 4, right: -5 },
+  { top: 8, left: -5 },
+]
+/** Dust motes scattered across the plate — ornament geometry, kept raw. */
+const DUST_SPOTS = [
+  [12, 10],
+  [62, 34],
+  [118, 12],
+  [168, 30],
+  [196, 14],
+  [46, 40],
+]
 
 const TIERS = VOTE_REFRAMES['coven'].tiers
-
-/** Inline heart glyph — filled (ramp color) or outline-only when empty. */
-function HeartGlyph({ filled, color, size = 30 }: { filled: boolean; color: string; size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 36 36" aria-hidden="true">
-      <path
-        d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
-        fill={filled ? color : 'none'}
-        stroke={filled ? '#fff' : 'var(--faction-coven-border)'}
-        strokeWidth={filled ? 2.2 : 2}
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
 
 export default function CovenVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
 
   if (!user) {
     return <VoteLoginGate />
   }
 
+  const active = hovered || selected
+  const caption = active ? TIERS[active - 1].label : t('coven.idle')
+
   return (
     <div>
-      <div style={{ display: 'flex', gap: 'var(--space-sm)' }}>
+      <div
+        onMouseLeave={() => setHovered(0)}
+        style={{
+          position: 'relative',
+          display: 'flex',
+          gap: 'var(--space-sm)',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 'var(--space-sm) var(--space-md)',
+          borderRadius: 12,
+          background:
+            'radial-gradient(120% 150% at 50% -20%, var(--faction-coven-moon-plate-from), var(--faction-coven-moon-plate-to))',
+          border: '1px solid var(--faction-coven-moon-plate-border)',
+          boxShadow: 'inset 0 1px 8px rgba(0, 0, 0, 0.5)',
+        }}
+      >
+        {DUST_SPOTS.map(([x, y], index) => (
+          <span
+            key={`dust${index}`}
+            aria-hidden
+            className="coven-moon-dust"
+            style={{
+              position: 'absolute',
+              left: x,
+              top: y,
+              width: 5,
+              height: 5,
+              opacity: 0.7,
+              pointerEvents: 'none',
+              ['--tw-delay' as string]: `${index * 0.4}s`,
+            }}
+          >
+            <svg viewBox="0 0 24 24" width={5} height={5}>
+              <path d={SPARK_D} fill="var(--faction-coven-moon-dust)" />
+            </svg>
+          </span>
+        ))}
+
         {TIERS.map((tier) => {
-          const fill = HEART_FILLS[tier.value] ?? HEART_FILLS[1]
-          const filled = selected >= tier.value
-          const active = selected === tier.value
+          const reached = active >= tier.value
+          const picked = selected === tier.value
+          const top = tier.value === 5
+          const size = top ? 40 : 30
           return (
-            <div
+            <button
               key={tier.value}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-xs)' }}
+              disabled={saving}
+              onClick={() => void vote(tier.value)}
+              onMouseEnter={() => setHovered(tier.value)}
+              aria-label={t('chrome.coven.rateAria', { value: tier.value, label: tier.label })}
+              aria-pressed={picked}
+              style={{
+                position: 'relative',
+                border: 'none',
+                background: 'transparent',
+                padding: 0,
+                // ≥44px touch target; the moon floats centred inside.
+                minWidth: 44,
+                minHeight: 44,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: saving ? 'default' : 'pointer',
+                transform: picked ? 'scale(1.12)' : 'none',
+                transition: 'transform 150ms',
+              }}
             >
-              <button
-                disabled={saving}
-                onClick={() => void vote(tier.value)}
-                aria-label={t('chrome.coven.rateAria', { value: tier.value, label: tier.label })}
+              <svg
+                viewBox="0 0 30 30"
+                width={size}
+                height={size}
                 style={{
-                  width: HEART_TILE,
-                  height: HEART_TILE,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  cursor: saving ? 'default' : 'pointer',
-                  padding: 0,
-                  borderRadius: 9,
-                  border: `1.5px solid ${filled ? 'var(--faction-coven)' : 'var(--faction-coven-border)'}`,
-                  background: filled ? 'var(--faction-coven-notepad-bg)' : 'transparent',
-                  boxShadow: filled ? '0 3px 7px var(--faction-coven-light)' : 'none',
-                  transform: active ? 'scale(1.08)' : 'none',
-                  transition: 'all 120ms',
-                } as React.CSSProperties}
-              >
-                <HeartGlyph filled={filled} color={fill} />
-              </button>
-              <span
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  fontSize: 'var(--text-xs)',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.04em',
-                  color: filled ? fill : 'var(--faction-coven-card-muted)',
-                  maxWidth: HEART_TILE + 2,
-                  textAlign: 'center',
-                  lineHeight: 1.2,
+                  overflow: 'visible',
+                  filter: reached ? 'drop-shadow(0 0 6px rgba(190, 120, 225, 0.6))' : 'none',
                 }}
               >
-                {tier.label}
-              </span>
-            </div>
+                <circle
+                  cx={15}
+                  cy={15}
+                  r={R}
+                  fill={reached ? 'var(--faction-coven-moon-disc-on)' : 'var(--faction-coven-moon-disc-off)'}
+                />
+                <path
+                  d={phasePath(tier.value / 5)}
+                  fill={reached ? 'var(--faction-coven-moon-gold)' : 'var(--faction-coven-moon-lit-off)'}
+                />
+                <circle
+                  cx={15}
+                  cy={15}
+                  r={R}
+                  fill="none"
+                  stroke={reached ? 'var(--faction-coven-moon-ring-on)' : 'var(--faction-coven-moon-ring-off)'}
+                  strokeWidth={1.2}
+                />
+                {reached && top && (
+                  <g>
+                    <path d="M10.6 13.6 Q11.9 12.1 13.2 13.6" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.2} strokeLinecap="round" />
+                    <path d="M16.8 13.6 Q18.1 12.1 19.4 13.6" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.2} strokeLinecap="round" />
+                    <path d="M12 17.4 Q15 20 18 17.4" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.3} strokeLinecap="round" />
+                    <circle cx={10.6} cy={16.4} r={1.6} fill="var(--faction-coven-moon-cheek)" />
+                    <circle cx={19.4} cy={16.4} r={1.6} fill="var(--faction-coven-moon-cheek)" />
+                    <path d={SPARK_D} transform="translate(21 7) scale(0.22) translate(-12 -12)" fill="var(--faction-coven-moon-star)" />
+                  </g>
+                )}
+              </svg>
+              {reached &&
+                top &&
+                SPARK_SPOTS.map((spot, index) => (
+                  <span
+                    key={`sp${index}`}
+                    aria-hidden
+                    className="coven-moon-sparkle"
+                    style={{
+                      position: 'absolute',
+                      ...spot,
+                      width: index % 2 ? 8 : 11,
+                      height: index % 2 ? 8 : 11,
+                      pointerEvents: 'none',
+                      ['--tw-delay' as string]: `${index * 0.18}s`,
+                    }}
+                  >
+                    <svg viewBox="0 0 24 24" width="100%" height="100%">
+                      <path d={SPARK_D} fill="var(--faction-coven-moon-gold)" />
+                    </svg>
+                  </span>
+                ))}
+            </button>
           )
         })}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', marginTop: 'var(--space-sm)', minHeight: 20 }}>
+        <span
+          style={{
+            fontFamily: 'var(--faction-coven-card-font)',
+            fontSize: 'var(--text-content)',
+            letterSpacing: '0.02em',
+            color: active ? 'var(--faction-coven-vote-on)' : 'var(--faction-coven-vote-off)',
+            transition: 'color 140ms',
+          }}
+        >
+          {caption}
+        </span>
+        {selected > 0 && (
+          <span
+            style={{
+              fontSize: 'var(--text-xs)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--faction-coven-vote-off)',
+            }}
+          >
+            {`· ${t('coven.tag')}`}
+          </span>
+        )}
       </div>
 
       <VoteSummary

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -58,7 +58,7 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
   }
 
   const active = hovered || selected
-  const caption = active ? TIERS[active - 1].label : t('coven.idle')
+  const caption = active ? TIERS[active - 1].label : t('chrome.coven.idle')
 
   return (
     <div>
@@ -214,7 +214,7 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
               color: 'var(--faction-coven-vote-off)',
             }}
           >
-            {`· ${t('coven.tag')}`}
+            {`· ${t('chrome.coven.tag')}`}
           </span>
         )}
       </div>

--- a/frontend/src/components/vote/SnideVote.tsx
+++ b/frontend/src/components/vote/SnideVote.tsx
@@ -1,3 +1,4 @@
+import { useState, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
@@ -5,94 +6,142 @@ import { VoteLoginGate, VoteSummary } from './VoteShell'
 import { VOTE_REFRAMES } from './voteReframes'
 
 /**
- * S.N.I.D.E. faction vote UI — the 1-5 rating rendered as a junk-drawer of
- * mismatched rubber stamps climbing from a dismissive "meh" to a black ANARCHY
- * seal. Mixed faces, sizes, and tilts; colours are theme-aware tokens so the
- * stamps read on both the xerox-paper and concrete-night surfaces. Same 1-5
- * data model as every other faction — purely a visual reskin.
+ * S.N.I.D.E. vote UI (#821) — the 1-5 rating rendered as an amp / EQ METER: five
+ * bar-graph columns on a dark amp face. Reached columns light their segments
+ * acid → amber → pink; hit ANARCHY (rank 5) and the lit segments jump like a
+ * party VU. Replaces the retired rubber-stamp drawer.
  *
- * Plugs into the vote dispatcher via the shared {@link useVote} hook so the
- * cast/refetch logic lives in exactly one place.
+ * Plugs into the vote dispatcher via the shared {@link useVote} hook. The amp
+ * face is a dark surface that reads in both themes, so its inner colours do not
+ * flip — only the caption ink does. Motion is a reduced-motion-gated class.
  */
 
-interface StampVisual {
-  /** Border + idle text colour (theme-aware token). */
-  color: string
-  font: string
-  /** Corner rounding — square, seal, or full circle. */
-  radius: number | string
-  rot: number
-  fontSize: number
-}
-
-/**
- * Visual tokens per tier value — labels come from voteReframes.
- *
- * ornament: each tier is a rubber stamp (rotation, radius, face, size are one
- * illustration); the sizes here draw the stamp, they are not read as text.
- */
-const SNIDE_VISUALS: Record<number, StampVisual> = {
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: each tier is a rubber stamp; the size draws the stamp, it is not read as text.
-  1: { color: 'var(--color-text-tertiary)', font: 'var(--font-body)', radius: 2, rot: -3, fontSize: 10 },
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: each tier is a rubber stamp; the size draws the stamp, it is not read as text.
-  2: { color: '#b59a3a', font: 'var(--font-body)', radius: 2, rot: 2, fontSize: 10 },
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: each tier is a rubber stamp; the size draws the stamp, it is not read as text.
-  3: { color: 'var(--faction-snide)', font: 'var(--faction-snide-font-cond)', radius: '50%', rot: -2, fontSize: 13 },
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: each tier is a rubber stamp; the size draws the stamp, it is not read as text.
-  4: { color: 'var(--faction-snide-pink)', font: 'var(--faction-snide-font-black)', radius: 3, rot: 3, fontSize: 12 },
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: each tier is a rubber stamp; the size draws the stamp, it is not read as text.
-  5: { color: 'var(--color-text-primary)', font: 'var(--faction-snide-font-black)', radius: 4, rot: -4, fontSize: 12 },
-}
+/** Per-segment lit colour, bottom → top (acid ×3, amber, pink). */
+const SEG_COLORS = [
+  'var(--faction-snide-acid)',
+  'var(--faction-snide-acid)',
+  'var(--faction-snide-acid)',
+  'var(--faction-snide-amber)',
+  'var(--faction-snide-pink)',
+]
 
 const TIERS = VOTE_REFRAMES['snide'].tiers
 
 export default function SnideVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
 
   if (!user) {
     return <VoteLoginGate />
   }
 
+  const active = hovered || selected
+  const party = active >= 5
+  const caption = active ? TIERS[active - 1].label : t('chrome.snide.idle')
+
   return (
     <div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-sm)', alignItems: 'center' }}>
+      <div
+        onMouseLeave={() => setHovered(0)}
+        style={{
+          position: 'relative',
+          display: 'flex',
+          gap: 'var(--space-xs)',
+          alignItems: 'flex-end',
+          padding: 'var(--space-sm) var(--space-md)',
+          background:
+            'linear-gradient(var(--faction-snide-amp-panel-from), var(--faction-snide-amp-panel-to))',
+          border: '2px solid var(--faction-snide-amp-panel-border)',
+          borderRadius: 6,
+          boxShadow: 'inset 0 2px 7px rgba(0, 0, 0, 0.75)',
+        }}
+      >
+        {/* screws */}
+        <span aria-hidden style={{ position: 'absolute', top: 5, left: 5, width: 4, height: 4, borderRadius: '50%', background: 'var(--faction-snide-amp-screw)' }} />
+        <span aria-hidden style={{ position: 'absolute', top: 5, right: 5, width: 4, height: 4, borderRadius: '50%', background: 'var(--faction-snide-amp-screw)' }} />
+
         {TIERS.map((tier) => {
-          const visual = SNIDE_VISUALS[tier.value] ?? SNIDE_VISUALS[1]
-          const active = selected === tier.value
-          const reached = selected >= tier.value
+          const reached = active >= tier.value
+          const picked = selected === tier.value
+          const cells = [0, 1, 2, 3, 4].map((i) => {
+            const lit = reached && i < tier.value
+            const litColor = SEG_COLORS[i]
+            const cellStyle: CSSProperties = {
+              width: 30,
+              height: 5,
+              borderRadius: 1,
+              background: lit ? litColor : 'var(--faction-snide-amp-seg-off)',
+              boxShadow: lit ? `0 0 5px ${litColor}` : 'none',
+              transition: 'all 90ms',
+              ['--amp-dur' as string]: `${0.34 + i * 0.05}s`,
+              ['--amp-delay' as string]: `${tier.value * 0.06 + i * 0.04}s`,
+            }
+            return (
+              <span
+                key={i}
+                aria-hidden
+                className={party && lit ? 'snide-amp-party' : undefined}
+                style={cellStyle}
+              />
+            )
+          })
           return (
             <button
               key={tier.value}
               disabled={saving}
               onClick={() => void vote(tier.value)}
+              onMouseEnter={() => setHovered(tier.value)}
               aria-label={t('chrome.snide.rateAria', { value: tier.value, label: tier.label })}
+              aria-pressed={picked}
               style={{
-                minWidth: 46,
-                height: 40,
-                padding: '0 var(--space-md)',
+                display: 'flex',
+                flexDirection: 'column-reverse',
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: 2px inter-segment gap drawing the amp bar-graph, not layout spacing
+                gap: 2,
+                // ≥44px touch target; the column sits at the bottom.
+                minWidth: 44,
+                minHeight: 44,
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                padding: 0,
+                border: 'none',
+                background: 'transparent',
+                borderRadius: 2,
                 cursor: saving ? 'default' : 'pointer',
-                border: `2.5px ${tier.value === 5 ? 'double' : 'solid'} ${visual.color}`,
-                borderRadius: visual.radius,
-                background: active
-                  ? visual.color
-                  : reached
-                    ? `color-mix(in srgb, ${visual.color} 16%, transparent)`
-                    : 'transparent',
-                color: active ? '#fff' : visual.color,
-                fontFamily: visual.font,
-                fontSize: visual.fontSize,
-                letterSpacing: '0.06em',
-                textTransform: 'uppercase',
-                transform: `rotate(${visual.rot}deg) scale(${active ? 1.08 : 1})`,
-                boxShadow: active ? '2px 3px 0 rgba(0,0,0,0.35)' : 'none',
-                transition: 'all 120ms',
+                outline: picked ? '1px solid var(--faction-snide-acid)' : 'none',
+                outlineOffset: 2,
               }}
             >
-              {tier.label}
+              {cells}
             </button>
           )
         })}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', marginTop: 'var(--space-sm)', minHeight: 20 }}>
+        <span
+          style={{
+            fontFamily: 'var(--faction-snide-font-marker)',
+            fontSize: 'var(--text-content)',
+            color: active ? 'var(--faction-snide-acid)' : 'var(--faction-snide-vote-off)',
+            transition: 'color 140ms',
+          }}
+        >
+          {caption}
+        </span>
+        {selected > 0 && (
+          <span
+            style={{
+              fontSize: 'var(--text-xs)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--faction-snide-vote-off)',
+            }}
+          >
+            {`· ${t('chrome.snide.tag')}`}
+          </span>
+        )}
       </div>
 
       <VoteSummary

--- a/frontend/src/components/vote/WowVote.tsx
+++ b/frontend/src/components/vote/WowVote.tsx
@@ -67,7 +67,7 @@ export default function WowVote({ praxisId, currentValue, points, totalVotes }: 
 
   const active = hovered || selected
   const cheering = active >= 5
-  const caption = active ? TIERS[active - 1].label : t('wow.idle')
+  const caption = active ? TIERS[active - 1].label : t('chrome.wow.idle')
 
   return (
     <div>
@@ -142,7 +142,7 @@ export default function WowVote({ praxisId, currentValue, points, totalVotes }: 
               color: 'var(--faction-wow-vote-off)',
             }}
           >
-            {`· ${t('wow.tag')}`}
+            {`· ${t('chrome.wow.tag')}`}
           </span>
         )}
       </div>

--- a/frontend/src/components/vote/WowVote.tsx
+++ b/frontend/src/components/vote/WowVote.tsx
@@ -1,0 +1,164 @@
+import { useState, type CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { VoteUIProps } from './VoteUI'
+import { useVote } from './useVote'
+import { VoteLoginGate, VoteSummary } from './VoteShell'
+import { VOTE_REFRAMES } from './voteReframes'
+
+/**
+ * Warriors of Whimsy vote UI (#821) — the 1-5 rating rendered as a row of GOOGLY
+ * BALLOONS on a warm plate, WOW's first bespoke skin. Reached balloons fill the
+ * yellow ramp and bob; the whole bunch group-cheers when you reach the top. This
+ * is the balloon variant the prototype bundled with the chronicle chrome (its
+ * `.wow-gballoon*` classes) — recoloured to WOW yellow, never coven's gold/plum.
+ *
+ * Plugs into the vote dispatcher via the shared {@link useVote} hook. Every
+ * motion is a reduced-motion-gated CSS class (never inline `animation:`); the
+ * balloons still fill and read when stilled.
+ */
+
+/** Balloon fill ramp (yellow, deepening) — one token per tier. */
+const BALLOON_FILLS = [
+  'var(--faction-wow-balloon-1)',
+  'var(--faction-wow-balloon-2)',
+  'var(--faction-wow-balloon-3)',
+  'var(--faction-wow-balloon-4)',
+  'var(--faction-wow-balloon-5)',
+]
+
+/** Per-tier balloon diameters — ornament geometry, kept raw. */
+const BALLOON_SIZES = [30, 33, 36, 39, 44]
+
+const TIERS = VOTE_REFRAMES['wow'].tiers
+
+/** One googly balloon: body, knot, string, two wiggling eyes. */
+function Balloon({ fill, reached, size }: { fill: string; reached: boolean; size: number }) {
+  const body = reached ? fill : 'transparent'
+  const stroke = reached ? 'var(--faction-wow-balloon-4)' : 'var(--faction-wow-balloon-string)'
+  return (
+    <svg viewBox="0 0 44 60" width={size} height={size * (60 / 44)} style={{ overflow: 'visible' }}>
+      {/* string */}
+      <path d="M22 46 Q18 52 22 58" fill="none" stroke="var(--faction-wow-balloon-string)" strokeWidth={1.2} strokeLinecap="round" />
+      {/* body */}
+      <ellipse cx={22} cy={24} rx={19} ry={22} fill={body} stroke={stroke} strokeWidth={reached ? 1.5 : 2} />
+      {/* knot */}
+      <path d="M19 45 L25 45 L22 49 Z" fill={reached ? fill : 'none'} stroke={stroke} strokeWidth={reached ? 1.5 : 2} strokeLinejoin="round" />
+      {/* highlight */}
+      {reached && <ellipse cx={15} cy={16} rx={4} ry={6} fill="rgba(255,255,255,0.5)" />}
+      {/* googly eyes */}
+      <g>
+        <circle cx={16} cy={24} r={5} fill="#fff" stroke="var(--faction-wow-balloon-eye)" strokeWidth={1} />
+        <circle cx={28} cy={24} r={5} fill="#fff" stroke="var(--faction-wow-balloon-eye)" strokeWidth={1} />
+        <circle className="wow-balloon-eye" cx={16} cy={25.5} r={2.2} fill="var(--faction-wow-balloon-eye)" />
+        <circle className="wow-balloon-eye" cx={28} cy={25.5} r={2.2} fill="var(--faction-wow-balloon-eye)" />
+      </g>
+    </svg>
+  )
+}
+
+export default function WowVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
+  const { t } = useTranslation('votes')
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
+
+  if (!user) {
+    return <VoteLoginGate />
+  }
+
+  const active = hovered || selected
+  const cheering = active >= 5
+  const caption = active ? TIERS[active - 1].label : t('wow.idle')
+
+  return (
+    <div>
+      <div
+        onMouseLeave={() => setHovered(0)}
+        className={cheering ? 'wow-balloon-cheer' : undefined}
+        style={{
+          display: 'flex',
+          gap: 'var(--space-xs)',
+          alignItems: 'flex-end',
+          justifyContent: 'center',
+          padding: 'var(--space-sm) var(--space-md)',
+          borderRadius: 12,
+          background:
+            'linear-gradient(var(--faction-wow-balloon-plate-from), var(--faction-wow-balloon-plate-to))',
+          border: '1px solid var(--faction-wow-balloon-plate-border)',
+        }}
+      >
+        {TIERS.map((tier, index) => {
+          const reached = active >= tier.value
+          const picked = selected === tier.value
+          const balloonStyle: CSSProperties = {
+            border: 'none',
+            background: 'transparent',
+            padding: 0,
+            minWidth: 44,
+            minHeight: 44,
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'center',
+            cursor: saving ? 'default' : 'pointer',
+            transform: picked ? 'scale(1.1)' : 'none',
+            transition: 'transform 150ms',
+            ['--tw-delay' as string]: `${tier.value * 0.09}s`,
+          }
+          return (
+            <button
+              key={tier.value}
+              disabled={saving}
+              onClick={() => void vote(tier.value)}
+              onMouseEnter={() => setHovered(tier.value)}
+              aria-label={t('chrome.wow.rateAria', { value: tier.value, label: tier.label })}
+              aria-pressed={picked}
+              style={balloonStyle}
+            >
+              <span className={reached && !cheering ? 'wow-balloon-float' : undefined} style={{ display: 'flex', ['--tw-delay' as string]: `${tier.value * 0.09}s` }}>
+                <Balloon fill={BALLOON_FILLS[index]} reached={reached} size={BALLOON_SIZES[index]} />
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', marginTop: 'var(--space-sm)', minHeight: 20 }}>
+        <span
+          style={{
+            fontFamily: 'var(--faction-wow-card-font)',
+            fontSize: 'var(--text-content)',
+            letterSpacing: '0.02em',
+            color: active ? 'var(--faction-wow-vote-on)' : 'var(--faction-wow-vote-off)',
+            transition: 'color 140ms',
+          }}
+        >
+          {caption}
+        </span>
+        {selected > 0 && (
+          <span
+            style={{
+              fontSize: 'var(--text-xs)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--faction-wow-vote-off)',
+            }}
+          >
+            {`· ${t('wow.tag')}`}
+          </span>
+        )}
+      </div>
+
+      <VoteSummary
+        selected={selected}
+        points={points}
+        totalVotes={totalVotes}
+        error={error}
+        theme={{
+          muted: 'var(--faction-wow-card-muted)',
+          accent: 'var(--faction-wow-card-accent)',
+          accentFont: 'var(--faction-wow-card-font)',
+          errorColor: 'var(--color-danger)',
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -47,6 +47,15 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
       { value: 5, label: i18n.t('votes:coven.legendary') },
     ],
   },
+  wow: {
+    tiers: [
+      { value: 1, label: i18n.t('votes:wow.sweet') },
+      { value: 2, label: i18n.t('votes:wow.lovely') },
+      { value: 3, label: i18n.t('votes:wow.wonderful') },
+      { value: 4, label: i18n.t('votes:wow.magical') },
+      { value: 5, label: i18n.t('votes:wow.iconic') },
+    ],
+  },
   snide: {
     tiers: [
       { value: 1, label: i18n.t('votes:snide.meh') },

--- a/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
+++ b/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
@@ -1,28 +1,26 @@
 /**
- * Warriors of Whimsy has a COLOUR but not a SKIN (#784, then #812).
+ * Warriors of Whimsy is THEMED and PARTLY SKINNED (#784, #812, then #821).
  *
  * #784 moved its lo-fi pink `.exe` identity wholesale to Cozy Coven, leaving
- * `wow` with no manifest and no theme. #812 gave back only the second of those:
- * a minimal yellow `--faction-wow-*` block, so WOW rejoins the rainbow and its
- * members get faction-coloured ornament. The manifest is still empty, and that
- * is the settled intent — "most other aspects of them will be indistinguishable
- * from na until we ship the design".
+ * `wow` with no manifest and no theme. #812 gave back a minimal yellow
+ * `--faction-wow-*` block, so WOW rejoins the rainbow. #821 ships its FIRST
+ * bespoke surfaces: the praxis card, its mobile twin, and the vote widget. Every
+ * OTHER surface still falls through to `Default*` — WOW is themed-and-partly-
+ * skinned, not fully dressed, and definitely not "broken faction".
  *
- * That split is the whole point of this file, and it is fragile in BOTH
- * directions, neither of which crashes:
+ * That split is fragile in BOTH directions, neither of which crashes:
  *
- *  - Register a component "helpfully" and WOW starts wearing a half-built skin
- *    nobody designed, most likely one borrowed from the faction that took its
- *    old one.
+ *  - Register a component "helpfully" on an UNCLAIMED surface and WOW starts
+ *    wearing a half-built skin nobody designed, most likely one borrowed from the
+ *    faction that took its old one.
  *  - Let the theme lapse and `factionName()` falls through to `names.na`,
  *    silently labelling a real, populated, joinable faction "Unaffiliated".
  *
- * Neither produces a type error, a thrown key, or a visual diff a build can
- * see. So the three halves are asserted together — falls back on every surface,
- * AND resolves its own theme, AND still has words — because it is their
- * combination that means "colour, not skin" rather than "broken faction".
+ * So this file pins the exact skinned set AND the theme AND the words together:
+ * only the three redesign surfaces are claimed, the rest fall back, WOW resolves
+ * its own hue, and it still has a name and description of its own.
  *
- * DELETE THIS FILE when WOW's real design ships and it registers a manifest.
+ * DELETE (or re-scope) THIS FILE when WOW's remaining surfaces ship.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect } from 'vitest'
@@ -43,19 +41,34 @@ function Sentinel() {
   return <div>default-sentinel</div>
 }
 
-describe('wow falls back to Default on every surface', () => {
-  it('registers no manifest at all', () => {
-    expect(FACTION_MANIFESTS.map((manifest) => manifest.slug)).not.toContain('wow')
+/** The three surfaces #821 skinned. Every other surface must fall back. */
+const WOW_SKINNED: ReadonlySet<FactionSurface> = new Set([
+  'praxisCard',
+  'mobilePraxisCard',
+  'vote',
+])
+
+describe('wow is partly skinned: three surfaces claimed, the rest fall back', () => {
+  it('registers a manifest now (#821)', () => {
+    expect(FACTION_MANIFESTS.map((manifest) => manifest.slug)).toContain('wow')
   })
 
   for (const surface of SURFACE_KEYS) {
-    it(`claims nothing on the ${surface} surface, so it gets the fallback`, () => {
+    const claimed = WOW_SKINNED.has(surface as FactionSurface)
+    it(`${claimed ? 'claims' : 'falls back on'} the ${surface} surface`, () => {
       const map = surfaceMap(surface as FactionSurface)
 
-      // Unclaimed: no bespoke component is registered for the slug...
-      expect(map['wow'], `${surface} should be unclaimed by wow`).toBeUndefined()
+      if (claimed) {
+        // A bespoke component is registered for the slug, so the dispatcher
+        // hands it back rather than the caller's Default.
+        expect(map['wow'], `${surface} should be claimed by wow`).toBeDefined()
+        const Resolved = pickVariant(map as Record<string, typeof Sentinel>, 'wow', Sentinel)
+        expect(Resolved).not.toBe(Sentinel)
+        return
+      }
 
-      // ...so the dispatcher hands back the caller's Default, and it renders.
+      // Unclaimed: no component for the slug, so the caller's Default renders.
+      expect(map['wow'], `${surface} should be unclaimed by wow`).toBeUndefined()
       const Resolved = pickVariant(map as Record<string, typeof Sentinel>, 'wow', Sentinel)
       expect(Resolved).toBe(Sentinel)
       expect(renderToStaticMarkup(<Resolved />)).toContain('default-sentinel')

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -28,6 +28,8 @@
 import type { FactionManifest } from './manifest'
 
 import { AlbescentSelectCard } from '../components/cards/FactionSelectCard'
+import { AlbescentPraxisCard } from '../components/PraxisCard'
+import AlbescentMobilePraxisCard from '../components/praxisCard/mobile/AlbescentMobilePraxisCard'
 
 export const ALBESCENT_MANIFEST: FactionManifest = {
   slug: 'albescent',
@@ -40,4 +42,15 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * UA's costume, not a neutral card (#796).
    */
   factionSelectCard: () => AlbescentSelectCard,
+
+  /**
+   * The praxis-card tell (#821, ADR-0048). These are NOT bespoke skins: each
+   * renders the exact spectrum `Default` card an unaffiliated player sees, with
+   * a slow rainbow DRIFT washed over it — the flourish that reveals the society
+   * to someone already looking. A repaint in Albescent's own colours would put
+   * it back in the spectrum and un-hide it, so this stays "NA + drift". Every
+   * other surface still falls through to Default (#783).
+   */
+  praxisCard: () => AlbescentPraxisCard,
+  mobilePraxisCard: () => AlbescentMobilePraxisCard,
 }

--- a/frontend/src/factions/index.ts
+++ b/frontend/src/factions/index.ts
@@ -34,6 +34,7 @@ import { EVERYMEN_MANIFEST } from './everymen'
 import { SINGULARITY_MANIFEST } from './singularity'
 import { SNIDE_MANIFEST } from './snide'
 import { UA_MANIFEST } from './ua'
+import { WOW_MANIFEST } from './wow'
 
 export type { FactionManifest, FactionSurface } from './manifest'
 export { SURFACE_KEYS } from './manifest'
@@ -44,24 +45,18 @@ export { SURFACE_KEYS } from './manifest'
  * state rather than a faction and deliberately has no manifest: it falls through
  * to the neutral `Default*` skins everywhere (ADR-0039).
  *
- * `wow` has no manifest either, for a different reason (#784): Warriors of
- * Whimsy's lo-fi pink `.exe` identity moved wholesale to Cozy Coven. Registering
- * nothing is exactly what the override-only contract wants in the meantime —
- * every surface hands `wow` its `Default*` archetype, which is a clean slate
- * rather than a gap.
- *
- * Note that #812 has since given `wow` a yellow THEME, so it is a known faction
- * with coloured ornament and a slot in the rainbow. That changed nothing here,
- * and the gap between the two is the point: WOW is the one faction that is
- * themed without being skinned, so a WOW surface is *supposed* to look like an
- * unaffiliated one in every respect but hue. Do not "finish" it by registering
- * components — the design has not been made yet. Its name and description
- * resolve from the catalog, so it reads as a real faction throughout;
- * `wowRendersDefault.test.tsx` pins all three halves of that.
+ * `wow` (Warriors of Whimsy) began with no manifest (#784 moved its old pink
+ * identity to Cozy Coven) and then only a yellow THEME (#812). #821 gives it its
+ * FIRST bespoke surfaces: the praxis card (a yellow chronicle), its mobile twin,
+ * and the balloon vote widget. It is still override-only — every OTHER surface
+ * hands `wow` its `Default*` archetype, so WOW is themed-and-partly-skinned, not
+ * fully dressed. `wowRendersDefault.test.tsx` pins which three surfaces are
+ * claimed and that the rest fall back.
  */
 export const FACTION_MANIFESTS: readonly FactionManifest[] = [
   EVERYMEN_MANIFEST,
   UA_MANIFEST,
+  WOW_MANIFEST,
   SNIDE_MANIFEST,
   EPHEMERISTS_MANIFEST,
   SINGULARITY_MANIFEST,

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -1,0 +1,30 @@
+/**
+ * wow — Warriors of Whimsy's FIRST bespoke surfaces (#821).
+ *
+ * #784 stripped WOW's old lo-fi pink `.exe` identity (it moved to Cozy Coven),
+ * and #812 gave back only a yellow THEME — no skin. This manifest is the first
+ * slice of WOW's own kit: the praxis card (a yellow CHRONICLE, the same frame
+ * Coven wears in gold/plum, recoloured — never gold/plum here) plus its mobile
+ * twin and the googly-balloon vote widget.
+ *
+ * Override-only, like every manifest: WOW still falls through to the `Default*`
+ * archetype on every OTHER surface — it is themed-and-partly-skinned now, not
+ * fully dressed. `wowRendersDefault.test.tsx` pins exactly which three surfaces
+ * are claimed and asserts the rest still fall back.
+ *
+ * Entries are thunks (`() => Component`) so they are read at render time, never
+ * during module evaluation — see the cycle note in `./manifest.ts`.
+ */
+import type { FactionManifest } from './manifest'
+
+import WowVote from '../components/vote/WowVote'
+import WowMobilePraxisCard from '../components/praxisCard/mobile/WowMobilePraxisCard'
+import { WowPraxisCard } from '../components/PraxisCard'
+
+export const WOW_MANIFEST: FactionManifest = {
+  slug: 'wow',
+
+  praxisCard: () => WowPraxisCard,
+  mobilePraxisCard: () => WowMobilePraxisCard,
+  vote: () => WowVote,
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -282,6 +282,58 @@
   --faction-coven-ivy: #7cbf99;
   --faction-coven-ivy-leaf: #9ad3b1;
 
+  /* ══ Praxis-card redesign (#821) — chronicle frames + bespoke vote widgets ══
+     Coven wears a gold/plum chronicle; WOW wears the same structure recoloured
+     to its yellow. The moon-phase + balloon vote plates are always night/warm
+     plates, so their inner values do not flip — only the chronicle chrome does. */
+
+  /* Coven — gold/plum chronicle frame */
+  --faction-coven-chronicle-bg: #f6ecd6; /* vellum */
+  --faction-coven-chronicle-plum: #7a4a9e;
+  --faction-coven-chronicle-gold: #b8892f; /* readable gold for rules/labels */
+  --faction-coven-chronicle-header-from: #7a4a9e;
+  --faction-coven-chronicle-header-to: #ec5f99;
+  --faction-coven-chronicle-header-text: #fbeef5;
+  --faction-coven-chronicle-shadow: rgba(90, 40, 110, 0.24);
+
+  /* Coven — moon-phase vote plate (night plate; same in both themes) */
+  --faction-coven-moon-plate-from: #3a2352;
+  --faction-coven-moon-plate-to: #190f2b;
+  --faction-coven-moon-plate-border: #4a3168;
+  --faction-coven-moon-disc-on: #2a1740;
+  --faction-coven-moon-disc-off: #241a33;
+  --faction-coven-moon-gold: #f4d98a;
+  --faction-coven-moon-lit-off: #4a3a5e;
+  --faction-coven-moon-ring-on: #e6b8d6;
+  --faction-coven-moon-ring-off: #4a3560;
+  --faction-coven-moon-face: #6a2f7e;
+  --faction-coven-moon-cheek: rgba(236, 95, 153, 0.45);
+  --faction-coven-moon-star: #f0d36e;
+  --faction-coven-moon-dust: #b98fd6;
+  --faction-coven-vote-on: #d63f86;
+  --faction-coven-vote-off: #a76389;
+
+  /* WOW — yellow chronicle frame (NOT gold/plum; that is coven's) */
+  --faction-wow-chronicle-bg: #fffbe8;
+  --faction-wow-chronicle-header-from: #e0a800;
+  --faction-wow-chronicle-header-to: #f5c542;
+  --faction-wow-chronicle-header-text: #3a2a00;
+  --faction-wow-chronicle-shadow: rgba(160, 120, 0, 0.24);
+
+  /* WOW — googly-balloon vote plate (warm plate) */
+  --faction-wow-balloon-plate-from: #fff4c8;
+  --faction-wow-balloon-plate-to: #ffe9a0;
+  --faction-wow-balloon-plate-border: #e6c257;
+  --faction-wow-balloon-1: #f7e08a;
+  --faction-wow-balloon-2: #f5d15a;
+  --faction-wow-balloon-3: #f5c542;
+  --faction-wow-balloon-4: #e0a800;
+  --faction-wow-balloon-5: #c98a00;
+  --faction-wow-balloon-string: #b9902a;
+  --faction-wow-balloon-eye: #14110b;
+  --faction-wow-vote-on: #a9700a;
+  --faction-wow-vote-off: #b79a52;
+
   /* ══ Everymen — the rainbow's missing red (union/WW2 poster) ══
      Constants (cream/gold/ink) keep their role in both themes; the paper
      surface + its text FLIP in dark; accent red stays vivid; field is the
@@ -595,6 +647,33 @@
   --faction-coven-dot: rgba(244, 114, 182, 0.16);
   --faction-coven-ivy: #5fa882;
   --faction-coven-ivy-leaf: #7fc59e;
+
+  /* ══ Praxis-card redesign (#821) — chronicle frames flip; vote plates hold ══
+     The moon/balloon plates are night/warm surfaces that read in both themes,
+     so only the chronicle chrome + caption inks are overridden here. */
+
+  /* Coven — gold/plum chronicle (dark) */
+  --faction-coven-chronicle-bg: #241733;
+  --faction-coven-chronicle-plum: #b98fd6;
+  --faction-coven-chronicle-gold: #e6c273;
+  --faction-coven-chronicle-header-from: #4a2a63;
+  --faction-coven-chronicle-header-to: #8e2f5c;
+  --faction-coven-chronicle-header-text: #fbe4f0;
+  --faction-coven-chronicle-shadow: rgba(0, 0, 0, 0.5);
+  --faction-coven-vote-on: #f472b6;
+  --faction-coven-vote-off: #c78aa6;
+
+  /* WOW — yellow chronicle (dark) */
+  --faction-wow-chronicle-bg: #231c0e;
+  --faction-wow-chronicle-header-from: #8a6600;
+  --faction-wow-chronicle-header-to: #c99a1a;
+  --faction-wow-chronicle-header-text: #fff4cf;
+  --faction-wow-chronicle-shadow: rgba(0, 0, 0, 0.5);
+  --faction-wow-balloon-plate-from: #3a2f0e;
+  --faction-wow-balloon-plate-to: #241c08;
+  --faction-wow-balloon-plate-border: #7a6320;
+  --faction-wow-vote-on: #f5c542;
+  --faction-wow-vote-off: #b9a473;
 
   /* ── Watercolor splash opacities (dimmer in dark) ── */
   --wc-opacity-blob: 0.15;
@@ -1343,6 +1422,57 @@
 @keyframes cs-shimmer { to { background-position: 200% 0; } }
 @media (prefers-reduced-motion: no-preference) {
   .cs-shimmer { animation: cs-shimmer 4s linear infinite; }
+}
+
+/* ══ Praxis-card redesign vote widgets (#821) ══
+   Every animation is gated on reduced-motion and driven by a class, never an
+   inline `animation:` (the widgets would bypass the gate otherwise). Meaning is
+   carried by the fill/selection, not the motion — the widgets read correctly
+   stilled. */
+
+/* Coven — moon-phase plate: rank-5 sparkles twinkle, dust drifts. */
+@keyframes coven-twinkle { 0%, 100% { opacity: 0.25; transform: scale(0.6) rotate(0deg); } 50% { opacity: 1; transform: scale(1.15) rotate(20deg); } }
+@media (prefers-reduced-motion: no-preference) {
+  .coven-moon-sparkle { animation: coven-twinkle 1.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
+  .coven-moon-dust { animation: eph-twinkle 3.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
+}
+
+/* WOW — googly-balloon plate: reached balloons bob, rank-5 group-cheers, eyes wiggle. */
+@keyframes wow-bounce { 0%, 100% { transform: translateY(0); } 30% { transform: translateY(-9px); } 55% { transform: translateY(0); } 72% { transform: translateY(-4px); } }
+@keyframes wow-group-bounce { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }
+@keyframes wow-eye-wiggle { 0%, 100% { transform: translate(0, 0); } 25% { transform: translate(1.5px, -1px); } 50% { transform: translate(-1px, 1.5px); } 75% { transform: translate(1px, 1px); } }
+@media (prefers-reduced-motion: no-preference) {
+  .wow-balloon-float { animation: wow-bounce 2.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
+  .wow-balloon-cheer { animation: wow-group-bounce 1.05s ease-in-out infinite; }
+  .wow-balloon-eye { transform-box: fill-box; transform-origin: center; animation: wow-eye-wiggle 1.4s ease-in-out infinite; }
+}
+
+/* Albescent — the secret-society tell (#821, ADR-0048): the na spectrum card
+   with a slow rainbow drift washed over the whole sheet. A skin-fallthrough
+   faction, so this is a flourish LAYERED over Default, never a repaint. */
+@keyframes alb-drift { from { background-position: 0 0; } to { background-position: 220px 0; } }
+.alb-rainbow {
+  position: absolute;
+  left: -45%;
+  top: -45%;
+  width: 190%;
+  height: 190%;
+  transform: rotate(24deg);
+  pointer-events: none;
+  z-index: 0;
+  background-image: linear-gradient(90deg, rgba(193, 39, 45, 0.3), rgba(202, 138, 4, 0.3), rgba(22, 163, 74, 0.3), rgba(37, 99, 235, 0.3), rgba(190, 24, 93, 0.3), rgba(193, 39, 45, 0.3));
+  background-size: 220px 100%;
+  background-repeat: repeat;
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+[data-theme="dark"] .alb-rainbow {
+  background-image: linear-gradient(90deg, rgba(255, 96, 84, 0.55), rgba(247, 193, 74, 0.55), rgba(74, 222, 128, 0.55), rgba(96, 165, 250, 0.55), rgba(244, 114, 182, 0.55), rgba(255, 96, 84, 0.55));
+  mix-blend-mode: screen;
+  opacity: 0.45;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .alb-rainbow { animation: alb-drift 18s linear infinite; }
 }
 
 /* FieldDesk life-card hover-lift (#274). The CredentialCard owns its own rotation;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -209,6 +209,16 @@
   --faction-snide-font-type: var(--font-faction-typewriter); /* Special Elite */
   --faction-snide-font-marker: var(--font-faction-marker); /* Permanent Marker */
 
+  /* S.N.I.D.E. amp/EQ-meter vote widget (#821). The panel is an amp face — a
+     dark surface that reads in both themes, so its inner values do not flip. */
+  --faction-snide-amber: #f0c400;
+  --faction-snide-amp-panel-from: #100d09;
+  --faction-snide-amp-panel-to: #070603;
+  --faction-snide-amp-panel-border: #2c2a20;
+  --faction-snide-amp-seg-off: rgba(255, 255, 255, 0.07);
+  --faction-snide-amp-screw: #3a3830;
+  --faction-snide-vote-off: #8a9a6a;
+
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;
 
@@ -1435,6 +1445,12 @@
 @media (prefers-reduced-motion: no-preference) {
   .coven-moon-sparkle { animation: coven-twinkle 1.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
   .coven-moon-dust { animation: eph-twinkle 3.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
+}
+
+/* S.N.I.D.E. — amp/EQ meter: at rank 5 the lit segments jump like a party VU. */
+@keyframes snide-amp-party { 0%, 100% { transform: scaleY(1); } 50% { transform: scaleY(1.9); } }
+@media (prefers-reduced-motion: no-preference) {
+  .snide-amp-party { transform-origin: center; animation: snide-amp-party var(--amp-dur, 0.4s) ease-in-out infinite; animation-delay: var(--amp-delay, 0s); }
 }
 
 /* WOW — googly-balloon plate: reached balloons bob, rank-5 group-cheers, eyes wiggle. */

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -20,6 +20,10 @@ const FACTION_SLUGS = [
   'snide',
   'singularity',
   'ua',
+  // WOW gained a vote voice with its first bespoke skin (#821) — the balloon
+  // widget's whimsical tiers. Its idle/tag prompt lives under chrome.wow, not
+  // here, so this block stays exactly the five tier labels.
+  'wow',
 ] as const
 const EXPECTED_TIER_COUNT = 5
 

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -77,6 +77,8 @@
       "snide": "evidence locker",
       "albescent": "Account · filed",
       "singularity": "singularity protocol",
+      "coven": "Grimoire · entry",
+      "wow": "Chronicle of Whimsy",
       "default": "Praxis · unaffiliated"
     }
   },

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -18,7 +18,18 @@
     "solid": "solid",
     "good": "good",
     "excellent": "excellent",
-    "legendary": "legendary"
+    "legendary": "legendary",
+    "idle": "cast a spell",
+    "tag": "sealed"
+  },
+  "wow": {
+    "sweet": "sweet",
+    "lovely": "lovely",
+    "wonderful": "wonderful",
+    "magical": "magical",
+    "iconic": "iconic",
+    "idle": "tap to cheer",
+    "tag": "yay!"
   },
   "snide": {
     "meh": "meh",
@@ -67,6 +78,9 @@
     },
     "coven": {
       "rateAria": "Rate {{value}} — {{label}}"
+    },
+    "wow": {
+      "rateAria": "Cheer {{value}} — {{label}}"
     },
     "snide": {
       "rateAria": "Rate {{value}} — {{label}}"

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -18,18 +18,14 @@
     "solid": "solid",
     "good": "good",
     "excellent": "excellent",
-    "legendary": "legendary",
-    "idle": "cast a spell",
-    "tag": "sealed"
+    "legendary": "legendary"
   },
   "wow": {
     "sweet": "sweet",
     "lovely": "lovely",
     "wonderful": "wonderful",
     "magical": "magical",
-    "iconic": "iconic",
-    "idle": "tap to cheer",
-    "tag": "yay!"
+    "iconic": "iconic"
   },
   "snide": {
     "meh": "meh",
@@ -77,13 +73,19 @@
       "rateAria": "Rate {{value}} — {{label}}"
     },
     "coven": {
-      "rateAria": "Rate {{value}} — {{label}}"
+      "rateAria": "Rate {{value}} — {{label}}",
+      "idle": "cast a spell",
+      "tag": "sealed"
     },
     "wow": {
-      "rateAria": "Cheer {{value}} — {{label}}"
+      "rateAria": "Cheer {{value}} — {{label}}",
+      "idle": "tap to cheer",
+      "tag": "yay!"
     },
     "snide": {
-      "rateAria": "Rate {{value}} — {{label}}"
+      "rateAria": "Rate {{value}} — {{label}}",
+      "idle": "call it",
+      "tag": "locked in"
     },
     "singularity": {
       "rateAria": "Cast {{value}} — {{label}}",


### PR DESCRIPTION
## What this is

The flagship of the faction praxis-card redesign (#818). Rolls #820's reusable pieces (conditional score stamp, media slot, real `useVote`/`VoteShell` plumbing) out across the roster, plus the recombine + net-new faction work.

Closes #821

Base includes main `8054c40` (#819 + #820 merged).

## Done (committed incrementally)

- **Score stamp + media slot on EVERY faction** — `PraxisBody`/`MobilePraxisBody` now always render `PraxisScoreStamp`/`PraxisScoreStrip` (ADR-0047) and the empty-media drop target. `PraxisScoreHero` survives only for the praxis-**detail** surfaces that have not migrated (out of scope here).
- **Coven → gold/plum CHRONICLE + moon-phases** — new shared `ChroniclePraxisCard` frame (desktop) + chronicle mobile card, plus a faithful port of the moon-phase vote widget. Retires the pink scrap-collage + hearts.
- **WOW → yellow chronicle + balloons + first manifest** — the SAME chronicle structure recoloured to `--faction-wow-*` (never gold/plum) + a googly-balloon vote widget, wired through a new `WOW_MANIFEST` (`praxisCard`, `mobilePraxisCard`, `vote`) in rainbow order. `wowRendersDefault.test` now pins the three skinned surfaces and that every other surface still falls back to Default.
- **Albescent → NA spectrum + rainbow drift** (ADR-0048) — claims `praxisCard` + `mobilePraxisCard`, each rendering the Default card with a `.alb-rainbow` drift overlay. Not a repaint; every other surface still falls through to na.
- **Snide → amp/EQ-meter vote widget** — replaces the rubber-stamp drawer with lit bar-graph columns (acid→amber→pink) and a party-VU jump at rank 5.
- Tokens (chronicle / moon / balloon / drift / amp) in `index.css` light **and** dark; reduced-motion-gated keyframes (never inline `animation:`); coven/wow masthead + wow vote copy + reframe; idle/tag prompts under `chrome.<faction>`.

## NOT done (ran low on budget — see handback)

- **Four remaining widget rewrites** to the new mock metaphors: **UA** mandala, **Singularity** decode-strip, **Everymen** gearworks, **Ephemerists** constellation. These factions still dispatch to their **current, working** widgets, so nothing is broken — only the aesthetic upgrade is outstanding. Their desktop/mobile card frames already get the new score stamp + media slot + shared plumbing.

## Verification

`tsc --noEmit`, `eslint src`, and `vite build` all clean. Vitest green for the touched dispatch/manifest/slot/token/catalog/reframe tests.

**Visual QA is OUTSTANDING for a human** — no dev stack here and I cannot screenshot. Frame pixel-fidelity vs. the prototype `.dc.html` (unreachable) was a faithful pass from the README palette.

## What to eyeball (light AND dark, desktop + mobile)

- **coven** — desktop chronicle + mobile chronicle + vote shows **MOON-PHASES (not balloons)**; gold/plum, no yellow
- **wow** — desktop chronicle + mobile chronicle + vote shows **BALLOONS in YELLOW (not gold/plum)**; first WOW skin
- **albescent** — spectrum Default card + **drift shimmer** over the whole sheet, desktop + mobile; `wowRendersDefault` test still passes
- **snide** — amp-meter vote widget (segments light acid→amber→pink, party jump at ANARCHY); card + mobile
- **ua / singularity / everymen / ephemerists** — desktop + mobile cards now carry the new score stamp + media slot; vote widgets are still the **current** ones (rewrites outstanding)
- Score stamp/strip renders on all 8; media drop-target on empty proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
