### PR TITLE
Everymen broadsheet + Ephemerists codex: score box, total mark, frame (#841)

### DIFF
--- a/frontend/src/components/factionMarks/PointsRoundel.tsx
+++ b/frontend/src/components/factionMarks/PointsRoundel.tsx
@@ -1,0 +1,104 @@
+import { useId } from "react";
+import type { CSSProperties } from "react";
+
+/**
+ * The points roundel — Everymen's signature total mark (#841, ADR-0049).
+ *
+ * A rubber stamp struck onto the broadsheet: a double circle with the total
+ * across the middle, `POINTS` beneath it, and the certification legend arced
+ * around the inner ring on a `textPath`. #821 replaced it with a generic
+ * rectangle; the roundel IS the faction's claim that the work is on the record,
+ * so it comes back as a mark rather than as a border treatment.
+ *
+ * Inline SVG rather than a masked asset (the {@link Enso} route): the roundel
+ * carries live text, so it has to be typeset at render time, and at ~1 KB the
+ * bundle argument for masking never arises. Every `fill` reads the `color` prop,
+ * so one token dresses the whole mark and dark mode flows through the cascade.
+ *
+ * The multiply blend belongs to the CONSUMER, via `.everymen-stamp-print` — the
+ * blend has to invert in dark and that is a cascade decision, not a prop.
+ *
+ * Type sizes here are the design's, in the SVG's own user-space units on a
+ * 0..100 viewBox — they are neither `px` nor text-scale steps, and the scale
+ * factor is `size / 100`. Stamp lettering is ornament (`WORLD_ZERO_STYLE` §4a),
+ * and SVG geometry has never been on the `--text-*` scale.
+ */
+
+export interface PointsRoundelProps {
+  /** The total, already formatted for display (`13.6`). */
+  total: string;
+  /** The `POINTS` caption under the numeral. */
+  unitLabel: string;
+  /** The legend arced around the inner ring. */
+  arcLabel: string;
+  /** Rendered size in px, both axes. Design draws it at 102. */
+  size?: number;
+  /** The stamp ink. Pass a faction token; defaults to the surrounding ink. */
+  color?: string;
+  style?: CSSProperties;
+  className?: string;
+}
+
+/** The r=40 circle the legend runs along, as a path so `textPath` can use it. */
+const ARC_PATH = "M50,50 m0,-40 a40,40 0 1,1 -0.01,0 z";
+
+export default function PointsRoundel({
+  total,
+  unitLabel,
+  arcLabel,
+  size = 102,
+  color = "currentColor",
+  style,
+  className,
+}: PointsRoundelProps) {
+  // One roundel per card, many cards per feed — the textPath id must not
+  // collide. React's ids carry `:` delimiters, which are legal in an id but not
+  // in a CSS selector, so they come out before the id reaches a URL fragment.
+  const arcId = `wz-roundel-${useId().replace(/:/g, "")}`;
+  // The design shrinks the numeral for a four-glyph total (`29.6`) so it stays
+  // inside the inner ring; anything shorter is struck at full size.
+  const totalSize = total.length > 3 ? 31 : 33;
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      role="img"
+      aria-label={`${total} ${unitLabel}`}
+      className={className}
+      style={{ overflow: "visible", transform: "rotate(-6deg)", flexShrink: 0, ...style }}
+    >
+      <defs>
+        <path id={arcId} d={ARC_PATH} />
+      </defs>
+      <circle cx={50} cy={50} r={46} fill="none" stroke={color} strokeWidth={2.5} />
+      <circle cx={50} cy={50} r={40} fill="none" stroke={color} strokeWidth={1} />
+      <text fill={color} fontFamily="var(--font-faction-typewriter)" fontSize={8} letterSpacing={1.6}>
+        <textPath href={`#${arcId}`} startOffset="2%">
+          {arcLabel}
+        </textPath>
+      </text>
+      <text
+        x={50}
+        y={54}
+        textAnchor="middle"
+        fill={color}
+        fontFamily="var(--font-accent)"
+        fontSize={totalSize}
+      >
+        {total}
+      </text>
+      <text
+        x={50}
+        y={68}
+        textAnchor="middle"
+        fill={color}
+        fontFamily="var(--font-faction-typewriter)"
+        fontSize={7.5}
+        letterSpacing={2}
+      >
+        {unitLabel}
+      </text>
+    </svg>
+  );
+}

--- a/frontend/src/components/factionMarks/PointsRoundel.tsx
+++ b/frontend/src/components/factionMarks/PointsRoundel.tsx
@@ -96,6 +96,7 @@ export default function PointsRoundel({
         fontFamily="var(--font-faction-typewriter)"
         fontSize={7.5}
         letterSpacing={2}
+        style={{ textTransform: "uppercase" }}
       >
         {unitLabel}
       </text>

--- a/frontend/src/components/factionMarks/Rubric.tsx
+++ b/frontend/src/components/factionMarks/Rubric.tsx
@@ -1,0 +1,85 @@
+import type { CSSProperties } from "react";
+
+/**
+ * The rubric — the Ephemerists' signature total mark (#841, ADR-0049).
+ *
+ * In a manuscript the rubric is the passage struck in red: the line the scribe
+ * wanted read first. Here it is the total, set in the codex's engraved face and
+ * inked in rubrication red over a `Points` caption, ruled off from the working
+ * above it by a gold-to-verdigris hairline — gold leaf on the left, the
+ * faction's own celestial teal on the right.
+ *
+ * A mark rather than a stamp fragment (ADR-0049): the rubric is the object the
+ * Ephemerists' score box is BUILT AROUND, and #821 lost it by treating the whole
+ * right column as one generic plate. It is DOM rather than SVG because it is
+ * typeset text — the mark is the setting, not a drawing.
+ *
+ * Colours arrive as tokens, so the whole mark flips with `[data-theme="dark"]`
+ * and no hex reaches the markup.
+ */
+
+export interface RubricProps {
+  /** The total, already formatted for display (`13.6`). */
+  total: string;
+  /** The caption under — or rather beside — the numeral. */
+  unitLabel: string;
+  /** The rubrication ink for the numeral. */
+  color?: string;
+  /** The caption's gold. */
+  captionColor?: string;
+  /** Left-hand stop of the hairline rule (gold leaf). */
+  ruleFrom?: string;
+  /** Right-hand stop of the hairline rule (celestial teal). */
+  ruleTo?: string;
+  style?: CSSProperties;
+}
+
+export default function Rubric({
+  total,
+  unitLabel,
+  color = "var(--eph-rubric)",
+  captionColor = "var(--eph-gold)",
+  ruleFrom = "var(--eph-frame)",
+  ruleTo = "var(--faction-ephemerists)",
+  style,
+}: RubricProps) {
+  return (
+    <div style={style}>
+      <div
+        aria-hidden
+        style={{
+          height: 1,
+          background: `linear-gradient(90deg, ${ruleFrom}, ${ruleTo})`,
+          opacity: 0.7,
+          margin: "var(--space-sm) 0 var(--space-xs)",
+        }}
+      />
+      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-xs)" }}>
+        <span
+          style={{
+            fontFamily: "var(--eph-display)",
+            fontWeight: 600,
+            // ornament: the rubric numeral is the mark's own optical size —
+            // engraved caps struck at 28, not a step on the text scale (§4a).
+            fontSize: 28,
+            lineHeight: 0.8,
+            color,
+          }}
+        >
+          {total}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--eph-display)",
+            fontSize: "var(--text-sm)",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: captionColor,
+          }}
+        >
+          {unitLabel}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/factionMarks/Rubric.tsx
+++ b/frontend/src/components/factionMarks/Rubric.tsx
@@ -59,8 +59,7 @@ export default function Rubric({
           style={{
             fontFamily: "var(--eph-display)",
             fontWeight: 600,
-            // ornament: the rubric numeral is the mark's own optical size —
-            // engraved caps struck at 28, not a step on the text scale (§4a).
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: the rubric numeral is the mark's own optical size, engraved caps struck at 28, not a step on the text scale (§4a)
             fontSize: 28,
             lineHeight: 0.8,
             color,

--- a/frontend/src/components/factionMarks/index.ts
+++ b/frontend/src/components/factionMarks/index.ts
@@ -16,3 +16,5 @@
  */
 export { default as Lotus, type FactionMarkProps } from "./Lotus";
 export { default as Enso } from "./Enso";
+export { default as PointsRoundel, type PointsRoundelProps } from "./PointsRoundel";
+export { default as Rubric, type RubricProps } from "./Rubric";

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -1,11 +1,26 @@
 import { useTranslation } from "react-i18next";
-import { EphemeristsSigil, Foxing } from "../../cards/ephemeristsAtoms";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
 /**
- * The Ephemerists (ephemerists slug) — a sealed ephemeris entry. A foxed vellum
- * leaf with a lapis-ruled running head, the sigil, and rubric-accented text.
+ * The Ephemerists — THE CODEX (#841). A vellum folio bound in gold: a dotted
+ * leaf, a gold hairline frame, engraved caps for the entry, and the score box
+ * with its rubric set into the right column.
+ *
+ * What came off this card, and why — all three were inventions with no
+ * counterpart in the vendored prototype, and together they made the folio read
+ * as a filing header stapled to a texture:
+ *
+ *  • the dedicated RUNNING-HEAD BAR (a lapis-ruled strip across the frame). The
+ *    design's running head is an EYEBROW LINE inside the left column — the
+ *    first line of the entry, which stops at the score box instead of running
+ *    under it. It is passed to `PraxisBody` as `eyebrow`;
+ *  • the SIGIL that sat in that bar;
+ *  • the `Foxing` texture layer. The leaf's own dotted ground is the texture.
+ *
+ * The frame's border was a neutral `color-mix` of the ink. The design binds the
+ * folio in GOLD (`--eph-frame`), which is the difference between a codex and a
+ * beige card with a border.
  */
 export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
@@ -18,56 +33,38 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
         overflow: "hidden",
         background: "var(--eph-vellum)",
         color: "var(--eph-vellum-text)",
-        border: "2px solid color-mix(in srgb, var(--eph-vellum-text) 30%, transparent)",
+        border: "1px solid var(--eph-frame)",
         fontFamily: "var(--eph-serif)",
-        boxShadow: "0 1px 0 rgba(0,0,0,0.04), 0 8px 20px -16px rgba(0,0,0,0.6)",
+        // The leaf's own ground — a fine dotted tooth, the design's texture.
+        backgroundImage: "radial-gradient(rgba(42, 29, 18, 0.03) 1px, transparent 1px)",
+        backgroundSize: "6px 6px",
+        boxShadow: "0 3px 14px rgba(42, 29, 18, 0.14)",
+        padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
         transition: "background 150ms, color 150ms",
       }}
     >
-      <Foxing opacity={0.4} />
-      {/* running head — sigil + ephemeris label, lapis-ruled */}
-      <div
-        style={{
-          position: "relative",
-          zIndex: 2,
-          display: "flex",
-          alignItems: "center",
-          gap: "var(--space-sm)",
-          padding: "var(--space-sm) var(--space-lg) var(--space-sm)",
-          borderBottom: "1px solid var(--eph-gold-deep)",
-          boxShadow: "0 2px 0 -1px color-mix(in srgb, var(--eph-lapis) 55%, transparent)",
-        }}
-      >
-        <EphemeristsSigil size={13} color="var(--eph-lapis)" />
-        <span
-          style={{
-            fontFamily: "var(--eph-serif)",
-            fontSize: "var(--text-xs)",
-            letterSpacing: "0.18em",
-            textTransform: "uppercase",
-            color: "var(--eph-rubric)",
-          }}
-        >
-          {t("card.masthead.ephemerists")}
-        </span>
-      </div>
-      <div
-        style={{
-          position: "relative",
-          zIndex: 2,
-          padding: "var(--space-md) var(--space-xl) var(--space-xl)",
-        }}
-      >
-        <AdminOverlay {...adminProps} />
-        <PraxisBody
-          praxis={praxis}
-          tint="var(--eph-rubric)"
-          muted="var(--eph-muted)"
-          paper="var(--eph-vellum)"
-          titleStyle={{ fontFamily: "var(--eph-display)", color: "var(--eph-vellum-text)" }}
-          showCrown={showCrown}
-        />
-      </div>
+      <AdminOverlay {...adminProps} />
+      <PraxisBody
+        praxis={praxis}
+        tint="var(--eph-rubric)"
+        muted="var(--eph-muted)"
+        paper="var(--eph-vellum)"
+        titleStyle={{ fontFamily: "var(--eph-display)", color: "var(--eph-vellum-text)" }}
+        showCrown={showCrown}
+        eyebrow={
+          <div
+            className="eyebrow"
+            style={{
+              fontFamily: "var(--eph-display)",
+              letterSpacing: "0.2em",
+              color: "var(--faction-ephemerists)",
+              marginBottom: "var(--space-xs)",
+            }}
+          >
+            {t("card.masthead.ephemerists")}
+          </div>
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
@@ -1,46 +1,106 @@
 import type { CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
 import { factionCssVar } from "../../../utils/factions";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
-/** The red margin rule down the Everymen ruled sheet. Static (#586). */
+/**
+ * Everymen — THE BROADSHEET (#841). A union work report printed on ruled cream
+ * newsprint: a full-width red masthead across the head of the sheet, a red
+ * margin rule down the left, and the tally stamp + points roundel struck into
+ * the right column.
+ *
+ * Three corrections to what #821/#586 left here, all from the vendored
+ * prototype:
+ *
+ *  • the MASTHEAD was absent entirely — the loudest single thing the design
+ *    gives this faction, and the reason the card reads as a newspaper rather
+ *    than as a beige panel;
+ *  • the frame's border was `--color-border`, the app's neutral chrome. On a
+ *    broadsheet the rule around the sheet is part of the PRINTING, so it is the
+ *    faction ink (`--everymen-frame`);
+ *  • the torn-bottom `clipPath` had no design counterpart at all. It was
+ *    invented, and it clipped the foot of every card it was on.
+ *
+ * The masthead is kept deliberately low and tightly tracked so it frames the
+ * report rather than shouting over the headline.
+ */
+
+/** The red margin rule down the ruled sheet. Static (#586). */
 const everymenMarginRule: CSSProperties = {
   position: "absolute",
   left: 22,
   top: 0,
   bottom: 0,
   width: 1,
-  background: "rgba(220,80,80,0.2)",
+  background: "color-mix(in srgb, var(--everymen-red) 28%, transparent)",
 };
 
 export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+  const { t } = useTranslation("praxis");
   return (
     <div
       style={{
         ...frameBase,
         borderRadius: 2, // broadsheet — near-square
+        overflow: "hidden",
         background: factionCssVar("everymen", "card-bg"),
-        border: "2px solid var(--color-border)",
-        clipPath:
-          "polygon(0 0, 100% 0, 100% 90%, 92% 100%, 80% 95%, 68% 100%, 56% 93%, 44% 100%, 32% 94%, 20% 100%, 8% 94%, 0 100%)",
+        border: "1px solid var(--everymen-frame)",
+        boxShadow: "0 3px 14px rgba(34, 26, 18, 0.16)",
         position: "relative",
-        padding: "var(--space-xl) var(--space-xl) var(--space-2xl) var(--space-2xl)",
-        fontFamily: "'Special Elite', serif",
+        fontFamily: "var(--font-faction-typewriter)",
         color: factionCssVar("everymen", "card-text"),
         backgroundImage:
           "repeating-linear-gradient(to bottom, transparent, transparent 17px, rgba(100,140,200,0.08) 17px, rgba(100,140,200,0.08) 18px)",
         transition: "background 150ms, color 150ms",
       }}
     >
-      <div style={everymenMarginRule} />
-      <AdminOverlay {...adminProps} />
-      <PraxisBody
-        praxis={praxis}
-        tint={factionCssVar("everymen", "card-accent")}
-        muted={factionCssVar("everymen", "card-muted")}
-        paper={factionCssVar("everymen", "card-bg")}
-        showCrown={showCrown}
-      />
+      {/* Masthead — the paper's name across the head of the sheet. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "var(--space-md)",
+          padding: "var(--space-xs) var(--space-lg)",
+          background: "var(--everymen-red)",
+          color: "var(--everymen-masthead-text)",
+          fontFamily: "var(--font-accent)",
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: masthead lettering at the design's 15, kept low so it frames rather than shouts (§4a)
+          fontSize: 15,
+          letterSpacing: "0.3em",
+          textTransform: "uppercase",
+          boxShadow: "0 2px 0 rgba(34, 26, 18, 0.22)",
+        }}
+      >
+        {/* Cogs flank the name — a drawn glyph, not an icon (§7). */}
+        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: flanking cog glyph, sized under the lettering (§4a) */}
+        <span aria-hidden style={{ fontSize: 12, opacity: 0.85 }}>
+          ⚙
+        </span>
+        <span>{t("card.masthead.everymen")}</span>
+        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: flanking cog glyph, sized under the lettering (§4a) */}
+        <span aria-hidden style={{ fontSize: 12, opacity: 0.85 }}>
+          ⚙
+        </span>
+      </div>
+
+      <div
+        style={{
+          position: "relative",
+          padding: "var(--space-lg) var(--space-xl) var(--space-xl) var(--space-2xl)",
+        }}
+      >
+        <div style={everymenMarginRule} />
+        <AdminOverlay {...adminProps} />
+        <PraxisBody
+          praxis={praxis}
+          tint={factionCssVar("everymen", "card-accent")}
+          muted={factionCssVar("everymen", "card-muted")}
+          paper={factionCssVar("everymen", "card-bg")}
+          showCrown={showCrown}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import type { PraxisCardOut } from "../../../api/praxis";
 import {
   PraxisTitle,
@@ -77,6 +77,7 @@ export function PraxisBody({
   paper,
   titleStyle,
   showCrown,
+  eyebrow,
 }: {
   praxis: PraxisCardOut;
   tint: string;
@@ -85,6 +86,14 @@ export function PraxisBody({
   paper?: string;
   titleStyle?: CSSProperties;
   showCrown?: boolean;
+  /**
+   * An optional running head, rendered INSIDE the left column above the title
+   * (#841). Some archetypes carry their eyebrow as a full-width bar across the
+   * frame (Everymen's masthead); others — the Ephemerists' codex folio line —
+   * draw it as the first line of the entry itself, where it must sit in the
+   * text column and stop at the score stamp rather than run under it.
+   */
+  eyebrow?: ReactNode;
 }) {
   return (
     <>
@@ -97,6 +106,7 @@ export function PraxisBody({
         }}
       >
         <div style={{ flex: 1, minWidth: 0 }}>
+          {eyebrow}
           <PraxisTitle praxis={praxis} style={titleStyle} />
           <PraxisTaskLink praxis={praxis} style={{ color: muted }} />
           <PraxisExcerpt praxis={praxis} style={{ color: muted }} />

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -1,0 +1,153 @@
+import { useTranslation } from "react-i18next";
+import { TaskCrown } from "../../cards/TaskCrown";
+import { Rubric } from "../../factionMarks";
+import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import type { ScoreStampProps } from "./ScoreStamp";
+
+/**
+ * The Ephemerists score stamp (#841, ADR-0049) — the codex's SCORE BOX with the
+ * {@link Rubric} set into its foot.
+ *
+ * The design files this faction under the shared box pattern ("Ephemerists …
+ * follow the Unaffiliated mechanism exactly"), so the row mechanics match
+ * {@link DefaultScoreStamp} — base numeral with the multiplier chip pinned
+ * right, the working underneath, then the total. Everything else is the codex:
+ * gold leaf binding the box, the brighter leaf inside it, engraved caps for
+ * every figure, the chip in celestial teal rather than spectrum, and the total
+ * struck in rubrication red under a gold-to-verdigris hairline.
+ *
+ * Row selection stays in `scoreBreakdown` (ADR-0047); this file is presentation
+ * only. Each optional row is its own line, so the box reads as a shorter or
+ * longer entry in all five conditional states rather than as a form with gaps.
+ */
+export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampProps) {
+  const { t } = useTranslation("praxis");
+  if (praxis.total === null || praxis.total === undefined) return null;
+  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const crowned = praxis.is_top_for_task && showCrown !== false;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        flexShrink: 0,
+        minWidth: 116,
+        boxSizing: "border-box",
+        background: "var(--eph-stamp-bg)",
+        border: "1.5px solid var(--eph-frame)",
+        borderRadius: 4,
+        boxShadow: "0 2px 6px rgba(42, 29, 18, 0.12)",
+        transform: "rotate(-1deg)",
+        padding: "var(--space-sm) var(--space-md)",
+        lineHeight: 1.1,
+      }}
+    >
+      {crowned && (
+        <TaskCrown
+          size={26}
+          ringInset={3}
+          innerBg="var(--eph-stamp-bg)"
+          glyphColor="var(--eph-gold)"
+          rotate="6deg"
+          style={{ position: "absolute", top: -13, right: -12, zIndex: 3 }}
+        />
+      )}
+
+      {/* Base, with the multiplier chip pinned to the right rail. */}
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", whiteSpace: "nowrap" }}>
+        <span
+          style={{
+            fontFamily: "var(--eph-serif)",
+            fontSize: "var(--text-sm)",
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            color: "var(--eph-muted)",
+          }}
+        >
+          {t("card.stamp.base")}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--eph-display)",
+            fontWeight: 600,
+            fontSize: "var(--text-title)",
+            lineHeight: 0.8,
+            color: "var(--eph-vellum-text)",
+          }}
+        >
+          {base}
+        </span>
+        {mult !== null && (
+          <span
+            style={{
+              marginLeft: "auto",
+              fontFamily: "var(--eph-display)",
+              fontSize: "var(--text-md)",
+              color: "var(--faction-ephemerists-on-fill)",
+              background: "var(--faction-ephemerists)",
+              borderRadius: 3,
+              padding: "0 var(--space-xs)",
+            }}
+          >
+            {formatMult(mult)}
+          </span>
+        )}
+      </div>
+
+      {meta !== null && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-xs)",
+            marginTop: "var(--space-xs)",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--eph-display)",
+              fontSize: "var(--text-sm)",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "var(--eph-parchment)",
+              // The design's meta chip is spectrum green; here it is the deep
+              // rubric — a manuscript marks an addition in red, and the gold
+              // that would otherwise be the codex choice pays only 4.2:1
+              // against parchment at this size.
+              background: "var(--eph-rubric-deep)",
+              borderRadius: 3,
+              padding: "0 var(--space-xs)",
+            }}
+          >
+            {t("card.stamp.meta")}
+          </span>
+          <span
+            style={{
+              fontFamily: "var(--eph-serif)",
+              fontStyle: "italic",
+              fontSize: "var(--text-md)",
+              color: "var(--eph-muted)",
+            }}
+          >
+            +{meta}
+          </span>
+        </div>
+      )}
+
+      <div
+        style={{
+          fontFamily: "var(--eph-serif)",
+          fontStyle: "italic",
+          fontSize: "var(--text-md)",
+          color: "var(--eph-muted)",
+          marginTop: "var(--space-xs)",
+        }}
+      >
+        {t("card.stamp.fromVotes", { votes })}
+      </div>
+
+      {/* The total mark. */}
+      <Rubric total={total.toFixed(1)} unitLabel={t("card.stamp.points")} />
+    </div>
+  );
+}

--- a/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
@@ -1,0 +1,165 @@
+import { useTranslation } from "react-i18next";
+import { TaskCrown } from "../../cards/TaskCrown";
+import { PointsRoundel } from "../../factionMarks";
+import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import type { ScoreStampProps } from "./ScoreStamp";
+
+/**
+ * The Everymen score stamp (#841, ADR-0049) — the TALLY STAMP and the POINTS
+ * ROUNDEL, the two objects the design draws in the broadsheet's right column.
+ *
+ * The tally is a rubber stamp struck crooked on the sheet: a dashed `TALLY`
+ * rule header, then one fill-in-the-blank row per term of the working, the
+ * figures written into dashed fields in the poster face. Under it, struck
+ * separately and crooked the other way, the {@link PointsRoundel} carries the
+ * total. #821 had neither — one upright rectangle stood in for both.
+ *
+ * ROW SELECTION IS NOT OURS. `scoreBreakdown` decides which rows exist
+ * (ADR-0047); this file only decides what a row looks like. The one row this
+ * stamp adds on its own is GROUP — `(base + meta)`, drawn under a rule — and it
+ * appears only when a metatask AND a multiplier are both in play, which is
+ * exactly the design's "full formula" column. Without a multiplier the subtotal
+ * explains nothing, so it stays off; the stamp must read as a completed form in
+ * all five states, not as a form with holes in it.
+ *
+ * Both marks print through `.everymen-stamp-print`, which multiplies them into
+ * the paper in light and drops the blend in dark (§8 — the theme switch is in
+ * the cascade, never a ternary here).
+ */
+
+/** The stamp's fill-in field width — ornament geometry, the design's own. */
+const FIELD_WIDTH = 38;
+
+export default function EverymenScoreStamp({ praxis, showCrown }: ScoreStampProps) {
+  const { t } = useTranslation("praxis");
+  if (praxis.total === null || praxis.total === undefined) return null;
+  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const crowned = praxis.is_top_for_task && showCrown !== false;
+
+  /** Rows in working order. `ruled` draws the subtotal rule above the row. */
+  const rows: { key: string; label: string; value: string; gold?: boolean; ruled?: boolean }[] = [
+    { key: "base", label: t("card.stamp.base"), value: `${base}` },
+  ];
+  if (meta !== null) {
+    rows.push({ key: "meta", label: t("card.stamp.meta"), value: `+${meta}` });
+    if (mult !== null) {
+      rows.push({ key: "group", label: t("card.stamp.group"), value: `${base + meta}`, ruled: true });
+    }
+  }
+  if (mult !== null) {
+    rows.push({ key: "mult", label: t("card.stamp.mult"), value: formatMult(mult), gold: true });
+  }
+  rows.push({ key: "votes", label: t("card.stamp.votes"), value: `+${votes}` });
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--space-sm)",
+        width: 118,
+      }}
+    >
+      {crowned && (
+        <TaskCrown
+          size={26}
+          ringInset={3}
+          innerBg="var(--faction-everymen-card-bg)"
+          glyphColor="var(--everymen-red)"
+          rotate="8deg"
+          style={{ position: "absolute", top: -13, right: -10, zIndex: 3 }}
+        />
+      )}
+
+      {/* The tally stamp — struck crooked, inked into the sheet. */}
+      <div
+        className="everymen-stamp-print"
+        style={{
+          width: "100%",
+          boxSizing: "border-box",
+          transform: "rotate(1.3deg)",
+          border: "2px solid var(--everymen-red)",
+          outline: "1px solid var(--everymen-red)",
+          outlineOffset: 2,
+          borderRadius: 2,
+          padding: "var(--space-xs) var(--space-sm)",
+          background: "var(--everymen-stamp-field)",
+          fontFamily: "var(--font-faction-typewriter)",
+          color: "var(--everymen-stamp-ink)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-xs)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)" }}>
+          <span aria-hidden style={{ flex: 1, height: 1, background: "var(--everymen-red)", opacity: 0.45 }} />
+          <span
+            style={{
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the stamp's own rule header, struck at 8 (§4a)
+              fontSize: 8,
+              letterSpacing: "0.2em",
+              color: "var(--everymen-red)",
+            }}
+          >
+            {t("card.stamp.tally")}
+          </span>
+          <span aria-hidden style={{ flex: 1, height: 1, background: "var(--everymen-red)", opacity: 0.45 }} />
+        </div>
+
+        {rows.map((row) => (
+          <div key={row.key}>
+            {row.ruled && (
+              <div
+                aria-hidden
+                style={{
+                  height: 1,
+                  background: "var(--everymen-red)",
+                  opacity: 0.4,
+                  margin: "0 0 var(--space-xs)",
+                }}
+              />
+            )}
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end" }}>
+              <span
+                style={{
+                  // eslint-disable-next-line local/no-raw-style-values -- ornament: typewriter row label on the stamp, the design's 11 (§4a)
+                  fontSize: 11,
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                }}
+              >
+                {row.label}
+              </span>
+              <b
+                style={{
+                  fontFamily: "var(--font-accent)",
+                  // eslint-disable-next-line local/no-raw-style-values -- ornament: poster-face figures written into the field, the design's 17 (§4a)
+                  fontSize: 17,
+                  lineHeight: 0.8,
+                  color: row.gold ? "var(--everymen-stamp-mult)" : "var(--everymen-stamp-numeral)",
+                  borderBottom: "1px dashed var(--everymen-red)",
+                  minWidth: FIELD_WIDTH,
+                  textAlign: "center",
+                }}
+              >
+                {row.value}
+              </b>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* The total mark — a second, separate strike. */}
+      <PointsRoundel
+        className="everymen-stamp-print"
+        total={total.toFixed(1)}
+        unitLabel={t("card.stamp.points")}
+        arcLabel={t("card.stamp.onTheRecord")}
+        color="var(--everymen-red)"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -11,11 +11,21 @@
  * `Default*` fall-through, like every other surface (ADR-0039).
  */
 import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import '../../../../i18n'
 import type { PraxisCardOut } from '../../../../api/praxis'
 import { pickVariant } from '../../../../utils/factionDispatch'
 import { surfaceMap } from '../../../../factions'
 import { scoreBreakdown, formatMult } from '../scoreBreakdown'
 import DefaultScoreStamp from '../DefaultScoreStamp'
+import EverymenScoreStamp from '../EverymenScoreStamp'
+import EphemeristsScoreStamp from '../EphemeristsScoreStamp'
+
+/** No hex may reach a stamp's markup — every colour is a token (ADR-0049). */
+const HEX = /#[0-9a-fA-F]{3,8}\b/
+
+/** Strip tags so a copy assertion cannot be satisfied by an attribute value. */
+const text = (html: string) => html.replace(/<[^>]*>/g, '')
 
 /**
  * Overrides are loosely typed on purpose: several cases below feed `null` into
@@ -81,9 +91,73 @@ describe('scoreBreakdown row selection (ADR-0047)', () => {
 })
 
 describe('scoreStamp surface dispatch (ADR-0049)', () => {
-  it('falls through to the Default stamp for every slug until a faction claims it', () => {
-    for (const slug of ['ua', 'snide', 'everymen', 'ephemerists', 'singularity', 'coven', 'wow', 'albescent', 'na', null]) {
+  it('falls through to the Default stamp for every slug that has not claimed it', () => {
+    for (const slug of ['ua', 'snide', 'singularity', 'coven', 'wow', 'albescent', 'na', null]) {
       expect(pickVariant(surfaceMap('scoreStamp'), slug, DefaultScoreStamp)).toBe(DefaultScoreStamp)
     }
+  })
+
+  it('gives Everymen and the Ephemerists their own stamps (#841)', () => {
+    expect(pickVariant(surfaceMap('scoreStamp'), 'everymen', DefaultScoreStamp)).toBe(
+      EverymenScoreStamp,
+    )
+    expect(pickVariant(surfaceMap('scoreStamp'), 'ephemerists', DefaultScoreStamp)).toBe(
+      EphemeristsScoreStamp,
+    )
+  })
+})
+
+/**
+ * The five conditional states of design v2, on both #841 stamps. The failure
+ * mode this guards is not a missing row — `scoreBreakdown` is tested above —
+ * but a stamp that stops READING as itself when a row drops out: a tally whose
+ * subtotal rule floats with nothing above it, or a rubric with no working over
+ * it. Each state must still print the total and its own device.
+ */
+describe('#841 stamps across the conditional states (ADR-0047)', () => {
+  const STATES = [
+    ['base only', { display_multiplier: 1, metatask_points: 0, points_from_votes: 0, total: 12 }],
+    ['+ votes', { display_multiplier: 1, metatask_points: 0, points_from_votes: 4, total: 16 }],
+    ['× mult', { display_multiplier: 0.8, metatask_points: 0, points_from_votes: 0, total: 9.6 }],
+    ['+ metatask', { display_multiplier: 1, metatask_points: 20, points_from_votes: 0, total: 32 }],
+    ['full formula', { display_multiplier: 0.8, metatask_points: 20, points_from_votes: 4, total: 29.6 }],
+  ] as const
+
+  for (const [name, fields] of STATES) {
+    it(`Everymen prints the tally and the roundel — ${name}`, () => {
+      const html = text(renderToStaticMarkup(<EverymenScoreStamp praxis={praxis({ ...fields })} />))
+      expect(html).toContain('TALLY')
+      expect(html).toContain('ON THE RECORD')
+      // The roundel carries the total whichever rows are present.
+      expect(html).toContain(fields.total.toFixed(1))
+      // The votes row survives at 0 — the deliberate ADR-0047 deviation.
+      expect(html).toContain('votes')
+      expect(html).not.toMatch(HEX)
+    })
+
+    it(`Ephemerists prints the working and the rubric — ${name}`, () => {
+      const html = text(
+        renderToStaticMarkup(<EphemeristsScoreStamp praxis={praxis({ ...fields })} />),
+      )
+      expect(html).toContain('base')
+      expect(html).toContain('from votes')
+      expect(html).toContain(fields.total.toFixed(1))
+      expect(html).not.toMatch(HEX)
+    })
+  }
+
+  it('draws the Everymen subtotal rule only when a metatask AND a multiplier are both live', () => {
+    const full = text(
+      renderToStaticMarkup(
+        <EverymenScoreStamp praxis={praxis({ display_multiplier: 0.8, metatask_points: 20 })} />,
+      ),
+    )
+    const metaOnly = text(
+      renderToStaticMarkup(
+        <EverymenScoreStamp praxis={praxis({ display_multiplier: 1, metatask_points: 20 })} />,
+      ),
+    )
+    expect(full).toContain('group')
+    expect(metaOnly).not.toContain('group')
   })
 })

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -22,27 +22,41 @@ import { VOTE_REFRAMES } from './voteReframes'
  * stilled; motion is decoration, not meaning.
  */
 
-/** Star anchor points on the 284×68 plate — ornament geometry, kept raw. */
+/**
+ * Star anchor points on the plate — ornament geometry, kept raw.
+ *
+ * GEOMETRY RE-SOLVE (#841). The design draws the constellation on a 284×68
+ * plate at intrinsic star sizes (21/28px). #821 kept that plate but hung 44px
+ * touch targets off the same anchors, and a 44px box centred on y=18 starts at
+ * −4: every outer star's hit box hung off the top or bottom edge of its own
+ * plate, so a third of each target was unclickable.
+ *
+ * Touch targets win, but a port is not a drop-in (`design-fidelity.md`): the
+ * layout is RE-SOLVED rather than the target shrunk. The constellation's shape
+ * is untouched — every anchor moves down by the same 8px and the plate grows to
+ * 84 — which leaves each 44px box inside the plate with room to spare while the
+ * figure the stars draw is bit-identical to the design's.
+ */
 const STAR_POINTS = [
-  [24, 44],
-  [80, 18],
-  [136, 50],
-  [196, 20],
-  [256, 42],
+  [24, 52],
+  [80, 26],
+  [136, 58],
+  [196, 28],
+  [256, 50],
 ]
 const PLATE_W = 284
-const PLATE_H = 68
-/** Touch-target box centred on each star (WCAG ≥44px). */
+const PLATE_H = 84
+/** Touch-target box centred on each star (WCAG ≥44px). Never shrink this. */
 const HIT = 44
 
 /** Faint background dust motes scattered across the plate — ornament, raw. */
 const DUST = [
-  [40, 12],
-  [110, 60],
-  [172, 10],
-  [232, 60],
-  [270, 16],
-  [60, 54],
+  [40, 20],
+  [110, 68],
+  [172, 18],
+  [232, 68],
+  [270, 24],
+  [60, 62],
 ]
 /** Corner-sparkle offsets around the rank-5 star (marginLeft/Top from centre). */
 const SPARK_SPOTS = [
@@ -237,7 +251,8 @@ export default function EphemeristsVote({
           style={{
             fontFamily: 'var(--eph-serif)',
             fontStyle: 'italic',
-            fontSize: 'var(--text-content)',
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: the widget's tier word is part of the mark, set at the design's 15 in the codex hand (#841, design-fidelity.md standing carve-out)
+            fontSize: 15,
             letterSpacing: '0.02em',
             color: active ? 'var(--eph-rubric)' : 'var(--eph-muted)',
             transition: 'color 140ms',

--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -212,7 +212,8 @@ export default function EverymenVote({ praxisId, currentValue, points, totalVote
         <span
           style={{
             fontFamily: 'var(--faction-everymen-card-font)',
-            fontSize: 'var(--text-content)',
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: the widget's tier word is part of the mark, struck at the design's 17 in the poster face (#841, design-fidelity.md standing carve-out)
+            fontSize: 17,
             letterSpacing: '0.06em',
             color: active ? 'var(--everymen-red)' : 'var(--everymen-muted)',
             transition: 'color 140ms',

--- a/frontend/src/factions/ephemerists.ts
+++ b/frontend/src/factions/ephemerists.ts
@@ -34,6 +34,7 @@ import EphemeristsTaskCard from '../components/cards/EphemeristsTaskCard'
 import EphemeristsTaskDetail from '../pages/taskDetail/archetypes/EphemeristsTaskDetail'
 import EphemeristsVote from '../components/vote/EphemeristsVote'
 import EphemeristsPraxisCard from '../components/praxisCard/desktop/EphemeristsPraxisCard'
+import EphemeristsScoreStamp from '../components/praxisCard/scoreStamp/EphemeristsScoreStamp'
 import { EphemeristsSigil } from '../components/cards/ephemeristsAtoms'
 import { EphemeristsCard } from '../components/cards/FactionCard'
 import { EphemeristsSelectCard } from '../components/cards/FactionSelectCard'
@@ -45,6 +46,7 @@ export const EPHEMERISTS_MANIFEST: FactionManifest = {
   factionSelectCard: () => EphemeristsSelectCard,
   taskCard: () => EphemeristsTaskCard,
   praxisCard: () => EphemeristsPraxisCard,
+  scoreStamp: () => EphemeristsScoreStamp,
   avatar: () => EphemeristsAvatar,
   backdrop: () => EphemeristsBackdrop,
   sigil: () => EphemeristsSigil,

--- a/frontend/src/factions/everymen.ts
+++ b/frontend/src/factions/everymen.ts
@@ -34,6 +34,7 @@ import EverymenTaskCard from '../components/cards/EverymenTaskCard'
 import EverymenTaskDetail from '../pages/taskDetail/archetypes/EverymenTaskDetail'
 import EverymenVote from '../components/vote/EverymenVote'
 import EverymenPraxisCard from '../components/praxisCard/desktop/EverymenPraxisCard'
+import EverymenScoreStamp from '../components/praxisCard/scoreStamp/EverymenScoreStamp'
 import { EverymenSigil } from '../components/cards/EverymenSigil'
 import EverymenCard from '../components/cards/EverymenFactionCard'
 import { EverymenSelectCard } from '../components/cards/FactionSelectCard'
@@ -45,6 +46,7 @@ export const EVERYMEN_MANIFEST: FactionManifest = {
   factionSelectCard: () => EverymenSelectCard,
   taskCard: () => EverymenTaskCard,
   praxisCard: () => EverymenPraxisCard,
+  scoreStamp: () => EverymenScoreStamp,
   avatar: () => EverymenAvatar,
   backdrop: () => EverymenBackdrop,
   sigil: () => EverymenSigil,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -274,6 +274,10 @@
   --eph-parchment: #f1e8cf; /* bright text on dark elements */
   --eph-field: #1d4f6e; /* lapis celestial-diagram field */
   --eph-field-deep: #143b54;
+  /* Codex chrome (#841) — the folio is bound in GOLD, not in a neutral rule.
+     Paler than --eph-gold so the frame reads as leaf, not as ochre ink. */
+  --eph-frame: #cdae6a; /* card + score-box border */
+  --eph-stamp-bg: #f8f0d9; /* the score box's brighter leaf */
   /* Ephemerist faces — Cinzel display caps, EB Garamond body, Cormorant flourishes */
   --eph-display: "Cinzel", "Trajan Pro", Georgia, serif;
   --eph-serif: "EB Garamond", Georgia, serif;
@@ -424,6 +428,17 @@
   --faction-everymen-card-accent: var(--everymen-red);
   --faction-everymen-card-muted: var(--everymen-muted);
   --faction-everymen-card-font: var(--font-accent); /* Bebas Neue */
+
+  /* ── Broadsheet chrome (#841) — the masthead bar, the frame ink and the
+     rubber TALLY stamp. The praxis card's border is the faction INK, not the
+     neutral --color-border: on a broadsheet the rule around the sheet is part
+     of the printing, not the app's chrome. ── */
+  --everymen-frame: #221a12; /* frame rule — the ink, not --color-border */
+  --everymen-masthead-text: #fbf3dd; /* cream on the red bar (5.2:1) */
+  --everymen-stamp-field: rgba(193, 39, 45, 0.05); /* stamped ink wash */
+  --everymen-stamp-ink: #a3402f; /* typewriter row labels */
+  --everymen-stamp-numeral: #7a1f18; /* the filled-in figures */
+  --everymen-stamp-mult: #a9741a; /* gold — the multiplier figure only */
 
   /* ── Gearworks vote widget (#821) — reached gears heat a cold→ember ramp with
      pale hubs; unreached gears are edge-only outlines; rank 5 throws sparks. The
@@ -716,6 +731,11 @@
   --eph-parchment: #efe3c6;
   --eph-field: #102a3a; /* celestial field deepens */
   --eph-field-deep: #0a1d2a;
+  /* Codex chrome (#841): the gilt binding would glare on the dark leaf, so the
+     frame goes to the faction's verdigris at low alpha — the design's own dark
+     value. The stamp leaf darkens with the vellum rather than lightening. */
+  --eph-frame: rgba(58, 160, 164, 0.35);
+  --eph-stamp-bg: #181208;
 
   /* ── Warriors of Whimsy collage scrap layers (dark) ── */
   --faction-coven-scrap-deep: #091209;
@@ -801,10 +821,36 @@
   --everymen-muted: #b6a079;
   --everymen-field: #3c1416;
   --everymen-field-deep: #5a1d20;
+  /* Broadsheet chrome (#841): the frame rule lifts off near-black (the light
+     ink would vanish), and the masthead's red bar carries INK, not cream —
+     white/cream on #e2433f fails AA, which is the same call
+     --faction-everymen-on-fill already makes. */
+  --everymen-frame: #3e3320;
+  --everymen-masthead-text: #161009;
+  --everymen-stamp-field: rgba(226, 67, 63, 0.08);
+  --everymen-stamp-ink: #d67b6a;
+  --everymen-stamp-numeral: #ece1c6;
+  --everymen-stamp-mult: #e6b34a;
   /* Gearworks: cooler edge for cold gears, a brighter single-halo rank-5 glow on
      the dark paper (the light double-drop-shadow would muddy against it). */
   --faction-everymen-vote-edge: #8a7856;
   --faction-everymen-vote-glow-5: drop-shadow(0 0 9px rgba(255, 175, 60, 0.95));
+}
+
+/* ══ Everymen rubber-stamp print (#841) ══
+   The tally stamp and the points roundel are INKED onto the sheet, so in light
+   they multiply into the paper's rule lines. On the dark broadsheet multiply
+   would subtract the mark to nothing, so the dark cascade drops the blend and
+   lifts the opacity instead — the theme switch belongs here, never in a
+   `dark ? a : b` ternary (§8). */
+.everymen-stamp-print {
+  mix-blend-mode: multiply;
+  opacity: 0.9;
+}
+
+[data-theme="dark"] .everymen-stamp-print {
+  mix-blend-mode: normal;
+  opacity: 0.95;
 }
 
 /* ══ Everymen poster-wall backdrop (faction-context pages; theme-aware) ══ */

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -57,7 +57,10 @@
       "total": "total",
       "totalShort": "tot",
       "fromVotes": "+ {{votes}} from votes",
-      "points": "points"
+      "points": "points",
+      "tally": "TALLY",
+      "group": "group",
+      "onTheRecord": "★ VERIFIED ★ ON THE RECORD "
     },
     "mediaEmpty": "no proof attached",
     "adminStatus": {
@@ -76,6 +79,7 @@
     "masthead": {
       "ua": "Acquisition · filed",
       "ephemerists": "Ephemeris · sealed entry",
+      "everymen": "The Everymen",
       "snide": "evidence locker",
       "albescent": "Account · filed",
       "singularity": "singularity protocol",


### PR DESCRIPTION
Closes #841

Everymen and the Ephemerists get their two right-column objects — a **score box** and a **total mark** — plus the frame corrections the vendored prototype asks for. Ported from `.design-sync/praxis-cards/design_handoff_faction_vote_stamps/Faction Praxis Cards.dc.html` (light **and** dark bands, plus `SCORE STAMP · CONDITIONAL STATES`). **No `Ua*` file is touched.**

### Everymen — the broadsheet

- **Masthead** (was absent entirely): full-width red bar, `⚙ THE EVERYMEN ⚙`, Bebas Neue 15, `letter-spacing .3em`, cream on red in light / ink on red in dark.
- **Tally stamp** replaces the generic score box: `rotate(1.3deg)`, dashed `TALLY` rule header, `BASE / META / GROUP / MULT / VOTES` rows with dashed fill-in fields, figures in Bebas 17, gold for the multiplier only.
- **Points roundel** — new `components/factionMarks/PointsRoundel.tsx`: 102px SVG, `rotate(-6deg)`, double circle r=46/40, `★ VERIFIED ★ ON THE RECORD` arced on a `textPath` (Special Elite 8), total in Bebas 33 (31 at four glyphs), `POINTS` in Special Elite 7.5.
- **Frame**: border is now the faction ink (`--everymen-frame`), not `--color-border`; the invented torn-bottom `clipPath` is deleted; radius 2 kept; the margin rule now mixes from `--everymen-red` at the design's 28%.
- The `mix-blend-mode: multiply` both marks print with lives in `.everymen-stamp-print` — light multiplies, dark drops the blend and lifts opacity, through the `[data-theme="dark"]` cascade, never a ternary.

### Ephemerists — the codex

- **Rubric** — new `components/factionMarks/Rubric.tsx`: total in Cinzel 28 rubrication red over `Points`, under a gold→verdigris hairline.
- **Score box**: `1.5px solid var(--eph-frame)` on `--eph-stamp-bg`, base in Cinzel 24, teal `×0.80` chip, italic `+ N from votes`, `rotate(-1deg)`.
- **Frame**: gold border (`--eph-frame`), not the neutral `color-mix`.
- **Inventions removed**: the dedicated running-head bar, the sigil in it, and the `Foxing` layer. The design's running head is an eyebrow line *inside the left column* — added via a new optional `eyebrow` slot on `PraxisBody`.
- **Widget geometry re-solved**: anchors move down 8px and the plate grows 68 → 84 so every 44px target sits inside the plate. **Targets are not shrunk** and the constellation's shape is unchanged.

### Both

- `scoreStamp` registered in both manifests; `scoreBreakdown()` untouched; mobile reuses the same stamps.
- Five conditional states covered, with **the votes row kept at 0** (ADR-0047's deliberate deviation from the design).
- Motion untouched and still CSS-class gated.

## Deviations

| Design value | What shipped | Rule that forced it |
|---|---|---|
| Totals drawn as integers (`12`, `16`, `32`) | `12.0`, `16.0`, `32.0` — `toFixed(1)` | ADR-0047 "total to 1 decimal by default", and `DefaultScoreStamp` already ships that; a per-faction format would make two stamps disagree in one feed |
| Votes row hidden at `0` | Votes row always drawn | ADR-0047 / owner decision 2026-07-20 — `+0 from votes` says "nobody has voted yet"; an absent row cannot |
| Vote-caption sizes swapped to `--text-content` (18) by #821 | Back to the design's **17** (Everymen) / **15** (Ephemerists) | The standing ornament carve-out in `design-fidelity.md` — a widget's tier word is part of the mark |
| Ephemerists metatask chip in spectrum green | Deep rubric red (`--eph-rubric-deep`) | Contrast — the codex-native gold pays only ~4.2:1 against parchment at 9px; green is not in this faction's palette |
| Ephemerists mult-chip text in parchment `#f1e8cf` | `--faction-ephemerists-on-fill` | It is the contrast-audited token and it flips correctly (parchment stays light in dark, where the chip fill lightens) |
| Everymen masthead text cream in **both** themes | Cream in light, ink in dark | Cream on the dark red `#e2433f` fails AA — the same call `--faction-everymen-on-fill` already makes |
| Ephemerists running head reads `Codex folio №663 · attested` | Existing `card.masthead.ephemerists` copy (`Ephemeris · sealed entry`) | The folio number is prototype sample data; there is no folio field on the wire, and inventing copy is out of scope for a style issue |
| Everymen "full formula" column drawn without dashed fields | Dashed fields kept in all five states | The fill-in field is the stamp's device; dropping it only in one state makes that state read as a different object |
| Everymen `GROUP` subtotal row | Drawn only when a metatask **and** a multiplier are both live | Without a multiplier the subtotal restates the row above it — the stamp has to read as a completed form in every state |
| Star anchors on a 68px plate | Anchors +8px, plate 84px | 44px touch targets win, but the layout is re-solved rather than the target shrunk (`design-fidelity.md`) |

**Two places the brief/design disagreed with the code — reported, not smoothed over:**

1. **The Ephemerists hit boxes never overlapped each other.** The anchors are 56/56/60/60px apart and the boxes are 44px, so the horizontal spacing was always fine. The real defect was **vertical**: anchors at y=18/20/50 on a 68px plate put each outer box 2–4px off the top or bottom edge, so part of every outer target fell outside the plate. That is what this PR fixes.
2. **The design's dark Ephemerists card is navy** (`#0e1f2e`, teal border, blue-grey muted ink). The repo's Ephemerists dark palette is **tobacco** (`--eph-vellum: #211a10`) and drives the backdrop and every other Ephemerists surface. Repainting it is a faction-wide decision well outside this issue, so the dark stamp and frame are built in the repo's tobacco idiom (with the design's teal frame alpha). **Flagging for a follow-up call.**

## What to eyeball

**Visual QA is outstanding — I cannot screenshot and there is no dev stack here. Everything below is unverified visually.**

- The Everymen masthead in **dark**: ink on `#e2433f`, and that the bar's `letter-spacing: .3em` does not push `THE EVERYMEN` into the cogs on a narrow card.
- `mix-blend-mode: multiply` on the tally + roundel in **light**: they should sink into the ruled newsprint, not float on it. In dark they should read as clean red line-work (blend dropped).
- The roundel's arced legend: that Special Elite actually resolves, and that `★ VERIFIED ★ ON THE RECORD` completes the circle without overrunning itself.
- Everymen with a metatask **and** a multiplier — the five-row tally is the tallest state; check the stamp column against the card's left column height.
- The Ephemerists gold frame against the vellum in light and against tobacco in dark (is the teal-alpha border visible enough?).
- The eyebrow line now inside the left column: it should stop at the score box, not run under it.
- The re-solved constellation: 44px targets, no clipping, and the figure still reading as the design's constellation.
- Both stamps on **mobile**, where the Ephemerists box stretches full-width and the Everymen column stays 118px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
