### PR TITLE
feat(praxis): Singularity decode-strip vote widget (#821)

### DIFF
--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
@@ -5,116 +6,172 @@ import { VoteLoginGate, VoteSummary } from './VoteShell'
 import { VOTE_REFRAMES } from './voteReframes'
 
 /**
- * Singularity faction vote UI — THE CONSENSUS ARRAY. The 1-5 rating is rendered
- * as a signal-strength ramp cast into the terminal: noise → weak → signal →
- * clear → verified, measuring how confidently a sealed output holds up to
- * scrutiny. Square mono "cast signal" keys glow when reached; the selected key
- * scales up. Singularity is ALWAYS-DARK — its tokens hold identical terminal
- * values in both themes, so this never touches data-theme.
+ * Singularity faction vote UI (#821) — THE TERMINAL DECODE STRIP. The 1-5 rating
+ * is five columns of a scrolling terminal read-out: every unreached tier scrambles
+ * katakana/symbol noise on a 120ms interval, and each tier you reach RESOLVES to a
+ * density glyph (· + * # █) in phosphor green — rank 5 ("verified") locking to cyan.
+ * The metaphor is signal decode: noise → weak → signal → clear → verified, measuring
+ * how confidently a sealed output holds up to scrutiny.
  *
- * Same 1-5 data model as every other faction — a pure terminal reskin driven by
- * the shared {@link useVote} hook so cast/refetch logic lives in one place.
+ * Same 1-5 data model as every other faction — a pure terminal reskin driven by the
+ * shared {@link useVote} hook so cast/refetch/tally-override logic lives in one place.
+ * Singularity is ALWAYS-DARK: its tokens hold identical terminal values in both
+ * themes, so this never touches the [data-theme] cascade.
+ *
+ * The always-on scramble is a JS interval (a decode strip that stood still would
+ * read as broken, not stilled), so it cannot be class-gated like the other widgets'
+ * CSS animations. Instead it reads `prefers-reduced-motion` directly and FREEZES the
+ * tick when set — the strip still shows noise vs. resolved glyphs, it just stops
+ * churning.
  */
 
-/**
- * Signal ramp fills per tier value — labels come from voteReframes. The ramp
- * runs cool→warm→green: terminal-green accent mixed up from the blue brand chrome
- * as confidence rises.
- */
-const SG_FILLS: Record<number, string> = {
-  1: 'var(--faction-singularity-card-muted)',
-  2: 'color-mix(in srgb, var(--faction-singularity-card-muted) 70%, var(--faction-singularity-card-accent))',
-  3: 'color-mix(in srgb, var(--faction-singularity-card-muted) 40%, var(--faction-singularity-card-accent))',
-  4: 'color-mix(in srgb, var(--faction-singularity-card-accent) 75%, var(--faction-singularity-card-muted))',
-  5: 'var(--faction-singularity-card-accent)',
+/** Density glyphs a resolved tier prints, tier 1→5: noise floor → solid block. */
+const DENSITY = ['·', '+', '*', '#', '█']
+
+/** Katakana + symbol pool the unreached tiers scramble through. */
+const SCRAMBLE_CHARS = 'ｱｲｳｴｵｶｷｸｹｺﾊﾋﾌﾍﾎﾐﾑ0123456789#%$*+=<>?/'.split('')
+
+/** Deterministic per-cell glyph from a seed + the animation tick (matches the design). */
+function scrambleGlyph(seed: number, tick: number): string {
+  const length = SCRAMBLE_CHARS.length
+  const index = ((Math.floor(seed * 131 + tick * 71) % length) + length) % length
+  return SCRAMBLE_CHARS[index]
 }
 
-const KEY_SIZE = 42
+/** Key geometry (ornament, not layout) — ≥44px touch target. */
+const KEY_WIDTH = 46
+const KEY_HEIGHT = 44
+const SCRAMBLE_INTERVAL_MS = 120
 
 const TIERS = VOTE_REFRAMES['singularity'].tiers
+
+/** matchMedia-backed reduced-motion flag; defaults to stilled when absent (SSR/test). */
+function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(
+    (onChange) => {
+      const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+      mql.addEventListener('change', onChange)
+      return () => mql.removeEventListener('change', onChange)
+    },
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    () => true,
+  )
+}
+
+/** 120ms scramble clock; frozen (never ticks) when `enabled` is false. */
+function useScrambleTick(enabled: boolean): number {
+  const [tick, setTick] = useState(0)
+  useEffect(() => {
+    if (!enabled) return
+    const id = setInterval(() => setTick((value) => value + 1), SCRAMBLE_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [enabled])
+  return tick
+}
 
 export default function SingularityVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
+  const reducedMotion = usePrefersReducedMotion()
+  const tick = useScrambleTick(!reducedMotion)
 
   if (!user) {
     return <VoteLoginGate />
   }
 
+  const active = hovered || selected
+  const caption = active ? TIERS[active - 1].label : t('chrome.singularity.idle')
+
   return (
     <div style={{ fontFamily: 'var(--font-faction-terminal)' }}>
       <div
-        style={{
-          fontSize: 'var(--text-xs)',
-          letterSpacing: '0.18em',
-          color: 'color-mix(in srgb, var(--faction-singularity-card-muted) 75%, transparent)',
-          textTransform: 'uppercase',
-          marginBottom: 'var(--space-xs)',
-        }}
+        onMouseLeave={() => setHovered(0)}
+        style={{ display: 'flex', gap: 'var(--space-xs)', alignItems: 'flex-end' }}
       >
-        {t('chrome.singularity.prompt')}
-      </div>
-      <div
-        style={{
-          fontSize: 'var(--text-xs)',
-          fontStyle: 'italic',
-          color: 'color-mix(in srgb, var(--faction-singularity-card-accent) 50%, transparent)',
-          marginBottom: 'var(--space-md)',
-        }}
-      >
-        {t('chrome.singularity.promptHint')}
-      </div>
-
-      <div style={{ display: 'flex', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
         {TIERS.map((tier) => {
-          const fill = SG_FILLS[tier.value] ?? SG_FILLS[1]
-          const reached = selected >= tier.value
+          const reached = active >= tier.value
           const picked = selected === tier.value
+          const top = tier.value === 5
+          const color = top
+            ? 'var(--faction-singularity-vote-verified)'
+            : 'var(--faction-singularity-vote-reached)'
+          // Three stacked read-out lines: resolved density if reached, else churning noise.
+          const rows = [0, 1, 2].map((row) => {
+            const text = reached
+              ? DENSITY[tier.value - 1].repeat(3)
+              : scrambleGlyph(tier.value * 30 + row * 3 + 1, tick) +
+                scrambleGlyph(tier.value * 30 + row * 3 + 2, tick) +
+                scrambleGlyph(tier.value * 30 + row * 3 + 3, tick)
+            return (
+              <div key={row} style={{ lineHeight: 1 }}>
+                {text}
+              </div>
+            )
+          })
           return (
-            <div key={tier.value} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-xs)' }}>
-              <button
-                disabled={saving}
-                onClick={() => void vote(tier.value)}
-                aria-label={t('chrome.singularity.rateAria', { value: tier.value, label: tier.label })}
-                style={{
-                  position: 'relative',
-                  width: KEY_SIZE,
-                  height: KEY_SIZE,
-                  cursor: saving ? 'default' : 'pointer',
-                  padding: 0,
-                  border: 'none',
-                  background: reached ? fill : 'var(--faction-singularity-light)',
-                  color: reached ? 'var(--faction-singularity-card-bg)' : 'color-mix(in srgb, var(--faction-singularity-card-muted) 55%, transparent)',
-                  fontFamily: 'var(--font-faction-terminal)',
-                  fontWeight: 700,
-                  fontSize: 'var(--text-lg)',
-                  lineHeight: 1,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  transform: picked ? 'scale(1.12)' : 'none',
-                  transition: 'all 110ms',
-                  outline: `1px solid ${reached ? fill : 'var(--faction-singularity-border)'}`,
-                  boxShadow: reached ? `0 0 12px color-mix(in srgb, ${fill} 33%, transparent)` : 'none',
-                }}
-              >
-                {tier.value}
-              </button>
-              <span
-                style={{
-                  fontSize: 'var(--text-xs)',
-                  letterSpacing: '0.08em',
-                  color: picked ? fill : 'color-mix(in srgb, var(--faction-singularity-card-muted) 45%, transparent)',
-                  maxWidth: KEY_SIZE + 8,
-                  textAlign: 'center',
-                  lineHeight: 1.2,
-                }}
-              >
-                {tier.label}
-              </span>
-            </div>
+            <button
+              key={tier.value}
+              disabled={saving}
+              onClick={() => void vote(tier.value)}
+              onMouseEnter={() => setHovered(tier.value)}
+              aria-label={t('chrome.singularity.rateAria', { value: tier.value, label: tier.label })}
+              aria-pressed={picked}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                // ≥44px touch target; the decode column sits centred inside.
+                width: KEY_WIDTH,
+                height: KEY_HEIGHT,
+                padding: 0,
+                border: 'none',
+                borderRadius: 2,
+                fontFamily: 'var(--font-faction-terminal)',
+                fontSize: 'var(--text-lg)',
+                letterSpacing: '2px',
+                color: reached ? color : 'var(--faction-singularity-vote-scramble)',
+                textShadow: reached ? `0 0 8px ${color}` : 'none',
+                background: reached ? 'var(--faction-singularity-vote-reached-bg)' : 'transparent',
+                outline: picked ? `1px solid ${color}` : 'none',
+                outlineOffset: 2,
+                cursor: saving ? 'default' : 'pointer',
+                transition: 'color 120ms, background 120ms',
+              }}
+            >
+              {rows}
+            </button>
           )
         })}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', marginTop: 'var(--space-sm)', minHeight: 20 }}>
+        <span
+          style={{
+            fontFamily: 'var(--font-faction-terminal)',
+            fontSize: 'var(--text-content)',
+            letterSpacing: '0.08em',
+            color: active
+              ? 'var(--faction-singularity-vote-reached)'
+              : 'var(--faction-singularity-vote-off)',
+            transition: 'color 140ms',
+          }}
+        >
+          {caption}
+        </span>
+        {selected > 0 && (
+          <span
+            style={{
+              fontSize: 'var(--text-xs)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--faction-singularity-vote-off)',
+            }}
+          >
+            {`· ${t('chrome.singularity.tag')}`}
+          </span>
+        )}
       </div>
 
       <VoteSummary

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -232,6 +232,17 @@
      (Singularity is always-dark), so this one value serves both themes. */
   --faction-singularity-phosphor-dim: #7ba98a;
 
+  /* ── Singularity decode-strip vote widget (#821) ──
+     The terminal decode strip: unreached tiers scramble katakana in dim green;
+     reached tiers resolve to density glyphs in phosphor green, with the rank-5
+     "verified" tier in cyan. Terminal tokens are theme-invariant (Singularity is
+     always-dark), so these serve both themes — no [data-theme] override. */
+  --faction-singularity-vote-reached: #4ade80; /* phosphor green — resolved glyphs */
+  --faction-singularity-vote-verified: #60a5fa; /* cyan — rank 5 "verified" */
+  --faction-singularity-vote-scramble: rgba(74, 222, 128, 0.24); /* dim, unreached noise */
+  --faction-singularity-vote-reached-bg: rgba(74, 222, 128, 0.05); /* faint lit key */
+  --faction-singularity-vote-off: #3f7a58; /* idle caption ink */
+
   /* ══ Ephemerists illuminated-codex palette (the ephemerists slot) ══
      The card contract above rebinds to these. CONSTANTS (gold/rubric/
      lapis/verdigris/ink) keep their role in both themes; the VELLUM

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -90,7 +90,9 @@
     "singularity": {
       "rateAria": "Cast {{value}} — {{label}}",
       "prompt": "Cast Signal",
-      "promptHint": "how confidently does this output hold?"
+      "promptHint": "how confidently does this output hold?",
+      "idle": "no signal",
+      "tag": "locked"
     },
     "ua": {
       "rateAria": "Appraise {{value}} — {{label}}",


### PR DESCRIPTION
Part of #821 — Singularity decode-strip vote widget

Rewrites `SingularityVote.tsx` to its new metaphor: a **terminal decode strip**. The old signal-strength key ramp is replaced by five columns of a scrolling terminal read-out. Unreached tiers scramble katakana/symbol noise on a 120ms interval; each tier you reach resolves to a density glyph (`· + * # █`) in phosphor green, with rank 5 ("verified") locking to cyan. Tiers 1→5: Noise · Weak · Signal · Clear · Verified. Caption idle `no signal`, picked tag `· locked`.

Wired to the real WZ vote flow (`useVote` + `VoteShell`/`VoteSummary`), with hover + selected preview like the other #821/#830 widgets. Dispatch is unchanged (`factions/singularity.ts` already maps here).

## Notes
- **Reduced motion**: the always-on scramble is a JS interval (a decode strip standing still reads as broken, not stilled — it can't be class-gated like the CSS-animated siblings). It reads `prefers-reduced-motion` via `useSyncExternalStore` and freezes the tick when set; the strip still shows noise vs. resolved glyphs, it just stops churning.
- **Tokens**: new namespaced `--faction-singularity-vote-*` block in `index.css` (theme-invariant — Singularity is always-dark, so no `[data-theme]` override). No raw hex/font-size/spacing in the component.
- **Copy**: added `chrome.singularity.idle` / `chrome.singularity.tag` to `votes.json`; the 5 tier labels already existed. Catalog exactly-5-tiers invariant still passes.
- Shared files (`index.css`, `votes.json`) touched only in a namespaced Singularity block — expect `gh pr update-branch` at merge alongside sibling PRs.

## Verification
- `tsc --noEmit`: clean for this change (the only errors are the known #675 stale-junction `Cannot find module 'node:fs'` false alarms in unrelated test files).
- `eslint`: clean on `SingularityVote.tsx`.
- `vite build`: clean (736 modules).
- `vitest` `locales/__tests__/catalog.test.ts`: 28/28 pass.

## Visual QA — OUTSTANDING (no dev stack / cannot screenshot)
What to eyeball:
- scramble → resolve as you hover/click across ranks 1–5
- rank 5 "Verified" resolves in **cyan**, ranks 1–4 in phosphor green
- click locks (outline + `· locked` tag); click same rank clears
- light + dark modes (should look identical — terminal is always-dark)
- `prefers-reduced-motion` freezes the scramble (noise still visible, no churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)