### PR TITLE
Logged-out vote gate: faction-voiced VoteLoginGate (#855)

### DIFF
--- a/frontend/src/components/vote/VoteShell.tsx
+++ b/frontend/src/components/vote/VoteShell.tsx
@@ -1,3 +1,4 @@
+import { createContext, useContext, type CSSProperties } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 /**
@@ -8,10 +9,165 @@ import { Trans, useTranslation } from 'react-i18next'
  * in the votes:chrome catalog branch (ADR-0032).
  */
 
-/** Logged-out gate shown in place of the vote control. */
-export function VoteLoginGate() {
+/**
+ * The task faction whose vote widget is being rendered, published by
+ * {@link VoteUI} so shared chrome can speak in that faction's voice without
+ * every widget threading a slug prop (#855).
+ *
+ * A context rather than a prop on purpose: the gate is returned by each
+ * faction widget's own `if (!user)` early return — which is where the design
+ * puts the swap, BENEATH the card's prompt heading and nothing else — and
+ * those nine call sites are owned by nine parallel faction slices. Reading the
+ * slug from above leaves them untouched.
+ */
+export const VoteFactionContext = createContext<string | null | undefined>(undefined)
+
+/**
+ * One faction's eyebrow voice for the gate line. Colour, face and casing only:
+ * the gate is a single line of text, so a treatment can never grow chrome of
+ * its own (design v2: "no stamps, no disabled buttons").
+ */
+interface GateTreatment {
+  /** Faction display/body face — always a `--font-*` token. */
+  fontFamily: string
+  /** Off the `--text-*` label ramp; the gate is label tier, not content tier. */
+  fontSize: string
+  letterSpacing?: string
+  /** Overrides `.eyebrow`'s uppercase where the faction speaks in its own case. */
+  textTransform?: CSSProperties['textTransform']
+  fontWeight?: CSSProperties['fontWeight']
+  /** Solid ink. Mutually exclusive with `gradient`. */
+  color?: string
+  /** Gradient-clipped ink (the unaffiliated spectrum). Wins over `color`. */
+  gradient?: string
+  textShadow?: string
+  /**
+   * An ornament glyph prefixed to the line — Singularity's terminal caret.
+   * Deliberately NOT catalog copy: it is part of that faction's eyebrow
+   * treatment (a prompt marker), the same way its scanline is, and the gate is
+   * a single translatable string shared by all nine factions.
+   */
+  prefix?: string
+}
+
+/**
+ * The unaffiliated spectrum gate, and the fall-through for every slug without
+ * a treatment of its own — `na`, `albescent` (which the design says inherits
+ * the unaffiliated eyebrow) and any faction added later (ADR-0039).
+ */
+const DEFAULT_GATE: GateTreatment = {
+  fontFamily: 'var(--faction-default-card-font)',
+  fontSize: 'var(--text-xl)',
+  letterSpacing: '0.1em',
+  gradient: 'var(--faction-default-rainbow)',
+}
+
+/**
+ * Per-faction gate voices, from the vendored design's `LOGGED OUT · VOTE GATE`
+ * board. The board draws seven tiles; the `wow` entry is the one labelled
+ * "Cozy Coven" there (MedievalSharp, plum) — every artifact in this epic labels
+ * WOW and Coven backwards, see `.design-sync/praxis-cards/LABELS.md` and
+ * ADR-0050. `coven` therefore keeps its own pink marker voice.
+ */
+const GATE_TREATMENTS: Record<string, GateTreatment> = {
+  ua: {
+    fontFamily: 'var(--faction-ua-body-font)',
+    fontSize: 'var(--text-lg)',
+    letterSpacing: '0.16em',
+    color: 'var(--faction-ua-card-accent)',
+  },
+  snide: {
+    fontFamily: 'var(--font-body)',
+    fontSize: 'var(--text-lg)',
+    fontWeight: 700,
+    letterSpacing: '0.16em',
+    color: 'var(--faction-snide-card-accent)',
+  },
+  singularity: {
+    fontFamily: 'var(--faction-singularity-card-font)',
+    fontSize: 'var(--text-lg)',
+    letterSpacing: '0.06em',
+    // The terminal never shouts; the caret does the talking.
+    textTransform: 'lowercase',
+    color: 'var(--faction-singularity-card-accent)',
+    textShadow: '0 0 8px color-mix(in srgb, var(--faction-singularity-card-accent) 50%, transparent)',
+    prefix: '> ',
+  },
+  everymen: {
+    fontFamily: 'var(--faction-everymen-card-font)',
+    fontSize: 'var(--text-xl)',
+    letterSpacing: '0.14em',
+    color: 'var(--faction-everymen-card-accent)',
+  },
+  ephemerists: {
+    fontFamily: 'var(--faction-ephemerists-card-font)',
+    fontSize: 'var(--text-lg)',
+    letterSpacing: '0.1em',
+    color: 'var(--faction-ephemerists-card-accent)',
+  },
+  wow: {
+    fontFamily: 'var(--faction-wow-card-font)',
+    fontSize: 'var(--text-xl)',
+    // The chronicle sets its verdicts in sentence case, not small caps.
+    textTransform: 'none',
+    color: 'var(--faction-wow-card-accent)',
+  },
+  coven: {
+    fontFamily: 'var(--faction-coven-card-font)',
+    fontSize: 'var(--text-xl)',
+    textTransform: 'none',
+    color: 'var(--faction-coven-card-accent)',
+  },
+}
+
+/** Resolve a slug to its gate voice; unknown/absent slugs get the spectrum. */
+export function gateTreatment(slug: string | null | undefined): GateTreatment {
+  return (slug && GATE_TREATMENTS[slug]) || DEFAULT_GATE
+}
+
+/**
+ * Logged-out gate shown in place of the vote control (#855).
+ *
+ * ONE line, in the faction's eyebrow voice: no stamp chrome, no disabled 1-5
+ * control, no second sentence. The card around it is untouched — a signed-out
+ * viewer keeps the headline, the media and the read-only score stamp, because
+ * neither `ScoreStamp` nor any other card slot consults the viewer; only the
+ * widget below the prompt heading swaps.
+ *
+ * The copy is one catalog key for all nine factions. The casing differences the
+ * design draws (LOG IN TO VOTE vs Log in to vote) are `text-transform` on the
+ * treatment, never nine strings.
+ */
+export function VoteLoginGate({ factionSlug }: { factionSlug?: string | null } = {}) {
   const { t } = useTranslation('votes')
-  return <p className="eyebrow">{t('chrome.loginGate')}</p>
+  const contextSlug = useContext(VoteFactionContext)
+  const treatment = gateTreatment(factionSlug ?? contextSlug)
+
+  return (
+    <p
+      className="eyebrow"
+      style={{
+        margin: 0,
+        fontFamily: treatment.fontFamily,
+        fontSize: treatment.fontSize,
+        fontWeight: treatment.fontWeight,
+        letterSpacing: treatment.letterSpacing,
+        textTransform: treatment.textTransform,
+        textShadow: treatment.textShadow,
+        ...(treatment.gradient
+          ? {
+              background: treatment.gradient,
+              WebkitBackgroundClip: 'text',
+              backgroundClip: 'text',
+              color: 'transparent',
+            }
+          : { color: treatment.color }),
+      }}
+    >
+      {treatment.prefix}
+      {t('chrome.loginGate')}
+    </p>
+  )
 }
 
 /**

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -2,6 +2,7 @@ import type { } from 'react'
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
 import UnaffiliatedVote from './UnaffiliatedVote'
+import { VoteFactionContext } from './VoteShell'
 
 /**
  * Per-faction vote/rating UI dispatcher (Tier-3 surface). Keyed by the voted
@@ -22,5 +23,12 @@ export default function VoteUI({
   ...props
 }: VoteUIProps & { factionSlug?: string | null }) {
   const Variant = pickVariant(surfaceMap('vote'), factionSlug, UnaffiliatedVote)
-  return <Variant {...props} />
+  // The slug is published to the shared chrome as well as dispatched on: the
+  // logged-out gate speaks in the task faction's eyebrow voice (#855) and is
+  // returned from inside each widget, which takes no slug prop.
+  return (
+    <VoteFactionContext.Provider value={factionSlug}>
+      <Variant {...props} />
+    </VoteFactionContext.Provider>
+  )
 }

--- a/frontend/src/components/vote/__tests__/voteLoginGate.test.tsx
+++ b/frontend/src/components/vote/__tests__/voteLoginGate.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * The logged-out vote gate (#855, design v2 `LOGGED OUT · VOTE GATE`).
+ *
+ * The contract these cases pin, in the order it is easy to break:
+ *  1. ONE catalog key for all nine slugs — the casing the design draws is
+ *     `text-transform`, never nine hardcoded strings.
+ *  2. ONE line: no disabled 1-5 control, no stamp chrome.
+ *  3. A faction VOICE: the slug reaches the gate through the context published
+ *     by VoteUI, so the nine widgets keep their zero-prop call site.
+ *  4. `wow` wears the chronicle plum and `coven` the marker pink — the design
+ *     board labels those two backwards (ADR-0050, LABELS.md), so an inversion
+ *     here would look correct against the artifact and be wrong.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import { VoteLoginGate, VoteFactionContext } from '../VoteShell'
+
+/** Every faction slug the vote surface can be asked for, plus the no-faction case. */
+const SLUGS = [
+  'ua',
+  'snide',
+  'singularity',
+  'everymen',
+  'ephemerists',
+  'wow',
+  'coven',
+  'albescent',
+  'na',
+]
+
+/** No colour may reach the markup as a literal — tokens only (ADR-0049). */
+const HEX = /#[0-9a-fA-F]{3,8}\b/
+
+const gate = (slug?: string | null) => renderToStaticMarkup(<VoteLoginGate factionSlug={slug} />)
+
+/**
+ * Strip tags so a copy assertion cannot be satisfied by an attribute value, and
+ * put back the entities React escapes (Singularity's caret is one).
+ */
+const text = (html: string) =>
+  html.replace(/<[^>]*>/g, '').replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&')
+
+describe('VoteLoginGate', () => {
+  it('renders the one shared copy key for every slug', () => {
+    const copy = i18n.t('votes:chrome.loginGate')
+    expect(copy).toBeTruthy()
+    for (const slug of SLUGS) {
+      expect(text(gate(slug))).toContain(copy)
+    }
+  })
+
+  it('is a single line — no control, no stamp chrome', () => {
+    for (const slug of [...SLUGS, null, undefined, 'not-a-faction']) {
+      const html = gate(slug)
+      expect(html).not.toContain('<button')
+      expect(html).not.toContain('disabled')
+      expect(html).not.toContain('<svg')
+      // one element, and it is the eyebrow
+      expect(html.match(/</g)?.length).toBe(2)
+      expect(html).toContain('class="eyebrow"')
+    }
+  })
+
+  it('spells every colour and face as a token', () => {
+    for (const slug of [...SLUGS, 'not-a-faction']) {
+      expect(gate(slug)).not.toMatch(HEX)
+      expect(gate(slug)).toContain('var(--')
+    }
+  })
+
+  it('gives each faction its own voice', () => {
+    expect(gate('ua')).toContain('--faction-ua-card-accent')
+    expect(gate('snide')).toContain('--faction-snide-card-accent')
+    expect(gate('everymen')).toContain('--faction-everymen-card-accent')
+    expect(gate('ephemerists')).toContain('--faction-ephemerists-card-accent')
+  })
+
+  it('keeps wow on the chronicle plum and coven on the marker pink', () => {
+    const wow = gate('wow')
+    expect(wow).toContain('--faction-wow-card-accent')
+    expect(wow).toContain('--faction-wow-card-font')
+    expect(wow).not.toContain('coven')
+
+    const coven = gate('coven')
+    expect(coven).toContain('--faction-coven-card-accent')
+    expect(coven).toContain('--faction-coven-card-font')
+    expect(coven).not.toContain('wow')
+  })
+
+  it('prefixes the Singularity caret and keeps the terminal lowercase', () => {
+    const html = gate('singularity')
+    expect(text(html).trim().startsWith('>')).toBe(true)
+    expect(html).toContain('text-transform:lowercase')
+  })
+
+  it('falls the unaffiliated spectrum through for na, albescent and unknown slugs', () => {
+    for (const slug of ['na', 'albescent', 'not-a-faction', null, undefined]) {
+      const html = gate(slug)
+      expect(html).toContain('--faction-default-rainbow')
+      expect(html).toContain('background-clip:text')
+    }
+  })
+
+  it('reads the slug from the context VoteUI publishes', () => {
+    const html = renderToStaticMarkup(
+      <VoteFactionContext.Provider value="snide">
+        <VoteLoginGate />
+      </VoteFactionContext.Provider>,
+    )
+    expect(html).toContain('--faction-snide-card-accent')
+  })
+
+  it('lets an explicit prop win over the context', () => {
+    const html = renderToStaticMarkup(
+      <VoteFactionContext.Provider value="snide">
+        <VoteLoginGate factionSlug="ua" />
+      </VoteFactionContext.Provider>,
+    )
+    expect(html).toContain('--faction-ua-card-accent')
+    expect(html).not.toContain('--faction-snide-card-accent')
+  })
+})


### PR DESCRIPTION
Design v2's `LOGGED OUT · VOTE GATE` board validates the `VoteLoginGate` that
already existed and specifies its voice. This makes it match.

Closes #855

## What changed

- **`frontend/src/components/vote/VoteShell.tsx`** — `VoteLoginGate` now renders
  one eyebrow line in the task faction's voice: face, label-ramp size,
  letter-spacing, casing and token ink per faction, Singularity's `> ` caret,
  and the unaffiliated spectrum (rainbow-clipped text) as the fall-through.
  Still ONE component and ONE copy key, `votes.chrome.loginGate` — no faction
  string is hardcoded; the LOG IN TO VOTE / Log in to vote difference is
  `text-transform`.
- **`frontend/src/components/vote/VoteUI.tsx`** — publishes the task faction
  slug on a new `VoteFactionContext`. The gate is returned from *inside* each
  faction widget's `if (!user)` early return, which is exactly where the design
  puts the swap (beneath the prompt heading, replacing the widget and nothing
  else). A context lets the gate read the slug without editing those nine
  widget files, which nine parallel slices own. `VoteLoginGate` also takes an
  optional `factionSlug` prop, which wins over the context.
- **`frontend/src/components/vote/__tests__/voteLoginGate.test.tsx`** — new.

`votes.json` was **not** touched: `chrome.loginGate` already exists and its value
is right.

## Contract check

1. **Prompt heading stays.** Verified on `main`: no vote widget renders a prompt
   heading today (the only `prompt` keys, `chrome.singularity.prompt` and
   `chrome.albescent.prompt`, are unreferenced), and the design puts the prompt
   in the CARD, above the `{{ factionVote }}` slot. Nothing in this PR moves or
   removes anything above the widget — the gate replaces the widget slot only.
2. **Score stamp still renders read-only when signed out — verified true.**
   `PraxisBody` (`praxisCard/desktop/shared.tsx`) calls `<ScoreStamp>`
   unconditionally, and neither `ScoreStamp` nor `scoreBreakdown` consults
   `useAuth`. The viewer gate lives only inside the vote widgets. No change
   needed; recording it here because the issue asked for the check.
3. **One line only.** A test asserts the gate's markup contains no `<button`,
   no `disabled`, no `<svg`, and exactly one element.

WOW/Coven are **not** taken from the board's labels: the tile headed "Cozy
Coven" (MedievalSharp, plum `#7A4A9E`) is `wow`'s, per ADR-0050 and
`.design-sync/praxis-cards/LABELS.md`. `wow` gets `--faction-wow-card-*`
(chronicle plum/MedievalSharp); `coven` keeps its pink marker voice. A test pins
the inversion so it can't drift back.

## Deviations, and the rule forcing each

| # | Deviation | Rule |
|---|---|---|
| 1 | Gate sizes are `var(--text-lg)` (12px) and `var(--text-xl)` (14px). The design draws 12 / 15 / 16px. | The label ramp has no 15 or 16; skins may not set raw sizes (WORLD_ZERO_STYLE §4a, and `no-raw-style-values` fails CI on raw font-size). |
| 2 | Unaffiliated/albescent gate ink is the full `--faction-default-rainbow`, not the design's 2-stop `#16a34a → #2563eb` slice. | Colours live only in `index.css`, and `index.css` is fenced to #848 in this batch. The existing spectrum token is the nearest true thing. |
| 3 | Singularity's glow is `color-mix(in srgb, var(--faction-singularity-card-accent) 50%, transparent)` rather than the design's `rgba(74,222,128,0.5)`. | Same rule — no raw colour outside `index.css`. Same hue, same alpha. |
| 4 | The gate's per-faction table lives in `VoteShell.tsx`, not in the faction manifests as a registered surface. | The issue settles this: one shared component, one key; nine slices editing `VoteShell.tsx` is the collision this issue exists to avoid. |
| 5 | Singularity's `> ` caret is a field on the treatment, not catalog copy. | The issue settles this: the caret "comes from its eyebrow treatment", and the copy is one shared key. |
| 6 | The **mobile praxis-detail** star caster (`pages/praxisDetail/mobileArchetypes/shared.tsx` → `MobileStarVote`) renders the gate with the DEFAULT spectrum voice, not its faction's. | It is not dispatched through `VoteUI`, so there's no slug in scope; giving it one means editing its seven archetype call sites, outside this issue's footprint. The design board covers the card's widget slot. Flag if you want it followed up. |

## What to eyeball

- **Nine slugs × light/dark**, signed out, on a praxis card: ua, snide,
  singularity, everymen, ephemerists, wow, coven, albescent, na.
- The gate line's **contrast on its own card ground** — each ink is that
  faction's `card-accent`, which is AA-rated against its `card-bg`, but the gate
  sits low in the card where some frames tint.
- **Unaffiliated/albescent**: gradient-clipped text is invisible if
  `background-clip:text` fails; confirm the line is not blank.
- **Singularity**: caret + lowercase + glow, and that `.eyebrow`'s uppercase is
  genuinely overridden.
- **WOW vs Coven**: plum MedievalSharp vs pink Caveat — the one thing that would
  look "right" against the mockup while being wrong.
- Vertical rhythm: the gate is `margin: 0` inside `PraxisVoteFooter`'s
  `--space-md` top margin; the design draws a rule above it that belongs to the
  card frame, not to the gate.

## Verification

`tsc --noEmit` clean (only the known stale-junction `node:fs`/`node:url` false
alarm, PR #675), `vite build` OK, `eslint` clean on the changed files, vitest
**1122 passed / 106 files** including 9 new cases.

**No visual QA was done** — I cannot screenshot and there is no dev stack in
this worktree. Every claim above is from types, tests and markup assertions, not
from looking at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
