### PR TITLE
feat(vote): UA growing-mandala vote widget (#821)

### DIFF
--- a/frontend/src/components/__tests__/voteReframes.test.tsx
+++ b/frontend/src/components/__tests__/voteReframes.test.tsx
@@ -79,7 +79,7 @@ describe('EverymenVote renders from registry', () => {
 
 describe('reframeLabel', () => {
   it('labels a value in the task faction vocabulary', () => {
-    expect(reframeLabel('ua', 5)).toBe('masterwork')
+    expect(reframeLabel('ua', 5)).toBe('radiant')
     expect(reframeLabel('snide', 1)).toBe('meh')
   })
 

--- a/frontend/src/components/vote/UaVote.tsx
+++ b/frontend/src/components/vote/UaVote.tsx
@@ -1,3 +1,4 @@
+import { useState, type CSSProperties, type ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
@@ -5,97 +6,288 @@ import { VoteLoginGate, VoteSummary } from './VoteShell'
 import { VOTE_REFRAMES } from './voteReframes'
 
 /**
- * UA (University of Asthmatics) vote UI — THE GILT SALON. The 1-5 approval is
- * cast as an acquisition/appraisal ramp: the Salon judging a filed work from a
- * polite "noted" up to the gilt "ACQUIRED" plate. Each rung is an engraved
- * museum placard on parchment, framed in old gold; the chosen rung lights up
- * in burnt amber. Always-light — the salon never dims, so every token reads
- * identically in both themes and we never touch data-theme.
+ * UA (University of Asthmatics) vote UI (#821) — THE GROWING MANDALA. The 1-5
+ * approval is cast as a mandala that blooms fuller and warmer per rank: rank 1 is
+ * a faint asterisk, and each rung adds a turning ring of petals until rank 5 is a
+ * full, breathing bloom. A lowercase "reading" word sits below — faint · forming
+ * · true · alive · radiant — the salon's verdict on the filed work. The mandala
+ * cores are punched out to the sheet colour so the figure reads as an aperture.
  *
- * Same 1-5 data model as every other faction; purely a visual reskin driven by
- * the shared {@link useVote} hook so cast/refetch logic lives in one place.
+ * UA is always-light (the salon never dims, #240), so every colour token is
+ * theme-invariant and the core punch simply tracks --faction-ua-card-bg, which
+ * is parchment in both themes — no `data-theme` branch, no `dark` ternary.
+ *
+ * Same 1-5 data model as every faction; a pure visual reskin driven by the shared
+ * {@link useVote} hook so cast/refetch/tally-override logic lives in one place.
+ * Every motion is a reduced-motion-gated CSS class (never inline `animation:`);
+ * the mandala's fullness and the reading word carry the meaning when stilled.
  */
 
-const PLATE_FONT = 'var(--faction-ua-card-font)'
+/** Per-rank fill ramp (index 1-5) — taupe → deep red as the reading warms. */
+const RANK_COLOR = [
+  '',
+  'var(--faction-ua-vote-rank-1)',
+  'var(--faction-ua-vote-rank-2)',
+  'var(--faction-ua-vote-rank-3)',
+  'var(--faction-ua-vote-rank-4)',
+  'var(--faction-ua-vote-rank-5)',
+]
+
+/** Cormorant Garamond — UA's gilt display face, already loaded for the salon. */
+const READING_FONT = 'var(--font-faction-gilt)'
 
 const TIERS = VOTE_REFRAMES['ua'].tiers
 
-export default function UaVote({
-  praxisId,
-  currentValue,
-  points,
-  totalVotes,
-}: VoteUIProps) {
+/**
+ * One tapered petal as an SVG path, growing outward from centre `c` at angle
+ * `ang`: a spine of length `len` starting at radius `r0`, `wid` wide at the base.
+ * Pure ornament geometry (§4a) — the raw numbers stay raw.
+ */
+function petalPath(c: number, ang: number, r0: number, len: number, wid: number): string {
+  const ox = Math.cos(ang)
+  const oy = Math.sin(ang)
+  const px = -oy
+  const py = ox
+  const bx = c + ox * r0
+  const by = c + oy * r0
+  const tx = c + ox * (r0 + len)
+  const ty = c + oy * (r0 + len)
+  const s1x = bx + px * wid
+  const s1y = by + py * wid
+  const s2x = bx - px * wid
+  const s2y = by - py * wid
+  const m1x = tx + px * wid * 0.32
+  const m1y = ty + py * wid * 0.32
+  const m2x = tx - px * wid * 0.32
+  const m2y = ty - py * wid * 0.32
+  return `M ${bx} ${by} Q ${s1x} ${s1y} ${m1x} ${m1y} Q ${tx} ${ty} ${m2x} ${m2y} Q ${s2x} ${s2y} ${bx} ${by} Z`
+}
+
+/** A spinning mandala ring/aster/flame group; per-group tempo via custom props. */
+function ringStyle(growDelay: number, spinDur: number, reverse: boolean): CSSProperties {
+  return {
+    ['--ua-grow-delay' as string]: `${growDelay}s`,
+    ['--ua-spin-dur' as string]: `${spinDur}s`,
+    ['--ua-spin-dir' as string]: reverse ? 'reverse' : 'normal',
+  }
+}
+
+/**
+ * Build the SVG figure for a mandala of the given rank. All ornament geometry —
+ * raw numbers are §4a-exempt; only the fill/reading colours are tokens.
+ */
+function mandalaKids(rank: number, alive: boolean): ReactElement[] {
+  const size = 22 + rank * 4
+  const c = size / 2
+  const maxR = c * 0.84
+  const col = RANK_COLOR[rank]
+  const deep = RANK_COLOR[Math.min(5, rank + 1)]
+  const kids: ReactElement[] = []
+
+  // rank 3+ float on a faint filled disc
+  if (rank >= 3) {
+    kids.push(<circle key="disc" cx={c} cy={c} r={c * 0.97} fill={col} opacity={0.1} />)
+  }
+
+  if (rank === 1) {
+    const spokes = 12
+    const lines: ReactElement[] = []
+    for (let j = 0; j < spokes; j++) {
+      const a = (j / spokes) * Math.PI * 2
+      lines.push(
+        <line
+          key={j}
+          x1={c + Math.cos(a) * 2.6}
+          y1={c + Math.sin(a) * 2.6}
+          x2={c + Math.cos(a) * (maxR * 0.92)}
+          y2={c + Math.sin(a) * (maxR * 0.92)}
+          stroke={col}
+          strokeWidth={1.1}
+          strokeLinecap="round"
+          opacity={0.85}
+        />,
+      )
+    }
+    kids.push(
+      <g key="aster" className="ua-mandala-ring" style={ringStyle(0, 42, false)}>
+        {lines}
+      </g>,
+    )
+    kids.push(<circle key="cd" cx={c} cy={c} r={2.4} fill={RANK_COLOR[5]} />)
+  } else {
+    const rings = rank - 1
+    for (let ring = 1; ring <= rings; ring++) {
+      const outer = ring === rings
+      const pet = outer ? 6 + rank * 2 : 7 + ring * 3
+      const rEnd = (ring / rings) * maxR
+      const r0 = ((ring - 1) / rings) * maxR + 1.4
+      const len = Math.max(2, (rEnd - r0) * (outer ? 1.22 : 1))
+      const wid = outer ? 1.4 : Math.max(1.1, 2.6 - ring * 0.4)
+      const fill = ring % 2 ? col : deep
+      const petals: ReactElement[] = []
+      for (let j = 0; j < pet; j++) {
+        const a = (j / pet) * Math.PI * 2 + (ring % 2 ? Math.PI / pet : 0)
+        petals.push(
+          <path key={j} d={petalPath(c, a, r0, len, wid)} fill={fill} opacity={0.5 + (ring / rings) * 0.45} />,
+        )
+      }
+      const spin = alive ? 16 - ring * 2 : 34 - ring * 4
+      kids.push(
+        <g key={`r${ring}`} className="ua-mandala-ring" style={ringStyle(ring * 0.06, spin, ring % 2 === 0)}>
+          {petals}
+        </g>,
+      )
+    }
+
+    if (rank === 5) {
+      const pet = 16
+      const flames: ReactElement[] = []
+      for (let j = 0; j < pet; j++) {
+        const a = (j / pet) * Math.PI * 2 + Math.PI / pet
+        flames.push(
+          <path key={`fl${j}`} d={petalPath(c, a, maxR * 0.5, maxR * 0.56, 1.1)} fill={RANK_COLOR[5]} opacity={0.6} />,
+        )
+      }
+      kids.push(
+        <g key="flame" className="ua-mandala-ring" style={ringStyle(0.3, 11, true)}>
+          {flames}
+        </g>,
+      )
+    }
+
+    const florets: ReactElement[] = []
+    for (let j = 0; j < 8; j++) {
+      florets.push(
+        <path
+          key={j}
+          d={petalPath(c, (j / 8) * Math.PI * 2, 0, 2.2 + Math.min(rank, 3) * 0.5, 1.1)}
+          fill={RANK_COLOR[5]}
+          opacity={0.9}
+        />,
+      )
+    }
+    kids.push(<g key="cf">{florets}</g>)
+  }
+
+  // core punched to the sheet colour — the mandala reads as an aperture
+  kids.push(
+    <circle key="core" cx={c} cy={c} r={1.1 + Math.min(rank, 3) * 0.28} fill="var(--faction-ua-vote-core)" />,
+  )
+  return kids
+}
+
+const RANKS = [1, 2, 3, 4, 5]
+
+export default function UaVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
 
   if (!user) {
     return <VoteLoginGate />
   }
 
+  const active = hovered || selected
+  const reading = active ? TIERS[active - 1].label : ''
+
   return (
     <div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-md)', alignItems: 'center' }}>
-        {TIERS.map((tier) => {
-          const active = selected === tier.value
-          const reached = selected >= tier.value
-          const top = tier.value === 5
+      <div
+        onMouseLeave={() => setHovered(0)}
+        style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'flex-start', gap: 'var(--space-md)' }}
+      >
+        {RANKS.map((rank) => {
+          const size = 22 + rank * 4
+          const emph = rank <= active
+          const bloom = active === rank
+          const alive = active === 5
+          const picked = selected === rank
           return (
-            <div
-              key={tier.value}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-xs)' }}
+            <button
+              // remount the emphasized cell so the bloom pop replays on each move
+              key={bloom ? `${rank}-a` : rank}
+              disabled={saving}
+              onClick={() => void vote(rank)}
+              onMouseEnter={() => setHovered(rank)}
+              aria-label={t('chrome.ua.rateAria', { value: rank, label: TIERS[rank - 1].label })}
+              aria-pressed={picked}
+              style={{
+                border: 'none',
+                background: 'transparent',
+                padding: 0,
+                // ≥44px touch target (WCAG); the mandala floats centred inside.
+                minWidth: 44,
+                minHeight: 44,
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'center',
+                cursor: saving ? 'default' : 'pointer',
+              }}
             >
-              <button
-                disabled={saving}
-                onClick={() => void vote(tier.value)}
-                aria-label={t('chrome.ua.rateAria', { value: tier.value, label: tier.label })}
-                style={{
-                  minWidth: 60,
-                  height: 40,
-                  padding: '0 var(--space-lg)',
-                  cursor: saving ? 'default' : 'pointer',
-                  border: active && top ? 'none' : `1px solid ${reached ? 'var(--faction-ua-card-accent)' : 'var(--ua-line)'}`,
-                  background: active
-                    ? top
-                      ? 'var(--ua-gilt)'
-                      : 'var(--faction-ua-card-accent)'
-                    : reached
-                      ? 'color-mix(in srgb, var(--faction-ua-card-accent) 12%, var(--faction-ua-card-bg))'
-                      : 'var(--faction-ua-card-bg)',
-                  color: active
-                    ? 'var(--ua-paper)'
-                    : reached
-                      ? 'var(--faction-ua-card-accent)'
-                      : 'var(--faction-ua-card-muted)',
-                  fontFamily: PLATE_FONT,
-                  fontSize: 'var(--text-lg)',
-                  letterSpacing: '0.1em',
-                  textTransform: 'uppercase',
-                  transform: active ? 'scale(1.06)' : 'none',
-                  boxShadow: active
-                    ? '0 4px 10px color-mix(in srgb, var(--ua-ink) 22%, transparent), inset 0 0 0 1px color-mix(in srgb, var(--ua-paper) 40%, transparent)'
-                    : 'none',
-                  transition: 'all 120ms',
-                }}
-              >
-                {tier.label}
-              </button>
               <span
                 style={{
-                  fontFamily: PLATE_FONT,
-                  fontSize: 'var(--text-xs)',
-                  letterSpacing: '0.14em',
-                  color: active ? 'var(--faction-ua-card-accent)' : 'var(--faction-ua-card-muted)',
-                  textTransform: 'uppercase',
+                  position: 'relative',
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  filter: emph ? 'none' : 'saturate(0.45) opacity(0.5)',
+                  transform: emph ? 'scale(1.08)' : 'scale(0.9)',
+                  transformOrigin: 'bottom center',
+                  transition: 'filter 0.28s ease, transform 0.28s ease',
                 }}
               >
-                {tier.value === 5
-                  ? t('chrome.ua.plateTopMark')
-                  : t('chrome.ua.plateNumber', { value: tier.value })}
+                <span
+                  className={alive ? 'ua-mandala-alive' : undefined}
+                  style={{
+                    position: 'relative',
+                    width: size,
+                    height: size,
+                    transformOrigin: 'center',
+                    ['--ua-twist-dur' as string]: `${2 + rank * 0.22}s`,
+                  }}
+                >
+                  {bloom && (
+                    <span
+                      className="ua-mandala-halo"
+                      style={{
+                        position: 'absolute',
+                        inset: 0,
+                        borderRadius: '50%',
+                        border: '2px solid var(--faction-ua-vote-halo)',
+                        pointerEvents: 'none',
+                        opacity: 0,
+                      }}
+                    />
+                  )}
+                  <svg
+                    className={bloom ? 'ua-mandala-bloom' : undefined}
+                    width={size}
+                    height={size}
+                    viewBox={`0 0 ${size} ${size}`}
+                    style={{ position: 'absolute', inset: 0 }}
+                  >
+                    {mandalaKids(rank, alive)}
+                  </svg>
+                </span>
               </span>
-            </div>
+            </button>
           )
         })}
+      </div>
+
+      <div
+        style={{
+          marginTop: 'var(--space-sm)',
+          minHeight: 22,
+          fontFamily: READING_FONT,
+          fontWeight: 600,
+          fontSize: 'var(--text-content)',
+          lineHeight: 1,
+          letterSpacing: '0.01em',
+          color: 'var(--faction-ua-vote-reading)',
+          textTransform: 'lowercase',
+        }}
+      >
+        {reading}
       </div>
 
       <VoteSummary
@@ -106,7 +298,7 @@ export default function UaVote({
         theme={{
           muted: 'var(--faction-ua-card-muted)',
           accent: 'var(--faction-ua-card-accent)',
-          accentFont: PLATE_FONT,
+          accentFont: 'var(--faction-ua-card-font)',
           errorColor: 'var(--ua-orange-deep)',
           avgLetterSpacing: '0.04em',
         }}

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -75,12 +75,16 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
     ],
   },
   ua: {
+    // The growing-mandala vote widget (#821): each rank is a "reading" of the
+    // filed work as the mandala blooms fuller/warmer — faint → radiant. These
+    // words are the mandala's per-rank captions AND UA's app-wide vote
+    // vocabulary (the voter-breakdown resolver reads them via reframeLabel).
     tiers: [
-      { value: 1, label: i18n.t('votes:ua.rough-sketch') },
-      { value: 2, label: i18n.t('votes:ua.study') },
-      { value: 3, label: i18n.t('votes:ua.accomplished') },
-      { value: 4, label: i18n.t('votes:ua.distinguished') },
-      { value: 5, label: i18n.t('votes:ua.masterwork') },
+      { value: 1, label: i18n.t('votes:ua.faint') },
+      { value: 2, label: i18n.t('votes:ua.forming') },
+      { value: 3, label: i18n.t('votes:ua.true') },
+      { value: 4, label: i18n.t('votes:ua.alive') },
+      { value: 5, label: i18n.t('votes:ua.radiant') },
     ],
   },
   // Albescent has no vote voice (#783). It had the "bear witness" vocabulary

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -275,6 +275,21 @@
   --ua-line-soft: #e3cb98;
   --ua-gilt: linear-gradient(135deg, #eec06a 0%, #9c6a1a 24%, #f0c878 50%, #9c6a1a 76%, #dd9322 100%);
 
+  /* ── UA growing-mandala vote widget (#821) ──
+     Per-rank fill ramp: the mandala blooms taupe→deep-red as the reading warms
+     (faint → radiant). Cores are punched to the sheet colour so the mandala
+     reads as an aperture. UA is always-light (the salon never dims, #240), so
+     these theme-invariant values need no [data-theme="dark"] override; the core
+     punch tracks --faction-ua-card-bg, which is parchment in both themes. */
+  --faction-ua-vote-rank-1: #a69c8c;
+  --faction-ua-vote-rank-2: #c0894f;
+  --faction-ua-vote-rank-3: #d2762f;
+  --faction-ua-vote-rank-4: #dd5a1e;
+  --faction-ua-vote-rank-5: #b5361a;
+  --faction-ua-vote-core: var(--faction-ua-card-bg); /* punch cores to the sheet */
+  --faction-ua-vote-halo: var(--faction-ua-vote-rank-4); /* bloom pulse ring */
+  --faction-ua-vote-reading: #b8471a; /* the lowercase reading word */
+
   /* ── Warriors of Whimsy collage scrap layers (legacy — kept for back-compat) ── */
   --faction-coven-scrap-deep: #fbcfe0;
   --faction-coven-scrap-mid: #fce7ef;
@@ -1489,6 +1504,31 @@
 }
 @media (prefers-reduced-motion: no-preference) {
   .alb-rainbow { animation: alb-drift 18s linear infinite; }
+}
+
+/* UA — growing mandala: each rank blooms a fuller mandala; the emphasized cell
+   pops (bloom), rank-5 breathes (twist), rings turn (spin) and a halo pulses out
+   on selection. Every motion is class-gated on reduced-motion so the widget
+   never writes `animation:` inline; meaning is carried by the mandala's fullness
+   and the reading word, not the motion — it reads correctly stilled. Per-cell
+   spin duration/direction/grow-delay and twist tempo arrive as custom props. */
+@keyframes ua-ring-grow { 0% { transform: scale(0.4); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
+@keyframes ua-spin { to { transform: rotate(360deg); } }
+@keyframes ua-bloom { 0% { transform: scale(0.5) rotate(-24deg); opacity: 0.3; } 55% { transform: scale(1.18) rotate(4deg); } 78% { transform: scale(0.96); } 100% { transform: scale(1) rotate(0); opacity: 1; } }
+@keyframes ua-halo-pulse { 0% { transform: scale(0.6); opacity: 0.55; } 100% { transform: scale(1.9); opacity: 0; } }
+@keyframes ua-twist { 0% { transform: rotate(-5deg) scale(1); } 50% { transform: rotate(5deg) scale(1.05); } 100% { transform: rotate(-5deg) scale(1); } }
+@media (prefers-reduced-motion: no-preference) {
+  .ua-mandala-ring {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation:
+      ua-ring-grow 0.5s var(--ua-grow-delay, 0s) both ease-out,
+      ua-spin var(--ua-spin-dur, 34s) linear infinite;
+    animation-direction: normal, var(--ua-spin-dir, normal);
+  }
+  .ua-mandala-bloom { animation: ua-bloom 0.7s cubic-bezier(0.2, 1.25, 0.35, 1) both; }
+  .ua-mandala-halo { animation: ua-halo-pulse 0.7s ease-out both; }
+  .ua-mandala-alive { animation: ua-twist var(--ua-twist-dur, 2s) ease-in-out infinite; }
 }
 
 /* FieldDesk life-card hover-lift (#274). The CredentialCard owns its own rotation;

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -134,9 +134,9 @@ describe('i18next runtime', () => {
     expect(i18n.t('votes:snide.anarchy')).toBe('ANARCHY')
   })
 
-  it('resolves the salon-critique values for UA labels', () => {
-    expect(i18n.t('votes:ua.masterwork')).toBe('masterwork')
-    expect(i18n.t('votes:ua.distinguished')).toBe('distinguished')
+  it('resolves the growing-mandala reading values for UA labels', () => {
+    expect(i18n.t('votes:ua.radiant')).toBe('radiant')
+    expect(i18n.t('votes:ua.faint')).toBe('faint')
   })
 
   it('throws on a missing key outside production', () => {

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -42,11 +42,11 @@
     "verified": "VERIFIED"
   },
   "ua": {
-    "rough-sketch": "rough sketch",
-    "study": "study",
-    "accomplished": "accomplished",
-    "distinguished": "distinguished",
-    "masterwork": "masterwork"
+    "faint": "faint",
+    "forming": "forming",
+    "true": "true",
+    "alive": "alive",
+    "radiant": "radiant"
   },
   "unaffiliated": {
     "so-so": "so-so",


### PR DESCRIPTION
Part of #821 — UA mandala vote widget

Rewrites `UaVote.tsx` from the gilt-salon appraisal ramp to the **growing mandala**: each rank (1→5) blooms a fuller, warmer mandala — a faint asterisk at rank 1, adding a turning ring of petals per rung until rank 5 is a full, breathing bloom. A lowercase *reading* word sits below (faint · forming · true · alive · radiant). Mandala cores are punched out to the sheet colour so the figure reads as an aperture. UA is always-light (the salon never dims, #240), so every token is theme-invariant and the core punch tracks `--faction-ua-card-bg` — no `data-theme` branch, no `dark` ternary.

Wired to the real WZ vote flow (`useVote` / `VoteShell` / `VoteSummary`), same 1-5 data model as every faction; dispatch (UA → `UaVote`) unchanged.

### Changes
- `UaVote.tsx` — full rewrite to the mandala; `<button>` cells with ≥44px touch targets, `aria-label`/`aria-pressed`.
- `index.css` — new namespaced `--faction-ua-vote-*` rank ramp + core/halo/reading tokens; five keyframes (`ua-ring-grow`, `ua-spin`, `ua-bloom`, `ua-halo-pulse`, `ua-twist`) with a reduced-motion-gated class block, mirroring the #830 convention (no inline `animation:`). All in a clearly-namespaced UA block for a trivial rebase against the sibling widget PRs.
- `votes.json` / `voteReframes.ts` — UA's five tier labels become the mandala readings (was rough-sketch…masterwork), keeping the exactly-5-tiers invariant.

### ⚠️ App-wide ripple to flag
The UA tier vocabulary is shared: `reframeLabel` renders it in the **voter breakdown** on UA praxis detail pages (`pages/praxisDetail/shared.tsx`). Swapping the salon words for the mandala readings changes that readout too (e.g. a 5-star UA vote now shows *radiant*, not *masterwork*). This is coherent with the #821 UA metaphor swap, but it is broader than the single widget — updated the two dependent tests (`voteReframes.test.tsx`, `catalog.test.ts`) to match. Revert-able if unintended.

### Verification (no dev stack / no screenshots here)
- `tsc --noEmit`: clean for touched files. The only errors are the known stale-junction `node:fs/url/path` false alarm (PR #675) in unrelated test files — CI resolves them.
- `eslint` (touched files): clean (0).
- `vite build`: clean (exit 0).
- `vitest`: catalog + voteReframes suites pass (41); full `src/components` suite passes (368).

**Visual QA is OUTSTANDING** — could not render/screenshot in this environment.

### What to eyeball
- UA mandala hover + click across ranks 1–5 (blooms fuller/warmer each rung).
- The reading word swaps under the row (faint → radiant); clears on mouse-leave.
- Rank 5 animates (breathing twist + spinning flame ring); halo pulses on the emphasized cell.
- Light **and** dark (UA stays parchment in both — verify the mandala cores read as the sheet).
- ≥44px touch targets on every rank; keyboard focus + `aria-pressed`.
- Voter breakdown on a UA praxis detail page now shows the reading words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)