### PR TITLE
Snide, Singularity and Unaffiliated/Albescent praxis cards: typographic totals + one continuous spectrum

### DIFF
--- a/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
@@ -1,4 +1,5 @@
 import DefaultPraxisCard from "./DefaultPraxisCard";
+import { AlbescentSparks } from "../shared";
 import { frameBase, type ArchetypeProps } from "./shared";
 
 /**
@@ -9,12 +10,16 @@ import { frameBase, type ArchetypeProps } from "./shared";
  * Albescent's own colours would put it back in the spectrum and un-hide it, so
  * this stays "NA + drift". The overlay is pointer-events:none and blends over the
  * card; reduced-motion stills the drift (the wash remains).
+ *
+ * #842 added the other half of the tell: the design pairs the drift with three
+ * faint gold sparks ({@link AlbescentSparks}), and only the drift had shipped.
  */
 export function AlbescentPraxisCard(props: ArchetypeProps) {
   return (
     <div style={{ ...frameBase, borderRadius: 10, /* inherits the Default sheet */ position: "relative", overflow: "hidden" }}>
       <DefaultPraxisCard {...props} />
       <span aria-hidden className="alb-rainbow" />
+      <AlbescentSparks />
     </div>
   );
 }

--- a/frontend/src/components/praxisCard/desktop/DefaultPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/DefaultPraxisCard.tsx
@@ -1,63 +1,86 @@
 import { useTranslation } from "react-i18next";
-import DefaultSigil from "../../cards/DefaultSigil";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
 /**
- * Fallback praxis card for `na` / unaffiliated + any task faction without a
- * bespoke archetype — the SPECTRUM card (#820, ADR-0039). A clean sheet wrapped
- * in the community-rainbow band and marked with the seven-segment ring, holding
- * the conditional score stamp (ADR-0047) and the empty-media drop target. No
- * longer borrows the task faction's costume. All colours via --faction-default-*
- * / --spectrum-* tokens; flips light/dark through the [data-theme] cascade.
+ * The unaffiliated card — A PLAIN CREAM SHEET (#842, ADR-0039). The fallback for
+ * `na` and for any task faction without a bespoke archetype.
+ *
+ * The point of this skin is restraint: it is a quiet sheet, and the community
+ * rainbow appears in exactly FOUR places on it — the eyebrow's text-clip, the
+ * score box's hairline rule, the total, and one 2px divider above the vote
+ * widget. #820 read "the spectrum card" as a full-bleed rainbow BAND wrapped
+ * around the frame plus a `DefaultSigil` masthead row; neither exists in the
+ * prototype, and together they made the least-marked faction the loudest card
+ * on the page. Both are gone.
+ *
+ * The title is set in Bebas Neue (`--faction-default-card-font`), the design's
+ * unaffiliated face. It had been resolving to Lora through the shared
+ * `font-display` class — the site wordmark's serif, not this card's.
+ *
+ * All colour via `--faction-default-*`, so the sheet flips through the
+ * `[data-theme="dark"]` cascade with no `dark ?` branch.
  */
 export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
   return (
-    // Spectrum band → clean inner sheet.
     <div
       style={{
         ...frameBase,
+        position: "relative",
         borderRadius: 10, // plain cream sheet
-        padding: "var(--space-xs)",
-        background: "var(--faction-default-rainbow)",
-        boxShadow: "0 12px 26px -14px color-mix(in srgb, black 40%, transparent)",
+        background: "var(--faction-default-card-bg)",
+        color: "var(--faction-default-card-text)",
+        border: "1px solid var(--faction-default-card-line)",
+        boxShadow: "0 3px 14px rgba(34, 26, 18, 0.1)",
+        padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
       }}
     >
-      <div
-        style={{
-          position: "relative",
-          overflow: "hidden",
-          background: "var(--faction-default-card-bg)",
+      <AdminOverlay {...adminProps} />
+      <PraxisBody
+        praxis={praxis}
+        tint="var(--faction-default-card-accent)"
+        muted="var(--faction-default-card-muted)"
+        paper="var(--faction-default-card-bg)"
+        showCrown={showCrown}
+        titleStyle={{
+          fontFamily: "var(--faction-default-card-font)",
+          letterSpacing: "0.02em",
+          lineHeight: 1,
           color: "var(--faction-default-card-text)",
-          borderRadius: 4,
-          padding: "var(--space-xl)",
         }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "var(--space-sm)",
-            marginBottom: "var(--space-md)",
-            fontFamily: "'Courier Prime', monospace",
-            fontSize: "var(--text-xs)",
-            letterSpacing: "0.22em",
-            textTransform: "uppercase",
-            color: "var(--faction-default-card-muted)",
-          }}
-        >
-          <DefaultSigil size={22} /> {t("card.masthead.default")}
-        </div>
-        <AdminOverlay {...adminProps} />
-        <PraxisBody
-          praxis={praxis}
-          tint="var(--faction-default-card-accent)"
-          muted="var(--faction-default-card-muted)"
-          paper="var(--faction-default-card-bg)"
-          showCrown={showCrown}
-        />
-      </div>
+        eyebrow={
+          <div
+            className="eyebrow"
+            style={{
+              letterSpacing: "0.16em",
+              // Rainbow appearance 1 of 4: the running head, clipped to type.
+              background: "var(--faction-default-eyebrow-rainbow)",
+              WebkitBackgroundClip: "text",
+              backgroundClip: "text",
+              color: "transparent",
+              marginBottom: "var(--space-xs)",
+            }}
+          >
+            {t("card.masthead.default")}
+          </div>
+        }
+        voteRule={
+          <div
+            aria-hidden
+            style={{
+              height: 2,
+              // Rainbow appearance 4 of 4: the one divider on the sheet. The
+              // opacity sits between the design's light (0.4) and dark (0.5)
+              // values — a single number keeps this off a `dark ?` branch, and
+              // the difference is one step of a wash behind a 2px rule.
+              opacity: 0.45,
+              background: "var(--faction-default-rainbow)",
+              margin: "var(--space-lg) 0 var(--space-md)",
+            }}
+          />
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
@@ -3,73 +3,84 @@ import { useTranslation } from "react-i18next";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
-/** Punch-card sprocket strip — the row and one hole. Static (#586). */
-const holeRowStyle: CSSProperties = {
-  display: "flex",
-  justifyContent: "center",
-  gap: "var(--space-sm)",
-  padding: "var(--space-xs) 0",
-};
+/**
+ * Singularity — THE SYSTEM SLAB (#842). A booted terminal: near-black glass on
+ * a standing raster, a green hairline frame, four cyan corner brackets, a
+ * window-chrome header of three LEDs and a right-aligned log line, and a cyan
+ * SCANLINE that sweeps the slab every five seconds.
+ *
+ * Two inventions came off, both of which said "punch card" where the design
+ * says "screen":
+ *
+ *  • the SPROCKET-HOLE strips top and bottom — five perforations each, with no
+ *    counterpart in the prototype;
+ *  • the blinking BLOCK CURSOR in the header. The design has exactly one
+ *    cursor and it trails the computed total in the score stamp, where it is
+ *    the machine holding the line open on a number. A second one in the running
+ *    head made the card read as an input field.
+ *
+ * The corner brackets were also wrong in kind, not merely in size: 10px, at a
+ * 3px inset, drawn in the card's own text colour, so they read as a border's
+ * mitred corner. The design's are 12px CYAN at 6px — a viewfinder laid over the
+ * screen, in the brand blue rather than the phosphor green.
+ *
+ * Body ink is pale mint (`--faction-singularity-terminal-ink`), not the bright
+ * phosphor accent: the accent is a chrome colour and burns as running text.
+ *
+ * Both motions are class-gated on reduced-motion in `index.css` — the sweep
+ * parks off-slab, the cursor stops blinking but stays drawn.
+ */
 
-const holeStyle: CSSProperties = {
-  width: 6,
-  height: 4,
-  background: "rgba(10,26,14)",
-  border:
-    "1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))",
-  borderRadius: 1,
-};
-
-function SingularityHoles() {
-  return (
-    <div style={holeRowStyle}>
-      {Array.from({ length: 5 }).map((_, index) => (
-        <div key={index} style={holeStyle} />
-      ))}
-    </div>
-  );
-}
-
-/** Terminal scanline wash + the four corner brackets. Static (#586). */
-const scanlineStyle: CSSProperties = {
+/** The viewfinder brackets — ornament geometry, raw px by §4a. */
+const bracketRule = "2px solid var(--faction-singularity-bracket)";
+const bracketBase: CSSProperties = {
   position: "absolute",
-  inset: 0,
-  backgroundImage:
-    "repeating-linear-gradient(to bottom, transparent, transparent 2px, rgba(74,222,128,0.015) 2px, rgba(74,222,128,0.015) 4px)",
+  width: 12,
+  height: 12,
+  pointerEvents: "none",
+  zIndex: 2,
+};
+const bracketTopLeft: CSSProperties = {
+  ...bracketBase,
+  top: 6,
+  left: 6,
+  borderTop: bracketRule,
+  borderLeft: bracketRule,
+};
+const bracketTopRight: CSSProperties = {
+  ...bracketBase,
+  top: 6,
+  right: 6,
+  borderTop: bracketRule,
+  borderRight: bracketRule,
+};
+const bracketBottomLeft: CSSProperties = {
+  ...bracketBase,
+  bottom: 6,
+  left: 6,
+  borderBottom: bracketRule,
+  borderLeft: bracketRule,
+};
+const bracketBottomRight: CSSProperties = {
+  ...bracketBase,
+  bottom: 6,
+  right: 6,
+  borderBottom: bracketRule,
+  borderRight: bracketRule,
+};
+
+/** The sweeping scanline. Its `top` and the animation live on `.sg-scan`. */
+const scanSweepStyle: CSSProperties = {
+  position: "absolute",
+  left: "-30%",
+  right: "-30%",
+  height: 34,
+  background: "linear-gradient(transparent, var(--faction-singularity-scan), transparent)",
   pointerEvents: "none",
   zIndex: 1,
 };
 
-const cornerRule = "1px solid var(--faction-singularity-card-text)";
-const cornerBase: CSSProperties = { position: "absolute", width: 10, height: 10 };
-const cornerTopLeft: CSSProperties = {
-  ...cornerBase,
-  top: 3,
-  left: 3,
-  borderTop: cornerRule,
-  borderLeft: cornerRule,
-};
-const cornerTopRight: CSSProperties = {
-  ...cornerBase,
-  top: 3,
-  right: 3,
-  borderTop: cornerRule,
-  borderRight: cornerRule,
-};
-const cornerBottomLeft: CSSProperties = {
-  ...cornerBase,
-  bottom: 3,
-  left: 3,
-  borderBottom: cornerRule,
-  borderLeft: cornerRule,
-};
-const cornerBottomRight: CSSProperties = {
-  ...cornerBase,
-  bottom: 3,
-  right: 3,
-  borderBottom: cornerRule,
-  borderRight: cornerRule,
-};
+const ledStyle: CSSProperties = { width: 7, height: 7, borderRadius: "50%", flexShrink: 0 };
 
 export function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
@@ -78,60 +89,68 @@ export function SingularityPraxisCard({ praxis, adminProps, showCrown }: Archety
       style={{
         ...frameBase,
         borderRadius: 8, // terminal slab
-        background: "var(--faction-singularity-card-bg)",
-        border: "2px solid var(--faction-singularity-border-hard)",
         position: "relative",
-        fontFamily: "'Share Tech Mono', monospace",
-        color: "var(--faction-singularity-card-text)",
         overflow: "hidden",
+        background: "var(--faction-singularity-card-bg)",
+        border: "1px solid var(--faction-singularity-frame)",
+        boxShadow: "0 4px 18px rgba(0, 0, 0, 0.4)",
+        // The standing raster — ornament geometry, raw by §4a.
+        backgroundImage:
+          "repeating-linear-gradient(to bottom, transparent 0 2px, var(--faction-singularity-scanline) 2px 3px)",
+        padding: "var(--space-lg)",
+        fontFamily: "var(--font-faction-terminal)",
+        color: "var(--faction-singularity-terminal-ink)",
       }}
     >
-      <div style={scanlineStyle} />
-      <div style={cornerTopLeft} />
-      <div style={cornerTopRight} />
-      <div style={cornerBottomLeft} />
-      <div style={cornerBottomRight} />
-      <SingularityHoles />
-      <div
-        style={{
-          padding: "var(--space-sm) var(--space-xl) var(--space-md)",
-          position: "relative",
-          zIndex: 2,
-        }}
-      >
+      <span aria-hidden className="sg-scan" style={scanSweepStyle} />
+      <span aria-hidden style={bracketTopLeft} />
+      <span aria-hidden style={bracketTopRight} />
+      <span aria-hidden style={bracketBottomLeft} />
+      <span aria-hidden style={bracketBottomRight} />
+
+      <div style={{ position: "relative", zIndex: 2 }}>
+        {/* Window chrome: three LEDs, then the log line pushed to the rail. */}
         <div
           style={{
-            fontSize: "var(--text-xs)",
-            color: "var(--faction-singularity-card-muted)",
-            textTransform: "uppercase",
-            letterSpacing: "0.15em",
-            marginBottom: "var(--space-sm)",
+            display: "flex",
+            alignItems: "center",
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: the 6px pitch of the window-chrome LEDs, drawn geometry (§4a)
+            gap: 6,
+            paddingBottom: "var(--space-sm)",
+            marginBottom: "var(--space-md)",
+            borderBottom: "1px solid var(--faction-singularity-rule)",
           }}
         >
-          {t("card.masthead.singularity")}
+          <span aria-hidden style={{ ...ledStyle, background: "var(--faction-singularity-led-red)" }} />
+          <span aria-hidden style={{ ...ledStyle, background: "var(--faction-singularity-led-amber)" }} />
+          <span aria-hidden style={{ ...ledStyle, background: "var(--faction-singularity-led-green)" }} />
           <span
+            className="eyebrow"
             style={{
-              display: "inline-block",
-              width: 5,
-              height: 9,
-              background: "var(--faction-singularity-card-text)",
-              marginLeft: "var(--space-xs)",
-              verticalAlign: "middle",
-              animation: "blink 1s step-end infinite",
+              marginLeft: "auto",
+              letterSpacing: "0.14em",
+              color: "var(--faction-singularity-vote-off)",
             }}
-          />
+          >
+            {t("card.masthead.singularity")}
+          </span>
         </div>
+
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
-          tint="var(--faction-singularity-card-text)"
-          muted="var(--faction-singularity-card-muted)"
+          tint="var(--faction-singularity-card-accent)"
+          muted="var(--faction-singularity-phosphor-dim)"
           paper="var(--faction-singularity-card-bg)"
           showCrown={showCrown}
+          titleStyle={{
+            fontFamily: "var(--font-faction-terminal)",
+            textTransform: "uppercase",
+            lineHeight: 1.1,
+            color: "var(--faction-singularity-terminal-ink)",
+          }}
         />
       </div>
-      <SingularityHoles />
-      <style>{`@keyframes blink { 50% { opacity: 0; } }`}</style>
     </div>
   );
 }

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -1,25 +1,28 @@
-import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
-import { factionCssVar } from "../../../utils/factions";
-import SnideMasthead from "../../cards/SnideMasthead";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
-const SNIDE_TORN_CLIP =
-  "polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)";
-
-/** The torn top/bottom edges of the Snide scrap. Static (#586). */
-const snideTornBase: CSSProperties = {
-  position: "absolute",
-  left: 0,
-  right: 0,
-  height: 6,
-  background: "var(--color-bg-page)",
-  clipPath: SNIDE_TORN_CLIP,
-};
-const snideTornTop: CSSProperties = { ...snideTornBase, top: -1 };
-const snideTornBottom: CSSProperties = { ...snideTornBase, bottom: -1 };
-
+/**
+ * S.N.I.D.E. — THE EVIDENCE SLAB (#842). A photocopier-black plate ruled in
+ * deep acid, printed onto the page with a hard 6px/8px drop shadow (no blur: it
+ * is stuck down, not floating) over a 3px dot tooth, with the case title struck
+ * in Anton and skewed -3deg.
+ *
+ * Three pieces of chrome came off, all inventions with no counterpart in the
+ * vendored prototype and all pulling the slab toward a different archetype:
+ *
+ *  • the TORN-PAPER top/bottom edges (a 25-point clip-path). The design's slab
+ *    is guillotined — square corners, unbroken acid rule. The tearing read as
+ *    the Updates feed's aged-paper foe note;
+ *  • the TAPE strip;
+ *  • the `Special Elite` MASTHEAD block. The design's running head is a single
+ *    Courier eyebrow line in acid, inside the text column, where it stops at
+ *    the score tag instead of running under it — so it is passed to
+ *    {@link PraxisBody} as `eyebrow`, the seam #841 opened for the codex.
+ *
+ * The dashed acid rule above the vote widget is the design's, and is the one
+ * divider the slab carries.
+ */
 export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
   return (
@@ -27,25 +30,58 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
       style={{
         ...frameBase,
         // No borderRadius: the evidence slab has hard corners in the prototype.
-        background: factionCssVar("snide", "card-bg"),
         position: "relative",
-        padding: "var(--space-xl)",
-        fontFamily: "'Special Elite', serif",
-        color: factionCssVar("snide", "card-text"),
+        background: "var(--faction-snide-card-bg)",
+        border: "1.5px solid var(--faction-snide-acid-deep)",
+        boxShadow: "6px 8px 0 var(--faction-snide-slab-shadow)",
+        // The plate's xerox tooth — ornament geometry, raw by §4a.
+        backgroundImage: "radial-gradient(var(--faction-snide-slab-tooth) 1px, transparent 1px)",
+        backgroundSize: "3px 3px",
+        padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
+        fontFamily: "var(--faction-snide-font-type)",
+        color: "var(--faction-snide-card-text)",
         transition: "background 150ms, color 150ms",
       }}
     >
-      <div style={snideTornTop} />
-      <div style={snideTornBottom} />
-      <div className="snide-tape" style={{ top: -10, left: 22, transform: "rotate(-8deg)" }} />
-      <SnideMasthead subtitle={t("card.masthead.snide")} />
       <AdminOverlay {...adminProps} />
       <PraxisBody
         praxis={praxis}
-        tint={factionCssVar("snide", "card-accent")}
-        muted={factionCssVar("snide", "card-muted")}
-        paper={factionCssVar("snide", "card-bg")}
+        tint="var(--faction-snide-card-accent)"
+        muted="var(--faction-snide-card-muted)"
+        paper="var(--faction-snide-card-bg)"
         showCrown={showCrown}
+        titleStyle={{
+          fontFamily: "var(--faction-snide-font-impact)",
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+          lineHeight: 1,
+          transform: "skewX(-3deg)",
+          color: "var(--faction-snide-card-text)",
+        }}
+        eyebrow={
+          <div
+            className="eyebrow"
+            style={{
+              letterSpacing: "0.16em",
+              color: "var(--faction-snide-acid)",
+              marginBottom: "var(--space-xs)",
+            }}
+          >
+            {t("card.masthead.snide")}
+          </div>
+        }
+        voteRule={
+          <div
+            aria-hidden
+            style={{
+              height: 2,
+              opacity: 0.7,
+              background:
+                "repeating-linear-gradient(90deg, var(--faction-snide-acid-deep) 0 6px, transparent 6px 11px)",
+              margin: "var(--space-lg) 0 var(--space-md)",
+            }}
+          />
+        }
       />
     </div>
   );

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -78,6 +78,7 @@ export function PraxisBody({
   titleStyle,
   showCrown,
   eyebrow,
+  voteRule,
 }: {
   praxis: PraxisCardOut;
   tint: string;
@@ -94,6 +95,15 @@ export function PraxisBody({
    * text column and stop at the score stamp rather than run under it.
    */
   eyebrow?: ReactNode;
+  /**
+   * An optional rule drawn immediately above the vote widget (#842). Several
+   * archetypes close the record with a divider before the "how did this land?"
+   * prompt — S.N.I.D.E.'s dashed acid perforation, the unaffiliated sheet's one
+   * 2px rainbow. It is a per-faction MARK (dashed vs. solid, tooth spacing,
+   * pigment, opacity), so it arrives as a node rather than a boolean; an
+   * archetype that draws no rule simply passes nothing.
+   */
+  voteRule?: ReactNode;
 }) {
   return (
     <>
@@ -128,6 +138,7 @@ export function PraxisBody({
       <PraxisMediaGallery praxis={praxis} accent={tint} paper={paper} showPlaceholder />
       <PraxisByline praxis={praxis} style={{ color: muted }} />
       <PraxisVotedByMarker praxis={praxis} style={{ color: muted }} />
+      {voteRule}
       <PraxisVoteFooter praxis={praxis} />
     </>
   );

--- a/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/AlbescentMobilePraxisCard.tsx
@@ -1,18 +1,21 @@
 import type { PraxisCardOut } from '../../../api/praxis'
 import DefaultMobilePraxisCard from './DefaultMobilePraxisCard'
+import { AlbescentSparks } from '../shared'
 
 /**
  * Albescent MOBILE praxis card (#821, ADR-0048) — the mobile twin of the desktop
  * tell: the spectrum {@link DefaultMobilePraxisCard} an unaffiliated player sees,
  * with the slow rainbow DRIFT (`.alb-rainbow`) washed over the sheet. NOT a
  * from-scratch skin — a repaint would un-hide the society. Every other Albescent
- * surface still falls through to Default (#783).
+ * surface still falls through to Default (#783). #842 added the sparks the
+ * design pairs with the drift, which #821 left unbuilt.
  */
 export default function AlbescentMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   return (
     <div style={{ position: 'relative', overflow: 'hidden', borderRadius: 10 }}>
       <DefaultMobilePraxisCard praxis={praxis} />
       <span aria-hidden className="alb-rainbow" />
+      <AlbescentSparks />
     </div>
   )
 }

--- a/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
@@ -1,15 +1,19 @@
 import { useTranslation } from 'react-i18next'
 import type { PraxisCardOut } from '../../../api/praxis'
-import DefaultSigil from '../../cards/DefaultSigil'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
- * Default MOBILE praxis card (#573, #820) — the SPECTRUM fallback skin for `na`
- * / unaffiliated proof and any themed-but-unskinned task faction. A clean sheet
- * banded in the community rainbow and marked with the seven-segment ring,
- * carrying the conditional score strip (ADR-0047) and the empty-media drop
- * target. Mirrors the desktop DefaultPraxisCard; --faction-default-* tokens,
- * flips light/dark through the [data-theme] cascade.
+ * Default MOBILE praxis card (#573, #820, #842) — the unaffiliated PLAIN CREAM
+ * SHEET, the fallback skin for `na` proof and any themed-but-unskinned task
+ * faction. Mirrors the desktop DefaultPraxisCard, including what came off it:
+ * the full-bleed rainbow BAND and the `DefaultSigil` masthead row were both
+ * inventions with no counterpart in the vendored prototype, and made the
+ * least-marked faction the loudest card in the feed.
+ *
+ * The rainbow survives only as the eyebrow's text-clip here; the sheet's other
+ * three appearances (the score box's rule and total, the divider) belong to the
+ * shared score stamp and the desktop frame. All colour via --faction-default-*,
+ * so it flips light/dark through the [data-theme] cascade.
  */
 export default function DefaultMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   const { t } = useTranslation('praxis')
@@ -18,44 +22,35 @@ export default function DefaultMobilePraxisCard({ praxis }: { praxis: PraxisCard
     muted: 'var(--faction-default-card-muted)',
     accent: 'var(--faction-default-card-accent)',
     paper: 'var(--faction-default-card-bg)',
-    displayFont: "'Courier Prime', monospace",
+    displayFont: 'var(--faction-default-card-font)',
     bodyFont: "'Courier Prime', monospace",
   }
   return (
     <div
       style={{
+        position: 'relative',
         borderRadius: 10,
-        padding: 'var(--space-xs)',
-        background: 'var(--faction-default-rainbow)',
+        background: 'var(--faction-default-card-bg)',
+        color: 'var(--faction-default-card-text)',
+        border: '1px solid var(--faction-default-card-line)',
+        boxShadow: '0 3px 14px rgba(34, 26, 18, 0.1)',
+        padding: 'var(--space-lg)',
       }}
     >
       <div
+        className="eyebrow"
         style={{
-          position: 'relative',
-          background: 'var(--faction-default-card-bg)',
-          color: 'var(--faction-default-card-text)',
-          borderRadius: 6,
-          padding: 'var(--space-lg)',
+          letterSpacing: '0.16em',
+          background: 'var(--faction-default-eyebrow-rainbow)',
+          WebkitBackgroundClip: 'text',
+          backgroundClip: 'text',
+          color: 'transparent',
+          marginBottom: 'var(--space-sm)',
         }}
       >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--space-sm)',
-            marginBottom: 'var(--space-md)',
-            fontFamily: "'Courier Prime', monospace",
-            fontSize: 'var(--text-sm)',
-            letterSpacing: '0.2em',
-            textTransform: 'uppercase',
-            color: 'var(--faction-default-card-muted)',
-          }}
-        >
-          <DefaultSigil size={18} />
-          {t('card.masthead.default')}
-        </div>
-        <MobilePraxisBody praxis={praxis} theme={theme} />
+        {t('card.masthead.default')}
       </div>
+      <MobilePraxisBody praxis={praxis} theme={theme} />
     </div>
   )
 }

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -31,11 +31,14 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
         flexShrink: 0,
         minWidth: 116,
         boxSizing: "border-box",
-        border: "1px solid var(--faction-default-border)",
-        borderRadius: 6,
-        background: "var(--faction-default-card-bg)",
+        border: "1px solid var(--faction-default-card-line)",
+        borderRadius: 8,
+        background: "var(--faction-default-stamp-bg)",
         color: "var(--faction-default-card-text)",
-        padding: "var(--space-sm) var(--space-md)",
+        boxShadow: "0 2px 6px rgba(34, 26, 18, 0.1)",
+        // A sheet of scrap tucked into the record, not a printed field.
+        transform: "rotate(-1deg)",
+        padding: "var(--space-sm) var(--space-md) var(--space-md)",
         lineHeight: 1.1,
       }}
     >
@@ -43,7 +46,7 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
         <TaskCrown
           size={26}
           ringInset={3}
-          innerBg="var(--faction-default-card-bg)"
+          innerBg="var(--faction-default-stamp-bg)"
           glyphColor="var(--faction-default-card-accent)"
           rotate="8deg"
           style={{ position: "absolute", top: -13, right: -12, zIndex: 3 }}
@@ -65,7 +68,7 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
             fontSize: "var(--text-sm)",
             letterSpacing: "0.1em",
             textTransform: "uppercase",
-            color: "var(--faction-default-card-muted)",
+            color: "var(--faction-default-vote-off)",
           }}
         >
           {t("card.stamp.base")}
@@ -86,8 +89,10 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
               fontFamily: "var(--faction-default-card-font)",
               fontSize: "var(--text-lg)",
               letterSpacing: "0.04em",
-              color: "var(--faction-default-card-bg)",
-              background: "var(--faction-default-card-accent)",
+              // Rainbow appearance 2 of 4 is the RULE below; the chip carries
+              // the design's own short green-to-blue ramp, not the spectrum.
+              color: "var(--faction-default-chip-text)",
+              background: "var(--faction-default-chip)",
               borderRadius: 3,
               padding: "0 var(--space-xs)",
             }}
@@ -139,7 +144,10 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
             fontFamily: "var(--faction-default-card-font)",
             fontSize: "var(--text-heading)",
             lineHeight: 1.15,
-            background: "var(--faction-default-rainbow)",
+            // Rainbow appearance 3 of 4: the total, clipped to the design's
+            // warmer four-stop ramp rather than the full seven-stop spectrum,
+            // which smears to mud at four glyphs wide.
+            background: "var(--faction-default-total-rainbow)",
             WebkitBackgroundClip: "text",
             backgroundClip: "text",
             color: "transparent",
@@ -153,7 +161,7 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
             fontSize: "var(--text-base)",
             letterSpacing: "0.06em",
             textTransform: "uppercase",
-            color: "var(--faction-default-card-muted)",
+            color: "var(--faction-default-gold)",
           }}
         >
           {t("card.stamp.points")}

--- a/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
@@ -1,0 +1,129 @@
+import { useTranslation } from "react-i18next";
+import { TaskCrown } from "../../cards/TaskCrown";
+import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import type { ScoreStampProps } from "./ScoreStamp";
+
+/**
+ * The Singularity score stamp (#842, ADR-0049) — the COMPUTED READ-OUT. A darker
+ * well set into the system slab, ruled in cyan, printing the working as aligned
+ * `LABEL … value` register rows rather than a sentence.
+ *
+ * Its TOTAL MARK is typographic: `TOT` against the figure in cyan with a soft
+ * halo and a blinking block cursor, the machine still holding the line open.
+ *
+ * TWO DELIBERATE FORMATTING CHOICES, both the design's and both faction voice
+ * rather than data:
+ *  - the total prints to TWO decimals (`13.60`). ADR-0047 fixes the row
+ *    selection, not the notation, and a terminal pads its output;
+ *  - the votes row zero-pads to two digits (`+04`), for the same reason.
+ * Row SELECTION stays in `scoreBreakdown` — a hidden row leaves the register
+ * shorter, never gappy, so all five conditional states read as one read-out.
+ */
+export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampProps) {
+  const { t } = useTranslation("praxis");
+  if (praxis.total === null || praxis.total === undefined) return null;
+  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const crowned = praxis.is_top_for_task && showCrown !== false;
+
+  const rowStyle = {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: "var(--space-sm)",
+    // eslint-disable-next-line local/no-raw-style-values -- ornament: terminal register row, the design's 10; a read-out is illustration, not prose (§4a)
+    fontSize: 10,
+    color: "var(--faction-singularity-phosphor-dim)",
+    marginTop: "var(--space-xs)",
+  } as const;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        flexShrink: 0,
+        minWidth: 120,
+        boxSizing: "border-box",
+        background: "var(--faction-singularity-stamp-bg)",
+        border: "1px solid var(--faction-singularity-stamp-border)",
+        borderRadius: 4,
+        boxShadow: "inset 0 0 12px var(--faction-singularity-stamp-glow)",
+        fontFamily: "var(--font-faction-terminal)",
+        padding: "var(--space-sm) var(--space-md)",
+        lineHeight: 1.2,
+      }}
+    >
+      {crowned && (
+        <TaskCrown
+          size={26}
+          ringInset={3}
+          innerBg="var(--faction-singularity-stamp-bg)"
+          glyphColor="var(--faction-singularity-bracket)"
+          rotate="0deg"
+          style={{ position: "absolute", top: -13, right: -12, zIndex: 3 }}
+        />
+      )}
+
+      <div style={{ ...rowStyle, marginTop: 0 }}>
+        <span>{t("card.stamp.base")}</span>
+        <span style={{ color: "var(--faction-singularity-terminal-ink)" }}>{base}</span>
+      </div>
+
+      {mult !== null && (
+        <div style={rowStyle}>
+          <span>{t("card.stamp.mult")}</span>
+          <span style={{ color: "var(--faction-singularity-led-amber)" }}>{formatMult(mult)}</span>
+        </div>
+      )}
+
+      {meta !== null && (
+        <div style={rowStyle}>
+          <span>{t("card.stamp.meta")}</span>
+          <span style={{ color: "var(--faction-singularity-terminal-ink)" }}>+{meta}</span>
+        </div>
+      )}
+
+      <div style={rowStyle}>
+        <span>{t("card.stamp.votes")}</span>
+        <span style={{ color: "var(--faction-singularity-terminal-ink)" }}>
+          {`+${String(votes).padStart(2, "0")}`}
+        </span>
+      </div>
+
+      <div
+        aria-hidden
+        style={{
+          height: 1,
+          background: "var(--faction-singularity-stamp-rule)",
+          margin: "var(--space-sm) 0",
+        }}
+      />
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "var(--space-sm)" }}>
+        <span
+          style={{
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: stencilled register label on the read-out, the design's 8 (§4a)
+            fontSize: 8,
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            color: "var(--faction-singularity-vote-off)",
+          }}
+        >
+          {t("card.stamp.totalShort")}
+        </span>
+        <span
+          style={{
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: the glowing computed total, the design's 22 in a monospace read-out (§4a)
+            fontSize: 22,
+            lineHeight: 0.8,
+            color: "var(--faction-singularity-bracket)",
+            textShadow: "0 0 8px var(--faction-singularity-total-glow)",
+          }}
+        >
+          {total.toFixed(2)}
+          <span aria-hidden className="sg-cursor">
+            _
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
@@ -1,0 +1,168 @@
+import { useTranslation } from "react-i18next";
+import { TaskCrown } from "../../cards/TaskCrown";
+import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import type { ScoreStampProps } from "./ScoreStamp";
+
+/**
+ * The S.N.I.D.E. score stamp (#842, ADR-0049) — the EVIDENCE TAG wired to the
+ * slab: a black well punched into the plate, tilted -3deg, ruled in acid and
+ * printed with a hard (unblurred) drop shadow.
+ *
+ * The faction's TOTAL MARK is typographic, not graphic — Anton at the design's
+ * 30 with a 2px hot-pink offset shadow, the misregistered second pass of a
+ * two-colour photocopy. That mark is S.N.I.D.E.'s signature and it was absent
+ * entirely until this issue: #821's one generic tilted plate rendered the same
+ * numeral every faction got.
+ *
+ * Row SELECTION stays in `scoreBreakdown` (ADR-0047) — this file is presentation
+ * only. Each optional row is its own line so the tag stays legible across all
+ * five conditional states; nothing here is positioned relative to a row that
+ * may not exist.
+ */
+export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) {
+  const { t } = useTranslation("praxis");
+  if (praxis.total === null || praxis.total === undefined) return null;
+  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const crowned = praxis.is_top_for_task && showCrown !== false;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        flexShrink: 0,
+        minWidth: 116,
+        boxSizing: "border-box",
+        // No borderRadius: the tag is cut, not rounded.
+        background: "var(--faction-snide-stamp-bg)",
+        border: "2px solid var(--faction-snide-acid)",
+        boxShadow: "3px 4px 0 var(--faction-snide-stamp-shadow)",
+        transform: "rotate(-3deg)",
+        padding: "var(--space-sm) var(--space-md) var(--space-md)",
+        lineHeight: 1.1,
+      }}
+    >
+      {crowned && (
+        <TaskCrown
+          size={26}
+          ringInset={3}
+          innerBg="var(--faction-snide-card-bg)"
+          glyphColor="var(--faction-snide-acid)"
+          rotate="7deg"
+          style={{ position: "absolute", top: -13, right: -12, zIndex: 3 }}
+        />
+      )}
+
+      {/* Base, with the pink multiplier chip stuck on at the right. */}
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", whiteSpace: "nowrap" }}>
+        <span
+          style={{
+            fontFamily: "var(--font-body)",
+            fontSize: "var(--text-sm)",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            color: "var(--faction-snide-vote-off)",
+          }}
+        >
+          {t("card.stamp.base")}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--faction-snide-font-impact)",
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: Anton figure struck at the design's 27, a poster face rather than text (§4a)
+            fontSize: 27,
+            lineHeight: 0.8,
+            color: "var(--faction-snide-acid)",
+          }}
+        >
+          {base}
+        </span>
+        {mult !== null && (
+          <span
+            style={{
+              marginLeft: "auto",
+              fontFamily: "var(--faction-snide-font-black)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the stuck-on multiplier chip, the design's 11 (§4a)
+              fontSize: 11,
+              color: "var(--faction-snide-ink)",
+              background: "var(--faction-snide-pink)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the chip's drawn inset; rounding to a rung swells a sticker into a button (§4a)
+              padding: "2px 5px",
+              transform: "rotate(3deg)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {formatMult(mult)}
+          </span>
+        )}
+      </div>
+
+      {meta !== null && (
+        <div
+          style={{
+            fontFamily: "var(--font-body)",
+            fontWeight: 700,
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: typewriter working on the tag, the design's 11 (§4a)
+            fontSize: 11,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: "var(--faction-snide-acid)",
+            marginTop: "var(--space-xs)",
+          }}
+        >
+          {t("card.stamp.meta")} +{meta}
+        </div>
+      )}
+
+      <div
+        style={{
+          fontFamily: "var(--font-body)",
+          fontWeight: 700,
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: typewriter working on the tag, the design's 11 (§4a)
+          fontSize: 11,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          color: "var(--faction-snide-acid)",
+          marginTop: "var(--space-xs)",
+        }}
+      >
+        {t("card.stamp.fromVotes", { votes })}
+      </div>
+
+      {/* Torn-off perforation, then the total mark. */}
+      <div
+        aria-hidden
+        style={{
+          height: 0,
+          borderTop: "2px dashed var(--faction-snide-acid-deep)",
+          opacity: 0.75,
+          margin: "var(--space-sm) 0",
+        }}
+      />
+      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-xs)" }}>
+        <span
+          style={{
+            fontFamily: "var(--faction-snide-font-impact)",
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: the signature total, Anton at the design's 30 over a misregistered pink pass (§4a)
+            fontSize: 30,
+            lineHeight: 0.78,
+            color: "var(--faction-snide-acid)",
+            textShadow: "2px 2px 0 var(--faction-snide-pink)",
+          }}
+        >
+          {total.toFixed(1)}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--font-body)",
+            fontSize: "var(--text-xs)",
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "var(--faction-snide-card-muted)",
+          }}
+        >
+          {t("card.stamp.pointsShort")}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -20,6 +20,8 @@ import { scoreBreakdown, formatMult } from '../scoreBreakdown'
 import DefaultScoreStamp from '../DefaultScoreStamp'
 import EverymenScoreStamp from '../EverymenScoreStamp'
 import EphemeristsScoreStamp from '../EphemeristsScoreStamp'
+import SnideScoreStamp from '../SnideScoreStamp'
+import SingularityScoreStamp from '../SingularityScoreStamp'
 
 /** No hex may reach a stamp's markup — every colour is a token (ADR-0049). */
 const HEX = /#[0-9a-fA-F]{3,8}\b/
@@ -92,9 +94,16 @@ describe('scoreBreakdown row selection (ADR-0047)', () => {
 
 describe('scoreStamp surface dispatch (ADR-0049)', () => {
   it('falls through to the Default stamp for every slug that has not claimed it', () => {
-    for (const slug of ['ua', 'snide', 'singularity', 'coven', 'wow', 'albescent', 'na', null]) {
+    for (const slug of ['ua', 'coven', 'wow', 'albescent', 'na', null]) {
       expect(pickVariant(surfaceMap('scoreStamp'), slug, DefaultScoreStamp)).toBe(DefaultScoreStamp)
     }
+  })
+
+  it('gives S.N.I.D.E. and Singularity their own stamps (#842)', () => {
+    expect(pickVariant(surfaceMap('scoreStamp'), 'snide', DefaultScoreStamp)).toBe(SnideScoreStamp)
+    expect(pickVariant(surfaceMap('scoreStamp'), 'singularity', DefaultScoreStamp)).toBe(
+      SingularityScoreStamp,
+    )
   })
 
   it('gives Everymen and the Ephemerists their own stamps (#841)', () => {
@@ -160,4 +169,54 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
     expect(full).toContain('group')
     expect(metaOnly).not.toContain('group')
   })
+})
+
+/**
+ * The same five states on the #842 stamps, whose total marks are TYPOGRAPHIC —
+ * a numeral carrying its own device rather than a drawn one. The failure mode
+ * is the same: a working that stops reading as itself when a row drops out.
+ * Both faction stamps also format the numbers in their own voice, which
+ * ADR-0047 permits (it fixes which rows exist, not their notation), so the
+ * assertions below are deliberately notation-aware.
+ */
+describe('#842 stamps across the conditional states (ADR-0047)', () => {
+  const STATES = [
+    ['base only', { display_multiplier: 1, metatask_points: 0, points_from_votes: 0, total: 12 }],
+    ['+ votes', { display_multiplier: 1, metatask_points: 0, points_from_votes: 4, total: 16 }],
+    ['× mult', { display_multiplier: 0.8, metatask_points: 0, points_from_votes: 0, total: 9.6 }],
+    ['+ metatask', { display_multiplier: 1, metatask_points: 20, points_from_votes: 0, total: 32 }],
+    ['full formula', { display_multiplier: 0.8, metatask_points: 20, points_from_votes: 4, total: 29.6 }],
+  ] as const
+
+  for (const [name, fields] of STATES) {
+    it(`S.N.I.D.E. prints the working and the total in pts — ${name}`, () => {
+      const html = text(renderToStaticMarkup(<SnideScoreStamp praxis={praxis({ ...fields })} />))
+      expect(html).toContain('base')
+      expect(html).toContain('from votes')
+      expect(html).toContain(fields.total.toFixed(1))
+      expect(html).toContain('pts')
+      expect(html).not.toMatch(HEX)
+    })
+
+    it(`Singularity prints the register and the two-decimal total — ${name}`, () => {
+      const html = text(
+        renderToStaticMarkup(<SingularityScoreStamp praxis={praxis({ ...fields })} />),
+      )
+      expect(html).toContain('base')
+      expect(html).toContain('tot')
+      // The terminal pads its output: two decimals, and a zero-padded votes row.
+      expect(html).toContain(fields.total.toFixed(2))
+      expect(html).toContain(`+${String(fields.points_from_votes).padStart(2, '0')}`)
+      expect(html).not.toMatch(HEX)
+    })
+
+    it(`the unaffiliated sheet prints the working and the total — ${name}`, () => {
+      const html = text(renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({ ...fields })} />))
+      expect(html).toContain('base')
+      expect(html).toContain('from votes')
+      expect(html).toContain(fields.total.toFixed(1))
+      expect(html).toContain('points')
+      expect(html).not.toMatch(HEX)
+    })
+  }
 })

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -699,3 +699,39 @@ export function AdminOverlay({
     </>
   );
 }
+
+// ─── Albescent ────────────────────────────────────────────────────────────────
+
+/**
+ * The Albescent SPARKS (#842, ADR-0048) — three faint gold ✦ scattered over the
+ * sheet, the other half of the secret-society tell.
+ *
+ * The design pairs `.alb-rainbow`'s slow drift with `.alb-spark`; #821 shipped
+ * only the drift, so the card shimmered but never caught the light. Each spark
+ * carries its own position, size and delay so the three never pulse together,
+ * and all of them sit BEHIND the card content (`z-index: 0`, pointer-events
+ * none). Reduced motion parks them at a steady low opacity rather than freezing
+ * the keyframes — frozen at 0% they would be invisible, which is not "stilled".
+ *
+ * Shared by the desktop and mobile Albescent cards: both wrap the exact
+ * unaffiliated card and layer the same tell over it. A repaint in Albescent's
+ * own colours would put it back in the spectrum and un-hide it (#783).
+ */
+export function AlbescentSparks() {
+  return (
+    <>
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ✦ glyph used as a drawn spark, sized as illustration (§4a) */}
+      <span aria-hidden className="alb-spark" style={{ top: 118, left: 24, fontSize: 13, animationDelay: "0s" }}>
+        ✦
+      </span>
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ✦ glyph used as a drawn spark, sized as illustration (§4a) */}
+      <span aria-hidden className="alb-spark" style={{ top: 176, right: 36, fontSize: 9, animationDelay: "1.5s" }}>
+        ✦
+      </span>
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ✦ glyph used as a drawn spark, sized as illustration (§4a) */}
+      <span aria-hidden className="alb-spark" style={{ bottom: 104, left: 64, fontSize: 15, animationDelay: "2.8s" }}>
+        ✦
+      </span>
+    </>
+  );
+}

--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -87,7 +87,8 @@ export default function SingularityVote({ praxisId, currentValue, points, totalV
     <div style={{ fontFamily: 'var(--font-faction-terminal)' }}>
       <div
         onMouseLeave={() => setHovered(0)}
-        style={{ display: 'flex', gap: 'var(--space-xs)', alignItems: 'flex-end' }}
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: the decode strip's 6px column pitch, drawn geometry of the read-out (§4a)
+        style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}
       >
         {TIERS.map((tier) => {
           const reached = active >= tier.value
@@ -150,7 +151,8 @@ export default function SingularityVote({ praxisId, currentValue, points, totalV
         <span
           style={{
             fontFamily: 'var(--font-faction-terminal)',
-            fontSize: 'var(--text-content)',
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: terminal read-out caption, the design's 13; monospace print, not prose (§4a)
+            fontSize: 13,
             letterSpacing: '0.08em',
             color: active
               ? 'var(--faction-singularity-vote-reached)'

--- a/frontend/src/components/vote/SnideVote.tsx
+++ b/frontend/src/components/vote/SnideVote.tsx
@@ -47,19 +47,22 @@ export default function SnideVote({ praxisId, currentValue, points, totalVotes }
         style={{
           position: 'relative',
           display: 'flex',
-          gap: 'var(--space-xs)',
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: the amp face's 5px inter-column gap, drawn geometry of the chassis (§4a)
+          gap: 5,
           alignItems: 'flex-end',
-          padding: 'var(--space-sm) var(--space-md)',
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: the amp face's own inset, the design's 11/13 (§4a)
+          padding: '11px 13px',
           background:
             'linear-gradient(var(--faction-snide-amp-panel-from), var(--faction-snide-amp-panel-to))',
           border: '2px solid var(--faction-snide-amp-panel-border)',
           borderRadius: 6,
-          boxShadow: 'inset 0 2px 7px rgba(0, 0, 0, 0.75)',
+          boxShadow:
+            'inset 0 2px 7px rgba(0, 0, 0, 0.75), inset 0 0 0 1px var(--faction-snide-amp-panel-sheen)',
         }}
       >
         {/* screws */}
-        <span aria-hidden style={{ position: 'absolute', top: 5, left: 5, width: 4, height: 4, borderRadius: '50%', background: 'var(--faction-snide-amp-screw)' }} />
-        <span aria-hidden style={{ position: 'absolute', top: 5, right: 5, width: 4, height: 4, borderRadius: '50%', background: 'var(--faction-snide-amp-screw)' }} />
+        <span aria-hidden style={{ position: 'absolute', top: 5, left: 5, width: 4, height: 4, borderRadius: '50%', background: 'var(--faction-snide-amp-screw)', boxShadow: 'inset 0 0 0 1px var(--faction-snide-amp-screw-rim)' }} />
+        <span aria-hidden style={{ position: 'absolute', top: 5, right: 5, width: 4, height: 4, borderRadius: '50%', background: 'var(--faction-snide-amp-screw)', boxShadow: 'inset 0 0 0 1px var(--faction-snide-amp-screw-rim)' }} />
 
         {TIERS.map((tier) => {
           const reached = active >= tier.value
@@ -68,7 +71,7 @@ export default function SnideVote({ praxisId, currentValue, points, totalVotes }
             const lit = reached && i < tier.value
             const litColor = SEG_COLORS[i]
             const cellStyle: CSSProperties = {
-              width: 30,
+              width: 32,
               height: 5,
               borderRadius: 1,
               background: lit ? litColor : 'var(--faction-snide-amp-seg-off)',
@@ -123,7 +126,8 @@ export default function SnideVote({ praxisId, currentValue, points, totalVotes }
         <span
           style={{
             fontFamily: 'var(--faction-snide-font-marker)',
-            fontSize: 'var(--text-content)',
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: marker-scrawled verdict beside the meter, the design's 14; Permanent Marker's optical size is not the text scale (§4a)
+            fontSize: 14,
             color: active ? 'var(--faction-snide-acid)' : 'var(--faction-snide-vote-off)',
             transition: 'color 140ms',
           }}

--- a/frontend/src/components/vote/UnaffiliatedVote.tsx
+++ b/frontend/src/components/vote/UnaffiliatedVote.tsx
@@ -15,14 +15,29 @@ import { VoteLoginGate, VoteSummary } from './VoteShell'
  * ternary). Same 1-5 data model as every faction; drives the shared
  * {@link useVote} hook so cast/refetch/tally-override logic lives in one place.
  *
- * Each dot shows its own slice of the single rainbow via a 500%-wide background
- * positioned by index — so no pixel/gap math is needed and the row still reads
- * as one continuous spectrum. The rising-wave bob is a reduced-motion-gated CSS
- * class (`.spectrum-dot--reached`); the dot still fills when motion is stilled.
+ * THE ROW IS ONE GRADIENT, WINDOWED (#842). A single rainbow is stretched across
+ * the whole row and each dot shows the slice that falls where the dot actually
+ * sits, via `backgroundSize: <row span>` + a negative `backgroundPositionX`. The
+ * previous `500% 100%` gave every dot an equal fifth of the spectrum regardless
+ * of its size or position, so the 18px dot and the 30px dot spanned the same
+ * hues at different rates and the sweep restarted inside each dot — five little
+ * rainbows, not one. The rising-wave bob is a reduced-motion-gated CSS class
+ * (`.spectrum-dot--reached`); the dot still fills when motion is stilled.
+ *
+ * The windowing constants are DERIVED from the layout rather than copied from
+ * the design's 153px span: our buttons are ≥44px WCAG touch targets, so the row
+ * is wider than the prototype's bare dots and the offsets must be measured off
+ * the boxes we actually draw, or the gradient would drift out of register with
+ * the dots it is painting.
  */
 
 /** Rising dot diameters (px) — ornament geometry, §4a leaves these raw. */
 const DOT_SIZES = [18, 20, 23, 26, 30]
+/** ≥44px touch target (WCAG) and the pitch between dots — ornament geometry. */
+const HIT_SIZE = 44
+const ROW_GAP = 9
+/** Total row width the single rainbow is stretched across. */
+const ROW_SPAN = DOT_SIZES.length * HIT_SIZE + (DOT_SIZES.length - 1) * ROW_GAP
 const TIER_KEYS = ['so-so', 'decent', 'good', 'great', 'brilliant'] as const
 
 export default function UnaffiliatedVote({
@@ -51,12 +66,16 @@ export default function UnaffiliatedVote({
         style={{
           display: 'flex',
           alignItems: 'flex-end',
-          justifyContent: 'space-between',
-          maxWidth: 320,
+          // ornament: the dot row's own pitch, and the ruler the gradient
+          // windowing is measured against (§4a).
+          gap: ROW_GAP,
         }}
       >
         {DOT_SIZES.map((size, index) => {
           const value = index + 1
+          // Where this dot's left edge lands in the row: whole hit boxes before
+          // it, plus the inset that centres the dot inside its own box.
+          const dotOffset = index * (HIT_SIZE + ROW_GAP) + (HIT_SIZE - size) / 2
           const reached = active >= value
           const picked = selected === value
           const top = value === 5
@@ -68,9 +87,9 @@ export default function UnaffiliatedVote({
             backgroundColor: 'transparent',
             backgroundImage: reached ? 'var(--faction-default-rainbow)' : 'none',
             backgroundRepeat: 'no-repeat',
-            // A 5×-wide rainbow, windowed by index → dot 1 red … dot 5 magenta.
-            backgroundSize: '500% 100%',
-            backgroundPositionX: `${(index / (DOT_SIZES.length - 1)) * 100}%`,
+            // One rainbow across the whole row, windowed to where this dot sits.
+            backgroundSize: `${ROW_SPAN}px ${size}px`,
+            backgroundPositionX: `${-dotOffset}px`,
             boxShadow: reached
               ? `0 0 8px color-mix(in srgb, ${glow} 60%, transparent), inset 0 0 0 1px color-mix(in srgb, white 50%, transparent)${
                   top ? `, 0 0 16px color-mix(in srgb, ${glow} 53%, transparent)` : ''
@@ -99,8 +118,11 @@ export default function UnaffiliatedVote({
                 background: 'transparent',
                 padding: 0,
                 // ≥44px touch target (WCAG); the dot floats centred inside.
-                minWidth: 44,
-                minHeight: 44,
+                // FIXED, not min-: the gradient windowing above measures its
+                // offsets off these boxes, so they cannot be free to grow.
+                width: HIT_SIZE,
+                height: HIT_SIZE,
+                flexShrink: 0,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -117,7 +139,8 @@ export default function UnaffiliatedVote({
         <span
           style={{
             fontFamily: 'var(--faction-default-card-font)',
-            fontSize: 'var(--text-content)',
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: Bebas Neue verdict under the row, the design's 15; a condensed poster face is not on the text scale (§4a)
+            fontSize: 15,
             letterSpacing: '0.04em',
             color: active ? 'var(--faction-default-vote-on)' : 'var(--faction-default-vote-off)',
             transition: 'color 140ms',

--- a/frontend/src/factions/singularity.ts
+++ b/frontend/src/factions/singularity.ts
@@ -34,6 +34,7 @@ import SingularityTaskCard from '../components/cards/SingularityTaskCard'
 import SingularityTaskDetail from '../pages/taskDetail/archetypes/SingularityTaskDetail'
 import SingularityVote from '../components/vote/SingularityVote'
 import SingularityPraxisCard from '../components/praxisCard/desktop/SingularityPraxisCard'
+import SingularityScoreStamp from '../components/praxisCard/scoreStamp/SingularityScoreStamp'
 import { SingularitySigilAdapter } from '../components/cards/FactionSigil'
 import { SingularityCard } from '../components/cards/FactionCard'
 import { SingularitySelectCard } from '../components/cards/FactionSelectCard'
@@ -45,6 +46,7 @@ export const SINGULARITY_MANIFEST: FactionManifest = {
   factionSelectCard: () => SingularitySelectCard,
   taskCard: () => SingularityTaskCard,
   praxisCard: () => SingularityPraxisCard,
+  scoreStamp: () => SingularityScoreStamp,
   avatar: () => SingularityAvatar,
   backdrop: () => SingularityBackdrop,
   sigil: () => SingularitySigilAdapter,

--- a/frontend/src/factions/snide.ts
+++ b/frontend/src/factions/snide.ts
@@ -34,6 +34,7 @@ import SnideTaskCard from '../components/cards/SnideTaskCard'
 import SnideTaskDetail from '../pages/taskDetail/archetypes/SnideTaskDetail'
 import SnideVote from '../components/vote/SnideVote'
 import SnidePraxisCard from '../components/praxisCard/desktop/SnidePraxisCard'
+import SnideScoreStamp from '../components/praxisCard/scoreStamp/SnideScoreStamp'
 import { SnideSigil } from '../components/cards/SnideSigil'
 import { SnideCard } from '../components/cards/FactionCard'
 import { SnideSelectCard } from '../components/cards/FactionSelectCard'
@@ -45,6 +46,7 @@ export const SNIDE_MANIFEST: FactionManifest = {
   factionSelectCard: () => SnideSelectCard,
   taskCard: () => SnideTaskCard,
   praxisCard: () => SnidePraxisCard,
+  scoreStamp: () => SnideScoreStamp,
   avatar: () => SnideAvatar,
   backdrop: () => SnideBackdrop,
   sigil: () => SnideSigil,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -206,6 +206,9 @@
   --faction-default-stamp-bg: #ffffff;
   --faction-default-gold: #ca8a04;
   --faction-default-chip: linear-gradient(90deg, #16a34a, #2563eb);
+  /* White in BOTH themes: the chip is a saturated green→blue pill in either,
+     and the ink has to answer to the pill, not to the page. */
+  --faction-default-chip-text: #ffffff;
   --faction-default-total-rainbow: linear-gradient(90deg, #c1272d, #ca8a04 40%, #16a34a 60%, #2563eb);
   --faction-default-eyebrow-rainbow: linear-gradient(90deg, #16a34a, #2563eb, #be185d);
   --spectrum-glow-1: #c1352a;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -249,6 +249,11 @@
   --faction-snide-amp-panel-border: #2c2a20;
   --faction-snide-amp-seg-off: rgba(255, 255, 255, 0.07);
   --faction-snide-amp-screw: #3a3830;
+  /* The screw's countersunk rim and the faint acid sheen along the amp face's
+     inner edge (#842) — both were dropped when the widget was first built, and
+     without them the panel reads as a flat rectangle rather than a chassis. */
+  --faction-snide-amp-screw-rim: #000000;
+  --faction-snide-amp-panel-sheen: rgba(182, 255, 46, 0.06);
   --faction-snide-vote-off: #8a9a6a;
 
   /* S.N.I.D.E. EVIDENCE SLAB (#842) — the praxis card and its score box. The

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -192,6 +192,22 @@
   --faction-default-dot-ring: #d6cfbf;
   --faction-default-vote-on: #c2541f;
   --faction-default-vote-off: #a8895a;
+  /* The unaffiliated PLAIN CREAM SHEET (#842). The design's card is a quiet
+     sheet, and the rainbow appears in exactly four places on it — the eyebrow
+     text-clip, the score-box rule, the total, and one 2px divider. The
+     full-bleed rainbow BAND #820 wrapped the sheet in had no counterpart in the
+     prototype and is gone; these tokens are what replaced it. `card-line` is
+     the sheet + stamp hairline, `stamp-bg` the whiter plate the score sits on,
+     `gold` the POINTS caption. The last two gradients are deliberately NOT the
+     seven-stop spectrum: the design draws the chip and the total with their own
+     shorter ramps, and substituting --faction-default-rainbow would flatten a
+     green→blue chip into a full spectrum smear at 40px wide. */
+  --faction-default-card-line: #e6ddc8;
+  --faction-default-stamp-bg: #ffffff;
+  --faction-default-gold: #ca8a04;
+  --faction-default-chip: linear-gradient(90deg, #16a34a, #2563eb);
+  --faction-default-total-rainbow: linear-gradient(90deg, #c1272d, #ca8a04 40%, #16a34a 60%, #2563eb);
+  --faction-default-eyebrow-rainbow: linear-gradient(90deg, #16a34a, #2563eb, #be185d);
   --spectrum-glow-1: #c1352a;
   --spectrum-glow-2: #cf861a;
   --spectrum-glow-3: #16a34a;
@@ -235,6 +251,16 @@
   --faction-snide-amp-screw: #3a3830;
   --faction-snide-vote-off: #8a9a6a;
 
+  /* S.N.I.D.E. EVIDENCE SLAB (#842) — the praxis card and its score box. The
+     slab is a photocopier-black plate with a hard drop shadow (no blur: it is
+     printed, not floating) and a 3px dot tooth; the score box is a darker well
+     punched into it, tilted -3deg. Like the amp face these are ink-dark in both
+     themes, so only the two shadow alphas deepen under [data-theme="dark"]. */
+  --faction-snide-slab-shadow: rgba(0, 0, 0, 0.4);
+  --faction-snide-slab-tooth: rgba(244, 241, 232, 0.05);
+  --faction-snide-stamp-bg: rgba(0, 0, 0, 0.4);
+  --faction-snide-stamp-shadow: rgba(0, 0, 0, 0.5);
+
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;
 
@@ -258,6 +284,27 @@
   --faction-singularity-vote-scramble: rgba(74, 222, 128, 0.24); /* dim, unreached noise */
   --faction-singularity-vote-reached-bg: rgba(74, 222, 128, 0.05); /* faint lit key */
   --faction-singularity-vote-off: #3f7a58; /* idle caption ink */
+
+  /* ── Singularity SYSTEM SLAB (#842) — the praxis card and its computed stamp.
+     A booted terminal: pale-mint body ink (NOT the bright phosphor accent, which
+     is a chrome colour and burns as running text), a green hairline frame, four
+     cyan corner brackets, a slow cyan scanline sweep, and the stamp as a darker
+     well with a glowing cyan total. Terminal tokens are theme-invariant —
+     Singularity is always-dark (§6) — so there is no [data-theme] override for
+     this group, deliberately. */
+  --faction-singularity-terminal-ink: #d7ffe6; /* pale mint — titles + body */
+  --faction-singularity-frame: rgba(74, 222, 128, 0.35);
+  --faction-singularity-rule: rgba(74, 222, 128, 0.2);
+  --faction-singularity-bracket: #60a5fa; /* cyan corner brackets */
+  --faction-singularity-scan: rgba(96, 165, 250, 0.16); /* scanline sweep peak */
+  --faction-singularity-stamp-bg: #030b06;
+  --faction-singularity-stamp-border: rgba(96, 165, 250, 0.5);
+  --faction-singularity-stamp-rule: rgba(74, 222, 128, 0.25);
+  --faction-singularity-stamp-glow: rgba(96, 165, 250, 0.1); /* inner box glow */
+  --faction-singularity-total-glow: rgba(96, 165, 250, 0.7); /* the TOT halo */
+  --faction-singularity-led-red: #ff5f56;
+  --faction-singularity-led-amber: #f0c400;
+  --faction-singularity-led-green: #4ade80;
 
   /* ══ Ephemerists illuminated-codex palette (the ephemerists slot) ══
      The card contract above rebinds to these. CONSTANTS (gold/rubric/
@@ -721,6 +768,11 @@
   --faction-snide-wall: #141310;
   --faction-snide-wall-deep: #0b0a08;
   --faction-snide-wall-text: #e9e6da;
+  /* The evidence slab, lights out (#842): the plate itself is already ink, so
+     only its printed shadow and the score well deepen. */
+  --faction-snide-slab-shadow: rgba(0, 0, 0, 0.5);
+  --faction-snide-stamp-bg: rgba(0, 0, 0, 0.5);
+  --faction-snide-stamp-shadow: rgba(0, 0, 0, 0.6);
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
 
   /* ── DEFAULT · unaffiliated (dark — brightened spectrum) ── */
@@ -737,6 +789,15 @@
   --faction-default-dot-ring: rgba(240, 230, 208, 0.3);
   --faction-default-vote-on: #e07a3a;
   --faction-default-vote-off: #b0925f;
+  /* The cream sheet, lights out (#842) — the design's own dark card, not an
+     inversion: the hairline becomes a white scrim, the stamp plate lifts off
+     the sheet rather than sinking into it, and both narrow rainbows swap their
+     stops for the brightened spectrum's. */
+  --faction-default-card-line: rgba(255, 255, 255, 0.14);
+  --faction-default-stamp-bg: #26252f;
+  --faction-default-gold: #e6b34a;
+  --faction-default-total-rainbow: linear-gradient(90deg, #e2433f, #e6b34a 40%, #4ade80 60%, #60a5fa);
+  --faction-default-eyebrow-rainbow: linear-gradient(90deg, #4ade80, #60a5fa, #f472b6);
   --glow-neutral: rgba(255, 255, 255, 0.75);
 
   /* ══ Ephemerists palette (dark) — pigments stay vivid; vellum darkens
@@ -1574,6 +1635,21 @@
   .sg-rotate { animation: sg-rotate 120s linear infinite; }
 }
 
+/* Singularity system slab (#842) — the praxis card's two terminal motions: a
+   cyan SCANLINE that sweeps down the slab every 5s, and the block CURSOR
+   trailing the computed total. Both are class-gated on reduced-motion, so the
+   slab stills into a legible screenshot: the sweep parks off-slab and the
+   cursor stops blinking but stays drawn (it is punctuation on the number, not
+   an indicator, so it must not vanish). The sweep element is a scrim, not
+   content — the card gives it `position:absolute; pointer-events:none`. */
+@keyframes sg-scan-sweep { 0% { top: -24%; } 100% { top: 120%; } }
+@keyframes sg-term-blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+.sg-scan { top: -24%; }
+@media (prefers-reduced-motion: no-preference) {
+  .sg-scan { animation: sg-scan-sweep 5s linear infinite; }
+  .sg-cursor { animation: sg-term-blink 1s steps(1) infinite; }
+}
+
 /* S.N.I.D.E. duel rail — the settled-state dot flickers like a failing xerox
    lamp. Class-gated on reduced-motion like every other faction animation, so a
    component never writes `animation:` inline and bypasses the gate. (#722) */
@@ -1674,6 +1750,30 @@
 }
 @media (prefers-reduced-motion: no-preference) {
   .alb-rainbow { animation: alb-drift 18s linear infinite; }
+}
+
+/* The other half of the tell (#842). The design draws the drift AND three faint
+   gold ✦ sparks scattered over the sheet; #821 shipped only the drift, so the
+   sheet shimmered but never caught the light. Each spark carries its own
+   position, size and animation-delay at the call site, so the three never
+   pulse together.
+
+   Unlike .alb-rainbow, the spark's motion IS the mark: a spark frozen at its
+   own keyframe start would be invisible (opacity 0), so reduced motion parks it
+   at a steady low opacity rather than freezing the animation. The glyph is a
+   typographic ✦, not an emoji (§10), and stays behind the card content. */
+@keyframes alb-spark { 0%, 100% { opacity: 0; transform: scale(0.5) rotate(0); } 50% { opacity: 0.75; transform: scale(1) rotate(28deg); } }
+.alb-spark {
+  position: absolute;
+  z-index: 0;
+  pointer-events: none;
+  line-height: 1;
+  color: #bf7f3a;
+  opacity: 0.4;
+}
+[data-theme="dark"] .alb-spark { color: #f2cc72; }
+@media (prefers-reduced-motion: no-preference) {
+  .alb-spark { opacity: 0; animation: alb-spark 4.5s ease-in-out infinite; }
 }
 
 /* UA — growing mandala: each rank blooms a fuller mandala; the emphasized cell

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -302,6 +302,7 @@
   --faction-singularity-rule: rgba(74, 222, 128, 0.2);
   --faction-singularity-bracket: #60a5fa; /* cyan corner brackets */
   --faction-singularity-scan: rgba(96, 165, 250, 0.16); /* scanline sweep peak */
+  --faction-singularity-scanline: rgba(74, 222, 128, 0.03); /* the standing raster */
   --faction-singularity-stamp-bg: #030b06;
   --faction-singularity-stamp-border: rgba(96, 165, 250, 0.5);
   --faction-singularity-stamp-rule: rgba(74, 222, 128, 0.25);

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -58,6 +58,7 @@
       "totalShort": "tot",
       "fromVotes": "+ {{votes}} from votes",
       "points": "points",
+      "pointsShort": "pts",
       "tally": "TALLY",
       "group": "group",
       "onTheRecord": "★ VERIFIED ★ ON THE RECORD "


### PR DESCRIPTION
Closes #842

Builds the three remaining card skins against the vendored
`.design-sync/praxis-cards/design_handoff_faction_vote_stamps/Faction Praxis Cards.dc.html`,
whose total marks are typographic rather than graphic, and ships the half of the
Albescent tell that never got built.

## What landed

**S.N.I.D.E. — the evidence slab.** Black plate, 1.5px deep-acid rule, hard
6px/8px printed drop shadow (no blur), 3px dot tooth, Anton title skewed -3deg.
New `SnideScoreStamp`: a tilted black well ruled in acid, `BASE` + Anton figure
+ pink Archivo Black chip, bold Courier working, 2px dashed rule, then the
signature **total in Anton 30 with a 2px hot-pink offset shadow** — the
misregistered second pass of a two-colour photocopy, absent entirely until now.
Widget: chassis geometry per the design (segment 32 not 30, gap 5, padding
11/13, countersunk screw rims, acid sheen on the inner edge). Party timings
untouched.

**Singularity — the system slab.** Terminal glass on a standing raster, green
hairline frame, cyan scanline sweeping every 5s, window-chrome header of three
LEDs + the log line. Brackets fixed in *kind*, not just size: 12px **cyan** at a
6px inset (they were 10px of the card's own text colour at 3px, reading as a
mitred border corner). New `SingularityScoreStamp`: aligned `BASE / MULT / META
/ VOTES` register rows, cyan rule, then `TOT` against **`13.60`** in cyan with a
`0 0 8px` halo and a blinking cursor. Widget: 6px column pitch; the
reduced-motion scramble freeze is untouched.

**Unaffiliated / Default + Albescent — the plain cream sheet.** The rainbow now
appears in exactly the four places the design puts it: the eyebrow text-clip,
the score box's rule, the total, and one 2px divider. Stamp: white plate, radius
8, tilted -1deg, green→blue chip, total clipped to the design's warmer four-stop
ramp, `POINTS` in gold. Widget: **the row is one gradient again** — a single
rainbow stretched across the row, each dot windowing the slice where it actually
sits. `.alb-spark` shipped (`AlbescentSparks`, shared by the desktop and mobile
Albescent cards): three faint gold `✦` behind the sheet, each with its own size
and delay, reduced-motion gated.

**Invented chrome deleted** (the other half of the issue): Snide's 25-point
torn-paper clip, tape strip and `Special Elite` masthead; Singularity's
punch-card sprocket strips and header block cursor; Default's full-bleed rainbow
band frame and the `DefaultSigil` + Courier masthead row — on desktop **and**
mobile.

## Deviations, and the rule that forced each

| Deviation | Rule |
|---|---|
| Card padding lands on `--space-*` rungs (Snide 24/24/16 not 22/20/18; Singularity 16 not 16/18/18; Default 24/24/16 not 20/20/18) | §4a: `padding`/`margin`/`gap` take a token; enforced by `local/no-raw-style-values`. Ornament spacing is carved out, but a card's outer inset is layout. |
| Frames stay on the shared `frameBase` 394px flex basis, not the design's 398/380 | §4a/UX 1 (responsive over pixel-perfect); the deviation is pre-existing and documented on `frameBase`. |
| Titles keep `.content-title` (24px), not the design's Anton 26 / Bebas 26 / mono 18 | §4a "skins don't own type size" + the content-text floor. Skins set face, colour, transform, letter-spacing — never size. |
| Vote-dot row is 5×44px hit boxes + a 9px pitch (256px span), so the gradient window is **derived**, not the design's literal `backgroundSize: 153px` | WCAG ≥44px touch targets, already shipped. The offsets must be measured off the boxes we actually draw or the gradient drifts out of register with the dots. |
| The unaffiliated 2px divider uses one opacity (0.45) where the design has 0.4 light / 0.5 dark | §8 / §3: no `dark ? a : b`. A per-theme token for one wash step behind a 2px rule is not worth a variable. |
| Eyebrow copy is the existing i18n masthead string, not the design's `dispatch №663 · closed case` / `SYS://LOG.663 · VERIFIED` / `record №663 · logged` | ADR-0032: copy lives in the catalogs; those strings are mock record numbers we do not have. |
| Snide/Singularity stamp figures carry raw sizes with per-line `eslint-disable` hatches; the Default stamp keeps its `--text-*` tokens | §4a ornament escape hatch (Anton and a monospace register are display faces whose exact sizes are load-bearing), matching the #841 precedent. The Default stamp shipped tokenized in #839/#820 and rewriting it would be churn. |
| Caption sizes de-tokenized to raw 14 / 13 / 15 | The issue's ornament exemption; each carries a per-line hatch naming the face. |
| Singularity prints `13.60` and `+04` | ADR-0047 fixes which rows exist, not their notation (settled in the issue). |
| Added `card.stamp.pointsShort` ("pts") to `praxis.json` | The slab's unit label is not the `points` the other stamps spell out; no bare literals (ADR-0032). |
| New optional `voteRule` slot on `PraxisBody` (desktop `shared.tsx`) | The design's pre-widget divider is a per-faction mark (dashed vs. solid, tooth pitch, pigment); a shared boolean would have unified three archetypes' ornament. Additive — every other card passes nothing and is unchanged. |
| Mobile **Snide/Singularity** cards untouched (they still carry tape, a torn edge and a header cursor) | Those are a separate design surface (`Singularity Mobile Card.dc.html`, the #495 Field Kit), and this issue's geometry is the desktop card. Flagging for triage rather than guessing. The mobile **Default/Albescent** cards *were* fixed, because they explicitly mirror the desktop sheet and carried the same invented band. |

## What to eyeball

- **Snide**: the pink offset shadow on the Anton total — 2px right/down, no blur, and the numeral must still read acid-green, not muddy. Also that the slab's hard drop shadow does not collide with neighbouring cards in the flex-wrap grid.
- **Singularity**: the scanline sweep crossing the card without washing out the score stamp; the four cyan brackets clearing the header LEDs and the vote strip; the blinking `_` sitting on the baseline of `13.60`, not below it.
- **Unaffiliated**: whether the dot row genuinely reads as ONE spectrum left-to-right (the whole point of the change) — and it is the thing most likely to still be subtly wrong, since our row is wider than the design's.
- **Albescent**: the three sparks. They are positioned in the design's absolute px, over a card whose height is fluid — the `bottom: 104` one may land on the vote widget for a short card.
- The `-1deg` / `-3deg` stamp rotations against long titles, where the box is tightest.
- All of the above in **dark mode**, and at mobile width.

## Verification

`tsc --noEmit` clean, `eslint src` clean (0 warnings), `vite build` clean,
`vitest run` 1129/1129 — including new five-conditional-state coverage
(ADR-0047) for all three stamps and dispatch cases for the two new ones.

**No visual QA was done.** I cannot screenshot in this environment and there is
no dev stack, so every claim above is from reading the vendored design against
the code. Treat the "what to eyeball" list as outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
