### PR TITLE
Duelist badge glyph: crossed blades (#748 item 4)

### DIFF
--- a/frontend/src/components/badges/badgeArt.tsx
+++ b/frontend/src/components/badges/badgeArt.tsx
@@ -60,6 +60,31 @@ function SockPuppetArt({ size = 18 }: BadgeArtProps) {
   )
 }
 
+/** duelist — two crossed blades, guards and pommels, meeting dead centre. */
+function DuelistArt({ size = 18 }: BadgeArtProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Duelist badge"
+    >
+      <path d="M4.5 19.5 18.5 5.5" />
+      <path d="M19.5 19.5 5.5 5.5" />
+      <path d="M6.2 15.2 8.8 17.8" />
+      <path d="M17.8 15.2 15.2 17.8" />
+      <circle cx="3.6" cy="20.4" r="1.1" fill="currentColor" stroke="none" />
+      <circle cx="20.4" cy="20.4" r="1.1" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
 /** Unknown key → a plain medallion ring, so a new backend badge never renders
  *  blank while its art is pending. */
 function UnknownBadgeArt({ size = 18 }: BadgeArtProps) {
@@ -83,6 +108,7 @@ function UnknownBadgeArt({ size = 18 }: BadgeArtProps) {
 const BADGE_ART: Record<string, ComponentType<BadgeArtProps>> = {
   sock_puppeteer: SockPuppeteerArt,
   sock_puppet: SockPuppetArt,
+  duelist: DuelistArt,
 }
 
 export function badgeArtFor(key: string): ComponentType<BadgeArtProps> {


### PR DESCRIPTION
Part of #748.

Item 4 of the issue — the frontend glyph — was left undone by PR #871, whose scope was `backend/` only. With the `duelist` key registered on the backend but no art row, `badgeArtFor()` fell through to `UnknownBadgeArt` (the dashed medallion placeholder). This adds the real glyph.

## Change

One file, `frontend/src/components/badges/badgeArt.tsx`:

- `DuelistArt` — two crossed blades meeting dead centre at (12,12), with angled crossguards and filled pommels. Built in the file's existing house style: `viewBox="0 0 24 24"`, `fill="none"`, `stroke="currentColor"`, `strokeWidth={1.8}`, rounded caps/joins, `role="img"` + `aria-label`. Modelled on the `sock_puppet` / `sock_puppeteer` neighbours.
- One `duelist: DuelistArt` row in `BADGE_ART`.

No new tokens, no `index.css` change, no hex — colour is `currentColor` throughout, so it inherits the surrounding skin's ink and flips light/dark through the `[data-theme="dark"]` cascade. No test added: `badgeArt.tsx` has no existing test file and the frontend harness is `renderToStaticMarkup`-only, so a smoke render would assert nothing the type checker doesn't already.

## Verification

- `tsc --noEmit` — clean. (The only output is the known stale-junction `Cannot find module 'node:fs'/'node:url'/'node:path'` false alarm in `__tests__` files, per PR #675; nothing in `src/components/`.)
- `vite build` — built in 3.02s.
- `eslint src/components/badges/badgeArt.tsx` — clean, including the `no-raw-style-values` ratchet.
- `vitest run` — 107 files / 1188 tests passed.

**No visual QA was done.** I cannot screenshot (the Browser pane renderer times out) and there is no dev stack running here, so the glyph has never been rendered on screen — only type-checked, linted and built. The geometry is reasoned, not eyeballed.

## What to eyeball

- The glyph at its real size. Default is `size = 18` px, and at 18px a 1.8-stroke crossed pair can read as a smudge or an X rather than as swords — check whether the crossguards survive or should be dropped.
- The pommel dots at (3.6, 20.4) and (20.4, 20.4) — they sit near the corners of the 24-box and may crowd or clip depending on the container's padding.
- Optical weight against `sock_puppet` and `sock_puppeteer` when badges sit side by side in a row: the two long diagonals may read heavier than the neighbours.
- Contrast in dark mode on each faction skin that renders badges (`DefaultProfileBody`, `DefaultProfile` mobile, `DefaultPlayers` mobile, `RosterTable`) — `currentColor` should handle it, but the roster rank surface is a known low-contrast spot.
- Whether crossed blades is the wanted read at all, versus a laurel. The issue leaves this to developer judgement, so it's a cheap swap if the owner prefers the laurel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
