### PR TITLE
docs: ADR-0049/0050 + design-fidelity policy for the praxis-card rebuild

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ identity + era-as-ruleset in ADR-0041 / ADR-0042.
 | User-facing frontend copy (i18n catalogs) | `frontend/src/locales/en/*.json` — editor guide: `frontend/src/locales/README.md` |
 | Testing approach | `docs/spec/SPEC-testing.md` |
 | Design intent, UX, faction archetypes | `WORLD_ZERO_STYLE.md` |
+| Building against a Claude design (fidelity rule, vendor-then-delete, what a green build misses) | `docs/agents/design-fidelity.md` |
 | CSS variables (colors, type, themes) | `frontend/src/index.css` |
 | JS faction config | `frontend/src/utils/factions.ts` |
 | Open work / issues | GitHub Issues — `gh issue list` (see `docs/agents/issue-tracker.md`) |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -270,6 +270,38 @@ computed **total** via the conditional score stamp (solo: `base × faction + vot
 side's own total with faction×duel combined). The multiplier/metatask rows appear only when
 non-identity. Merit remains the collab-card number and the submission sort key.
 
+**Score stamp** *(the pair, not one object)*:
+The praxis card's right column. It is **two** distinct things and conflating them is what
+lost every faction's signature device in #821:
+- **Score box** — the bordered pill carrying the working: `base` numeral, the coloured
+  `×0.80` multiplier chip, and `+ N from votes`. Broadly the same *shape* across factions;
+  which rows exist is decided by `scoreBreakdown()` under ADR-0047.
+- **Total mark** — the faction's own **faction mark** holding the total over a `POINTS`
+  label. Frequently not a box at all: UA's is the ensō, Everymen's a rubber-stamp roundel
+  with arced text under `mix-blend-mode: multiply`, Ephemerists' a rubric, Snide's an Anton
+  numeral with a hot-pink text-shadow, Unaffiliated's the total background-clipped to the
+  rainbow.
+Shared logic, bespoke presentation: one `scoreBreakdown()` decides *which numbers show*; each
+faction's registered `scoreStamp` surface decides *what they look like* (ADR-0049).
+_Avoid_: "the score stamp" for the score box alone; "stamp" for the total mark; assuming one
+themed component can carry both.
+
+**Faction mark**:
+A faction's signature graphic device — ensō (UA), rubber-stamp roundel (Everymen), rubric
+(Ephemerists), `✦` (WOW), `✨` (Coven). Lives as a **React SVG component** in
+`components/factionMarks/`, never as a file under `public/`: an external `.svg` behind an
+`<img>` cannot read CSS custom properties, so it would reintroduce hardcoded hex and break in
+dark mode. As a component every `fill` reads a token.
+_Avoid_: sigil (that's the existing roster/avatar surface), logo, icon, asset.
+
+**Ornament text**:
+Type that is part of a mark rather than something to read — a vote widget's tier label, a
+stamp's `POINTS`, a plate's caption. **Exempt from the content-text floor** (#623/#627) and
+takes the design's per-faction size; the floor governs body copy, descriptions and task text.
+Forcing all eight vote captions to `--text-content` is what flattened the widgets' tonal
+hierarchy in #821.
+_Avoid_: treating every string as content text; using `--text-content` inside a widget.
+
 **Metatask**:
 A flat-points **add-on to a praxis**, not a doable task — it has no praxis, no votes, no
 lifecycle of its own beyond **propose → approve → retire**. Owned by a faction

--- a/docs/adr/0049-the-score-stamp-is-a-manifest-surface.md
+++ b/docs/adr/0049-the-score-stamp-is-a-manifest-surface.md
@@ -56,11 +56,22 @@ The split between shared and bespoke is drawn at **logic vs. presentation**:
 registered `scoreStamp` renders the neutral default. `na`/unaffiliated has no
 manifest and keeps that behaviour.
 
-**Faction marks are React SVG components** under `components/factionMarks/`, not
-files under `public/`. This is forced rather than stylistic: an external `.svg`
-referenced by `<img>` cannot read CSS custom properties, so shipping the ensō as
-an asset would reintroduce hardcoded hex and make the mark un-themeable in dark
-mode. As components, every `fill` reads a token.
+**Faction marks live in `components/factionMarks/`, and the requirement is that a
+mark is tintable from a token** — never that its colour is baked in. An `<img
+src="…svg">` cannot read CSS custom properties, so the naive "just ship the SVG"
+route would reintroduce hardcoded hex and break dark mode. Two implementations
+satisfy the requirement; pick per mark:
+
+- **Inline React SVG** — for small and/or multi-colour marks. Every `fill` and
+  `stroke` reads a var. `lotus.svg` (9 KB, radial-gradient fills) goes here.
+- **`public/` asset + CSS `mask-image`**, tinted by `background-color:
+  var(--token)` — for large single-colour marks. `enso-detailed.svg` is **705 KB**
+  across 284 paths with exactly two fill values; inlining it would put three
+  quarters of a megabyte into the main JS bundle. As a mask it stays out of the
+  bundle, caches separately, and is still coloured entirely by a token.
+
+Either way `factionMarks/` is the single module that owns marks, so consumers have
+one import site and do not care which mechanism is underneath.
 
 ## Alternatives rejected
 

--- a/docs/adr/0049-the-score-stamp-is-a-manifest-surface.md
+++ b/docs/adr/0049-the-score-stamp-is-a-manifest-surface.md
@@ -1,0 +1,87 @@
+# ADR-0049 — The score stamp is a manifest surface, not a themed component
+
+**Status:** Accepted
+**Date:** 2026-07-20
+**Narrows:** **ADR-0047** (its row-selection rules survive intact; only the
+"one presentation" implication is withdrawn)
+**Relates to:** ADR-0039 (`Default*` fall-through), ADR-0050 (WOW/Coven identity),
+`docs/agents/design-fidelity.md`
+
+## Context
+
+The Faction Praxis Cards design specifies **two** objects in a card's right
+column, not one:
+
+- a **score box** — a bordered pill holding `base 12`, a coloured `×0.80` chip,
+  and an italic `+ 4 from votes`; broadly the same *shape* on every faction; and
+- a **total mark** — the faction's own signature device holding the total over a
+  `POINTS` label. UA's is the **ensō**. Everymen's is a 102px rubber-stamp
+  roundel with `★ VERIFIED ★ ON THE RECORD` arced on a `textPath` under
+  `mix-blend-mode: multiply`. Ephemerists' is a **rubric**. Snide's is an Anton
+  numeral with `text-shadow: 2px 2px 0` in hot zine pink. Unaffiliated's is the
+  total **background-clipped to the rainbow**.
+
+Issue #821 collapsed both into one phrase — "faction-styled score stamp" — and
+the implementation followed: a single `PraxisScoreStamp` called unconditionally
+by all nine archetypes, themed by four colour props, in a shape borrowed from
+Singularity (the one faction whose designed score box happened to be
+row-shaped).
+
+The result was the largest single source of drift in the redesign. The ensō, the
+roundel, the rubric, the pink-shadowed total and the rainbow-clipped total were
+all simply absent — not approximated, absent. `enso-detailed.svg` and
+`lotus.svg` shipped in the design bundle and neither string appeared anywhere in
+`frontend/`.
+
+The house rule already covering this case is in `CLAUDE.md`: *"Each faction has
+its own card archetype; don't unify."* The stamp was the exception, and the
+exception was wrong.
+
+## Decision
+
+**`scoreStamp` becomes a registered faction surface**, dispatched by slug through
+`FACTION_MANIFESTS` exactly like `praxisCard`, `vote` and the other 27.
+
+The split between shared and bespoke is drawn at **logic vs. presentation**:
+
+- **Shared, unchanged:** `scoreBreakdown(praxis)` — the pure function that
+  decides *which rows exist* under ADR-0047 (mult hidden at `×1.0` or collab,
+  meta hidden at `≤ 0`, votes always, total to one decimal). One function, one
+  test, nine consumers. This is the invariant and it stays exactly where it is.
+- **Bespoke, per faction:** everything about *what those rows look like* — the
+  numerals' face and size, the chip, the rule, the rotation, the blend mode, and
+  above all the **total mark**, which is frequently not a box at all.
+
+`Default*` fall-through applies as everywhere else (ADR-0039): a slug with no
+registered `scoreStamp` renders the neutral default. `na`/unaffiliated has no
+manifest and keeps that behaviour.
+
+**Faction marks are React SVG components** under `components/factionMarks/`, not
+files under `public/`. This is forced rather than stylistic: an external `.svg`
+referenced by `<img>` cannot read CSS custom properties, so shipping the ensō as
+an asset would reintroduce hardcoded hex and make the mark un-themeable in dark
+mode. As components, every `fill` reads a token.
+
+## Alternatives rejected
+
+- **Slot composition** — one `PraxisScoreStamp` taking `renderTotal` /
+  `renderChip` / `renderRule` slots. Rejected: the shell would have to be
+  permissive enough to host both a four-row pill and a 102px arced-text roundel
+  with a blend mode, at which point it constrains nothing and only adds a hop.
+- **A wider theme descriptor** — one component, a per-faction record of font,
+  rotation, chip shape, rule style, shadow. Rejected for the same reason, plus it
+  encodes "the ways a stamp may differ" as a closed set, and the design's answer
+  is that they differ *completely*.
+
+## Consequences
+
+- Nine small presentation files instead of one shared one, with no deduplication
+  between them. Accepted deliberately; it is the same trade the faction card
+  archetypes already make.
+- ADR-0047 is **not** superseded. Its conditional-row rules are the shared half
+  of this decision and one `scoreBreakdown` test keeps all nine honest.
+- `PraxisScoreStrip` (the invented mobile `BASE ∣ MULT ∣ VOTES ∣ TOT` strip) is
+  no longer the mobile presentation by default; a faction's stamp is
+  size-agnostic and mobile reuses it, per the design's mobile guidance.
+- Adding a faction still costs one manifest line. Adding a *mark* costs one file
+  in `factionMarks/`.

--- a/docs/adr/0050-wow-and-coven-visual-identity.md
+++ b/docs/adr/0050-wow-and-coven-visual-identity.md
@@ -1,0 +1,84 @@
+# ADR-0050 — WOW and Coven visual identity, and why the design artifacts are mislabelled
+
+**Status:** Accepted
+**Date:** 2026-07-20
+**Relates to:** #784 (Cozy Coven splits off Warriors of Whimsy), #812/#814 (WOW
+rejoins the rainbow as yellow), #821 (the praxis-card redesign), ADR-0049,
+`docs/agents/design-fidelity.md`
+
+## Context
+
+Warriors of Whimsy and Cozy Coven have swapped visual identity **twice**, and
+every design artifact we hold was authored before the second swap. The result is
+that the artifacts' filenames, section headings and sample bylines all disagree
+with what the artifacts actually depict — and #821 read a heading at face value
+and inverted the two factions across the entire praxis-card redesign.
+
+The lineage:
+
+1. The faction was originally **`gestalt`** — "gestalt.exe", a pink
+   computer-witch desktop. The design system's own token file still carries it
+   that way: `--gestalt-pink: #ec5f99`, `--gestalt-border: #f3b6d2`,
+   `--gestalt-card-bg: #fffdfa`, and — decisively —
+   **`--gestalt-moon-lit` / `--gestalt-moon-shadow`**. The moon-phase metaphor was
+   always a token of the *pink* faction.
+2. `gestalt` was renamed **Warriors of Whimsy**.
+3. **#784** split **Cozy Coven** off, giving it Warriors of Whimsy's
+   then-current gold/plum chronicle aesthetic.
+4. **#812/#814** gave Warriors of Whimsy a new identity — **yellow**, rejoining
+   the rainbow spine.
+
+Designs authored between (2) and (3) therefore label *both* identities "Warriors
+of Whimsy" — which is why the vote-stamps bundle files the gold/plum chronicle
+under "Cozy Coven", the pink card's sample byline reads "Warriors of Whimsy", and
+the two faction-kit projects carry each other's names.
+
+#821 observed the mock's *original* pairing correctly — balloons bundled with the
+chronicle, moons with the pink card — and then deliberately instructed a
+**recombine** to swap them, because it trusted the heading. Everything downstream
+inverted: the moons landed on Coven, the balloons on WOW, WOW's tier ladder
+(`…legendary`) landed on Coven, Coven's (`sweet…iconic`) landed on WOW, and an
+entirely new yellow token family was authored from nothing. No recombine was ever
+needed.
+
+## Decision
+
+**Visual identity is assigned from tokens and metaphor, never from a label.**
+
+| | **WOW** (Warriors of Whimsy) | **Coven** (Cozy Coven) |
+|---|---|---|
+| Card | cream / gold / plum chronicle | pink marker-sticker card, light **and** dark |
+| Widget | googly **balloons** | **moon phases** on a night plate |
+| Glyph | `✦` (the one place the retired `✦` survives) | `✨` |
+| Tier ladder | `…excellent · legendary` | `sweet · lovely · wonderful · magical · iconic` |
+| Caption | `Cast thy Verdict` / `thou dubbed it legendary!` | `how'd this land?` / `magical · YAY!` |
+| Register | archaic — *"for the quest"*, *"Sealed by the Court"*, *"here, an illumination"* | cozy-casual — *"all done!"*, *"Drop a happy little photo"*, *"a crew of four"* |
+
+The palettes swap back to match, and **the swap lands first**, as a standalone
+token repoint, before any card, stamp or widget work. Coven currently owns
+gold/plum across 27 registered surfaces and WOW owns 3; because every surface
+already reads `var(--faction-<slug>-*)`, moving the *values* moves all 30 through
+the cascade in one reviewable change. Doing card work first would mean building
+nine stamps against a palette assignment already known to be wrong, and flipping
+the praxis card alone would leave each faction contradicting itself site-wide.
+
+Two things the swap does **not** carry:
+
+- **The rainbow spine is a separate concern from the faction skin.** WOW's yellow
+  stop in `--faction-default-rainbow` is spectrum membership, not skin, and does
+  not move with the chronicle.
+- **Dark mode must be re-derived, not translated.** Coven's dark surfaces were
+  tuned for plum-on-black; pink does not clear the same contrast slots by
+  substitution.
+
+## Consequences
+
+- **Any future design artifact naming these factions is untrusted.** Read the
+  tokens and the metaphor — pink + moons is Coven, cream/gold/plum + balloons is
+  WOW — and correct the label in the vendored copy before dispatching work.
+- WOW graduates from three override surfaces to a full skin; `wowRendersDefault`
+  changes shape and its comment about "themed-and-partly-skinned" goes stale.
+- The tier words in `locales/en/votes.json` are currently inverted between the
+  two slugs and must swap with everything else.
+- This ADR exists mainly so the inversion cannot happen a third time. The cost of
+  the second one was a full build wave.

--- a/docs/agents/design-fidelity.md
+++ b/docs/agents/design-fidelity.md
@@ -1,0 +1,73 @@
+# Building against a design
+
+How to turn a Claude design into shipped World Zero surfaces without the design
+quietly evaporating on the way. Written after the #821 praxis-card wave, where
+the vote widgets came out near-perfect and the card chrome came out wrong — and
+the only difference between them was **which file the agent could open**.
+
+## The one rule
+
+**The design value is the default. Any deviation names itself.**
+
+House rules — the token system, the content-text floor, touch-target minimums,
+contrast — win where they genuinely conflict. They do not win by default, and
+they do not win silently. When a house rule overrides a design value, the code
+carries a one-line comment saying which rule overrode which value, and the issue
+declares the carve-out **before** the build starts.
+
+What went wrong last time was not that substitutions happened. It was that they
+were mechanical and invisible: every per-faction caption size (13/14/15/17/19/20)
+became `--text-content` (18px), every faction face was mapped onto whichever
+`--font-*` token already existed, and every design gap became the nearest
+`--space-*`. Each swap was locally defensible; together they flattened eight
+distinct widgets into one.
+
+### Known standing carve-outs
+
+- **Ornament text is exempt from the content-text floor** (#623/#627). A vote
+  widget's tier label is part of the mark, like the gear teeth or the star
+  anchors — not body copy. Take the design's size.
+- **Touch targets win, but re-solve the layout.** A 44×44 minimum is
+  non-negotiable; dropping it into a layout drawn for intrinsic sizes is not a
+  port. Ephemerists shipped 44px hit boxes on star anchors 60px apart on a 68px
+  plate — overlapping each other and overflowing the plate.
+- **Real contrast failures win.** Ship the nearest compliant value, say so in a
+  comment, and flag it for design.
+
+## Vendor, build, delete
+
+Designs are **vendored into the repo for the life of the epic and deleted by its
+last PR.** Subagents cannot reach `claude.ai` design URLs from a worktree; a
+design summarised into an issue is prose, and prose cannot carry geometry.
+
+1. **Orchestrator** pulls the bundle (`DesignSync`, or a local handoff folder)
+   and drops it under `.design-sync/<epic>/`.
+2. **Correct the labels in the vendored copy before dispatch.** Design artifacts
+   go stale against the roster — see ADR-0050, where a heading inverted two
+   factions across an entire wave. Annotate, don't assume.
+3. **Agents port from the source files**, not from the issue's description of
+   them. Where the bundle ships production-intent code, port it; do not
+   reimplement.
+4. **Every PR body lists its deviations** — what the design said, what shipped,
+   which rule forced it.
+5. **The epic's last PR removes `.design-sync/<epic>/`.**
+
+## What a green build does not prove
+
+`tsc`, `eslint` and `vitest` all passed on a praxis card with no ensō, no lotus
+watermark, two fonts that were never loaded (silently resolving to generic
+serif), one vote widget that was never built at all, and two factions wearing
+each other's identity. None of that is visible to a type checker.
+
+So visual verification is a **separate gate**, and it is split:
+
+- **Agents** verify structure — the mark renders, the font resolves to the
+  intended family, the contrast ratio clears, the tokens exist.
+- **Orchestrator** checks desktop: DOM, computed styles, resolved font families,
+  contrast. Note the tooling limits — the in-app Browser pane cannot screenshot
+  (CDP `captureScreenshot` times out), and real Chrome's `resize_window` reports
+  success without resizing.
+- **A human** does the mobile looking. Nothing in the toolchain covers it.
+
+Related: ADR-0049 (score stamp as a manifest surface), ADR-0050 (WOW/Coven
+identity), `docs/spec/SPEC-faction-ui-profile.md`.


### PR DESCRIPTION
Docs only. Lands the decisions from the praxis-card post-mortem grill so issues #837-844 have something to cite.

- **ADR-0049** — the score stamp becomes a manifest surface. The design specifies a score box AND a per-faction total mark; #821 collapsed them into one themed component, so every signature device (ensō, rubber roundel, rubric, pink-shadowed Anton total, rainbow-clipped total) was lost. Narrows ADR-0047 rather than superseding it — its row-selection rules are the shared half.
- **ADR-0050** — WOW/Coven visual identity, and why every design artifact labels them backwards (the pre-split `gestalt` lineage). Exists so the inversion cannot happen a third time.
- **docs/agents/design-fidelity.md** — design value is the default, deviations name themselves, vendor-then-delete, and what a green build does not prove.
- **CONTEXT.md** — *score box* vs *total mark* as distinct terms, plus *faction mark* and *ornament text*. The language collapsing into one word called "stamp" is how the ensō got lost.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)