### PR TITLE
Build AlbescentVote — the ferrofluid spectrum widget (#843)

### DIFF
--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState, useSyncExternalStore, type CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { VoteUIProps } from './VoteUI'
+import { useVote } from './useVote'
+import { VoteLoginGate, VoteSummary } from './VoteShell'
+import { reframeLabel } from './voteReframes'
+
+/**
+ * Albescent vote UI (#843) — FERROFLUID. Ported from the design handoff
+ * (`.design-sync/praxis-cards/design_handoff_faction_vote_stamps/`,
+ * `AlbescentVote`). It is the eighth widget; until now Albescent fell through to
+ * {@link import('./UnaffiliatedVote').default} and nobody noticed, because the
+ * fallback renders something plausible.
+ *
+ * It wears the SAME neutral spectrum as unaffiliated — that is the point, and the
+ * rule the whole manifest is built on (see `factions/albescent.ts`): a surface
+ * that repaints Albescent in its own colours puts it back in the rainbow and
+ * un-hides the society. What Albescent adds is a FLOURISH over that structure,
+ * exactly like the praxis card's drift (ADR-0048): each dot is a blob of
+ * ferrofluid that slowly morphs between polygon lobe counts — circle → triangle →
+ * square → pentagon → hexagon — on a shared clock, offset per dot. Someone
+ * already looking sees it; a glance reads a row of dots.
+ *
+ * Colour is all `--faction-default-*` / `--spectrum-*`, flipped by the
+ * [data-theme] cascade (never a `dark` ternary), so the design's dark-only
+ * hairline drop-shadows are deliberately dropped rather than branched in JS.
+ *
+ * TIER WORDS — a deliberate divergence from the design. The handoff gives
+ * Albescent the same word ladder as unaffiliated (so-so … brilliant). The repo
+ * removed Albescent's vote voice on lore grounds (#783/#232, ADR-0048): a task
+ * filed under Albescent used to label its tiers in the society's own words for
+ * every voter, revealed or not, which was the loudest tell left. `voteReframes`
+ * therefore has no `albescent` entry and {@link reframeLabel} returns the plain
+ * numeral. That resolver is the single source of the decision, so this widget
+ * calls it rather than hardcoding either ladder.
+ *
+ * MOTION. Two separate things move, and both are gated:
+ *  - the rising-wave bob reuses the shared `.spectrum-dot--reached` class, which
+ *    lives behind `prefers-reduced-motion: no-preference` in index.css;
+ *  - the morph is a JS clock, so it reads the media query directly and FREEZES.
+ * Stilled, every dot holds a distinct static polygon and still fills with its
+ * slice of the spectrum — the control reads and votes exactly the same.
+ */
+
+/** Rising blob diameters (px) and their gap — ornament geometry, §4a leaves these raw. */
+const DOT_SIZES = [22, 24, 26, 28, 30]
+const GAP = 14
+
+/**
+ * The row is ONE rainbow, windowed. Each blob paints a `SPAN`-wide gradient
+ * pushed left by everything before it, so the spectrum runs continuously across
+ * the whole row (and across the gaps) instead of each dot showing an isolated
+ * slice. SPAN is the row's exact laid-out width, so the button boxes must stay
+ * exactly `size` wide with `GAP` between them or the illusion breaks.
+ */
+const SPAN = DOT_SIZES.reduce((total, size) => total + size, 0) + (DOT_SIZES.length - 1) * GAP
+
+/** Lobe counts the blob morphs through. 64 ≈ a circle at this radius. */
+const LOBE_SEQUENCE = [64, 3, 4, 5, 6]
+/** Clock tick, and how long one lobe count is held. */
+const TICK_MS = 120
+const MORPH_STEP_MS = 1700
+/** The morph IS the effect: a long eased clip-path tween between lobe counts. */
+const MORPH_TRANSITION =
+  'clip-path .85s cubic-bezier(.65,0,.35,1), -webkit-clip-path .85s cubic-bezier(.65,0,.35,1), transform .18s'
+
+/**
+ * A 48-point `polygon()` approximating a regular `sides`-gon inscribed in the
+ * box. Ported as-is from the handoff: a fixed point count is what lets CSS
+ * interpolate between two different lobe counts at all — polygons only tween
+ * when they have the same number of vertices, so a triangle here is a 48-point
+ * shape whose points happen to lie on three straight edges.
+ */
+function polyClipN(sides: number): string {
+  const POINTS = 48
+  const effectiveSides = sides < 3 ? 64 : sides
+  const segment = (2 * Math.PI) / effectiveSides
+  const points: string[] = []
+  for (let index = 0; index < POINTS; index++) {
+    const theta = (index / POINTS) * Math.PI * 2 - Math.PI / 2
+    const angle = (((theta % segment) + segment) % segment) - segment / 2
+    const radius = Math.cos(Math.PI / effectiveSides) / Math.cos(angle)
+    points.push(
+      `${(50 + 48 * radius * Math.cos(theta)).toFixed(1)}% ${(50 + 48 * radius * Math.sin(theta)).toFixed(1)}%`,
+    )
+  }
+  return `polygon(${points.join(',')})`
+}
+
+/** matchMedia-backed reduced-motion flag; defaults to stilled when absent (SSR/test). */
+function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(
+    (onChange) => {
+      const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+      mql.addEventListener('change', onChange)
+      return () => mql.removeEventListener('change', onChange)
+    },
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    () => true,
+  )
+}
+
+/** 120ms morph clock; frozen (never ticks) when `enabled` is false. */
+function useMorphTick(enabled: boolean): number {
+  const [tick, setTick] = useState(0)
+  useEffect(() => {
+    if (!enabled) return
+    const id = setInterval(() => setTick((value) => value + 1), TICK_MS)
+    return () => clearInterval(id)
+  }, [enabled])
+  return tick
+}
+
+export default function AlbescentVote({
+  praxisId,
+  currentValue,
+  points,
+  totalVotes,
+}: VoteUIProps) {
+  const { t } = useTranslation('votes')
+  const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
+  const [hovered, setHovered] = useState(0)
+  const reducedMotion = usePrefersReducedMotion()
+  const tick = useMorphTick(!reducedMotion)
+
+  if (!user) {
+    return <VoteLoginGate />
+  }
+
+  const active = hovered || selected
+  // Plain numerals, not a word ladder — see the TIER WORDS note above.
+  const caption = active ? reframeLabel('albescent', active) : t('unaffiliated.idle')
+  const step = Math.floor((tick * TICK_MS) / MORPH_STEP_MS)
+  let offset = 0
+
+  return (
+    <div>
+      <div
+        onMouseLeave={() => setHovered(0)}
+        style={{ display: 'flex', gap: GAP, alignItems: 'center' }}
+      >
+        {DOT_SIZES.map((size, index) => {
+          const value = index + 1
+          const reached = active >= value
+          const picked = selected === value
+          const top = value === 5
+          const glow = `var(--spectrum-glow-${value})`
+          const positionX = -offset
+          offset += size + GAP
+          const clip = polyClipN(LOBE_SEQUENCE[(step + index) % LOBE_SEQUENCE.length])
+          const dotStyle: CSSProperties = {
+            width: size,
+            height: size,
+            clipPath: clip,
+            WebkitClipPath: clip,
+            transition: MORPH_TRANSITION,
+            // Unreached blobs sit as a faint neutral fill (the spectrum has not
+            // reached them yet); reached ones window the shared rainbow.
+            backgroundColor: reached ? 'transparent' : 'var(--faction-default-dot-ring)',
+            backgroundImage: reached ? 'var(--faction-default-rainbow)' : 'none',
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: `${SPAN}px ${size}px`,
+            backgroundPositionX: `${positionX}px`,
+            // A clipped blob has no border-box to cast a box-shadow from, so the
+            // glow has to be a drop-shadow filter that follows the silhouette.
+            filter: reached
+              ? `drop-shadow(0 0 4px color-mix(in srgb, ${glow} 67%, transparent))${
+                  top ? ` drop-shadow(0 0 7px color-mix(in srgb, ${glow} 53%, transparent))` : ''
+                }`
+              : 'none',
+            // Per-dot rising-wave tempo (consumed by .spectrum-dot--reached).
+            ['--spec-dur' as string]: `${1.9 - value * 0.18}s`,
+            ['--spec-delay' as string]: `${value * 0.12}s`,
+            ['--spec-bounce' as string]: `${-2 - value * 1.6}px`,
+          }
+          return (
+            <button
+              key={value}
+              disabled={saving}
+              onClick={() => void vote(value)}
+              onMouseEnter={() => setHovered(value)}
+              aria-label={t('chrome.albescent.rateAria', { value })}
+              aria-pressed={picked}
+              style={{
+                border: 'none',
+                background: 'transparent',
+                padding: 0,
+                // Exactly `size` wide — the continuous-spectrum windowing above
+                // depends on it. Height grows to a 44px touch target instead;
+                // the blob floats centred inside.
+                width: size,
+                minHeight: 44,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: saving ? 'default' : 'pointer',
+                transform: picked ? 'scale(1.14)' : 'none',
+                transition: 'transform 140ms',
+              }}
+            >
+              <span className={reached ? 'spectrum-dot--reached' : undefined} style={dotStyle} />
+            </button>
+          )
+        })}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          marginTop: 'var(--space-sm)',
+          minHeight: 20,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--faction-default-card-font)',
+            fontSize: 'var(--text-content)',
+            letterSpacing: '0.04em',
+            color: active ? 'var(--faction-default-vote-on)' : 'var(--faction-default-vote-off)',
+            transition: 'color 140ms',
+          }}
+        >
+          {caption}
+        </span>
+        {selected > 0 && (
+          <span
+            style={{
+              fontSize: 'var(--text-xs)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              color: 'var(--faction-default-vote-off)',
+            }}
+          >
+            {`· ${t('unaffiliated.tag')}`}
+          </span>
+        )}
+      </div>
+
+      <VoteSummary
+        selected={selected}
+        points={points}
+        totalVotes={totalVotes}
+        error={error}
+        theme={{
+          muted: 'var(--faction-default-card-muted)',
+          accent: 'var(--faction-default-card-accent)',
+          accentFont: 'var(--faction-default-card-font)',
+          errorColor: 'var(--color-danger)',
+          avgLetterSpacing: '0.04em',
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/vote/__tests__/albescentVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/albescentVote.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * AlbescentVote (#843) — the eighth vote widget, and the ONE thing this file
+ * exists to stop from silently regressing: Albescent used to fall through to
+ * `UnaffiliatedVote`, and because the fallback renders a plausible row of dots,
+ * nothing looked broken. So the registration is pinned as hard as the geometry.
+ *
+ * The harness is SSR-only (renderToStaticMarkup, no DOM, effects never run), so
+ * everything here is asserted from markup given props:
+ *   - the manifest claims the `vote` surface and the dispatcher hands it back,
+ *   - the row is ONE windowed rainbow, not five isolated slices,
+ *   - each blob holds a distinct polygon at rest (the morph clock is frozen
+ *     without effects, which is exactly the reduced-motion state),
+ *   - the tier words stay gone (#783): plain numerals, no word ladder.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({
+  user: null as CurrentUser | null,
+  castVote: vi.fn(async () => ({}) as unknown),
+}))
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: mocks.user, refetch: async () => {} }),
+}))
+vi.mock('../../../api/votes', () => ({
+  castVote: mocks.castVote,
+}))
+
+import AlbescentVote from '../AlbescentVote'
+import UnaffiliatedVote from '../UnaffiliatedVote'
+import { surfaceMap } from '../../../factions'
+import { pickVariant } from '../../../utils/factionDispatch'
+
+function currentUser(): CurrentUser {
+  return {
+    account_id: 1,
+    character: {
+      id: 9,
+      username: 'ada',
+      display_name: 'Ada',
+      bio: null,
+      avatar_url: null,
+      location: null,
+      level: 8,
+      score: 100,
+      all_time_score: 100,
+      faction_slug: 'albescent',
+      status: 'active',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: true,
+    albescent_revealed: true,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: 'Era 3',
+  }
+}
+
+function render(currentValue?: number): string {
+  return renderToStaticMarkup(
+    <AlbescentVote praxisId={7} currentValue={currentValue} points={16} totalVotes={4} />,
+  )
+}
+
+describe('albescent claims the vote surface', () => {
+  it('registers its own widget instead of falling through to UnaffiliatedVote', () => {
+    const map = surfaceMap('vote')
+    expect(map['albescent']).toBeDefined()
+    const Resolved = pickVariant(
+      map as Record<string, typeof AlbescentVote>,
+      'albescent',
+      UnaffiliatedVote,
+    )
+    expect(Resolved).toBe(AlbescentVote)
+    expect(Resolved).not.toBe(UnaffiliatedVote)
+  })
+})
+
+describe('AlbescentVote markup', () => {
+  it('renders five rate buttons for a logged-in viewer', () => {
+    mocks.user = currentUser()
+    const html = render()
+    expect((html.match(/aria-label="Rate \d of 5"/g) ?? []).length).toBe(5)
+  })
+
+  it('renders the shared login gate for an anonymous viewer', () => {
+    mocks.user = null
+    const html = render()
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Log in to vote')
+    expect(html).not.toContain('aria-label="Rate 1 of 5"')
+  })
+
+  it('windows ONE rainbow across the row rather than slicing per dot', () => {
+    mocks.user = currentUser()
+    const html = render(5)
+    // SPAN = 22+24+26+28+30 + 4×14 = 186; each blob is pushed left by every
+    // blob and gap before it. Per-dot slices would repeat a single offset.
+    for (const size of [22, 24, 26, 28, 30]) {
+      expect(html).toContain(`background-size:186px ${size}px`)
+    }
+    for (const offset of [0, -36, -74, -114, -156]) {
+      expect(html).toContain(`background-position-x:${offset}px`)
+    }
+  })
+
+  it('gives every blob its own lobe count at rest, so a stilled row still reads', () => {
+    mocks.user = currentUser()
+    const html = render(5)
+    const clips = html.match(/clip-path:polygon\([^)]*\)/g) ?? []
+    // Five blobs × (clip-path + -webkit-clip-path), all five shapes distinct.
+    expect(clips).toHaveLength(10)
+    expect(new Set(clips).size).toBe(5)
+    // 48 points each — the fixed count is what lets CSS tween 3 lobes into 6.
+    expect((clips[0] ?? '').split(',')).toHaveLength(48)
+  })
+
+  it('fills reached blobs with the neutral spectrum and nothing faction-coloured', () => {
+    mocks.user = currentUser()
+    const html = render(3)
+    expect(html).toContain('background-image:var(--faction-default-rainbow)')
+    expect(html).toContain('var(--spectrum-glow-3)')
+    expect(html).not.toContain('--faction-albescent')
+  })
+
+  it('gates the bob through the shared reduced-motion CSS class, never inline', () => {
+    mocks.user = currentUser()
+    const html = render(2)
+    expect((html.match(/spectrum-dot--reached/g) ?? []).length).toBe(2)
+    expect(html).not.toContain('animation:')
+  })
+
+  it('prints plain numerals — Albescent gave up its vote voice (#783)', () => {
+    mocks.user = currentUser()
+    const html = render(4)
+    const text = html.replace(/<[^>]*>/g, '')
+    expect(text).toContain('4')
+    for (const word of ['Witness', 'Inscribed', 'brilliant', 'great', 'so-so']) {
+      expect(text).not.toContain(word)
+    }
+  })
+})

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -28,6 +28,7 @@
 import type { FactionManifest } from './manifest'
 
 import { AlbescentSelectCard } from '../components/cards/FactionSelectCard'
+import AlbescentVote from '../components/vote/AlbescentVote'
 import AlbescentPraxisCard from '../components/praxisCard/desktop/AlbescentPraxisCard'
 import AlbescentMobilePraxisCard from '../components/praxisCard/mobile/AlbescentMobilePraxisCard'
 
@@ -53,4 +54,15 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    */
   praxisCard: () => AlbescentPraxisCard,
   mobilePraxisCard: () => AlbescentMobilePraxisCard,
+
+  /**
+   * The ferrofluid vote widget (#843, the eighth of #821's eight). Same rule as
+   * the cards above: it is the neutral spectrum row an unaffiliated player sees,
+   * with the blobs slowly morphing between polygon lobe counts — a flourish over
+   * Default's structure, not a repaint in Albescent's colours. Without this
+   * registration Albescent fell through to `UnaffiliatedVote`, which looked
+   * plausible enough that the gap went unnoticed. Its tier WORDS stay gone
+   * (#783): the widget prints plain numerals via `reframeLabel`.
+   */
+  vote: () => AlbescentVote,
 }

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -104,8 +104,7 @@
       "plateTopMark": "✦"
     },
     "albescent": {
-      "rateAria": "Witness {{value}} — {{label}}",
-      "prompt": "Bear Witness"
+      "rateAria": "Rate {{value}} of 5"
     },
     "unaffiliated": {
       "rateAria": "Rate {{value}} — {{label}}"


### PR DESCRIPTION
Ports `AlbescentVote` from the vendored design handoff
(`.design-sync/praxis-cards/design_handoff_faction_vote_stamps/FactionVoteWidgets.jsx`)
and registers it on Albescent's manifest. It was the eighth of #821's eight
widgets and was never built — `albescent.ts` claimed no `vote` surface, so
Albescent silently rendered `UnaffiliatedVote`, which looks plausible enough that
nobody noticed.

Closes #843

## What landed

- **`components/vote/AlbescentVote.tsx`** (new) — ferrofluid blobs. `GAP = 14`,
  `sizes = [22,24,26,28,30]`, lobe sequence `[64,3,4,5,6]` stepping every 1700ms
  off a 120ms tick and offset per dot by index, `clip-path` transition
  `.85s cubic-bezier(.65,0,.35,1)`, the 48-point `polyClipN(sides)` generator
  ported as-is, `spec-rise` bob on reached blobs plus the rank-5 glow.
- **Continuous-spectrum windowing** exactly as the source has it:
  `backgroundSize: SPAN × size` with `backgroundPositionX: -cumulativeOffset`
  (SPAN = 186px), so the row is one rainbow running across the gaps rather than
  five isolated slices. The buttons stay exactly `size` wide for that reason and
  grow to a 44px touch target vertically instead.
- **`factions/albescent.ts`** — `vote: () => AlbescentVote`, with a comment on why
  a flourish-over-Default is the only kind of override Albescent may take
  (ADR-0048 / #783).
- **`components/vote/__tests__/albescentVote.test.tsx`** (new, 8 tests) — pins the
  registration (`pickVariant` returns `AlbescentVote`, not `UnaffiliatedVote`),
  the windowing offsets, five distinct at-rest polygons, the neutral tokens, the
  motion gating, and the numerals.
- **`locales/en/votes.json`** — `chrome.albescent` held two orphaned keys from the
  retired "bear witness" voice (`rateAria: "Witness {{value}} — {{label}}"`,
  `prompt: "Bear Witness"`), referenced by nothing. Replaced with
  `rateAria: "Rate {{value}} of 5"`, which is what the widget now announces.

No `index.css` change was needed: the bob reuses the existing
`.spectrum-dot--reached` class and every colour resolves from
`--faction-default-*` / `--spectrum-glow-*`.

## Colour, theming, motion

- Same neutral spectrum as unaffiliated, deliberately — a surface that repaints
  Albescent in its own colours puts it back in the rainbow and un-hides the
  society. The tell is the morph, not the palette.
- The design's dark-only hairline `drop-shadow`s are **dropped**, not branched:
  they were a `dark ? … : …` ternary in the JSX, which the house rules forbid.
  Everything else flips through the `[data-theme]` cascade.
- Two things move and both are gated. The bob is the shared reduced-motion CSS
  class (no inline `animation:` anywhere — a test asserts that). The morph is a JS
  clock, so it reads `prefers-reduced-motion` directly and freezes; stilled, each
  blob holds a distinct static polygon and the row still fills and reads.

## Deliberate divergence from the design: tier words

The handoff gives Albescent the same word ladder as unaffiliated
(so-so … brilliant). **The repo's decision is kept instead**: #783/#232 and
ADR-0048 removed Albescent's vote voice on lore grounds — per-faction vote words
render to *every* voter on an Albescent-filed task, revealed or not, which was the
loudest tell left. `voteReframes.ts` therefore has no `albescent` entry, and this
widget calls `reframeLabel('albescent', value)` so the resolver stays the single
source of that decision. Result: plain numerals in the caption, "Rate N of 5" in
the aria-label. This is a documented divergence, not a miss.

The idle/tag chrome ("cast a vote" / "your vote") is unaffiliated's, matching both
the design and the indistinguishability rule.

## Verification

- `tsc --noEmit` — clean (only the known stale-junction `Cannot find module
  'node:fs'` false alarms from PR #675).
- `vitest run` — 1121 passed / 106 files.
- `eslint` on the three touched source files — clean.
- `vite build` — succeeds.

**No visual QA was done.** I cannot screenshot and there is no dev stack in this
worktree; everything above is verified from markup, types and lint only.

## What to eyeball

- Does the row read as ONE continuous rainbow, including across the 14px gaps —
  no seam or repeat at each blob boundary?
- The morph itself: circle → triangle → square → pentagon → hexagon, each blob a
  step ahead of its neighbour, easing over ~0.85s every 1.7s. Does it read as
  ferrofluid rather than as flicker?
- Unreached blobs use `--faction-default-dot-ring` as a flat faint fill (the
  design used a bespoke 20%-alpha taupe). Too heavy or too faint in either theme?
- Rank-5 glow and the `spec-rise` bob on reached blobs, light and dark.
- With `prefers-reduced-motion: reduce`: five static, distinct polygons that still
  fill and still vote.
- Hit targets — the buttons are 22–30px wide (the windowing math depends on it)
  and 44px tall. Comfortable enough on touch?
- The plain-numeral caption ("4") next to unaffiliated's word ladder — read the
  two side by side and confirm the lore call still feels right in situ.
