### PR TITLE
Everymen gearworks vote widget

### DIFF
--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -1,3 +1,4 @@
+import { useState, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
@@ -5,100 +6,211 @@ import { VoteLoginGate, VoteSummary } from './VoteShell'
 import { VOTE_REFRAMES } from './voteReframes'
 
 /**
- * Everymen faction vote UI — union "approval stamps" with an escalating
- * ink ramp (gold → red → the authoritative black seal at 5). Square stamp
- * buttons with a 2px border and a dashed inset on the active stamp, Bebas
- * Neue numerals, tiny uppercase labels, and an average display below.
+ * Everymen vote UI (#821) — THE GEARWORKS. The 1-5 rating is a row of gears on
+ * the union workbench: reach up the scale and each reached gear heats along a
+ * cold → ember ramp (its hub staying pale) and begins to turn — odd tiers
+ * clockwise, even counter-clockwise — while unreached gears sit as cold
+ * edge-only outlines. Hit LEGENDARY (rank 5) and the top gear throws sparks.
+ * Replaces the retired approval-stamp drawer.
  *
  * Plugs into the vote dispatcher via the shared {@link useVote} hook so the
- * cast/refetch logic lives in exactly one place.
+ * cast/refetch logic lives in exactly one place. All colour flips light/dark
+ * through the [data-theme] cascade (the edge tone and the rank-5 glow), never a
+ * `dark` ternary in TS. Every motion is a reduced-motion-gated CSS class (never
+ * an inline `animation:`); stilled, the gears keep their heat/glow — which is
+ * what carries the rank — and the sparks stay hidden.
  */
 
-/** Visual tokens per tier value — labels come from voteReframes. */
-const STAMP_VISUALS: Record<number, { fill: string; ink: string }> = {
-  1: { fill: 'var(--everymen-gold)',      ink: 'var(--everymen-ink)' },
-  2: { fill: 'var(--everymen-gold-deep)', ink: 'var(--everymen-cream)' },
-  3: { fill: 'var(--everymen-red)',       ink: 'var(--everymen-cream)' },
-  4: { fill: 'var(--everymen-red-deep)',  ink: 'var(--everymen-cream)' },
-  5: { fill: 'var(--everymen-ink)',       ink: 'var(--everymen-gold)' },
-}
+/** Heat ramp + pale hub, one token per tier (cold slate → ember). */
+const GEAR_HEAT = [1, 2, 3, 4, 5].map((v) => `var(--faction-everymen-vote-heat-${v})`)
+const GEAR_HUB = [1, 2, 3, 4, 5].map((v) => `var(--faction-everymen-vote-hub-${v})`)
+/** Glow filter per tier (tier 1 gets none); the rank-5 entry flips in the dark cascade. */
+const GEAR_GLOW = ['none', ...[2, 3, 4, 5].map((v) => `var(--faction-everymen-vote-glow-${v})`)]
 
-const STAMP_SIZE = 40
+/** Per-tier gear diameter (px) — ornament geometry, kept raw. */
+const GEAR_SIZES = [32, 35, 37, 40, 42]
+
+/** Rank-5 spark trajectories [dx, dy] (px) — ornament geometry, kept raw. */
+const SPARK_DIRS: [number, number][] = [
+  [-16, -20],
+  [14, -22],
+  [20, -6],
+  [-20, -8],
+  [6, -26],
+  [-8, -24],
+]
 
 const TIERS = VOTE_REFRAMES['everymen'].tiers
+
+/** Eight gear teeth — filled (reached) or a thin edge outline (unreached). */
+function teeth(fill: string, stroke: string | undefined) {
+  return [0, 1, 2, 3, 4, 5, 6, 7].map((k) => (
+    <rect
+      key={k}
+      x={10.9}
+      y={1.4}
+      width={2.2}
+      height={3.8}
+      rx={0.5}
+      transform={`rotate(${k * 45} 12 12)`}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={stroke ? 0.8 : undefined}
+    />
+  ))
+}
 
 export default function EverymenVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
 
   if (!user) {
     return <VoteLoginGate />
   }
 
+  const active = hovered || selected
+  const caption = active ? TIERS[active - 1].label : t('chrome.everymen.idle')
+  const edge = 'var(--faction-everymen-vote-edge)'
+
   return (
     <div>
-      <div style={{ display: 'flex', gap: 'var(--space-sm)' }}>
-        {TIERS.map((tier) => {
-          const visual = STAMP_VISUALS[tier.value] ?? STAMP_VISUALS[1]
-          const filled = selected >= tier.value
-          const active = selected === tier.value
+      <div
+        onMouseLeave={() => setHovered(0)}
+        style={{ display: 'flex', gap: 'var(--space-xs)', alignItems: 'center' }}
+      >
+        {TIERS.map((tier, index) => {
+          const reached = active >= tier.value
+          const picked = selected === tier.value
+          const top = tier.value === 5
+          const size = GEAR_SIZES[index]
+          const heat = GEAR_HEAT[index]
+
+          const gearStyle: CSSProperties = {
+            transformOrigin: 'center',
+            filter: reached ? GEAR_GLOW[index] : 'none',
+            ['--ev-gear-dur' as string]: `${2.6 + tier.value * 0.4}s`,
+          }
+          const gearClass = reached
+            ? tier.value % 2 === 1
+              ? 'ev-gear--cw'
+              : 'ev-gear--ccw'
+            : undefined
+
           return (
-            <div
+            <button
               key={tier.value}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-xs)' }}
+              disabled={saving}
+              onClick={() => void vote(tier.value)}
+              onMouseEnter={() => setHovered(tier.value)}
+              aria-label={t('chrome.everymen.rateAria', { value: tier.value, label: tier.label })}
+              aria-pressed={picked}
+              style={{
+                position: 'relative',
+                border: 'none',
+                background: 'transparent',
+                padding: 0,
+                // ≥44px touch target (WCAG); the gear floats centred inside.
+                minWidth: 44,
+                minHeight: 44,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: saving ? 'default' : 'pointer',
+                transform: picked ? 'scale(1.12)' : 'none',
+                transition: 'transform 140ms',
+              }}
             >
-              <button
-                disabled={saving}
-                onClick={() => void vote(tier.value)}
-                aria-label={t('chrome.everymen.rateAria', { value: tier.value, label: tier.label })}
-                style={{
-                  position: 'relative',
-                  width: STAMP_SIZE,
-                  height: STAMP_SIZE,
-                  cursor: saving ? 'default' : 'pointer',
-                  padding: 0,
-                  border: '2px solid var(--everymen-ink)',
-                  borderRadius: 0,
-                  background: filled ? visual.fill : 'var(--everymen-paper)',
-                  color: filled ? visual.ink : 'var(--everymen-ink)',
-                  fontFamily: 'var(--faction-everymen-card-font)',
-                  fontSize: STAMP_SIZE * 0.5,
-                  lineHeight: 1,
-                  transform: active ? 'rotate(-4deg) scale(1.08)' : 'none',
-                  transition: 'all 110ms',
-                } as React.CSSProperties}
+              <svg
+                viewBox="0 0 24 24"
+                width={size}
+                height={size}
+                className={gearClass}
+                style={gearStyle}
+                aria-hidden
               >
-                <span
-                  style={{
-                    position: 'absolute',
-                    inset: 3,
-                    border: `1px dashed ${
-                      filled
-                        ? 'rgba(255,255,255,0.4)'
-                        : 'color-mix(in srgb, var(--everymen-ink) 30%, transparent)'
-                    }`,
-                    pointerEvents: 'none',
-                  }}
+                {reached ? teeth(heat, undefined) : teeth('none', edge)}
+                <circle
+                  cx={12}
+                  cy={12}
+                  r={7}
+                  fill={reached ? heat : 'none'}
+                  stroke={reached ? undefined : edge}
+                  strokeWidth={reached ? undefined : 1}
                 />
-                {tier.value}
-              </button>
-              <span
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  fontSize: 'var(--text-xs)',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.04em',
-                  color: active ? 'var(--everymen-red)' : 'var(--everymen-muted)',
-                  maxWidth: STAMP_SIZE + 8,
-                  textAlign: 'center',
-                  lineHeight: 1.2,
-                }}
-              >
-                {tier.label}
-              </span>
-            </div>
+                <circle
+                  cx={12}
+                  cy={12}
+                  r={2.5}
+                  fill={reached ? GEAR_HUB[index] : 'none'}
+                  stroke={reached ? undefined : edge}
+                  strokeWidth={reached ? undefined : 1}
+                />
+              </svg>
+
+              {reached &&
+                top &&
+                SPARK_DIRS.map((d, i) => {
+                  const sparkSize = i % 2 === 1 ? 3 : 2
+                  const sparkStyle: CSSProperties = {
+                    position: 'absolute',
+                    top: '22%',
+                    left: '50%',
+                    width: sparkSize,
+                    height: sparkSize,
+                    borderRadius: '50%',
+                    background:
+                      i % 2 === 1
+                        ? 'var(--faction-everymen-vote-spark-a)'
+                        : 'var(--faction-everymen-vote-spark-b)',
+                    boxShadow: '0 0 4px var(--faction-everymen-vote-spark-glow)',
+                    pointerEvents: 'none',
+                    // Hidden at rest; the keyframe fades it in only when motion is allowed.
+                    opacity: 0,
+                    ['--ev-sx' as string]: `${d[0]}px`,
+                    ['--ev-sy' as string]: `${d[1]}px`,
+                    ['--ev-spark-dur' as string]: `${1 + i * 0.15}s`,
+                    ['--ev-spark-delay' as string]: `${i * 0.22}s`,
+                  }
+                  return <span key={i} aria-hidden className="ev-gear-spark" style={sparkStyle} />
+                })}
+            </button>
           )
         })}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          marginTop: 'var(--space-sm)',
+          minHeight: 20,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--faction-everymen-card-font)',
+            fontSize: 'var(--text-content)',
+            letterSpacing: '0.06em',
+            color: active ? 'var(--everymen-red)' : 'var(--everymen-muted)',
+            transition: 'color 140ms',
+          }}
+        >
+          {caption}
+        </span>
+        {selected > 0 && (
+          <span
+            style={{
+              fontSize: 'var(--text-xs)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--everymen-muted)',
+            }}
+          >
+            {`· ${t('chrome.everymen.tag')}`}
+          </span>
+        )}
       </div>
 
       <VoteSummary
@@ -111,7 +223,7 @@ export default function EverymenVote({ praxisId, currentValue, points, totalVote
           accent: 'var(--everymen-red)',
           accentFont: 'var(--faction-everymen-card-font)',
           errorColor: 'var(--everymen-red)',
-          avgLetterSpacing: '0.04em',
+          avgLetterSpacing: '0.06em',
         }}
       />
     </div>

--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -21,11 +21,32 @@ import { VOTE_REFRAMES } from './voteReframes'
  * what carries the rank — and the sparks stay hidden.
  */
 
+// Full literal var() strings, one per tier — NOT built by template literal:
+// the #806 factionTokensDeclared guard scans for literal `var(--faction-*)` and
+// a `...-heat-${v}` construction reads as the undeclared bare prefix `...-heat-`.
 /** Heat ramp + pale hub, one token per tier (cold slate → ember). */
-const GEAR_HEAT = [1, 2, 3, 4, 5].map((v) => `var(--faction-everymen-vote-heat-${v})`)
-const GEAR_HUB = [1, 2, 3, 4, 5].map((v) => `var(--faction-everymen-vote-hub-${v})`)
+const GEAR_HEAT = [
+  'var(--faction-everymen-vote-heat-1)',
+  'var(--faction-everymen-vote-heat-2)',
+  'var(--faction-everymen-vote-heat-3)',
+  'var(--faction-everymen-vote-heat-4)',
+  'var(--faction-everymen-vote-heat-5)',
+]
+const GEAR_HUB = [
+  'var(--faction-everymen-vote-hub-1)',
+  'var(--faction-everymen-vote-hub-2)',
+  'var(--faction-everymen-vote-hub-3)',
+  'var(--faction-everymen-vote-hub-4)',
+  'var(--faction-everymen-vote-hub-5)',
+]
 /** Glow filter per tier (tier 1 gets none); the rank-5 entry flips in the dark cascade. */
-const GEAR_GLOW = ['none', ...[2, 3, 4, 5].map((v) => `var(--faction-everymen-vote-glow-${v})`)]
+const GEAR_GLOW = [
+  'none',
+  'var(--faction-everymen-vote-glow-2)',
+  'var(--faction-everymen-vote-glow-3)',
+  'var(--faction-everymen-vote-glow-4)',
+  'var(--faction-everymen-vote-glow-5)',
+]
 
 /** Per-tier gear diameter (px) — ornament geometry, kept raw. */
 const GEAR_SIZES = [32, 35, 37, 40, 42]

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -31,7 +31,7 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
   },
   everymen: {
     tiers: [
-      { value: 1, label: i18n.t('votes:everymen.a-start') },
+      { value: 1, label: i18n.t('votes:everymen.fair') },
       { value: 2, label: i18n.t('votes:everymen.solid') },
       { value: 3, label: i18n.t('votes:everymen.good') },
       { value: 4, label: i18n.t('votes:everymen.excellent') },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -370,6 +370,27 @@
   --faction-everymen-card-muted: var(--everymen-muted);
   --faction-everymen-card-font: var(--font-accent); /* Bebas Neue */
 
+  /* ── Gearworks vote widget (#821) — reached gears heat a cold→ember ramp with
+     pale hubs; unreached gears are edge-only outlines; rank 5 throws sparks. The
+     edge + rank-5 glow flip in the dark cascade (see the dark block). ── */
+  --faction-everymen-vote-heat-1: #6e747e;
+  --faction-everymen-vote-heat-2: #9c7d4a;
+  --faction-everymen-vote-heat-3: #c8842a;
+  --faction-everymen-vote-heat-4: #eb5f14;
+  --faction-everymen-vote-heat-5: #ffcf6e;
+  --faction-everymen-vote-hub-1: #f4ecd6;
+  --faction-everymen-vote-hub-2: #f4ecd6;
+  --faction-everymen-vote-hub-3: #fbe6c2;
+  --faction-everymen-vote-hub-4: #ffe6b0;
+  --faction-everymen-vote-hub-5: #fff3c8;
+  --faction-everymen-vote-edge: #c9b58f;
+  --faction-everymen-vote-spark-a: #ffe08a;
+  --faction-everymen-vote-spark-b: #ff9838;
+  --faction-everymen-vote-spark-glow: #ffb347;
+  --faction-everymen-vote-glow-2: drop-shadow(0 0 2px rgba(180, 120, 40, 0.5));
+  --faction-everymen-vote-glow-3: drop-shadow(0 0 4px rgba(210, 132, 42, 0.7));
+  --faction-everymen-vote-glow-4: drop-shadow(0 0 6px rgba(235, 95, 20, 0.8));
+  --faction-everymen-vote-glow-5: drop-shadow(0 1px 1px rgba(120, 60, 10, 0.55)) drop-shadow(0 0 7px rgba(235, 120, 20, 0.85));
 
   /* ── Vote stamp colors (orange → yellow → green → blue → magenta) ── */
   --vote-1: #c2410c;
@@ -725,6 +746,10 @@
   --everymen-muted: #b6a079;
   --everymen-field: #3c1416;
   --everymen-field-deep: #5a1d20;
+  /* Gearworks: cooler edge for cold gears, a brighter single-halo rank-5 glow on
+     the dark paper (the light double-drop-shadow would muddy against it). */
+  --faction-everymen-vote-edge: #8a7856;
+  --faction-everymen-vote-glow-5: drop-shadow(0 0 9px rgba(255, 175, 60, 0.95));
 }
 
 /* ══ Everymen poster-wall backdrop (faction-context pages; theme-aware) ══ */
@@ -1461,6 +1486,20 @@
   .wow-balloon-float { animation: wow-bounce 2.2s ease-in-out infinite; animation-delay: var(--tw-delay, 0s); }
   .wow-balloon-cheer { animation: wow-group-bounce 1.05s ease-in-out infinite; }
   .wow-balloon-eye { transform-box: fill-box; transform-origin: center; animation: wow-eye-wiggle 1.4s ease-in-out infinite; }
+}
+
+/* Everymen — gearworks: reached gears turn (odd tiers clockwise, even counter),
+   rank-5 sparks fly outward. Per-gear duration (--ev-gear-dur) and per-spark
+   travel/tempo (--ev-sx/--ev-sy/--ev-spark-dur/--ev-spark-delay) arrive as inline
+   custom properties. Class-gated on reduced-motion: stilled, the gears keep their
+   heat/glow (that carries the rank) and the sparks stay hidden (opacity:0 inline). */
+@keyframes ev-gear-cw { to { transform: rotate(360deg); } }
+@keyframes ev-gear-ccw { to { transform: rotate(-360deg); } }
+@keyframes ev-gear-spark { 0% { opacity: 0; transform: translate(0, 0) scale(1); } 10% { opacity: 1; } 100% { opacity: 0; transform: translate(var(--ev-sx, 0), var(--ev-sy, 0)) scale(0.3); } }
+@media (prefers-reduced-motion: no-preference) {
+  .ev-gear--cw { transform-origin: center; animation: ev-gear-cw var(--ev-gear-dur, 3s) linear infinite; }
+  .ev-gear--ccw { transform-origin: center; animation: ev-gear-ccw var(--ev-gear-dur, 3s) linear infinite; }
+  .ev-gear-spark { animation: ev-gear-spark var(--ev-spark-dur, 1s) ease-out infinite; animation-delay: var(--ev-spark-delay, 0s); }
 }
 
 /* Albescent — the secret-society tell (#821, ADR-0048): the na spectrum card

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -125,7 +125,7 @@ describe('i18next runtime', () => {
   })
 
   it('resolves kebab-case keys for multi-word labels', () => {
-    expect(i18n.t('votes:everymen.a-start')).toBe('a start')
+    expect(i18n.t('votes:coven.a-start')).toBe('a start')
     expect(i18n.t('votes:snide.not-bad')).toBe('not bad')
   })
 

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -7,7 +7,7 @@
     "canonical": "canonical"
   },
   "everymen": {
-    "a-start": "a start",
+    "fair": "fair",
     "solid": "solid",
     "good": "good",
     "excellent": "excellent",
@@ -70,7 +70,9 @@
       "rateAria": "Mark {{value}} — {{label}}"
     },
     "everymen": {
-      "rateAria": "Rate {{value}} — {{label}}"
+      "rateAria": "Rate {{value}} — {{label}}",
+      "idle": "awaiting",
+      "tag": "earned"
     },
     "coven": {
       "rateAria": "Rate {{value}} — {{label}}",


### PR DESCRIPTION
Part of #821 — Everymen gearworks vote widget

Rewrites `EverymenVote` from the retired approval-stamp drawer to the **gearworks** metaphor: a row of gears on the union workbench. As you reach up the 1–5 scale, each reached gear heats along a cold→ember ramp (`#6e747e→#9c7d4a→#c8842a→#eb5f14→#ffcf6e`) with a pale hub and begins to turn — odd tiers clockwise, even counter — while unreached gears sit as cold edge-only outlines. Hit **Legendary** (rank 5) and the top gear throws sparks. Tiers 1→5: **Fair · Solid · Good · Excellent · Legendary**; caption idle `awaiting`, picked tag `· earned`. Bebas Neue.

Wired to the real WZ vote flow exactly like the #820/#830 siblings: consumes `VoteUIProps`, drives the shared `useVote` hook, renders `VoteLoginGate` / `VoteSummary`. Manifest dispatch (`everymen.ts` → `EverymenVote`) unchanged. Touch targets ≥44px.

## Changes
- `components/vote/EverymenVote.tsx` — full rewrite to the gearworks SVG widget.
- `index.css` — new namespaced `--faction-everymen-vote-*` heat/hub/edge/glow/spark tokens (light `:root` + dark block). **Edge tone and rank-5 glow flip through the `[data-theme="dark"]` cascade**, never a `dark` ternary. Reuses existing `--everymen-red`/`--everymen-muted`/`--faction-everymen-card-font` for caption/summary.
- `index.css` — reduced-motion-gated keyframe classes `ev-gear--cw` / `ev-gear--ccw` / `ev-gear-spark` (per-gear duration + per-spark travel/tempo arrive as inline custom properties; no inline `animation:`). Stilled: gears keep their heat/glow (that carries the rank) and sparks stay hidden.
- `locales/en/votes.json` — everymen tier 1 `a-start`→`fair`; add `chrome.everymen.idle` = "awaiting", `tag` = "earned".
- `components/vote/voteReframes.ts` — everymen tier 1 key → `votes:everymen.fair`.
- `locales/__tests__/catalog.test.ts` — kebab-case example repointed to `coven.a-start` (still valid) since everymen's key is now single-word.

## Repo rules
- No raw hex/font-size/spacing: all colour via `--faction-everymen-vote-*` tokens; spacing via `--space-*`; sizes via `--text-*`. Font is Bebas Neue via `--faction-everymen-card-font`.
- Dark mode via cascade only.

## Verification
- `tsc --noEmit`: no errors in any changed file (the `node:fs/url/path` warnings are the documented #675 stale-junction false alarm, all in untouched `*.test.*` files).
- `eslint .`: **exit 0** (repo-wide; `no-raw-style-values` ratchet clean).
- `vitest run catalog.test.ts`: **28/28 pass** (exactly-5-tiers invariant holds).
- `vite build`: **success**.

## What to eyeball (visual QA OUTSTANDING — no dev stack)
- Gears rotate + glow across ranks 1–5 on hover/click; direction alternates (odd CW / even CCW).
- Rank-5 gear throws sparks.
- Click locks (scale + `· earned` tag); click same rank clears.
- Light **and** dark: edge tone + rank-5 glow flip via `[data-theme]`.
- `prefers-reduced-motion`: gears sit still (heat/glow intact), sparks hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)