### PR TITLE
WOW mobile composer: The Squire's Writ on the phone (#836)

### DIFF
--- a/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
+++ b/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
@@ -6,8 +6,8 @@
  * `--faction-wow-*` block, so WOW rejoins the rainbow. #821 ships its FIRST
  * bespoke surfaces: the praxis card, its mobile twin, and the vote widget; #840
  * adds the score stamp when it rebuilds the chronicle from source; #835 adds the
- * desktop edit-praxis composer. Every OTHER surface still falls through to
- * `Default*` — WOW is themed-and-partly-skinned, not fully dressed, and
+ * desktop edit-praxis composer and #836 its mobile twin. Every OTHER surface
+ * still falls through to `Default*` — WOW is themed-and-partly-skinned, and
  * definitely not "broken faction".
  *
  * That split is fragile in BOTH directions, neither of which crashes:
@@ -45,9 +45,10 @@ function Sentinel() {
 
 /**
  * The surfaces WOW has skinned: #821's three, the `scoreStamp` its own chronicle
- * plate claims in #840 (ADR-0049), and #835's DESKTOP edit-praxis composer.
- * `mobileEditPraxis` is deliberately absent — that is #836, and the desktop skin
- * landing without it is exactly the half-dressed state this file guards.
+ * plate claims in #840 (ADR-0049), #835's DESKTOP edit-praxis composer and, as
+ * of #836, its `mobileEditPraxis` twin — the composer is the one surface WOW
+ * dresses on BOTH form factors. Every other surface is still unclaimed, which is
+ * exactly the half-dressed state this file guards.
  */
 const WOW_SKINNED: ReadonlySet<FactionSurface> = new Set([
   'praxisCard',
@@ -55,9 +56,10 @@ const WOW_SKINNED: ReadonlySet<FactionSurface> = new Set([
   'scoreStamp',
   'vote',
   'editPraxis',
+  'mobileEditPraxis',
 ])
 
-describe('wow is partly skinned: five surfaces claimed, the rest fall back', () => {
+describe('wow is partly skinned: six surfaces claimed, the rest fall back', () => {
   it('registers a manifest now (#821)', () => {
     expect(FACTION_MANIFESTS.map((manifest) => manifest.slug)).toContain('wow')
   })

--- a/frontend/src/factions/index.ts
+++ b/frontend/src/factions/index.ts
@@ -48,12 +48,12 @@ export { SURFACE_KEYS } from './manifest'
  * `wow` (Warriors of Whimsy) began with no manifest (#784 moved its old pink
  * identity to Cozy Coven) and then only a yellow THEME (#812). #821 gave it its
  * FIRST bespoke surfaces: the praxis card (the cream/gold/plum chronicle), its
- * mobile twin and the balloon vote widget; #840 added the score stamp and #835
- * the desktop edit-praxis composer ("The Squire's Writ"). It is still
- * override-only — every OTHER surface hands `wow` its `Default*` archetype, so
- * WOW is themed-and-partly-skinned, not fully dressed.
- * `wowRendersDefault.test.tsx` pins which five surfaces are claimed and that the
- * rest fall back.
+ * mobile twin and the balloon vote widget; #840 added the score stamp, #835 the
+ * desktop edit-praxis composer ("The Squire's Writ") and #836 its
+ * `mobileEditPraxis` twin. It is still override-only — every OTHER surface hands
+ * `wow` its `Default*` archetype, so WOW is themed-and-partly-skinned, not fully
+ * dressed. `wowRendersDefault.test.tsx` pins which six surfaces are claimed and
+ * that the rest fall back.
  */
 export const FACTION_MANIFESTS: readonly FactionManifest[] = [
   EVERYMEN_MANIFEST,

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -9,11 +9,13 @@
  * vote widget.
  *
  * #835 adds the DESKTOP edit-praxis composer — "The Squire's Writ", the kit's
- * one form surface. Mobile stays on the default until #836.
+ * one form surface — and #836 its phone twin: the same writ dress on the settled
+ * mobile composer structure (Write/Preview toggle, fluid media grid, sticky
+ * submit bar), since the kit draws no mobile composer of its own.
  *
  * Override-only, like every manifest: WOW still falls through to the `Default*`
  * archetype on every OTHER surface — it is themed-and-partly-skinned now, not
- * fully dressed. `wowRendersDefault.test.tsx` pins exactly which five surfaces
+ * fully dressed. `wowRendersDefault.test.tsx` pins exactly which six surfaces
  * are claimed and asserts the rest still fall back.
  *
  * Entries are thunks (`() => Component`) so they are read at render time, never
@@ -26,6 +28,7 @@ import WowMobilePraxisCard from '../components/praxisCard/mobile/WowMobilePraxis
 import WowPraxisCard from '../components/praxisCard/desktop/WowPraxisCard'
 import WowScoreStamp from '../components/praxisCard/scoreStamp/WowScoreStamp'
 import WowEditPraxis from '../pages/editPraxis/archetypes/WowEditPraxis'
+import WowMobileEditPraxis from '../pages/editPraxis/mobileArchetypes/WowEditPraxis'
 
 export const WOW_MANIFEST: FactionManifest = {
   slug: 'wow',
@@ -35,4 +38,5 @@ export const WOW_MANIFEST: FactionManifest = {
   mobilePraxisCard: () => WowMobilePraxisCard,
   vote: () => WowVote,
   editPraxis: () => WowEditPraxis,
+  mobileEditPraxis: () => WowMobileEditPraxis,
 }

--- a/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
@@ -1,0 +1,596 @@
+/**
+ * Warriors of Whimsy MOBILE composer (#836) — The Squire's Writ on a phone.
+ *
+ * Same single-column composer every faction gets on mobile (#494/#498): a
+ * Write/Preview segmented toggle instead of a stacked textarea+preview, a fluid
+ * media grid, and a sticky submit bar riding above the tab bar. The WoW kit has
+ * no mobile composer design of its own (its section 09 is the Field Desk, a home
+ * surface), so this file dresses the settled mobile structure in the writ
+ * identity shipped on desktop by #835: gilt frame, gold/plum checker rule,
+ * wax-seal mark, and each field on its own inset parchment plate.
+ *
+ * PALETTE — no new tokens. Reads the same post-#838/#840 chronicle block the
+ * desktop archetype does (ADR-0050): `--faction-wow-card-accent` IS the kit's
+ * plum, `--faction-wow-stamp-total` its legible gold ink, `-chronicle-*` the
+ * parchment. Nothing here mints or repoints a colour.
+ *
+ * Consumes `useEditPraxis` verbatim through the shared skinnable controls — no
+ * editor, upload, or submit logic lives here. Presentation-only.
+ */
+import { useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { factionCssVar } from "../../../utils/factions";
+import { mediaUrl } from "../../../utils/media";
+import MediaArt from "../blocks/MediaArt";
+import { pickArtKey } from "../blocks/useMediaArt";
+import { ErrorBanner, TaskMetaInline, TitleCounter, formatAutosave } from "../archetypes/shared";
+import {
+  BodyPreview,
+  BodyTextarea,
+  DropButton,
+  FilePicker,
+  InviteSearch,
+  MetatasksList,
+  PublishButton,
+  TitleField,
+} from "../archetypes/controls";
+import type { EditPraxisState } from "../useEditPraxis";
+import { MobileStickyBar, SegToggle, type ComposerTab } from "./shared";
+
+/* The chronicle palette, straight off the post-#838 token block. */
+const GOLD = factionCssVar("wow", "chronicle-gold"); // gilt frame + rules
+const GOLD_INK = factionCssVar("wow", "stamp-total"); // gold that is legible AS TEXT
+const PLUM = factionCssVar("wow", "card-accent"); // the kit's "whimsy"
+const PLUM_DEEP = factionCssVar("wow", "stamp-chip-bg"); // the plum pill ground
+const ON_PLUM = factionCssVar("wow", "stamp-chip-text");
+const FRAME_BG = factionCssVar("wow", "chronicle-bg");
+const PANEL_BG = factionCssVar("wow", "chronicle-panel"); // inset parchment plate
+const PANEL_BORDER = factionCssVar("wow", "border");
+const FIELD_BG = factionCssVar("wow", "card-bg");
+const INK = factionCssVar("wow", "card-text");
+const MUTED = factionCssVar("wow", "card-muted");
+const TINT = factionCssVar("wow", "light");
+const ON_GOLD = factionCssVar("wow", "on-fill"); // 8.1:1 on the gold, both themes
+const SHADOW = factionCssVar("wow", "chronicle-shadow");
+const DISPLAY = factionCssVar("wow", "card-font"); // MedievalSharp
+const BODY = factionCssVar("wow", "body-font"); // Lora
+
+const eyebrow: CSSProperties = {
+  display: "block",
+  fontFamily: DISPLAY,
+  fontSize: "var(--text-md)",
+  textTransform: "uppercase",
+  letterSpacing: "0.14em",
+  color: GOLD_INK,
+};
+
+/** The wax seal, reduced to a phone-sized roundel: gilt rim, plum wax, ✦ mark. */
+function WaxSeal({ size = 30 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 30 30" aria-hidden role="presentation">
+      <circle cx="15" cy="15" r="13" fill={PLUM_DEEP} stroke={GOLD} strokeWidth="2" />
+      <circle
+        cx="15"
+        cy="15"
+        r="9.5"
+        fill="none"
+        stroke={GOLD}
+        strokeWidth="0.9"
+        strokeDasharray="2 2"
+      />
+      <path
+        d="M15 6.5c.6 4 2 5.4 6 6-4 .6-5.4 2-6 6-.6-4-2-5.4-6-6 4-.6 5.4-2 6-6Z"
+        fill={GOLD}
+      />
+    </svg>
+  );
+}
+
+/** A hairline of the gold/plum checker band the writ is framed in. */
+function CheckerRule() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        height: 6,
+        background: `repeating-linear-gradient(90deg, ${GOLD} 0 9px, ${PLUM_DEEP} 9px 18px)`,
+      }}
+    />
+  );
+}
+
+/**
+ * One field on its own inset parchment plate: gilt frame, checker rule, an
+ * eyebrow-titled header (with an optional right-hand aside for counters), and
+ * the control below. Fluid — no fixed width anywhere, so it survives 375px.
+ */
+function Plate({
+  title,
+  aside,
+  children,
+}: {
+  title: string;
+  aside?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        borderRadius: 14,
+        overflow: "hidden",
+        background: FRAME_BG,
+        border: `1.5px solid ${GOLD}`,
+        boxShadow: `0 10px 24px -14px ${SHADOW}`,
+      }}
+    >
+      <CheckerRule />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: "var(--space-sm)",
+          padding: "var(--space-sm) var(--space-md)",
+          background: TINT,
+          borderBottom: `1px solid ${PANEL_BORDER}`,
+        }}
+      >
+        <span style={eyebrow}>{title}</span>
+        {aside}
+      </div>
+      <div style={{ padding: "var(--space-md)", background: PANEL_BG }}>{children}</div>
+    </section>
+  );
+}
+
+/** Italic marginalia — autosave line, word count, the closing note. */
+function Marginalia({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        fontFamily: BODY,
+        fontStyle: "italic",
+        fontSize: "var(--text-lg)",
+        color: MUTED,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation("forms");
+  const [tab, setTab] = useState<ComposerTab>("write");
+  const praxis = state.praxis!;
+  const task = state.task;
+
+  return (
+    <div
+      data-skin="wow"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-md)",
+        fontFamily: BODY,
+        color: INK,
+        background: FRAME_BG,
+      }}
+    >
+      {/* ── writ header + Write/Preview toggle ── */}
+      <header style={{ display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+          <WaxSeal />
+          <div style={{ minWidth: 0 }}>
+            <h1
+              style={{
+                margin: 0,
+                fontFamily: DISPLAY,
+                fontSize: "var(--text-title)",
+                lineHeight: 1.05,
+                color: INK,
+              }}
+            >
+              {t("editPraxis.wow.pageTitle")}
+            </h1>
+            <Marginalia>
+              {state.autosaveAt
+                ? t("editPraxis.wow.autosaveSaved", {
+                    ago: formatAutosave(state.autosaveAt),
+                  })
+                : t("editPraxis.wow.autosaveUnsaved")}
+            </Marginalia>
+          </div>
+          <span
+            style={{
+              marginLeft: "auto",
+              flexShrink: 0,
+              fontFamily: DISPLAY,
+              fontSize: "var(--text-lg)",
+              letterSpacing: "0.08em",
+              color: PLUM,
+              background: PANEL_BG,
+              border: `1px solid ${PANEL_BORDER}`,
+              borderRadius: 20,
+              padding: "var(--space-xs) var(--space-sm)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {t("editPraxis.wow.draftChip")}
+          </span>
+        </div>
+
+        <SegToggle
+          tab={tab}
+          setTab={setTab}
+          skin={{
+            containerStyle: {
+              gap: "var(--space-xs)",
+              padding: "var(--space-xs)",
+              background: PANEL_BG,
+              border: `1.5px solid ${GOLD}`,
+              borderRadius: 999,
+            },
+            buttonStyle: (active) => ({
+              padding: "var(--space-sm)",
+              borderRadius: 999,
+              border: active ? `1.5px solid ${GOLD_INK}` : "1.5px solid transparent",
+              fontFamily: DISPLAY,
+              fontSize: "var(--text-lg)",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              background: active ? GOLD : "transparent",
+              color: active ? ON_GOLD : MUTED,
+            }),
+          }}
+        />
+      </header>
+
+      {/* ── the quest, read only ── */}
+      <div
+        style={{
+          padding: "var(--space-md)",
+          background: PANEL_BG,
+          border: `1px solid ${PANEL_BORDER}`,
+          borderLeft: `4px solid ${GOLD}`,
+          borderRadius: 12,
+        }}
+      >
+        <span style={{ ...eyebrow, marginBottom: "var(--space-xs)" }}>
+          {t("editPraxis.wow.taskRefLabel")}
+        </span>
+        <div
+          style={{
+            fontFamily: DISPLAY,
+            fontSize: "var(--text-content)",
+            lineHeight: 1.15,
+            color: INK,
+            marginBottom: "var(--space-xs)",
+          }}
+        >
+          {praxis.task_title}
+        </div>
+        <TaskMetaInline praxis={praxis} task={task} textColor={GOLD_INK} />
+      </div>
+
+      {tab === "write" ? (
+        <>
+          <Plate
+            title={t("editPraxis.wow.titleLabel")}
+            aside={<TitleCounter length={state.title.length} color={MUTED} />}
+          >
+            <TitleField
+              state={state}
+              skin={{
+                placeholder: t("editPraxis.wow.titlePlaceholder"),
+                inputStyle: {
+                  width: "100%",
+                  boxSizing: "border-box",
+                  fontFamily: DISPLAY,
+                  color: INK,
+                  background: FIELD_BG,
+                  border: `1.5px solid ${PANEL_BORDER}`,
+                  borderRadius: 9,
+                  padding: "var(--space-sm) var(--space-md)",
+                  outline: "none",
+                },
+              }}
+            />
+          </Plate>
+
+          <Plate
+            title={t("editPraxis.wow.bodyLabel")}
+            aside={
+              <Marginalia>
+                {t("editPraxis.wow.bodyWords", { words: state.wordCount })}
+              </Marginalia>
+            }
+          >
+            <BodyTextarea
+              state={state}
+              skin={{
+                rows: 10,
+                placeholder: t("editPraxis.wow.bodyPlaceholder"),
+                toolbarButtonStyle: {
+                  background: FIELD_BG,
+                  color: INK,
+                  border: `1.5px solid ${PANEL_BORDER}`,
+                  borderRadius: 7,
+                  fontFamily: BODY,
+                },
+                textareaStyle: {
+                  width: "100%",
+                  boxSizing: "border-box",
+                  fontFamily: BODY,
+                  lineHeight: 1.55,
+                  color: INK,
+                  background: FIELD_BG,
+                  border: `1.5px solid ${PANEL_BORDER}`,
+                  borderRadius: 9,
+                  padding: "var(--space-md)",
+                  outline: "none",
+                  resize: "vertical",
+                  minHeight: 180,
+                },
+              }}
+            />
+          </Plate>
+
+          {state.showInviteBox && (
+            <Plate
+              title={
+                state.duelMode
+                  ? t("editPraxis.wow.inviteLabelDuel")
+                  : t("editPraxis.wow.inviteLabel")
+              }
+              aside={<Marginalia>{t("editPraxis.wow.inviteHelper")}</Marginalia>}
+            >
+              <InviteSearch
+                state={state}
+                skin={{
+                  fontFamily: BODY,
+                  inputBg: FIELD_BG,
+                  inputColor: INK,
+                  inputBorder: `1.5px solid ${PANEL_BORDER}`,
+                  dropdownBg: PANEL_BG,
+                  dropdownBorder: `1.5px solid ${GOLD}`,
+                  acceptedBg: PLUM_DEEP,
+                  acceptedColor: ON_PLUM,
+                  pendingColor: PLUM,
+                  placeholder: t("editPraxis.wow.invitePlaceholder"),
+                }}
+              />
+            </Plate>
+          )}
+
+          <Plate
+            title={t("editPraxis.wow.filesLabel")}
+            aside={<Marginalia>{t("editPraxis.wow.fileHelper")}</Marginalia>}
+          >
+            <RelicGrid state={state} />
+          </Plate>
+
+          {state.showMetatasks && (
+            <Plate title={t("editPraxis.wow.metatasksLabel")}>
+              <MetatasksList
+                state={state}
+                skin={{
+                  containerStyle: {
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "var(--space-xs)",
+                  },
+                  rowStyle: (selected) => ({
+                    padding: "var(--space-sm) var(--space-md)",
+                    background: selected ? TINT : FIELD_BG,
+                    border: `1.5px solid ${selected ? GOLD : PANEL_BORDER}`,
+                    borderRadius: 9,
+                    fontFamily: DISPLAY,
+                  }),
+                  titleColor: INK,
+                  descColor: MUTED,
+                  pointsActiveColor: GOLD_INK,
+                  pointsIdleColor: MUTED,
+                }}
+              />
+            </Plate>
+          )}
+        </>
+      ) : (
+        <Plate title={t("editPraxis.wow.previewLabel")}>
+          <div
+            style={{
+              fontFamily: DISPLAY,
+              fontSize: "var(--text-title)",
+              lineHeight: 1.15,
+              color: INK,
+              marginBottom: "var(--space-sm)",
+            }}
+          >
+            {state.title || t("editPraxis.wow.titlePlaceholder")}
+          </div>
+          {state.media.length > 0 && (
+            <div style={{ marginBottom: "var(--space-md)" }}>
+              <RelicGrid state={state} readOnly />
+            </div>
+          )}
+          <BodyPreview
+            state={state}
+            skin={{
+              wrapperStyle: {
+                background: FIELD_BG,
+                border: `1px dashed ${PANEL_BORDER}`,
+                borderRadius: 9,
+                padding: "var(--space-md)",
+              },
+              markdownStyle: {
+                fontFamily: BODY,
+                lineHeight: 1.6,
+                color: INK,
+              },
+            }}
+          />
+        </Plate>
+      )}
+
+      <ErrorBanner message={state.error} />
+
+      {/* ── seal it ── */}
+      <MobileStickyBar
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-md)",
+          padding: "var(--space-md) 0 var(--space-xs)",
+          background: "var(--color-nav-bg)",
+          backdropFilter: "blur(var(--nav-blur))",
+          borderTop: `1.5px solid ${GOLD}`,
+        }}
+      >
+        {!state.isPublished && (
+          <DropButton
+            state={state}
+            skin={{
+              label: t("editPraxis.wow.dropLabel"),
+              style: {
+                background: "transparent",
+                border: "none",
+                color: PLUM,
+                fontFamily: DISPLAY,
+                fontSize: "var(--text-lg)",
+                whiteSpace: "nowrap",
+                cursor: "pointer",
+              },
+            }}
+          />
+        )}
+        <PublishButton
+          state={state}
+          skin={{
+            ornament: <WaxSeal size={18} />,
+            idleLabel: t("editPraxis.wow.publishIdle"),
+            busyLabel: t("editPraxis.wow.publishBusy"),
+            style: {
+              flex: 1,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-sm)",
+              background: GOLD,
+              color: ON_GOLD,
+              fontFamily: DISPLAY,
+              fontSize: "var(--text-lg)",
+              letterSpacing: "0.06em",
+              padding: "var(--space-md) var(--space-lg)",
+              border: `2px solid ${GOLD_INK}`,
+              borderRadius: 12,
+              cursor: state.submitting ? "wait" : "pointer",
+            },
+          }}
+        />
+      </MobileStickyBar>
+    </div>
+  );
+}
+
+/** Fluid 3-column grid of illuminations & relics, each in a gilt-edged tile. */
+function RelicGrid({
+  state,
+  readOnly = false,
+}: {
+  state: EditPraxisState;
+  readOnly?: boolean;
+}) {
+  const { t } = useTranslation("forms");
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gap: "var(--space-sm)",
+      }}
+    >
+      {state.media.map((item) => {
+        const filename = item.file_path.split("/").pop() ?? item.file_path;
+        const src = mediaUrl(item.file_path);
+        return (
+          <div
+            key={item.id}
+            style={{
+              position: "relative",
+              aspectRatio: "1 / 1",
+              overflow: "hidden",
+              borderRadius: 9,
+              border: `1.5px solid ${GOLD}`,
+              background: FIELD_BG,
+            }}
+          >
+            {item.type === "image" ? (
+              <img
+                src={src}
+                alt=""
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : item.type === "video" ? (
+              <video
+                src={src}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : (
+              <MediaArt art={pickArtKey(filename, "audio")} width={120} height={120} />
+            )}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => void state.removeMedia(item)}
+                aria-label={t("media.removeAria", { name: filename })}
+                style={{
+                  position: "absolute",
+                  top: 4,
+                  right: 4,
+                  width: 24,
+                  height: 24,
+                  borderRadius: "50%",
+                  background: PLUM_DEEP,
+                  border: `1px solid ${GOLD}`,
+                  color: ON_PLUM,
+                  fontSize: "var(--text-lg)",
+                  lineHeight: 1,
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        );
+      })}
+      {!readOnly && (
+        <FilePicker
+          state={state}
+          skin={{
+            buttonStyle: {
+              aspectRatio: "1 / 1",
+              width: "100%",
+              background: FIELD_BG,
+              border: `2px dashed ${GOLD}`,
+              borderRadius: 9,
+              cursor: "pointer",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-xs)",
+              fontFamily: DISPLAY,
+              fontSize: "var(--text-xl)",
+              color: PLUM,
+            },
+            buttonLabel: t("editPraxis.wow.fileButton"),
+          }}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #836

Ports **The Squire's Writ** — WOW's desktop edit-praxis composer from #835 (PR #874) — onto the phone.

## What this does

Adds `frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx` and registers it as `mobileEditPraxis` on the existing WOW manifest.

Per the issue, **no new design was consulted and none was needed** — the WoW Faction Kit's section 09 is the mobile *Field Desk* (a home surface), not a composer. The mobile composer idiom is already settled by #494/#498 and is identical for every faction: single column, a Write/Preview segmented toggle instead of a stacked textarea+preview, a fluid media grid, and a sticky submit bar. This dresses *that* structure in the writ identity: gilt frame, gold/plum checker rule, a wax-seal mark, and each field on its own inset parchment plate.

`CovenEditPraxis.tsx` (mobile) was the structural precedent only — none of its pink was taken. Its stale `"wow.exe"` header docstring is a pre-ADR-0050 label inversion and was deliberately left alone (that belongs to #844).

## Settled constraints, honoured

- **Zero new tokens; zero changes to `index.css`.** Reads the same post-#838/#840 chronicle block the desktop archetype maps: `--faction-wow-card-accent` is the kit's plum, `--faction-wow-stamp-total` its legible gold ink, `-chronicle-{bg,panel,gold,shadow}` the parchment, `--faction-wow-on-fill` the ink on gold.
- **Zero new strings.** The `editPraxis.wow.*` block from #835 already covers every slot the mobile skin needs; the Write/Preview toggle copy stays shared at `editPraxis.mobile.*`. `forms.json` is untouched.
- **Zero changes to `useEditPraxis.ts`, `EditPraxis.tsx`, or any backend.** Every control is a shared skinnable one (`TitleField`, `BodyTextarea`, `BodyPreview`, `InviteSearch`, `FilePicker`, `MetatasksList`, `DropButton`, `PublishButton`) plus `MobileStickyBar` / `SegToggle` from `mobileArchetypes/shared.tsx`.
- **No fixed-px layout grids.** Single column, `repeat(3, 1fr)` media grid with `aspect-ratio` tiles, `width: 100%` fields — nothing carries a fixed layout width.
- **Praxis card untouched** — no file under `components/praxisCard/**`, no `praxis.json`/`votes.json`, no `praxisCard`/`mobilePraxisCard` entry changed.
- No `Ua*` file under `mobileArchetypes/` was touched (#852 owns those).

The `ModePicker` is omitted, matching every other mobile composer (Default, Coven, UA, Snide, Singularity, Everymen, Ephemerists all omit it) — mode selection stays a desktop affordance.

## Other files edited

- `factions/wow.ts` — one added entry, `mobileEditPraxis: () => WowMobileEditPraxis`. All **five** pre-existing surfaces (`praxisCard`, `mobilePraxisCard`, `vote`, `scoreStamp`, `editPraxis`) are intact; the manifest now declares six.
- `factions/__tests__/wowRendersDefault.test.tsx` — carve-out widened from five to six. Every other surface still asserts `undefined` and still resolves to the caller's Sentinel; the test's intent is unchanged.
- `factions/index.ts` — doc comment now names `mobileEditPraxis` and says six.

## Verification

- `npx vitest run` — **107 files / 1210 tests passed**, including `wowRendersDefault.test.tsx` with both carve-outs and every mobile-composer dispatch test (which assert only `na`/`null`/`__unregistered__` fall back, so registering `wow` doesn't disturb them).
- `npx tsc --noEmit` — clean for all changed files. The only output is the known stale-junction `Cannot find module 'node:fs'/'node:url'` false alarm in pre-existing `__tests__` files (PR #675), plus its TS7006 knock-on. Nothing in this diff.
- `npx vite build` — built in 3.08s.
- `npx eslint` on all four changed files — clean (no `no-raw-style-values` hits; all font sizes are `var(--text-*)` and all spacing is `var(--space-*)`).

## No visual QA was done

Stated plainly: **this is a structure-and-palette pass verified by reading, not by looking.** The agent cannot screenshot and the frontend test harness is `renderToStaticMarkup` only — no jsdom, so effects never run and the Write/Preview toggle was never actually flipped in a browser.

## What to eyeball

1. **375px width.** The header row is seal + title + `❦ Draft` chip; confirm the chip doesn't shove the title into an ugly wrap. It has `flexShrink: 0` and the title block has `minWidth: 0`.
2. **The Write/Preview toggle** — active pill is solid gold with `--faction-wow-on-fill` ink. Check it reads as gold rather than muddy against the cream plate, in both themes.
3. **Dark mode overall.** The plates go `chronicle-panel` (`#2a2210`) inside a `chronicle-gold` frame on a `card-bg` ground. Confirm the three darks are distinguishable and the gold hairlines don't glow.
4. **The checker rule** at the top of each plate (9px gold / 9px plum repeat) — six of them stacked down the page may be one rule too many; easy to drop to just the first plate if it's noisy.
5. **Sticky submit bar** — "Discard the Writ" in plum next to the gold "Seal & Publish". Check the discard label doesn't wrap (it has `whiteSpace: nowrap`) and the bar clears the tab bar.
6. **The wax seal at 18px inside the publish button** — the dashed inner ring may disappear at that size.
7. **Media grid** with 4+ items: 3 fluid columns of square tiles with a gold border and a plum remove button.
8. **Desktop unchanged** — a `wow` task on a wide viewport should still render the #874 desktop writ, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
