### PR TITLE
UA redesign 4/6: desktop archetypes (#851)

### DIFF
--- a/frontend/src/components/avatar/UaAvatar.tsx
+++ b/frontend/src/components/avatar/UaAvatar.tsx
@@ -12,8 +12,7 @@ import { UaSigil } from "../cards/UaSigil";
  * one of the mark's two sanctioned uses (brief §4).
  *
  * Both themes come from the `[data-theme="dark"]` cascade; the badge sits on
- * `--faction-ua-lift`, which dims with everything else. UA is not always-light
- * any more.
+ * `--faction-ua-lift`, which dims with everything else.
  */
 export default function UaAvatar({ character, size }: FactionAvatarProps) {
   return (

--- a/frontend/src/components/avatar/UaAvatar.tsx
+++ b/frontend/src/components/avatar/UaAvatar.tsx
@@ -2,16 +2,18 @@ import { BadgedAvatar, type FactionAvatarProps } from "./FactionAvatar";
 import { UaSigil } from "../cards/UaSigil";
 
 /**
- * UA (University of Asthmatics) avatar — the Salon "Artist in Residence"
- * portrait: a parchment disc ringed in gilt with a regal italic monogram (or
- * the character's uploaded portrait), plus the heraldic UA crest clipped to the
- * lower-right as the membership badge.
+ * UA avatar — the portrait ringed in the practice's own orange, with the ensō
+ * as the membership medallion at the corner (kit §11, #851).
  *
- * Reuses the shared BadgedAvatar shell (image/initial circle + corner badge)
- * and the repo's own {@link UaSigil} for the badge glyph rather than porting a
- * separate sigil. UA is ALWAYS LIGHT: its --ua-* / --faction-ua-* tokens are
- * identical in both themes, so the salon styles itself with them and never
- * mutates data-theme. All colors via tokens (never hardcode hex — CLAUDE.md).
+ * The kit frames the portrait in a faint full ensō ring. At the sizes this
+ * component actually renders (24-32px) a two-arc brushstroke around a 24px disc
+ * is mud, so the ring is the plain orange stroke the shared circle already
+ * draws and the ensō does its work in the badge, where it is the FACTION MARK —
+ * one of the mark's two sanctioned uses (brief §4).
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade; the badge sits on
+ * `--faction-ua-lift`, which dims with everything else. UA is not always-light
+ * any more.
  */
 export default function UaAvatar({ character, size }: FactionAvatarProps) {
   return (
@@ -19,16 +21,15 @@ export default function UaAvatar({ character, size }: FactionAvatarProps) {
       character={character}
       size={size}
       circle={{
-        borderColor: "var(--ua-orange)",
-        bg: "var(--faction-ua-card-bg)",
-        textColor: "var(--ua-ink)",
+        borderColor: "var(--faction-ua)",
+        bg: "var(--faction-ua-panel)",
+        textColor: "var(--faction-ua-card-text)",
         fontFamily: "var(--faction-ua-card-font)",
       }}
-      badgeBg="var(--ua-paper-warm)"
-      badgeRing="var(--ua-gold)"
-      // The crest is a shield (100×120 viewBox); render it square at badge
-      // scale — BadgedAvatar hands us the inner glyph size and the ring color
-      // (unused here; the crest carries its own --ua-* palette).
+      badgeBg="var(--faction-ua-lift)"
+      badgeRing="var(--faction-ua-border)"
+      // The ensō is square; the badge slot is square. It carries its own
+      // --faction-ua-glow stroke, so the ring colour is unused here.
       glyph={(s) => <UaSigil width={s} height={s} />}
     />
   );

--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -28,18 +28,19 @@ function character(overrides: Partial<CharacterOut> = {}): CharacterOut {
 }
 
 describe("FactionAvatar — UA variant (#200)", () => {
-  it("renders the UA gilt-salon avatar for a ua character", () => {
+  it("renders the UA practice avatar for a ua character", () => {
     const html = renderToStaticMarkup(
       <FactionAvatar character={character({ faction_slug: "ua" })} />,
     );
     // Monogram fallback (no avatar_url) — the initial letter, uppercased.
     expect(html).toContain("I");
-    // Parchment disc ringed in UA gilt tokens (never hardcoded hex).
-    expect(html).toContain("var(--ua-orange)");
+    // The disc is ringed and badged in --faction-ua-* tokens only. The legacy
+    // gilt family is no longer read here (#851); the ring is the practice's
+    // orange and the badge sits on the lifted surface.
+    expect(html).toContain("var(--faction-ua)");
     expect(html).toContain("var(--faction-ua-card-font)");
-    // The disc's own ring/badge tokens (still legacy --ua-*, #853 deletes them).
-    expect(html).toContain("var(--ua-gold)");
-    expect(html).toContain("var(--ua-paper-warm)");
+    expect(html).toContain("var(--faction-ua-lift)");
+    expect(html).not.toContain("var(--ua-gold)");
     // The sigil badge is present — the ensō's heavy sweep (#849 retired the
     // gilt shield, so the 100x120 viewBox marker is gone with it).
     expect(html).toContain('d="M134 41.2 A68 68 0 1 1 66 158.8"');

--- a/frontend/src/components/backdrop/UaBackdrop.tsx
+++ b/frontend/src/components/backdrop/UaBackdrop.tsx
@@ -14,8 +14,8 @@ import { UaSigil } from '../cards/UaSigil'
  * neutral page keeps the global rainbow watercolour — never theme a mixed page
  * to one faction — and the dispatcher, not this file, makes that call.
  *
- * Both themes come from the `[data-theme="dark"]` cascade. The gilt wall and
- * its ledger dot-grid are gone, and so is the always-light ruling behind them.
+ * Both themes come from the `[data-theme="dark"]` cascade. The gilt wall, its
+ * ledger dot-grid and the ruling that kept them undimmed are all gone.
  */
 export default function UaBackdrop() {
   return (

--- a/frontend/src/components/backdrop/UaBackdrop.tsx
+++ b/frontend/src/components/backdrop/UaBackdrop.tsx
@@ -1,29 +1,51 @@
-import type { CSSProperties } from 'react'
+import UaMandala from '../cards/UaMandala'
+import { UaSigil } from '../cards/UaSigil'
 
 /**
- * UA full-page backdrop — the gilt salon: a parchment wall (`--ua-wall`) lit by
- * a low gilt glow from the corners and overlaid with a faint ledger dot-grid.
- * UA is always-light: its `--ua-*` / `--faction-ua-*` tokens are identical in
- * both themes, so this never flips with data-theme. Fixed behind page content
- * at z-index 0.
+ * UA page backdrop — mesa sand (kit §10, #851).
+ *
+ * The ground is one flat token, `--faction-ua-page`, with two figures bled off
+ * opposite corners: the mandala at TEXTURE strength and one ensō. Both sit at
+ * 6-8% so unrelated content can be read straight through them — the backdrop's
+ * whole job is to be felt and not seen. That is the second of the mandala's
+ * three strengths (brief §5); full strength belongs to the vote control alone.
+ *
+ * It themes a page only when UA is that page's single context. A mixed or
+ * neutral page keeps the global rainbow watercolour — never theme a mixed page
+ * to one faction — and the dispatcher, not this file, makes that call.
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade. The gilt wall and
+ * its ledger dot-grid are gone, and so is the always-light ruling behind them.
  */
-const backdropStyle: CSSProperties = {
-  position: 'fixed',
-  inset: 0,
-  zIndex: 0,
-  pointerEvents: 'none',
-  backgroundColor: 'var(--ua-wall)',
-  backgroundImage: [
-    // low gilt glow — top-left origin (old gold, light)
-    'radial-gradient(70% 50% at 8% 0%, color-mix(in srgb, var(--ua-gold-lt) 7%, transparent), transparent 70%)',
-    // burnt-amber echo — top-right
-    'radial-gradient(60% 50% at 100% 8%, color-mix(in srgb, var(--ua-orange) 6%, transparent), transparent 70%)',
-    // faint ledger dot-grid (gilt ink)
-    'radial-gradient(color-mix(in srgb, var(--ua-gold) 5%, transparent) 1px, transparent 1px)',
-  ].join(', '),
-  backgroundSize: 'auto, auto, 6px 6px',
-}
-
 export default function UaBackdrop() {
-  return <div style={backdropStyle} aria-hidden="true" />
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 0,
+        pointerEvents: 'none',
+        overflow: 'hidden',
+        backgroundColor: 'var(--faction-ua-page)',
+      }}
+    >
+      {/* mandala, bled off the lower right */}
+      <UaMandala
+        size={620}
+        strength="texture"
+        opacity={0.07}
+        rings={4}
+        petalsPerRing={16}
+        rotation={-9}
+        style={{ position: 'absolute', right: -180, bottom: -210 }}
+      />
+      {/* the mark, bled off the upper left */}
+      <span
+        style={{ position: 'absolute', left: -130, top: -120, opacity: 0.06 }}
+      >
+        <UaSigil width={420} height={420} />
+      </span>
+    </div>
+  )
 }

--- a/frontend/src/components/cards/FactionSelectCard.tsx
+++ b/frontend/src/components/cards/FactionSelectCard.tsx
@@ -2,6 +2,8 @@ import i18n from "../../i18n";
 import { pickVariant } from "../../utils/factionDispatch";
 import { surfaceMap } from "../../factions";
 import { UaSigil } from "./UaSigil";
+import UaMandala from "./UaMandala";
+import { UA_DISPLAY, UA_EYEBROW, UA_TEXT, uaShade } from "./uaAtoms";
 import { CovenSigil } from "./CovenSigil";
 import { SnideSigil } from "../snide/snideAtoms";
 import { EphemeristsSigil } from "./ephemeristsAtoms";
@@ -45,43 +47,64 @@ export interface FactionSelectCardProps {
 
 // ─── Per-faction archetypes ───────────────────────────────────────────────────
 
+/**
+ * UA join card — a quiet invitation, not a sales pitch (kit §4, #851).
+ *
+ * The crest band carries the ensō over the mandala at TEXTURE strength — one of
+ * the three surfaces the pattern is allowed on (brief §5). Everything below is
+ * centred, sentence-case and hairline-ruled. The gilt double border, the gold
+ * rule and the ghost-outline CTA went with the salon.
+ */
 export function UaSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.ua.status.${state}` as const);
   return (
     <div style={{
       width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
-      background: "var(--ua-paper)", color: "var(--ua-ink)", fontFamily: "var(--font-body)",
-      border: "1px solid var(--ua-line)", boxShadow: "0 6px 24px rgba(61,36,16,0.12)",
+      background: "linear-gradient(160deg, var(--faction-ua-lift), var(--faction-ua-card-bg) 60%)",
+      color: "var(--faction-ua-card-text)", fontFamily: UA_TEXT,
+      border: "1px solid var(--faction-ua-rule)", borderRadius: "var(--radius-md)",
+      boxShadow: `0 12px 34px -20px ${uaShade(55)}`,
       display: "flex", flexDirection: "column",
     }}>
-      <div style={{ position: "absolute", inset: 6, border: "2px solid var(--ua-gold)", pointerEvents: "none" }} />
-      <div style={{ position: "absolute", inset: 9, border: "1px solid var(--ua-line-soft)", pointerEvents: "none" }} />
-      <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0", display: "flex", flexDirection: "column" }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-          <div>
-            <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: "var(--text-base)", letterSpacing: "0.32em", color: "var(--ua-gold)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.ua.masthead")}</div>
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: gilt-placard wordmark — display type at 0.9 leading, the UA archetype's voice */}
-            <div style={{ fontFamily: "var(--font-faction-gilt)", fontStyle: "italic", fontWeight: 800, fontSize: 52, lineHeight: 0.9, letterSpacing: "0.01em", marginTop: "var(--space-sm)" }}>{i18n.t("feed:factionSelect.ua.wordmark")}</div>
-            <div style={{ fontFamily: "var(--font-faction-engraved-caps)", fontSize: "var(--text-lg)", letterSpacing: "0.24em", color: "var(--ua-sub)", textTransform: "uppercase", marginTop: "var(--space-xs)" }}>{i18n.t("feed:factionSelect.ua.subtitle")}</div>
-          </div>
-          <UaSigil width={44} height={53} />
-        </div>
-        <div style={{ height: 2, background: "var(--ua-gilt)", margin: "var(--space-lg) 0 var(--space-md)", opacity: 0.85 }} />
-        <p className="content-text" style={{ margin: 0, fontFamily: "var(--font-faction-gilt)", fontStyle: "italic", lineHeight: 1.4, color: "var(--ua-ink)" }}>
+      {/* crest band — the mark over the pattern */}
+      <div style={{
+        position: "relative", height: 132, display: "flex", alignItems: "center", justifyContent: "center",
+        background: "var(--faction-ua-panel)", borderBottom: "1px solid var(--faction-ua-hair)", overflow: "hidden",
+      }}>
+        <UaMandala
+          size={300}
+          strength="texture"
+          opacity={0.16}
+          rings={4}
+          petalsPerRing={14}
+          style={{ position: "absolute", left: "50%", top: "52%", transform: "translate(-50%, -50%)" }}
+        />
+        <span style={{ position: "relative" }}><UaSigil width={96} height={96} /></span>
+      </div>
+
+      <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0", textAlign: "center" }}>
+        <div style={{ ...UA_EYEBROW, letterSpacing: "0.24em" }}>{i18n.t("feed:factionSelect.ua.masthead")}</div>
+        <div style={{ fontFamily: UA_DISPLAY, fontWeight: 600, fontSize: "var(--text-display)", lineHeight: 1, letterSpacing: "-0.01em", marginTop: "var(--space-sm)" }}>{i18n.t("feed:factionSelect.ua.wordmark")}</div>
+        {/* #850 made the subtitle a full sentence. A sentence cannot be set in
+            0.24em all-caps, so it takes the display cut here rather than the
+            kicker treatment it inherited. */}
+        <div style={{ fontFamily: UA_DISPLAY, fontWeight: 600, fontSize: "var(--text-title)", lineHeight: 1.1, marginTop: "var(--space-sm)" }}>{i18n.t("feed:factionSelect.ua.subtitle")}</div>
+        <p className="content-text" style={{ margin: "var(--space-md) 0 0", fontFamily: UA_TEXT, lineHeight: 1.55, color: "var(--faction-ua-card-body)" }}>
           {i18n.t("feed:factionSelect.ua.blurb")}
         </p>
       </div>
-      <div style={{ position: "relative", padding: "0 var(--space-xl) var(--space-lg)" }}>
-        <div style={{ fontSize: "var(--text-base)", letterSpacing: "0.04em", color: "var(--ua-sub)", marginBottom: "var(--space-md)" }}>
-          {status}{members != null && <> · <span style={{ color: "var(--ua-muted)" }}>{i18n.t("feed:factionSelect.ua.members", { count: members })}</span></>}
+      <div style={{ position: "relative", padding: "var(--space-lg) var(--space-xl)", textAlign: "center" }}>
+        <div style={{ fontFamily: UA_TEXT, fontSize: "var(--text-content)", color: "var(--faction-ua-card-muted)", marginBottom: "var(--space-md)" }}>
+          {status}{members != null && <> · <span>{i18n.t("feed:factionSelect.ua.members", { count: members })}</span></>}
         </div>
         <button onClick={onVisit} style={{
-          width: "100%", cursor: "pointer", border: "1px solid var(--ua-gold)", background: "transparent",
-          color: "var(--ua-orange)", fontFamily: "var(--font-faction-engraved-caps)", fontSize: "var(--text-xl)", letterSpacing: "0.18em",
-          textTransform: "uppercase", padding: "var(--space-md)", transition: "background 140ms, color 140ms",
+          width: "100%", cursor: "pointer", border: "none", borderRadius: "var(--radius-sm)",
+          background: "var(--faction-ua)", color: "var(--faction-ua-on-fill)",
+          fontFamily: UA_TEXT, fontSize: "var(--text-xl)", letterSpacing: "0.14em",
+          textTransform: "uppercase", padding: "var(--space-md)", transition: "background 140ms",
         }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = "var(--ua-orange)"; e.currentTarget.style.color = "var(--ua-paper)"; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--ua-orange)"; }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = "var(--faction-ua-card-accent)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = "var(--faction-ua)"; }}
         >{i18n.t("feed:factionSelect.ua.cta")}</button>
       </div>
     </div>

--- a/frontend/src/components/cards/UaFactionHero.tsx
+++ b/frontend/src/components/cards/UaFactionHero.tsx
@@ -1,44 +1,25 @@
 import type { FactionHeroProps } from "../../pages/FactionDetail";
 import i18n from "../../i18n";
-import { UaSigil, MottoRibbon } from "./UaSigil";
+import { UaSigil } from "./UaSigil";
+import UaMandala from "./UaMandala";
+import { UA_DISPLAY, UA_EYEBROW, UA_TEXT } from "./uaAtoms";
 
 /**
- * UA (University of Asthmatics) faction-page hero — a gilt-salon frontispiece.
- * The masthead reads as an art-academy museum plate: a gold museum frame
- * (--ua-gilt) around a parchment field, a heraldic crest, a regal serif
- * wordmark, a Latin motto cartouche, and the three counts engraved as salon
- * regalia. The regalia wording lives in the copy catalog
- * (feed:factionHero.ua.stats.*), not here. Ported from the UA design kit
- * (UaTaskDetail hero / ua.css); conforms to {@link FactionHeroProps}.
+ * UA faction-page hero (kit §13, #851).
  *
- * UA is ALWAYS LIGHT: its --faction-ua-* / --ua-* tokens are identical in both
- * themes, so the salon styles itself with them and never dims — it does not
- * mutate data-theme.
+ * A wash of sand with the ensō beside the wordmark and the mandala bled off the
+ * top-right at TEXTURE strength — the faction hero is one of the three surfaces
+ * the pattern is allowed on (brief §5). The three counts sit in a hairline-ruled
+ * strip beneath, not as engraved regalia stacked in a side column.
  *
- * The page passes raw counts; the salon labels them in its own regal voice.
- * Motto + full name are faction constants (not backend fields).
+ * The gilt museum frame, the gold leaf, the dot grid and the Latin motto ribbon
+ * are gone. So is the always-light ruling: both themes come from the
+ * `[data-theme="dark"]` cascade.
+ *
+ * The page passes raw counts; the practice supplies its own labels from the
+ * copy catalog (feed:factionHero.ua.stats.*), per ADR-0016 — presentation only,
+ * no new fields.
  */
-
-// Token shorthands — every value resolves to a --ua-* / --faction-ua-* var.
-const GILT = "var(--ua-gilt)";
-const PAPER = "var(--faction-ua-card-bg)"; // parchment sheet
-const INK = "var(--faction-ua-card-text)"; // brown ink — all text
-const ACCENT = "var(--faction-ua-card-accent)"; // burnt amber
-const SUB = "var(--faction-ua-card-muted)"; // secondary serif
-const MUTED = "var(--ua-muted)"; // mono / metadata labels
-const GOLD = "var(--ua-gold)";
-const GOLD_PALE = "var(--ua-gold-pale)";
-const LINE = "var(--ua-line)"; // hairline borders
-
-// Regal serif faces. The display face is the UA card-font token (a loaded
-// serif); engraved regalia labels fall back to Georgia serif.
-const DISPLAY = "var(--faction-ua-card-font)";
-const ENGRAVED = 'var(--faction-ua-body-font)';
-
-// color-mix helper for shades with no dedicated token.
-const ink = (pct: number): string =>
-  `color-mix(in srgb, ${INK} ${pct}%, transparent)`;
-
 export default function UaFactionHero({
   name,
   description,
@@ -46,7 +27,6 @@ export default function UaFactionHero({
   tasks,
   praxes,
 }: FactionHeroProps) {
-  // The salon engraves its own counts — page passes raw numbers only.
   const stats = [
     { value: members, label: i18n.t("feed:factionHero.ua.stats.members") },
     { value: tasks, label: i18n.t("feed:factionHero.ua.stats.tasks") },
@@ -55,151 +35,110 @@ export default function UaFactionHero({
 
   return (
     <header style={{ marginBottom: "var(--space-2xl)" }}>
-      {/* gilt museum frame — outer leaf */}
       <div
         style={{
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: the padding IS the outer gilt leaf width; rounding reflows the museum frame.
-          padding: 11,
-          background: GILT,
-          boxShadow:
-            "0 18px 40px rgba(60,40,10,0.28), inset 0 0 0 1px rgba(255,255,255,0.45)",
+          border: "1px solid var(--faction-ua-rule)",
+          borderRadius: "var(--radius-lg)",
+          overflow: "hidden",
+          background: "var(--faction-ua-card-bg)",
         }}
       >
-        {/* inner gold leaf */}
+        {/* ── the plate ── */}
         <div
           style={{
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: the padding IS the inner gold leaf width; rounding reflows the museum frame.
-            padding: 5,
-            background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
+            position: "relative",
+            overflow: "hidden",
+            background:
+              "linear-gradient(160deg, var(--faction-ua-lift), var(--faction-ua-panel))",
+            borderBottom: "1px solid var(--faction-ua-hair)",
+            padding: "var(--space-3xl) var(--space-2xl)",
           }}
         >
-          {/* parchment plate */}
+          <UaMandala
+            size={420}
+            strength="texture"
+            opacity={0.14}
+            rings={4}
+            petalsPerRing={16}
+            rotation={11}
+            style={{ position: "absolute", right: -140, top: -150 }}
+          />
           <div
             style={{
               position: "relative",
-              overflow: "hidden",
-              border: `1px solid ${ink(45)}`,
-              background: PAPER,
-              backgroundImage: `radial-gradient(${ink(3)} 1px, transparent 1px)`,
-              backgroundSize: "5px 5px",
-              padding: "var(--space-2xl) var(--space-3xl) var(--space-2xl)",
               display: "flex",
               flexWrap: "wrap",
-              gap: "var(--space-2xl)",
               alignItems: "center",
+              gap: "var(--space-xl)",
             }}
           >
-            <UaSigil width={150} height={180} />
-
+            <UaSigil width={96} height={96} />
             <div style={{ flex: 1, minWidth: 260 }}>
-              {/* engraved house line */}
-              <div
-                style={{
-                  fontFamily: ENGRAVED,
-                  fontSize: "var(--text-md)",
-                  letterSpacing: "0.16em",
-                  textTransform: "uppercase",
-                  color: ACCENT,
-                  marginBottom: "var(--space-xs)",
-                }}
-              >
-                {i18n.t("feed:identity.ua.fullName")}
-              </div>
-              {/* eyebrow — engraved metadata */}
-              <div
-                style={{
-                  fontFamily: ENGRAVED,
-                  fontSize: "var(--text-xs)",
-                  letterSpacing: "0.3em",
-                  textTransform: "uppercase",
-                  color: MUTED,
-                  marginBottom: "var(--space-lg)",
-                }}
-              >
+              <div style={UA_EYEBROW}>
                 {i18n.t("feed:factionHero.ua.eyebrow")}
               </div>
-
-              {/* regal wordmark */}
               <h1
                 style={{
-                  fontFamily: DISPLAY,
-                  fontStyle: "italic",
-                  fontWeight: 700,
-                  // eslint-disable-next-line local/no-raw-style-values -- ornament: gilt regal wordmark — the UA hero's display type
-                  fontSize: 54,
-                  lineHeight: 1.04,
-                  letterSpacing: "0.01em",
-                  margin: "0 0 var(--space-lg)",
-                  color: INK,
+                  fontFamily: UA_DISPLAY,
+                  fontWeight: 600,
+                  fontSize: "var(--text-display)",
+                  lineHeight: 1.02,
+                  letterSpacing: "-0.01em",
+                  color: "var(--faction-ua-card-text)",
+                  margin: "var(--space-xs) 0 var(--space-sm)",
                   overflowWrap: "anywhere",
                 }}
               >
                 {name}
               </h1>
-
-              {/* motto cartouche */}
-              <div style={{ marginBottom: "var(--space-lg)" }}>
-                <MottoRibbon />
-              </div>
-
-              {/* statement */}
               <p
                 className="content-text"
                 style={{
-                  fontFamily: DISPLAY,
-                  fontStyle: "italic",
-                  lineHeight: 1.7,
-                  color: SUB,
-                  maxWidth: 560,
-                  margin: "0 0 var(--space-xl)",
+                  fontFamily: UA_TEXT,
+                  lineHeight: 1.5,
+                  color: "var(--faction-ua-card-body)",
+                  maxWidth: 520,
+                  margin: 0,
                 }}
               >
                 {description ??
                   i18n.t("feed:factionHero.ua.descriptionFallback")}
               </p>
-
-            </div>
-
-            {/* stats on the side — engraved regalia stacked in a side column */}
-            <div style={{ flexShrink: 0, width: 168, display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
-              {stats.map((s) => (
-                <div
-                  key={s.label}
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "baseline",
-                    borderTop: `1px solid ${LINE}`,
-                    paddingTop: "var(--space-sm)",
-                  }}
-                >
-                  <span
-                    style={{
-                      fontFamily: ENGRAVED,
-                      fontSize: "var(--text-xs)",
-                      letterSpacing: "0.12em",
-                      textTransform: "uppercase",
-                      color: MUTED,
-                    }}
-                  >
-                    {s.label}
-                  </span>
-                  <span
-                    className="content-title"
-                    style={{
-                      fontFamily: DISPLAY,
-                      fontStyle: "italic",
-                      fontWeight: 700,
-                      lineHeight: 1,
-                      color: ACCENT,
-                    }}
-                  >
-                    {s.value}
-                  </span>
-                </div>
-              ))}
             </div>
           </div>
+        </div>
+
+        {/* ── the counts ── */}
+        <div style={{ display: "flex", flexWrap: "wrap" }}>
+          {stats.map((stat, index) => (
+            <div
+              key={stat.label}
+              style={{
+                flex: "1 1 120px",
+                minWidth: 120,
+                padding: "var(--space-lg) var(--space-xl)",
+                borderRight:
+                  index === stats.length - 1
+                    ? undefined
+                    : "1px solid var(--faction-ua-hair)",
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: UA_DISPLAY,
+                  fontWeight: 600,
+                  fontSize: "var(--text-title)",
+                  lineHeight: 1,
+                  color: "var(--faction-ua-card-text)",
+                }}
+              >
+                {stat.value}
+              </div>
+              <div style={{ ...UA_EYEBROW, marginTop: "var(--space-xs)" }}>
+                {stat.label}
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </header>

--- a/frontend/src/components/cards/UaFactionHero.tsx
+++ b/frontend/src/components/cards/UaFactionHero.tsx
@@ -13,8 +13,8 @@ import { UA_DISPLAY, UA_EYEBROW, UA_TEXT } from "./uaAtoms";
  * strip beneath, not as engraved regalia stacked in a side column.
  *
  * The gilt museum frame, the gold leaf, the dot grid and the Latin motto ribbon
- * are gone. So is the always-light ruling: both themes come from the
- * `[data-theme="dark"]` cascade.
+ * are gone, and so is the ruling that kept this surface undimmed: both themes
+ * come from the `[data-theme="dark"]` cascade.
  *
  * The page passes raw counts; the practice supplies its own labels from the
  * copy catalog (feed:factionHero.ua.stats.*), per ADR-0016 — presentation only,

--- a/frontend/src/components/cards/UaTaskCard.tsx
+++ b/frontend/src/components/cards/UaTaskCard.tsx
@@ -2,21 +2,37 @@ import { Link } from "react-router-dom";
 import type { TaskOut } from "../../api/tasks";
 import i18n from "../../i18n";
 import LevelGem from "../ui/LevelGem";
-import { UaSigil, MottoRibbon } from "./UaSigil";
+import {
+  UA_DISPLAY,
+  UA_EYEBROW,
+  UA_HAIRLINE,
+  UA_TEXT,
+  UaEnsoScore,
+  UaInkColumn,
+  uaShade,
+} from "./uaAtoms";
 
 /**
- * UA — Gilt salon crest placard (the University of Asthmatics archetype).
- * A gold-framed acquisition plate on the salon wall, center-composed around the
- * heraldic crest: masthead ("University of Asthmatics · EST · MMXX"), motto
- * ribbon, Cormorant-italic title, and a "Matriculate" sign-up affordance. The
- * crest + motto are shared with UaFactionHero (see UaSigil.tsx), not re-drawn.
- * All colors via --ua-* tokens (never hardcode hex — CLAUDE.md); the salon is
- * always-light, so tokens read identically in both themes.
+ * UA task card — THE INK COLUMN (kit §1 "3a", the reference surface for the
+ * whole UA redesign, #851).
+ *
+ * A sheet of sun-bleached stock with a single hairline of orange running down
+ * the left margin and the task's marks held in an ensō at the head. That is
+ * the entire ornament budget: no gilt sandwich, no rotation, no dot grid, no
+ * motto ribbon, no crest.
+ *
+ * The mandala is deliberately ABSENT here (brief §5). A task card lives in a
+ * list — dense, text-heavy, read in bulk — and the pattern is reserved for the
+ * three surfaces that can afford it. The kit draws a lotus corner-bleed on this
+ * card; the brief's strength ruling supersedes it, and the brief is the
+ * contract.
+ *
+ * The level indicator is the shared {@link LevelGem}, tinted via
+ * `factionCssVar` — tint only, no bespoke UA shape (brief §9).
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade. Nothing here is
+ * always-light any more.
  */
-
-const REGALIA = "var(--faction-ua-body-font)";
-const DISPLAY = "var(--faction-ua-card-font)";
-const SERIF = "'EB Garamond', serif";
 
 interface Props {
   task: TaskOut;
@@ -26,121 +42,98 @@ interface Props {
 
 export default function UaTaskCard({ task, displayPoints, onSignup }: Props) {
   return (
-    // Gilt frame: gold-leaf gradient border, then the parchment plate, hung with
-    // a slight rotation like a plate on the salon wall.
-    <div
+    <article
       style={{
+        position: "relative",
+        overflow: "hidden",
         minWidth: 240,
         maxWidth: 282,
         flex: "0 1 264px",
-        padding: "var(--space-xs)",
-        background: "var(--ua-gilt)",
-        transform: "rotate(-0.6deg)",
-        boxShadow:
-          "0 10px 22px color-mix(in srgb, var(--ua-ink) 20%, transparent), inset 0 0 0 1px color-mix(in srgb, white 40%, transparent)",
+        background: "var(--faction-ua-card-bg)",
+        color: "var(--faction-ua-card-text)",
+        border: UA_HAIRLINE,
+        borderRadius: "var(--radius-sm)",
+        boxShadow: `0 10px 30px -18px ${uaShade(50)}`,
+        padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
       }}
     >
-      <div
+      <UaInkColumn
         style={{
-          background: "var(--ua-paper)",
-          backgroundImage:
-            "radial-gradient(color-mix(in srgb, var(--ua-ink) 3%, transparent) 1px, transparent 1px)",
-          backgroundSize: "5px 5px",
-          border: "1px solid var(--ua-line-soft)",
-          padding: "var(--space-lg) var(--space-lg) var(--space-md)",
-          color: "var(--ua-ink)",
-          textAlign: "center",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
+          left: "var(--space-sm)",
+          top: "var(--space-xl)",
+          bottom: "var(--space-lg)",
         }}
-      >
-        {/* Crest */}
-        <UaSigil width={72} height={86} />
+      />
 
-        {/* Masthead */}
+      <div style={{ position: "relative", paddingLeft: "var(--space-lg)" }}>
+        <div style={UA_EYEBROW}>{i18n.t("feed:taskCard.ua.estLine")}</div>
+
+        {/* The score, in the ensō — the mark's one sanctioned use besides the
+            faction mark itself. */}
         <div
           style={{
-            fontFamily: REGALIA,
-            fontSize: "var(--text-base)",
-            letterSpacing: "0.16em",
-            textTransform: "uppercase",
-            color: "var(--ua-orange)",
-            marginTop: "var(--space-sm)",
+            display: "flex",
+            justifyContent: "center",
+            margin: "var(--space-lg) 0",
           }}
         >
-          {i18n.t("feed:identity.ua.fullName")}
+          <UaEnsoScore
+            size={96}
+            value={displayPoints}
+            unit={i18n.t("tasks:ua.stats.honoraria")}
+          />
         </div>
-        <div
-          style={{
-            fontFamily: REGALIA,
-            fontSize: "var(--text-xs)",
-            letterSpacing: "0.3em",
-            textTransform: "uppercase",
-            color: "var(--ua-muted)",
-            marginBottom: "var(--space-md)",
-          }}
-        >
-          {i18n.t("feed:taskCard.ua.estLine")}
-        </div>
-
-        {/* Motto ribbon */}
-        <MottoRibbon fontSize={9} padding="4px 18px" />
 
         <Link
           to={`/tasks/${task.id}`}
           style={{ textDecoration: "none", color: "inherit" }}
         >
-          <div
+          <h3
             className="content-title"
             style={{
-              fontFamily: DISPLAY,
-              fontStyle: "italic",
+              fontFamily: UA_DISPLAY,
               fontWeight: 600,
-              lineHeight: 1.2,
-              margin: "var(--space-md) 0 var(--space-sm)",
+              lineHeight: 1.14,
+              letterSpacing: "-0.005em",
+              color: "var(--faction-ua-card-text)",
+              margin: "0 0 var(--space-sm)",
               overflowWrap: "anywhere",
             }}
           >
             {task.title}
-          </div>
+          </h3>
         </Link>
 
         {task.description && (
-          <div
+          <p
             className="card-description"
-            style={{ fontFamily: SERIF, color: "var(--ua-sub)", marginBottom: "var(--space-xs)" }}
+            style={{
+              fontFamily: UA_TEXT,
+              lineHeight: 1.55,
+              color: "var(--faction-ua-card-body)",
+              margin: "0 0 var(--space-lg)",
+            }}
           >
             {task.description}
-          </div>
+          </p>
         )}
-
-        <div
-          style={{
-            fontFamily: REGALIA,
-            fontSize: "var(--text-sm)",
-            letterSpacing: "0.12em",
-            textTransform: "uppercase",
-            color: "var(--ua-gold)",
-            margin: "var(--space-sm) 0 var(--space-md)",
-          }}
-        >
-          {i18n.t("feed:taskCard.ua.pointsLine", { points: displayPoints })}
-        </div>
 
         {onSignup && (
           <button
             onClick={() => onSignup(task.id)}
-            className="btn-primary"
             style={{
-              fontFamily: REGALIA,
-              fontSize: "var(--text-base)",
+              width: "100%",
+              cursor: "pointer",
+              fontFamily: UA_TEXT,
+              fontSize: "var(--text-xl)",
               letterSpacing: "0.12em",
               textTransform: "uppercase",
-              padding: "var(--space-sm) var(--space-xl)",
-              marginBottom: "var(--space-md)",
-              background: "var(--ua-orange)",
-              border: "none",
+              padding: "var(--space-sm) var(--space-lg)",
+              marginBottom: "var(--space-lg)",
+              background: "var(--faction-ua-card-bg)",
+              color: "var(--faction-ua-card-accent)",
+              border: "1.5px solid var(--faction-ua)",
+              borderRadius: "var(--radius-sm)",
             }}
           >
             {i18n.t("feed:taskCard.ua.signup")}
@@ -149,25 +142,14 @@ export default function UaTaskCard({ task, displayPoints, onSignup }: Props) {
 
         <div
           className="card-footer"
-          style={{
-            width: "100%",
-            borderTop: "1px solid var(--ua-line-soft)",
-          }}
+          style={{ borderTop: UA_HAIRLINE, paddingTop: "var(--space-md)" }}
         >
           <LevelGem level={task.level_required} factionSlug="ua" />
-          <span
-            className="content-title"
-            style={{
-              fontFamily: DISPLAY,
-              fontStyle: "italic",
-              fontWeight: 700,
-              color: "var(--ua-orange)",
-            }}
-          >
-            {displayPoints}
+          <span style={{ ...UA_EYEBROW, letterSpacing: "0.16em" }}>
+            {i18n.t("feed:taskCard.ua.pointsLine", { points: displayPoints })}
           </span>
         </div>
       </div>
-    </div>
+    </article>
   );
 }

--- a/frontend/src/components/cards/UaTaskCard.tsx
+++ b/frontend/src/components/cards/UaTaskCard.tsx
@@ -30,8 +30,8 @@ import {
  * The level indicator is the shared {@link LevelGem}, tinted via
  * `factionCssVar` — tint only, no bespoke UA shape (brief §9).
  *
- * Both themes come from the `[data-theme="dark"]` cascade. Nothing here is
- * always-light any more.
+ * Both themes come from the `[data-theme="dark"]` cascade; the card dims
+ * with the app like every other faction's.
  */
 
 interface Props {

--- a/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
+++ b/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * UA desktop skin — rendered-output guard (#851).
+ *
+ * The whole UA redesign is a set of rulings that are invisible to tsc, eslint
+ * and the token-declared guard: which tokens a surface may read, where the
+ * mandala may appear, and what the ensō is reserved for. Each of those failed
+ * silently in the praxis-card wave, so they are asserted here on RENDERED
+ * markup rather than on registry contents (`renderToStaticMarkup` only — no
+ * jsdom, no testing-library, effects never run).
+ *
+ * The four heavy archetypes (task detail, faction body, edit-praxis, profile)
+ * need a whole page state to render and are covered by the source guard at the
+ * bottom plus their existing dispatch tests.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+
+// Initialize the catalog so copy keys resolve to English text.
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import type { CharacterOut } from '../../../api/auth'
+import type { TaskOut } from '../../../api/tasks'
+import UaTaskCard from '../UaTaskCard'
+import UaFactionHero from '../UaFactionHero'
+import { UaSelectCard } from '../FactionSelectCard'
+import UaFeedFrame from '../../feed/UaFeedFrame'
+import UaAvatar from '../../avatar/UaAvatar'
+import UaBackdrop from '../../backdrop/UaBackdrop'
+import UaComment from '../../comments/voices/UaComment'
+
+const SRC_DIR = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', '..')
+
+/** The ensō's heavy sweep — the one path that proves the mark is on a surface. */
+const ENSO_SWEEP = 'd="M134 41.2 A68 68 0 1 1 66 158.8"'
+
+const TASK: TaskOut = {
+  id: 12,
+  title: 'Render the old library façade in charcoal',
+  description: 'Draw only what the light is doing.',
+  point_value: 30,
+  level_required: 2,
+  status: 'active',
+  primary_faction_slug: 'ua',
+} as unknown as TaskOut
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'ada',
+  display_name: 'Ada Reed',
+  avatar_url: null,
+  faction_slug: 'ua',
+  bio: null,
+  location: null,
+  level: 2,
+  score: 0,
+  all_time_score: 0,
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+} as unknown as CharacterOut
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'The way you let the cornice dissolve.',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: 42,
+    username: 'ada',
+    display_name: 'Ada Reed',
+    avatar_url: null,
+    faction_slug: 'ua',
+  },
+  mentions: [],
+}
+
+function routed(node: React.ReactNode): string {
+  return renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>)
+}
+
+const taskCard = () =>
+  routed(<UaTaskCard task={TASK} displayPoints={30} onSignup={() => {}} />)
+const feedRow = () => routed(<UaFeedFrame><span>card-body</span></UaFeedFrame>)
+const comment = () =>
+  routed(<UaComment mode="row" comment={COMMENT} />)
+const composer = () =>
+  routed(
+    <UaComment
+      mode="composer"
+      character={CHARACTER}
+      value=""
+      onChange={() => {}}
+      onSubmit={() => {}}
+      submitting={false}
+    />,
+  )
+const hero = () =>
+  routed(
+    <UaFactionHero
+      name="University of Asthmatics"
+      description="One true mark, then another."
+      members={214}
+      tasks={9}
+      praxes={1489}
+    />,
+  )
+const joinCard = () => routed(<UaSelectCard state="eligible" members={214} />)
+const avatar = () => routed(<UaAvatar character={CHARACTER} />)
+const backdrop = () => renderToStaticMarkup(<UaBackdrop />)
+
+/** Every UA desktop surface that renders from props alone. */
+const SURFACES: Array<[string, () => string]> = [
+  ['task card', taskCard],
+  ['feed row', feedRow],
+  ['comment row', comment],
+  ['comment composer', composer],
+  ['faction hero', hero],
+  ['join card', joinCard],
+  ['avatar', avatar],
+  ['backdrop', backdrop],
+]
+
+describe('UA desktop skin — the salon is dead', () => {
+  it('reads no legacy --ua-* token on any surface', () => {
+    // The legacy gilt family survives until #853 deletes it, but nothing in the
+    // rebuilt skin may still be reading it. A missed reference does not fail
+    // the build — it renders as an unstyled element — so only markup catches it.
+    for (const [name, render] of SURFACES) {
+      expect(render(), `${name} still paints with the legacy family`).not.toMatch(
+        /var\(--ua-[a-z]/,
+      )
+    }
+  })
+
+  it('paints every surface from the --faction-ua-* family', () => {
+    for (const [name, render] of SURFACES) {
+      expect(render(), `${name} paints with no UA token at all`).toContain(
+        '--faction-ua',
+      )
+    }
+  })
+})
+
+describe('UA mandala strengths (brief §5)', () => {
+  // The mandala primitive draws lens petals; nothing else in the skin does.
+  const PETAL = /A \d+\.\d\d \d+\.\d\d 0 0 1/
+
+  it('carries the pattern on exactly the three surfaces that may have it', () => {
+    for (const [name, render] of [
+      ['backdrop', backdrop],
+      ['faction hero', hero],
+      ['join card', joinCard],
+    ] as const) {
+      expect(render(), `${name} lost its texture`).toMatch(PETAL)
+    }
+  })
+
+  it('renders NOTHING on the dense, text-heavy surfaces', () => {
+    // `absent` is a real strength, not a missing case: a task list, a feed row
+    // and a comment thread are read in bulk and stay clean.
+    for (const [name, render] of [
+      ['task card', taskCard],
+      ['feed row', feedRow],
+      ['comment row', comment],
+      ['comment composer', composer],
+    ] as const) {
+      expect(render(), `${name} grew a mandala`).not.toMatch(PETAL)
+    }
+  })
+})
+
+describe('the ensō is reserved for the score and the faction mark', () => {
+  it('draws the mark where it belongs', () => {
+    // Score: the task card's marks sit inside it. Faction mark: the avatar
+    // badge, the hero, the join card's crest band, the feed row's corner.
+    for (const [name, render] of [
+      ['task card score', taskCard],
+      ['avatar badge', avatar],
+      ['faction hero', hero],
+      ['join card', joinCard],
+      ['feed row', feedRow],
+      ['composer', composer],
+    ] as const) {
+      expect(render(), `${name} lost the ensō`).toContain(ENSO_SWEEP)
+    }
+  })
+
+  it('never draws it as a container border', () => {
+    // The mark spent as decoration is the failure this rule exists to stop: no
+    // surface may put the ensō in a border/outline declaration.
+    for (const [name, render] of SURFACES) {
+      expect(render(), `${name} outlined itself in the mark`).not.toMatch(
+        /border[^;"]*enso/i,
+      )
+    }
+  })
+})
+
+describe('the eleven rebuilt surfaces carry no salon left-overs', () => {
+  const REBUILT = [
+    'components/cards/UaTaskCard.tsx',
+    'components/cards/UaFactionHero.tsx',
+    'components/cards/uaAtoms.tsx',
+    'components/feed/UaFeedFrame.tsx',
+    'components/avatar/UaAvatar.tsx',
+    'components/backdrop/UaBackdrop.tsx',
+    'components/comments/voices/UaComment.tsx',
+    'pages/taskDetail/archetypes/UaTaskDetail.tsx',
+    'pages/factionDetail/archetypes/UaFactionBody.tsx',
+    'pages/editPraxis/archetypes/UaEditPraxis.tsx',
+    'pages/characterProfile/archetypes/UaProfileBody.tsx',
+  ]
+
+  it('reads no legacy --ua-* token, including in the four heavy archetypes', () => {
+    for (const file of REBUILT) {
+      const source = readFileSync(join(SRC_DIR, file), 'utf-8')
+      expect(source, `${file} still reads the legacy family`).not.toMatch(
+        /var\(--ua-[a-z]/,
+      )
+    }
+  })
+
+  it('keeps no ternary standing in for the dark cascade', () => {
+    // Dark mode is the [data-theme="dark"] cascade in index.css, never a
+    // `dark ? a : b` in a component.
+    for (const file of REBUILT) {
+      const source = readFileSync(join(SRC_DIR, file), 'utf-8')
+      expect(source, `${file} branches on the theme`).not.toMatch(
+        /\bdark\s*\?/,
+      )
+    }
+  })
+})

--- a/frontend/src/components/cards/uaAtoms.tsx
+++ b/frontend/src/components/cards/uaAtoms.tsx
@@ -1,0 +1,147 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import { UaSigil } from "./UaSigil";
+
+/**
+ * UA shared presentation atoms — the pieces every UA desktop surface repeats
+ * (#851, brief §1).
+ *
+ * THE SALON IS DEAD. UA is a quiet, sun-bleached practice with a real dark
+ * mode: two faces (a Cormorant display cut and an EB Garamond text cut), a
+ * wide-tracked uppercase eyebrow, a hairline, and the ensō carrying a score.
+ * Those five things are the whole vocabulary, so they live here rather than
+ * being re-typed with slightly different tracking on eleven surfaces.
+ *
+ * Every value is a token. Both themes come from the `[data-theme="dark"]`
+ * cascade in index.css — there is no ternary anywhere in the UA skin.
+ */
+
+/** Headline cut — Cormorant Garamond. Titles, numerals, names. Never italic. */
+export const UA_DISPLAY = "var(--faction-ua-card-font)";
+/** Text cut — EB Garamond. Body copy, labels, metadata. */
+export const UA_TEXT = "var(--faction-ua-body-font)";
+
+/**
+ * The eyebrow — small, uppercase, widely tracked, quiet.
+ *
+ * The one label shape UA has. It replaces the salon's four competing regalia
+ * treatments (engraved caps, mono kicker, gold small-caps, italic slug), which
+ * is most of why the old skin read as loud.
+ */
+export const UA_EYEBROW: CSSProperties = {
+  fontFamily: UA_TEXT,
+  fontSize: "var(--text-md)",
+  letterSpacing: "0.22em",
+  textTransform: "uppercase",
+  color: "var(--faction-ua-card-muted)",
+};
+
+/** The same label in the accent, for a section head that must lead the eye. */
+export const UA_EYEBROW_ACCENT: CSSProperties = {
+  ...UA_EYEBROW,
+  color: "var(--faction-ua-card-accent)",
+};
+
+/**
+ * A drop shadow mixed from the ink token rather than a raw rgba.
+ *
+ * The kit shadows with `rgba(20,12,6,.x)`, which is a light-mode value: on the
+ * dark ground it is invisible where it should be deepest. Mixing from
+ * `--faction-ua-card-text` inverts with the theme for free.
+ */
+export function uaShade(percent: number): string {
+  return `color-mix(in srgb, var(--faction-ua-card-text) ${percent}%, transparent)`;
+}
+
+/** The neutral hairline, as a border shorthand. */
+export const UA_HAIRLINE = "1px solid var(--faction-ua-rule)";
+
+/**
+ * The ensō carrying a number.
+ *
+ * The mark is reserved for the SCORE and the FACTION MARK (brief §4) — this is
+ * the score half. The circle is drawn once in {@link UaSigil}; this atom only
+ * centres a numeral and its unit inside it.
+ *
+ * Sizes are raw px because they are ornament geometry, not type or spacing:
+ * the numeral scales with the circle, and the circle is a drawn figure.
+ */
+export function UaEnsoScore({
+  size,
+  value,
+  unit,
+  valueColor = "var(--faction-ua-card-text)",
+}: {
+  size: number;
+  value: ReactNode;
+  /** The unit word under the numeral. Omit for a bare mark. */
+  unit?: string;
+  valueColor?: string;
+}) {
+  return (
+    <span
+      style={{
+        position: "relative",
+        display: "inline-block",
+        width: size,
+        height: size,
+        flexShrink: 0,
+      }}
+    >
+      <UaSigil width={size} height={size} />
+      <span
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          lineHeight: 0.9,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: UA_DISPLAY,
+            fontWeight: 600,
+            fontSize: "var(--text-heading)",
+            lineHeight: 0.9,
+            color: valueColor,
+          }}
+        >
+          {value}
+        </span>
+        {unit && (
+          <span style={{ ...UA_EYEBROW, fontSize: "var(--text-sm)" }}>
+            {unit}
+          </span>
+        )}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * The ink column — a hairline of UA orange running down the left of a surface,
+ * fading out at both ends.
+ *
+ * The task card's signature (kit §1, "3a Ink Column") and the one piece of
+ * chrome that carries the faction on a surface too dense for the mandala.
+ * Absolutely positioned: the caller owns the padding it sits inside.
+ */
+export function UaInkColumn({ style }: { style?: CSSProperties }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        width: 2,
+        background:
+          "linear-gradient(180deg, transparent, var(--faction-ua) 12%, var(--faction-ua) 88%, transparent)",
+        opacity: 0.34,
+        pointerEvents: "none",
+        ...style,
+      }}
+    />
+  );
+}

--- a/frontend/src/components/comments/voices/UaComment.tsx
+++ b/frontend/src/components/comments/voices/UaComment.tsx
@@ -1,104 +1,157 @@
 import { Link } from 'react-router-dom'
-import type { ReactNode } from 'react'
+import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
+import { UaSigil } from '../../cards/UaSigil'
+import { UA_DISPLAY, UA_TEXT } from '../../cards/uaAtoms'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 import { CommentFlagControl } from '../FlagControl'
 
 /**
- * UA — University of Asthmatics. The gilt salon (ADR-0026, superseding
- * ADR-0018's comment-scoped orange letterhead): a gold museum-frame around a
- * parchment plate, EB-Garamond small-caps house line, Cormorant-italic body. Mirrors
- * UaFeedFrame / UaPraxisDetail; all colors via --ua-* tokens (no hex — CLAUDE.md).
- * UA is always-light, so tokens read identically in both themes.
+ * UA comment — THE MARGINAL NOTE (kit §14, #851).
+ *
+ * SUPERSEDES ADR-0026's gilt salon. A UA comment is now a note written in the
+ * margin of the work: rag paper, one dashed orange rule down the left edge, an
+ * ensō on the composer, and nothing else. No gold-leaf frame, no house line, no
+ * ornament. The mandala is ABSENT — a comment thread is the densest text
+ * surface in the app (brief §5).
+ *
+ * The three invariant slots are unchanged (ADR-0016): author identity · body ·
+ * timestamp+edited. A posted row takes the AUTHOR's faction; the composer takes
+ * the current character's.
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade. The salon that never
+ * dimmed is gone.
  */
-const GILT = 'var(--ua-gilt)'
-const PAPER = 'var(--ua-paper)'
-const PAPER_WARM = 'var(--ua-paper-warm)'
-const INK = 'var(--ua-ink)'
-const ORANGE = 'var(--ua-orange)'
-const SUB = 'var(--ua-sub)'
-const SERIF = "var(--faction-ua-card-font)"
-const LABEL = "var(--faction-ua-body-font)"
 
-/** Gilt museum frame — gold-leaf border around the parchment plate. */
-function GiltFrame({ children, gap }: { children: ReactNode; gap: string }) {
-  return (
-    <div
-      style={{
-        background: GILT,
-        // eslint-disable-next-line local/no-raw-style-values -- ornament: this inset *is* the gold-leaf border drawn around the parchment plate, not spacing
-        padding: 3,
-        borderRadius: 6,
-        boxShadow: 'inset 0 0 0 1px color-mix(in srgb, white 40%, transparent)',
-      }}
-    >
-      <div
-        style={{
-          background: PAPER,
-          color: INK,
-          border: '1px solid var(--ua-line-soft)',
-          borderRadius: 4,
-          padding: 'var(--space-md) var(--space-lg)',
-          display: 'flex',
-          gap,
-          alignItems: 'flex-start',
-        }}
-      >
-        {children}
-      </div>
-    </div>
-  )
+/** The margin — a dashed orange rule down the left of the note. */
+function note(active: boolean): CSSProperties {
+  return {
+    display: 'flex',
+    gap: 'var(--space-lg)',
+    alignItems: 'flex-start',
+    padding: 'var(--space-lg) var(--space-lg)',
+    borderRadius: 'var(--radius-sm)',
+    border: active
+      ? '1px solid var(--faction-ua)'
+      : '1px solid var(--faction-ua-rule)',
+    borderLeft: '2px dashed var(--faction-ua)',
+    background: active
+      ? 'var(--faction-ua-lift)'
+      : 'var(--faction-ua-card-bg)',
+    color: 'var(--faction-ua-card-text)',
+  }
 }
 
 export default function UaComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
   if (props.mode === 'composer') {
-    const { character, value, onChange, onSubmit, submitting } = props
+    const { value, onChange, onSubmit, submitting } = props
     return (
-      <GiltFrame gap="var(--space-md)">
-        <FactionAvatar character={character} size="sm" />
-        <div style={{ flex: 1 }}>
-          <div style={{ fontFamily: LABEL, fontSize: 'var(--text-base)', letterSpacing: '0.14em', textTransform: 'uppercase', color: ORANGE, marginBottom: 'var(--space-sm)' }}>
-            {t('comments.ua.house')}
+      <div style={note(true)}>
+        {/* The mark stands in for the portrait on the composer, as the kit
+            draws it: you are writing in the practice's margin, not signing.
+            The three invariant slots (ADR-0016) belong to the posted row. */}
+        <span aria-hidden="true" style={{ flexShrink: 0 }}>
+          <UaSigil width={38} height={38} />
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontFamily: UA_TEXT,
+              fontSize: 'var(--text-content)',
+              fontStyle: 'italic',
+              color: 'var(--faction-ua-card-muted)',
+              marginBottom: 'var(--space-md)',
+            }}
+          >
+            {t('comments.ua.prompt')}
           </div>
-          <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent={ORANGE} bg={PAPER_WARM} text={INK} />
+          <ComposerControls
+            value={value}
+            onChange={onChange}
+            onSubmit={onSubmit}
+            submitting={submitting}
+            accent="var(--faction-ua-card-accent)"
+            bg="var(--faction-ua-panel)"
+            text="var(--faction-ua-card-text)"
+          />
         </div>
-      </GiltFrame>
+      </div>
     )
   }
+
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
-    <GiltFrame gap="var(--space-lg)">
+    <div style={note(false)}>
       <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontFamily: LABEL, fontSize: 'var(--text-base)', letterSpacing: '0.14em', textTransform: 'uppercase', color: ORANGE }}>
-          {t('comments.ua.house')}
-        </div>
-        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 'var(--space-md)' }}>
-          <Link to={`/characters/${comment.author.id}`} style={{ fontFamily: SERIF, fontStyle: 'italic', fontWeight: 600, fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'space-between',
+            gap: 'var(--space-md)',
+          }}
+        >
+          <Link
+            to={`/characters/${comment.author.id}`}
+            style={{
+              fontFamily: UA_DISPLAY,
+              fontWeight: 600,
+              fontSize: 'var(--text-content)',
+              color: 'var(--faction-ua-card-text)',
+              textDecoration: 'none',
+            }}
+          >
             {comment.author.display_name}
           </Link>
-          <span style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 'var(--text-lg)', color: SUB, whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
+          <span
+            style={{
+              fontFamily: UA_TEXT,
+              fontSize: 'var(--text-lg)',
+              color: 'var(--faction-ua-card-muted)',
+              whiteSpace: 'nowrap',
+              display: 'inline-flex',
+              alignItems: 'baseline',
+              gap: 'var(--space-sm)',
+            }}
+          >
             {formatCommentTime(slug, comment.created_at)}
             {comment.is_edited ? ` · ${t('comments.ua.edited')}` : ''}
             <OwnerControls owner={owner} />
             <CommentFlagControl comment={comment} />
           </span>
         </div>
-        <div style={{ height: 1, background: 'color-mix(in srgb, var(--ua-gold) 55%, transparent)', margin: 'var(--space-sm) 0' }} />
-        <div style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 'var(--text-content)', lineHeight: 1.5, color: INK }}>
+        <div
+          style={{
+            fontFamily: UA_TEXT,
+            fontSize: 'var(--text-content)',
+            lineHeight: 1.55,
+            color: 'var(--faction-ua-card-body)',
+            marginTop: 'var(--space-sm)',
+          }}
+        >
           {owner.editing ? (
-            <CommentEditor owner={owner} accent={ORANGE} bg={PAPER_WARM} text={INK} />
+            <CommentEditor
+              owner={owner}
+              accent="var(--faction-ua-card-accent)"
+              bg="var(--faction-ua-panel)"
+              text="var(--faction-ua-card-text)"
+            />
           ) : (
-            <MentionText body={comment.body_text} mentions={comment.mentions} accent={ORANGE} />
+            <MentionText
+              body={comment.body_text}
+              mentions={comment.mentions}
+              accent="var(--faction-ua-card-accent)"
+            />
           )}
         </div>
       </div>
-    </GiltFrame>
+    </div>
   )
 }

--- a/frontend/src/components/feed/UaFeedFrame.tsx
+++ b/frontend/src/components/feed/UaFeedFrame.tsx
@@ -1,93 +1,50 @@
 import type { ReactNode } from 'react'
 
-import i18n from '../../i18n'
+import { UaSigil } from '../cards/UaSigil'
 
 /**
- * University of Asthmatics per-faction feed frame (surface #12,
- * SPEC-faction-ui-profile.md).
+ * UA feed frame (per-faction surface #12, kit §12, #851).
  *
- * A thin presentational WRAPPER: it skins the neutral feed card (`children`) as a
- * gilt-salon submission. The frame supplies only the OUTER chrome — a gilt border
- * holding a gold-gradient liner around a parchment body, topped by an engraved
- * masthead strip — and renders the unchanged card as the salon-mounted body. It
- * must NOT reimplement the card internals; those arrive via `children`.
+ * A thin presentational WRAPPER: it dresses the neutral feed card (`children`)
+ * as a UA row and reimplements none of the card's internals, which arrive as
+ * children and keep their slot order (ADR-0016).
  *
- * UA is ALWAYS LIGHT: its --ua-* / --faction-ua-* tokens are identical in both
- * themes, so the container styles itself with them and reads as a lit salon
- * regardless of the global theme — it never mutates data-theme. (Mirror of
- * SingularityFeedFrame, which is always-dark.)
+ * The dress is two things: a 3px orange rule down the left edge and one small
+ * ensō as the faction mark. No mandala — a feed is a dense, text-heavy surface
+ * and the pattern is ABSENT there (brief §5). No gilt sandwich, no gold liner,
+ * no engraved masthead: the salon is dead, and a feed row was the worst place
+ * it lived.
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade.
  */
-
-// Token shorthands — every color resolves to a --ua-* var.
-const GILT = 'var(--ua-gilt)' // gold frame gradient
-const GOLD = 'var(--ua-gold)' // old gold liner
-const GOLD_PALE = 'var(--ua-gold-pale)'
-const PAPER = 'var(--ua-paper)' // parchment body
-const INK = 'var(--ua-ink)' // brown ink — borders & shadow
-const ORANGE = 'var(--ua-orange)' // burnt amber — masthead eyebrow
-const FONT_ENGRAVED = 'var(--font-faction-engraved)' // Cinzel
-
-// color-mix helper for brown ink derivatives (border, shadow, dot texture).
-const ink = (pct: number): string =>
-  `color-mix(in srgb, ${INK} ${pct}%, transparent)`
-
 export default function UaFeedFrame({ children }: { children: ReactNode }) {
   return (
-    // Outer gilt border + soft brown drop-shadow & inset white hairline.
     <div
       style={{
-        // eslint-disable-next-line local/no-raw-style-values -- ornament: the padding IS the gilt border width, not a gutter.
-        padding: 6,
-        background: GILT,
-        boxShadow: `0 10px 24px ${ink(26)}, inset 0 0 0 1px rgba(255,255,255,0.45)`,
+        position: 'relative',
+        overflow: 'hidden',
+        background: 'var(--faction-ua-card-bg)',
+        color: 'var(--faction-ua-card-text)',
+        border: '1px solid var(--faction-ua-rule)',
+        borderLeft: '3px solid var(--faction-ua)',
+        borderRadius: 'var(--radius-md)',
+        padding: 'var(--space-lg) var(--space-xl)',
       }}
     >
-      {/* gold-gradient liner */}
-      <div
+      {/* the faction mark — one of the ensō's two sanctioned uses (brief §4) */}
+      <span
+        aria-hidden="true"
         style={{
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: the padding IS the gold liner width, not a gutter.
-          padding: 3,
-          background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
+          position: 'absolute',
+          right: 10,
+          top: 10,
+          opacity: 0.5,
+          pointerEvents: 'none',
         }}
       >
-        {/* parchment body — brown hairline + faint radial-dot texture */}
-        <div
-          style={{
-            border: `1px solid ${ink(45)}`,
-            background: PAPER,
-            backgroundImage: `radial-gradient(${ink(3)} 1px, transparent 1px)`,
-            backgroundSize: '5px 5px',
-            padding: 'var(--space-md) var(--space-lg)',
-          }}
-        >
-          {/* engraved masthead strip + gold hairline divider */}
-          <div
-            aria-hidden="true"
-            style={{
-              fontFamily: FONT_ENGRAVED,
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: aria-hidden engraved masthead, part of the frame illustration
-              fontSize: 8.5,
-              letterSpacing: '0.13em',
-              textTransform: 'uppercase',
-              color: ORANGE,
-            }}
-          >
-            {i18n.t('feed:identity.ua.fullName')}
-          </div>
-          <div
-            aria-hidden="true"
-            style={{
-              height: 1,
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: lead around the gold hairline divider; in register with its raw 1px rule.
-              margin: '9px 0 11px',
-              background: `linear-gradient(90deg, ${GOLD}, transparent)`,
-            }}
-          />
-
-          {/* salon-mounted body — the neutral card, unchanged */}
-          {children}
-        </div>
-      </div>
+        <UaSigil width={18} height={18} />
+      </span>
+      {children}
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1459,6 +1459,19 @@
     color: var(--color-text-tertiary);
   }
 
+  /* A label slot whose content is a SENTENCE rather than a word.
+     `.eyebrow`'s uppercase + 0.15em tracking is tuned for one or two words; a
+     sentence set that way is a wall. The propose-task faction descriptors are
+     the live case — six factions answer with one word and UA answers with
+     "Practise with us — one true mark a day." (#850). Same size and colour, so
+     the row still reads as one rank of labels; only the casing gives way. */
+  .eyebrow-sentence {
+    @apply font-body;
+    font-size: var(--text-sm);
+    letter-spacing: 0.02em;
+    color: var(--color-text-tertiary);
+  }
+
   /* ── Level gem (issue #728) ──
      A square rotated 45° — outlined, never filled, so the numeral sits on
      whatever surface the gem lands on and stays AA-safe without per-faction

--- a/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
@@ -1,37 +1,41 @@
 /**
- * UaProfileBody — University of Asthmatics gilt-salon player-profile skin (#460).
- * Ported from docs/design/profile/templates/UA Profile.dc.html: a gilt double-
- * border frame around the shared CredentialCard, paper-grain dot texture, burnt-
- * amber accent, ANNO/roman-numeral motif. UA is ALWAYS LIGHT — its --faction-ua-*
- * / --ua-* tokens are identical in both themes, so the container scopes
- * data-theme="light" to itself and never mutates the global theme.
+ * UaProfileBody — the University of Asthmatics player-profile skin (#460,
+ * rebuilt for #851).
+ *
+ * The gilt double-border frame, the paper-grain dot texture, the gold progress
+ * bar and the ANNO regalia are gone with the salon. What is left is the
+ * practice's own dress: mesa-sand ground, card stock inside a neutral hairline,
+ * an uppercase eyebrow, and orange used once — on the accent and the bar.
+ *
+ * The skin no longer scopes `data-theme="light"` to itself. UA dims now (#848),
+ * so every token below resolves through the `[data-theme="dark"]` cascade and
+ * the profile follows the app's theme like every other faction's.
  *
  * Structure is DefaultProfileBody's locked spine via ProfileSkin; only the
- * costume differs. No hardcoded hex — all colours via --ua-* / --faction-ua-*.
+ * costume differs (ADR-0016). No hardcoded hex — every colour is a token.
  */
 import type { ReactNode } from 'react'
 
 import type { ProfileBodyProps } from '../FactionProfileBody'
 import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileKit } from './profileSkin'
+import { UA_DISPLAY, UA_TEXT, uaShade } from '../../../components/cards/uaAtoms'
 
-const INK = 'var(--ua-ink)'
-const MUTED = 'var(--ua-muted)'
-const ACCENT = 'var(--ua-orange)'
-const GILT = 'var(--ua-gilt)'
-const PAPER = 'var(--ua-paper)'
-const LINE = 'var(--ua-line)'
-const DISPLAY = 'var(--font-faction-old)' // IM Fell English — salon display serif
-const EYEBROW = 'var(--font-body)' // Courier Prime mono labels
-const BODY = "'EB Garamond', Georgia, serif"
+const INK = 'var(--faction-ua-card-text)'
+const MUTED = 'var(--faction-ua-card-muted)'
+const ACCENT = 'var(--faction-ua-card-accent)'
+const SURFACE = 'var(--faction-ua-card-bg)'
+const PANEL = 'var(--faction-ua-panel)'
+const RULE = 'var(--faction-ua-rule)'
+const HAIR = 'var(--faction-ua-hair)'
 
 function heading(title: string, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div
         style={{
-          fontFamily: EYEBROW,
-          fontSize: 'var(--text-xs)',
-          letterSpacing: '0.26em',
+          fontFamily: UA_TEXT,
+          fontSize: 'var(--text-md)',
+          letterSpacing: '0.22em',
           textTransform: 'uppercase',
           color: MUTED,
           marginBottom: 'var(--space-sm)',
@@ -39,7 +43,16 @@ function heading(title: string, eyebrow: string): ReactNode {
       >
         {eyebrow}
       </div>
-      <h2 style={{ fontFamily: DISPLAY, fontSize: 'var(--text-heading)', lineHeight: 1, color: INK, margin: 0 }}>
+      <h2
+        style={{
+          fontFamily: UA_DISPLAY,
+          fontWeight: 600,
+          fontSize: 'var(--text-heading)',
+          lineHeight: 1.05,
+          color: INK,
+          margin: 0,
+        }}
+      >
         {title}
       </h2>
     </div>
@@ -48,51 +61,46 @@ function heading(title: string, eyebrow: string): ReactNode {
 
 const kit: ProfileKit = {
   slug: 'ua',
-  dataTheme: 'light',
-  pageBackground: 'var(--ua-wall)',
+  pageBackground: 'var(--faction-ua-page)',
+  // One faint warm wash off the top-left. Mixed from the ornament token so it
+  // inverts with the theme; the mandala itself stays on the page backdrop.
   pageOverlay:
-    'radial-gradient(70% 50% at 8% 0%, rgba(221,147,34,.07), transparent 70%), radial-gradient(rgba(140,106,30,.045) 1px, transparent 1px)',
+    'radial-gradient(70% 50% at 8% 0%, color-mix(in srgb, var(--faction-ua-glow) 9%, transparent), transparent 70%)',
   ink: INK,
   muted: MUTED,
   accent: ACCENT,
-  surface: PAPER,
-  border: LINE,
-  displayFont: DISPLAY,
-  eyebrowFont: EYEBROW,
-  bodyFont: BODY,
+  surface: SURFACE,
+  border: RULE,
+  displayFont: UA_DISPLAY,
+  eyebrowFont: UA_TEXT,
+  bodyFont: UA_TEXT,
   headerStyle: {
-    background: PAPER,
-    border: `1px solid ${LINE}`,
-    boxShadow: 'inset 0 0 0 4px var(--ua-paper), inset 0 0 0 5px var(--ua-line-soft)',
+    background: SURFACE,
+    border: `1px solid ${RULE}`,
+    borderRadius: 'var(--radius-md)',
     padding: 'var(--space-2xl) var(--space-3xl)',
     marginBottom: 'var(--space-3xl)',
   },
-  headerDecoration: (
-    <div
-      aria-hidden
-      style={{
-        position: 'absolute',
-        inset: 0,
-        pointerEvents: 'none',
-        backgroundImage: 'radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)',
-        backgroundSize: '6px 6px',
-      }}
-    />
-  ),
   credentialFrame: (card) => (
-    <div style={{ padding: 'var(--space-md)', background: GILT }}>
-      <div style={{ padding: 'var(--space-xs)', background: 'linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))' }}>
-        {card}
-      </div>
+    <div
+      style={{
+        padding: 'var(--space-xs)',
+        background: PANEL,
+        border: `1px solid ${RULE}`,
+        borderRadius: 'var(--radius-md)',
+        boxShadow: `0 12px 30px -20px ${uaShade(50)}`,
+      }}
+    >
+      {card}
     </div>
   ),
   nameSize: 56,
-  playerEyebrow: 'Player · University of Asthmatics',
+  playerEyebrow: 'Practising · University of Asthmatics',
   progressionStyle: {
     marginTop: 'var(--space-xl)',
-    background: 'var(--ua-paper-warm)',
-    border: `1px solid ${ACCENT}`,
-    boxShadow: 'inset 0 0 0 3px var(--ua-paper-warm), inset 0 0 0 4px var(--ua-line-soft)',
+    background: PANEL,
+    border: `1px solid ${RULE}`,
+    borderRadius: 'var(--radius-sm)',
     padding: 'var(--space-lg)',
     display: 'flex',
     alignItems: 'center',
@@ -100,46 +108,49 @@ const kit: ProfileKit = {
     maxWidth: 440,
   },
   ringLabel: 'anno',
-  barFill: 'linear-gradient(90deg, var(--ua-gold-lt), var(--ua-orange))',
-  barTrack: 'var(--ua-line-soft)',
-  levelUnitLabel: 'pts this anno',
+  barFill:
+    'linear-gradient(90deg, var(--faction-ua-glow), var(--faction-ua-vermil))',
+  barTrack: HAIR,
+  levelUnitLabel: 'marks this anno',
   nextLevelLabel: (next) => `next · anno ${next}`,
   sectionHeading: heading,
-  praxisEyebrow: (name) => `Exhibited by ${name}`,
+  praxisEyebrow: (name) => `Sealed by ${name}`,
   praxisEmpty: {
-    title: 'Nothing hung in the Salon yet',
-    body: 'The first piece exhibited is always the boldest.',
+    title: 'Nothing sealed yet',
+    body: 'One true mark, then another. The first is always the boldest.',
   },
   emptyStateStyle: {
-    border: `1.5px dashed ${ACCENT}`,
+    border: `1px dashed var(--faction-ua-border)`,
+    borderRadius: 'var(--radius-sm)',
     padding: 'var(--space-2xl)',
     textAlign: 'center',
-    background: PAPER,
+    background: SURFACE,
   },
-  laurel: <SpectrumLaurel centerBg={PAPER} glyphColor={ACCENT} />,
-  badgeTitle: 'Distinctions',
+  laurel: <SpectrumLaurel centerBg={SURFACE} glyphColor={ACCENT} />,
+  badgeTitle: 'Marks of the practice',
   badgeBoardStyle: {
-    border: `1px solid ${LINE}`,
-    background: PAPER,
+    border: `1px solid ${RULE}`,
+    borderRadius: 'var(--radius-sm)',
+    background: SURFACE,
     padding: 'var(--space-xs) var(--space-lg)',
   },
   badgeChipStyle: {
-    fontFamily: EYEBROW,
-    fontSize: 'var(--text-sm)',
-    letterSpacing: '0.1em',
+    fontFamily: UA_TEXT,
+    fontSize: 'var(--text-md)',
+    letterSpacing: '0.16em',
     textTransform: 'uppercase',
     color: MUTED,
     marginLeft: 'auto',
-    border: `1px solid ${LINE}`,
-    borderRadius: 20,
+    border: `1px solid ${RULE}`,
+    borderRadius: 999,
     padding: 'var(--space-xs) var(--space-sm)',
   },
   badgeRow: (badge, last) => (
     <BadgeRow
       badge={badge}
       last={last}
-      dividerColor={LINE}
-      nameStyle={{ fontFamily: DISPLAY, color: INK, lineHeight: 1.15 }}
+      dividerColor={HAIR}
+      nameStyle={{ fontFamily: UA_DISPLAY, fontWeight: 600, color: INK, lineHeight: 1.15 }}
       medallion={(glyph) => (
         <span
           style={{
@@ -147,29 +158,16 @@ const kit: ProfileKit = {
             width: 34,
             height: 34,
             borderRadius: '50%',
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: gilt ring thickness on a 34px medallion; the nearest rung (4px) is a 60% thicker ring and visibly shrinks the inner disc.
-            padding: 2.5,
-            background: GILT,
+            background: PANEL,
+            border: `1px solid var(--faction-ua-border)`,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
             boxSizing: 'border-box',
+            color: ACCENT,
           }}
         >
-          <span
-            style={{
-              width: '100%',
-              height: '100%',
-              borderRadius: '50%',
-              background: PAPER,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: ACCENT,
-            }}
-          >
-            {glyph}
-          </span>
+          {glyph}
         </span>
       )}
     />

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -10,8 +10,10 @@
  * kit (tokens, fonts, copy, chrome slots) and delegates here.
  *
  * No hardcoded hex: kits reference the repo's `--faction-<slug>-*` CSS vars.
- * Always-dark (snide, singularity) / always-light (ua) factions scope
- * their tokens to the skin container and NEVER mutate the global [data-theme].
+ * A faction whose identity is pinned to one theme (snide and singularity are
+ * always-dark) scopes `dataTheme` to the skin container and NEVER mutates the
+ * global [data-theme]. UA used to pin itself light; it dims with the app now
+ * (#848, #851) and sets no `dataTheme` at all.
  */
 import type { CSSProperties, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -1,16 +1,19 @@
 /**
- * The University of Asthmatics (UA) edit-praxis archetype — THE ATELIER.
+ * UA edit-praxis — SEAL A PRAXIS (kit §3, #851).
  *
- * The gilt-salon counterpart to the read-page sheet (UaPraxisDetail) and UaVote:
- * a work-in-progress acquisition being prepared on the salon's workbench. Gilt
- * frames, parchment grounds, Cormorant italic display, EB-Garamond serif body,
- * EB-Garamond small-caps regalia, burnt-amber accent. The salon never dims — UA
- * is always-light, so every --ua-* token reads identically in both themes and
- * we style with them directly without touching data-theme.
+ * The praxis archetype as a form: the same dress the card wears, in composer
+ * mode. Quiet labels, generous space, one ensō at the head, and a single
+ * saturated note on the seal button.
+ *
+ * The atelier is gone with the salon — no gilt frames, no gold liners, no
+ * parchment dot grid, no polaroid plates. The mandala is ABSENT: an editor is
+ * the most text-dense surface UA has (brief §5).
  *
  * Behaviour (autosave, mode-switch guards, invite, media, publish) comes from
- * the shared control primitives; this archetype owns only presentation. All
- * colors via --ua-* tokens (index.css) — never hardcode hex (CLAUDE.md).
+ * the shared control primitives; this archetype owns only presentation, and
+ * fills the same slots the card renders so data parity holds (ADR-0016).
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade. UA dims now.
  */
 import { useTranslation } from "react-i18next";
 import { mediaUrl } from "../../../utils/media";
@@ -25,6 +28,12 @@ import {
   formatAutosave,
 } from "./shared";
 import { UaSigil } from "../../../components/cards/UaSigil";
+import {
+  UA_DISPLAY,
+  UA_EYEBROW,
+  UA_TEXT,
+  uaShade,
+} from "../../../components/cards/uaAtoms";
 import {
   BodyPreview,
   BodyTextarea,
@@ -42,20 +51,14 @@ interface Props {
   state: EditPraxisState;
 }
 
-const DISPLAY = "var(--faction-ua-card-font)";
-const REGALIA = "var(--faction-ua-body-font)";
-const SERIF = "'EB Garamond', serif";
-const MONO = "'Courier Prime', monospace";
-
-/** A gilt-framed card — the recurring salon surface for each editor region. */
+/** A block of the sheet — card stock inside a neutral hairline. */
 function Plate({ children, style }: { children: ReactNode; style?: CSSProperties }) {
   return (
     <div
       style={{
-        background: "var(--ua-paper)",
-        border: "1px solid var(--ua-line)",
-        boxShadow:
-          "0 8px 22px color-mix(in srgb, var(--ua-ink) 12%, transparent), inset 0 0 0 4px var(--ua-paper), inset 0 0 0 5px var(--ua-line-soft)",
+        background: "var(--faction-ua-card-bg)",
+        border: "1px solid var(--faction-ua-rule)",
+        borderRadius: "var(--radius-md)",
         padding: "var(--space-lg) var(--space-xl)",
         marginBottom: "var(--space-xl)",
         ...style,
@@ -66,14 +69,21 @@ function Plate({ children, style }: { children: ReactNode; style?: CSSProperties
   );
 }
 
-/** Small-caps section label with a fading gold rule, like the read sheet. */
-function RegaliaLabel({ children }: { children: ReactNode }) {
+/** Field label — the eyebrow, with a hairline running out to the margin. */
+function FieldLabel({ children }: { children: ReactNode }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)", marginBottom: "var(--space-md)" }}>
-      <span style={{ fontFamily: REGALIA, fontSize: "var(--text-sm)", letterSpacing: "0.2em", color: "var(--ua-gold)", whiteSpace: "nowrap" }}>
-        {children}
-      </span>
-      <div style={{ height: 1, flex: 1, background: "var(--ua-line-soft)" }} />
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-sm)",
+        marginBottom: "var(--space-md)",
+      }}
+    >
+      <span style={{ ...UA_EYEBROW, whiteSpace: "nowrap" }}>{children}</span>
+      <div
+        style={{ height: 1, flex: 1, background: "var(--faction-ua-hair)" }}
+      />
     </div>
   );
 }
@@ -95,11 +105,9 @@ export default function UaEditPraxis({ state }: Props) {
   return (
     <div
       style={{
-        background:
-          "radial-gradient(color-mix(in srgb, var(--ua-ink) 4%, transparent) 1px, transparent 1px), var(--ua-wall)",
-        backgroundSize: "22px 22px, 100% 100%",
-        fontFamily: SERIF,
-        color: "var(--ua-ink)",
+        background: "var(--faction-ua-page)",
+        fontFamily: UA_TEXT,
+        color: "var(--faction-ua-page-text)",
         padding: "var(--space-2xl) var(--space-xl) var(--space-5xl)",
         minHeight: "100vh",
       }}
@@ -109,29 +117,47 @@ export default function UaEditPraxis({ state }: Props) {
           praxisId={praxis.id}
           taskId={praxis.task_id}
           taskTitle={praxis.task_title}
-          inkColor="var(--ua-gold)"
+          inkColor="var(--faction-ua-card-accent)"
         />
 
-        {/* Masthead — the salon submission sheet's letterhead */}
-        <Plate style={{ padding: 0, marginBottom: "var(--space-xl)" }}>
-          {/* burnt-amber ribbon — crest + house line */}
+        {/* Masthead — the mark, the sheet number, the autosave whisper */}
+        <Plate
+          style={{
+            padding: "var(--space-xl)",
+            background:
+              "linear-gradient(158deg, var(--faction-ua-lift), var(--faction-ua-card-bg) 55%, var(--faction-ua-panel))",
+            boxShadow: `0 16px 42px -24px ${uaShade(55)}`,
+          }}
+        >
           <div
             style={{
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
               gap: "var(--space-md)",
-              padding: "var(--space-sm) var(--space-lg)",
-              background: "var(--ua-orange)",
+              marginBottom: "var(--space-lg)",
             }}
           >
-            <span style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-sm)", minWidth: 0 }}>
-              <UaSigil width={22} height={26} />
-              <span style={{ fontFamily: REGALIA, fontSize: "var(--text-base)", letterSpacing: "0.14em", color: "var(--ua-paper-warm)" }}>
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "var(--space-md)",
+                minWidth: 0,
+              }}
+            >
+              <UaSigil width={40} height={40} />
+              <span style={UA_EYEBROW}>
                 {t("editPraxis.ua.masthead", { number: praxis.id })}
               </span>
             </span>
-            <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ua-paper-warm)", fontStyle: "italic", whiteSpace: "nowrap" }}>
+            <span
+              style={{
+                ...UA_EYEBROW,
+                letterSpacing: "0.14em",
+                whiteSpace: "nowrap",
+              }}
+            >
               {state.autosaveAt
                 ? t("editPraxis.ua.autosaveSaved", {
                     ago: formatAutosave(state.autosaveAt),
@@ -139,45 +165,83 @@ export default function UaEditPraxis({ state }: Props) {
                 : t("editPraxis.ua.autosaveUnsaved")}
             </span>
           </div>
-          <div style={{ padding: "var(--space-xl)" }}>
-            <h1 style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 600, fontSize: "var(--text-display)", lineHeight: 1.04, color: "var(--ua-ink)", margin: "0 0 var(--space-md)" }}>
-              {t("editPraxis.ua.pageTitle")}
-            </h1>
-            {/* red/gold dashed rule */}
-            <div style={{ height: 0, borderTop: "1.5px dashed var(--ua-gold)", marginBottom: "var(--space-lg)" }} />
-            {/* commission reference slip — crest, task, points, era mark */}
-            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", border: "1px solid var(--ua-line)", background: "var(--ua-paper-warm)", padding: "var(--space-md) var(--space-lg)" }}>
-              <UaSigil width={50} height={60} />
-              <div style={{ minWidth: 0 }}>
-                <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--ua-muted)", marginBottom: "var(--space-xs)" }}>
-                  {t("editPraxis.ua.commissionLabel")}
-                </div>
-                <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: "var(--text-content)", color: "var(--ua-ink)", lineHeight: 1.15, overflowWrap: "anywhere" }}>
-                  {praxis.task_title}
-                </div>
-                {task?.description && (
-                  <div style={{ fontFamily: MONO, fontSize: "var(--text-content)", lineHeight: 1.45, color: "var(--ua-muted)", marginTop: "var(--space-xs)", overflowWrap: "anywhere" }}>
-                    {task.description}
-                  </div>
-                )}
-                <div style={{ fontFamily: REGALIA, fontSize: "var(--text-base)", letterSpacing: "0.12em", color: "var(--ua-gold)", marginTop: "var(--space-xs)" }}>
-                  {t("editPraxis.ua.pointsLabel", {
-                    points: praxis.task_point_value,
-                  })}
-                </div>
+
+          <h1
+            style={{
+              fontFamily: UA_DISPLAY,
+              fontWeight: 600,
+              fontSize: "var(--text-display)",
+              lineHeight: 1.02,
+              letterSpacing: "-0.01em",
+              color: "var(--faction-ua-card-text)",
+              margin: "0 0 var(--space-lg)",
+            }}
+          >
+            {t("editPraxis.ua.pageTitle")}
+          </h1>
+
+          {/* the task this mark answers to */}
+          <div
+            style={{
+              border: "1px solid var(--faction-ua-rule)",
+              borderRadius: "var(--radius-sm)",
+              background: "var(--faction-ua-panel)",
+              padding: "var(--space-md) var(--space-lg)",
+            }}
+          >
+            <div style={UA_EYEBROW}>{t("editPraxis.ua.commissionLabel")}</div>
+            <div
+              style={{
+                fontFamily: UA_DISPLAY,
+                fontWeight: 600,
+                fontSize: "var(--text-title)",
+                lineHeight: 1.15,
+                color: "var(--faction-ua-card-text)",
+                margin: "var(--space-xs) 0",
+                overflowWrap: "anywhere",
+              }}
+            >
+              {praxis.task_title}
+            </div>
+            {task?.description && (
+              <div
+                style={{
+                  fontFamily: UA_TEXT,
+                  fontSize: "var(--text-content)",
+                  lineHeight: 1.5,
+                  color: "var(--faction-ua-card-body)",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {task.description}
               </div>
+            )}
+            <div
+              style={{
+                ...UA_EYEBROW,
+                color: "var(--faction-ua-card-accent)",
+                marginTop: "var(--space-xs)",
+              }}
+            >
+              {t("editPraxis.ua.pointsLabel", {
+                points: praxis.task_point_value,
+              })}
             </div>
           </div>
         </Plate>
 
-        {/* Mode — engraved plates */}
+        {/* Mode */}
         {!state.controlsLocked && (
           <div style={{ marginBottom: "var(--space-xl)" }}>
-            <RegaliaLabel>{t("editPraxis.ua.modeLabel")}</RegaliaLabel>
+            <FieldLabel>{t("editPraxis.ua.modeLabel")}</FieldLabel>
             <ModePicker
               state={state}
               skin={{
-                containerStyle: { display: "flex", gap: "var(--space-md)", flexWrap: "wrap" },
+                containerStyle: {
+                  display: "flex",
+                  gap: "var(--space-md)",
+                  flexWrap: "wrap",
+                },
                 options: modeOptions,
                 allowedModes,
                 renderOption: (opt, { active, disabled, onSelect }) => (
@@ -191,18 +255,39 @@ export default function UaEditPraxis({ state }: Props) {
                       minWidth: 150,
                       textAlign: "left",
                       padding: "var(--space-md) var(--space-lg)",
+                      borderRadius: "var(--radius-sm)",
                       cursor: disabled && !active ? "not-allowed" : "pointer",
-                      background: active ? "var(--ua-gilt)" : "var(--ua-paper)",
-                      border: active ? "none" : "1px solid var(--ua-line)",
-                      boxShadow: active
-                        ? "0 4px 10px color-mix(in srgb, var(--ua-ink) 22%, transparent), inset 0 0 0 1px color-mix(in srgb, white 40%, transparent)"
-                        : "none",
+                      background: active
+                        ? "var(--faction-ua)"
+                        : "var(--faction-ua-card-bg)",
+                      border: `1px solid ${
+                        active ? "var(--faction-ua)" : "var(--faction-ua-rule)"
+                      }`,
                     }}
                   >
-                    <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, fontSize: "var(--text-content)", color: active ? "var(--ua-paper)" : "var(--ua-ink)", lineHeight: 1 }}>
+                    <div
+                      style={{
+                        fontFamily: UA_DISPLAY,
+                        fontWeight: 600,
+                        fontSize: "var(--text-content)",
+                        lineHeight: 1.1,
+                        color: active
+                          ? "var(--faction-ua-on-fill)"
+                          : "var(--faction-ua-card-text)",
+                      }}
+                    >
                       {opt.label}
                     </div>
-                    <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.06em", textTransform: "uppercase", color: active ? "var(--ua-paper)" : "var(--ua-muted)", marginTop: "var(--space-xs)" }}>
+                    <div
+                      style={{
+                        ...UA_EYEBROW,
+                        letterSpacing: "0.1em",
+                        color: active
+                          ? "var(--faction-ua-on-fill)"
+                          : "var(--faction-ua-card-muted)",
+                        marginTop: "var(--space-xs)",
+                      }}
+                    >
                       {opt.desc}
                     </div>
                   </button>
@@ -215,22 +300,22 @@ export default function UaEditPraxis({ state }: Props) {
         {/* Invite — the other hands */}
         {state.showInviteBox && (
           <Plate>
-            <RegaliaLabel>
+            <FieldLabel>
               {praxis.type === "duel"
                 ? t("editPraxis.ua.inviteLabelDuel")
                 : t("editPraxis.ua.inviteLabel")}
-            </RegaliaLabel>
+            </FieldLabel>
             <InviteSearch
               state={state}
               skin={{
-                fontFamily: SERIF,
-                inputBg: "var(--ua-paper-warm)",
-                inputColor: "var(--ua-ink)",
-                inputBorder: "1px solid var(--ua-line)",
-                dropdownBg: "var(--ua-paper)",
-                dropdownBorder: "1px solid var(--ua-line)",
-                acceptedBg: "var(--ua-orange)",
-                acceptedColor: "var(--ua-paper)",
+                fontFamily: UA_TEXT,
+                inputBg: "var(--faction-ua-panel)",
+                inputColor: "var(--faction-ua-card-text)",
+                inputBorder: "1px solid var(--faction-ua-rule)",
+                dropdownBg: "var(--faction-ua-card-bg)",
+                dropdownBorder: "1px solid var(--faction-ua-rule)",
+                acceptedBg: "var(--faction-ua)",
+                acceptedColor: "var(--faction-ua-on-fill)",
                 placeholder: t("editPraxis.ua.invitePlaceholder"),
               }}
             />
@@ -239,35 +324,38 @@ export default function UaEditPraxis({ state }: Props) {
 
         {/* Title */}
         <Plate>
-          <RegaliaLabel>{t("editPraxis.ua.titleLabel")}</RegaliaLabel>
+          <FieldLabel>{t("editPraxis.ua.titleLabel")}</FieldLabel>
           <TitleField
             state={state}
             skin={{
               placeholder: t("editPraxis.ua.titlePlaceholder"),
               inputStyle: {
                 width: "100%",
-                fontFamily: DISPLAY,
-                fontStyle: "italic",
+                fontFamily: UA_DISPLAY,
                 fontWeight: 600,
-                color: "var(--ua-ink)",
+                fontSize: "var(--text-title)",
+                color: "var(--faction-ua-card-text)",
                 background: "transparent",
                 border: "none",
                 outline: "none",
-                borderBottom: "1px solid var(--ua-line-soft)",
+                borderBottom: "1px solid var(--faction-ua-rule)",
                 padding: "var(--space-xs) 0 var(--space-sm)",
               },
             }}
           />
           <div style={{ marginTop: "var(--space-sm)" }}>
-            <TitleCounter length={state.title.length} color="var(--ua-muted)" />
+            <TitleCounter
+              length={state.title.length}
+              color="var(--faction-ua-card-muted)"
+            />
           </div>
         </Plate>
 
-        {/* Body — the process */}
+        {/* Body — a note on the mark */}
         <Plate>
-          <RegaliaLabel>
+          <FieldLabel>
             {t("editPraxis.ua.bodyLabel", { words: state.wordCount })}
-          </RegaliaLabel>
+          </FieldLabel>
           <BodyTextarea
             state={state}
             skin={{
@@ -275,11 +363,13 @@ export default function UaEditPraxis({ state }: Props) {
               placeholder: t("editPraxis.ua.bodyPlaceholder"),
               textareaStyle: {
                 width: "100%",
-                fontFamily: SERIF,
-                lineHeight: 1.75,
-                color: "var(--ua-sub)",
-                background: "var(--ua-paper-warm)",
-                border: "1px solid var(--ua-line-soft)",
+                fontFamily: UA_TEXT,
+                fontSize: "var(--text-content)",
+                lineHeight: 1.7,
+                color: "var(--faction-ua-card-text)",
+                background: "var(--faction-ua-panel)",
+                border: "1px solid var(--faction-ua-rule)",
+                borderRadius: "var(--radius-sm)",
                 outline: "none",
                 resize: "vertical",
                 minHeight: 200,
@@ -290,34 +380,70 @@ export default function UaEditPraxis({ state }: Props) {
           <BodyPreview
             state={state}
             skin={{
-              wrapperStyle: { borderTop: "1px solid var(--ua-line-soft)", marginTop: "var(--space-md)", paddingTop: "var(--space-md)" },
+              wrapperStyle: {
+                borderTop: "1px solid var(--faction-ua-hair)",
+                marginTop: "var(--space-md)",
+                paddingTop: "var(--space-md)",
+              },
               label: (
-                <div style={{ fontFamily: REGALIA, fontSize: "var(--text-sm)", letterSpacing: "0.2em", color: "var(--ua-gold)", marginBottom: "var(--space-sm)" }}>
+                <div style={{ ...UA_EYEBROW, marginBottom: "var(--space-sm)" }}>
                   {t("editPraxis.ua.previewLabel")}
                 </div>
               ),
-              markdownStyle: { fontFamily: SERIF, lineHeight: 1.85, color: "var(--ua-sub)" },
+              markdownStyle: {
+                fontFamily: UA_TEXT,
+                lineHeight: 1.8,
+                color: "var(--faction-ua-card-body)",
+              },
             }}
           />
         </Plate>
 
-        {/* The plates — media */}
+        {/* The work — media */}
         <div style={{ marginBottom: "var(--space-xl)" }}>
-          <RegaliaLabel>{t("editPraxis.ua.filesLabel")}</RegaliaLabel>
-          <div style={{ display: "flex", gap: "var(--space-lg)", flexWrap: "wrap", alignItems: "flex-start" }}>
+          <FieldLabel>{t("editPraxis.ua.filesLabel")}</FieldLabel>
+          <div
+            style={{
+              display: "flex",
+              gap: "var(--space-lg)",
+              flexWrap: "wrap",
+              alignItems: "flex-start",
+            }}
+          >
             {state.media.map((item) => {
               const filename = item.file_path.split("/").pop() ?? item.file_path;
               const src = mediaUrl(item.file_path);
               return (
-                <GiltPlate key={item.id} caption={filename} onRemove={() => void state.removeMedia(item)}>
+                <MediaPlate
+                  key={item.id}
+                  caption={filename}
+                  onRemove={() => void state.removeMedia(item)}
+                >
                   {item.type === "image" ? (
-                    <img src={src} alt="" style={{ width: 140, height: 100, objectFit: "cover", display: "block" }} />
+                    <img
+                      src={src}
+                      alt=""
+                      style={{
+                        width: 140,
+                        height: 100,
+                        objectFit: "cover",
+                        display: "block",
+                      }}
+                    />
                   ) : item.type === "video" ? (
-                    <video src={src} style={{ width: 140, height: 100, objectFit: "cover", display: "block" }} />
+                    <video
+                      src={src}
+                      style={{
+                        width: 140,
+                        height: 100,
+                        objectFit: "cover",
+                        display: "block",
+                      }}
+                    />
                   ) : (
                     <MediaArt art={pickArtKey(filename, "audio")} />
                   )}
-                </GiltPlate>
+                </MediaPlate>
               );
             })}
             <FilePicker
@@ -326,14 +452,13 @@ export default function UaEditPraxis({ state }: Props) {
                 buttonStyle: {
                   width: 152,
                   height: 130,
-                  background: "var(--ua-paper-warm)",
-                  border: "2px dashed var(--ua-line)",
+                  background: "var(--faction-ua-panel)",
+                  border: "1px dashed var(--faction-ua)",
+                  borderRadius: "var(--radius-sm)",
                   cursor: "pointer",
-                  fontFamily: REGALIA,
-                  fontSize: "var(--text-md)",
-                  letterSpacing: "0.14em",
-                  textTransform: "uppercase",
-                  color: "var(--ua-gold)",
+                  fontFamily: UA_TEXT,
+                  fontSize: "var(--text-content)",
+                  color: "var(--faction-ua-card-muted)",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
@@ -341,9 +466,13 @@ export default function UaEditPraxis({ state }: Props) {
                   gap: "var(--space-xs)",
                 },
                 buttonLabel: t("editPraxis.ua.fileButton"),
-                errorColor: "var(--ua-orange-deep)",
+                errorColor: "var(--faction-ua-vermil)",
                 helperText: t("editPraxis.ua.fileHelper"),
-                helperStyle: { fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.08em", color: "var(--ua-muted)", marginTop: "var(--space-sm)", fontStyle: "italic" },
+                helperStyle: {
+                  ...UA_EYEBROW,
+                  letterSpacing: "0.14em",
+                  marginTop: "var(--space-sm)",
+                },
               }}
             />
           </div>
@@ -352,21 +481,26 @@ export default function UaEditPraxis({ state }: Props) {
         {/* Metatasks */}
         {state.showMetatasks && (
           <Plate>
-            <RegaliaLabel>{t("editPraxis.ua.metatasksLabel")}</RegaliaLabel>
+            <FieldLabel>{t("editPraxis.ua.metatasksLabel")}</FieldLabel>
             <MetatasksList
               state={state}
               skin={{
                 rowStyle: (selected) => ({
                   padding: "var(--space-sm)",
-                  background: selected ? "color-mix(in srgb, var(--ua-gold-pale) 22%, var(--ua-paper))" : "transparent",
-                  border: selected ? "1px solid var(--ua-line)" : "1px solid transparent",
+                  borderRadius: "var(--radius-sm)",
+                  background: selected
+                    ? "var(--faction-ua-panel)"
+                    : "transparent",
+                  border: `1px solid ${
+                    selected ? "var(--faction-ua-rule)" : "transparent"
+                  }`,
                   marginBottom: "var(--space-xs)",
-                  fontFamily: SERIF,
+                  fontFamily: UA_TEXT,
                 }),
-                titleColor: "var(--ua-ink)",
-                descColor: "var(--ua-sub)",
-                pointsActiveColor: "var(--ua-orange)",
-                pointsIdleColor: "var(--ua-muted)",
+                titleColor: "var(--faction-ua-card-text)",
+                descColor: "var(--faction-ua-card-body)",
+                pointsActiveColor: "var(--faction-ua-card-accent)",
+                pointsIdleColor: "var(--faction-ua-card-muted)",
               }}
             />
           </Plate>
@@ -374,8 +508,18 @@ export default function UaEditPraxis({ state }: Props) {
 
         <ErrorBanner message={state.error} />
 
-        {/* CTAs */}
-        <div style={{ display: "flex", gap: "var(--space-lg)", alignItems: "center", marginTop: "var(--space-xl)", flexWrap: "wrap" }}>
+        {/* CTAs — the helper the copy deck wrote for this spot, then the seal */}
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--space-lg)",
+            alignItems: "center",
+            marginTop: "var(--space-xl)",
+            paddingTop: "var(--space-lg)",
+            borderTop: "1px solid var(--faction-ua-hair)",
+            flexWrap: "wrap",
+          }}
+        >
           <DropButton
             state={state}
             skin={{
@@ -383,31 +527,41 @@ export default function UaEditPraxis({ state }: Props) {
               style: {
                 background: "transparent",
                 border: "none",
-                color: "var(--ua-muted)",
-                fontFamily: SERIF,
-                fontStyle: "italic",
-                fontSize: "var(--text-xl)",
+                color: "var(--faction-ua-card-muted)",
+                fontFamily: UA_TEXT,
+                fontSize: "var(--text-content)",
                 textDecoration: "underline",
                 cursor: "pointer",
               },
             }}
           />
+          <span
+            style={{
+              marginLeft: "auto",
+              fontFamily: UA_TEXT,
+              fontSize: "var(--text-content)",
+              fontStyle: "italic",
+              color: "var(--faction-ua-card-muted)",
+            }}
+          >
+            {t("editPraxis.ua.publishHelper")}
+          </span>
           <PublishButton
             state={state}
             skin={{
               idleLabel: t("editPraxis.ua.publishIdle"),
               busyLabel: t("editPraxis.ua.publishBusy"),
               style: {
-                background: "var(--ua-orange)",
-                color: "var(--ua-paper)",
-                fontFamily: REGALIA,
-                fontSize: "var(--text-lg)",
-                letterSpacing: "0.1em",
+                background: "var(--faction-ua)",
+                color: "var(--faction-ua-on-fill)",
+                fontFamily: UA_TEXT,
+                fontSize: "var(--text-xl)",
+                letterSpacing: "0.14em",
+                textTransform: "uppercase",
                 padding: "var(--space-md) var(--space-xl)",
                 border: "none",
-                borderRadius: 0,
+                borderRadius: "var(--radius-sm)",
                 cursor: state.submitting ? "wait" : "pointer",
-                boxShadow: "0 4px 10px color-mix(in srgb, var(--ua-ink) 22%, transparent)",
               },
             }}
           />
@@ -417,8 +571,8 @@ export default function UaEditPraxis({ state }: Props) {
   );
 }
 
-/** A gilt-framed plate for one piece of evidence — the salon's polaroid. */
-function GiltPlate({
+/** One piece of the work — a hairline plate with its filename beneath. */
+function MediaPlate({
   children,
   caption,
   onRemove,
@@ -429,12 +583,38 @@ function GiltPlate({
 }) {
   const { t } = useTranslation("forms");
   return (
-    <div style={{ position: "relative", background: "var(--ua-gilt)", padding: "var(--space-xs)", boxShadow: "0 8px 18px color-mix(in srgb, var(--ua-ink) 20%, transparent)" }}>
-      <div style={{ background: "var(--ua-paper)", padding: "var(--space-xs)" }}>
-        <div style={{ width: 140, height: 100, overflow: "hidden" }}>{children}</div>
-        <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.04em", color: "var(--ua-muted)", textAlign: "center", marginTop: "var(--space-xs)", maxWidth: 140, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-          {caption}
-        </div>
+    <div
+      style={{
+        position: "relative",
+        background: "var(--faction-ua-panel)",
+        border: "1px solid var(--faction-ua-rule)",
+        borderRadius: "var(--radius-sm)",
+        padding: "var(--space-xs)",
+      }}
+    >
+      <div
+        style={{
+          width: 140,
+          height: 100,
+          overflow: "hidden",
+          borderRadius: "var(--radius-sm)",
+        }}
+      >
+        {children}
+      </div>
+      <div
+        style={{
+          ...UA_EYEBROW,
+          letterSpacing: "0.08em",
+          textAlign: "center",
+          marginTop: "var(--space-xs)",
+          maxWidth: 140,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {caption}
       </div>
       <button
         type="button"
@@ -447,9 +627,9 @@ function GiltPlate({
           width: 22,
           height: 22,
           borderRadius: "50%",
-          background: "var(--ua-paper)",
-          border: "1.5px solid var(--ua-orange)",
-          color: "var(--ua-orange)",
+          background: "var(--faction-ua-card-bg)",
+          border: "1.5px solid var(--faction-ua)",
+          color: "var(--faction-ua-card-accent)",
           fontSize: "var(--text-lg)",
           fontWeight: 700,
           cursor: "pointer",

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -5,99 +5,98 @@ import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { toRoman } from "../../../components/cards/ephemeristsAtoms";
+import {
+  UA_DISPLAY,
+  UA_EYEBROW,
+  UA_TEXT,
+  uaShade,
+} from "../../../components/cards/uaAtoms";
 import { computeDisplayPoints } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
- * UA (University of Asthmatics) faction-body — the gilt-salon skin of the
- * standardized six-section spine (② The Practice, ③ The Registry, ④ Tasks,
- * ⑤ Praxis, ⑥ Members). Section ① (hero + side stats) is UaFactionHero above.
+ * UA faction body — the standardized six-section spine in the practice's dress
+ * (② The Practice, ③ The Registry, ④ Tasks, ⑤ Praxis, ⑥ Members). Section ① is
+ * {@link UaFactionHero} above.
  *
- * Same shape as EverymenFactionBody — Tasks/Praxis reuse the app-wide per-faction
- * cards (TaskCard/PraxisCard already dispatch to the UA archetypes); this file
- * owns the salon chrome: the two-column layout, fixed "Tasks"/"Praxis" titles
- * with salon kickers, the enroll/gate registry block, the artist-in-residence
- * spotlight + register, and the FDL laurel on the top-scoring praxis. Levels read
- * as "Anno {roman}". UA has a real dark mode as of #848; the styling of this
- * file is being reworked under #851, which owns everything here except the copy
- * keys.
+ * Rebuilt for #851. Every plate was a gilt sandwich — gold-leaf inset shadows,
+ * a parchment dot-grain overlay, gold hairlines, italic Cormorant everywhere.
+ * It is now one repeated surface: card stock, a neutral hairline, an uppercase
+ * eyebrow, and the orange used once per block at most.
+ *
+ * The mandala is ABSENT on this page; the hero above it carries the pattern and
+ * the page backdrop carries it behind (brief §5). Tasks and Praxis reuse the
+ * app-wide per-faction cards, which already dispatch to the UA archetypes.
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade.
  */
 
-const PAPER = "var(--faction-ua-card-bg)";
-const PAPER_WARM = "var(--ua-paper-warm)";
-const INK = "var(--faction-ua-card-text)";
-const ACCENT = "var(--faction-ua-card-accent)";
-const SUB = "var(--faction-ua-card-muted)";
-const MUTED = "var(--ua-muted)";
-const GOLD = "var(--ua-gold)";
-const GOLD_LT = "var(--ua-gold-lt)";
-const GOLD_PALE = "var(--ua-gold-pale)";
-const LINE = "var(--ua-line)";
-const LINE_SOFT = "var(--ua-line-soft)";
-const GILT = "var(--ua-gilt)";
-
-const DISPLAY = "var(--faction-ua-card-font)";
-const ENGRAVED = 'var(--faction-ua-body-font)';
-const MONO = "var(--font-body)";
-
-/** Parchment card with the salon's inset gold-leaf border. */
-const PLATE: CSSProperties = {
+/** The one surface this page repeats: card stock inside a neutral hairline. */
+const SHEET: CSSProperties = {
   position: "relative",
   overflow: "hidden",
-  background: PAPER,
-  border: `1px solid ${LINE}`,
-  boxShadow: `0 6px 20px rgba(60,40,10,.09), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`,
+  background: "var(--faction-ua-card-bg)",
+  color: "var(--faction-ua-card-text)",
+  border: "1px solid var(--faction-ua-rule)",
+  borderRadius: "var(--radius-md)",
 };
 
-/** Faint parchment dot texture. */
-function Grain() {
+const SOLID_ACTION: CSSProperties = {
+  fontFamily: UA_TEXT,
+  fontSize: "var(--text-xl)",
+  letterSpacing: "0.14em",
+  textTransform: "uppercase",
+  color: "var(--faction-ua-on-fill)",
+  background: "var(--faction-ua)",
+  border: "none",
+  borderRadius: "var(--radius-sm)",
+  padding: "var(--space-md)",
+};
+
+/** An eyebrow with a hairline running out to the margin. */
+function RuledLabel({ children }: { children: ReactNode }) {
   return (
     <div
-      aria-hidden="true"
       style={{
-        position: "absolute",
-        inset: 0,
-        pointerEvents: "none",
-        backgroundImage: "radial-gradient(rgba(60,40,10,.03) 1px, transparent 1px)",
-        backgroundSize: "5px 5px",
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-md)",
+        marginBottom: "var(--space-lg)",
       }}
-    />
+    >
+      <span style={{ ...UA_EYEBROW, whiteSpace: "nowrap" }}>{children}</span>
+      <span
+        style={{ flex: 1, height: 1, background: "var(--faction-ua-hair)" }}
+      />
+    </div>
   );
 }
 
-const KICKER: CSSProperties = {
-  fontFamily: MONO,
-  fontSize: "var(--text-xs)",
-  letterSpacing: "0.26em",
-  textTransform: "uppercase",
-  color: MUTED,
-  marginBottom: "var(--space-sm)",
-};
-
-function Kicker({ children }: { children: ReactNode }) {
-  return <div style={KICKER}>{children}</div>;
-}
-
-const SECTION_HEADING_WRAP: CSSProperties = { marginBottom: "var(--space-xl)" };
-
-const SECTION_HEADING_TEXT: CSSProperties = {
-  fontFamily: DISPLAY,
-  fontStyle: "italic",
-  fontWeight: 700,
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: the salon's engraved plate cut, a step above the content ramp; rounding it to --text-heading would flatten it into the other archetypes.
-  fontSize: 30,
-  lineHeight: 1,
-  color: INK,
-  margin: 0,
-};
-
-function SectionHeading({ kicker, children }: { kicker: string; children: ReactNode }) {
+function SectionHeading({
+  kicker,
+  children,
+}: {
+  kicker: string;
+  children: ReactNode;
+}) {
   return (
-    <div style={SECTION_HEADING_WRAP}>
-      <Kicker>{kicker}</Kicker>
-      <h2 style={SECTION_HEADING_TEXT}>{children}</h2>
+    <div style={{ marginBottom: "var(--space-xl)" }}>
+      <div style={UA_EYEBROW}>{kicker}</div>
+      <h2
+        style={{
+          fontFamily: UA_DISPLAY,
+          fontWeight: 600,
+          fontSize: "var(--text-heading)",
+          lineHeight: 1.05,
+          letterSpacing: "-0.01em",
+          color: "var(--faction-ua-card-text)",
+          margin: "var(--space-xs) 0 0",
+        }}
+      >
+        {children}
+      </h2>
     </div>
   );
 }
@@ -106,8 +105,16 @@ const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
 // "Anno {roman}"; level 0 shows an em-dash, matching the ephemerists convention.
 const anno = (level: number) => (level > 0 ? toRoman(level) : "—");
 
-/** Circular initials medallion — parchment face, amber italic glyph. */
-function Medallion({ name, size, spotlight = false }: { name: string; size: number; spotlight?: boolean }) {
+/** Circular initials medallion — panel face, display glyph. */
+function Medallion({
+  name,
+  size,
+  spotlight = false,
+}: {
+  name: string;
+  size: number;
+  spotlight?: boolean;
+}) {
   return (
     <span
       style={{
@@ -115,17 +122,17 @@ function Medallion({ name, size, spotlight = false }: { name: string; size: numb
         width: size,
         height: size,
         borderRadius: "50%",
-        background: PAPER_WARM,
-        border: `${spotlight ? 2 : 1}px solid ${spotlight ? ACCENT : GOLD_LT}`,
-        boxShadow: spotlight ? `0 0 0 3px ${PAPER_WARM}, 0 0 0 4px ${GOLD_LT}` : undefined,
+        background: "var(--faction-ua-panel)",
+        border: `${spotlight ? 2 : 1}px solid ${
+          spotlight ? "var(--faction-ua)" : "var(--faction-ua-rule)"
+        }`,
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        fontFamily: DISPLAY,
-        fontStyle: "italic",
-        fontWeight: 700,
+        fontFamily: UA_DISPLAY,
+        fontWeight: 600,
         fontSize: size * 0.42,
-        color: ACCENT,
+        color: "var(--faction-ua-card-text)",
       }}
     >
       {initial(name)}
@@ -135,38 +142,65 @@ function Medallion({ name, size, spotlight = false }: { name: string; size: numb
 
 export default function UaFactionBody({ state }: { state: FactionDetailState }) {
   const { t } = useTranslation("factions");
-  const { faction, members, tasks, recentPraxis, viewerFactionSlug, gameFactions, membership } = state;
+  const {
+    faction,
+    members,
+    tasks,
+    recentPraxis,
+    viewerFactionSlug,
+    gameFactions,
+    membership,
+  } = state;
   const [confirming, setConfirming] = useState(false);
 
   if (!faction) return null;
 
-  const paragraphs = factionDescription(faction.slug).split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const paragraphs = factionDescription(faction.slug)
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
   const ranked = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const spot: CharacterOut | undefined = ranked[0];
   const register = ranked.slice(1);
 
+  const prose: CSSProperties = {
+    fontFamily: UA_TEXT,
+    lineHeight: 1.7,
+    color: "var(--faction-ua-card-body)",
+    margin: 0,
+  };
+
   return (
     <div className="wz-faction-grid">
       {/* ── MAIN COLUMN ── */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-2xl)",
+        }}
+      >
         {/* ② THE PRACTICE */}
-        <div style={{ ...PLATE, padding: "var(--space-xl) var(--space-2xl)" }}>
-          <Grain />
-          <div style={{ position: "relative", display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-lg)" }}>
-            <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.26em", textTransform: "uppercase", color: MUTED }}>
-              {t("ua.practice.heading")}
-            </span>
-            <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD_LT}, transparent)` }} />
-          </div>
-          <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
+        <div style={{ ...SHEET, padding: "var(--space-xl) var(--space-2xl)" }}>
+          <RuledLabel>{t("ua.practice.heading")}</RuledLabel>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-md)",
+            }}
+          >
             {paragraphs.length ? (
               paragraphs.map((para, i) => (
-                <p key={i} className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.75, color: INK, margin: 0 }}>
+                <p key={i} className="content-text" style={prose}>
                   {para}
                 </p>
               ))
             ) : (
-              <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.75, color: SUB, margin: 0 }}>
+              <p
+                className="content-text"
+                style={{ ...prose, color: "var(--faction-ua-card-muted)" }}
+              >
                 {t("ua.practice.empty")}
               </p>
             )}
@@ -175,11 +209,25 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
         {/* ④ TASKS */}
         <div>
-          <SectionHeading kicker={t("ua.tasks.kicker")}>{t("ua.tasks.heading")}</SectionHeading>
+          <SectionHeading kicker={t("ua.tasks.kicker")}>
+            {t("ua.tasks.heading")}
+          </SectionHeading>
           {tasks.length === 0 ? (
-            <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", color: SUB }}>{t("ua.tasks.empty")}</p>
+            <p
+              className="content-text"
+              style={{ ...prose, color: "var(--faction-ua-card-muted)" }}
+            >
+              {t("ua.tasks.empty")}
+            </p>
           ) : (
-            <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-xl)", alignItems: "flex-start" }}>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "var(--space-xl)",
+                alignItems: "flex-start",
+              }}
+            >
               {tasks.map((task) => (
                 <TaskCard
                   key={task.id}
@@ -198,23 +246,45 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
         {/* ⑤ PRAXIS */}
         <div>
-          <SectionHeading kicker={t("ua.praxis.kicker")}>{t("ua.praxis.heading")}</SectionHeading>
+          <SectionHeading kicker={t("ua.praxis.kicker")}>
+            {t("ua.praxis.heading")}
+          </SectionHeading>
           {recentPraxis.length === 0 ? (
-            <p className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", color: SUB }}>{t("ua.praxis.empty")}</p>
+            <p
+              className="content-text"
+              style={{ ...prose, color: "var(--faction-ua-card-muted)" }}
+            >
+              {t("ua.praxis.empty")}
+            </p>
           ) : (
-            <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-lg)", alignItems: "flex-start" }}>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "var(--space-lg)",
+                alignItems: "flex-start",
+              }}
+            >
               {recentPraxis.map((praxis) => (
-                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                <div
+                  key={praxis.id}
+                  style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}
+                >
                   {/* Task Crown (ADR-0028) — the skin's own corner medallion,
                       so the card's built-in stamp is suppressed. */}
                   {praxis.is_top_for_task && (
                     <TaskCrown
                       size={42}
-                      innerBg={PAPER_WARM}
-                      glyphColor={INK}
+                      innerBg="var(--faction-ua-panel)"
+                      glyphColor="var(--faction-ua-card-accent)"
                       rotate="-8deg"
-                      shadow="drop-shadow(1.5px 2px 0 rgba(60,40,10,.28))"
-                      style={{ position: "absolute", top: -12, right: -8, zIndex: 5 }}
+                      shadow={`drop-shadow(1.5px 2px 0 ${uaShade(28)})`}
+                      style={{
+                        position: "absolute",
+                        top: -12,
+                        right: -8,
+                        zIndex: 5,
+                      }}
                     />
                   )}
                   <PraxisCard praxis={praxis} showCrown={false} />
@@ -226,135 +296,228 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
       </div>
 
       {/* ── RIGHT RAIL ── */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
-        {/* ③ THE REGISTRY — enroll / gate / standing */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-2xl)",
+        }}
+      >
+        {/* ③ THE REGISTRY — join / gate / standing */}
         {membership.state !== "none" && (
-          <div style={{ ...PLATE, boxShadow: `0 8px 24px rgba(60,40,10,.12), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`, padding: "var(--space-xl)" }}>
-            <Grain />
-            <div style={{ position: "relative", display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-lg)" }}>
-              <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
-                {t("ua.registry.heading")}
-              </span>
-              <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${GOLD_LT}, transparent)` }} />
-            </div>
-            <div style={{ position: "relative" }}>
-              {membership.state === "member" && (
-                <div>
-                  <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1, color: INK }}>
-                    {t("ua.registry.memberTitle")}
-                  </div>
-                  <div style={{ fontFamily: DISPLAY, fontStyle: "italic", fontSize: "var(--text-xl)", color: SUB, margin: "var(--space-md) 0 0" }}>
-                    <Trans t={t} i18nKey="ua.registry.memberStanding">
-                      Standing · <span style={{ color: ACCENT }}>enrolled</span>
-                    </Trans>
-                  </div>
-                </div>
-              )}
+          <div style={{ ...SHEET, padding: "var(--space-xl)" }}>
+            <RuledLabel>{t("ua.registry.heading")}</RuledLabel>
 
-              {membership.state === "eligible" && !confirming && (
-                <div>
-                  <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-base)", letterSpacing: "0.1em", color: GOLD, marginBottom: "var(--space-xs)" }}>{t("ua.registry.eligibleKicker")}</div>
-                  <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1.02, color: INK, marginBottom: "var(--space-md)" }}>
-                    {t("ua.registry.eligibleTitle")}
-                  </div>
-                  <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.55, color: SUB, marginBottom: "var(--space-lg)" }}>
-                    {t("ua.registry.eligibleBody")}
-                  </div>
-                  <button
-                    onClick={() => setConfirming(true)}
-                    style={{ width: "100%", fontFamily: ENGRAVED, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: PAPER_WARM, background: ACCENT, border: "none", padding: "var(--space-md)", boxShadow: "0 6px 16px rgba(194,84,31,.28)", cursor: "pointer" }}
+            {membership.state === "member" && (
+              <div>
+                <div
+                  className="content-title"
+                  style={{
+                    fontFamily: UA_DISPLAY,
+                    fontWeight: 600,
+                    lineHeight: 1.05,
+                    color: "var(--faction-ua-card-text)",
+                  }}
+                >
+                  {t("ua.registry.memberTitle")}
+                </div>
+                <div
+                  style={{
+                    ...prose,
+                    fontSize: "var(--text-content)",
+                    marginTop: "var(--space-md)",
+                  }}
+                >
+                  <Trans t={t} i18nKey="ua.registry.memberStanding">
+                    Standing ·{" "}
+                    <span style={{ color: "var(--faction-ua-card-accent)" }}>
+                      practising
+                    </span>
+                  </Trans>
+                </div>
+              </div>
+            )}
+
+            {membership.state === "eligible" && !confirming && (
+              <div>
+                <div style={UA_EYEBROW}>{t("ua.registry.eligibleKicker")}</div>
+                <div
+                  className="content-title"
+                  style={{
+                    fontFamily: UA_DISPLAY,
+                    fontWeight: 600,
+                    lineHeight: 1.05,
+                    color: "var(--faction-ua-card-text)",
+                    margin: "var(--space-xs) 0 var(--space-md)",
+                  }}
+                >
+                  {t("ua.registry.eligibleTitle")}
+                </div>
+                <p
+                  className="content-text"
+                  style={{ ...prose, marginBottom: "var(--space-lg)" }}
+                >
+                  {t("ua.registry.eligibleBody")}
+                </p>
+                <button
+                  onClick={() => setConfirming(true)}
+                  style={{ ...SOLID_ACTION, width: "100%", cursor: "pointer" }}
+                >
+                  {t("ua.registry.joinButton")}
+                </button>
+              </div>
+            )}
+
+            {membership.state === "eligible" && confirming && (
+              <div>
+                <p
+                  className="content-text"
+                  style={{
+                    ...prose,
+                    color: "var(--faction-ua-card-text)",
+                    marginBottom: "var(--space-lg)",
+                  }}
+                >
+                  {membership.currentFactionSlug &&
+                  membership.currentFactionSlug !== "na"
+                    ? t("ua.registry.confirmSwitch", {
+                        faction: factionName(faction.slug),
+                        current: factionName(membership.currentFactionSlug),
+                      })
+                    : t("ua.registry.confirm", {
+                        faction: factionName(faction.slug),
+                      })}
+                </p>
+                {membership.joinError && (
+                  <p
+                    className="content-text"
+                    style={{
+                      ...prose,
+                      color: "var(--color-danger)",
+                      marginBottom: "var(--space-sm)",
+                    }}
                   >
-                    {t("ua.registry.joinButton")}
+                    {membership.joinError}
+                  </p>
+                )}
+                <div style={{ display: "flex", gap: "var(--space-sm)" }}>
+                  <button
+                    onClick={() => void membership.join()}
+                    disabled={membership.joining}
+                    style={{
+                      ...SOLID_ACTION,
+                      flex: 1,
+                      cursor: membership.joining ? "not-allowed" : "pointer",
+                    }}
+                  >
+                    {membership.joining
+                      ? t("ua.registry.joining")
+                      : t("ua.registry.confirmButton")}
+                  </button>
+                  <button
+                    onClick={() => setConfirming(false)}
+                    disabled={membership.joining}
+                    style={{
+                      ...UA_EYEBROW,
+                      background: "transparent",
+                      border: "1px solid var(--faction-ua-rule)",
+                      borderRadius: "var(--radius-sm)",
+                      padding: "var(--space-md) var(--space-lg)",
+                      cursor: membership.joining ? "not-allowed" : "pointer",
+                    }}
+                  >
+                    {t("detail.join.cancel")}
                   </button>
                 </div>
-              )}
+              </div>
+            )}
 
-              {membership.state === "eligible" && confirming && (
-                <div>
-                  <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.6, color: INK, marginBottom: "var(--space-lg)" }}>
-                    {membership.currentFactionSlug &&
-                    membership.currentFactionSlug !== "na"
-                      ? t("ua.registry.confirmSwitch", {
-                          faction: factionName(faction.slug),
-                          current: factionName(membership.currentFactionSlug),
-                        })
-                      : t("ua.registry.confirm", { faction: factionName(faction.slug) })}
-                  </div>
-                  {membership.joinError && (
-                    <div className="content-text" style={{ fontFamily: MONO, color: "var(--color-danger)", marginBottom: "var(--space-sm)" }}>{membership.joinError}</div>
-                  )}
-                  <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                    <button
-                      onClick={() => void membership.join()}
-                      disabled={membership.joining}
-                      style={{ flex: 1, fontFamily: ENGRAVED, fontSize: "var(--text-md)", letterSpacing: "0.12em", color: PAPER_WARM, background: ACCENT, border: "none", padding: "var(--space-md)", cursor: membership.joining ? "not-allowed" : "pointer" }}
-                    >
-                      {membership.joining
-                        ? t("ua.registry.joining")
-                        : t("ua.registry.confirmButton")}
-                    </button>
-                    <button
-                      onClick={() => setConfirming(false)}
-                      disabled={membership.joining}
-                      style={{ fontFamily: ENGRAVED, fontSize: "var(--text-base)", letterSpacing: "0.12em", color: SUB, background: "transparent", border: `1px solid ${LINE}`, padding: "var(--space-md) var(--space-lg)", cursor: membership.joining ? "not-allowed" : "pointer" }}
-                    >
-                      {t("detail.join.cancel")}
-                    </button>
-                  </div>
+            {membership.state === "gate" && (
+              <div>
+                <div style={UA_EYEBROW}>{t("ua.registry.gateKicker")}</div>
+                <div
+                  className="content-title"
+                  style={{
+                    fontFamily: UA_DISPLAY,
+                    fontWeight: 600,
+                    lineHeight: 1.05,
+                    color: "var(--faction-ua-card-text)",
+                    margin: "var(--space-xs) 0 var(--space-md)",
+                  }}
+                >
+                  {t("ua.registry.gateTitle")}
                 </div>
-              )}
-
-              {membership.state === "gate" && (
-                <div>
-                  <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-base)", letterSpacing: "0.1em", color: GOLD, marginBottom: "var(--space-xs)" }}>{t("ua.registry.gateKicker")}</div>
-                  <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1.04, color: INK, marginBottom: "var(--space-md)" }}>
-                    {t("ua.registry.gateTitle")}
-                  </div>
-                  <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", lineHeight: 1.65, color: SUB }}>
-                    {t("ua.registry.gateBody", { faction: factionName(faction.slug) })}
-                  </div>
-                </div>
-              )}
-            </div>
+                <p className="content-text" style={prose}>
+                  {t("ua.registry.gateBody", {
+                    faction: factionName(faction.slug),
+                  })}
+                </p>
+              </div>
+            )}
           </div>
         )}
 
-        {/* ⑥ MEMBERS — artist in residence + the register */}
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-xl)" }}>
+        {/* ⑥ MEMBERS — held up + the circle */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-xl)",
+          }}
+        >
           {spot && (
             <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none" }}>
-              {/* gilt sandwich frame */}
-              <div style={{ padding: "var(--space-md)", background: GILT, boxShadow: "0 12px 28px rgba(60,40,10,.22), inset 0 0 0 1px rgba(255,255,255,.45)" }}>
-                <div style={{ padding: "var(--space-xs)", background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})` }}>
-                  <div style={{ background: PAPER_WARM, border: `1px solid ${LINE}`, padding: "var(--space-xl) var(--space-lg) var(--space-lg)", textAlign: "center" }}>
-                    <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.3em", textTransform: "uppercase", color: MUTED, marginBottom: "var(--space-md)" }}>
-                      {t("ua.spotlight.label")}
-                    </div>
-                    <div style={{ display: "flex", justifyContent: "center", marginBottom: "var(--space-md)" }}>
-                      <Medallion name={spot.display_name} size={72} spotlight />
-                    </div>
-                    <div className="content-title" style={{ fontFamily: DISPLAY, fontStyle: "italic", fontWeight: 700, lineHeight: 1, color: INK }}>
-                      {spot.display_name}
-                    </div>
-                    <div style={{ fontFamily: ENGRAVED, fontSize: "var(--text-xs)", letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, marginTop: "var(--space-sm)" }}>
-                      {t("ua.spotlight.stat", {
-                        anno: anno(spot.level),
-                        score: spot.all_time_score.toLocaleString(),
-                      })}
-                    </div>
-                  </div>
+              <div
+                style={{
+                  ...SHEET,
+                  background:
+                    "linear-gradient(160deg, var(--faction-ua-lift), var(--faction-ua-card-bg) 60%)",
+                  padding: "var(--space-xl) var(--space-lg)",
+                  textAlign: "center",
+                }}
+              >
+                <div style={{ ...UA_EYEBROW, marginBottom: "var(--space-md)" }}>
+                  {t("ua.spotlight.label")}
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "center",
+                    marginBottom: "var(--space-md)",
+                  }}
+                >
+                  <Medallion name={spot.display_name} size={72} spotlight />
+                </div>
+                <div
+                  className="content-title"
+                  style={{
+                    fontFamily: UA_DISPLAY,
+                    fontWeight: 600,
+                    lineHeight: 1.05,
+                    color: "var(--faction-ua-card-text)",
+                  }}
+                >
+                  {spot.display_name}
+                </div>
+                <div style={{ ...UA_EYEBROW, marginTop: "var(--space-sm)" }}>
+                  {t("ua.spotlight.stat", {
+                    anno: anno(spot.level),
+                    score: spot.all_time_score.toLocaleString(),
+                  })}
                 </div>
               </div>
             </Link>
           )}
 
-          <div style={{ ...PLATE, boxShadow: `0 4px 14px rgba(60,40,10,.08), inset 0 0 0 3px ${PAPER}, inset 0 0 0 4px ${GOLD_PALE}`, padding: "var(--space-lg) var(--space-xl) var(--space-lg)" }}>
-            <Grain />
-            <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED, marginBottom: "var(--space-md)" }}>
-              {t("ua.roster.heading")}
-            </div>
+          <div
+            style={{ ...SHEET, padding: "var(--space-lg) var(--space-xl)" }}
+          >
+            <RuledLabel>{t("ua.roster.heading")}</RuledLabel>
             {register.length === 0 ? (
-              <p className="content-text" style={{ position: "relative", fontFamily: DISPLAY, fontStyle: "italic", color: SUB }}>
+              <p
+                className="content-text"
+                style={{ ...prose, color: "var(--faction-ua-card-muted)" }}
+              >
                 {spot
                   ? t("ua.roster.emptyWithSpotlight")
                   : t("detail.membersEmpty")}
@@ -364,15 +527,33 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                 <Link
                   key={m.id}
                   to={`/characters/${m.id}`}
-                  style={{ position: "relative", display: "flex", alignItems: "center", gap: "var(--space-md)", padding: "var(--space-sm) 0", borderBottom: `1px solid ${LINE_SOFT}`, textDecoration: "none" }}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "var(--space-md)",
+                    padding: "var(--space-sm) 0",
+                    borderBottom: "1px solid var(--faction-ua-hair)",
+                    textDecoration: "none",
+                  }}
                 >
                   <Medallion name={m.display_name} size={32} />
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <div className="content-text" style={{ fontFamily: DISPLAY, fontStyle: "italic", color: INK, lineHeight: 1.1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    <div
+                      className="content-text"
+                      style={{
+                        fontFamily: UA_DISPLAY,
+                        fontWeight: 600,
+                        color: "var(--faction-ua-card-text)",
+                        lineHeight: 1.15,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
                       {m.display_name}
                     </div>
                   </div>
-                  <span style={{ fontFamily: ENGRAVED, fontSize: "var(--text-sm)", letterSpacing: "0.08em", color: GOLD }}>
+                  <span style={{ ...UA_EYEBROW, letterSpacing: "0.16em" }}>
                     {t("ua.roster.level", { anno: anno(m.level) })}
                   </span>
                 </Link>

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -294,7 +294,10 @@ export default function DefaultProposeTask({
                     >
                       {factionName(slug)}
                     </span>
-                    <span className="eyebrow">
+                    {/* Sentence-case: the descriptors are no longer uniformly
+                        one word (#850 gave UA a full sentence), and 0.15em
+                        all-caps is a wall at that length. */}
+                    <span className="eyebrow-sentence">
                       {factionDescriptor(slug)}
                     </span>
                   </button>

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -28,9 +28,9 @@ import type { TaskDetailState } from "../useTaskDetail";
  * three surfaces — page backdrop, faction hero, join card — and a detail page
  * is dense reading; the UA page backdrop already carries the texture behind it.
  *
- * Both themes come from the `[data-theme="dark"]` cascade. This page used to
- * declare itself always-light and paint with four font tokens that were never
- * declared anywhere (`--ua-display`, `--ua-engraved`, `--ua-mono`,
+ * Both themes come from the `[data-theme="dark"]` cascade; the page dims with
+ * the app. It also used to paint with four font tokens that are declared
+ * nowhere in index.css (`--ua-display`, `--ua-engraved`, `--ua-mono`,
  * `--ua-serif`) — undefined custom properties that silently fell back to the
  * inherited face. Both are fixed here.
  */

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -2,40 +2,40 @@ import type { CSSProperties, ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
+import { UaSigil } from "../../../components/cards/UaSigil";
+import {
+  UA_DISPLAY,
+  UA_EYEBROW,
+  UA_TEXT,
+  UaEnsoScore,
+  UaInkColumn,
+  uaShade,
+} from "../../../components/cards/uaAtoms";
 import { mediaUrl } from "../../../utils/media";
 import { ErrorBanner, relationOf } from "./shared";
 import type { TaskSignupOut } from "../../../api/tasks";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
- * The UA task-detail archetype — the GILT SALON: an art-academy "acquisition"
- * voice rendered as a museum acquisition plate. A gold-framed heraldic masthead
- * (burnt amber / cream / gold / brown ink), a matriculation CTA, the commission
- * brief on parchment, the hands matriculated, "The Salon Wall" of filed praxis
- * (the finest hand wears a fleur-de-lis), and a read-only critique aggregate.
- * Ported from the UA design kit (UaTaskDetail.tsx); wired to the real
- * {@link TaskDetailState}.
+ * UA task detail — the sheet (#851).
  *
- * UA is ALWAYS-LIGHT — its --faction-ua-* / --ua-* tokens are identical in both
- * themes, so the salon never dims and we never mutate the document theme. The
- * kit's top <nav> and critique/comment thread are dropped (TaskDetail.tsx renders
- * the breadcrumb context and CommentThread). Every raw hex from the kit is mapped
- * onto the existing UA CSS vars in index.css.
+ * The gilt salon is dead: no crest shield, no gold-leaf sandwich, no dot-grid
+ * parchment, no fleur-de-lis. A task reads as a sheet of sun-bleached stock
+ * with one orange hairline down the left margin, the marks held in an ensō, and
+ * quiet uppercase labels over hairline rules.
+ *
+ * The mandala is ABSENT here (brief §5). The pattern is allowed on exactly
+ * three surfaces — page backdrop, faction hero, join card — and a detail page
+ * is dense reading; the UA page backdrop already carries the texture behind it.
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade. This page used to
+ * declare itself always-light and paint with four font tokens that were never
+ * declared anywhere (`--ua-display`, `--ua-engraved`, `--ua-mono`,
+ * `--ua-serif`) — undefined custom properties that silently fell back to the
+ * inherited face. Both are fixed here.
  */
 
-const INK = "var(--ua-ink)";
-const SUB = "var(--ua-sub)";
-const MUTED = "var(--ua-muted)";
-const ORANGE = "var(--ua-orange)";
-const ORANGE_DEEP = "var(--ua-orange-deep)";
-const GOLD = "var(--ua-gold)";
-const GOLD_PALE = "var(--ua-gold-pale)";
-const PAPER = "var(--ua-paper)";
-const PAPER_WARM = "var(--ua-paper-warm)";
-const LINE = "var(--ua-line)";
-const GILT = "var(--ua-gilt)";
-
-/** Roman numeral for the salon's "ANNO" (level) label. */
+/** Roman numeral for the practice's "ANNO" (level) label. */
 function romanLevel(n: number): string {
   return (
     ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"][
@@ -44,89 +44,51 @@ function romanLevel(n: number): string {
   );
 }
 
-/** The UA heraldic crest — a shield, sun, and crossed brushes. */
-function CrestShield({ size = 150 }: { size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={size * 1.2}
-      viewBox="0 0 100 120"
-      style={{ display: "block", flexShrink: 0 }}
-    >
-      <defs>
-        <clipPath id="ua-det-shield">
-          <path d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z" />
-        </clipPath>
-      </defs>
-      <g clipPath="url(#ua-det-shield)">
-        <rect x="0" y="0" width="100" height="120" fill={ORANGE} />
-        <rect
-          x="0"
-          y="60"
-          width="100"
-          height="60"
-          fill="color-mix(in srgb, var(--ua-gold-pale) 55%, var(--ua-paper))"
-        />
-        <circle cx="50" cy="60" r="15" fill={GOLD_PALE} />
-        <g stroke={GOLD_PALE} strokeWidth="2.4" strokeLinecap="round">
-          <line x1="50" y1="60" x2="50" y2="20" />
-          <line x1="50" y1="60" x2="22" y2="30" />
-          <line x1="50" y1="60" x2="78" y2="30" />
-          <line x1="50" y1="60" x2="14" y2="48" />
-          <line x1="50" y1="60" x2="86" y2="48" />
-          <line x1="50" y1="60" x2="34" y2="22" />
-          <line x1="50" y1="60" x2="66" y2="22" />
-        </g>
-        <g transform="translate(50 84)">
-          <g transform="rotate(38)">
-            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill={INK} />
-            <rect x="-3" y="10" width="6" height="6" fill={GOLD_PALE} />
-            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill={ORANGE} />
-          </g>
-          <g transform="rotate(-38)">
-            <rect x="-2" y="-30" width="4" height="44" rx="1.5" fill={GOLD} />
-            <rect x="-3" y="10" width="6" height="6" fill={GOLD_PALE} />
-            <path d="M-3 16 L3 16 L1.5 26 L-1.5 26 Z" fill="var(--ua-gold-lt)" />
-          </g>
-        </g>
-      </g>
-      <path
-        d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z"
-        fill="none"
-        stroke="var(--ua-gold-lt)"
-        strokeWidth="2.5"
-      />
-      <path
-        d="M8 6 H92 V60 C92 92 66 108 50 116 C34 108 8 92 8 60 Z"
-        fill="none"
-        stroke={INK}
-        strokeWidth="0.8"
-      />
-    </svg>
-  );
-}
-
-const sectionRule: CSSProperties = {
-  flex: 1,
-  height: 1,
-  background: `linear-gradient(90deg, ${LINE}, transparent)`,
-};
-const sectionH2: CSSProperties = {
-  fontFamily: "var(--ua-engraved)",
-  letterSpacing: "0.06em",
-  margin: 0,
-  color: INK,
-  whiteSpace: "nowrap",
+const PANEL: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "var(--space-lg)",
+  flexWrap: "wrap",
+  padding: "var(--space-lg) var(--space-xl)",
+  border: "1px solid var(--faction-ua-rule)",
+  borderRadius: "var(--radius-sm)",
+  background: "var(--faction-ua-card-bg)",
 };
 
-/** Section header — engraved-caps heading with a fading gold rule. */
-function SectionHead({
-  title,
-  trailing,
-}: {
-  title: string;
-  trailing?: ReactNode;
-}) {
+/**
+ * The banner surface for a signup error.
+ *
+ * #848 turned `--faction-ua-light` from `rgba(194,84,31,.08)` into an opaque
+ * `#f2e0cb`; what used to be a whisper behind this banner became a solid wash.
+ * It now names the panel token it was always reaching for, and takes an accent
+ * ink that clears AA on it in both themes.
+ */
+const BANNER: CSSProperties = {
+  flexBasis: "100%",
+  marginTop: 0,
+  background: "var(--faction-ua-panel)",
+  border: "1px solid var(--faction-ua-border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--faction-ua-card-accent)",
+};
+
+/** Solid-fill affordance — the practice's one saturated note. */
+const FILLED_ACTION: CSSProperties = {
+  cursor: "pointer",
+  fontFamily: UA_TEXT,
+  fontSize: "var(--text-xl)",
+  letterSpacing: "0.14em",
+  textTransform: "uppercase",
+  color: "var(--faction-ua-on-fill)",
+  background: "var(--faction-ua)",
+  border: "none",
+  borderRadius: "var(--radius-sm)",
+  padding: "var(--space-md) var(--space-xl)",
+  textDecoration: "none",
+};
+
+/** Section header — the eyebrow over a hairline that runs to the margin. */
+function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
   return (
     <div
       style={{
@@ -136,14 +98,16 @@ function SectionHead({
         marginBottom: "var(--space-lg)",
       }}
     >
-      <h2 className="content-title" style={sectionH2}>{title}</h2>
-      <span style={sectionRule} />
+      <h2 style={{ ...UA_EYEBROW, margin: 0, whiteSpace: "nowrap" }}>{title}</h2>
+      <span
+        style={{ flex: 1, height: 1, background: "var(--faction-ua-rule)" }}
+      />
       {trailing}
     </div>
   );
 }
 
-/** Hands matriculated — real signup avatars with friend/foe dots. */
+/** Those practising — signup portraits with friend/foe dots. */
 function HandsRow({
   signups,
   friends,
@@ -156,22 +120,21 @@ function HandsRow({
   const { t } = useTranslation("tasks");
   return (
     <div
-      style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", flexWrap: "wrap" }}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-md)",
+        flexWrap: "wrap",
+      }}
     >
       {signups.map((hand) => {
         const rel = relationOf(hand.character_id, friends, foes);
-        const relColor = rel === "friend" ? GOLD : ORANGE;
         return (
           <Link
             key={hand.character_id}
             to={`/characters/${hand.character_id}`}
             title={`${hand.display_name}${rel ? ` · ${rel}` : ""}`}
-            style={{
-              position: "relative",
-              width: 40,
-              height: 40,
-              flexShrink: 0,
-            }}
+            style={{ position: "relative", width: 40, height: 40, flexShrink: 0 }}
           >
             {hand.avatar_url ? (
               <img
@@ -182,7 +145,7 @@ function HandsRow({
                   height: 40,
                   borderRadius: "50%",
                   objectFit: "cover",
-                  border: `2px solid ${GOLD}`,
+                  border: "1.5px solid var(--faction-ua-rule)",
                 }}
               />
             ) : (
@@ -192,13 +155,13 @@ function HandsRow({
                   width: 40,
                   height: 40,
                   borderRadius: "50%",
-                  background: INK,
-                  border: `2px solid ${GOLD}`,
+                  background: "var(--faction-ua-panel)",
+                  border: "1.5px solid var(--faction-ua-rule)",
                   alignItems: "center",
                   justifyContent: "center",
-                  color: GOLD_PALE,
-                  fontFamily: "var(--ua-display)",
-                  fontStyle: "italic",
+                  color: "var(--faction-ua-card-text)",
+                  fontFamily: UA_DISPLAY,
+                  fontWeight: 600,
                   fontSize: "var(--text-content)",
                 }}
               >
@@ -215,82 +178,60 @@ function HandsRow({
                   width: 12,
                   height: 12,
                   borderRadius: "50%",
-                  background: relColor,
-                  border: `2px solid ${PAPER_WARM}`,
+                  background:
+                    rel === "friend"
+                      ? "var(--faction-ua)"
+                      : "var(--faction-ua-vermil)",
+                  border: "2px solid var(--faction-ua-card-bg)",
                 }}
               />
             )}
           </Link>
         );
       })}
-      <span
-        style={{
-          fontFamily: "var(--ua-mono)",
-          fontSize: "var(--text-base)",
-          letterSpacing: "0.12em",
-          textTransform: "uppercase",
-          color: MUTED,
-          marginLeft: "var(--space-xs)",
-        }}
-      >
+      <span style={{ ...UA_EYEBROW, marginLeft: "var(--space-xs)" }}>
         {t("ua.matriculated")}
       </span>
     </div>
   );
 }
 
-/** An acquisition stat plate — engraved label over a didone value. */
-function StatPlate({
+/** One count from the sheet's head — a numeral over its label. */
+function StatCell({
   label,
   children,
-  accent = false,
+  last = false,
 }: {
   label: string;
   children: ReactNode;
-  accent?: boolean;
+  last?: boolean;
 }) {
   return (
     <div
       style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "var(--space-xs)",
-        padding: "var(--space-sm) var(--space-lg)",
-        border: `1px solid ${accent ? ORANGE : LINE}`,
-        background: accent ? ORANGE : PAPER,
+        flex: "1 1 140px",
+        minWidth: 140,
+        padding: "var(--space-lg) var(--space-xl)",
+        borderRight: last ? undefined : "1px solid var(--faction-ua-hair)",
       }}
     >
-      <span
+      <div
         style={{
-          fontFamily: "var(--ua-engraved)",
-          fontSize: "var(--text-xs)",
-          letterSpacing: "0.14em",
-          color: accent ? "var(--ua-paper-warm)" : MUTED,
-        }}
-      >
-        {label}
-      </span>
-      <span
-        className="content-title"
-        style={{
-          fontFamily: "var(--ua-display)",
-          fontStyle: "italic",
-          fontWeight: 700,
-          lineHeight: 0.9,
-          color: accent ? PAPER_WARM : INK,
+          fontFamily: UA_DISPLAY,
+          fontWeight: 600,
+          fontSize: "var(--text-title)",
+          lineHeight: 1,
+          color: "var(--faction-ua-card-text)",
         }}
       >
         {children}
-      </span>
+      </div>
+      <div style={{ ...UA_EYEBROW, marginTop: "var(--space-xs)" }}>{label}</div>
     </div>
   );
 }
 
-export default function UaTaskDetail({
-  state,
-}: {
-  state: TaskDetailState;
-}) {
+export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
   const { t } = useTranslation("tasks");
   const {
     task,
@@ -318,14 +259,11 @@ export default function UaTaskDetail({
   // Guarded non-null by the dispatcher.
   if (!task) return null;
 
-  // Status in the salon's voice: active reads as an open salon "on view".
   const statusVoice =
     task.status === "active" ? t("ua.statusOpen") : task.status;
-
-  // Decorative: the salon's "commission №" — derived from the real task id.
   const commissionNo = String(task.id).padStart(4, "0");
 
-  // The finest hand on the Salon Wall wears the ⚜ fleur-de-lis.
+  // The truest hand on the sheet wears a quiet orange tag.
   const topId = submissions.length
     ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
     : null;
@@ -333,190 +271,152 @@ export default function UaTaskDetail({
   return (
     <div
       className="py-8"
-      style={{ fontFamily: "var(--ua-mono)", color: INK }}
+      style={{ fontFamily: UA_TEXT, color: "var(--faction-ua-page-text)" }}
     >
       {/* ── Breadcrumb ── */}
-      <nav
-        className="mb-4"
-        style={{
-          fontFamily: "var(--ua-mono)",
-          fontSize: "var(--text-base)",
-          letterSpacing: "0.18em",
-          textTransform: "uppercase",
-          color: MUTED,
-        }}
-      >
-        <Link to="/tasks" style={{ color: ORANGE, textDecoration: "none" }}>
+      <nav className="mb-4" style={UA_EYEBROW}>
+        <Link
+          to="/tasks"
+          style={{ color: "var(--faction-ua-card-accent)", textDecoration: "none" }}
+        >
           {t("default.breadcrumb")}
         </Link>
-        <span style={{ opacity: 0.5, margin: "0 var(--space-sm)" }}>›</span>
-        <span style={{ fontFamily: "var(--ua-engraved)" }}>{t("ua.faction")}</span>
-        <span style={{ opacity: 0.5, margin: "0 var(--space-sm)" }}>›</span>
-        <span style={{ color: ORANGE }}>{task.title}</span>
+        <span style={{ margin: "0 var(--space-sm)" }}>·</span>
+        <span>{t("ua.faction")}</span>
+        <span style={{ margin: "0 var(--space-sm)" }}>·</span>
+        <span style={{ color: "var(--faction-ua-card-accent)" }}>{task.title}</span>
       </nav>
 
       <div style={{ maxWidth: 920 }}>
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
-          {/* ── HERO — gilt salon acquisition plate ── */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2xl)",
+          }}
+        >
+          {/* ── THE SHEET — masthead + counts ── */}
           <div
             style={{
-              padding: "var(--space-md)",
-              background: GILT,
-              boxShadow:
-                "0 18px 40px rgba(60,40,10,0.28), inset 0 0 0 1px rgba(255,255,255,0.45)",
+              position: "relative",
+              overflow: "hidden",
+              border: "1px solid var(--faction-ua-rule)",
+              borderRadius: "var(--radius-md)",
+              background: "var(--faction-ua-card-bg)",
+              boxShadow: `0 14px 38px -24px ${uaShade(52)}`,
             }}
           >
             <div
               style={{
-                padding: "var(--space-xs)",
-                background: `linear-gradient(135deg, ${GOLD}, ${GOLD_PALE})`,
+                position: "relative",
+                background:
+                  "linear-gradient(160deg, var(--faction-ua-lift), var(--faction-ua-panel))",
+                borderBottom: "1px solid var(--faction-ua-hair)",
+                padding: "var(--space-2xl) var(--space-2xl) var(--space-xl)",
               }}
             >
+              <UaInkColumn
+                style={{
+                  left: "var(--space-md)",
+                  top: "var(--space-2xl)",
+                  bottom: "var(--space-xl)",
+                }}
+              />
               <div
                 style={{
                   position: "relative",
-                  border: "1px solid color-mix(in srgb, var(--ua-ink) 45%, transparent)",
-                  background: PAPER_WARM,
-                  backgroundImage:
-                    "radial-gradient(color-mix(in srgb, var(--ua-ink) 3%, transparent) 1px, transparent 1px)",
-                  backgroundSize: "5px 5px",
-                  // eslint-disable-next-line local/no-raw-style-values -- ornament: the inset of the crest panel within its gilt border, sized to the dot-grid ground rather than the layout scale.
-                  padding: "34px 38px 30px",
+                  paddingLeft: "var(--space-lg)",
                   display: "flex",
                   gap: "var(--space-2xl)",
                   alignItems: "center",
                   flexWrap: "wrap",
                 }}
               >
-                <CrestShield size={150} />
-                <div style={{ flex: 1, minWidth: 240 }}>
-                  <div
-                    style={{
-                      fontFamily: "var(--ua-engraved)",
-                      fontSize: "var(--text-md)",
-                      letterSpacing: "0.16em",
-                      color: ORANGE,
-                      marginBottom: "var(--space-xs)",
-                    }}
-                  >
-                    {t("ua.masthead")}
-                  </div>
-                  <div
-                    style={{
-                      fontFamily: "var(--ua-mono)",
-                      fontSize: "var(--text-xs)",
-                      letterSpacing: "0.3em",
-                      color: MUTED,
-                      marginBottom: "var(--space-lg)",
-                    }}
-                  >
+                <UaEnsoScore
+                  size={124}
+                  value={modifiedPoints}
+                  unit={t("ua.stats.honoraria")}
+                  valueColor="var(--faction-ua-vermil)"
+                />
+                <div style={{ flex: 1, minWidth: 260 }}>
+                  <div style={UA_EYEBROW}>{t("ua.masthead")}</div>
+                  <div style={{ ...UA_EYEBROW, letterSpacing: "0.3em" }}>
                     {t("ua.commissionLine", { number: commissionNo })}
                   </div>
                   <h1
-                    className="content-title"
                     style={{
-                      fontFamily: "var(--ua-display)",
-                      fontStyle: "italic",
-                      fontWeight: 700,
+                      fontFamily: UA_DISPLAY,
+                      fontWeight: 600,
+                      fontSize: "var(--text-heading)",
                       lineHeight: 1.06,
-                      color: INK,
-                      margin: "0 0 var(--space-lg)",
+                      letterSpacing: "-0.01em",
+                      color: "var(--faction-ua-card-text)",
+                      margin: "var(--space-sm) 0 var(--space-md)",
                       overflowWrap: "anywhere",
                     }}
                   >
                     {task.title}
                   </h1>
-                  <div
+                  {/* The status tag. It used to paint its ink with
+                      --faction-ua-light, a background tint that was invisible
+                      at 8% alpha and pale cream once #848 made it opaque; the
+                      ink token for a solid fill is --faction-ua-on-fill. */}
+                  <span
                     style={{
-                      position: "relative",
-                      width: "fit-content",
-                      background: ORANGE,
-                      color: "var(--faction-ua-light)",
-                      fontFamily: "var(--ua-engraved)",
-                      fontSize: "var(--text-sm)",
-                      letterSpacing: "0.1em",
-                      padding: "var(--space-xs) var(--space-xl)",
-                      clipPath:
-                        "polygon(0 0,100% 0,96% 50%,100% 100%,0 100%,4% 50%)",
-                      marginBottom: "var(--space-lg)",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "var(--space-sm)",
+                      background: "var(--faction-ua)",
+                      color: "var(--faction-ua-on-fill)",
+                      fontFamily: UA_TEXT,
+                      fontSize: "var(--text-md)",
+                      letterSpacing: "0.16em",
+                      textTransform: "uppercase",
+                      borderRadius: "var(--radius-sm)",
+                      padding: "var(--space-xs) var(--space-md)",
                     }}
                   >
-                    <span style={{ color: PAPER_WARM }}>{statusVoice}</span>
-                  </div>
-                  <div style={{ display: "flex", gap: "var(--space-md)", flexWrap: "wrap" }}>
-                    <StatPlate label={t("ua.stats.anno")}>
-                      {romanLevel(task.level_required)}
-                    </StatPlate>
-                    <StatPlate label={t("ua.stats.honoraria")} accent>
-                      {modifiedPoints}
-                      <span
-                        style={{
-                          fontFamily: "var(--ua-engraved)",
-                          fontSize: "var(--text-sm)",
-                          marginLeft: "var(--space-xs)",
-                          fontStyle: "normal",
-                          fontWeight: 400,
-                        }}
-                      >
-                        {t("ua.stats.honorariaUnit")}
-                      </span>
-                    </StatPlate>
-                    <StatPlate label={t("ua.stats.onView")}>
-                      <span
-                        className="content-text"
-                        style={{
-                          fontWeight: 600,
-                          lineHeight: 1.2,
-                          color: SUB,
-                        }}
-                      >
-                        {t("ua.stats.onViewValue", {
-                          signups: signups.length,
-                          completed: submissions.length,
-                        })}
-                      </span>
-                    </StatPlate>
-                  </div>
+                    {statusVoice}
+                  </span>
                 </div>
               </div>
             </div>
+
+            <div style={{ display: "flex", flexWrap: "wrap" }}>
+              <StatCell label={t("ua.stats.anno")}>
+                {romanLevel(task.level_required)}
+              </StatCell>
+              <StatCell label={t("ua.stats.honorariaUnit")}>
+                {modifiedPoints}
+              </StatCell>
+              <StatCell label={t("ua.stats.onView")} last>
+                <span
+                  style={{
+                    fontSize: "var(--text-content)",
+                    lineHeight: 1.2,
+                    color: "var(--faction-ua-card-body)",
+                  }}
+                >
+                  {t("ua.stats.onViewValue", {
+                    signups: signups.length,
+                    completed: submissions.length,
+                  })}
+                </span>
+              </StatCell>
+            </div>
           </div>
 
-          {/* ── Matriculation CTA / signed-on states ── */}
+          {/* ── Sign-up / signed-on states ── */}
           {canSignUp && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-lg)",
-                flexWrap: "wrap",
-                padding: "var(--space-lg) var(--space-xl)",
-                border: `1px solid ${LINE}`,
-                background: PAPER,
-              }}
-            >
-              <button
-                onClick={handleSignup}
-                style={{
-                  cursor: "pointer",
-                  fontFamily: "var(--ua-engraved)",
-                  fontSize: "var(--text-lg)",
-                  letterSpacing: "0.14em",
-                  color: PAPER_WARM,
-                  background: ORANGE,
-                  border: "none",
-                  padding: "var(--space-md) var(--space-xl)",
-                  boxShadow: "0 3px 8px rgba(194,84,31,0.3)",
-                }}
-              >
+            <div style={PANEL}>
+              <button onClick={handleSignup} style={FILLED_ACTION}>
                 {t("ua.signup.cta", { points: modifiedPoints })}
               </button>
               <div
                 style={{
-                  fontFamily: "var(--ua-serif)",
-                  fontStyle: "italic",
-                  fontSize: "var(--text-xl)",
-                  color: SUB,
+                  fontFamily: UA_TEXT,
+                  fontSize: "var(--text-content)",
+                  color: "var(--faction-ua-card-body)",
                 }}
               >
                 {t("ua.signup.meta", {
@@ -525,53 +425,23 @@ export default function UaTaskDetail({
                   level: romanLevel(task.level_required),
                 })}
               </div>
-              <ErrorBanner
-                message={signupError}
-                style={{
-                  flexBasis: "100%",
-                  marginTop: 0,
-                  background: "var(--faction-ua-light)",
-                  border: `1px solid ${ORANGE}`,
-                  color: ORANGE_DEEP,
-                }}
-              />
+              <ErrorBanner message={signupError} style={BANNER} />
             </div>
           )}
 
           {mySubmission && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-lg)",
-                flexWrap: "wrap",
-                padding: "var(--space-lg) var(--space-xl)",
-                border: `1px solid ${LINE}`,
-                background: PAPER,
-              }}
-            >
+            <div style={PANEL}>
               <span
                 style={{
-                  fontFamily: "var(--ua-engraved)",
-                  fontSize: "var(--text-xl)",
-                  letterSpacing: "0.1em",
-                  color: GOLD,
+                  ...UA_EYEBROW,
+                  color: "var(--faction-ua-card-accent)",
                 }}
               >
                 {t("ua.submitted.text")}
               </span>
               <Link
                 to={`/praxes/${mySubmission.id}/edit`}
-                style={{
-                  marginLeft: "auto",
-                  fontFamily: "var(--ua-engraved)",
-                  fontSize: "var(--text-md)",
-                  letterSpacing: "0.12em",
-                  padding: "var(--space-md) var(--space-xl)",
-                  background: INK,
-                  color: PAPER_WARM,
-                  textDecoration: "none",
-                }}
+                style={{ ...FILLED_ACTION, marginLeft: "auto" }}
               >
                 {t("ua.submitted.edit")}
               </Link>
@@ -579,87 +449,54 @@ export default function UaTaskDetail({
           )}
 
           {!mySubmission && isInProgress && inProgressPraxisId !== null && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-lg)",
-                flexWrap: "wrap",
-                padding: "var(--space-lg) var(--space-xl)",
-                border: `1px solid ${LINE}`,
-                background: PAPER,
-              }}
-            >
+            <div style={PANEL}>
               <span
                 style={{
-                  fontFamily: "var(--ua-engraved)",
-                  fontSize: "var(--text-xl)",
-                  letterSpacing: "0.1em",
-                  color: ORANGE,
+                  ...UA_EYEBROW,
+                  color: "var(--faction-ua-card-accent)",
                 }}
               >
                 {t("ua.inProgress.text")}
               </span>
               <Link
                 to={`/praxes/${inProgressPraxisId}/edit`}
-                style={{
-                  marginLeft: "auto",
-                  fontFamily: "var(--ua-engraved)",
-                  fontSize: "var(--text-md)",
-                  letterSpacing: "0.12em",
-                  padding: "var(--space-md) var(--space-xl)",
-                  background: ORANGE,
-                  color: PAPER_WARM,
-                  textDecoration: "none",
-                }}
+                style={{ ...FILLED_ACTION, marginLeft: "auto" }}
               >
                 {t("ua.inProgress.continue")}
               </Link>
               <button
                 onClick={handleDrop}
                 style={{
+                  ...UA_EYEBROW,
                   background: "none",
                   border: "none",
                   cursor: "pointer",
-                  fontFamily: "var(--ua-mono)",
-                  fontSize: "var(--text-base)",
-                  letterSpacing: "0.1em",
-                  textTransform: "uppercase",
-                  color: MUTED,
                 }}
               >
                 {t("ua.inProgress.drop")}
               </button>
-              <ErrorBanner
-                message={signupError}
-                style={{
-                  flexBasis: "100%",
-                  marginTop: 0,
-                  background: "var(--faction-ua-light)",
-                  border: `1px solid ${ORANGE}`,
-                  color: ORANGE_DEEP,
-                }}
-              />
+              <ErrorBanner message={signupError} style={BANNER} />
             </div>
           )}
 
-          {/* ── The Commission — the user-written brief ── */}
+          {/* ── The Mark — the user-written brief ── */}
           <section>
             <SectionHead title={t("ua.commissionHeading")} />
             <div
               style={{
-                border: `1px solid ${LINE}`,
-                background: PAPER,
-                padding: "var(--space-2xl) var(--space-2xl)",
+                border: "1px solid var(--faction-ua-rule)",
+                borderRadius: "var(--radius-sm)",
+                background: "var(--faction-ua-card-bg)",
+                padding: "var(--space-xl)",
                 maxWidth: 660,
               }}
             >
               <p
                 className="content-text"
                 style={{
-                  fontFamily: "var(--ua-serif)",
-                  lineHeight: 1.75,
-                  color: SUB,
+                  fontFamily: UA_TEXT,
+                  lineHeight: 1.7,
+                  color: "var(--faction-ua-card-body)",
                   margin: 0,
                   whiteSpace: "pre-wrap",
                 }}
@@ -669,7 +506,7 @@ export default function UaTaskDetail({
             </div>
           </section>
 
-          {/* ── Hands matriculated ── */}
+          {/* ── Those practising ── */}
           {signups.length > 0 && (
             <section>
               <SectionHead title={t("ua.matriculatedHeading")} />
@@ -677,42 +514,35 @@ export default function UaTaskDetail({
             </section>
           )}
 
-          {/* ── The Critique — read-only aggregate verdict ── */}
+          {/* ── The Reading — read-only aggregate ── */}
           <section>
             <SectionHead title={t("ua.critiqueHeading")} />
             {voteCount > 0 ? (
-              <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)" }}>
-                <span
-                  className="content-title"
-                  style={{
-                    fontFamily: "var(--ua-display)",
-                    fontStyle: "italic",
-                    fontWeight: 700,
-                    lineHeight: 0.8,
-                    color: ORANGE,
-                  }}
-                >
-                  {topScore}
-                </span>
-                <div style={{ paddingBottom: "var(--space-sm)" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-lg)",
+                }}
+              >
+                <UaEnsoScore
+                  size={96}
+                  value={topScore}
+                  valueColor="var(--faction-ua-vermil)"
+                />
+                <div>
                   <div
                     style={{
-                      fontFamily: "var(--ua-engraved)",
-                      fontSize: "var(--text-xl)",
-                      letterSpacing: "0.06em",
-                      color: INK,
+                      fontFamily: UA_DISPLAY,
+                      fontWeight: 600,
+                      fontSize: "var(--text-title)",
+                      lineHeight: 1.1,
+                      color: "var(--faction-ua-card-text)",
                     }}
                   >
                     {t("ua.critique.finest")}
                   </div>
-                  <div
-                    style={{
-                      fontFamily: "var(--ua-mono)",
-                      fontSize: "var(--text-base)",
-                      letterSpacing: "0.06em",
-                      color: MUTED,
-                    }}
-                  >
+                  <div style={{ ...UA_EYEBROW, marginTop: "var(--space-xs)" }}>
                     {t("ua.critique.appraised", { count: voteCount })}
                   </div>
                 </div>
@@ -721,9 +551,8 @@ export default function UaTaskDetail({
               <p
                 className="content-text"
                 style={{
-                  fontFamily: "var(--ua-serif)",
-                  fontStyle: "italic",
-                  color: SUB,
+                  fontFamily: UA_TEXT,
+                  color: "var(--faction-ua-card-muted)",
                 }}
               >
                 {t("ua.critique.none")}
@@ -731,12 +560,12 @@ export default function UaTaskDetail({
             )}
           </section>
 
-          {/* ── The Salon Wall — filed praxis (completions) ── */}
+          {/* ── Sealed work ── */}
           <section>
             <SectionHead
               title={t("ua.salonWallHeading")}
               trailing={
-                <div style={{ display: "flex", gap: 0 }}>
+                <div style={{ display: "flex", gap: "var(--space-sm)" }}>
                   {(["score", "recent"] as const).map((sort) => {
                     const on = submissionSort === sort;
                     return (
@@ -744,17 +573,17 @@ export default function UaTaskDetail({
                         key={sort}
                         onClick={() => setSubmissionSort(sort)}
                         style={{
-                          fontFamily: "var(--ua-engraved)",
-                          fontSize: "var(--text-base)",
-                          letterSpacing: "0.1em",
-                          textTransform: "uppercase",
+                          ...UA_EYEBROW,
                           padding: "var(--space-xs) var(--space-md)",
-                          background: on ? INK : "transparent",
-                          color: on ? PAPER_WARM : MUTED,
+                          borderRadius: "var(--radius-sm)",
+                          background: on
+                            ? "var(--faction-ua)"
+                            : "transparent",
+                          color: on
+                            ? "var(--faction-ua-on-fill)"
+                            : "var(--faction-ua-card-muted)",
                           border: `1px solid ${
-                            on
-                              ? INK
-                              : "color-mix(in srgb, var(--ua-ink) 30%, transparent)"
+                            on ? "var(--faction-ua)" : "var(--faction-ua-rule)"
                           }`,
                           cursor: "pointer",
                         }}
@@ -772,9 +601,8 @@ export default function UaTaskDetail({
               <p
                 className="content-text"
                 style={{
-                  fontFamily: "var(--ua-serif)",
-                  fontStyle: "italic",
-                  color: SUB,
+                  fontFamily: UA_TEXT,
+                  color: "var(--faction-ua-card-muted)",
                 }}
               >
                 {t("ua.empty")}
@@ -792,13 +620,16 @@ export default function UaTaskDetail({
                   {sortedSubmissions.slice(0, 4).map((s) => (
                     <div
                       key={s.id}
-                      style={{ position: "relative", paddingTop: "var(--space-xl)" }}
+                      style={{
+                        position: "relative",
+                        paddingTop: "var(--space-xl)",
+                      }}
                     >
                       {s.id === topId && (
                         <div
                           style={{
                             position: "absolute",
-                            top: -4,
+                            top: 0,
                             left: "50%",
                             transform: "translateX(-50%)",
                             zIndex: 3,
@@ -806,16 +637,17 @@ export default function UaTaskDetail({
                             alignItems: "center",
                             gap: "var(--space-xs)",
                             whiteSpace: "nowrap",
-                            background: ORANGE,
-                            color: PAPER_WARM,
-                            fontFamily: "var(--ua-engraved)",
-                            fontSize: "var(--text-sm)",
-                            letterSpacing: "0.12em",
+                            background: "var(--faction-ua)",
+                            color: "var(--faction-ua-on-fill)",
+                            fontFamily: UA_TEXT,
+                            fontSize: "var(--text-md)",
+                            letterSpacing: "0.16em",
+                            textTransform: "uppercase",
+                            borderRadius: "var(--radius-sm)",
                             padding: "var(--space-xs) var(--space-md)",
-                            boxShadow: "0 3px 8px rgba(60,40,10,0.3)",
                           }}
                         >
-                          <span style={{ fontSize: "var(--text-lg)", lineHeight: 1 }}>⚜</span>{" "}
+                          <UaSigil width={13} height={13} />
                           {t("ua.finestHand")}
                         </div>
                       )}
@@ -828,10 +660,9 @@ export default function UaTaskDetail({
                     <Link
                       to={`/praxes?task_id=${task.id}`}
                       style={{
-                        fontFamily: "var(--ua-engraved)",
-                        fontSize: "var(--text-lg)",
-                        letterSpacing: "0.06em",
-                        color: ORANGE,
+                        fontFamily: UA_TEXT,
+                        fontSize: "var(--text-content)",
+                        color: "var(--faction-ua-card-accent)",
                         textDecoration: "none",
                       }}
                     >

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -67,7 +67,9 @@ describe('mobile Updates mixed multi-faction stream', () => {
     // Distinct per-faction frame markers appearing TOGETHER in one render
     // prove a mixed stream, not one uniform tint.
     expect(text, 'COVEN window chrome').toContain('whimsy.exe')
-    expect(text, 'UA salon masthead').toContain('University of Asthmatics')
+    // UA's frame is dress only now (#851): a 3px orange rule and the ensō, no
+    // engraved masthead, so the marker is the token rather than a house line.
+    expect(html, 'UA ink-rule frame').toContain('3px solid var(--faction-ua)')
     expect(html, 'SNIDE dossier tokens').toContain('--faction-snide')
     expect(html, 'COVEN scrapbook tokens').toContain('--faction-coven')
   })


### PR DESCRIPTION
Closes #851

Rebuilds the eleven UA desktop surfaces on #848's tokens, #849's ensō/mandala primitives and #850's copy deck. The salon is dead everywhere in this diff: no gilt sandwiches, no gold leaf, no parchment dot grids, no crest shield, no motto ribbon, no fleur-de-lis, and no surface that pins itself to light.

### Shared vocabulary
New `components/cards/uaAtoms.tsx` types UA's whole vocabulary once instead of eleven times: the two faces (`UA_DISPLAY` Cormorant, `UA_TEXT` EB Garamond), the one eyebrow shape, the hairline, `uaShade()` (drop shadows mixed from the ink token so they invert with the theme rather than being a light-mode `rgba(20,12,6,…)`), `UaEnsoScore` and `UaInkColumn`.

### The eleven
`UaTaskCard` (the reference surface, kit §1 "3a") · `UaTaskDetail` · `UaFactionBody` §13 · `UaFactionHero` · `UaEditPraxis` §3 · `UaProfileBody` · `UaComment` §14 · `UaFeedFrame` §12 · `UaAvatar` §11 · `UaBackdrop` §10 · the UA branch of `FactionSelectCard` §4.

Level indicator and filter pennant are untouched: both remain the shared `LevelGem` / pennant shape tinted through `factionCssVar` — no bespoke UA shape was built.

### Carried over from #848
- `UaTaskDetail`'s status tag painted its **ink** with `--faction-ua-light`. At 8% alpha it was invisible; opaque it is pale cream on a light ground. It now takes `--faction-ua-on-fill`, the ink token for a solid fill.
- Both signup-error banners backed onto the same tint, which became a solid wash. They name `--faction-ua-panel`.
- **Bonus bug**: that file also painted with `--ua-display`, `--ua-engraved`, `--ua-mono` and `--ua-serif` — four font tokens that are declared **nowhere** in `index.css`. Every heading, label and body run on the UA task-detail page has been silently falling back to the inherited face. The #806 guard only walks `--faction-*`, so it never tripped. Fixed here.

### Copy #850 could not wire
- `praxis:comments.ua.prompt` → `UaComment` composer (as a label above `ComposerControls`, matching the Ephemerists/Snide prior art — the shared control hardcodes its own placeholder).
- `forms:editPraxis.ua.publishHelper` → beside the seal button.
- `factionSelect.ua.subtitle` is now a full sentence, so it moves off the 0.24em all-caps kicker onto the display cut.
- `proposeTask.factionDescriptor.ua` is a sentence sitting beside six one-word peers in an `.eyebrow`. New `.eyebrow-sentence` class: same size and colour, sentence casing. Styling, not copy.

### Guards
`uaDesktopSkin.test.tsx` asserts rendered markup for the three rulings nothing else can see: **no surface reads the legacy `--ua-*` family** (that failure renders as an unstyled element, not a build error), the **mandala appears on exactly three surfaces and nowhere else**, and the **ensō is only ever the score or the faction mark**, never a container border. A source-level half covers the four heavy archetypes that need a whole page state to render.

Two existing tests asserted the salon (`factionAvatar` expected `--ua-gold`; `mixedStream` expected the feed frame's engraved masthead) and were updated to the new chrome.

### Judgement calls, flagged
- **The task card's mandala.** The kit draws a lotus corner-bleed on it; brief §5 puts "task lists" in the ABSENT tier and enumerates only three texture surfaces. The brief is the contract, so the card is clean. Say the word and it is one prop.
- **The feed row lost its faction name.** The kit's §12 row has no masthead — actor + headline + the orange rule. `feed:identity.ua.fullName` is still used by the hero.
- **`UaProfileBody`'s kit strings** ("Nothing hung in the Salon yet", "Distinctions", "Exhibited by") are hardcoded English in a style object, not i18n keys, so #850's deck never touched them. Shipping "Salon" alongside "the salon is dead" seemed worse than retuning them; retuned to the practice voice.
- **`pages/praxisDetail/archetypes/UaPraxisDetail.tsx`** is a UA desktop surface still wearing the full salon (`--ua-gilt`, "the salon never dims"). It is not in #851's list and not the fenced praxis *card*. Someone should own it before #853 runs its grep.

### Fences respected
Nothing under `praxisCard/`, `scoreStamp/`, `mobileArchetypes/`, or `UaVote.tsx` was touched, no `--faction-ua-card-*` token was moved, and the legacy `--ua-*` family is left declared for #853.

### What to eyeball

**No visual QA was done.** The Browser pane renderer times out and there is no dev stack in this worktree; everything below is verified by `tsc --noEmit`, `vite build`, `eslint src` and 1241 vitest assertions only. This is a token-and-structure pass, not a pixel match.

1. **Dark mode, every surface.** This is the first time UA dims. Walk `/tasks`, a task detail, `/factions/ua`, a profile, the praxis editor and the comment thread with `data-theme="dark"`.
2. **The task card in a grid.** It keeps its old 264px footprint; the 96px ensō plus the ink column may be tight beside the other factions' cards.
3. **The ensō at 13px and 18px** — the "truest hand" tag on task detail and the feed row's corner mark. Two arcs at that size may read as a smudge.
4. **The mandala's three appearances** — backdrop (7%), hero (14%), join card (16%). Check the backdrop truly sits *behind* unrelated content and that the hero's bleed does not fight the wordmark.
5. **`--faction-ua-page` vs `--faction-ua-card-bg`** on the faction page and the editor. Both are pale sand; the sheets may not separate from the ground.
6. **`.eyebrow-sentence`** in the propose-task faction picker — does the UA sentence still sit in rank with the six one-word peers?
7. **The join card's crest band** at 132px with a 96px ensō over a 300px mandala.
8. **The signup-error banner** on task detail, in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
