### PR TITLE
UA praxis card: the ensō, the score box and the vellum sheet (#857)

### DIFF
--- a/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
@@ -1,62 +1,102 @@
 import { useTranslation } from "react-i18next";
-import { factionCssVar } from "../../../utils/factions";
+import { Lotus } from "../../factionMarks";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
 /**
- * UA — Gilt salon placard, filed. A gold-framed acquisition plate: gilt-leaf
- * gradient border, parchment ground with a faint dotted tooth, an engraved
- * "Acquisition · filed" regalia line. Matches the UA praxis-read sheet, UaVote,
- * and the DS FactionPraxisCard reference. All colors via --ua-* tokens.
+ * UA — the vellum sheet, sealed. A single 2px vermilion rule around a parchment
+ * ground that runs highlight-to-shadow across the sheet at 158°, with the
+ * {@link Lotus} floated off the left edge as a ground watermark and the ensō
+ * carrying the total in the right column (see `UaScoreStamp`).
+ *
+ * WHY THIS CARD IS WARM WHEN THE FACTION IS NOT (#857). UA has two live plans
+ * and the owner split them by surface on 2026-07-20: the PRAXIS HANDOFF wins
+ * the praxis card; the UA IDENTITY KIT (#788, #848–853) wins every other UA
+ * surface. So this card keeps its parchment-and-vermilion salon voice and its
+ * ensō even as the rest of UA becomes a sun-bleached, gold-free practice. It is
+ * a deliberate exception — do not harmonise it with the kit.
+ *
+ * What makes the exception survivable is the TOKEN CONTRACT: every colour here
+ * resolves from the `--faction-ua-card-*` block minted for this surface, and
+ * nothing reads the legacy gilt-salon token family (ua-gold, ua-gilt, ua-ink,
+ * ua-paper, ua-line …) that #853 deletes. That is an acceptance gate, not a
+ * preference: this file must stay at zero hits for that prefix.
+ *
+ * The gilt double-frame that used to wrap this card was invented, not designed
+ * — the handoff draws ONE border, and #848 took gold out of UA entirely. #839
+ * fixed the radius at 7; this slice removed the second frame and the dotted
+ * tooth. Do not reintroduce either.
  */
 export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
   return (
-    // Gilt frame: gold-leaf gradient border, then the parchment plate.
     <div
       style={{
         ...frameBase,
+        position: "relative",
+        overflow: "hidden",
         borderRadius: 7, // ensō salon sheet
-        padding: "var(--space-xs)",
-        background: "var(--ua-gilt)",
+        background: "var(--faction-ua-card-parchment)",
+        border: "2px solid var(--faction-ua-card-frame)",
         boxShadow:
-          "0 12px 26px color-mix(in srgb, var(--ua-ink) 22%, transparent), inset 0 0 0 1px color-mix(in srgb, white 45%, transparent)",
+          "0 14px 40px -22px color-mix(in srgb, var(--faction-ua-card-text) 50%, transparent)",
+        padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
+        fontFamily: "var(--faction-ua-body-font)",
+        color: "var(--faction-ua-card-text)",
       }}
     >
-      <div
+      {/*
+       * The ground watermark: the lotus hangs off the left edge with its centre
+       * pulled up onto the sheet. Raw geometry on purpose — an ornament's
+       * position is illustration, not layout spacing (§4a). Its opacity is a
+       * token so dark mode lifts it through the cascade, never a ternary; the
+       * design's `filter: brightness(2)` is folded into the dark ink instead.
+       */}
+      <Lotus
+        size={420}
+        color="var(--faction-ua-card-lotus)"
         style={{
-          position: "relative",
-          background: factionCssVar("ua", "card-bg"),
-          border: "2px solid color-mix(in srgb, var(--ua-ink) 30%, transparent)",
-          borderRadius: 4,
-          padding: "var(--space-xl)",
-          fontFamily: "var(--faction-ua-body-font)",
-          color: factionCssVar("ua", "card-text"),
-          backgroundImage:
-            "radial-gradient(color-mix(in srgb, var(--ua-ink) 4%, transparent) 1px, transparent 1px)",
-          backgroundSize: "5px 5px",
+          position: "absolute",
+          left: -150,
+          top: 250,
+          transform: "translateY(-50%)",
+          opacity: "var(--faction-ua-card-lotus-opacity)",
+          pointerEvents: "none",
         }}
-      >
-        <div
-          style={{
-            fontFamily: "var(--faction-ua-body-font)",
-            fontSize: "var(--text-xs)",
-            letterSpacing: "0.12em",
-            textTransform: "uppercase",
-            color: factionCssVar("ua", "card-accent"),
-            marginBottom: "var(--space-sm)",
-          }}
-        >
-          {t("card.masthead.ua")}
-        </div>
+      />
+
+      <div style={{ position: "relative" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
-          tint={factionCssVar("ua", "card-accent")}
-          muted={factionCssVar("ua", "card-muted")}
-          paper={factionCssVar("ua", "card-bg")}
-          titleStyle={{ fontFamily: "var(--faction-ua-card-font)", fontStyle: "italic" }}
+          tint="var(--faction-ua-card-accent)"
+          muted="var(--faction-ua-card-muted)"
+          paper="var(--faction-ua-card-bg)"
+          titleStyle={{
+            fontFamily: "var(--faction-ua-card-font)",
+            fontWeight: 600,
+            letterSpacing: "-0.01em",
+          }}
           showCrown={showCrown}
+          eyebrow={
+            /*
+             * The running head sits INSIDE the text column, above the title, so
+             * it stops at the score box rather than running under the ensō —
+             * the `eyebrow` slot #841 added for exactly this shape.
+             */
+            <div
+              style={{
+                fontFamily: "var(--faction-ua-body-font)",
+                fontSize: "var(--text-base)",
+                letterSpacing: "0.22em",
+                textTransform: "uppercase",
+                color: "var(--faction-ua-card-muted)",
+                marginBottom: "var(--space-sm)",
+              }}
+            >
+              {t("card.masthead.ua")}
+            </div>
+          }
         />
       </div>
     </div>

--- a/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/UaMobilePraxisCard.tsx
@@ -1,56 +1,82 @@
 import { useTranslation } from 'react-i18next'
 import type { PraxisCardOut } from '../../../api/praxis'
-import { factionCssVar } from '../../../utils/factions'
+import { Lotus } from '../../factionMarks'
 import { UaSigil } from '../../cards/UaSigil'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
- * University of Asthmatics MOBILE praxis card (#573) — a gilt-salon acquisition
- * plate: gold-leaf frame, parchment ground with a faint dotted tooth, an
- * engraved "Acquisition · filed" running head with the salon crest. Mirrors the
- * desktop UA praxis frame; all colours via --ua-* tokens (always-light).
+ * University of Asthmatics MOBILE praxis card (#573, reskinned #857) — the
+ * vellum sheet in the hand: one 2px vermilion rule, the 158° parchment ground,
+ * the lotus floated off the left edge, and the salon crest on the running head.
+ * Single column, no fixed-px layout grid (SPEC-faction-ui-profile §1a); the
+ * ensō total mark arrives with the shared `ScoreStamp`, which mobile renders
+ * unchanged (it is size-agnostic by design — ADR-0049).
+ *
+ * WHY THIS CARD IS WARM WHEN THE FACTION IS NOT (#857): the praxis handoff wins
+ * the praxis card, the UA identity kit (#788, #848–853) wins every other UA
+ * surface. Deliberate exception. Every colour resolves from the
+ * `--faction-ua-card-*` namespace; nothing reads the legacy gilt-salon token
+ * family (ua-gold, ua-gilt, ua-ink, ua-paper, ua-line …) that #853 deletes —
+ * an acceptance gate, so this file stays at zero hits for that prefix. UA dims
+ * in dark now, too (#848 reversed the "always-light" ruling).
  */
 export default function UaMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   const { t } = useTranslation('praxis')
   const theme: MobileSlotTheme = {
-    ink: factionCssVar('ua', 'card-text'),
-    muted: factionCssVar('ua', 'card-muted'),
-    accent: factionCssVar('ua', 'card-accent'),
-    paper: factionCssVar('ua', 'card-bg'),
-    displayFont: "var(--faction-ua-card-font)",
-    bodyFont: "'EB Garamond', serif",
-    titleStyle: { fontStyle: 'italic' },
+    ink: 'var(--faction-ua-card-text)',
+    muted: 'var(--faction-ua-card-muted)',
+    accent: 'var(--faction-ua-card-accent)',
+    paper: 'var(--faction-ua-card-bg)',
+    displayFont: 'var(--faction-ua-card-font)',
+    bodyFont: 'var(--faction-ua-body-font)',
+    titleStyle: { fontWeight: 600, letterSpacing: '-0.01em' },
   }
   return (
     <div
       style={{
-        padding: 'var(--space-xs)',
-        background: 'var(--ua-gilt)',
-        borderRadius: 2,
+        position: 'relative',
+        overflow: 'hidden',
+        borderRadius: 7,
+        background: 'var(--faction-ua-card-parchment)',
+        border: '2px solid var(--faction-ua-card-frame)',
+        boxShadow:
+          '0 14px 40px -22px color-mix(in srgb, var(--faction-ua-card-text) 50%, transparent)',
+        padding: 'var(--space-lg) var(--space-lg) var(--space-md)',
+        fontFamily: 'var(--faction-ua-body-font)',
+        color: 'var(--faction-ua-card-text)',
       }}
     >
-      <div
+      {/*
+       * The ground watermark, scaled to the hand — the desktop sheet floats a
+       * 420px lotus at left:-150; a phone-width card takes a smaller ring at a
+       * proportionally shallower offset so the same crescent shows. Ornament
+       * geometry, raw on purpose (§4a). Opacity is a token, so dark lifts it
+       * through the cascade rather than through a ternary here.
+       */}
+      <Lotus
+        size={300}
+        color="var(--faction-ua-card-lotus)"
         style={{
-          position: 'relative',
-          background: factionCssVar('ua', 'card-bg'),
-          border: '1px solid color-mix(in srgb, var(--ua-ink) 30%, transparent)',
-          padding: 'var(--space-lg) var(--space-lg) var(--space-md)',
-          backgroundImage:
-            'radial-gradient(color-mix(in srgb, var(--ua-ink) 4%, transparent) 1px, transparent 1px)',
-          backgroundSize: '5px 5px',
+          position: 'absolute',
+          left: -110,
+          top: 190,
+          transform: 'translateY(-50%)',
+          opacity: 'var(--faction-ua-card-lotus-opacity)',
+          pointerEvents: 'none',
         }}
-      >
+      />
+      <div style={{ position: 'relative' }}>
         <div
           style={{
             display: 'flex',
             alignItems: 'center',
             gap: 'var(--space-sm)',
             marginBottom: 'var(--space-md)',
-            fontFamily: "var(--faction-ua-body-font)",
-            fontSize: 'var(--text-sm)',
-            letterSpacing: '0.14em',
+            fontFamily: 'var(--faction-ua-body-font)',
+            fontSize: 'var(--text-base)',
+            letterSpacing: '0.22em',
             textTransform: 'uppercase',
-            color: factionCssVar('ua', 'card-accent'),
+            color: 'var(--faction-ua-card-muted)',
           }}
         >
           <UaSigil width={16} height={19} />

--- a/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
@@ -1,0 +1,272 @@
+import type { CSSProperties, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { TaskCrown } from "../../cards/TaskCrown";
+import { Enso } from "../../factionMarks";
+import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import type { ScoreStampProps } from "./ScoreStamp";
+
+/**
+ * The UA score stamp (#857, ADR-0049) — the SCORE BOX and the ENSŌ, the two
+ * objects the praxis handoff draws in UA's right column.
+ *
+ * The box is a quiet ruled plate on the lifted sheet: `base` in engraved caps,
+ * the figure in Cormorant beside it, the multiplier chip pinned to the right
+ * rail on the same no-wrap row, then the working underneath in EB Garamond
+ * italic. Below it, overlapping by a few pixels, the {@link Enso} carries the
+ * total — Cormorant over a letter-spaced `points` caption, centred in the ring.
+ * #821 had neither: one generic tilted plate stood in for both, which is what
+ * ADR-0049 exists to stop happening again.
+ *
+ * WHY THIS CARD IS WARM WHEN THE FACTION IS NOT. UA has two live plans and the
+ * owner split them by surface: the praxis handoff wins the praxis card, the
+ * identity kit (#788, #848–853) wins everything else. The card therefore keeps
+ * vermilion-on-vellum and its ensō. Every colour here resolves from the
+ * `--faction-ua-card-*` block minted for exactly this purpose — nothing reads
+ * the legacy gilt-salon token family (ua-gold, ua-gilt, ua-ink, ua-paper,
+ * ua-line …) that #853 deletes.
+ *
+ * ROW SELECTION IS NOT OURS. `scoreBreakdown` decides which rows exist
+ * (ADR-0047); this file only decides what a row looks like. The votes row
+ * survives at `+0` — a declared deviation from the design, which drops it.
+ *
+ * Every raw number below is ornament: the plate's own insets and leads, and
+ * display type sized to the drawing rather than to the text scale (§4a).
+ */
+
+/** The design's box width. Ornament geometry, not layout spacing. */
+const BOX_WIDTH = 134;
+/** The ensō on the card. The conditional-state sheets draw it at 118. */
+const ENSO_SIZE = 138;
+
+const labelStyle: CSSProperties = {
+  fontFamily: "var(--faction-ua-body-font)",
+  // eslint-disable-next-line local/no-raw-style-values -- ornament: engraved cap label, sized to the plate.
+  fontSize: 10.5,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+  color: "var(--faction-ua-card-muted)",
+};
+
+const workingStyle: CSSProperties = {
+  fontFamily: "var(--faction-ua-body-font)",
+  fontStyle: "italic",
+  // eslint-disable-next-line local/no-raw-style-values -- ornament: the working written under the plate's rule.
+  fontSize: 12,
+  color: "var(--faction-ua-card-muted)",
+};
+
+/** The vermilion chip that carries the multiplier. */
+function MultChip({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        marginLeft: "auto",
+        fontFamily: "var(--faction-ua-card-font)",
+        fontWeight: 600,
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: chip lettering, sized to the pill.
+        fontSize: 13,
+        color: "var(--faction-ua-card-chip-ink)",
+        background: "var(--faction-ua-card-chip-bg)",
+        borderRadius: 3,
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: the chip's drawn inset, not a gutter.
+        padding: "2px 7px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
+  const { t } = useTranslation("praxis");
+  if (praxis.total === null || praxis.total === undefined) return null;
+  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const crowned = praxis.is_top_for_task && showCrown !== false;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: the composition's own lead, plate to ring.
+        gap: 3,
+      }}
+    >
+      {crowned && (
+        <TaskCrown
+          size={26}
+          ringInset={3}
+          innerBg="var(--faction-ua-card-box-bg)"
+          glyphColor="var(--faction-ua-card-frame)"
+          rotate="-5deg"
+          style={{ position: "absolute", top: -13, right: -10, zIndex: 3 }}
+        />
+      )}
+
+      {/* The score box — a ruled plate on the lifted sheet. */}
+      <div
+        style={{
+          boxSizing: "border-box",
+          width: BOX_WIDTH,
+          border: "1px solid var(--faction-ua-card-rule)",
+          borderRadius: 6,
+          background: "var(--faction-ua-card-box-bg)",
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's inset within its own rule.
+          padding: "7px 11px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: lead between the cap label and its figure.
+            gap: 7,
+            whiteSpace: "nowrap",
+          }}
+        >
+          <span style={labelStyle}>{t("card.stamp.base")}</span>
+          <span
+            style={{
+              fontFamily: "var(--faction-ua-card-font)",
+              fontWeight: 600,
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's engraved figure.
+              fontSize: 25,
+              lineHeight: 0.8,
+              color: "var(--faction-ua-card-text)",
+            }}
+          >
+            {base}
+          </span>
+          {/*
+           * The chip stays on the base row in EVERY state. The design's
+           * "full formula" column moves it onto a `× mult` row of its own; the
+           * other four keep it here, and a plate that rearranges itself stops
+           * reading as the same object when a row drops out (§6 — the archetype
+           * is the identity). Declared deviation.
+           */}
+          {mult !== null && <MultChip>{formatMult(mult)}</MultChip>}
+        </div>
+
+        {meta !== null && (
+          <div
+            style={{
+              ...workingStyle,
+              color: "var(--faction-ua-card-accent)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's lead between working lines.
+              marginTop: 3,
+            }}
+          >
+            + {meta} {t("card.stamp.meta")}
+          </div>
+        )}
+
+        {/*
+         * The grouped subtotal, drawn under a hairline. It exists only when a
+         * metatask AND a multiplier are both live — the design's "full formula"
+         * column — because without a multiplier `(base + meta)` explains
+         * nothing and the plate reads as a form with a hole in it.
+         */}
+        {meta !== null && mult !== null && (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "baseline",
+              borderTop: "1px solid var(--faction-ua-card-rule)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the drawn rule's clearance.
+              marginTop: 5,
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: matches the lead of the working lines.
+              paddingTop: 3,
+            }}
+          >
+            <span style={workingStyle}>{t("card.stamp.group")}</span>
+            <span
+              style={{
+                fontFamily: "var(--faction-ua-card-font)",
+                fontWeight: 600,
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: the subtotal figure, a step under base.
+                fontSize: 20,
+                lineHeight: 0.9,
+                color: "var(--faction-ua-card-text)",
+              }}
+            >
+              {base + meta}
+            </span>
+          </div>
+        )}
+
+        {/*
+         * The votes row survives at `+0` — ADR-0047 beats the design here, which
+         * drops the line when votes are zero. Deliberate, and the same call
+         * every other #841 stamp makes.
+         */}
+        <div
+          style={{
+            ...workingStyle,
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's lead between working lines.
+            marginTop: 3,
+          }}
+        >
+          {t("card.stamp.fromVotes", { votes })}
+        </div>
+      </div>
+
+      {/* The total mark — the ensō, holding the figure in its ring. */}
+      <div
+        style={{
+          position: "relative",
+          width: ENSO_SIZE,
+          height: ENSO_SIZE,
+          // ornament: the ring overlaps the plate's foot; that overlap IS the
+          // drawing. No directive — a unary minus is not a Literal, so the rule
+          // never sees it (one of the #750 laundering shapes) and the directive
+          // would report as unused.
+          marginTop: -6,
+        }}
+      >
+        <Enso size={ENSO_SIZE} color="var(--faction-ua-card-enso)" />
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: hairline lead between figure and caption.
+            gap: 1,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--faction-ua-card-font)",
+              fontWeight: 600,
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the total, set to fill the brush ring.
+              fontSize: 38,
+              lineHeight: 0.8,
+              color: "var(--faction-ua-card-total)",
+            }}
+          >
+            {total.toFixed(1)}
+          </span>
+          <span
+            style={{
+              fontFamily: "var(--faction-ua-body-font)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the caption inside the ring.
+              fontSize: 8.5,
+              letterSpacing: "0.2em",
+              textTransform: "uppercase",
+              color: "var(--faction-ua-card-points)",
+            }}
+          >
+            {t("card.stamp.points")}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -24,6 +24,7 @@ import SnideScoreStamp from '../SnideScoreStamp'
 import SingularityScoreStamp from '../SingularityScoreStamp'
 import WowScoreStamp from '../WowScoreStamp'
 import CovenScoreStamp from '../CovenScoreStamp'
+import UaScoreStamp from '../UaScoreStamp'
 
 /** No hex may reach a stamp's markup — every colour is a token (ADR-0049). */
 const HEX = /#[0-9a-fA-F]{3,8}\b/
@@ -96,7 +97,7 @@ describe('scoreBreakdown row selection (ADR-0047)', () => {
 
 describe('scoreStamp surface dispatch (ADR-0049)', () => {
   it('falls through to the Default stamp for every slug that has not claimed it', () => {
-    for (const slug of ['ua', 'albescent', 'na', null]) {
+    for (const slug of ['albescent', 'na', null]) {
       expect(pickVariant(surfaceMap('scoreStamp'), slug, DefaultScoreStamp)).toBe(DefaultScoreStamp)
     }
   })
@@ -126,6 +127,10 @@ describe('scoreStamp surface dispatch (ADR-0049)', () => {
   it('gives WOW the chronicle plate and Coven the sticker, not the reverse (#840)', () => {
     expect(pickVariant(surfaceMap('scoreStamp'), 'wow', DefaultScoreStamp)).toBe(WowScoreStamp)
     expect(pickVariant(surfaceMap('scoreStamp'), 'coven', DefaultScoreStamp)).toBe(CovenScoreStamp)
+  })
+
+  it('gives UA its own stamp — the ensō (#857)', () => {
+    expect(pickVariant(surfaceMap('scoreStamp'), 'ua', DefaultScoreStamp)).toBe(UaScoreStamp)
   })
 })
 
@@ -166,6 +171,20 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       expect(html).toContain(fields.total.toFixed(1))
       expect(html).not.toMatch(HEX)
     })
+
+    it(`UA prints the score box and the ensō — ${name}`, () => {
+      const markup = renderToStaticMarkup(<UaScoreStamp praxis={praxis({ ...fields })} />)
+      const html = text(markup)
+      expect(html).toContain('base')
+      // The votes row survives at 0 — the deliberate ADR-0047 deviation.
+      expect(html).toContain('from votes')
+      expect(html).toContain(fields.total.toFixed(1))
+      expect(html).toContain('points')
+      // The total mark is the ensō, masked from the asset and tinted by a token.
+      expect(markup).toContain('/factionMarks/enso.svg')
+      expect(markup).toContain('var(--faction-ua-card-enso)')
+      expect(markup).not.toMatch(HEX)
+    })
   }
 
   for (const [name, fields] of STATES) {
@@ -201,6 +220,34 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
     expect(wow).toContain('rotate(-2deg)')
     expect(coven).toContain('rotate(-3deg)')
     expect(coven).toContain('dashed')
+  })
+
+  it('shows the UA multiplier chip only when a multiplier is live', () => {
+    const withMult = text(
+      renderToStaticMarkup(<UaScoreStamp praxis={praxis({ display_multiplier: 0.8 })} />),
+    )
+    const withoutMult = text(
+      renderToStaticMarkup(<UaScoreStamp praxis={praxis({ display_multiplier: 1 })} />),
+    )
+    expect(withMult).toContain('×0.80')
+    expect(withoutMult).not.toContain('×')
+  })
+
+  it('draws the UA grouped subtotal only when a metatask AND a multiplier are both live', () => {
+    const full = text(
+      renderToStaticMarkup(
+        <UaScoreStamp praxis={praxis({ display_multiplier: 0.8, metatask_points: 20 })} />,
+      ),
+    )
+    const metaOnly = text(
+      renderToStaticMarkup(
+        <UaScoreStamp praxis={praxis({ display_multiplier: 1, metatask_points: 20 })} />,
+      ),
+    )
+    // (base + meta) = 32, under the plate's rule.
+    expect(full).toContain('group')
+    expect(full).toContain('32')
+    expect(metaOnly).not.toContain('group')
   })
 
   it('draws the Everymen subtotal rule only when a metatask AND a multiplier are both live', () => {

--- a/frontend/src/factions/ua.ts
+++ b/frontend/src/factions/ua.ts
@@ -26,6 +26,7 @@ import UaMobileTaskCard from '../pages/tasks/mobileArchetypes/cards/UaMobileTask
 import UaMobileTaskDetail from '../pages/taskDetail/mobileArchetypes/UaTaskDetail'
 import UaPraxisDetail from '../pages/praxisDetail/archetypes/UaPraxisDetail'
 import UaProfileBody from '../pages/characterProfile/archetypes/UaProfileBody'
+import UaScoreStamp from '../components/praxisCard/scoreStamp/UaScoreStamp'
 import UaTaskCard from '../components/cards/UaTaskCard'
 import UaTaskDetail from '../pages/taskDetail/archetypes/UaTaskDetail'
 import UaVote from '../components/vote/UaVote'
@@ -41,6 +42,7 @@ export const UA_MANIFEST: FactionManifest = {
   factionSelectCard: () => UaSelectCard,
   taskCard: () => UaTaskCard,
   praxisCard: () => UaPraxisCard,
+  scoreStamp: () => UaScoreStamp,
   avatar: () => UaAvatar,
   backdrop: () => UaBackdrop,
   sigil: () => UaSigilAdapter,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -388,6 +388,45 @@
   --faction-ua-glow: #dd5a1e; /* ORNAMENT ONLY — ensō, mandala. 3.12:1. Never text. */
   --faction-ua-vermil: #b5361a; /* the ensō score numeral — large display type only */
 
+/* ── UA · PRAXIS CARD ONLY — the parchment-and-ensō exception (#857) ──
+     WHY THIS SURFACE KEEPS A VOICE THE FACTION NO LONGER HAS.
+     Two live plans for UA disagree on purpose, and the owner split them by
+     surface (2026-07-20): the PRAXIS HANDOFF wins the praxis card; the UA
+     IDENTITY KIT (#788, #848–853) wins every other UA surface. So this one card
+     keeps its warm vellum-and-vermilion salon voice and its ensō while the rest
+     of UA becomes a sun-bleached, gold-free practice. That is a DELIBERATE
+     EXCEPTION. Do not "harmonise" it away when you read #848.
+
+     WHAT MAKES IT SURVIVABLE: the card reads NOTHING from the legacy `--ua-*`
+     family above (--ua-gold, --ua-gilt, --ua-ink, --ua-paper, --ua-line, …),
+     which #853 deletes wholesale. Everything it needs is named here, in its own
+     `--faction-ua-card-*` namespace, so #853 can run its grep and delete the
+     legacy family without touching this surface. `UaPraxisCard.tsx` and
+     `UaMobilePraxisCard.tsx` are asserted at zero `--ua-` hits.
+
+     Values are the design handoff's UA band verbatim
+     (.design-sync/praxis-cards/design_handoff_faction_vote_stamps). Where #848
+     already ported the same hex under a primitive name, this block POINTS at it
+     rather than repeating the literal — one namespace at the call site, one
+     definition on disk. There is no gilt double-frame: #839 removed the
+     invented one and the handoff never had it. */
+  --faction-ua-card-frame: #b8471a; /* the card's 2px border — design's own */
+  --faction-ua-card-parchment: linear-gradient(
+    158deg,
+    var(--faction-ua-lift),
+    var(--faction-ua-card-bg) 46%,
+    var(--faction-ua-panel)
+  );
+  --faction-ua-card-rule: var(--faction-ua-rule); /* score box + media hairline */
+  --faction-ua-card-box-bg: var(--faction-ua-lift); /* the score box's lifted sheet */
+  --faction-ua-card-chip-bg: #b8471a; /* the ×0.80 multiplier chip */
+  --faction-ua-card-chip-ink: var(--faction-ua-on-fill);
+  --faction-ua-card-enso: var(--faction-ua-glow); /* the ensō brush ink */
+  --faction-ua-card-total: var(--faction-ua-vermil); /* the total, display size */
+  --faction-ua-card-points: var(--faction-ua-glow); /* the "points" caption */
+  --faction-ua-card-lotus: var(--faction-ua-glow); /* the ground watermark */
+  --faction-ua-card-lotus-opacity: 0.2;
+
   /* ── UA growing-mandala reading ramp (#821, re-read for dark by #849) ──
      The five rungs of the vote widget's reading — faint · forming · true ·
      alive · radiant — as the mandala blooms fuller per rank. Named
@@ -910,6 +949,23 @@
   --faction-ua-rank-3: #c77a33; /* true */
   --faction-ua-rank-4: #e0672c; /* alive */
   --faction-ua-rank-5: #f0894a; /* radiant */
+
+  /* ── UA · PRAXIS CARD ONLY, after dark (#857) ──
+     The handoff carries a `UA DARK` band for this card, so it dims like every
+     other UA surface — #848 reversed the old "the salon never dims" ruling.
+     The parchment gradient needs no dark entry: it is composed from
+     lift/card-bg/panel, all three of which flip above, and the design's dark
+     stops (#372E25, #241E18, #2D261F) are exactly those three values.
+     The design dims the ensō with `filter: brightness(1.15)` on an orange
+     asset; the repo's ensō is a MASK tinted from a token, so the lift is
+     expressed as a lighter ink instead of a filter — same result, one fewer
+     paint layer, and it stays in the cascade rather than in a component. */
+  --faction-ua-card-frame: #f0894a;
+  --faction-ua-card-box-bg: #1f1913; /* the box sinks BELOW the sheet in dark */
+  --faction-ua-card-chip-bg: #e86a2c;
+  --faction-ua-card-total: var(--faction-ua-card-accent); /* #f0894a — design's own */
+  --faction-ua-card-points: #f0a85a;
+  --faction-ua-card-lotus-opacity: 0.22;
 
   /* ── DEFAULT · unaffiliated (dark — brightened spectrum) ── */
   --faction-default: #8b8aa0;


### PR DESCRIPTION
UA's praxis card, built from the vendored praxis handoff
(`.design-sync/praxis-cards/design_handoff_faction_vote_stamps/Faction Praxis Cards.dc.html`,
the **UA** section and the **UA DARK** band).

Closes #857

## The owner decision this encodes

There are two live plans for UA and they disagree on purpose. **The praxis
handoff wins THIS CARD; the UA identity kit (#788, #848–853) wins every other UA
surface.** So this card keeps its parchment-and-vermilion salon voice and its
ensō even as the rest of UA becomes a sun-bleached, gold-free practice. That is a
deliberate exception, not an oversight, and it is written down in three places
(the token block, `UaPraxisCard`, `UaScoreStamp`) so the next person reading #848
does not "clean it up".

## The token contract

#853 deletes the legacy `--ua-*` family. Everything this card needs now lives in
its own `--faction-ua-card-*` block:

```
--faction-ua-card-frame · -parchment · -rule · -box-bg · -chip-bg · -chip-ink
--faction-ua-card-enso · -total · -points · -lotus · -lotus-opacity
```

Where #848 already ported the same hex under a primitive name
(`--faction-ua-lift`, `-panel`, `-rule`, `-glow`, `-vermil`, `-on-fill`), the new
token **points at it** rather than repeating the literal — one namespace at the
call site, one definition on disk. Dark values are a second block under
`[data-theme="dark"]`.

**Acceptance gate:**

```
$ grep -c -- '--ua-' UaPraxisCard.tsx UaMobilePraxisCard.tsx
UaPraxisCard.tsx:0
UaMobilePraxisCard.tsx:0
```

(`UaScoreStamp.tsx` is 0 as well. The docstrings deliberately name the doomed
family as `ua-gold, ua-gilt, …` without the leading `--` so the gate stays at 0
while the prose stays readable.)

## What changed

- **New `UaScoreStamp`** — the score BOX (134px, 1px rule, radius 6, `base` +
  Cormorant figure + vermilion `×0.80` chip on one no-wrap row, working
  underneath in EB Garamond italic) and the **ENSŌ** as the total mark (`Enso`
  at 138px, total in Cormorant 38px over a letter-spaced `points` caption).
  Registered on the `ua` manifest. All five ADR-0047 conditional states.
- **Desktop + mobile frames repainted** — one 2px vermilion rule, radius 7, the
  design's `linear-gradient(158deg, …)` parchment, the `Lotus` watermark
  floated off the left edge, the running head moved into the `eyebrow` slot so
  it stops at the score box instead of running under the ensō.
- **Real dark mode**, through the `[data-theme="dark"]` cascade only.
- **Removed**: the invented gilt double-frame and the dotted tooth. The handoff
  draws one border and #848 took gold out of UA. Not reintroduced.

## Deviations, and the rule forcing each

| Deviation | Rule |
|---|---|
| **Votes row stays at `+0`** where the design drops it | **ADR-0047** wins. `scoreBreakdown()` is untouched; the same call every #841/#842 stamp makes. |
| Muted text is `--faction-ua-card-muted` (`#675b4c` / `#a8947a`), not the design's `#8B7C67` / `#A08C72` | #848's contrast gate (`factionContrast.test.ts`). The design's muted fails AA on the lifted sheet. |
| Card border is `#b8471a`, not `--faction-ua-card-accent` (`#a5400f`) | Design fidelity — a border carries no text, so the contrast lift that produced `-accent` does not apply. Dark (`#f0894a`) matches the design exactly. |
| Ensō dimmed by a **lighter ink token**, not `filter: brightness(1.15)` | The repo's ensō is a **CSS mask** tinted from a token (`Enso`'s ADR-0049 rationale). A brightness filter on a mask does nothing; same for the lotus's `brightness(2)`. Keeps the theme flip in the cascade, not in a component. |
| The multiplier chip stays on the **base row** in all five states; the design's "full formula" column gives it a `× mult` row of its own | §6 — a plate that rearranges itself stops reading as the same object when a row drops out. Four of five design columns already keep it inline. |
| Grouped `(base + meta)` subtotal appears **only** when a metatask AND a multiplier are both live | Without a multiplier the subtotal explains nothing and the plate reads as a form with a hole in it. Same call `EverymenScoreStamp` made in #841. |
| Raw px throughout the stamp | §4a **ornament escape hatch**, per-line `eslint-disable-next-line` (the files are delisted — phase 2). Insets, leads and display type sized to the drawing, not to the scale. |
| Mobile lotus is 300px at `left:-110; top:190`, not 420 at `-150/250` | The handoff has no UA mobile band. Proportional restatement so the same crescent shows at phone width. |

## Out of scope, untouched

`UaSigil`, `UaTaskCard`, `UaTaskDetail`, `UaFactionBody`, `UaFactionHero`,
`UaEditPraxis`, `UaProfileBody`, `UaComment`, `UaFeedFrame`, `UaAvatar`,
`UaBackdrop`, `FactionSelectCard`, `UaVote` — all owned by the identity chain.
`UaSigil` is *rendered* by the mobile card (unchanged) but not edited. The two
ensōs stay separate: `.design-sync/ua-enso.svg` is the sigil (#849),
`public/factionMarks/enso.svg` is this card's total mark.

`scoreStamp.test.tsx` is edited because it is the shared dispatch test and
asserted UA fell through to `Default`.

## Verification

- `tsc --noEmit` — clean (only the known stale-junction `node:fs` false alarms, PR #675)
- `vitest run` — **1151 passing**, including 5 new UA conditional-state cases + chip/subtotal cases
- `eslint src` — clean, 0 warnings
- `vite build` — clean

## ⚠️ NO VISUAL QA WAS DONE

The Browser-pane renderer times out and there is no dev stack in this worktree.
Nothing below has been looked at; it is a token-and-geometry pass verified by
tests, lint and the type checker only.

**What to eyeball:**

1. The **ensō overlapping the score box** (`marginTop: -6`) — does the brush ring
   crowd the plate's foot, and does the 138px ring fit the right column without
   pushing the title text?
2. The **total inside the ring** — 38px Cormorant over an 8.5px caption, centred.
   Does `29.6` (the full-formula state) still sit inside the brush?
3. The **lotus watermark** — the crescent should read off the left edge at 0.2.
   Check that `overflow: hidden` on the frame is clipping it the way the design
   does, and that dark mode's 0.22 + lighter ink is visible rather than muddy.
4. **Dark mode overall** — this is UA's first dark praxis card. The score box now
   sinks *below* the sheet (`#1f1913`) rather than lifting; confirm that reads.
5. The **five conditional states** side by side — the plate should read as one
   object as rows appear and disappear.
6. **Mobile** — the lotus offset is a judgement call, not a design value.
7. That losing the gilt double-frame and the dotted tooth is what the owner wants
   on this card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
