### PR TITLE
Freeze duel outcomes at era close (ADR-0052)

### DIFF
--- a/backend/alembic/versions/0001_squashed.py
+++ b/backend/alembic/versions/0001_squashed.py
@@ -44,7 +44,7 @@ ENUMS: list[tuple[str, list[str]]] = [
     ("relationshiptype", ["friend", "foe"]),
     ("relationshipstatus", ["active", "blocked"]),
     ("taunttriggertype", ["score_overtake", "level_up", "praxis_complete"]),
-    ("duelstatus", ["pending", "active", "settled", "declined"]),
+    ("duelstatus", ["pending", "active", "settled", "declined", "resolved"]),
 ]
 
 

--- a/backend/alembic/versions/0007_duel_frozen_outcome.py
+++ b/backend/alembic/versions/0007_duel_frozen_outcome.py
@@ -1,0 +1,58 @@
+"""Freeze duel outcomes at era close: `resolved` status + outcome snapshot (ADR-0052).
+
+Adds the terminal ``duelstatus.resolved`` value and the four columns
+``apply_era_reset`` writes when it freezes a duel:
+``winner_character_id`` (NULL = tie / no-contest), ``resolved_at``, and the
+per-side ``challenger_final_points`` / ``opponent_final_points`` vote snapshot.
+
+0001_squashed builds a *fresh* DB straight from the ORM models, so CI and local
+resets already land on this shape (its ENUMS list carries ``resolved`` too). A
+deployed DB is stamped at 0001 and never re-runs it, and ``create_all`` skips
+tables that already exist — hence this revision. Idempotent either way.
+
+Revision ID: 0007_duel_frozen_outcome
+Revises: 0006_faction_drop_prose
+Create Date: 2026-07-20
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0007_duel_frozen_outcome"
+down_revision: Union[str, None] = "0006_faction_drop_prose"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ADD VALUE cannot be followed by a *use* of the new value in the same
+    # transaction; autocommit_block keeps it out of the migration's txn.
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE duelstatus ADD VALUE IF NOT EXISTS 'resolved'")
+
+    op.execute("ALTER TABLE duel ADD COLUMN IF NOT EXISTS winner_character_id INTEGER")
+    op.execute("ALTER TABLE duel ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE duel ADD COLUMN IF NOT EXISTS challenger_final_points INTEGER")
+    op.execute("ALTER TABLE duel ADD COLUMN IF NOT EXISTS opponent_final_points INTEGER")
+
+    # ADD CONSTRAINT has no IF NOT EXISTS in Postgres; guard on the catalog so a
+    # DB already built from the models (constraint present) is a no-op.
+    op.execute(
+        """
+        DO $$ BEGIN
+            ALTER TABLE duel
+                ADD CONSTRAINT duel_winner_character_id_fkey
+                FOREIGN KEY (winner_character_id) REFERENCES character (id);
+        EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE duel DROP CONSTRAINT IF EXISTS duel_winner_character_id_fkey")
+    op.execute("ALTER TABLE duel DROP COLUMN IF EXISTS opponent_final_points")
+    op.execute("ALTER TABLE duel DROP COLUMN IF EXISTS challenger_final_points")
+    op.execute("ALTER TABLE duel DROP COLUMN IF EXISTS resolved_at")
+    op.execute("ALTER TABLE duel DROP COLUMN IF EXISTS winner_character_id")
+    # ponytail: no enum rollback — Postgres cannot DROP a value from a type, and
+    # rows already written as 'resolved' would have nowhere to land.

--- a/backend/models/duel.py
+++ b/backend/models/duel.py
@@ -19,17 +19,22 @@ class DuelStatus(enum.Enum):
     active = "active"
     settled = "settled"
     declined = "declined"
+    resolved = "resolved"
 
 
 class Duel(CreatedAtMixin, Base):
     """Links two solo praxes as competing sides of a duel (ADR-0011).
 
-    Lifecycle: pending → active → settled (terminal), or pending → declined (terminal).
+    Lifecycle: pending → active → settled → resolved (terminal), or
+    pending → declined (terminal).
     - pending: challenger's praxis created; opponent has been challenged.
     - active: opponent accepted; opponent's praxis created.
     - settled: both praxes submitted; voting is open.
     - declined: opponent declined or challenger cancelled; challenger's praxis
       reverts to a plain solo praxis (Duel row is kept for history).
+    - resolved: the era closed and the outcome was frozen (ADR-0052). Every
+      active/settled duel lands here at era reset; an `active` duel never became
+      votable and resolves as a no-contest (null winner).
     """
 
     __tablename__ = "duel"
@@ -59,6 +64,19 @@ class Duel(CreatedAtMixin, Base):
     forfeited_by_character_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("character.id"), nullable=True
     )
+
+    # ── frozen outcome, written once at era close (ADR-0052) ────────────────
+    # NULL winner on a resolved duel = tie, or no-contest (never became votable).
+    winner_character_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("character.id"), nullable=True
+    )
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Snapshot of each side's points_from_votes at the moment of resolution, so a
+    # resolved surface can show vote shares without the live tally moving under it.
+    challenger_final_points: Mapped[Optional[int]] = mapped_column(nullable=True)
+    opponent_final_points: Mapped[Optional[int]] = mapped_column(nullable=True)
 
     challenger_praxis: Mapped["Praxis"] = relationship(
         "Praxis", foreign_keys=[challenger_praxis_id], lazy="selectin"

--- a/backend/services/duel_outcome.py
+++ b/backend/services/duel_outcome.py
@@ -1,0 +1,46 @@
+"""The single duel win/loss rule (ADR-0011, ADR-0052).
+
+One pure function decides who won a duel. It is deliberately dependency-free
+(plain ints in, an optional int out) so every consumer can share it without an
+import cycle:
+
+- ``services.praxis_scoring`` — derives the live duel multiplier on every read.
+- ``services.era`` — freezes ``Duel.winner_character_id`` at era close.
+- the duel-winner badge (#748) — reads the frozen winner.
+
+``services.duel`` already imports ``services.era``, so the rule cannot live in
+``services.duel`` without a cycle; it lives here instead.
+"""
+from typing import Optional
+
+
+def duel_winner(
+    *,
+    challenger_character_id: Optional[int],
+    opponent_character_id: Optional[int],
+    challenger_points: int,
+    opponent_points: int,
+    forfeited_by_character_id: Optional[int] = None,
+) -> Optional[int]:
+    """Return the winning character id, or ``None`` for a tie / no-contest.
+
+    Two branches, in priority order (ADR-0011):
+
+    1. **Forfeit.** ``forfeited_by_character_id`` set → the *other* side wins by
+       default and vote tallies do not decide the outcome.
+    2. **Tally.** Otherwise the side with *strictly greater*
+       ``VoteTally.points_from_votes`` wins. Equal points is a tie → ``None``.
+
+    ``None`` is also the correct answer for a no-contest (a duel that never
+    became votable), which callers express by passing equal points.
+    """
+    if forfeited_by_character_id is not None:
+        if forfeited_by_character_id == challenger_character_id:
+            return opponent_character_id
+        return challenger_character_id
+
+    if challenger_points > opponent_points:
+        return challenger_character_id
+    if opponent_points > challenger_points:
+        return opponent_character_id
+    return None

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -1,11 +1,17 @@
+from datetime import datetime, timezone
+
 from fastapi import HTTPException
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character_stats import CharacterStats
+from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.faction_defection_history import FactionDefectionHistory
+from models.praxis import Praxis
+from services.duel_outcome import duel_winner
+from services.vote_tally import get_tally, tally_votes
 
 ERA_RESET_DEFAULT_FACTION: str = "na"
 
@@ -98,6 +104,92 @@ async def get_or_create_stats(
     return stats
 
 
+async def resolve_duels_at_era_close(
+    session: AsyncSession,
+    resolved_at: datetime | None = None,
+) -> list[Duel]:
+    """Freeze every unresolved duel's outcome (ADR-0052). Returns the frozen rows.
+
+    A duel has no winner until the era closes — the tally floats live until this
+    runs (ADR-0011). Here every ``active`` or ``settled`` duel gets:
+
+    - ``winner_character_id`` from the one shared rule (``duel_winner``): forfeit
+      → the non-forfeiter, else strictly greater ``points_from_votes``, tie → NULL.
+    - a snapshot of both sides' ``points_from_votes``, so a resolved surface can
+      show vote shares without the live tally moving under it.
+    - ``resolved_at`` and the terminal ``resolved`` status.
+
+    ``active`` duels (accepted, but never both-submitted) never became votable, so
+    they resolve as a **no-contest**: null winner, zero snapshots. ``pending``
+    duels — never accepted, so never a contest at all — are left untouched, as are
+    ``declined`` ones.
+
+    Deliberately emits **no** per-duel activity-feed event: every duel resolves at
+    the same instant, so N identical-timestamp cards would flood the feed. The
+    single ``era_announcement`` the new ``Era`` row already produces is the
+    notification (ADR-0052).
+    """
+    resolved_at = resolved_at or datetime.now(timezone.utc)
+
+    duel_result = await session.execute(
+        select(Duel).where(Duel.status.in_([DuelStatus.active, DuelStatus.settled]))
+    )
+    duels = list(duel_result.scalars().all())
+    if not duels:
+        return []
+
+    # Bulk: one praxis fetch (for the challenger's character id), one vote tally.
+    praxis_ids: list[int] = []
+    for duel in duels:
+        praxis_ids.append(duel.challenger_praxis_id)
+        if duel.opponent_praxis_id is not None:
+            praxis_ids.append(duel.opponent_praxis_id)
+
+    praxis_result = await session.execute(
+        select(Praxis).where(Praxis.id.in_(praxis_ids))
+    )
+    praxes_by_id: dict[int, Praxis] = {p.id: p for p in praxis_result.scalars()}
+    tallies = await tally_votes(praxis_ids, session)
+
+    for duel in duels:
+        is_contest = duel.status == DuelStatus.settled
+        if is_contest:
+            challenger_points = get_tally(
+                tallies, duel.challenger_praxis_id
+            ).points_from_votes
+            opponent_points = (
+                get_tally(tallies, duel.opponent_praxis_id).points_from_votes
+                if duel.opponent_praxis_id is not None
+                else 0
+            )
+        else:
+            # No-contest: never votable, so there is nothing to snapshot.
+            challenger_points = 0
+            opponent_points = 0
+
+        challenger_praxis = praxes_by_id.get(duel.challenger_praxis_id)
+        duel.winner_character_id = (
+            duel_winner(
+                challenger_character_id=(
+                    challenger_praxis.created_by_id if challenger_praxis else None
+                ),
+                opponent_character_id=duel.opponent_character_id,
+                challenger_points=challenger_points,
+                opponent_points=opponent_points,
+                forfeited_by_character_id=duel.forfeited_by_character_id,
+            )
+            if is_contest
+            else None
+        )
+        duel.challenger_final_points = challenger_points
+        duel.opponent_final_points = opponent_points
+        duel.resolved_at = resolved_at
+        duel.status = DuelStatus.resolved
+
+    await session.flush()
+    return duels
+
+
 async def apply_era_reset(
     characters: list,
     new_era_row: Era,
@@ -106,8 +198,14 @@ async def apply_era_reset(
 ) -> None:
     """Create new CharacterStats rows for each character under the new era.
 
-    Preserves historical stats rows for prior eras.
+    Preserves historical stats rows for prior eras. Also freezes every unresolved
+    duel outcome — era close is the moment a duel acquires a definitive winner
+    (ADR-0011 / ADR-0052).
     """
+    # Freeze duels first: the outcome must be computed against the closing era's
+    # tallies, before any stats row for the new era exists.
+    await resolve_duels_at_era_close(session)
+
     for character in characters:
         # Find previous stats to carry all_time_score forward
         prev_result = await session.execute(

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -186,11 +186,20 @@ async def build_praxis_out(
     task_base = praxis.task.point_value if praxis.task else 0
     score = float(task_base + tally.points_from_votes)
 
-    # Look up the Duel row if this praxis is a duel side (ADR-0011).
+    # Look up the Duel row if this praxis is a duel side (ADR-0011). `resolved`
+    # is included so a card keeps its duel link after the era froze the outcome
+    # (ADR-0052) — otherwise a past duel's praxis reads back as a plain solo.
     duel_result = await session.execute(
         select(Duel).where(
             (Duel.challenger_praxis_id == praxis.id) | (Duel.opponent_praxis_id == praxis.id),
-            Duel.status.in_([DuelStatus.pending, DuelStatus.active, DuelStatus.settled]),
+            Duel.status.in_(
+                [
+                    DuelStatus.pending,
+                    DuelStatus.active,
+                    DuelStatus.settled,
+                    DuelStatus.resolved,
+                ]
+            ),
         )
     )
     duel_row = duel_result.scalar_one_or_none()

--- a/backend/services/praxis_scoring.py
+++ b/backend/services/praxis_scoring.py
@@ -19,6 +19,7 @@ from models.character import Character
 from models.duel import Duel, DuelStatus
 from models.praxis import ModerationStatus, Praxis, PraxisType
 from models.task import Task
+from services.duel_outcome import duel_winner
 from services.meta_task import get_meta_task_points_bulk
 from services.scoring import (
     COLLABORATION_MODE_COLLAB,
@@ -80,13 +81,17 @@ async def compute_contributions(
     tallies = await tally_votes(praxis_ids, session)
 
     # ── duel info for solo praxes ────────────────────────────────────────────
-    # A solo praxis may be a duel side (ADR-0011). Fetch all active/settled
-    # duels that reference any of our praxes in one query.
+    # A solo praxis may be a duel side (ADR-0011). Fetch all active/settled/
+    # resolved duels that reference any of our praxes in one query. `resolved`
+    # is included so an era-frozen duel keeps its win/loss modifier (ADR-0052) —
+    # dropping it there would silently rescore every past duel at era close.
     duel_result = await session.execute(
         select(Duel).where(
             (Duel.challenger_praxis_id.in_(praxis_ids))
             | (Duel.opponent_praxis_id.in_(praxis_ids)),
-            Duel.status.in_([DuelStatus.active, DuelStatus.settled]),
+            Duel.status.in_(
+                [DuelStatus.active, DuelStatus.settled, DuelStatus.resolved]
+            ),
         )
     )
     duels = list(duel_result.scalars().all())
@@ -176,26 +181,39 @@ async def compute_contributions(
                 character_faction, task_faction, era,
                 collaboration_mode=COLLABORATION_MODE_SOLO,
             )
-            if duel.forfeited_by_character_id is not None:
-                # ADR-0011 §Forfeit: the opponent wins by default; vote tallies
-                # don't decide the outcome. The forfeiter takes the loss modifier.
-                duel_multiplier = compute_duel_multiplier(
-                    character_faction,
-                    opponent_faction,
-                    is_winner=character.id != duel.forfeited_by_character_id,
-                    is_tied=False,
-                    era=era,
-                )
+            # One shared rule decides the winner (ADR-0052): forfeit first, then
+            # strictly-greater points_from_votes, else a tie. Read live here; the
+            # same call freezes Duel.winner_character_id at era close — after
+            # which the frozen winner is authoritative and the tally stops moving
+            # the multiplier.
+            if duel.status == DuelStatus.resolved:
+                winner_character_id: Optional[int] = duel.winner_character_id
             else:
-                own_pts = own_tally.points_from_votes
-                opp_pts = opp_tally.points_from_votes
-                duel_multiplier = compute_duel_multiplier(
-                    character_faction,
-                    opponent_faction,
-                    is_winner=own_pts > opp_pts,
-                    is_tied=own_pts == opp_pts,
-                    era=era,
+                if duel.challenger_praxis_id == praxis.id:
+                    challenger_character_id: Optional[int] = character.id
+                    challenger_points = own_tally.points_from_votes
+                    opponent_points = opp_tally.points_from_votes
+                else:
+                    challenger_character_id = (
+                        opp_praxis.created_by_id if opp_praxis is not None else None
+                    )
+                    challenger_points = opp_tally.points_from_votes
+                    opponent_points = own_tally.points_from_votes
+
+                winner_character_id = duel_winner(
+                    challenger_character_id=challenger_character_id,
+                    opponent_character_id=duel.opponent_character_id,
+                    challenger_points=challenger_points,
+                    opponent_points=opponent_points,
+                    forfeited_by_character_id=duel.forfeited_by_character_id,
                 )
+            duel_multiplier = compute_duel_multiplier(
+                character_faction,
+                opponent_faction,
+                is_winner=winner_character_id == character.id,
+                is_tied=winner_character_id is None,
+                era=era,
+            )
 
         else:
             # Plain solo praxis

--- a/backend/tests/integration/test_duel_era_resolution.py
+++ b/backend/tests/integration/test_duel_era_resolution.py
@@ -1,0 +1,366 @@
+"""Era close freezes every duel outcome (ADR-0052, #824).
+
+ADR-0011 says a duel's winner floats with the votes and "a definitive winner
+only exists at era close". These tests exercise that close: ``apply_era_reset``
+resolves a *mix* of duels in one pass — clear leader, forfeit win, tie, and an
+incomplete ``active`` duel — asserting ``winner_character_id``, the frozen
+per-side vote snapshot, and the terminal ``resolved`` status.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.duel import Duel, DuelStatus
+from models.era import Era
+from models.faction import Faction
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from models.vote import Vote
+from services.duel_outcome import duel_winner
+from services.era import apply_era_reset
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_character(
+    session: AsyncSession, era: Era, *, username: str, email: str
+) -> Character:
+    account = Account(email=email)
+    session.add(account)
+    await session.flush()
+    character = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username,
+        faction_slug="ua",
+    )
+    session.add(character)
+    await session.flush()
+    session.add(
+        CharacterStats(
+            character_id=character.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=0,
+            votes_spent_this_era=0,
+        )
+    )
+    await session.flush()
+    return character
+
+
+async def _make_task(session: AsyncSession, creator: Character) -> Task:
+    task = Task(
+        title="duel task",
+        description="proof",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=creator.id,
+        primary_faction_slug="ua",
+    )
+    session.add(task)
+    await session.flush()
+    return task
+
+
+async def _make_solo(
+    session: AsyncSession,
+    task: Task,
+    author: Character,
+    *,
+    status: PraxisStatus = PraxisStatus.submitted,
+) -> Praxis:
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=author.id,
+        type=PraxisType.solo,
+        status=status,
+        title="side",
+        body_text="proof",
+    )
+    session.add(praxis)
+    await session.flush()
+    session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id))
+    await session.flush()
+    return praxis
+
+
+async def _cast_vote(
+    session: AsyncSession, praxis: Praxis, voter: Character, value: int
+) -> None:
+    """Direct Vote insert — bypasses the service-layer budget/anti-vote checks."""
+    session.add(
+        Vote(
+            praxis_id=praxis.id,
+            voter_character_id=voter.id,
+            voter_account_id=voter.account_id,
+            value=value,
+        )
+    )
+    await session.flush()
+
+
+async def _make_duel(
+    session: AsyncSession,
+    era: Era,
+    *,
+    label: str,
+    status: DuelStatus,
+    challenger_votes: int | None,
+    opponent_votes: int | None,
+    forfeiter: str | None = None,
+) -> tuple[Duel, Character, Character]:
+    """Build a full duel: two characters, two solo praxes, optional votes."""
+    challenger = await _make_character(
+        session, era, username=f"{label}_ch", email=f"{label}_ch@x.com"
+    )
+    opponent = await _make_character(
+        session, era, username=f"{label}_op", email=f"{label}_op@x.com"
+    )
+    voter = await _make_character(
+        session, era, username=f"{label}_v", email=f"{label}_v@x.com"
+    )
+    task = await _make_task(session, challenger)
+    challenger_praxis = await _make_solo(session, task, challenger)
+    opponent_praxis = await _make_solo(session, task, opponent)
+
+    if challenger_votes:
+        await _cast_vote(session, challenger_praxis, voter, challenger_votes)
+    if opponent_votes:
+        await _cast_vote(session, opponent_praxis, voter, opponent_votes)
+
+    forfeited_by = None
+    if forfeiter == "challenger":
+        forfeited_by = challenger.id
+    elif forfeiter == "opponent":
+        forfeited_by = opponent.id
+
+    duel = Duel(
+        task_id=task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=opponent.id,
+        opponent_praxis_id=opponent_praxis.id,
+        status=status,
+        forfeited_by_character_id=forfeited_by,
+    )
+    session.add(duel)
+    await session.flush()
+    return duel, challenger, opponent
+
+
+async def _close_the_era(session: AsyncSession, starter: Account) -> Era:
+    new_era_row = Era(
+        name=CURRENT_ERA.name,
+        config_key=CURRENT_ERA.config_key,
+        started_by=starter.id,
+    )
+    session.add(new_era_row)
+    await session.flush()
+    await apply_era_reset([], new_era_row, session)
+    return new_era_row
+
+
+# ---------------------------------------------------------------------------
+# the pure rule
+# ---------------------------------------------------------------------------
+
+
+def test_duel_winner_prefers_forfeit_over_the_tally():
+    """A forfeit decides the duel even when the forfeiter is far ahead on votes."""
+    assert (
+        duel_winner(
+            challenger_character_id=1,
+            opponent_character_id=2,
+            challenger_points=99,
+            opponent_points=0,
+            forfeited_by_character_id=1,
+        )
+        == 2
+    )
+
+
+def test_duel_winner_needs_strictly_greater_points():
+    assert (
+        duel_winner(
+            challenger_character_id=1,
+            opponent_character_id=2,
+            challenger_points=4,
+            opponent_points=3,
+        )
+        == 1
+    )
+    assert (
+        duel_winner(
+            challenger_character_id=1,
+            opponent_character_id=2,
+            challenger_points=3,
+            opponent_points=3,
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# era close over a mix of duels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_era_reset_freezes_a_mix_of_duels(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """One reset resolves clear-leader, forfeit, tie and incomplete duels together."""
+    leader_duel, leader_ch, leader_op = await _make_duel(
+        db_session, era, label="lead", status=DuelStatus.settled,
+        challenger_votes=5, opponent_votes=2,
+    )
+    forfeit_duel, forfeit_ch, forfeit_op = await _make_duel(
+        db_session, era, label="forf", status=DuelStatus.settled,
+        challenger_votes=5, opponent_votes=1, forfeiter="challenger",
+    )
+    tie_duel, tie_ch, tie_op = await _make_duel(
+        db_session, era, label="tie", status=DuelStatus.settled,
+        challenger_votes=3, opponent_votes=3,
+    )
+    incomplete_duel, incomplete_ch, incomplete_op = await _make_duel(
+        db_session, era, label="inc", status=DuelStatus.active,
+        challenger_votes=None, opponent_votes=None,
+    )
+
+    await _close_the_era(db_session, account)
+
+    # ── clear leader: more vote points wins, both sides snapshotted ─────────
+    await db_session.refresh(leader_duel)
+    assert leader_duel.status == DuelStatus.resolved
+    assert leader_duel.winner_character_id == leader_ch.id
+    assert leader_duel.challenger_final_points == 5
+    assert leader_duel.opponent_final_points == 2
+    assert leader_duel.resolved_at is not None
+
+    # ── forfeit: the non-forfeiter wins despite trailing on votes ──────────
+    await db_session.refresh(forfeit_duel)
+    assert forfeit_duel.status == DuelStatus.resolved
+    assert forfeit_duel.winner_character_id == forfeit_op.id
+    # The snapshot still records what the tally actually said.
+    assert forfeit_duel.challenger_final_points == 5
+    assert forfeit_duel.opponent_final_points == 1
+
+    # ── tie: null winner, equal snapshots ──────────────────────────────────
+    await db_session.refresh(tie_duel)
+    assert tie_duel.status == DuelStatus.resolved
+    assert tie_duel.winner_character_id is None
+    assert tie_duel.challenger_final_points == 3
+    assert tie_duel.opponent_final_points == 3
+
+    # ── incomplete `active` duel: no-contest, never became votable ──────────
+    await db_session.refresh(incomplete_duel)
+    assert incomplete_duel.status == DuelStatus.resolved
+    assert incomplete_duel.winner_character_id is None
+    assert incomplete_duel.challenger_final_points == 0
+    assert incomplete_duel.opponent_final_points == 0
+
+
+@pytest.mark.asyncio
+async def test_era_reset_wins_for_the_opponent_side_too(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """The winner is not biased to the challenger — the opponent can win outright."""
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="opwin", status=DuelStatus.settled,
+        challenger_votes=1, opponent_votes=4,
+    )
+
+    await _close_the_era(db_session, account)
+
+    await db_session.refresh(duel)
+    assert duel.winner_character_id == opponent.id
+    assert duel.challenger_final_points == 1
+    assert duel.opponent_final_points == 4
+
+
+@pytest.mark.asyncio
+async def test_era_reset_leaves_pending_and_declined_duels_untouched(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """A duel that was never accepted was never a contest — it is not resolved."""
+    pending_duel, _, _ = await _make_duel(
+        db_session, era, label="pend", status=DuelStatus.pending,
+        challenger_votes=None, opponent_votes=None,
+    )
+    declined_duel, _, _ = await _make_duel(
+        db_session, era, label="decl", status=DuelStatus.declined,
+        challenger_votes=None, opponent_votes=None,
+    )
+
+    await _close_the_era(db_session, account)
+
+    await db_session.refresh(pending_duel)
+    await db_session.refresh(declined_duel)
+    assert pending_duel.status == DuelStatus.pending
+    assert pending_duel.resolved_at is None
+    assert declined_duel.status == DuelStatus.declined
+    assert declined_duel.resolved_at is None
+
+
+@pytest.mark.asyncio
+async def test_resolution_is_sticky_across_a_second_era_close(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """A resolved duel is terminal: later votes and later resets never move it."""
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="stick", status=DuelStatus.settled,
+        challenger_votes=5, opponent_votes=2,
+    )
+
+    await _close_the_era(db_session, account)
+    await db_session.refresh(duel)
+    frozen_at = duel.resolved_at
+
+    # Votes keep arriving (they are never reset) — the frozen outcome must hold.
+    late_voter = await _make_character(
+        db_session, era, username="late", email="late@x.com"
+    )
+    opponent_praxis = await db_session.get(Praxis, duel.opponent_praxis_id)
+    await _cast_vote(db_session, opponent_praxis, late_voter, 5)
+
+    await _close_the_era(db_session, account)
+
+    await db_session.refresh(duel)
+    assert duel.winner_character_id == challenger.id
+    assert duel.opponent_final_points == 2
+    assert duel.resolved_at == frozen_at
+
+
+@pytest.mark.asyncio
+async def test_admin_era_reset_endpoint_resolves_duels(
+    client, account: Account, auth_headers: dict, db_session: AsyncSession,
+    era: Era, faction_ua: Faction,
+):
+    """The freeze runs through the real admin endpoint, not just the service."""
+    from tests.integration.test_admin import _make_admin
+
+    await _make_admin(account, db_session)
+    duel, challenger, _ = await _make_duel(
+        db_session, era, label="api", status=DuelStatus.settled,
+        challenger_votes=4, opponent_votes=1,
+    )
+    await db_session.commit()
+
+    response = await client.put("/admin/era/reset", headers=auth_headers)
+    assert response.status_code == 200
+
+    result = await db_session.execute(select(Duel).where(Duel.id == duel.id))
+    resolved = result.scalar_one()
+    await db_session.refresh(resolved)
+    assert resolved.status == DuelStatus.resolved
+    assert resolved.winner_character_id == challenger.id

--- a/docs/adr/0011-duel-is-two-linked-praxes.md
+++ b/docs/adr/0011-duel-is-two-linked-praxes.md
@@ -48,6 +48,12 @@ A duel is **two separate praxes that compete**, joined by a new `Duel` row.
   always-live-on-read scoring model; there is no per-duel voting window or freeze. The
   duel win/loss multiplier is applied per side at scoring time from the current tally.
 
+  > **Amendment (2026-07-20, ADR-0052).** "Until era reset" is now implemented:
+  > the era reset freezes every `active`/`settled` duel into a terminal `resolved`
+  > state with `winner_character_id` + a vote snapshot. Per-duel voting windows
+  > remain rejected — the freeze is global and era-scoped, and the winner still
+  > floats right up to it.
+
 ### Forfeit
 
 Once a duel is `settled`, backing out of it forfeits the contest rather than reopening it.
@@ -75,3 +81,4 @@ Once a duel is `settled`, backing out of it forfeits the contest rather than reo
   (issue #181 tracks the broader projection-vs-event-log question).
 - There is no discrete "X won the duel" moment; a definitive winner only exists at era
   close. The `settled` transition feed event is "duel is live for voting."
+  Era-close resolution is specified in **ADR-0052**.

--- a/docs/adr/0052-duels-resolve-at-era-close.md
+++ b/docs/adr/0052-duels-resolve-at-era-close.md
@@ -1,0 +1,66 @@
+# Duels resolve at era close
+
+/ status: accepted
+
+## Context
+
+ADR-0011 established that a duel's winner **floats with the votes** — there is no
+per-duel voting window and no discrete "X won" moment — and closed with:
+"a definitive winner only exists at era close."
+
+Nothing implemented that close. `Duel` had no winner column, `apply_era_reset`
+only built new `CharacterStats` rows, and votes are never reset, so a duel's
+tally floated forever and a duel never actually ended. This ADR records the
+missing half of ADR-0011; it does **not** reverse it.
+
+## Decision
+
+**Era close is the moment a duel acquires a definitive winner.** At every era
+reset, `apply_era_reset` (`services/era.py`) freezes the outcome of every
+unresolved duel.
+
+- **New terminal state `DuelStatus.resolved`.** Lifecycle is now
+  `pending → active → settled → resolved`, or `pending → declined`.
+- **New columns on `duel`:** `winner_character_id` (FK `character.id`, NULL =
+  tie or no-contest), `resolved_at`, and the frozen vote snapshot
+  `challenger_final_points` / `opponent_final_points`.
+- **Winner determination reuses the scoring rule.** The forfeit-then-tally
+  comparison that already drove the live duel multiplier in
+  `services/praxis_scoring.py` is extracted to one pure function,
+  `duel_winner()` in **`services/duel_outcome.py`**: forfeit → the
+  non-`forfeited_by_character_id` side; else strictly greater
+  `VoteTally.points_from_votes`; equal → NULL. Read-time scoring and era-close
+  freezing therefore cannot disagree. (It lives in its own module because
+  `services/duel` already imports `services/era` — putting the rule in
+  `services/duel` would make a cycle.)
+- **The snapshot exists so resolved surfaces stop moving.** Votes are never
+  reset, so without a frozen copy a "past duel" screen would keep re-reading a
+  live tally that can still change. Once `status = resolved`, scoring reads
+  `winner_character_id` rather than recomputing from the tally.
+- **Incomplete duels are a no-contest.** An `active` duel (accepted, but never
+  both-submitted) never became votable, so it resolves with a NULL winner and
+  zero snapshots. `pending` duels — never accepted, never a contest — and
+  `declined` duels are left untouched.
+- **Resolution is announced once, by the era.** No new activity-feed source and
+  no per-duel card. Every duel resolves at the same instant, so per-duel events
+  would flood the feed with N identical-timestamp entries. The existing
+  `era_announcement` source (`services/activity_feed.py`, a read-time projection
+  over the `Era` table by `started_at`, ADR-0023) already fires exactly one
+  global announcement when the reset inserts the new `Era` row. That is the
+  notification. A player learns their own result from the resolved duel itself.
+- **Per-duel voting windows remain rejected** (ADR-0011). Nothing here adds a
+  freeze that is local to one duel; the only freeze is global and era-scoped.
+
+## Consequences
+
+- Duel resolution is coupled to the admin-triggered era reset. There is no other
+  path to a resolved duel, and no background job.
+- `Duel` still carries no `era_id`; "which era resolved it" is `resolved_at`.
+  A duel that spans an era boundary resolves in the era that was closing.
+- Any query that means "this praxis is part of a duel" must now decide whether it
+  includes `resolved`. Scoring and the praxis-card duel link do (a past duel must
+  keep its win/loss modifier and its identity); the live-duel gates in
+  `services/duel.get_duel_for_praxis` — challenge dedupe, forfeit-on-withdraw,
+  anti-participant voting — do not, because a resolved duel is over.
+- The resolved-duel **screen** is design work (#719); this ADR only guarantees
+  the frozen data it will read.


### PR DESCRIPTION
Implements ADR-0011's "a definitive winner only exists at era close" — the half that was never built. Today a duel never resolves: the tally floats forever and `apply_era_reset` only makes `CharacterStats`.

Closes #824

## What landed

**Model + migration**
- `DuelStatus.resolved` — terminal. Added to the model **and** to `0001_squashed`'s `ENUMS` list (CI builds the DB via `alembic upgrade head`), plus a new idempotent `0007_duel_frozen_outcome` for already-deployed DBs.
- New `duel` columns: `winner_character_id` (FK `character.id`, NULL = tie / no-contest), `resolved_at`, `challenger_final_points`, `opponent_final_points`.

**One shared winner rule — `backend/services/duel_outcome.py`**
- `duel_winner(...)` is a pure, dependency-free function: forfeit → the non-`forfeited_by_character_id` side; else strictly greater `points_from_votes`; tie → `None`.
- Extracted from the existing comparison at `praxis_scoring.py:179-198`, which now calls it — read-time scoring and era-close freezing cannot disagree.
- It lives in its own module because `services/duel` already imports `services/era`, so the rule could not go in `services/duel` without a cycle. Cleanly importable for #748.

**Freeze in `apply_era_reset`** (`backend/services/era.py`, new `resolve_duels_at_era_close`)
- Every `active`/`settled` duel gets a winner, both snapshots, `resolved_at`, and `status = resolved`. Bulk: one duel query, one praxis query, one tally.
- `active` duels never became votable → **no-contest** (null winner, zero snapshots). `pending` and `declined` are left untouched.

**No activity-feed change** — deliberately. Every duel resolves at the same instant, so per-duel events would flood the feed with N identical-timestamp cards. The existing `era_announcement` source already fires exactly one global announcement when the reset inserts the new `Era` row.

**ADR-0052** records era-close resolution, the new columns + state, that the winner reuses the scoring rule, that resolution surfaces via the single era announcement, and that per-duel voting windows remain **rejected**. ADR-0011 is amended with a pointer (0051 was taken by #825).

## Two knock-on decisions worth a look

1. `praxis_scoring` now includes `resolved` in its duel query, and reads `duel.winner_character_id` instead of recomputing once resolved. Without this, flipping the status would silently strip the win/loss multiplier off every past duel at era close.
2. `services/praxis.build_praxis_card_out`'s duel-link lookup also includes `resolved`, so a past duel's praxis does not read back as a plain solo. The *live*-duel gates in `services/duel.get_duel_for_praxis` (challenge dedupe, forfeit-on-withdraw, anti-participant voting) deliberately do **not** include it — a resolved duel is over.

## Tests

`backend/tests/integration/test_duel_era_resolution.py` — one reset over a **mix**: clear leader, forfeit win (winner trails on votes), tie, incomplete `active` no-contest; plus opponent-side win, `pending`/`declined` untouched, stickiness across a second era close with late votes, the real `/admin/era/reset` endpoint, and unit cases for `duel_winner`.

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://.../wz824_test \
  pytest --cov=. --cov-fail-under=80 -q
# 690 passed, coverage 89.01%
```

Migration verified on a scratch DB: `alembic upgrade head` (clean), `alembic check` (no drift), `downgrade -1` → `upgrade head` round-trip.

## What to eyeball

- **No visual QA was done** — this PR is backend-only and I cannot screenshot. Nothing renders differently on purpose, but see the two knock-on decisions above.
- The **no-contest default** for incomplete `active` duels (null winner, zero snapshots) — the issue asked to confirm it.
- Whether `resolved` belongs in `praxis_scoring`'s duel query (decision 1). The alternative is that resolved duels stop contributing a duel multiplier, which rescores history at reset.
- Whether the praxis card should keep its duel link after resolution (decision 2), or whether #719 wants to own that.
- **Forfeit snapshots record the tally, not the outcome** — a forfeiting side that was ahead on votes keeps its higher `*_final_points` while losing. Intentional (the snapshot is evidence, the winner is the verdict), but a resolved screen must not infer the winner from the numbers.
- `resolve_duels_at_era_close` resolves **every** unresolved duel globally — `Duel` still has no `era_id`, so a duel spanning a boundary resolves in the era that was closing. `resolved_at` is the only era marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
