### PR TITLE
feat(vote): Ephemerists constellation-attestation vote widget

### DIFF
--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -1,24 +1,63 @@
-import { useTranslation } from "react-i18next";
-import type { VoteUIProps } from "./VoteUI";
-import { useVote } from "./useVote";
-import { VoteLoginGate, VoteSummary } from "./VoteShell";
-import { CONCORD, toRoman } from "../cards/ephemeristsAtoms";
-import { VOTE_REFRAMES } from "./voteReframes";
+import { useState, type CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { VoteUIProps } from './VoteUI'
+import { useVote } from './useVote'
+import { VoteLoginGate, VoteSummary } from './VoteShell'
+import { VOTE_REFRAMES } from './voteReframes'
 
 /**
- * The Ephemerists vote UI — THE CONCORDANCE. The 1–5 approval becomes a
- * wax-seal ramp ("how well does the filed truth hold up?"): apocryphal → the
- * authoritative ink seal at V. Round seal buttons with a dashed inset, Cinzel
- * roman numerals, italic tier labels. Drives the shared useVote hook.
+ * The Ephemerists vote UI (#821) — THE CONSTELLATION ATTESTATION. The 1-5
+ * approval is a night-plate constellation: each reached star lights gold and a
+ * dashed gold line ties the reached stars together (apocryphal → the whitened
+ * CANONICAL star at V). Rank-5 twinkles with corner sparkles. It reframes the
+ * vote as "how well does the filed record hold up in the sky of the archive?"
+ *
+ * The plate is a fixed night surface that reads in BOTH themes (like coven's
+ * moon plate), so its inner colours do not flip through the cascade — only the
+ * caption ink does, via the already-flipping --eph-rubric/--eph-muted tokens
+ * (never a `dark ? a : b` ternary; §8). Plugs into the vote dispatcher through
+ * the shared {@link useVote} hook so cast/refetch/tally logic lives in one
+ * place. Every motion is a reduced-motion-gated CSS class (.eph-vote-star /
+ * .eph-vote-sparkle) — the stars still light and the line still connects when
+ * stilled; motion is decoration, not meaning.
  */
-const SEAL_SIZE = 42;
 
-/** Visual tokens (fill, ink) keyed by tier value — labels come from voteReframes. */
-const CONCORD_VISUALS: Record<number, { fill: string; ink: string }> = Object.fromEntries(
-  CONCORD.map((tier) => [tier.v, { fill: tier.fill, ink: tier.ink }])
-);
+/** Star anchor points on the 284×68 plate — ornament geometry, kept raw. */
+const STAR_POINTS = [
+  [24, 44],
+  [80, 18],
+  [136, 50],
+  [196, 20],
+  [256, 42],
+]
+const PLATE_W = 284
+const PLATE_H = 68
+/** Touch-target box centred on each star (WCAG ≥44px). */
+const HIT = 44
 
-const TIERS = VOTE_REFRAMES['ephemerists'].tiers;
+/** Faint background dust motes scattered across the plate — ornament, raw. */
+const DUST = [
+  [40, 12],
+  [110, 60],
+  [172, 10],
+  [232, 60],
+  [270, 16],
+  [60, 54],
+]
+/** Corner-sparkle offsets around the rank-5 star (marginLeft/Top from centre). */
+const SPARK_SPOTS = [
+  [-11, -9],
+  [12, -8],
+  [11, 12],
+  [-12, 9],
+]
+
+/** A five-point star, and a four-point twinkle spark. */
+const STAR_D = 'M12 0.5 L13 10.6 L23.5 12 L13 13.4 L12 23.5 L11 13.4 L0.5 12 L11 10.6 Z'
+const SPARK_D =
+  'M12 2c.4 4.6 1.4 6.6 6 7-4.6.4-5.6 2.4-6 7-.4-4.6-1.4-6.6-6-7 4.6-.4 5.6-2.4 6-7z'
+
+const TIERS = VOTE_REFRAMES['ephemerists'].tiers
 
 export default function EphemeristsVote({
   praxisId,
@@ -26,82 +65,198 @@ export default function EphemeristsVote({
   points,
   totalVotes,
 }: VoteUIProps) {
-  const { t } = useTranslation("votes");
-  const { user, selected, saving, error, vote } = useVote(praxisId, currentValue);
+  const { t } = useTranslation('votes')
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
 
   if (!user) {
-    return <VoteLoginGate />;
+    return <VoteLoginGate />
   }
+
+  const active = hovered || selected
+  const caption = active ? TIERS[active - 1].label : t('chrome.ephemerists.idle')
+  // Reached stars, in order, connected head-to-tail by the dashed gold line.
+  const linePts = STAR_POINTS.slice(0, active)
+    .map(([x, y]) => `${x},${y}`)
+    .join(' ')
 
   return (
     <div>
-      <div style={{ display: "flex", gap: "var(--space-md)", flexWrap: "wrap" }}>
-        {TIERS.map((tier) => {
-          const visual = CONCORD_VISUALS[tier.value] ?? CONCORD_VISUALS[1];
-          const filled = selected >= tier.value;
-          const active = selected === tier.value;
+      <div
+        onMouseLeave={() => setHovered(0)}
+        style={{
+          position: 'relative',
+          width: PLATE_W,
+          height: PLATE_H,
+          maxWidth: '100%',
+          background:
+            'radial-gradient(130% 160% at 50% -10%, var(--faction-ephemerists-vote-plate-from), var(--faction-ephemerists-vote-plate-to))',
+          borderRadius: 6,
+          border: '1px solid var(--faction-ephemerists-vote-plate-border)',
+          boxShadow: 'inset 0 1px 6px rgba(0, 0, 0, 0.6)',
+        }}
+      >
+        {/* Dust + the constellation line, behind the star buttons. */}
+        <svg
+          viewBox={`0 0 ${PLATE_W} ${PLATE_H}`}
+          width={PLATE_W}
+          height={PLATE_H}
+          aria-hidden
+          style={{ position: 'absolute', inset: 0, maxWidth: '100%', pointerEvents: 'none' }}
+        >
+          {DUST.map(([x, y], index) => (
+            <circle
+              key={`dust${index}`}
+              cx={x}
+              cy={y}
+              r={0.8}
+              fill="var(--faction-ephemerists-vote-dust)"
+              opacity={0.5}
+            />
+          ))}
+          {active >= 2 && (
+            <polyline
+              points={linePts}
+              fill="none"
+              stroke="var(--faction-ephemerists-vote-line)"
+              strokeWidth={1.4}
+              strokeDasharray="3 3"
+              opacity={0.9}
+              style={{ filter: 'drop-shadow(0 0 3px rgba(212, 171, 85, 0.85))' }}
+            />
+          )}
+        </svg>
+
+        {TIERS.map((tier, index) => {
+          const [x, y] = STAR_POINTS[index]
+          const reached = active >= tier.value
+          const picked = selected === tier.value
+          const top = tier.value === 5
+          const size = top ? 28 : 21
+          const twinkling = reached && !top
+          const buttonStyle: CSSProperties = {
+            position: 'absolute',
+            left: x - HIT / 2,
+            top: y - HIT / 2,
+            width: HIT,
+            height: HIT,
+            border: 'none',
+            background: 'transparent',
+            padding: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: saving ? 'default' : 'pointer',
+            transform: picked ? 'scale(1.18)' : 'none',
+            transition: 'transform 150ms',
+            ['--tw-delay' as string]: `${index * 0.4}s`,
+          }
           return (
-            <div key={tier.value} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--space-xs)" }}>
-              <button
-                disabled={saving}
-                onClick={() => void vote(tier.value)}
-                aria-label={t("chrome.ephemerists.rateAria", { value: tier.value, label: tier.label })}
+            <button
+              key={tier.value}
+              disabled={saving}
+              onClick={() => void vote(tier.value)}
+              onMouseEnter={() => setHovered(tier.value)}
+              aria-label={t('chrome.ephemerists.rateAria', { value: tier.value, label: tier.label })}
+              aria-pressed={picked}
+              className={twinkling ? 'eph-vote-star' : undefined}
+              style={buttonStyle}
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width={size}
+                height={size}
                 style={{
-                  position: "relative",
-                  width: SEAL_SIZE,
-                  height: SEAL_SIZE,
-                  cursor: saving ? "default" : "pointer",
-                  padding: 0,
-                  borderRadius: "50%",
-                  border: "2px solid var(--eph-ink)",
-                  background: filled ? visual.fill : "var(--eph-vellum)",
-                  color: filled ? visual.ink : "var(--eph-muted)",
-                  fontFamily: "var(--eph-display)",
-                  fontWeight: 700,
-                  fontSize: SEAL_SIZE * 0.34,
-                  lineHeight: 1,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  transform: active ? "rotate(-5deg) scale(1.09)" : "none",
-                  transition: "all 110ms",
-                  boxShadow: filled
-                    ? "inset 0 -2px 4px rgba(0,0,0,0.3), inset 0 2px 3px rgba(255,255,255,0.18)"
-                    : "none",
+                  overflow: 'visible',
+                  filter: reached ? 'drop-shadow(0 0 5px rgba(240, 211, 120, 0.95))' : 'none',
                 }}
               >
-                <span
-                  style={{
-                    position: "absolute",
-                    inset: 3,
-                    borderRadius: "50%",
-                    border: `1px dashed ${
-                      filled
-                        ? "color-mix(in srgb, #fff 40%, transparent)"
-                        : "color-mix(in srgb, var(--eph-vellum-text) 28%, transparent)"
-                    }`,
-                    pointerEvents: "none",
-                  }}
+                <path
+                  d={STAR_D}
+                  fill={
+                    reached
+                      ? top
+                        ? 'var(--faction-ephemerists-vote-star-top)'
+                        : 'var(--faction-ephemerists-vote-star-on)'
+                      : 'var(--faction-ephemerists-vote-star-off)'
+                  }
+                  opacity={reached ? 1 : 0.85}
                 />
-                {toRoman(tier.value)}
-              </button>
-              <span
-                style={{
-                  fontFamily: "var(--eph-serif)",
-                  fontSize: "var(--text-xs)",
-                  fontStyle: "italic",
-                  letterSpacing: "0.02em",
-                  color: active ? "var(--eph-rubric)" : "var(--eph-muted)",
-                  maxWidth: SEAL_SIZE + 12,
-                  textAlign: "center",
-                  lineHeight: 1.2,
-                }}
-              >
-                {tier.label}
-              </span>
-            </div>
-          );
+                <circle
+                  cx={12}
+                  cy={12}
+                  r={reached ? (top ? 2.4 : 1.9) : 1.4}
+                  fill={
+                    reached
+                      ? top
+                        ? 'var(--faction-ephemerists-vote-core-top)'
+                        : 'var(--faction-ephemerists-vote-core-on)'
+                      : 'var(--faction-ephemerists-vote-core-off)'
+                  }
+                />
+              </svg>
+              {reached &&
+                top &&
+                SPARK_SPOTS.map(([mx, my], sparkIndex) => (
+                  <span
+                    key={`sp${sparkIndex}`}
+                    aria-hidden
+                    className="eph-vote-sparkle"
+                    style={{
+                      position: 'absolute',
+                      left: '50%',
+                      top: '50%',
+                      width: 9,
+                      height: 9,
+                      marginLeft: mx,
+                      marginTop: my,
+                      pointerEvents: 'none',
+                      ['--tw-delay' as string]: `${sparkIndex * 0.2}s`,
+                    }}
+                  >
+                    <svg viewBox="0 0 24 24" width="100%" height="100%">
+                      <path d={SPARK_D} fill="var(--faction-ephemerists-vote-spark)" />
+                    </svg>
+                  </span>
+                ))}
+            </button>
+          )
         })}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          marginTop: 'var(--space-sm)',
+          minHeight: 20,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--eph-serif)',
+            fontStyle: 'italic',
+            fontSize: 'var(--text-content)',
+            letterSpacing: '0.02em',
+            color: active ? 'var(--eph-rubric)' : 'var(--eph-muted)',
+            transition: 'color 140ms',
+          }}
+        >
+          {caption}
+        </span>
+        {selected > 0 && (
+          <span
+            style={{
+              fontSize: 'var(--text-xs)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--eph-muted)',
+            }}
+          >
+            {`· ${t('chrome.ephemerists.tag')}`}
+          </span>
+        )}
       </div>
 
       <VoteSummary
@@ -110,13 +265,13 @@ export default function EphemeristsVote({
         totalVotes={totalVotes}
         error={error}
         theme={{
-          muted: "var(--eph-muted)",
-          accent: "var(--eph-rubric)",
-          accentFont: "var(--eph-display)",
-          errorColor: "var(--eph-rubric)",
-          avgLetterSpacing: "0.02em",
+          muted: 'var(--eph-muted)',
+          accent: 'var(--eph-rubric)',
+          accentFont: 'var(--eph-display)',
+          errorColor: 'var(--eph-rubric)',
+          avgLetterSpacing: '0.02em',
         }}
       />
     </div>
-  );
+  )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -344,6 +344,24 @@
   --faction-wow-vote-on: #a9700a;
   --faction-wow-vote-off: #b79a52;
 
+  /* Ephemerists — constellation-attestation vote plate (#821). A night sky read
+     in BOTH themes (the plate is a fixed dark surface like coven's moon plate),
+     so these stay constant across the cascade; only the caption ink (--eph-*)
+     flips. Reached stars light gold, the rank-5 star whitens, a dashed gold line
+     ties the reached stars together. */
+  --faction-ephemerists-vote-plate-from: #1c2e40;
+  --faction-ephemerists-vote-plate-to: #0a121c;
+  --faction-ephemerists-vote-plate-border: #122b3d;
+  --faction-ephemerists-vote-dust: #5a6b7d;
+  --faction-ephemerists-vote-line: #d4ab55; /* dashed gold constellation line */
+  --faction-ephemerists-vote-star-on: #d4ab55; /* reached star (tiers I–IV) */
+  --faction-ephemerists-vote-star-top: #fff4cf; /* reached rank-5 (canonical) star */
+  --faction-ephemerists-vote-star-off: #3a4655; /* unreached star */
+  --faction-ephemerists-vote-core-on: #fff1c8; /* reached star core */
+  --faction-ephemerists-vote-core-top: #ffffff; /* rank-5 star core */
+  --faction-ephemerists-vote-core-off: #556374; /* unreached star core */
+  --faction-ephemerists-vote-spark: #fff4cf; /* rank-5 corner sparkles */
+
   /* ══ Everymen — the rainbow's missing red (union/WW2 poster) ══
      Constants (cream/gold/ink) keep their role in both themes; the paper
      surface + its text FLIP in dark; accent red stays vivid; field is the
@@ -1445,6 +1463,15 @@
 @media (prefers-reduced-motion: no-preference) {
   .coven-moon-sparkle { animation: coven-twinkle 1.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
   .coven-moon-dust { animation: eph-twinkle 3.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
+}
+
+/* Ephemerists — constellation plate: reached stars (tiers I–IV) breathe on the
+   opacity `eph-twinkle`; the rank-5 star's four corner sparkles twinkle on the
+   shared scale/rotate `coven-twinkle`. Reached stars still light and the gold
+   line still connects them when stilled — motion is decoration, not meaning. */
+@media (prefers-reduced-motion: no-preference) {
+  .eph-vote-star { animation: eph-twinkle 3s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
+  .eph-vote-sparkle { animation: coven-twinkle 1.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
 }
 
 /* S.N.I.D.E. — amp/EQ meter: at rank 5 the lit segments jump like a party VU. */

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -67,7 +67,9 @@
       "rateAria": "Rate {{value}} of 5"
     },
     "ephemerists": {
-      "rateAria": "Mark {{value}} — {{label}}"
+      "rateAria": "Mark {{value}} — {{label}}",
+      "idle": "attest the record",
+      "tag": "sealed"
     },
     "everymen": {
       "rateAria": "Rate {{value}} — {{label}}"


### PR DESCRIPTION
Part of #821 — Ephemerists constellation vote widget

Rewrites `EphemeristsVote` from the wax-seal *concordance* to the new **constellation attestation** metaphor. The 1–5 approval is a night-plate of five stars: reached stars light gold and a dashed gold line ties them together (apocryphal → the whitened **canonical** star at V), and the rank-5 star twinkles with corner sparkles. Tiers unchanged: apocryphal · disputed · plausible · corroborated · canonical.

Only the visual differs — the WZ vote plumbing is copied exactly from the merged sibling widgets (`UnaffiliatedVote`/`WowVote`/`CovenVote`): consumes `VoteUIProps`, drives the shared `useVote` hook, wraps in `VoteShell` (`VoteLoginGate` + `VoteSummary`). Manifest dispatch (`ephemerists.ts` → `vote: EphemeristsVote`) is untouched.

## Changes
- `frontend/src/components/vote/EphemeristsVote.tsx` — full rewrite to the constellation.
- `frontend/src/index.css` — new namespaced `--faction-ephemerists-vote-*` night-plate tokens (constant in both themes, like coven's moon plate) + reduced-motion-gated `.eph-vote-star` (reached-star twinkle, `eph-twinkle`) and `.eph-vote-sparkle` (rank-5 corner sparkles, shared `coven-twinkle`) classes.
- `frontend/src/locales/en/votes.json` — `chrome.ephemerists.idle` (`attest the record`) + `chrome.ephemerists.tag` (`sealed`). Tier labels already existed under `ephemerists.*`.

## Conventions
- No raw hex / font-size / spacing on style properties — colours are namespaced tokens, sizes off `--text-*`, spacing off `--space-*`. Caption is EB Garamond italic via `--eph-serif`; caption ink flips through the `[data-theme="dark"]` cascade via `--eph-rubric`/`--eph-muted` — no `dark ? a : b` ternary, no `useTheme` needed.
- No inline `animation:` — motion is class-gated on `prefers-reduced-motion`; stilled, the stars still light and the line still connects (motion is decoration, not meaning).
- ≥44px hit targets centred on each star.

## What to eyeball (visual QA OUTSTANDING — no dev stack)
- Stars light and the dashed gold line connects across ranks 1→5 as you hover/select.
- Rank-5 (canonical) star whitens + corner sparkles twinkle; reached tiers I–IV breathe.
- Hover previews up to a rank; click locks (`· sealed` tag); click again clears; mouse-leave drops the hover.
- Light **and** dark: the night plate stays constant; only the caption ink shifts.
- `prefers-reduced-motion`: the twinkle stills but stars/line still render.

## Verification
- `tsc --noEmit` — clean (only the known stale-junction `node:*` false alarms in test files, hazard #2; none in changed files).
- `eslint src/components/vote/EphemeristsVote.tsx` — 0 problems.
- `vite build` — ✓ built.
- `vitest run src/locales/__tests__/catalog.test.ts` — 28 passed (exactly-5-tiers + no-duplicate-keys invariants hold).

## Shared-file note
`index.css` and `votes.json` additions are in a clearly-namespaced Ephemerists block; expect a `gh pr update-branch` at merge alongside the sibling vote PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)