### PR TITLE
style(tokens): give WOW the chronicle and Coven the pink back (#838)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -80,18 +80,29 @@ Two traps, both of which have already been sprung:
 
 The one exception is the **reveal surfaces** — the invitation letter, the sealed placeholder, the `/factions` tile — which are only ever shown to an account already revealed to the society. They read the private `--albescent-reveal-*` palette by direct reference, never through `factionCssVar`. That palette is not a theme and must not become one.
 
-### Warriors of Whimsy has a colour but no skin (#812)
+### A faction's SPINE HUE and its SKIN are two different things (#812, #814, #838)
 
-Read this next to the Albescent note above. They are the repo's two partly-registered factions, and they are partial on **different axes** — theme and skin are independent, and knowing which one a faction is missing is what tells you whether a Default-looking surface is correct or broken.
+Warriors of Whimsy is the case that proves it, and the case that got it wrong twice.
 
-Albescent has **neither**, on purpose: no theme and an all-but-empty manifest, because it is hiding. WOW has a **theme but no skin**, purely by timing: #784 moved its lo-fi pink `.exe` aesthetic wholesale to Cozy Coven, and #812 gave it back a colour — yellow — without giving it back a design. So it has the full §3 token block and `isKnownFaction('wow')` is **true** (its members get faction-coloured ornament, and it holds index 2 of `FACTION_RAINBOW_ORDER`, between UA's orange and S.N.I.D.E.'s green), while it registers **no manifest at all** (there is no `factions/wow.ts`), so every surface renders its `Default*` archetype. A WOW profile and an unaffiliated one are structurally identical and differ only in hue. That is the target state until the redesign ships, not a half-built skin.
+WOW's **spine hue is yellow**: `--faction-wow` (#e0a800 light / #f5c542 dark) and its stop in `--faction-default-rainbow`. That is its membership of the rainbow — index 2 of `FACTION_RAINBOW_ORDER`, between UA's orange and S.N.I.D.E.'s green — and it is why `isKnownFaction('wow')` is true and its members get faction-coloured ornament.
 
-Two consequences worth stating, because both look like omissions:
+WOW's **skin is the chronicle**: cream parchment (`#fbf4e0`), a gold frame (`#c8a02a`) and plum ink (`#7a4a9e` light → `#c79be0` dark), MedievalSharp for display, the `✦` glyph, the googly-balloon verdict and an archaic register. None of that is yellow, and none of it should be pulled toward yellow.
 
-- **Its block is nine tokens, not forty.** Only the §3 contract, no archetype-private primitives. Coven's block is fat because it carries 22 bespoke `.exe` chrome tokens for components WOW no longer has; cloning that shape here would be dead weight the redesign has to delete first.
-- **Its headline font is the shared display face, not Caveat.** Caveat left with the script aesthetic. Choosing a replacement display face is a design decision, and this issue was explicitly a colour — so WOW stays typographically identical to unaffiliated, and colour is the only axis that differs.
+The two axes are independent, and #830 collapsed them: it read a mislabelled mockup heading, gave the chronicle to Cozy Coven, and then *derived a whole yellow skin for WOW from its spine hue*, out of nothing. #838 retired that ramp. **ADR-0050** is the record, and `.design-sync/praxis-cards/LABELS.md` is the short version — every design artifact for this faction pair is labelled backwards, so go by tokens and metaphor:
 
-**On the hue.** Yellow is the palette's hard case (#651, #669, #677), for two reasons that pull in opposite directions. A yellow saturated enough to read as yellow needs **dark ink** on it, never white — hence `--faction-wow-on-fill` is ink in both themes. And WOW sits **adjacent to UA** in the spectrum, so the two are painted touching in the Leaderboard/DefaultPlayers stripe bars and Meadow's bloom; a goldenrod too near UA's burnt orange reads as a second brown at that size. The shipped light value resolves this by pushing hue rather than lightness — clear of orange, deep enough to stay legible. The `card-accent` is deliberately **not** the primary in light mode: §3 calls the accent metadata, metadata is text, and no readable yellow pays 4.5:1 on a light card, so the accent is the primary walked down until it clears.
+| | **`wow`** (Warriors of Whimsy) | **`coven`** (Cozy Coven) |
+|---|---|---|
+| Card | cream / gold / **plum** chronicle | **pink** marker sticker |
+| Widget | googly **balloons** | **moon phases** on a night plate |
+| Glyph | `✦` | `✨` |
+| Tier ladder | `a start … excellent · legendary` | `sweet · lovely · wonderful · magical · iconic` |
+| Register | archaic — *"Cast thy Verdict"* | cozy-casual — *"how'd this land?"* |
+
+**On the hue.** Yellow is the palette's hard case (#651, #669, #677), for two reasons that pull in opposite directions. A yellow saturated enough to read as yellow needs **dark ink** on it, never white — hence `--faction-wow-on-fill` is ink in both themes. And WOW sits **adjacent to UA** in the spectrum, so the two are painted touching in the Leaderboard/DefaultPlayers stripe bars and Meadow's bloom; a goldenrod too near UA's burnt orange reads as a second brown at that size. The shipped light value resolves this by pushing hue rather than lightness — clear of orange, deep enough to stay legible.
+
+**On the gold.** `#c8a02a` is **theme-invariant** — it is the same value in light and dark, because a metal-leaf frame does not brighten when the lights go out. The plum is what carries the theme flip. The gold is a *frame and rule* colour, never an ink: it measures 2.24:1 on the cream, so nothing legible is ever painted in it. Where the chronicle's running head needs text, both gradient stops are deepened until cream clears 4.5:1 across the band — a declared deviation from the design's undimmed gold/plum stripe, which carries no text.
+
+Read this next to the Albescent note above: those are the repo's two partly-registered factions, partial on **different axes**. Albescent has neither theme nor skin, on purpose, because it is hiding. WOW now has both, but only a few manifest surfaces claim it, so the rest still render `Default*` until the card rebuild lands.
 
 ---
 
@@ -112,7 +123,7 @@ All fonts loaded from Google Fonts.
 | UA          | `IM Fell English`  | `--faction-ua-card-font`          |
 | Everymen    | `Special Elite`    | `--faction-everymen-card-font`    |
 | Cozy Coven  | `Caveat`           | `--faction-coven-card-font`       |
-| Warriors of Whimsy | `Lora` — the shared display face, not a faction face (see §3) | `--faction-wow-card-font` |
+| Warriors of Whimsy | `MedievalSharp` — the chronicle's display face; `Lora` italic is its secondary (§3) | `--faction-wow-card-font` |
 | S.N.I.D.E.  | `Permanent Marker` (+ a punk set: Anton / Bebas Neue / Archivo Black / Special Elite, via `--faction-snide-font-*`) | `--faction-snide-card-font`       |
 | Ephemerists | `Cinzel`           | `--faction-ephemerists-card-font` |
 | Singularity | `Share Tech Mono`  | `--faction-singularity-card-font` |

--- a/frontend/src/components/praxisCard/desktop/ChroniclePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/ChroniclePraxisCard.tsx
@@ -2,12 +2,14 @@ import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
 /**
- * The gold/plum + WOW-yellow CHRONICLE frame (#821). A bound almanac leaf: a
- * gradient running-head band over a vellum sheet ruled in the faction's accent.
- * Both Cozy Coven (gold/plum) and Warriors of Whimsy (yellow) share this
- * structure and differ only in tokens — never mix the two palettes. Frame
- * pixel-fidelity vs. the prototype is flagged for human QA (the `.dc.html` is
- * not reachable from here).
+ * The CHRONICLE frame (#821). A bound almanac leaf: a gradient running-head band
+ * over a sheet ruled in the faction's accent.
+ *
+ * The chronicle is Warriors of Whimsy's aesthetic — cream, gold and plum
+ * (ADR-0050). Cozy Coven also renders through this structure, but wearing the
+ * pink marker sticker's tokens since #838; that pairing is temporary and #840
+ * replaces it with a sticker archetype. Never mix the two palettes. Frame
+ * pixel-fidelity vs. the prototype is flagged for human QA.
  */
 export interface ChronicleTheme {
   /** Vellum sheet colour (also the Task Crown inner disc). */

--- a/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
@@ -3,7 +3,12 @@ import { factionCssVar } from "../../../utils/factions";
 import ChroniclePraxisCard from "./ChroniclePraxisCard";
 import type { ArchetypeProps } from "./shared";
 
-/** Cozy Coven — the gold/plum chronicle (moon-phase vote widget). */
+/**
+ * Cozy Coven — pink, with the ☾ device and the moon-phase vote widget. The
+ * gold/plum chronicle it wore was WOW's (#838 / ADR-0050); the tokens below are
+ * now the pink sticker's, rendered through the shared chronicle STRUCTURE until
+ * #840 rebuilds the surface as a marker sticker.
+ */
 export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
   return (

--- a/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
@@ -17,7 +17,7 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
         bg: "var(--faction-coven-chronicle-bg)",
         ink: factionCssVar("coven", "card-text"),
         muted: factionCssVar("coven", "card-muted"),
-        accent: "var(--faction-coven-chronicle-plum)",
+        accent: "var(--faction-coven-chronicle-accent)",
         headerFrom: "var(--faction-coven-chronicle-header-from)",
         headerTo: "var(--faction-coven-chronicle-header-to)",
         headerText: "var(--faction-coven-chronicle-header-text)",

--- a/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
@@ -4,9 +4,10 @@ import ChroniclePraxisCard from "./ChroniclePraxisCard";
 import type { ArchetypeProps } from "./shared";
 
 /**
- * Warriors of Whimsy — the SAME chronicle structure recoloured to WOW yellow
- * (balloon vote widget). WOW's first bespoke skin (#821, #812). Uses only
- * `--faction-wow-*` tokens; deliberately NOT coven's gold/plum.
+ * Warriors of Whimsy — the CHRONICLE OF PROOF (#821, #812): cream parchment, a
+ * gold frame, plum ink, the ✦ device and the googly-balloon verdict. This is
+ * WOW's own aesthetic, not a recolour of Coven's — #838 repointed the tokens
+ * after ADR-0050 found the two factions wearing each other's identity.
  */
 export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");

--- a/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
@@ -14,7 +14,7 @@ export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
   const theme: MobileSlotTheme = {
     ink: factionCssVar('coven', 'card-text'),
     muted: factionCssVar('coven', 'card-muted'),
-    accent: 'var(--faction-coven-chronicle-plum)',
+    accent: 'var(--faction-coven-chronicle-accent)',
     paper: 'var(--faction-coven-chronicle-bg)',
     displayFont: 'var(--font-faction-script)',
     bodyFont: "'EB Garamond', serif",
@@ -25,7 +25,7 @@ export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
         position: 'relative',
         overflow: 'hidden',
         background: 'var(--faction-coven-chronicle-bg)',
-        border: '2px solid var(--faction-coven-chronicle-plum)',
+        border: '2px solid var(--faction-coven-chronicle-accent)',
         borderRadius: 7,
         boxShadow: '0 12px 26px -12px var(--faction-coven-chronicle-shadow)',
       }}

--- a/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/CovenMobilePraxisCard.tsx
@@ -4,10 +4,11 @@ import { factionCssVar } from '../../../utils/factions'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
- * Cozy Coven MOBILE praxis card (#821) — the gold/plum CHRONICLE: a vellum leaf
- * with a plum→pink running-head band and a moon device. Mirrors the desktop
- * chronicle frame; replaces the old taped-scrap collage. Single column, tokens
- * only. Frame pixel-fidelity flagged for human QA.
+ * Cozy Coven MOBILE praxis card (#821) — PINK, with a moon device. The gold/plum
+ * chronicle it wore was WOW's (#838 / ADR-0050); its tokens are now the pink
+ * marker sticker's, though it still renders through the shared chronicle
+ * STRUCTURE until #840 rebuilds it as a sticker. Single column, tokens only.
+ * Frame pixel-fidelity flagged for human QA.
  */
 export default function CovenMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   const { t } = useTranslation('praxis')

--- a/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/WowMobilePraxisCard.tsx
@@ -4,10 +4,11 @@ import { factionCssVar } from '../../../utils/factions'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
- * Warriors of Whimsy MOBILE praxis card (#821) — the SAME chronicle structure as
- * Coven's, recoloured to WOW yellow (`--faction-wow-*`), never gold/plum. WOW's
- * first bespoke mobile skin (#812 gave it a colour, this gives it a card).
- * Single column, tokens only. Frame pixel-fidelity flagged for human QA.
+ * Warriors of Whimsy MOBILE praxis card (#821) — the CHRONICLE, which is WOW's
+ * own aesthetic and not a recolour of anyone's: cream parchment, a gold frame
+ * and plum ink (`--faction-wow-*`, repointed by #838; the yellow it briefly wore
+ * came from a mislabelled mockup, see ADR-0050). Single column, tokens only.
+ * Frame pixel-fidelity flagged for human QA.
  */
 export default function WowMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   const { t } = useTranslation('praxis')

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -8,9 +8,10 @@ import { VOTE_REFRAMES } from './voteReframes'
 /**
  * Cozy Coven vote UI (#821) — the 1-5 rating rendered as witchy MOON PHASES on a
  * night plate. Each reached moon waxes gold toward full; the rank-5 moon gets a
- * little face and sparkles. This is the recombination the redesign calls for: the
- * moon-phase metaphor (the prototype's `WowVote`) lands on Coven, while the old
- * pink hearts retire. The plate is a night surface that reads in both themes, so
+ * little face and sparkles. No recombination was ever needed here: the
+ * moon phases were always the PINK faction's metaphor. The prototype files them
+ * under a "WOW" heading only because both identities were still called Warriors
+ * of Whimsy when it was drawn (ADR-0050). The plate is a night surface that reads in both themes, so
  * its inner colours do not flip — only the caption ink does.
  *
  * Plugs into the vote dispatcher via the shared {@link useVote} hook so the

--- a/frontend/src/components/vote/WowVote.tsx
+++ b/frontend/src/components/vote/WowVote.tsx
@@ -7,17 +7,18 @@ import { VOTE_REFRAMES } from './voteReframes'
 
 /**
  * Warriors of Whimsy vote UI (#821) — the 1-5 rating rendered as a row of GOOGLY
- * BALLOONS on a warm plate, WOW's first bespoke skin. Reached balloons fill the
- * yellow ramp and bob; the whole bunch group-cheers when you reach the top. This
- * is the balloon variant the prototype bundled with the chronicle chrome (its
- * `.wow-gballoon*` classes) — recoloured to WOW yellow, never coven's gold/plum.
+ * BALLOONS on a parchment plate, WOW's first bespoke skin. Reached balloons fill
+ * the ramp (plum climbing to gold) and bob; the whole bunch group-cheers when you
+ * reach the top. The prototype bundles these balloons with the chronicle chrome
+ * (its `.wow-gballoon*` classes) and both belong to WOW — #838 repointed the
+ * ramp off the yellow #830 invented for it (ADR-0050).
  *
  * Plugs into the vote dispatcher via the shared {@link useVote} hook. Every
  * motion is a reduced-motion-gated CSS class (never inline `animation:`); the
  * balloons still fill and read when stilled.
  */
 
-/** Balloon fill ramp (yellow, deepening) — one token per tier. */
+/** Balloon fill ramp (plum climbing to gold) — one token per tier. */
 const BALLOON_FILLS = [
   'var(--faction-wow-balloon-1)',
   'var(--faction-wow-balloon-2)',

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -38,22 +38,26 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
       { value: 5, label: i18n.t('votes:everymen.legendary') },
     ],
   },
+  // The two ladders below were inverted between these slugs by #821 and are put
+  // back by #838. Coven is the cozy-casual voice (moon phases, "how'd this
+  // land?"); WOW is the archaic one (balloon verdict, "Cast thy Verdict").
+  // ADR-0050 / .design-sync/praxis-cards/LABELS.md — go by metaphor, not label.
   coven: {
     tiers: [
-      { value: 1, label: i18n.t('votes:coven.a-start') },
-      { value: 2, label: i18n.t('votes:coven.solid') },
-      { value: 3, label: i18n.t('votes:coven.good') },
-      { value: 4, label: i18n.t('votes:coven.excellent') },
-      { value: 5, label: i18n.t('votes:coven.legendary') },
+      { value: 1, label: i18n.t('votes:coven.sweet') },
+      { value: 2, label: i18n.t('votes:coven.lovely') },
+      { value: 3, label: i18n.t('votes:coven.wonderful') },
+      { value: 4, label: i18n.t('votes:coven.magical') },
+      { value: 5, label: i18n.t('votes:coven.iconic') },
     ],
   },
   wow: {
     tiers: [
-      { value: 1, label: i18n.t('votes:wow.sweet') },
-      { value: 2, label: i18n.t('votes:wow.lovely') },
-      { value: 3, label: i18n.t('votes:wow.wonderful') },
-      { value: 4, label: i18n.t('votes:wow.magical') },
-      { value: 5, label: i18n.t('votes:wow.iconic') },
+      { value: 1, label: i18n.t('votes:wow.a-start') },
+      { value: 2, label: i18n.t('votes:wow.solid') },
+      { value: 3, label: i18n.t('votes:wow.good') },
+      { value: 4, label: i18n.t('votes:wow.excellent') },
+      { value: 5, label: i18n.t('votes:wow.legendary') },
     ],
   },
   snide: {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -81,7 +81,7 @@
 
   /* ── Faction card backgrounds (light mode) ── */
   --faction-ua-card-bg: var(--ua-paper); /* parchment sheet */
-  --faction-wow-card-bg: #fffcf0; /* Default's paper, warmed a shade */
+  --faction-wow-card-bg: #fbf4e0; /* chronicle cream parchment (#838) */
   --faction-coven-card-bg: #fdeef3; /* blush collage */
   --faction-snide-card-bg: #14110b; /* photocopier ink (dark-in-light, Singularity precedent) */
   --faction-ephemerists-card-bg: var(--eph-vellum); /* Ephemerists: aged manuscript stock */
@@ -89,7 +89,7 @@
 
   /* ── Faction card text (light mode) ── */
   --faction-ua-card-text: var(--ua-ink);
-  --faction-wow-card-text: #1a1209; /* 18.01:1 — same ink as Default */
+  --faction-wow-card-text: #2b2412; /* chronicle body ink — 14.02:1 */
   --faction-coven-card-text: #581c39;
   --faction-snide-card-text: #f4f1e8; /* warm xerox paper on ink */
   --faction-ephemerists-card-text: var(--eph-vellum-text);
@@ -97,12 +97,14 @@
 
   /* ── Faction card accents (light mode) ── */
   --faction-ua-card-accent: var(--ua-orange);
-  /* NOT --faction-wow. §3 calls the accent "metadata / decorative accent" and
-     metadata is text, so it owes 4.5:1 on card-bg — which no yellow bright
-     enough to read as yellow can pay. This is the primary walked down until it
-     clears (6.73:1). The three factions that skipped that step are exactly the
-     three sitting in factionContrast's BASELINE allowlist. */
-  --faction-wow-card-accent: #7a5200; /* deep amber — 6.73:1 */
+  /* NOT --faction-wow. WOW's skin is the cream/gold/plum chronicle (#838,
+     ADR-0050); the yellow is its RAINBOW-SPINE hue and stays in --faction-wow
+     alone. §3 calls the accent "metadata / decorative accent" and metadata is
+     text, so it owes 4.5:1 on card-bg — the design's plum pays it outright
+     (5.79:1) where no readable yellow ever could. The gold #c8a02a is the
+     chronicle's frame/rule colour, not an ink: it measures 2.24:1 on the cream
+     and never carries text. */
+  --faction-wow-card-accent: #7a4a9e; /* chronicle plum — 5.79:1 */
   --faction-coven-card-accent: #ec5f99;
   --faction-snide-card-accent: #b6ff2e; /* toxic acid */
   --faction-ephemerists-card-accent: var(--eph-rubric);
@@ -110,7 +112,10 @@
 
   /* ── Faction card secondary text (descriptions, metadata) ── */
   --faction-ua-card-muted: var(--ua-sub);
-  --faction-wow-card-muted: #6b5320; /* 7.09:1 */
+  /* The design's metadata olive is #8a7b54, which measures 3.79:1 on the cream
+     and is body text — the contrast house rule wins, so it is walked down to
+     the nearest compliant shade of the same hue (4.76:1). */
+  --faction-wow-card-muted: #7a6b45;
   --faction-coven-card-muted: #831843;
   --faction-snide-card-muted: #d8d6c8; /* faded newsprint grey on ink */
   --faction-ephemerists-card-muted: var(--eph-muted);
@@ -137,30 +142,30 @@
   --faction-ephemerists-card-font: var(--eph-display);
   --faction-singularity-card-font: var(--font-faction-terminal);
 
-  /* ── WARRIORS OF WHIMSY · a colour, not a skin (#812) ──
-     WOW's nine tokens are scattered through the suffix groups above rather than
-     gathered here, like every other faction. What is worth stating in one place
-     is why there are only nine.
+  /* ── WARRIORS OF WHIMSY · yellow SPINE, cream/gold/plum SKIN (#812, #838) ──
+     These are two different things and conflating them is the mistake ADR-0050
+     exists to stop.
 
-     WOW lost its lo-fi pink `.exe` identity to Cozy Coven in #784 and has been
-     unthemed since. The owner has settled its replacement colour — yellow — but
-     NOT its design. So this block is deliberately the bare §3 contract and
-     nothing else: no archetype-private primitives, no chrome tokens, and no
-     manifest in src/factions at all, which means every surface renders its
-     Default* archetype. A WOW profile and an unaffiliated one are structurally
-     identical; only the hue differs. Anything more here is dead weight the real
-     redesign has to delete first.
+     THE SPINE. `--faction-wow` is yellow (#e0a800 light / #f5c542 dark) and its
+     stop in --faction-default-rainbow is yellow. That is WOW's membership of the
+     rainbow, settled in #812/#814, and #838 does not touch it. Yellow is the
+     palette's hard case (#651, #669, #677); this one is deep (l44) rather than
+     bright, because hue 45° puts daylight between it and UA's burnt-orange 20°
+     — the two sit ADJACENT in FACTION_RAINBOW_ORDER and are painted touching in
+     the Leaderboard/DefaultPlayers stripe bars and Meadow's bloom, where a
+     goldenrod nearer 40° reads as a second brown. Every ink measured against it
+     clears AA with room to spare. It is a shade brighter and yellower than the
+     rainbow gradient's own yellow stop (#ca8a04), which is unchanged — that
+     gradient is `na`'s spectrum and answers to nobody's hue but its own.
 
-     ON THE HUE. Yellow is the palette's hard case (#651, #669, #677). This one
-     is deep (l44) rather than bright, for two independent reasons:
-       - Hue 45° puts clear daylight between it and UA's burnt-orange 20°. The
-         two sit ADJACENT in FACTION_RAINBOW_ORDER, so they are painted touching
-         in the Leaderboard/DefaultPlayers stripe bars and in Meadow's bloom.
-         A goldenrod nearer 40° reads as a second brown at that size.
-       - Every text ink measured against it clears AA with room to spare.
-     It is a shade brighter and yellower than the rainbow gradient's own yellow
-     stop (#ca8a04), which is unchanged — that gradient is `na`'s spectrum and
-     answers to nobody's hue but its own. */
+     THE SKIN. WOW's surfaces are the CHRONICLE: cream parchment, a gold frame
+     (#c8a02a, theme-invariant — it does not lift in dark) and plum ink (#7a4a9e
+     light → #c79be0 dark, which is what carries the theme flip). Its widget is
+     the googly-balloon verdict, its glyph is ✦, its face is MedievalSharp.
+     #830 authored a yellow chronicle + yellow balloon ramp for WOW from no
+     design source at all, on the strength of a mislabelled mockup heading; #838
+     retired it. The chronicle was never Coven's — see ADR-0050 and
+     .design-sync/praxis-cards/LABELS.md before moving anything here. */
 
   /* ── DEFAULT · unaffiliated (no faction; rainbow = every path still open) ──
      Not a rainbow-spine faction — the blank-slate / first-life state (na). Its
@@ -329,19 +334,29 @@
   --faction-coven-ivy: #7cbf99;
   --faction-coven-ivy-leaf: #9ad3b1;
 
-  /* ══ Praxis-card redesign (#821) — chronicle frames + bespoke vote widgets ══
-     Coven wears a gold/plum chronicle; WOW wears the same structure recoloured
-     to its yellow. The moon-phase + balloon vote plates are always night/warm
-     plates, so their inner values do not flip — only the chronicle chrome does. */
+  /* ══ Praxis-card redesign (#821, repointed by #838) ══
+     WOW wears the cream/gold/plum CHRONICLE + the googly-balloon verdict; Coven
+     wears the PINK MARKER STICKER + the moon-phase plate. #830 had these two
+     inverted — it took a mislabelled mockup heading at face value and authored a
+     yellow chronicle for WOW out of nothing. ADR-0050 is the record; go by
+     tokens and metaphor, never by a label. The moon plate is a night surface
+     that reads in both themes, so its inner values do not flip.
 
-  /* Coven — gold/plum chronicle frame */
-  --faction-coven-chronicle-bg: #f6ecd6; /* vellum */
-  --faction-coven-chronicle-plum: #7a4a9e;
-  --faction-coven-chronicle-gold: #b8892f; /* readable gold for rules/labels */
-  --faction-coven-chronicle-header-from: #7a4a9e;
-  --faction-coven-chronicle-header-to: #ec5f99;
-  --faction-coven-chronicle-header-text: #fbeef5;
-  --faction-coven-chronicle-shadow: rgba(90, 40, 110, 0.24);
+     Coven's surfaces still render through the shared ChroniclePraxisCard
+     structure, so the `-chronicle-` family name survives here as the frame
+     contract it feeds; the VALUES are the pink sticker's. #840 replaces the
+     structure and can then rename the family. */
+
+  /* Coven — pink marker-sticker frame */
+  --faction-coven-chronicle-bg: #fffdfa; /* sticker ground */
+  --faction-coven-chronicle-accent: #ec5f99; /* border, rules, stamp */
+  /* The running head carries small uppercase text, so its two stops each owe
+     4.5:1 to the header ink. #ec5f99 pays only 3.10:1 against the near-white,
+     so the band deepens to the sticker's own ink range. */
+  --faction-coven-chronicle-header-from: #b93a72;
+  --faction-coven-chronicle-header-to: #8e2f5c;
+  --faction-coven-chronicle-header-text: #fffdfa;
+  --faction-coven-chronicle-shadow: rgba(214, 90, 150, 0.35);
 
   /* Coven — moon-phase vote plate (night plate; same in both themes) */
   --faction-coven-moon-plate-from: #3a2352;
@@ -360,26 +375,36 @@
   --faction-coven-vote-on: #d63f86;
   --faction-coven-vote-off: #a76389;
 
-  /* WOW — yellow chronicle frame (NOT gold/plum; that is coven's) */
-  --faction-wow-chronicle-bg: #fffbe8;
-  --faction-wow-chronicle-header-from: #e0a800;
-  --faction-wow-chronicle-header-to: #f5c542;
-  --faction-wow-chronicle-header-text: #3a2a00;
-  --faction-wow-chronicle-shadow: rgba(160, 120, 0, 0.24);
+  /* WOW — cream/gold/plum chronicle frame (the chronicle is WOW's, ADR-0050) */
+  --faction-wow-chronicle-bg: var(--faction-wow-card-bg); /* cream parchment */
+  --faction-wow-chronicle-gold: #c8a02a; /* frame + rules; theme-invariant */
+  --faction-wow-chronicle-panel: #f3e7c4; /* the inset parchment plate */
+  /* The design's running head is a 6px gold/plum stripe with NO text on it;
+     ChroniclePraxisCard puts the masthead there, and no ink clears 4.5:1 on both
+     a #c8a02a gold and a #7a4a9e plum (cream measures 2.24 on the gold, ink 2.65
+     on the plum). Both stops therefore deepen one step — the design's own
+     "gold bright" #8a5a16 into the plum — so cream reads across the whole band
+     (5.38:1 → 5.79:1). The undimmed gold survives as the frame and the rules. */
+  --faction-wow-chronicle-header-from: #8a5a16;
+  --faction-wow-chronicle-header-to: #7a4a9e;
+  --faction-wow-chronicle-header-text: #fbf4e0;
+  --faction-wow-chronicle-shadow: rgba(74, 56, 10, 0.5);
 
-  /* WOW — googly-balloon vote plate (warm plate) */
-  --faction-wow-balloon-plate-from: #fff4c8;
-  --faction-wow-balloon-plate-to: #ffe9a0;
-  --faction-wow-balloon-plate-border: #e6c257;
-  --faction-wow-balloon-1: #f7e08a;
-  --faction-wow-balloon-2: #f5d15a;
-  --faction-wow-balloon-3: #f5c542;
-  --faction-wow-balloon-4: #e0a800;
-  --faction-wow-balloon-5: #c98a00;
-  --faction-wow-balloon-string: #b9902a;
-  --faction-wow-balloon-eye: #14110b;
-  --faction-wow-vote-on: #a9700a;
-  --faction-wow-vote-off: #b79a52;
+  /* WOW — googly-balloon vote plate. The balloon ramp climbs plum → gold and is
+     THEME-INVARIANT (the prototype ships one ramp for both themes); only the
+     plate and the caption inks flip. */
+  --faction-wow-balloon-plate-from: var(--faction-wow-card-bg);
+  --faction-wow-balloon-plate-to: var(--faction-wow-chronicle-panel);
+  --faction-wow-balloon-plate-border: var(--faction-wow-chronicle-gold);
+  --faction-wow-balloon-1: #7a4a9e;
+  --faction-wow-balloon-2: #9c5e8e;
+  --faction-wow-balloon-3: #be7370;
+  --faction-wow-balloon-4: #d69a48;
+  --faction-wow-balloon-5: #e7b94e;
+  --faction-wow-balloon-string: rgba(60, 44, 6, 0.42);
+  --faction-wow-balloon-eye: #241c0b;
+  --faction-wow-vote-on: var(--faction-wow-card-accent); /* plum — 5.79:1 */
+  --faction-wow-vote-off: var(--faction-wow-card-muted); /* olive — 4.76:1 */
 
   /* Ephemerists — constellation-attestation vote plate (#821). A night sky read
      in BOTH themes (the plate is a fixed dark surface like coven's moon plate),
@@ -648,7 +673,7 @@
 
   /* ── Faction card backgrounds (dark mode) ── */
   --faction-ua-card-bg: var(--ua-paper); /* salon never dims (#240) */
-  --faction-wow-card-bg: #231c0e; /* Default's dark card, warmed a shade */
+  --faction-wow-card-bg: #1b1508; /* chronicle deep ground (#838) */
   --faction-coven-card-bg: #2a0d1c;
   --faction-snide-card-bg: #0c0a07; /* deeper ink */
   /* ephemerists card-bg inherits the :root var(--eph-vellum) rebind (flips below) */
@@ -656,7 +681,7 @@
 
   /* ── Faction card text (dark mode) ── */
   --faction-ua-card-text: var(--ua-ink);
-  --faction-wow-card-text: #f5ecd6; /* 14.35:1 */
+  --faction-wow-card-text: #f3e7c4; /* chronicle parchment ink — 14.72:1 */
   --faction-coven-card-text: #fbcfe0;
   --faction-snide-card-text: #f4f1e8;
   --faction-singularity-card-text: #4ade80;
@@ -664,15 +689,17 @@
   /* ── Faction card accents (dark mode) ── */
   --faction-ua-card-accent: var(--ua-orange);
   /* Dark inverts the light-mode problem: on a dark card the bright primary is
-     the legible choice, so here the accent CAN be the faction colour. */
-  --faction-wow-card-accent: #f5c542; /* 10.41:1 */
+     the legible choice, so here the accent CAN be the faction colour — for the
+     factions whose skin IS their spine hue. WOW's is not (#838): the plum lifts
+     instead, which is the flip the chronicle's gold deliberately does not make. */
+  --faction-wow-card-accent: #c79be0; /* chronicle plum, lifted — 7.94:1 */
   --faction-coven-card-accent: #f472b6;
   --faction-snide-card-accent: #b6ff2e;
   --faction-singularity-card-accent: #4ade80; /* terminal green */
 
   /* ── Faction card secondary text (dark mode) ── */
   --faction-ua-card-muted: var(--ua-sub);
-  --faction-wow-card-muted: #b9a473; /* 6.93:1 */
+  --faction-wow-card-muted: #b69c64; /* chronicle metadata — 6.85:1 */
   --faction-coven-card-muted: #dd719c;
   --faction-snide-card-muted: #cfcdbf;
   /* SNIDE flyposted wall flips to concrete-at-night */
@@ -734,32 +761,41 @@
   --faction-coven-ivy: #5fa882;
   --faction-coven-ivy-leaf: #7fc59e;
 
-  /* ══ Praxis-card redesign (#821) — chronicle frames flip; vote plates hold ══
-     The moon/balloon plates are night/warm surfaces that read in both themes,
-     so only the chronicle chrome + caption inks are overridden here. */
+  /* ══ Praxis-card redesign (#821, repointed by #838) — dark ══
+     Re-DERIVED against the pink/chronicle assignment, not translated from the
+     inverted one: Coven's old dark surfaces were tuned for plum-on-black and
+     pink does not clear the same slots by substitution (ADR-0050). The moon and
+     balloon ramps are fixed surfaces that read in both themes, so only the frame
+     chrome, the balloon plate and the caption inks are overridden here. */
 
-  /* Coven — gold/plum chronicle (dark) */
-  --faction-coven-chronicle-bg: #241733;
-  --faction-coven-chronicle-plum: #b98fd6;
-  --faction-coven-chronicle-gold: #e6c273;
-  --faction-coven-chronicle-header-from: #4a2a63;
-  --faction-coven-chronicle-header-to: #8e2f5c;
-  --faction-coven-chronicle-header-text: #fbe4f0;
+  /* Coven — pink marker-sticker frame (dark) */
+  --faction-coven-chronicle-bg: #2a0d1c;
+  --faction-coven-chronicle-accent: #f472b6;
+  --faction-coven-chronicle-header-from: #7a3358; /* ink 6.18:1 */
+  --faction-coven-chronicle-header-to: #5e2a46; /* ink 7.97:1 */
+  --faction-coven-chronicle-header-text: #fbcfe0;
   --faction-coven-chronicle-shadow: rgba(0, 0, 0, 0.5);
   --faction-coven-vote-on: #f472b6;
   --faction-coven-vote-off: #c78aa6;
 
-  /* WOW — yellow chronicle (dark) */
-  --faction-wow-chronicle-bg: #231c0e;
-  --faction-wow-chronicle-header-from: #8a6600;
-  --faction-wow-chronicle-header-to: #c99a1a;
-  --faction-wow-chronicle-header-text: #fff4cf;
-  --faction-wow-chronicle-shadow: rgba(0, 0, 0, 0.5);
-  --faction-wow-balloon-plate-from: #3a2f0e;
-  --faction-wow-balloon-plate-to: #241c08;
-  --faction-wow-balloon-plate-border: #7a6320;
-  --faction-wow-vote-on: #f5c542;
-  --faction-wow-vote-off: #b9a473;
+  /* WOW — cream/gold/plum chronicle (dark). The gold #c8a02a does NOT lift; the
+     plum is what carries the flip (#7a4a9e → #c79be0). */
+  --faction-wow-chronicle-bg: var(--faction-wow-card-bg);
+  --faction-wow-chronicle-panel: #2a2210; /* the inset parchment plate, darkened */
+  /* Same masthead-legibility problem as light, one step further: the design's
+     dark stripe pairs #c8a02a with #8a5aae, and parchment ink measures 4.10:1 on
+     that plum. Both stops deepen until the band carries text (6.52 / 7.18). */
+  --faction-wow-chronicle-header-from: #6b4a12;
+  --faction-wow-chronicle-header-to: #5e3a7c;
+  --faction-wow-chronicle-header-text: #f3e7c4;
+  --faction-wow-chronicle-shadow: rgba(0, 0, 0, 0.8);
+  --faction-wow-balloon-plate-from: var(--faction-wow-chronicle-panel);
+  --faction-wow-balloon-plate-to: var(--faction-wow-card-bg);
+  /* plate-border inherits the theme-invariant --faction-wow-chronicle-gold */
+  /* The prototype has no dark balloon variant. Its outline rgba(60,44,6,.42) is
+     invisible on a dark plate, so the unreached-balloon hairline inverts to
+     parchment; the reached fills stay the one authored ramp. */
+  --faction-wow-balloon-string: rgba(243, 231, 196, 0.45);
 
   /* ── Watercolor splash opacities (dimmer in dark) ── */
   --wc-opacity-blob: 0.15;

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -21,8 +21,9 @@ const FACTION_SLUGS = [
   'singularity',
   'ua',
   // WOW gained a vote voice with its first bespoke skin (#821) — the balloon
-  // widget's whimsical tiers. Its idle/tag prompt lives under chrome.wow, not
-  // here, so this block stays exactly the five tier labels.
+  // verdict's archaic tiers (#838 put them back on the right slug; #821 had
+  // WOW and Coven wearing each other's, see ADR-0050). Its idle/tag prompt
+  // lives under chrome.wow, not here, so this block stays five tier labels.
   'wow',
 ] as const
 const EXPECTED_TIER_COUNT = 5
@@ -125,7 +126,7 @@ describe('i18next runtime', () => {
   })
 
   it('resolves kebab-case keys for multi-word labels', () => {
-    expect(i18n.t('votes:coven.a-start')).toBe('a start')
+    expect(i18n.t('votes:wow.a-start')).toBe('a start')
     expect(i18n.t('votes:snide.not-bad')).toBe('not bad')
   })
 

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -14,18 +14,18 @@
     "legendary": "legendary"
   },
   "coven": {
-    "a-start": "a start",
-    "solid": "solid",
-    "good": "good",
-    "excellent": "excellent",
-    "legendary": "legendary"
-  },
-  "wow": {
     "sweet": "sweet",
     "lovely": "lovely",
     "wonderful": "wonderful",
     "magical": "magical",
     "iconic": "iconic"
+  },
+  "wow": {
+    "a-start": "a start",
+    "solid": "solid",
+    "good": "good",
+    "excellent": "excellent",
+    "legendary": "legendary"
   },
   "snide": {
     "meh": "meh",
@@ -77,14 +77,14 @@
       "tag": "earned"
     },
     "coven": {
-      "rateAria": "Rate {{value}} — {{label}}",
-      "idle": "cast a spell",
-      "tag": "sealed"
-    },
-    "wow": {
       "rateAria": "Cheer {{value}} — {{label}}",
       "idle": "tap to cheer",
       "tag": "yay!"
+    },
+    "wow": {
+      "rateAria": "Judge {{value}} — {{label}}",
+      "idle": "awaiting thy judgment",
+      "tag": "thy verdict"
     },
     "snide": {
       "rateAria": "Rate {{value}} — {{label}}",

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -42,6 +42,8 @@ const FACTION_FALLBACKS: Record<string, FactionConfig> = {
   // `wow` returns (#812) with the yellow the owner settled on — NOT the pink it
   // lost to `coven` in #784. Must equal --faction-wow in :root (§4 item 7 of
   // SPEC-faction-ui-profile.md) so JS and CSS agree before the API hydrates.
+  // This is the RAINBOW SPINE hue only. WOW's skin is the cream/gold/plum
+  // chronicle and never appears here; #838 / ADR-0050 keep the two apart.
   wow: { slug: "wow", color: "#e0a800" },
   ephemerists: { slug: "ephemerists", color: "#1d6e72" },
   singularity: { slug: "singularity", color: "#2563eb" },
@@ -75,12 +77,12 @@ const CSS_KEY: Record<string, string> = {
   coven: "coven",
   snide: "snide",
   // Warriors of Whimsy is themed again (#812) — this is the flip the #784
-  // comment anticipated, and the --faction-wow-* yellow block it was waiting on
-  // now exists in index.css. This ONE line is what re-themes WOW, because
+  // comment anticipated. This ONE line is what re-themes WOW, because
   // isKnownFaction tests the mapped VALUE (`!== "default"`), not key presence
-  // (#749). WOW's colour is back; its SKIN is not — it still registers no
-  // manifest at all, so every surface renders its Default* archetype and WOW
-  // reads as a yellow-tinted unaffiliated player until the real design ships.
+  // (#749). Its colour is the rainbow's yellow; its SKIN is the cream/gold/plum
+  // chronicle, which is a different thing and does not follow the hue (#838,
+  // ADR-0050). WOW still registers only a few manifest surfaces, so the rest
+  // fall back to Default* until #840.
   wow: "wow",
   ephemerists: "ephemerists",
   singularity: "singularity",


### PR DESCRIPTION
Closes #838

Repoints the WOW and Coven token families so each faction wears its own identity, per **ADR-0050**. This is a token + copy change: both factions' surfaces already read `var(--faction-<slug>-*)`, so moving the values moves every registered surface through the cascade. No archetype was rebuilt (#840 owns that).

Assignment taken from the vendored prototype, not from any label — `.design-sync/praxis-cards/design_handoff_faction_vote_stamps/Faction Praxis Cards.dc.html`, whose section at line 803 is annotated `<!-- COZY COVEN (WOW) -->` and whose balloon builder at line 1783 is `ccBalloons`. Cross-checked against `LABELS.md` and ADR-0050; nothing I read contradicted them.

## What changed

**`frontend/src/index.css`**

- **WOW → the chronicle.** `card-bg` `#fffcf0` → `#fbf4e0` (cream), `card-text` → `#2b2412`, `card-accent` `#7a5200` deep amber → `#7a4a9e` plum, `card-muted` → `#7a6b45`. Dark: `#1b1508` / `#f3e7c4` / `#c79be0` / `#b69c64`.
- **The invented yellow skin ramp is retired.** `--faction-wow-chronicle-*` and `--faction-wow-balloon-*` no longer hold the yellows #830 authored with no design source. The balloon ramp is now the prototype's own `SPEC` array (plum `#7a4a9e` climbing to gold `#e7b94e`), the plate is parchment, the gold `#c8a02a` is a new named token and is **theme-invariant**.
- **Coven → the pink sticker.** `--faction-coven-chronicle-*` repointed off gold/plum: ground `#fffdfa`, accent `#ec5f99`, dark ground `#2a0d1c` / accent `#f472b6`. `--faction-coven-chronicle-plum` is renamed `-accent` (a token named "plum" holding pink is the exact "tokenized-looking, not tokenized" trap); `--faction-coven-chronicle-gold` is deleted — unused, and gold was never Coven's.
- Coven's other 22 `.exe`/collage/moon tokens were **already pink** and are untouched.
- The stale "WARRIORS OF WHIMSY · a colour, not a skin" note is rewritten to separate spine hue from skin.

**`frontend/src/locales/en/votes.json` + `voteReframes.ts`** — the two tier ladders swap slugs (`a start … legendary` → `wow`, `sweet … iconic` → `coven`), and the vote captions swap with them.

**`WORLD_ZERO_STYLE.md`** — §3's WOW section rewritten as "spine hue and skin are two different things"; the §4 font table corrected (WOW is MedievalSharp, not Lora).

Docblocks in `ChroniclePraxisCard`, `Wow/CovenPraxisCard`, the two mobile cards, `Wow/CovenVote` and `utils/factions.ts` asserted the inverted pairing in prose; all corrected, since that prose is what a future agent will read first.

## The rainbow spine did not move

`--faction-wow` stays `#e0a800` / `#f5c542`, its stop in `--faction-default-rainbow` stays yellow, and `FACTION_FALLBACKS.wow.color` is unchanged. `factionRainbowOrder`, `factionFill`, `isKnownFaction` and `wowRendersDefault` all still pass untouched. Retiring the yellow *skin* ramp is not touching the yellow *spectrum stop* (#814).

## MedievalSharp

Already in `frontend/index.html` — #839/#856 landed it, and `--faction-wow-card-font` already points at it. No change needed; `fontsLoaded.test.ts` confirms.

## Deviations

| Design value | What shipped | Rule that forced it |
|---|---|---|
| WOW metadata olive `#8a7b54` | `#7a6b45` | 3.79:1 on the cream; metadata is text and owes 4.5:1. Walked down the same hue to 4.76:1. |
| Running head: 6px `#c8a02a`/`#7a4a9e` stripe, **no text on it** | Band deepened to `#8a5a16` → `#7a4a9e`, cream ink | `ChroniclePraxisCard` puts the uppercase masthead on that band. No ink clears 4.5:1 on both stops (cream 2.24 on the gold, ink 2.65 on the plum). Now 5.38 / 5.79. |
| Dark stripe `#c8a02a` / `#8a5aae` | `#6b4a12` → `#5e3a7c` | Same slot; parchment ink measures 4.10:1 on `#8a5aae`. Now 6.52 / 7.18. |
| Coven sticker accent `#ec5f99` as the header band | `#b93a72` → `#8e2f5c` | 3.10:1 against the near-white header ink. Now 5.29 / 7.63. |
| Card frame is a **gold** `#c8a02a` border | Plum border | `ChronicleTheme.accent` is one field driving border, rules **and** the score stamp, and the accent owes 4.5:1 as metadata text — which the gold cannot pay (2.24:1). Splitting it needs a component change; left for #840. Gold survives on the balloon plate border. |
| Reached-balloon outline `rgba(60,44,6,.42)` | `var(--faction-wow-balloon-4)` (gold) | `WowVote` reuses the ramp token as the reached stroke. Component-level; not repointed here. |
| Prototype has **no** dark balloon variant | Dark `--faction-wow-balloon-string` inverts to parchment `rgba(243,231,196,.45)` | The design's dark-brown hairline is invisible on the dark plate, and unreached balloons render as outline-only. |
| WOW secondary face is **Lora italic** | `'EB Garamond', serif` still hardcoded in the card components | Component literal, outside a token repoint. Flagged for #840. |
| WOW tier ladder `a start · quite solid · jolly good · splendid! · legendary!` | `a start · solid · good · excellent · legendary` | ADR-0050 and the issue both specify a **swap** of the existing words, not a rewrite. The richer ladder is noted here so #840 can take it. |

Coven's `--faction-coven-card-*` were deliberately **not** repointed to the design's `#fffdfa`/`#a8728e`: they are already pink, and moving `card-bg` would churn the `light | coven card accent` entry in `factionContrast`'s BASELINE for no identity gain. That allowlist is unchanged — no entry added, none invalidated.

## Verification

`tsc --noEmit` clean (only the known stale-junction `node:fs` false alarms), `eslint .` clean, `vite build` clean, `vitest run` — **105 files / 1101 tests pass**, including `factionContrast`, `factionTokensDeclared`, `fontsLoaded`, `factionRainbowOrder` and `wowRendersDefault`. Every new/changed colour pair was hand-computed against WCAG AA before landing.

**Visual QA is outstanding.** I cannot screenshot and there is no dev stack here. Nothing in a green build sees a colour.

## What to eyeball

1. **WOW praxis card, light and dark** — cream sheet, plum ink, plum border where the design wants gold. Is the deepened gold→plum running head acceptable, or should the masthead move off the band so the undimmed stripe can come back?
2. **WOW balloon widget** — the ramp now climbs plum→gold on a near-invisible parchment plate. The design has no plate at all; check whether the faint gold hairline should just be dropped.
3. **Balloon outlines in dark** — the inverted parchment hairline is my call, not the design's.
4. **Coven praxis card** — pink values inside a chronicle *structure*. It should read pink and wrong-shaped, not pink and broken. #840 fixes the shape.
5. **Coven's header band** — deepened to `#8e2f5c` for legibility; noticeably darker than the `#ec5f99` the sticker leads with.
6. **Both vote captions** — WOW should read `awaiting thy judgment` → `legendary · THY VERDICT`; Coven `tap to cheer` → `iconic · YAY!`.
7. **Anywhere WOW yellow and WOW cream now sit together** — leaderboard stripe bars, faction pills, Meadow. The spine is still yellow by design; confirm that reads as intentional rather than as a leftover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
