### PR TITLE
UA redesign 5/6: the five mobile skins, rebuilt on the new tokens

### DIFF
--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { CSSProperties, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { UaSigil } from '../../../components/cards/UaSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import MediaArt from '../blocks/MediaArt'
@@ -20,51 +21,57 @@ import type { EditPraxisState } from '../useEditPraxis'
 import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
 
 /**
- * University of Asthmatics MOBILE composer (#525) — "Submit to the Salon" on a
- * phone. The same single-column composer as the Default mobile skin
- * (Write/Preview toggle, fluid media grid, sticky submit bar) dressed in gilt
- * salon chrome: parchment plates in gold-leaf frames, engraved kickers, Cormorant
- * italic titles. Ported from the desktop UA Atelier archetype; grounds on the
- * `--faction-ua-*` / `--ua-*` tokens (always-light). Consumes `useEditPraxis`
- * verbatim — no editor, upload, or submit logic lives here.
+ * University of Asthmatics MOBILE composer (#525/#852) — sealing a mark, on a
+ * phone.
+ *
+ * The gilt salon is gone with #788. Where every field used to sit in its own
+ * three-layer gold-leaf plate, the composer is now one quiet sheet: a tracked
+ * small-caps label above each control, a hairline under the title, and the
+ * ensō at the head as the faction mark. That collapse is what lets the form
+ * hold at 375px — three nested frames per field spent most of the width on
+ * borders.
+ *
+ * NO MANDALA. The kit draws its editor card with a lotus at 10% behind it, but
+ * the brief's §5 ruling puts the editor in the `absent` bucket with feed rows
+ * and comments, and where the two disagree the brief wins. That is a build-cost
+ * ruling, and it holds.
+ *
+ * Consumes {@link EditPraxisState} verbatim — no editor, upload, or submit logic
+ * lives here — and keeps every `editPraxis.ua.*` copy key (#850 owns the words).
+ * Every colour is a `--faction-ua-*` token with both themes, so the composer
+ * dims through the `[data-theme="dark"]` cascade.
  */
 
-const PAPER = 'var(--faction-ua-card-bg)'
-const PAPER_WARM = 'var(--ua-paper-warm)'
-const WALL = 'var(--ua-wall)'
+const SHEET = 'var(--faction-ua-card-bg)'
+const PANEL = 'var(--faction-ua-panel)'
+const LIFT = 'var(--faction-ua-lift)'
 const INK = 'var(--faction-ua-card-text)'
+const BODY = 'var(--faction-ua-card-body)'
+const MUTED = 'var(--faction-ua-card-muted)'
 const ACCENT = 'var(--faction-ua-card-accent)'
-const SUB = 'var(--faction-ua-card-muted)'
-const MUTED = 'var(--ua-muted)'
-const GOLD = 'var(--ua-gold)'
-const GOLD_PALE = 'var(--ua-gold-pale)'
-const LINE = 'var(--ua-line)'
-const GILT = 'var(--ua-gilt)'
+const RULE = 'var(--faction-ua-rule)'
+const HAIR = 'var(--faction-ua-hair)'
+const FILL = 'var(--faction-ua)'
+const ON_FILL = 'var(--faction-ua-on-fill)'
 const DISPLAY = 'var(--faction-ua-card-font)'
-const ENGRAVED = 'var(--font-faction-engraved)'
-const MONO = 'var(--font-body)'
+const SERIF = 'var(--faction-ua-body-font)'
 
-const kicker: CSSProperties = {
+/** The label voice: EB Garamond, tracked small caps. */
+const smallCaps: CSSProperties = {
   display: 'block',
-  fontFamily: MONO,
-  fontSize: "var(--text-xs)",
-  letterSpacing: '0.22em',
+  fontFamily: SERIF,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.18em',
   textTransform: 'uppercase',
   color: MUTED,
 }
 
-/** A parchment plate in the gilt sandwich frame, headed by an engraved title. */
-function Plate({ title, children }: { title: string; children: ReactNode }) {
+/** A labelled field. No frame — the label carries the structure. */
+function Field({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <section style={{ padding: "var(--space-sm)", background: GILT, boxShadow: '0 8px 20px rgba(60,40,10,.16), inset 0 0 0 1px rgba(255,255,255,0.45)' }}>
-      <div style={{ padding: "var(--space-xs)", background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
-        <div style={{ background: PAPER, border: `1px solid ${LINE}`, padding: "var(--space-md)" }}>
-          <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-sm)", letterSpacing: '0.13em', textTransform: 'uppercase', color: ACCENT, marginBottom: "var(--space-sm)" }}>
-            {title}
-          </div>
-          {children}
-        </div>
-      </div>
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
+      <span style={smallCaps}>{label}</span>
+      {children}
     </section>
   )
 }
@@ -76,13 +83,33 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
   const task = state.task
 
   return (
-    <div data-skin="ua" style={{ display: 'flex', flexDirection: 'column', gap: "var(--space-md)", fontFamily: MONO, color: INK, background: WALL }}>
-      <header style={{ display: 'flex', flexDirection: 'column', gap: "var(--space-md)" }}>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: "var(--space-sm)" }}>
-          <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: "var(--text-title)", lineHeight: 1, color: INK, margin: 0 }}>
+    <div
+      data-skin="ua"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--space-lg)',
+        fontFamily: SERIF,
+        color: INK,
+        background: `linear-gradient(158deg, ${LIFT}, ${SHEET} 55%, ${PANEL})`,
+      }}
+    >
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--space-md)' }}>
+          <UaSigil width={34} height={34} />
+          <h1
+            style={{
+              fontFamily: DISPLAY,
+              fontWeight: 600,
+              fontSize: 'var(--text-title)',
+              lineHeight: 1,
+              color: INK,
+              margin: 0,
+            }}
+          >
             {t('editPraxis.ua.pageTitle')}
           </h1>
-          <span style={{ ...kicker, marginLeft: 'auto' }}>
+          <span style={{ ...smallCaps, marginLeft: 'auto' }}>
             {state.autosaveAt
               ? t('editPraxis.ua.autosaveSaved', { ago: formatAutosave(state.autosaveAt) })
               : t('editPraxis.ua.autosaveUnsaved')}
@@ -93,37 +120,56 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
           tab={tab}
           setTab={setTab}
           skin={{
-            containerStyle: { gap: "var(--space-xs)", padding: "var(--space-xs)", background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999 },
+            containerStyle: {
+              gap: 'var(--space-xs)',
+              padding: 'var(--space-xs)',
+              background: PANEL,
+              border: `1px solid ${RULE}`,
+              borderRadius: 999,
+            },
             buttonStyle: (active) => ({
               padding: 'var(--space-sm)',
               borderRadius: 999,
               border: 'none',
-              fontFamily: ENGRAVED,
-              fontSize: "var(--text-md)",
-              letterSpacing: '0.1em',
+              fontFamily: SERIF,
+              fontSize: 'var(--text-md)',
+              letterSpacing: '0.14em',
               textTransform: 'uppercase',
-              background: active ? ACCENT : 'transparent',
-              color: active ? PAPER_WARM : SUB,
+              background: active ? FILL : 'transparent',
+              color: active ? ON_FILL : MUTED,
             }),
           }}
         />
       </header>
 
-      {/* For-commission reference */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: "var(--space-sm)", padding: 'var(--space-md)', background: PAPER, border: `1px solid ${LINE}` }}>
-        <span style={kicker}>{t('editPraxis.ua.taskRefLabel')}</span>
-        <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: "var(--text-content)", color: INK, textAlign: 'right', flex: 1, lineHeight: 1.1 }}>
-          {praxis.task_title}
+      {/* For the task */}
+      <Field label={t('editPraxis.ua.taskRefLabel')}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 'var(--space-sm)',
+            padding: 'var(--space-md)',
+            background: PANEL,
+            border: `1px solid ${RULE}`,
+            borderRadius: 4,
+          }}
+        >
+          <span aria-hidden style={{ width: 6, height: 6, borderRadius: '50%', background: FILL, flex: 'none' }} />
+          <span className="content-text" style={{ fontFamily: DISPLAY, fontWeight: 600, color: ACCENT, lineHeight: 1.2 }}>
+            {praxis.task_title}
+          </span>
+        </div>
+        <span style={smallCaps}>
+          {factionName(task?.primary_faction_slug ?? null)}
+          {task ? ` · ${t('taskMeta.points', { points: task.point_value })}` : ''}
         </span>
-      </div>
-      <div style={{ ...kicker, color: ACCENT }}>
-        {factionName(task?.primary_faction_slug ?? null)}
-        {task ? ` · ${t('taskMeta.points', { points: task.point_value })}` : ''}
-      </div>
+      </Field>
 
       {tab === 'write' ? (
         <>
-          <Plate title={t('editPraxis.ua.titleLabel')}>
+          <Field label={t('editPraxis.ua.titleLabel')}>
             <TitleField
               state={state}
               skin={{
@@ -131,20 +177,19 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
                 inputStyle: {
                   width: '100%',
                   fontFamily: DISPLAY,
-                  fontStyle: 'italic',
-                  fontWeight: 700,
+                  fontWeight: 600,
                   color: INK,
                   background: 'transparent',
                   border: 'none',
                   outline: 'none',
-                  borderBottom: `1px solid ${LINE}`,
+                  borderBottom: `1px solid ${RULE}`,
                   padding: 'var(--space-xs) 0 var(--space-sm)',
                 },
               }}
             />
-          </Plate>
+          </Field>
 
-          <Plate title={t('editPraxis.ua.bodyLabel', { words: state.wordCount })}>
+          <Field label={t('editPraxis.ua.bodyLabel', { words: state.wordCount })}>
             <BodyTextarea
               state={state}
               skin={{
@@ -152,78 +197,80 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
                 placeholder: t('editPraxis.ua.bodyPlaceholder'),
                 textareaStyle: {
                   width: '100%',
-                  fontFamily: DISPLAY,
+                  fontFamily: SERIF,
                   lineHeight: 1.6,
                   color: INK,
-                  background: PAPER_WARM,
-                  border: `1px solid ${LINE}`,
-                  padding: 'var(--space-md) var(--space-lg)',
+                  background: SHEET,
+                  border: `1px solid ${RULE}`,
+                  borderRadius: 4,
+                  padding: 'var(--space-md)',
                   outline: 'none',
                   resize: 'vertical',
                   minHeight: 180,
                 },
               }}
             />
-          </Plate>
+          </Field>
 
           {state.showInviteBox && (
-            <Plate title={state.duelMode ? t('editPraxis.ua.inviteLabelDuel') : t('editPraxis.ua.inviteLabel')}>
+            <Field label={state.duelMode ? t('editPraxis.ua.inviteLabelDuel') : t('editPraxis.ua.inviteLabel')}>
               <InviteSearch
                 state={state}
                 skin={{
-                  fontFamily: MONO,
-                  inputBg: PAPER_WARM,
+                  fontFamily: SERIF,
+                  inputBg: SHEET,
                   inputColor: INK,
-                  inputBorder: `1px solid ${LINE}`,
-                  acceptedBg: ACCENT,
-                  acceptedColor: PAPER_WARM,
+                  inputBorder: `1px solid ${RULE}`,
+                  acceptedBg: FILL,
+                  acceptedColor: ON_FILL,
                   placeholder: t('editPraxis.ua.invitePlaceholder'),
                 }}
               />
-            </Plate>
+            </Field>
           )}
 
-          <Plate title={t('editPraxis.ua.filesLabel')}>
+          <Field label={t('editPraxis.ua.filesLabel')}>
             <MediaGrid state={state} />
-          </Plate>
+          </Field>
 
           {state.showMetatasks && (
-            <Plate title={t('editPraxis.ua.metatasksLabel')}>
+            <Field label={t('editPraxis.ua.metatasksLabel')}>
               <MetatasksList
                 state={state}
                 skin={{
-                  containerStyle: { display: 'flex', flexDirection: 'column', gap: "var(--space-xs)" },
+                  containerStyle: { display: 'flex', flexDirection: 'column', gap: 'var(--space-xs)' },
                   rowStyle: (selected) => ({
                     padding: 'var(--space-sm) var(--space-md)',
-                    background: selected ? PAPER_WARM : 'transparent',
-                    border: `1px solid ${selected ? ACCENT : LINE}`,
+                    background: selected ? PANEL : 'transparent',
+                    border: `1px solid ${selected ? FILL : RULE}`,
+                    borderRadius: 4,
                   }),
                   titleColor: INK,
-                  descColor: SUB,
+                  descColor: BODY,
                   pointsActiveColor: ACCENT,
-                  pointsIdleColor: SUB,
+                  pointsIdleColor: MUTED,
                 }}
               />
-            </Plate>
+            </Field>
           )}
         </>
       ) : (
-        <Plate title={t('editPraxis.ua.previewLabel')}>
-          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: "var(--text-title)", color: INK, marginBottom: "var(--space-sm)" }}>
-            {state.title || t('editPraxis.ua.titlePlaceholder')}
-          </div>
-          {state.media.length > 0 && (
-            <div style={{ marginBottom: "var(--space-md)" }}>
-              <MediaGrid state={state} readOnly />
+        <Field label={t('editPraxis.ua.previewLabel')}>
+          <div style={{ background: SHEET, border: `1px solid ${RULE}`, borderRadius: 6, padding: 'var(--space-lg)' }}>
+            <div
+              className="content-title"
+              style={{ fontFamily: DISPLAY, fontWeight: 600, color: INK, marginBottom: 'var(--space-sm)' }}
+            >
+              {state.title || t('editPraxis.ua.titlePlaceholder')}
             </div>
-          )}
-          <BodyPreview
-            state={state}
-            skin={{
-              markdownStyle: { fontFamily: DISPLAY, lineHeight: 1.6, color: INK },
-            }}
-          />
-        </Plate>
+            {state.media.length > 0 && (
+              <div style={{ marginBottom: 'var(--space-md)' }}>
+                <MediaGrid state={state} readOnly />
+              </div>
+            )}
+            <BodyPreview state={state} skin={{ markdownStyle: { fontFamily: SERIF, lineHeight: 1.6, color: BODY } }} />
+          </div>
+        </Field>
       )}
 
       <ErrorBanner message={state.error} />
@@ -232,11 +279,12 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: "var(--space-md)",
+          flexWrap: 'wrap',
+          gap: 'var(--space-md)',
           padding: 'var(--space-md) 0 var(--space-xs)',
           background: 'var(--color-nav-bg)',
           backdropFilter: 'blur(var(--nav-blur))',
-          borderTop: `1px solid ${GOLD}`,
+          borderTop: `1px solid ${HAIR}`,
         }}
       >
         {!state.isPublished && (
@@ -248,9 +296,8 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
                 background: 'transparent',
                 border: 'none',
                 color: MUTED,
-                fontFamily: DISPLAY,
-                fontStyle: 'italic',
-                fontSize: "var(--text-xl)",
+                fontFamily: SERIF,
+                fontSize: 'var(--text-xl)',
                 cursor: 'pointer',
               },
             }}
@@ -263,14 +310,15 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
             busyLabel: t('editPraxis.ua.publishBusy'),
             style: {
               flex: 1,
-              background: ACCENT,
-              color: PAPER_WARM,
-              fontFamily: ENGRAVED,
-              fontSize: "var(--text-lg)",
-              letterSpacing: '0.12em',
+              background: FILL,
+              color: ON_FILL,
+              fontFamily: SERIF,
+              fontSize: 'var(--text-xl)',
+              letterSpacing: '0.14em',
               textTransform: 'uppercase',
               padding: 'var(--space-md) var(--space-lg)',
-              border: `1px solid ${ACCENT}`,
+              border: 'none',
+              borderRadius: 3,
               cursor: state.submitting ? 'wait' : 'pointer',
             },
           }}
@@ -280,16 +328,26 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
   )
 }
 
-/** Fluid 3-column media grid in the salon plate idiom. */
+/** Fluid three-across media grid — proportional columns, never fixed-px (§1a). */
 function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOnly?: boolean }) {
   const { t } = useTranslation('forms')
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: "var(--space-sm)" }}>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--space-sm)' }}>
       {state.media.map((item) => {
         const filename = item.file_path.split('/').pop() ?? item.file_path
         const src = mediaUrl(item.file_path)
         return (
-          <div key={item.id} style={{ position: 'relative', aspectRatio: '1 / 1', overflow: 'hidden', border: `1px solid ${GOLD}`, background: PAPER_WARM }}>
+          <div
+            key={item.id}
+            style={{
+              position: 'relative',
+              aspectRatio: '1 / 1',
+              overflow: 'hidden',
+              border: `1px solid ${RULE}`,
+              borderRadius: 4,
+              background: PANEL,
+            }}
+          >
             {item.type === 'image' ? (
               <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : item.type === 'video' ? (
@@ -309,10 +367,10 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
                   width: 24,
                   height: 24,
                   borderRadius: '50%',
-                  background: PAPER,
-                  border: `1px solid ${ACCENT}`,
+                  background: SHEET,
+                  border: `1px solid ${RULE}`,
                   color: ACCENT,
-                  fontSize: "var(--text-lg)",
+                  fontSize: 'var(--text-lg)',
                   fontWeight: 700,
                   lineHeight: 1,
                   cursor: 'pointer',
@@ -332,17 +390,18 @@ function MediaGrid({ state, readOnly = false }: { state: EditPraxisState; readOn
             buttonStyle: {
               aspectRatio: '1 / 1',
               width: '100%',
-              background: PAPER_WARM,
-              border: `1.5px dashed ${GOLD}`,
+              background: PANEL,
+              border: `1px dashed ${FILL}`,
+              borderRadius: 4,
               cursor: 'pointer',
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
               justifyContent: 'center',
-              gap: "var(--space-xs)",
-              fontFamily: ENGRAVED,
-              fontSize: "var(--text-base)",
-              letterSpacing: '0.08em',
+              gap: 'var(--space-xs)',
+              fontFamily: SERIF,
+              fontSize: 'var(--text-md)',
+              letterSpacing: '0.1em',
               textTransform: 'uppercase',
               color: ACCENT,
             },

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -1,14 +1,24 @@
 /**
- * Mobile composer UA dispatch (#525). Asserts the mobile registry resolves a `ua`
- * task to the bespoke UA "Seal a praxis" composer, and that every other
- * faction falls through to the Default mobile composer.
+ * Mobile composer UA dispatch + rendered identity (#525, #852).
+ *
+ * The registry half asserts the mobile map resolves a `ua` task to the bespoke
+ * UA "Seal a praxis" composer and that everything else falls through to
+ * Default. The rendered half asserts the MARKUP now the salon is dead (#788): the ensō at the head,
+ * NO mandala (§5 puts the editor in the `absent` bucket), and no gold.
  */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so copy keys resolve to English text.
+import '../../../../i18n'
 import { pickVariant } from '../../../../utils/factionDispatch'
 import { surfaceMap } from '../../../../factions'
 import DefaultMobileEditPraxis from '../DefaultEditPraxis'
 import UAMobileEditPraxis from '../UaComposer'
 import SnideMobileEditPraxis from '../SnideComposer'
+import type { EditPraxisState } from '../../useEditPraxis'
+import type { PraxisOut } from '../../../../api/praxis'
+import type { TaskOut } from '../../../../api/tasks'
 
 describe('mobile composer UA dispatch', () => {
   it('mobile + a UA task resolves to the bespoke UA composer', () => {
@@ -29,5 +39,133 @@ describe('mobile composer UA dispatch', () => {
         DefaultMobileEditPraxis,
       )
     }
+  })
+})
+
+const praxis = {
+  id: 55,
+  task_id: 7,
+  task_title: 'Render the old library façade in charcoal',
+  type: 'solo',
+  status: 'in_progress',
+  title: 'Charcoal study, north portico',
+  body_text: 'Let the cornice go soft.',
+  moderation_status: 'visible',
+  duel_id: null,
+  members: [],
+  invites: [],
+  media_items: [],
+} as unknown as PraxisOut
+
+const task: TaskOut = {
+  id: 7,
+  title: 'Render the old library façade in charcoal',
+  description: 'Draw only what the light is doing.',
+  point_value: 30,
+  level_required: 2,
+  status: 'active',
+  task_type: 'standard',
+  created_by: 3,
+  primary_faction_slug: 'ua',
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: '2026-01-01T00:00:00Z',
+  can_submit_praxis: true,
+  allowed_modes: ['solo'],
+  eligible_for_current_user: true,
+}
+
+function baseState(): EditPraxisState {
+  return {
+    loading: false,
+    praxis,
+    task,
+    error: '',
+    setError: () => {},
+    title: 'Charcoal study, north portico',
+    setTitle: () => {},
+    body: 'Let the cornice go soft.',
+    setBody: () => {},
+    wordCount: 5,
+    media: [],
+    fileError: '',
+    handleFileChange: () => {},
+    removeMedia: async () => {},
+    pendingImage: null,
+    confirmImageEdit: async () => {},
+    cancelImageEdit: () => {},
+    switchingMode: null,
+    changeMode: async () => {},
+    inviteQuery: '',
+    setInviteQuery: () => {},
+    inviteResults: [],
+    inviteOpen: false,
+    setInviteOpen: () => {},
+    inviting: false,
+    sendInvite: async () => {},
+    cancelInvite: async () => {},
+    duel: null,
+    sendChallenge: async () => {},
+    cancelDuel: async () => {},
+    metaTasks: [],
+    appliedMetatasks: new Set(),
+    applyingMetatask: null,
+    toggleMetatask: async () => {},
+    submitting: false,
+    publish: async () => {},
+    pullBack: async () => {},
+    collabSuccess: false,
+    continueFromCollabSuccess: () => {},
+    duelSealOpen: false,
+    requestDuelSeal: () => {},
+    cancelDuelSeal: () => {},
+    cancel: async () => {},
+    autosaveAt: null,
+    saveStatus: 'idle',
+    isPublished: false,
+    controlsLocked: false,
+    modeIsLocked: false,
+    showInviteBox: false,
+    showMetatasks: false,
+    duelMode: false,
+    duelChipVisible: false,
+    currentCharacterId: 3,
+  }
+}
+
+function render(): { html: string; text: string } {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <UAMobileEditPraxis state={baseState()} />
+    </MemoryRouter>,
+  )
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+describe('UA mobile composer — what it draws', () => {
+  it('heads the form with the ensō', () => {
+    const { html } = render()
+    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
+    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    expect(html).toContain('var(--faction-ua-glow)')
+  })
+
+  it('draws NO mandala — §5 puts the editor in the absent bucket', () => {
+    const { html } = render()
+    // The mandala's outer guide circle; the ensō draws no such hairline stroke.
+    expect(html).not.toContain('stroke-width="0.6"')
+  })
+
+  it('keeps its slots: the task reference, the title and the body', () => {
+    const { html, text } = render()
+    expect(text).toContain('Render the old library façade in charcoal')
+    expect(html).toContain('Charcoal study, north portico')
+    expect(html).toContain('Let the cornice go soft.')
+  })
+
+  it('carries no gold: the legacy --ua-* palette and Cinzel are gone here', () => {
+    const { html } = render()
+    expect(html).not.toMatch(/--ua-(gold|gilt|paper|wall|line|ink|sub|muted|orange)/)
+    expect(html).not.toMatch(/--font-faction-engraved/)
   })
 })

--- a/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
@@ -1,14 +1,71 @@
 /**
- * Mobile faction-page UA dispatch (#525). Asserts the #518 mobile registry
- * resolves the `ua` faction to the gilt-salon page skin, and that every other
- * faction (and null) falls through to the single-column DefaultFactionPage.
- * Mirrors the other surfaces' ua-dispatch tests.
+ * Mobile faction-page UA dispatch + rendered identity (#525, #852).
+ *
+ * The registry half asserts the #518 mobile map resolves `ua` to the bespoke
+ * page and that everything else falls through to DefaultFactionPage. The
+ * rendered half asserts the MARKUP the practice's page emits now the salon is
+ * dead (#788): the ensō as the faction mark, the mandala at `texture` behind the
+ * hero only, and no gold anywhere.
  */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so faction copy keys resolve to English text.
+import '../../../i18n'
 import { pickVariant } from '../../../utils/factionDispatch'
 import { surfaceMap } from '../../../factions'
 import DefaultFactionPage from '../mobileArchetypes/DefaultFactionPage'
 import UaFactionPage from '../mobileArchetypes/UaFactionPage'
+import type { FactionDetailState, Membership } from '../useFactionDetail'
+import type { CharacterOut } from '../../../api/auth'
+
+const MEMBER: CharacterOut = {
+  id: 7,
+  username: 'ada',
+  display_name: 'Ada Reed',
+  bio: null,
+  avatar_url: null,
+  location: null,
+  level: 2,
+  score: 120,
+  all_time_score: 340,
+  faction_slug: 'ua',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function membership(overrides: Partial<Membership> = {}): Membership {
+  return {
+    state: 'eligible',
+    currentFactionSlug: null,
+    join: async () => {},
+    joining: false,
+    joinError: null,
+    ...overrides,
+  }
+}
+
+function baseState(overrides: Partial<FactionDetailState> = {}): FactionDetailState {
+  return {
+    slug: 'ua',
+    loading: false,
+    faction: { slug: 'ua' },
+    fetchError: null,
+    members: [MEMBER],
+    tasks: [],
+    recentPraxis: [],
+    viewerFactionSlug: null,
+    gameFactions: [],
+    membership: membership(),
+    ...overrides,
+  }
+}
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
 
 describe('mobile faction-page UA dispatch', () => {
   it('mobile + the UA faction resolves to the bespoke UA page', () => {
@@ -19,5 +76,37 @@ describe('mobile faction-page UA dispatch', () => {
     for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(surfaceMap('mobileFactionPage'), slug, DefaultFactionPage)).toBe(DefaultFactionPage)
     }
+  })
+})
+
+describe('UA mobile faction page — what it draws', () => {
+  it('sets the ensō beside the name as the faction mark', () => {
+    const { html } = render(<UaFactionPage state={baseState()} />)
+    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
+    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    expect(html).toContain('var(--faction-ua-glow)')
+  })
+
+  it('runs the mandala behind the hero only', () => {
+    const { html } = render(<UaFactionPage state={baseState()} />)
+    // The mandala's outer guide circle; the ensō draws no such hairline stroke.
+    expect(html.match(/stroke-width="0\.6"/g)).toHaveLength(1)
+    expect(html).toContain('opacity:0.14')
+  })
+
+  it('keeps its slots: name, stats, the circle, and the invite-gated join', () => {
+    const { html, text } = render(<UaFactionPage state={baseState()} />)
+    expect(text).toContain('UA')
+    expect(text).toContain('Ada Reed')
+    expect(html).toContain('href="/characters/7"')
+
+    const gated = render(<UaFactionPage state={baseState({ membership: membership({ state: 'gate' }) })} />)
+    expect(gated.text, 'no CTA for a gated viewer').not.toContain('Join UA')
+  })
+
+  it('carries no gold: the legacy --ua-* palette and Cinzel are gone here', () => {
+    const { html } = render(<UaFactionPage state={baseState()} />)
+    expect(html).not.toMatch(/--ua-(gold|gilt|paper|wall|line|ink|sub|muted|orange)/)
+    expect(html).not.toMatch(/--font-faction-engraved/)
   })
 })

--- a/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/UaFactionPage.tsx
@@ -2,52 +2,59 @@ import { useState, type CSSProperties, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import PraxisCard from '../../../components/PraxisCard'
+import UaMandala from '../../../components/cards/UaMandala'
+import { UaSigil } from '../../../components/cards/UaSigil'
 import { factionName, factionDescription } from '../../../utils/factions'
 import { MobileStickyBar } from '../../taskDetail/mobileArchetypes/shared'
 import type { CharacterOut } from '../../../api/auth'
 import type { FactionDetailState } from '../useFactionDetail'
 
 /**
- * University of Asthmatics MOBILE faction page (#525) — the gilt salon, phone shaped.
- * The same single-column slots as the Default mobile faction page (a hero with
- * real member/task counts, top members, recent praxis, and the invite-gated Join
- * model via `state.membership`, ADR-0019) — only the dress changes: parchment
- * plates in gold-leaf frames, engraved (Cinzel) kickers, Cormorant-italic titles,
- * amber accents. Grounds on the `--faction-ua-*` / `--ua-*` tokens; always-light
- * (UA never dims). Reuses the shared `mobile.*` faction copy so the slot contract
- * holds. Presentation-only — all data + the join handler arrive via
- * {@link FactionDetailState}.
+ * University of Asthmatics MOBILE faction page (#525/#852) — the practice,
+ * phone shaped.
+ *
+ * Same single-column slots as the Default mobile page (hero with real
+ * member/task counts, top members, recent praxis, the invite-gated join via
+ * `state.membership`, ADR-0019) — only the dress changes (ADR-0016). The gilt
+ * salon is gone with #788: no gold-leaf sandwich, no Cinzel, no parchment
+ * dot-screen. A sun-bleached sheet on mesa sand, the ensō as the faction mark
+ * beside the name, and the mandala at `texture` behind the hero — the one
+ * surface besides the vote control that is entitled to the pattern.
+ *
+ * Every colour is a `--faction-ua-*` token with both themes, so the page dims
+ * through the `[data-theme="dark"]` cascade. Rows and lists ask the mandala for
+ * `absent` and get nothing.
  */
 
 const NA_SLUG = 'na'
 
-const PAPER = 'var(--faction-ua-card-bg)'
-const PAPER_WARM = 'var(--ua-paper-warm)'
-const WALL = 'var(--ua-wall)'
+const PAGE = 'var(--faction-ua-page)'
+const PAGE_TEXT = 'var(--faction-ua-page-text)'
+const SHEET = 'var(--faction-ua-card-bg)'
+const PANEL = 'var(--faction-ua-panel)'
 const INK = 'var(--faction-ua-card-text)'
+const BODY = 'var(--faction-ua-card-body)'
+const MUTED = 'var(--faction-ua-card-muted)'
 const ACCENT = 'var(--faction-ua-card-accent)'
-const SUB = 'var(--faction-ua-card-muted)'
-const MUTED = 'var(--ua-muted)'
-const GOLD = 'var(--ua-gold)'
-const GOLD_LT = 'var(--ua-gold-lt)'
-const GOLD_PALE = 'var(--ua-gold-pale)'
-const LINE = 'var(--ua-line)'
-const GILT = 'var(--ua-gilt)'
+const RULE = 'var(--faction-ua-rule)'
+const FILL = 'var(--faction-ua)'
+const ON_FILL = 'var(--faction-ua-on-fill)'
+const VERMIL = 'var(--faction-ua-vermil)'
 const DISPLAY = 'var(--faction-ua-card-font)'
-const ENGRAVED = 'var(--font-faction-engraved)'
-const MONO = 'var(--font-body)'
+const SERIF = 'var(--faction-ua-body-font)'
 
-const kicker: CSSProperties = {
-  fontFamily: MONO,
-  fontSize: 'var(--text-xs)',
-  letterSpacing: '0.24em',
+/** The label voice: EB Garamond, tracked small caps. */
+const smallCaps: CSSProperties = {
+  fontFamily: SERIF,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.16em',
   textTransform: 'uppercase',
   color: MUTED,
 }
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || '?'
 
-/** Circular initials medallion — parchment face, amber italic glyph. */
+/** Circular initials medallion — inset panel, one hairline, a Cormorant glyph. */
 function Medallion({ name, size }: { name: string; size: number }) {
   return (
     <span
@@ -56,15 +63,14 @@ function Medallion({ name, size }: { name: string; size: number }) {
         width: size,
         height: size,
         borderRadius: '50%',
-        background: PAPER_WARM,
-        border: `1px solid ${GOLD_LT}`,
+        background: PANEL,
+        border: `1px solid ${RULE}`,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: DISPLAY,
-        fontStyle: 'italic',
-        fontWeight: 700,
-        // ornament: avatar monogram, sized from the medallion it sits in — geometry, not text.
+        fontWeight: 600,
+        // ornament: monogram sized from the medallion it sits in — geometry, not text.
         fontSize: size * 0.42,
         color: ACCENT,
       }}
@@ -77,37 +83,36 @@ function Medallion({ name, size }: { name: string; size: number }) {
 function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-md)' }}>
-      <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
-        {children}
-      </span>
-      <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+      <span style={{ ...smallCaps, color: INK }}>{children}</span>
+      <span aria-hidden style={{ flex: 1, minWidth: 'var(--space-xl)', height: 1, background: RULE }} />
     </div>
   )
 }
 
 const joinButton: CSSProperties = {
   width: '100%',
-  fontFamily: ENGRAVED,
+  fontFamily: SERIF,
   fontSize: 'var(--text-xl)',
   letterSpacing: '0.12em',
   textTransform: 'uppercase',
-  color: PAPER_WARM,
-  background: ACCENT,
-  border: `1px solid ${ACCENT}`,
+  color: ON_FILL,
+  background: FILL,
+  border: `1px solid ${FILL}`,
+  borderRadius: 3,
   padding: 'var(--space-md) var(--space-lg)',
-  boxShadow: '0 6px 16px rgba(194,84,31,.28)',
   cursor: 'pointer',
 }
 
 /** The Cancel affordance beside Join — static, so it lives at module scope (#586). */
 const cancelButton: CSSProperties = {
-  fontFamily: ENGRAVED,
+  fontFamily: SERIF,
   fontSize: 'var(--text-md)',
-  letterSpacing: '0.1em',
+  letterSpacing: '0.12em',
   textTransform: 'uppercase',
-  color: SUB,
+  color: MUTED,
   background: 'transparent',
-  border: `1px solid ${LINE}`,
+  border: `1px solid ${RULE}`,
+  borderRadius: 3,
   padding: 'var(--space-md) var(--space-lg)',
   cursor: 'pointer',
 }
@@ -125,56 +130,68 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
   const switching = currentSlug && currentSlug !== NA_SLUG
 
   return (
-    <div data-skin="ua" className="py-4" style={{ fontFamily: MONO, color: INK, background: WALL }} data-testid="mobile-faction-page">
-      {/* Hero — gilt-framed parchment masthead */}
-      <section style={{ padding: 'var(--space-sm)', background: GILT, boxShadow: '0 12px 28px rgba(60,40,10,.2), inset 0 0 0 1px rgba(255,255,255,0.45)' }}>
-        <div style={{ padding: 'var(--space-xs)', background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
-          <div
+    <div
+      data-skin="ua"
+      className="py-4"
+      style={{ fontFamily: SERIF, color: PAGE_TEXT, background: PAGE }}
+      data-testid="mobile-faction-page"
+    >
+      {/* Hero — one sheet, the pattern felt behind it */}
+      <section
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          background: SHEET,
+          border: `1px solid ${RULE}`,
+          borderRadius: 6,
+          padding: 'var(--space-xl) var(--space-lg)',
+        }}
+      >
+        <UaMandala
+          size={260}
+          strength="texture"
+          style={{ position: 'absolute', right: -84, top: -72, pointerEvents: 'none' }}
+        />
+
+        <div style={{ position: 'relative' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}>
+            <UaSigil width={34} height={34} />
+            <div style={{ ...smallCaps, color: ACCENT }}>{t('ua.mobile.eyebrow')}</div>
+          </div>
+          <h1
             style={{
-              position: 'relative',
-              overflow: 'hidden',
-              background: PAPER,
-              backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
-              backgroundSize: '5px 5px',
-              border: `1px solid ${LINE}`,
-              padding: 'var(--space-xl) var(--space-lg)',
+              fontFamily: DISPLAY,
+              fontWeight: 600,
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: masthead display type — the practice's name is the skin's identity (§4).
+              fontSize: 34,
+              lineHeight: 1.05,
+              color: INK,
+              margin: 'var(--space-sm) 0 0',
             }}
           >
-            <div style={{ ...kicker, color: ACCENT }}>{t('ua.mobile.eyebrow')}</div>
-            <h1
-              style={{
-                fontFamily: DISPLAY,
-                fontStyle: 'italic',
-                fontWeight: 700,
-                // eslint-disable-next-line local/no-raw-style-values -- ornament: masthead display type — the engraved title is the skin's identity (§4/§270).
-                fontSize: 34,
-                lineHeight: 1.05,
-                color: INK,
-                margin: 'var(--space-xs) 0 0',
-              }}
-            >
-              {name}
-            </h1>
-            <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', lineHeight: 1.6, color: SUB, margin: 'var(--space-sm) 0 0' }}>
-              {factionDescription(faction.slug)}
-            </p>
-            <div style={{ display: 'flex', gap: 'var(--space-sm)', marginTop: 'var(--space-lg)' }}>
-              <HeroStat value={members.length} label={t('mobile.membersStat')} />
-              <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
-            </div>
+            {name}
+          </h1>
+          <p className="content-text" style={{ fontFamily: SERIF, lineHeight: 1.6, color: BODY, margin: 'var(--space-sm) 0 0' }}>
+            {factionDescription(faction.slug)}
+          </p>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-sm)', marginTop: 'var(--space-lg)' }}>
+            <HeroStat value={members.length} label={t('mobile.membersStat')} />
+            <HeroStat value={tasks.length} label={t('mobile.tasksStat')} />
           </div>
         </div>
       </section>
 
       {membership.state === 'member' && (
-        <p style={{ ...kicker, marginTop: 'var(--space-md)', color: GOLD }}>{t('mobile.memberBadge')}</p>
+        <p style={{ ...smallCaps, marginTop: 'var(--space-md)', color: ACCENT }}>{t('mobile.memberBadge')}</p>
       )}
 
-      {/* Top members */}
+      {/* The circle */}
       <section className="mt-6">
         <SectionHead>{t('mobile.topMembers')}</SectionHead>
         {topMembers.length === 0 ? (
-          <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, margin: 0 }}>{t('mobile.membersEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: SERIF, color: MUTED, margin: 0 }}>
+            {t('mobile.membersEmpty')}
+          </p>
         ) : (
           <div className="flex flex-col gap-2">
             {topMembers.map((m, index) => (
@@ -184,11 +201,13 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
         )}
       </section>
 
-      {/* Recent praxis */}
+      {/* Sealed work */}
       <section className="mt-6">
         <SectionHead>{t('mobile.recentPraxis')}</SectionHead>
         {recentPraxis.length === 0 ? (
-          <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, margin: 0 }}>{t('mobile.praxisEmpty')}</p>
+          <p className="content-text" style={{ fontFamily: SERIF, color: MUTED, margin: 0 }}>
+            {t('mobile.praxisEmpty')}
+          </p>
         ) : (
           <div className="flex flex-col gap-3">
             {recentPraxis.map((p) => (
@@ -199,7 +218,7 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
       </section>
 
       {membership.state === 'gate' && (
-        <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, marginTop: 'var(--space-xl)' }}>
+        <p className="content-text" style={{ fontFamily: SERIF, color: MUTED, marginTop: 'var(--space-xl)' }}>
           {t('mobile.gateHint', { faction: name })}
         </p>
       )}
@@ -208,7 +227,9 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
       {membership.state === 'eligible' && (
         <MobileStickyBar>
           {membership.joinError && (
-            <p className="content-text" style={{ fontFamily: MONO, color: 'var(--color-danger)' }}>{membership.joinError}</p>
+            <p className="content-text" style={{ fontFamily: SERIF, color: 'var(--color-danger)' }}>
+              {membership.joinError}
+            </p>
           )}
           {!confirming ? (
             <button type="button" onClick={() => setConfirming(true)} style={joinButton}>
@@ -216,26 +237,21 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
             </button>
           ) : (
             <>
-              <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: INK }}>
+              <p className="content-text" style={{ fontFamily: SERIF, color: INK }}>
                 {switching
                   ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug) })
                   : t('detail.join.confirm', { faction: name })}
               </p>
-              <div style={{ display: 'flex', gap: 'var(--space-sm)' }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-sm)' }}>
                 <button
                   type="button"
                   onClick={() => void membership.join()}
                   disabled={membership.joining}
-                  style={{ ...joinButton, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+                  style={{ ...joinButton, flex: '1 1 0', width: 'auto', opacity: membership.joining ? 0.6 : 1 }}
                 >
                   {membership.joining ? t('mobile.joining') : t('mobile.confirm')}
                 </button>
-                <button
-                  type="button"
-                  onClick={() => setConfirming(false)}
-                  disabled={membership.joining}
-                  style={cancelButton}
-                >
+                <button type="button" onClick={() => setConfirming(false)} disabled={membership.joining} style={cancelButton}>
                   {t('detail.join.cancel')}
                 </button>
               </div>
@@ -249,11 +265,21 @@ export default function UaFactionPage({ state }: { state: FactionDetailState }) 
 
 function HeroStat({ value, label }: { value: number; label: string }) {
   return (
-    <div style={{ flex: '1 1 0', textAlign: 'center', background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: 'var(--space-md) var(--space-sm)' }}>
-      <b className="content-title" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, display: 'block', lineHeight: 1, color: INK }}>
+    <div
+      style={{
+        flex: '1 1 0',
+        minWidth: 0,
+        textAlign: 'center',
+        background: PANEL,
+        border: `1px solid ${RULE}`,
+        borderRadius: 5,
+        padding: 'var(--space-md) var(--space-sm)',
+      }}
+    >
+      <b className="content-title" style={{ fontFamily: DISPLAY, fontWeight: 600, display: 'block', lineHeight: 1, color: INK }}>
         {value}
       </b>
-      <span style={{ ...kicker, marginTop: 'var(--space-xs)', display: 'block' }}>{label}</span>
+      <span style={{ ...smallCaps, marginTop: 'var(--space-xs)', display: 'block' }}>{label}</span>
     </div>
   )
 }
@@ -268,13 +294,15 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         alignItems: 'center',
         gap: 'var(--space-md)',
         padding: 'var(--space-md) var(--space-lg)',
-        background: PAPER,
-        border: `1px solid ${LINE}`,
-        borderLeft: `4px solid ${ACCENT}`,
+        background: SHEET,
+        border: `1px solid ${RULE}`,
+        borderRadius: 6,
         textDecoration: 'none',
       }}
     >
-      <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-xl)', color: ACCENT, width: 16, flex: 'none' }}>{rank}</span>
+      <span style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-xl)', color: VERMIL, width: 16, flex: 'none' }}>
+        {rank}
+      </span>
       <Medallion name={member.display_name} size={28} />
       <span
         className="content-text"
@@ -282,7 +310,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
           flex: 1,
           minWidth: 0,
           fontFamily: DISPLAY,
-          fontStyle: 'italic',
+          fontWeight: 600,
           color: INK,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -291,7 +319,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.06em', color: GOLD, flex: 'none' }}>
+      <span style={{ ...smallCaps, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
@@ -1,14 +1,85 @@
 /**
- * Mobile FieldDesk-home UA dispatch (#525). Asserts the parallel mobile registry
- * resolves a `ua` carried life to the gilt-salon home skin, and that an
- * unregistered faction (and null) still falls through to the Default mobile home.
- * Mirrors the taskDetail mobileArchetypeDispatch pattern.
+ * Mobile FieldDesk-home UA dispatch + rendered identity (#525, #852).
+ *
+ * The registry half asserts the parallel mobile map resolves a `ua` carried life
+ * to the UA home skin and that everything else falls through to Default. The
+ * rendered half asserts the MARKUP the practice's home emits now the salon is
+ * dead (#788): the ensō beside the day's line, the mandala at `texture` behind
+ * the masthead only, and no gold anywhere.
  */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so copy keys resolve to English text.
+import '../../../i18n'
 import { pickVariant } from '../../../utils/factionDispatch'
 import { surfaceMap } from '../../../factions'
 import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
 import UaHome from '../mobileArchetypes/UaHome'
+import type { FieldDeskHomeState } from '../useFieldDeskHome'
+import type { CharacterOut } from '../../../api/auth'
+import type { PraxisCardOut } from '../../../api/praxis'
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'ada',
+  display_name: 'Ada Reed',
+  bio: null,
+  avatar_url: null,
+  location: null,
+  level: 2,
+  score: 340,
+  all_time_score: 900,
+  faction_slug: 'ua',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const ACTIVE_TASK: PraxisCardOut = {
+  id: 55,
+  task_id: 7,
+  task_title: 'Ten thumbnails before breakfast',
+  task_point_value: 15,
+  task_level_required: 1,
+  type: 'solo',
+  status: 'in_progress',
+  title: null,
+  moderation_status: 'visible',
+  created_by_id: 42,
+  created_by_display_name: 'Ada Reed',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  submitted_at: null,
+  member_count: 1,
+  score: 0,
+  voter_count: 0,
+  base_points: 0,
+  metatask_points: 0,
+  display_multiplier: null,
+  points_from_votes: 0,
+  total: 0,
+  is_top_for_task: false,
+  task_faction_slug: 'ua',
+}
+
+function baseState(overrides: Partial<FieldDeskHomeState> = {}): FieldDeskHomeState {
+  return {
+    character: CHARACTER,
+    eraName: 'Era 1',
+    votesReceived: 12,
+    activeTasks: [ACTIVE_TASK],
+    pendingCount: 0,
+    loadingTasks: false,
+    canProposeTask: true,
+    ...overrides,
+  }
+}
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
 
 describe('mobile FieldDesk-home UA dispatch', () => {
   it('mobile + a UA life resolves to the bespoke UA home skin', () => {
@@ -19,5 +90,37 @@ describe('mobile FieldDesk-home UA dispatch', () => {
     for (const slug of ['__unregistered__', 'na', null]) {
       expect(pickVariant(surfaceMap('mobileFieldDesk'), slug, DefaultFieldDesk)).toBe(DefaultFieldDesk)
     }
+  })
+})
+
+describe('UA mobile home — what it draws', () => {
+  it('heads the screen with the ensō', () => {
+    const { html } = render(<UaHome state={baseState()} />)
+    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
+    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    expect(html).toContain('var(--faction-ua-glow)')
+  })
+
+  it('runs the mandala behind the masthead only', () => {
+    const { html } = render(<UaHome state={baseState()} />)
+    // The mandala's outer guide circle; the ensō draws no such hairline stroke.
+    expect(html.match(/stroke-width="0\.6"/g)).toHaveLength(1)
+    expect(html).toContain('opacity:0.14')
+  })
+
+  it('keeps its slots: name, points, stat tiles, active work and both actions', () => {
+    const { html, text } = render(<UaHome state={baseState()} />)
+    expect(text).toContain('Ada Reed')
+    expect(text).toContain('340')
+    expect(text.toLowerCase()).toContain('era 1')
+    expect(text).toContain('Ten thumbnails before breakfast')
+    expect(html).toContain('href="/tasks"')
+    expect(html).toContain('href="/propose-task"')
+  })
+
+  it('carries no gold: the legacy --ua-* palette and Cinzel are gone here', () => {
+    const { html } = render(<UaHome state={baseState()} />)
+    expect(html).not.toMatch(/--ua-(gold|gilt|paper|wall|line|ink|sub|muted|orange)/)
+    expect(html).not.toMatch(/--font-faction-engraved/)
   })
 })

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -1,75 +1,57 @@
 import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import UaMandala from '../../../components/cards/UaMandala'
+import { UaSigil } from '../../../components/cards/UaSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
- * University of Asthmatics MOBILE FieldDesk home (#525) — the gilt salon on a
- * phone. The carried life and its in-progress commissions become parchment
- * plates set in a gold-leaf frame, headed by an engraved masthead. Same content
- * slots as the Default mobile home (character header, Points/Votes/Era stat
- * tiles, active-tasks list, primary actions) — only the dress changes. Grounds
- * on the `--faction-ua-*` / `--ua-*` tokens already in index.css (the set
- * UaFeedFrame / UaFactionBody use) and is always-light: UA never dims.
- * Presentation-only — all data arrives via {@link FieldDeskHomeState}.
+ * University of Asthmatics MOBILE FieldDesk home (#525/#852) — "One mark today.
+ * Begin."
+ *
+ * The gilt salon on a phone is gone with #788: no gold-leaf sandwich plates, no
+ * Cinzel, no parchment dot-screen. The home screen is the practice's own page —
+ * mesa sand under two sun-bleached sheets, the ensō beside the day's line, and
+ * the mandala at `texture` behind the masthead, which is the page backdrop case
+ * the primitive allows. The lists below it are dense and ask for nothing.
+ *
+ * Same content slots as the Default mobile home (character header, Points/Votes/
+ * Era tiles, active-tasks list, primary actions) — only the dress changes
+ * (ADR-0016), and all data still arrives via {@link FieldDeskHomeState}.
+ *
+ * Every colour is a `--faction-ua-*` token with both themes, so the screen dims
+ * through the `[data-theme="dark"]` cascade. UA dims now.
  */
 
-const PAPER = 'var(--faction-ua-card-bg)'
-const PAPER_WARM = 'var(--ua-paper-warm)'
-const WALL = 'var(--ua-wall)'
+const PAGE = 'var(--faction-ua-page)'
+const PAGE_TEXT = 'var(--faction-ua-page-text)'
+const SHEET = 'var(--faction-ua-card-bg)'
+const PANEL = 'var(--faction-ua-panel)'
 const INK = 'var(--faction-ua-card-text)'
+const MUTED = 'var(--faction-ua-card-muted)'
 const ACCENT = 'var(--faction-ua-card-accent)'
-const SUB = 'var(--faction-ua-card-muted)'
-const MUTED = 'var(--ua-muted)'
-const GOLD = 'var(--ua-gold)'
-const GOLD_PALE = 'var(--ua-gold-pale)'
-const LINE = 'var(--ua-line)'
-const GILT = 'var(--ua-gilt)'
+const RULE = 'var(--faction-ua-rule)'
+const FILL = 'var(--faction-ua)'
+const ON_FILL = 'var(--faction-ua-on-fill)'
 const DISPLAY = 'var(--faction-ua-card-font)'
-const ENGRAVED = 'var(--font-faction-engraved)'
-const MONO = 'var(--font-body)'
+const SERIF = 'var(--faction-ua-body-font)'
 
-const kicker: CSSProperties = {
-  fontFamily: MONO,
-  fontSize: 'var(--text-xs)',
-  letterSpacing: '0.24em',
+/** The label voice: EB Garamond, tracked small caps. */
+const smallCaps: CSSProperties = {
+  fontFamily: SERIF,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.16em',
   textTransform: 'uppercase',
   color: MUTED,
 }
 
-/** Parchment plate set in the salon's gold-leaf sandwich frame. */
-function Plate({ children }: { children: ReactNode }) {
+/** A sheet: one surface, one hairline. What is left after the gilt frame. */
+function Sheet({ children }: { children: ReactNode }) {
   return (
-    <div
-      style={{
-        padding: 'var(--space-sm)',
-        background: GILT,
-        boxShadow: '0 10px 24px rgba(60,40,10,.18), inset 0 0 0 1px rgba(255,255,255,0.45)',
-      }}
-    >
-      <div
-        style={{
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: inner gold rule of the gilt double-border frame; the nearest rung (4px) merges it into the outer gilt band.
-          padding: 3,
-          background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
-        }}
-      >
-        <div
-          style={{
-            position: 'relative',
-            overflow: 'hidden',
-            background: PAPER,
-            backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
-            backgroundSize: '5px 5px',
-            border: `1px solid ${LINE}`,
-            padding: 'var(--space-lg)',
-          }}
-        >
-          {children}
-        </div>
-      </div>
+    <div style={{ background: SHEET, border: `1px solid ${RULE}`, borderRadius: 6, padding: 'var(--space-lg)' }}>
+      {children}
     </div>
   )
 }
@@ -88,22 +70,47 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
     <div
       data-skin="ua"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: MONO, color: INK, background: WALL }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--space-lg)',
+        fontFamily: SERIF,
+        color: PAGE_TEXT,
+        background: PAGE,
+      }}
     >
-      {/* Engraved masthead */}
-      <header>
-        <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: 'var(--space-xs) 0 0' }}>
-          {t('fieldDesk.home.ua.masthead')}
-        </h1>
-        <div style={{ height: 1, marginTop: 'var(--space-sm)', background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
+      {/* The day's line */}
+      <header style={{ position: 'relative', overflow: 'hidden' }}>
+        <UaMandala
+          size={200}
+          strength="texture"
+          style={{ position: 'absolute', right: -64, top: -56, pointerEvents: 'none' }}
+        />
+        <div style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}>
+          <UaSigil width={34} height={34} />
+          <div style={{ minWidth: 0 }}>
+            <div style={smallCaps}>{t('nav.home')}</div>
+            <h1
+              style={{
+                fontFamily: DISPLAY,
+                fontWeight: 600,
+                fontSize: 'var(--text-heading)',
+                lineHeight: 1.05,
+                color: INK,
+                margin: 'var(--space-xs) 0 0',
+              }}
+            >
+              {t('fieldDesk.home.ua.masthead')}
+            </h1>
+          </div>
+        </div>
       </header>
 
-      {/* ── Sitter plate ── */}
-      <Plate>
-        <div className="flex items-center justify-between" style={{ marginBottom: 'var(--space-lg)' }}>
-          <span style={kicker}>{t('fieldDesk.home.ua.charEyebrow')}</span>
-          <Link to={`/characters/${character.id}/edit`} style={{ ...kicker, color: ACCENT, textDecoration: 'none' }}>
+      {/* ── The hand ── */}
+      <Sheet>
+        <div className="flex items-center justify-between flex-wrap" style={{ gap: 'var(--space-sm)', marginBottom: 'var(--space-lg)' }}>
+          <span style={smallCaps}>{t('fieldDesk.home.ua.charEyebrow')}</span>
+          <Link to={`/characters/${character.id}/edit`} style={{ ...smallCaps, color: ACCENT, textDecoration: 'none' }}>
             {t('fieldDesk.home.edit')}
           </Link>
         </div>
@@ -111,14 +118,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
         <div className="flex items-center gap-3">
           <div
             className="shrink-0"
-            style={{
-              width: 56,
-              height: 56,
-              borderRadius: '50%',
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: gilt ring thickness drawn around a 56px avatar; the nearest rung (4px) thickens the band by a third.
-              padding: 3,
-              background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
-            }}
+            style={{ width: 56, height: 56, borderRadius: '50%', overflow: 'hidden', background: PANEL, border: `1px solid ${RULE}` }}
           >
             {character.avatar_url ? (
               <img
@@ -131,7 +131,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
               <span
                 className="flex w-full h-full items-center justify-center rounded-full"
                 // eslint-disable-next-line local/no-raw-style-values -- ornament: avatar initial sized to its 56px medallion, not text
-                style={{ background: PAPER_WARM, fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 24, color: ACCENT }}
+                style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 24, color: ACCENT }}
               >
                 {character.display_name[0]?.toUpperCase()}
               </span>
@@ -141,11 +141,11 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             <Link
               to={`/characters/${character.id}`}
               className="block truncate"
-              style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: INK, textDecoration: 'none' }}
+              style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-title)', lineHeight: 1, color: INK, textDecoration: 'none' }}
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: SUB }}>
+            <div className="truncate" style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>
               {t('sidebar.characterCard.factionLevel', {
                 faction: factionName(character.faction_slug),
                 level: character.level,
@@ -153,55 +153,73 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             </div>
           </div>
           <div className="shrink-0 text-right">
-            <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-title)', lineHeight: 1, color: INK }}>
+            <div style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-title)', lineHeight: 1, color: INK }}>
               {character.score?.toLocaleString() ?? '0'}
             </div>
-            <div style={{ ...kicker, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
+            <div style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>{t('fieldDesk.home.stats.points')}</div>
           </div>
         </div>
 
-        <div className="flex gap-2" style={{ marginTop: 'var(--space-lg)' }}>
+        <div className="flex flex-wrap gap-2" style={{ marginTop: 'var(--space-lg)' }}>
           {stats.map((stat) => (
             <div
               key={stat.label}
               className="text-center"
-              style={{ flex: '1 1 0', minWidth: 0, background: PAPER_WARM, border: `1px solid ${LINE}`, padding: 'var(--space-md) var(--space-sm)' }}
+              style={{
+                flex: '1 1 0',
+                minWidth: 0,
+                background: PANEL,
+                border: `1px solid ${RULE}`,
+                borderRadius: 5,
+                padding: 'var(--space-md) var(--space-sm)',
+              }}
             >
-              <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
+              <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
                 {stat.value}
               </div>
-              <div style={{ ...kicker, marginTop: 'var(--space-sm)' }}>{stat.label}</div>
+              <div className="truncate" style={{ ...smallCaps, marginTop: 'var(--space-sm)' }}>
+                {stat.label}
+              </div>
             </div>
           ))}
         </div>
-      </Plate>
+      </Sheet>
 
       {/* ── Pending requests ── */}
       {pendingCount > 0 && (
         <Link
           to="/updates?filter=requests"
           className="flex items-center justify-between"
-          style={{ background: PAPER, border: `1px solid ${LINE}`, borderRadius: 999, padding: 'var(--space-md) var(--space-lg)', fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
+          style={{
+            background: SHEET,
+            border: `1px solid ${RULE}`,
+            borderRadius: 999,
+            padding: 'var(--space-md) var(--space-lg)',
+            fontFamily: SERIF,
+            fontSize: 'var(--text-content)',
+            color: INK,
+            textDecoration: 'none',
+          }}
         >
           <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
-          <span aria-hidden style={{ color: ACCENT }}>›</span>
+          <span aria-hidden style={{ color: ACCENT }}>
+            ›
+          </span>
         </Link>
       )}
 
-      {/* ── Commissions at the easel ── */}
-      <Plate>
+      {/* ── What is out on the table ── */}
+      <Sheet>
         <div className="flex items-center gap-2.5" style={{ marginBottom: 'var(--space-md)' }}>
-          <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: INK }}>
-            {t('fieldDesk.home.ua.questsHeading')}
-          </span>
-          <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
-          <Link to="/tasks" style={{ ...kicker, color: ACCENT, textDecoration: 'none' }}>
+          <span style={{ ...smallCaps, color: INK }}>{t('fieldDesk.home.ua.questsHeading')}</span>
+          <span aria-hidden style={{ flex: 1, minWidth: 'var(--space-xl)', height: 1, background: RULE }} />
+          <Link to="/tasks" style={{ ...smallCaps, color: ACCENT, textDecoration: 'none' }}>
             {t('fieldDesk.home.viewAll')}
           </Link>
         </div>
 
         {activeTasks.length === 0 ? (
-          <p style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-content)', color: SUB, margin: 0 }}>
+          <p className="content-text" style={{ fontFamily: SERIF, color: MUTED, margin: 0 }}>
             {t('fieldDesk.home.questsEmpty')}
           </p>
         ) : (
@@ -211,14 +229,14 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
                 key={praxis.id}
                 to={`/praxes/${praxis.id}/edit`}
                 className="flex items-center gap-3"
-                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
+                style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid var(--faction-ua-hair)`, textDecoration: 'none' }}
               >
-                <span className="shrink-0" style={{ width: 9, height: 9, borderRadius: '50%', background: ACCENT }} />
+                <span className="shrink-0" style={{ width: 7, height: 7, borderRadius: '50%', background: FILL }} />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
+                  <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: ENGRAVED, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: SUB }}>
+                  <div className="truncate" style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -227,7 +245,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: GOLD, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
+                  style={{ ...smallCaps, color: ACCENT, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${RULE}` }}
                 >
                   {t(`praxisType.${praxis.type}`)}
                 </span>
@@ -235,25 +253,53 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             ))}
           </div>
         )}
-      </Plate>
+      </Sheet>
 
-      {/* ── Primary actions ── */}
-      <div className="flex gap-2.5">
+      {/* ── Begin ── */}
+      <div className="flex flex-wrap gap-2.5">
         <Link
           to="/tasks"
-          className="flex-1 flex items-center justify-center"
-          style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: PAPER_WARM, background: ACCENT, border: `1px solid ${ACCENT}`, boxShadow: '0 6px 16px rgba(194,84,31,.28)', textDecoration: 'none' }}
+          className="flex items-center justify-center"
+          style={{
+            flex: '1 1 0',
+            minWidth: 0,
+            fontFamily: SERIF,
+            fontSize: 'var(--text-xl)',
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            padding: 'var(--space-lg)',
+            color: ON_FILL,
+            background: FILL,
+            border: `1px solid ${FILL}`,
+            borderRadius: 3,
+            textDecoration: 'none',
+          }}
         >
           {t('fieldDesk.home.browseTasks')}
         </Link>
         {canProposeTask && (
           <Link
             to="/propose-task"
-            className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: INK, background: PAPER, border: `1px solid ${LINE}`, textDecoration: 'none' }}
+            className="flex items-center justify-center gap-2"
+            style={{
+              flex: '1 1 0',
+              minWidth: 0,
+              fontFamily: SERIF,
+              fontSize: 'var(--text-xl)',
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              padding: 'var(--space-lg)',
+              color: INK,
+              background: SHEET,
+              border: `1px solid ${RULE}`,
+              borderRadius: 3,
+              textDecoration: 'none',
+            }}
           >
             {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
+            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>
+              +
+            </span>
             <span>{t('actions.proposeTask')}</span>
           </Link>
         )}

--- a/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
@@ -1,14 +1,78 @@
 /**
- * Mobile task-detail UA dispatch (#525). Asserts the mobile registry resolves a
- * `ua` task to the gilt-salon commission skin, that other factions fall through
- * to the Default mobile detail, and that the desktop archetype is untouched.
+ * Mobile task-detail UA dispatch + rendered identity (#525, #852).
+ *
+ * The registry half asserts the mobile map resolves a `ua` task to the bespoke
+ * mobile skin and that the desktop archetype is untouched. The rendered half is
+ * the one that matters now the salon is dead (#788): it asserts the MARKUP —
+ * the ensō carrying the point value, the mandala at `texture` behind the hero
+ * and nowhere else, the one dashed orange rule, and the absence of the legacy
+ * gold family.
  */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
+// Initialize the i18n catalog so copy keys resolve to English text.
+import "../../../i18n";
 import { pickVariant } from "../../../utils/factionDispatch";
 import { surfaceMap } from "../../../factions";
 import DefaultMobileTaskDetail from "../mobileArchetypes/DefaultTaskDetail";
 import UAMobileTaskDetail from "../mobileArchetypes/UaTaskDetail";
 import UADesktopTaskDetail from "../archetypes/UaTaskDetail";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut } from "../../../api/tasks";
+
+const TASK: TaskOut = {
+  id: 7,
+  title: "Render the old library façade in charcoal",
+  description: "Draw only what the light is doing.",
+  point_value: 30,
+  level_required: 2,
+  status: "active",
+  task_type: "standard",
+  created_by: 3,
+  primary_faction_slug: "ua",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    slotsOpen: 3,
+    maxTaskSlots: 8,
+    factionMultiplier: 1.0,
+    modifiedPoints: 42,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
 
 describe("mobile task-detail UA dispatch", () => {
   it("mobile + a UA task resolves to the bespoke UA mobile skin", () => {
@@ -29,5 +93,42 @@ describe("mobile task-detail UA dispatch", () => {
     const desktop = pickVariant(surfaceMap('taskDetail'), "ua", DefaultMobileTaskDetail);
     expect(desktop).toBe(UADesktopTaskDetail);
     expect(desktop).not.toBe(UAMobileTaskDetail);
+  });
+});
+
+describe("UA mobile task detail — what it draws", () => {
+  it("writes the point value inside the ensō", () => {
+    const { html, text } = render(<UAMobileTaskDetail state={baseState()} />);
+    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
+    expect(html).toContain("M134 41.2 A68 68 0 1 1 66 158.8");
+    expect(html).toContain("var(--faction-ua-vermil)");
+    expect(text).toContain("42");
+  });
+
+  it("runs the mandala behind the hero at texture strength, and nowhere else", () => {
+    const { html } = render(<UAMobileTaskDetail state={baseState()} />);
+    // The mandala's outer guide circle; the ensō draws no such hairline stroke.
+    expect(html.match(/stroke-width="0\.6"/g)).toHaveLength(1);
+    expect(html).toContain("opacity:0.14");
+  });
+
+  it("draws the one dashed orange rule", () => {
+    const { html } = render(<UAMobileTaskDetail state={baseState()} />);
+    expect(html.match(/1\.5px dashed var\(--faction-ua\)/g)).toHaveLength(1);
+  });
+
+  it("lifts a signup error instead of washing it in the now-opaque tint (#848)", () => {
+    const { html, text } = render(<UAMobileTaskDetail state={baseState({ signupError: "no sheet free" })} />);
+    expect(text).toContain("no sheet free");
+    expect(html).toContain("var(--faction-ua-lift)");
+    // --faction-ua-light stopped being translucent in #848, so it can no longer
+    // whisper behind a message; this surface must not reach for it.
+    expect(html).not.toContain("var(--faction-ua-light)");
+  });
+
+  it("carries no gold: the legacy --ua-* palette and Cinzel are gone here", () => {
+    const { html } = render(<UAMobileTaskDetail state={baseState()} />);
+    expect(html).not.toMatch(/--ua-(gold|gilt|paper|wall|line|ink|sub|muted|orange)/);
+    expect(html).not.toMatch(/--font-faction-engraved/);
   });
 });

--- a/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
@@ -2,40 +2,54 @@ import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import PraxisCard from '../../../components/PraxisCard'
+import UaMandala from '../../../components/cards/UaMandala'
+import { UaSigil } from '../../../components/cards/UaSigil'
 import { toRoman } from '../../../components/cards/ephemeristsAtoms'
 import { MobileStickyBar, MobileStickyCaption } from './shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
- * University of Asthmatics MOBILE task-detail skin (#525) — the salon
- * commission on a phone. A gilt-framed parchment hero (engraved masthead, title
- * in Cormorant italic, Anno + points plates, the commission brief), the
- * exhibited works, and a stamped **sticky action bar** ("Submit to the Salon")
- * pinned above the tab bar. Single-column, no fixed-px grid — the desktop
- * salon's wide plate would overflow a phone. Reuses the same
- * {@link TaskDetailState}, the shared mobile sticky bar, and the `ua.*` copy +
- * `--faction-ua-*` tokens as the desktop archetype. Always-light: UA never dims.
+ * University of Asthmatics MOBILE task-detail skin (#525/#852) — one sheet, read
+ * top to bottom.
+ *
+ * The gilt-framed commission plate is gone with the salon (#788). The hero is a
+ * single sun-bleached sheet on the mesa-sand ground: an eyebrow, the title in
+ * Cormorant, one dashed orange rule, and the point value written inside the
+ * ensō. Sections are separated by a neutral hairline instead of a gold gradient.
+ * Single-column and flow-laid throughout — no fixed-px grid survives 375px
+ * (SPEC-faction-ui-profile §1a).
+ *
+ * The mandala appears exactly once, as `texture` behind the hero — the one
+ * strength a hero is entitled to. Everything below it is a dense list and asks
+ * for nothing.
+ *
+ * Same {@link TaskDetailState}, same `ua.*` copy keys, same shared sticky bar as
+ * before; only the dress changes (ADR-0016). Every colour is a
+ * `--faction-ua-*` token with both themes, so this surface dims through the
+ * `[data-theme="dark"]` cascade — the "always-light" ruling is reversed.
  */
 
-const PAPER = 'var(--faction-ua-card-bg)'
-const PAPER_WARM = 'var(--ua-paper-warm)'
-const WALL = 'var(--ua-wall)'
+const PAGE = 'var(--faction-ua-page)'
+const PAGE_TEXT = 'var(--faction-ua-page-text)'
+const SHEET = 'var(--faction-ua-card-bg)'
+const PANEL = 'var(--faction-ua-panel)'
+const LIFT = 'var(--faction-ua-lift)'
 const INK = 'var(--faction-ua-card-text)'
+const BODY = 'var(--faction-ua-card-body)'
+const MUTED = 'var(--faction-ua-card-muted)'
 const ACCENT = 'var(--faction-ua-card-accent)'
-const SUB = 'var(--faction-ua-card-muted)'
-const MUTED = 'var(--ua-muted)'
-const GOLD = 'var(--ua-gold)'
-const GOLD_PALE = 'var(--ua-gold-pale)'
-const LINE = 'var(--ua-line)'
-const GILT = 'var(--ua-gilt)'
+const RULE = 'var(--faction-ua-rule)'
+const FILL = 'var(--faction-ua)'
+const ON_FILL = 'var(--faction-ua-on-fill)'
+const VERMIL = 'var(--faction-ua-vermil)'
 const DISPLAY = 'var(--faction-ua-card-font)'
-const ENGRAVED = 'var(--font-faction-engraved)'
-const MONO = 'var(--font-body)'
+const SERIF = 'var(--faction-ua-body-font)'
 
-const kicker: CSSProperties = {
-  fontFamily: MONO,
-  fontSize: "var(--text-xs)",
-  letterSpacing: '0.24em',
+/** The label voice: EB Garamond, tracked small caps. No Cinzel, no gold. */
+const smallCaps: CSSProperties = {
+  fontFamily: SERIF,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.16em',
   textTransform: 'uppercase',
   color: MUTED,
 }
@@ -43,23 +57,18 @@ const kicker: CSSProperties = {
 // "Anno {roman}"; level 0 shows an em-dash (matches the desktop UA convention).
 const anno = (level: number) => (level > 0 ? toRoman(level) : '—')
 
-function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: "var(--space-md)", marginBottom: "var(--space-md)" }}>
-      <h2 className="content-title" style={{ fontFamily: ENGRAVED, letterSpacing: '0.08em', textTransform: 'uppercase', margin: 0, color: INK, whiteSpace: 'nowrap' }}>
-        {title}
-      </h2>
-      <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
-      {trailing}
-    </div>
-  )
+/** The signature divider — one dashed orange rule, held back to a whisper. */
+function DashedRule({ margin }: { margin: string }) {
+  return <div aria-hidden style={{ height: 0, borderTop: `1.5px dashed ${FILL}`, opacity: 0.4, margin }} />
 }
 
-function plate(background: string, textColor: string, border: string, label: string) {
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
   return (
-    <span className="content-title" style={{ fontFamily: ENGRAVED, letterSpacing: '0.04em', color: textColor, background, border: `1px solid ${border}`, padding: "var(--space-xs) var(--space-md)" }}>
-      {label}
-    </span>
+    <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--space-md)', marginBottom: 'var(--space-md)' }}>
+      <h2 style={{ ...smallCaps, color: INK, margin: 0 }}>{title}</h2>
+      <span aria-hidden style={{ flex: 1, minWidth: 'var(--space-xl)', height: 1, background: RULE }} />
+      {trailing}
+    </div>
   )
 }
 
@@ -92,86 +101,136 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
     : null
 
   return (
-    <div className="py-4" style={{ fontFamily: MONO, color: INK, background: WALL, marginLeft: -16, marginRight: -16, paddingLeft: "var(--space-lg)", paddingRight: "var(--space-lg)" }}>
+    <div
+      className="py-4"
+      style={{
+        fontFamily: SERIF,
+        color: PAGE_TEXT,
+        background: PAGE,
+        marginLeft: 'calc(-1 * var(--space-lg))',
+        marginRight: 'calc(-1 * var(--space-lg))',
+        paddingLeft: 'var(--space-lg)',
+        paddingRight: 'var(--space-lg)',
+      }}
+    >
       {/* Breadcrumb */}
-      <nav className="mb-3" style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+      <nav className="mb-3" style={smallCaps}>
         <Link to="/tasks" style={{ color: ACCENT, textDecoration: 'none' }}>
           {t('default.breadcrumb')}
         </Link>
-        <span aria-hidden style={{ margin: "0 var(--space-sm)", color: GOLD }}>›</span>
-        <span style={{ color: SUB }}>{task.title}</span>
+        <span aria-hidden style={{ margin: '0 var(--space-sm)', color: MUTED }}>
+          ›
+        </span>
+        <span style={{ color: BODY }}>{task.title}</span>
       </nav>
 
-      {/* Hero — gilt-framed commission plate */}
-      <div style={{ padding: "var(--space-sm)", background: GILT, boxShadow: '0 12px 28px rgba(60,40,10,.2), inset 0 0 0 1px rgba(255,255,255,0.45)', marginBottom: "var(--space-xl)" }}>
-        <div style={{ padding: "var(--space-xs)", background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
-          <div
-            style={{
-              position: 'relative',
-              overflow: 'hidden',
-              background: PAPER,
-              backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
-              backgroundSize: '5px 5px',
-              border: `1px solid ${LINE}`,
-              padding: "var(--space-xl) var(--space-xl) var(--space-xl)",
-            }}
+      {/* Hero — one sheet, the mandala felt rather than read behind it */}
+      <section
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          background: SHEET,
+          border: `1px solid ${RULE}`,
+          borderRadius: 6,
+          padding: 'var(--space-xl)',
+          marginBottom: 'var(--space-xl)',
+        }}
+      >
+        <UaMandala
+          size={240}
+          strength="texture"
+          style={{ position: 'absolute', right: -72, top: -64, pointerEvents: 'none' }}
+        />
+
+        <div style={{ position: 'relative' }}>
+          <div className="flex items-center justify-between flex-wrap" style={{ gap: 'var(--space-sm)', marginBottom: 'var(--space-md)' }}>
+            <span style={{ ...smallCaps, color: ACCENT }}>{t('ua.masthead')}</span>
+            <span style={smallCaps}>{t('ua.statusOpen')}</span>
+          </div>
+
+          <h1
+            className="content-title"
+            style={{ fontFamily: DISPLAY, fontWeight: 600, lineHeight: 1.08, color: INK, margin: 0, overflowWrap: 'anywhere' }}
           >
-            <div className="flex items-center justify-between" style={{ marginBottom: "var(--space-md)" }}>
-              <span style={{ fontFamily: ENGRAVED, fontSize: "var(--text-sm)", letterSpacing: '0.13em', textTransform: 'uppercase', color: ACCENT }}>
-                {t('ua.masthead')}
+            {task.title}
+          </h1>
+
+          <DashedRule margin="var(--space-lg) 0" />
+
+          <div className="flex items-center flex-wrap" style={{ gap: 'var(--space-lg)' }}>
+            <span style={{ position: 'relative', width: 76, height: 76, flex: 'none' }}>
+              <UaSigil width={76} height={76} />
+              <span
+                className="content-title"
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontFamily: DISPLAY,
+                  fontWeight: 600,
+                  lineHeight: 1,
+                  color: VERMIL,
+                }}
+              >
+                {modifiedPoints}
               </span>
-              <span style={kicker}>{t('ua.statusOpen')}</span>
-            </div>
-
-            <h1 className="content-title" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, lineHeight: 1.05, color: INK, margin: 0, overflowWrap: 'anywhere' }}>
-              {task.title}
-            </h1>
-            <div style={{ height: 1, margin: "var(--space-lg) 0 var(--space-lg)", background: `linear-gradient(90deg, ${GOLD}, transparent)` }} />
-
-            <div className="flex items-center gap-2 flex-wrap">
-              {plate(PAPER_WARM, INK, GOLD, `${t('ua.stats.anno')} ${anno(task.level_required)}`)}
-              {plate(ACCENT, PAPER_WARM, ACCENT, t('mobile.points', { points: modifiedPoints }))}
+            </span>
+            <div>
+              <div style={{ ...smallCaps, color: INK }}>{t('ua.stats.honoraria')}</div>
+              <div style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>
+                {`${t('ua.stats.anno')} ${anno(task.level_required)}`}
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </section>
 
-      {/* The Commission — brief */}
-      <section style={{ marginBottom: "var(--space-xl)" }}>
+      {/* The brief */}
+      <section style={{ marginBottom: 'var(--space-xl)' }}>
         <SectionHead title={t('ua.commissionHeading')} />
-        <div style={{ background: PAPER, border: `1px solid ${LINE}`, padding: "var(--space-lg) var(--space-xl)" }}>
-          <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', lineHeight: 1.75, color: task.description ? INK : SUB, margin: 0, whiteSpace: 'pre-wrap' }}>
+        <div style={{ background: SHEET, border: `1px solid ${RULE}`, borderRadius: 6, padding: 'var(--space-lg)' }}>
+          <p
+            className="content-text"
+            style={{ fontFamily: SERIF, lineHeight: 1.7, color: task.description ? BODY : MUTED, margin: 0, whiteSpace: 'pre-wrap' }}
+          >
             {task.description || t('ua.commissionEmpty')}
           </p>
         </div>
       </section>
 
-      {/* The Standing — read-only aggregate */}
-      <section style={{ marginBottom: "var(--space-xl)" }}>
+      {/* The reading — read-only aggregate */}
+      <section style={{ marginBottom: 'var(--space-xl)' }}>
         <SectionHead title={t('ua.critiqueHeading')} />
         {voteCount > 0 ? (
-          <div style={{ display: 'flex', alignItems: 'flex-end', gap: "var(--space-md)" }}>
-            <span className="content-title" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, lineHeight: 0.85, color: ACCENT }}>
+          <div style={{ display: 'flex', alignItems: 'flex-end', flexWrap: 'wrap', gap: 'var(--space-md)' }}>
+            <span
+              className="content-title"
+              style={{ fontFamily: DISPLAY, fontWeight: 600, lineHeight: 0.85, color: VERMIL }}
+            >
               {topScore}
             </span>
-            <div style={{ paddingBottom: "var(--space-xs)" }}>
-              <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-lg)", letterSpacing: '0.06em', textTransform: 'uppercase', color: INK }}>
-                {t('ua.critique.finest')}
+            <div style={{ paddingBottom: 'var(--space-xs)' }}>
+              <div style={{ ...smallCaps, color: INK }}>{t('ua.critique.finest')}</div>
+              <div style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>
+                {t('ua.critique.appraised', { count: voteCount })}
               </div>
-              <div style={{ ...kicker, marginTop: "var(--space-xs)" }}>{t('ua.critique.appraised', { count: voteCount })}</div>
             </div>
           </div>
         ) : (
-          <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, margin: 0 }}>{t('ua.critique.none')}</p>
+          <p className="content-text" style={{ fontFamily: SERIF, color: MUTED, margin: 0 }}>
+            {t('ua.critique.none')}
+          </p>
         )}
       </section>
 
-      {/* Works exhibited (completions) */}
+      {/* Sealed work */}
       <section>
         <SectionHead
           title={t('ua.salonWallHeading')}
           trailing={
-            <div style={{ display: 'flex' }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
               {(['score', 'recent'] as const).map((sort) => {
                 const on = submissionSort === sort
                 return (
@@ -179,14 +238,14 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
                     key={sort}
                     onClick={() => setSubmissionSort(sort)}
                     style={{
-                      fontFamily: MONO,
-                      fontSize: "var(--text-xs)",
-                      letterSpacing: '0.1em',
+                      fontFamily: SERIF,
+                      fontSize: 'var(--text-md)',
+                      letterSpacing: '0.12em',
                       textTransform: 'uppercase',
-                      padding: "var(--space-xs) var(--space-md)",
-                      background: on ? ACCENT : 'transparent',
-                      color: on ? PAPER_WARM : MUTED,
-                      border: `1px solid ${on ? ACCENT : LINE}`,
+                      padding: 'var(--space-xs) var(--space-md)',
+                      background: on ? FILL : 'transparent',
+                      color: on ? ON_FILL : MUTED,
+                      border: `1px solid ${on ? FILL : RULE}`,
                       cursor: 'pointer',
                     }}
                   >
@@ -198,7 +257,9 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
           }
         />
         {sortedSubmissions.length === 0 ? (
-          <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', color: SUB, margin: 0 }}>{t('ua.empty')}</p>
+          <p className="content-text" style={{ fontFamily: SERIF, color: MUTED, margin: 0 }}>
+            {t('ua.empty')}
+          </p>
         ) : (
           <>
             <div className="flex flex-col gap-4">
@@ -213,14 +274,13 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
                         transform: 'translateX(-50%)',
                         zIndex: 3,
                         whiteSpace: 'nowrap',
-                        background: GOLD,
-                        color: PAPER_WARM,
-                        fontFamily: ENGRAVED,
-                        fontSize: "var(--text-base)",
-                        letterSpacing: '0.1em',
+                        background: FILL,
+                        color: ON_FILL,
+                        fontFamily: SERIF,
+                        fontSize: 'var(--text-md)',
+                        letterSpacing: '0.14em',
                         textTransform: 'uppercase',
-                        padding: "var(--space-xs) var(--space-md)",
-                        boxShadow: '0 3px 8px rgba(60,40,10,0.3)',
+                        padding: 'var(--space-xs) var(--space-md)',
                       }}
                     >
                       {t('ua.finestHand')}
@@ -231,8 +291,8 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
               ))}
             </div>
             {submissions.length > 4 && (
-              <div style={{ marginTop: "var(--space-lg)" }}>
-                <Link to={`/praxes?task_id=${task.id}`} style={{ fontFamily: ENGRAVED, fontSize: "var(--text-lg)", letterSpacing: '0.06em', color: ACCENT, textDecoration: 'none' }}>
+              <div style={{ marginTop: 'var(--space-lg)' }}>
+                <Link to={`/praxes?task_id=${task.id}`} style={{ ...smallCaps, color: ACCENT, textDecoration: 'none' }}>
                   {t('ua.viewAll', { count: submissions.length })}
                 </Link>
               </div>
@@ -245,7 +305,19 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
       {canSignUp && (
         <MobileStickyBar>
           {signupError && (
-            <div style={{ fontFamily: MONO, fontSize: "var(--text-lg)", color: 'var(--color-danger)', padding: "var(--space-sm) var(--space-md)", background: 'var(--faction-ua-light)', border: `1px solid ${LINE}` }}>
+            /* #848 turned --faction-ua-light opaque, so it can no longer whisper
+               behind an error line. A failure is lifted, not tinted: the raised
+               surface plus the shared danger ink, both themed. */
+            <div
+              className="content-text"
+              style={{
+                fontFamily: SERIF,
+                color: 'var(--color-danger)',
+                padding: 'var(--space-sm) var(--space-md)',
+                background: LIFT,
+                borderLeft: '3px solid var(--color-danger)',
+              }}
+            >
               {signupError}
             </div>
           )}
@@ -253,14 +325,15 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
             onClick={handleSignup}
             style={{
               width: '100%',
-              background: ACCENT,
-              color: PAPER_WARM,
-              fontFamily: ENGRAVED,
-              fontSize: "var(--text-xl)",
-              letterSpacing: '0.1em',
+              background: FILL,
+              color: ON_FILL,
+              fontFamily: SERIF,
+              fontSize: 'var(--text-xl)',
+              letterSpacing: '0.12em',
               textTransform: 'uppercase',
-              padding: "var(--space-lg) var(--space-xl)",
+              padding: 'var(--space-lg)',
               border: 'none',
+              borderRadius: 3,
               cursor: 'pointer',
             }}
           >
@@ -273,13 +346,23 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
       )}
 
       {mySubmission && (
-        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <span className="content-text" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, color: GOLD, flex: 1 }}>
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap' }}>
+          <span className="content-text" style={{ fontFamily: DISPLAY, fontWeight: 600, color: ACCENT, flex: 1 }}>
             {t('ua.submitted.text')}
           </span>
           <Link
             to={`/praxes/${mySubmission.id}/edit`}
-            style={{ fontFamily: ENGRAVED, fontSize: "var(--text-base)", letterSpacing: '0.12em', textTransform: 'uppercase', padding: "var(--space-md) var(--space-lg)", background: INK, color: PAPER_WARM, textDecoration: 'none' }}
+            style={{
+              fontFamily: SERIF,
+              fontSize: 'var(--text-md)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              padding: 'var(--space-md) var(--space-lg)',
+              background: PANEL,
+              color: INK,
+              border: `1px solid ${RULE}`,
+              textDecoration: 'none',
+            }}
           >
             {t('ua.submitted.edit')}
           </Link>
@@ -287,16 +370,26 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
       )}
 
       {!mySubmission && isInProgress && inProgressPraxisId !== null && (
-        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', gap: "var(--space-md)" }}>
+        <MobileStickyBar style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--space-md)' }}>
           <button
             onClick={handleDrop}
-            style={{ background: 'none', border: 'none', cursor: 'pointer', fontFamily: MONO, fontSize: "var(--text-base)", letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', ...smallCaps }}
           >
             {t('ua.inProgress.drop')}
           </button>
           <Link
             to={`/praxes/${inProgressPraxisId}/edit`}
-            style={{ marginLeft: "auto", fontFamily: ENGRAVED, fontSize: "var(--text-md)", letterSpacing: '0.12em', textTransform: 'uppercase', padding: "var(--space-md) var(--space-xl)", background: ACCENT, color: PAPER_WARM, textDecoration: 'none' }}
+            style={{
+              marginLeft: 'auto',
+              fontFamily: SERIF,
+              fontSize: 'var(--text-md)',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+              padding: 'var(--space-md) var(--space-xl)',
+              background: FILL,
+              color: ON_FILL,
+              textDecoration: 'none',
+            }}
           >
             {t('ua.inProgress.continue')}
           </Link>

--- a/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
@@ -26,7 +26,7 @@ import type { TaskDetailState } from '../useTaskDetail'
  * Same {@link TaskDetailState}, same `ua.*` copy keys, same shared sticky bar as
  * before; only the dress changes (ADR-0016). Every colour is a
  * `--faction-ua-*` token with both themes, so this surface dims through the
- * `[data-theme="dark"]` cascade — the "always-light" ruling is reversed.
+ * `[data-theme="dark"]` cascade. UA dims now (#848).
  */
 
 const PAGE = 'var(--faction-ua-page)'

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
@@ -2,75 +2,123 @@ import type { CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TaskOut } from '../../../../api/tasks'
+import { UaSigil } from '../../../../components/cards/UaSigil'
 import { factionCssVar, factionName } from '../../../../utils/factions'
 import { MobileTaskDescription } from './shared'
 
 /**
- * University of Asthmatics MOBILE task card (#525/#565) — a parchment commission
- * plate on a gilt rail. Reads `task.primary_faction_slug` for its own faction
- * tint. Grounds on the `--faction-ua-*` / `--ua-*` tokens; always-light.
+ * University of Asthmatics MOBILE task card (#525/#565/#852) — a sheet from the
+ * practice, torn off single-column.
+ *
+ * The gilt commission plate is gone with the salon (#788): no gold rail, no
+ * double frame, no parchment dot-screen. What is left is the kit's §1a task row
+ * — a sun-bleached sheet, one neutral hairline, a soft orange spine down the
+ * gutter, and the point value written inside the ensō. The mark carries the
+ * number; nothing else on the card is ornament.
+ *
+ * The mandala is deliberately ABSENT here (`UaMandala`'s third strength): a task
+ * list is a dense, text-heavy surface, and the pattern belongs behind heroes and
+ * the vote control, not behind rows.
+ *
+ * Every colour is a `--faction-ua-*` token with both themes, so the card dims
+ * through the `[data-theme="dark"]` cascade — the "always-light" ruling that
+ * used to justify this file is reversed. Reads `task.primary_faction_slug` for
+ * the dot so a mixed feed still names the faction it came from.
  */
 
-const PAPER = 'var(--faction-ua-card-bg)'
-const PAPER_WARM = 'var(--ua-paper-warm)'
+const SHEET = 'var(--faction-ua-card-bg)'
 const INK = 'var(--faction-ua-card-text)'
-const SUB = 'var(--faction-ua-card-muted)'
-const MUTED = 'var(--ua-muted)'
-const GOLD = 'var(--ua-gold)'
-const LINE = 'var(--ua-line)'
+const BODY = 'var(--faction-ua-card-body)'
+const MUTED = 'var(--faction-ua-card-muted)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const RULE = 'var(--faction-ua-rule)'
 const DISPLAY = 'var(--faction-ua-card-font)'
-const ENGRAVED = 'var(--font-faction-engraved)'
-const MONO = 'var(--font-body)'
+const SERIF = 'var(--faction-ua-body-font)'
 
-const kicker: CSSProperties = {
-  fontFamily: MONO,
-  fontSize: 'var(--text-xs)',
-  letterSpacing: '0.24em',
+/** Small caps in the body face — the kit's label voice. No Cinzel, no gold. */
+const smallCaps: CSSProperties = {
+  fontFamily: SERIF,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.14em',
   textTransform: 'uppercase',
   color: MUTED,
 }
 
 export default function UaMobileTaskCard({ task, points }: { task: TaskOut; points: number }) {
   const { t } = useTranslation('tasks')
-  const color = factionCssVar(task.primary_faction_slug)
+  const dot = factionCssVar(task.primary_faction_slug)
   return (
     <Link
       to={`/tasks/${task.id}`}
       style={{
+        position: 'relative',
+        overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
         gap: 'var(--space-sm)',
-        padding: 'var(--space-md) var(--space-lg)',
-        background: PAPER,
-        backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
-        backgroundSize: '5px 5px',
-        border: `1px solid ${LINE}`,
-        borderLeft: `4px solid ${color}`,
-        boxShadow: `inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px var(--ua-gold-pale)`,
+        padding: 'var(--space-lg)',
+        paddingLeft: 'var(--space-2xl)',
+        background: SHEET,
+        border: `1px solid ${RULE}`,
+        borderRadius: 6,
         textDecoration: 'none',
       }}
     >
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-sm)', fontFamily: ENGRAVED, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color }}>
-        <i style={{ width: 7, height: 7, borderRadius: '50%', background: color, flex: 'none' }} />
+      {/* The spine: a breath of orange down the gutter, fading at both ends. */}
+      <i
+        aria-hidden
+        style={{
+          position: 'absolute',
+          left: 14,
+          top: 16,
+          bottom: 16,
+          width: 2,
+          background: 'linear-gradient(180deg, transparent, var(--faction-ua), transparent)',
+          opacity: 0.34,
+        }}
+      />
+
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-sm)', ...smallCaps, color: ACCENT }}>
+        <i style={{ width: 6, height: 6, borderRadius: '50%', background: dot, flex: 'none' }} />
         {factionName(task.primary_faction_slug)}
       </span>
 
-      <h2 className="content-title" style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, lineHeight: 1.15, color: INK, margin: 0 }}>
+      {/* The mark holds the number. */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}>
+        <span style={{ position: 'relative', width: 52, height: 52, flex: 'none' }}>
+          <UaSigil width={52} height={52} />
+          <span
+            className="content-text"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontFamily: DISPLAY,
+              fontWeight: 600,
+              lineHeight: 1,
+              color: INK,
+            }}
+          >
+            {points}
+          </span>
+        </span>
+        <span style={smallCaps}>{t('mobile.level', { level: task.level_required })}</span>
+      </div>
+
+      <h2
+        className="content-title"
+        style={{ fontFamily: DISPLAY, fontWeight: 600, lineHeight: 1.15, color: INK, margin: 0 }}
+      >
         {task.title}
       </h2>
 
       <MobileTaskDescription
         text={task.description}
         className="content-text"
-        style={{ fontFamily: DISPLAY, fontStyle: 'italic', lineHeight: 1.5, color: SUB, margin: 0 }}
+        style={{ fontFamily: SERIF, lineHeight: 1.5, color: BODY, margin: 0 }}
       />
-
-      <div className="flex items-center gap-3" style={{ marginTop: 'var(--space-xs)' }}>
-        <span style={{ fontFamily: ENGRAVED, fontSize: 'var(--text-lg)', letterSpacing: '0.04em', color: INK, background: PAPER_WARM, border: `1px solid ${GOLD}`, padding: 'var(--space-xs) var(--space-sm)' }}>
-          {t('mobile.points', { points })}
-        </span>
-        <span style={{ ...kicker, color: MUTED }}>{t('mobile.level', { level: task.level_required })}</span>
-      </div>
     </Link>
   )
 }

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx
@@ -21,8 +21,8 @@ import { MobileTaskDescription } from './shared'
  * the vote control, not behind rows.
  *
  * Every colour is a `--faction-ua-*` token with both themes, so the card dims
- * through the `[data-theme="dark"]` cascade — the "always-light" ruling that
- * used to justify this file is reversed. Reads `task.primary_faction_slug` for
+ * through the `[data-theme="dark"]` cascade. UA dims now (#848), and the ruling
+ * that used to say otherwise is reversed. Reads `task.primary_faction_slug` for
  * the dot so a mixed feed still names the faction it came from.
  */
 

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/__tests__/uaMobileTaskCard.test.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/__tests__/uaMobileTaskCard.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * UA mobile task card, rendered (#852). The salon is dead: this asserts the
+ * MARKUP the card emits, not what the registry points at — the ensō carrying the
+ * point value, the orange spine, the practice's tokens, and the absence of both
+ * the legacy gold family and the mandala (a task list is the primitive's
+ * `absent` case).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so copy keys resolve to English text.
+import '../../../../../i18n'
+import UaMobileTaskCard from '../UaMobileTaskCard'
+import type { TaskOut } from '../../../../../api/tasks'
+
+const TASK: TaskOut = {
+  id: 7,
+  title: 'Render the old library façade in charcoal',
+  description: 'Draw only what the light is doing.',
+  point_value: 30,
+  level_required: 2,
+  status: 'active',
+  task_type: 'standard',
+  created_by: 3,
+  primary_faction_slug: 'ua',
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: '2026-01-01T00:00:00Z',
+  can_submit_praxis: true,
+  allowed_modes: ['solo'],
+  eligible_for_current_user: true,
+}
+
+const html = renderToStaticMarkup(
+  <MemoryRouter>
+    <UaMobileTaskCard task={TASK} points={30} />
+  </MemoryRouter>,
+)
+const text = html.replace(/<[^>]*>/g, '')
+
+describe('UA mobile task card', () => {
+  it('writes the point value inside the ensō', () => {
+    // The heavy sweep of the two-arc sigil (#849) — not the 705 KB textured one.
+    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    expect(html).toContain('var(--faction-ua-glow)')
+    expect(text).toContain('30')
+  })
+
+  it('still fills its slots: title, description, level and faction', () => {
+    expect(text).toContain('Render the old library façade in charcoal')
+    expect(text).toContain('Draw only what the light is doing.')
+    expect(text.toLowerCase()).toContain('lvl 2')
+    expect(text).toContain('UA')
+  })
+
+  it('draws the spine down the gutter', () => {
+    expect(html).toContain('linear-gradient(180deg, transparent, var(--faction-ua), transparent)')
+  })
+
+  it('carries no gold: the legacy --ua-* palette is gone from this surface', () => {
+    expect(html).not.toMatch(/--ua-(gold|gilt|paper|wall|line|ink|sub|muted|orange)/)
+  })
+
+  it('asks the mandala for nothing — a task list is the dense case', () => {
+    // The mandala primitive's outer guide circle; the ensō has no such stroke.
+    expect(html).not.toContain('stroke-width="0.6"')
+  })
+
+  it('paints only in tokens that have a dark value, so the card dims', () => {
+    expect(html).toContain('var(--faction-ua-card-bg)')
+    expect(html).toContain('var(--faction-ua-rule)')
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}/)
+  })
+})


### PR DESCRIPTION
Closes #852

Part of #788. Built on #848 (tokens + real dark mode) and #849 (ensō sigil + `UaMandala`), both merged. Rebased onto `main` after #872 (3/6, the copy deck) landed, so every string these surfaces render is already the practice's voice — **no catalog file is touched here**; the skins keep their existing keys and #850 owns the words.

## What changed

Five mobile archetypes rebuilt against `--faction-ua-*`:

- `pages/tasks/mobileArchetypes/cards/UaMobileTaskCard.tsx`
- `pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx`
- `pages/factionDetail/mobileArchetypes/UaFactionPage.tsx`
- `pages/fieldDesk/mobileArchetypes/UaHome.tsx`
- `pages/editPraxis/mobileArchetypes/UaComposer.tsx`

The gilt salon is gone from all five: no `--ua-gold` / `--ua-gilt` / `--ua-paper` / `--ua-wall` / `--ua-line`, no Cinzel (`--font-faction-engraved`), no parchment dot-screen, no gold-gradient section rules, and no three-layer "gilt sandwich" plates. Type is Cormorant (`--faction-ua-card-font`) for display and EB Garamond (`--faction-ua-body-font`) for body and tracked small caps. Every colour is a token with both themes, so the surfaces dim through the `[data-theme="dark"]` cascade — no ternaries.

**Ornament, per the brief's build-cost ruling:**

| surface | ensō | mandala |
|---|---|---|
| task card | 52px, holds the point value | **absent** — dense list |
| task detail | 76px, holds the point value (vermilion) | `texture` behind the hero, once |
| faction page | 34px, the faction mark | `texture` behind the hero, once |
| home | 34px, the faction mark | `texture` behind the masthead, once |
| composer | 34px, the faction mark | **absent** — the editor |

Always the small two-arc `UaSigil` from #849, never the 705 KB textured ensō the kit's mockups use.

**Layout:** single-column with flow/wrap throughout (§1a). The gutter-cancelling margins are `calc(-1 * var(--space-lg))` rather than raw `-16`; the join/cancel pair, the hero stats, the sticky rows and the two home actions all `flex-wrap` instead of holding a fixed row, so 375px survives even with the propose-task button present. No fixed-px grid carries layout structure (the media grid is `repeat(3, 1fr)` — proportional, not px).

**#848 carry-over, folded in:** `UaTaskDetail:248` used the now-opaque `--faction-ua-light` as a `background:` behind the signup error. It moves to `--faction-ua-lift` with the shared danger ink and a danger edge, and a test freezes it against reaching for the tint again. The three desktop call sites are left to #851.

## Deviations from the kit, and why

1. **No mandala on the composer.** The kit draws its editor card over a lotus at 10%; §5 of the brief puts the editor in the `absent` bucket with feed rows and comments. Brief wins, per its own precedence rule. Noted at the call site.
2. **The task card's point value loses the word "pts".** The kit's §1a task row writes the bare numeral inside the ensō with "Level N" beside it; that is what shipped. The slot is still filled — it is presentation, not a schema change (ADR-0016).

No schema was widened and no `use*` hook was touched.

## Tests

`renderToStaticMarkup` only — no jsdom, no testing-library, effects never run. Each surface's `uaDispatch` / `uaMobileDispatch` test keeps its registry checks and gains a rendered block asserting the markup: the ensō's heavy sweep, the mandala's guide circle **counted** (exactly one where it belongs, zero where it does not), the one dashed orange rule, the slots still filled, and two frozen regressions — no legacy `--ua-*` family, no Cinzel. The task card gets a new test file; it had none. Existing slot-invariant suites already walk all five skins and still pass.

`tsc --noEmit` clean, `eslint src/pages` clean, `vite build` clean, `vitest` 108 files / 1233 tests green.

## No visual QA was done

I cannot screenshot and there is no dev stack in this worktree. Everything above is verified by tests, typecheck, lint and build only. **Nobody has looked at these five screens.**

## What to eyeball

- **Task card at 375px** — the ensō is 52px with the point value centred in it. Does the numeral sit optically centred inside an open circle whose gap is at 7–8 o'clock, or does it look off-axis?
- **Task-detail hero** — the mandala is anchored `right:-72 top:-64` at 14%. Check it reads as texture and does not collide with the "MARKS / ANNO" block or bleed past the sheet's rounded corner.
- **Faction-page hero** — same question for the 260px mandala at `right:-84 top:-72`, plus the 34px ensō beside "A daily practice".
- **Home masthead** — "One mark today. Begin." at `--text-heading` next to a 34px ensō. Does the line wrap on a narrow phone, and does it look right if it does?
- **Composer** — every field lost its frame; the tracked small-caps label is now the only structure. Is that legible enough as a form, or does it read as undifferentiated?
- **Dark mode on all five** — this is UA's first real dark mode. The sun-bleached palette sits in a narrow luminance band; the muted/body/page trio is where it will fail if it fails.
- **The vermilion numerals** (task-detail points, faction-page rank) against the sheet in both themes.
- **The dashed orange rule at 40% opacity** — visible, or invisible?

🤖 Generated with [Claude Code](https://claude.com/claude-code)