### PR TITLE
UA redesign 6/6: delete the legacy --ua-* token family (#853)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -122,7 +122,7 @@ All fonts loaded from Google Fonts.
 
 | Faction     | Headline font      | CSS var                           |
 | ----------- | ------------------ | --------------------------------- |
-| UA          | `IM Fell English`  | `--faction-ua-card-font`          |
+| UA          | `Cormorant Garamond` — via `--font-faction-serif`; `EB Garamond` is its secondary, on `--faction-ua-body-font` (#848) | `--faction-ua-card-font`          |
 | Everymen    | `Special Elite`    | `--faction-everymen-card-font`    |
 | Cozy Coven  | `Caveat`           | `--faction-coven-card-font`       |
 | Warriors of Whimsy | `MedievalSharp` — the chronicle's display face; `Lora` italic is its secondary (§3) | `--faction-wow-card-font` |

--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -40,7 +40,7 @@ describe("FactionAvatar — UA variant (#200)", () => {
     expect(html).toContain("var(--faction-ua)");
     expect(html).toContain("var(--faction-ua-card-font)");
     expect(html).toContain("var(--faction-ua-lift)");
-    expect(html).not.toContain("var(--ua-gold)");
+    expect(html).not.toMatch(/var\(--ua-[a-z]/); // the whole legacy family, deleted in #853
     // The sigil badge is present — the ensō's heavy sweep (#849 retired the
     // gilt shield, so the 100x120 viewBox marker is gone with it).
     expect(html).toContain('d="M134 41.2 A68 68 0 1 1 66 158.8"');
@@ -62,7 +62,7 @@ describe("FactionAvatar — UA variant (#200)", () => {
       <FactionAvatar character={character({ faction_slug: "totally-unknown" })} />,
     );
     // No UA tokens and no ensō badge on the fallback circle.
-    expect(html).not.toContain("var(--ua-orange)");
+    expect(html).not.toMatch(/var\(--ua-[a-z]/); // the whole legacy family, deleted in #853
     expect(html).not.toContain('d="M134 41.2 A68 68 0 1 1 66 158.8"');
     // Default renders the plain initial circle.
     expect(html).toContain("I");

--- a/frontend/src/components/cards/UaSigil.tsx
+++ b/frontend/src/components/cards/UaSigil.tsx
@@ -67,7 +67,7 @@ export function UaSigil({ width, height }: { width: number; height: number }) {
 /**
  * The motto cartouche — a solid sienna ribbon with notched ends.
  *
- * Kept as-is structurally; only repointed off the legacy `--ua-*` family onto
+ * Kept as-is structurally; only repointed off the legacy gilt-salon family onto
  * the fill/on-fill pair, which carries both themes (4.59:1 light, 5.59:1 dark).
  * Whether the practice still wants a motto ribbon at all is an archetype
  * question and belongs to the surfaces that draw it, not to this file.

--- a/frontend/src/components/cards/__tests__/factionSigil.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionSigil.test.tsx
@@ -34,7 +34,7 @@ describe("FactionSigil dispatcher (#659)", () => {
     const html = renderToStaticMarkup(<FactionSigil slug="ua" />);
     expect(html).toContain("var(--faction-ua-glow)");
     // The salon is dead: no gilt shield, no legacy gold, no raw hex.
-    expect(html).not.toContain("var(--ua-gold)");
+    expect(html).not.toMatch(/var\(--ua-[a-z]/); // the whole legacy family, deleted in #853
     expect(html).not.toContain("#");
   });
 
@@ -54,7 +54,7 @@ describe("FactionSigil dispatcher (#659)", () => {
     const html = renderToStaticMarkup(<FactionSigil slug="totally-unknown" />);
     expect(html).toContain("var(--faction-default-ring)");
     expect(html).not.toContain("var(--faction-snide-acid)");
-    expect(html).not.toContain("var(--ua-gold)");
+    expect(html).not.toMatch(/var\(--ua-[a-z]/); // the whole legacy family, deleted in #853
     expect(html).not.toContain("var(--everymen-red)");
   });
 

--- a/frontend/src/components/vote/UaVote.tsx
+++ b/frontend/src/components/vote/UaVote.tsx
@@ -309,7 +309,7 @@ export default function UaVote({ praxisId, currentValue, points, totalVotes }: V
           accent: 'var(--faction-ua-card-accent)',
           accentFont: 'var(--faction-ua-card-font)',
           // Error text owes body contrast in BOTH themes; the legacy
-          // --ua-orange-deep had only a light value (#853 deletes the family).
+          // legacy deep-orange token had only a light value (deleted in #853).
           errorColor: 'var(--faction-ua-card-accent)',
           avgLetterSpacing: '0.04em',
         }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -351,26 +351,19 @@
   --eph-serif: "EB Garamond", Georgia, serif;
   --eph-script: "Cormorant Garamond", Georgia, serif;
 
-  /* ── UA · LEGACY gilt-salon palette — scheduled for deletion (#853) ──
-     The old art-academy skin. Superseded by the --faction-ua-* block above and
-     the sun-bleached primitives below; it survives only because ~20 components
-     still read these names directly rather than through factionCssVar(), so it
-     has to be unwound file-by-file. Do not paint anything new with it, and do
-     not add a [data-theme="dark"] override — it is going away, not dimming. */
-  --ua-orange: #c2541f; /* burnt amber — the accent */
-  --ua-orange-deep: #a8431a;
-  --ua-gold: #9c6a1a; /* old gold — frames & regalia */
-  --ua-gold-lt: #dd9322;
-  --ua-gold-pale: #eec06a;
-  --ua-ink: #3d2410; /* brown ink — all text */
-  --ua-sub: #8f6a3a; /* secondary serif text */
-  --ua-muted: #a8895a; /* mono labels / metadata */
-  --ua-paper: #fdf6ea; /* sheet / card surface */
-  --ua-paper-warm: #fef7ea;
-  --ua-wall: #ece4d2; /* page wall */
-  --ua-line: #cdab63; /* hairline borders */
-  --ua-line-soft: #e3cb98;
-  --ua-gilt: linear-gradient(135deg, #eec06a 0%, #9c6a1a 24%, #f0c878 50%, #9c6a1a 76%, #dd9322 100%);
+  /* The UA LEGACY gilt-salon palette stood here until #853 deleted it: a
+     fourteen-token second naming scheme (orange, gold, gilt, ink, sub, muted,
+     paper, wall, line and their variants) from the old art-academy skin, all
+     under a bare `ua` prefix. It is DELETED, not renamed — a rename would have preserved exactly
+     the thing that made it a problem, a private palette that components read as
+     bare var() strings instead of through factionCssVar(), which nothing
+     type-checks. Everything UA paints with is now named below or in the §3 card
+     contract, and UA's gold went to Warriors of Whimsy (#838).
+
+     Do not reintroduce a `--ua-*` COLOUR. The names that legitimately survive
+     under that prefix are the four animation-local properties on the mandala
+     keyframes (--ua-grow-delay, --ua-spin-dur, --ua-spin-dir, --ua-twist-dur),
+     which are timing, not palette. */
 
   /* ── UA · sun-bleached practice — archetype-private primitives (#788, #848) ──
      The surfaces and inks the UA skin paints with that the shared §3 card
@@ -397,12 +390,11 @@
      of UA becomes a sun-bleached, gold-free practice. That is a DELIBERATE
      EXCEPTION. Do not "harmonise" it away when you read #848.
 
-     WHAT MAKES IT SURVIVABLE: the card reads NOTHING from the legacy `--ua-*`
-     family above (--ua-gold, --ua-gilt, --ua-ink, --ua-paper, --ua-line, …),
-     which #853 deletes wholesale. Everything it needs is named here, in its own
-     `--faction-ua-card-*` namespace, so #853 can run its grep and delete the
-     legacy family without touching this surface. `UaPraxisCard.tsx` and
-     `UaMobilePraxisCard.tsx` are asserted at zero `--ua-` hits.
+     WHAT MADE IT SURVIVABLE: the card read NOTHING from the legacy gilt-salon
+     family, so #853 could delete that family wholesale without touching this
+     surface. Everything the card needs is named here, in its own
+     `--faction-ua-card-*` namespace. `UaPraxisCard.tsx` and
+     `UaMobilePraxisCard.tsx` are asserted at zero legacy hits.
 
      Values are the design handoff's UA band verbatim
      (.design-sync/praxis-cards/design_handoff_faction_vote_stamps). Where #848

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -1,20 +1,26 @@
 /**
- * The University of Asthmatics (UA) praxis-read page archetype — the GILT SALON.
+ * The University of Asthmatics (UA) praxis-read page archetype.
  *
- * Built from the UA canon: an acquisition sheet exhibited on a salon wall —
- * burnt-amber/cream/gold/brown-ink palette, gilt-framed plate for the evidence,
- * Cormorant italics for the headline, EB-Garamond serif body, EB-Garamond small
- * caps for the regalia labels. The salon never dims: UA is always-light, so its
- * --faction-ua* / --ua-* tokens are identical in both themes and we style the
- * container with them directly without mutating the document theme.
+ * REPOINTED, NOT REBUILT (#853). The layout, ornament and language here are
+ * still the old "gilt salon" — an acquisition sheet exhibited on a salon wall,
+ * with regalia labels and an "appraisal" ledger. #853 only swapped the colour
+ * names: every reference to the deleted legacy `--ua-*` family now reads the
+ * `--faction-ua-*` sun-bleached primitives instead, so the page stops painting
+ * with tokens that no longer exist. Gold is gone (it moved to WOW) and the
+ * evidence plate's gilt double-frame is now a sand/neutral mat. A real rebuild
+ * against the UA identity kit is a separate, future issue.
+ *
+ * It also dims now. The old "the salon never dims" claim died with #848: every
+ * `--faction-ua-*` token has a [data-theme="dark"] value, so this container
+ * follows the theme without any JS branch.
  *
  * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
  * the shared module — this archetype owns only presentation. Voting routes
  * through the <VoteUI factionSlug=…> dispatcher, which falls back to the global
  * vote stamps for UA (no bespoke UA vote component exists).
  *
- * All colors via --faction-ua* + the gilt private palette (--ua-*), index.css.
- * Actor-scoped byline themes to the AUTHOR's faction, not the task's.
+ * All colors via --faction-ua-* in index.css. Actor-scoped byline themes to the
+ * AUTHOR's faction, not the task's.
  */
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
@@ -84,20 +90,20 @@ function TheStanding({
       style={{
         marginTop: 'var(--space-sm)',
         marginBottom: 'var(--space-xl)',
-        background: 'var(--ua-paper)',
-        border: '1px solid var(--ua-line)',
-        boxShadow: 'inset 0 0 0 4px var(--ua-paper), inset 0 0 0 5px var(--ua-line-soft)',
+        background: 'var(--faction-ua-card-bg)',
+        border: '1px solid var(--faction-ua-rule)',
+        boxShadow: 'inset 0 0 0 4px var(--faction-ua-card-bg), inset 0 0 0 5px var(--faction-ua-hair)',
         padding: 'var(--space-xl) var(--space-xl)',
       }}
     >
-      <div style={{ fontFamily: REGALIA, fontSize: 'var(--text-base)', letterSpacing: '0.2em', color: 'var(--ua-gold)', marginBottom: 'var(--space-lg)' }}>
+      <div style={{ fontFamily: REGALIA, fontSize: 'var(--text-base)', letterSpacing: '0.2em', color: 'var(--faction-ua-card-accent)', marginBottom: 'var(--space-lg)' }}>
         {t('detail.ua.standing.heading')}
       </div>
 
       {/* Headline: points earned · appraisal headcount */}
       <div style={{ display: 'flex', marginBottom: voters.length ? "var(--space-xl)" : 0 }}>
         <div style={{ flex: 1, paddingRight: 'var(--space-lg)' }}>
-          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--ua-orange)', whiteSpace: 'nowrap' }}>
+          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-ua-card-accent)', whiteSpace: 'nowrap' }}>
             {base}
             {!isPlain && (
               <>
@@ -108,16 +114,16 @@ function TheStanding({
             <span style={{ opacity: 0.55, margin: '0 var(--space-xs)' }}>+</span>
             {votePoints}
           </div>
-          <div style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--ua-sub)', marginTop: 'var(--space-sm)' }}>
+          <div style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--faction-ua-card-body)', marginTop: 'var(--space-sm)' }}>
             {t('detail.ua.standing.pointsEarned')}
           </div>
         </div>
-        <div style={{ flex: 1, paddingLeft: 'var(--space-lg)', borderLeft: '1px solid var(--ua-line)' }}>
-          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--ua-ink)', display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
-            <span style={{ fontSize: 'var(--text-content)', color: 'var(--ua-gold)' }}>✦</span>
+        <div style={{ flex: 1, paddingLeft: 'var(--space-lg)', borderLeft: '1px solid var(--faction-ua-rule)' }}>
+          <div style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-ua-card-text)', display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
+            <span style={{ fontSize: 'var(--text-content)', color: 'var(--faction-ua-card-accent)' }}>✦</span>
             {votes.total_votes}
           </div>
-          <div style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--ua-sub)', marginTop: 'var(--space-sm)' }}>
+          <div style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--faction-ua-card-body)', marginTop: 'var(--space-sm)' }}>
             {t('detail.ua.standing.appraisal', { count: votes.total_votes })}
           </div>
         </div>
@@ -126,7 +132,7 @@ function TheStanding({
       {/* Appraisers' ledger — each patron + the rung they gave (value / 5) */}
       {voters.length > 0 && (
         <>
-          <div style={{ borderTop: '1px dashed var(--ua-line-soft)', paddingTop: 'var(--space-lg)', fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--ua-sub)', marginBottom: 'var(--space-md)' }}>
+          <div style={{ borderTop: '1px dashed var(--faction-ua-hair)', paddingTop: 'var(--space-lg)', fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--faction-ua-card-body)', marginBottom: 'var(--space-md)' }}>
             {t('detail.ua.standing.appraisedBy')}
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
@@ -141,12 +147,12 @@ function TheStanding({
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
-                      background: 'color-mix(in srgb, var(--ua-gold-pale) 28%, var(--ua-paper))',
-                      border: '1.5px solid var(--ua-line)',
+                      background: 'color-mix(in srgb, var(--faction-ua-panel) 28%, var(--faction-ua-card-bg))',
+                      border: '1.5px solid var(--faction-ua-rule)',
                       fontFamily: MONO,
                       fontWeight: 700,
                       fontSize: 'var(--text-sm)',
-                      color: 'var(--ua-orange)',
+                      color: 'var(--faction-ua-card-accent)',
                     }}
                   >
                     {initials(voter.display_name)}
@@ -154,24 +160,24 @@ function TheStanding({
                 </Link>
                 <Link
                   to={`/characters/${voter.character_id}`}
-                  style={{ width: 96, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontFamily: SERIF, fontSize: 'var(--text-lg)', color: 'var(--ua-ink)', textDecoration: 'none' }}
+                  style={{ width: 96, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontFamily: SERIF, fontSize: 'var(--text-lg)', color: 'var(--faction-ua-card-text)', textDecoration: 'none' }}
                 >
                   {voter.display_name}
                 </Link>
-                <div style={{ flex: 1, height: 9, background: 'color-mix(in srgb, var(--ua-gold-pale) 20%, var(--ua-paper))', border: '1px solid var(--ua-line-soft)', position: 'relative', overflow: 'hidden' }}>
-                  <div style={{ position: 'absolute', inset: 0, width: `${(voter.value / 5) * 100}%`, background: 'var(--ua-orange)', opacity: 0.9 }} />
+                <div style={{ flex: 1, height: 9, background: 'color-mix(in srgb, var(--faction-ua-panel) 20%, var(--faction-ua-card-bg))', border: '1px solid var(--faction-ua-hair)', position: 'relative', overflow: 'hidden' }}>
+                  <div style={{ position: 'absolute', inset: 0, width: `${(voter.value / 5) * 100}%`, background: 'var(--faction-ua-card-accent)', opacity: 0.9 }} />
                 </div>
-                <span style={{ width: 40, textAlign: 'right', whiteSpace: 'nowrap', fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-xl)', color: 'var(--ua-orange)' }}>
+                <span style={{ width: 40, textAlign: 'right', whiteSpace: 'nowrap', fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-xl)', color: 'var(--faction-ua-card-accent)' }}>
                   {voter.value === 5 ? '✦' : `№${voter.value}`}
                 </span>
               </div>
             ))}
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderTop: '1px solid var(--ua-line)', marginTop: 'var(--space-md)', paddingTop: 'var(--space-md)' }}>
-            <span style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ua-sub)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderTop: '1px solid var(--faction-ua-rule)', marginTop: 'var(--space-md)', paddingTop: 'var(--space-md)' }}>
+            <span style={{ fontFamily: MONO, fontSize: 'var(--text-xs)', letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--faction-ua-card-body)' }}>
               {t('detail.ua.standing.patronsTotal', { count: voters.length })}
             </span>
-            <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-title)', color: 'var(--ua-orange)' }}>
+            <span style={{ fontFamily: DISPLAY, fontStyle: 'italic', fontWeight: 700, fontSize: 'var(--text-title)', color: 'var(--faction-ua-card-accent)' }}>
               {t('detail.ua.standing.pts', { points: votes.total_score })}
             </span>
           </div>
@@ -193,12 +199,12 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
       className="py-8 max-w-2xl"
       style={{
         position: 'relative',
-        background: 'var(--ua-paper)',
+        background: 'var(--faction-ua-card-bg)',
         // gilt salon double-frame: paper inset, then a thin gold line
-        border: '1px solid var(--ua-line)',
-        boxShadow: `0 16px 38px color-mix(in srgb, var(--ua-ink) 16%, transparent),
-                    inset 0 0 0 4px var(--ua-paper),
-                    inset 0 0 0 5px var(--ua-line-soft)`,
+        border: '1px solid var(--faction-ua-rule)',
+        boxShadow: `0 16px 38px var(--color-overlay-medium),
+                    inset 0 0 0 4px var(--faction-ua-card-bg),
+                    inset 0 0 0 5px var(--faction-ua-hair)`,
         padding: 0,
       }}
     >
@@ -210,8 +216,8 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
           justifyContent: 'space-between',
           gap: 'var(--space-lg)',
           padding: 'var(--space-md) var(--space-xl)',
-          borderBottom: '1px solid var(--ua-line-soft)',
-          background: 'linear-gradient(180deg, color-mix(in srgb, var(--ua-gold-pale) 28%, var(--ua-paper)), var(--ua-paper))',
+          borderBottom: '1px solid var(--faction-ua-hair)',
+          background: 'linear-gradient(180deg, color-mix(in srgb, var(--faction-ua-panel) 28%, var(--faction-ua-card-bg)), var(--faction-ua-card-bg))',
         }}
       >
         <Link
@@ -220,7 +226,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
             fontFamily: REGALIA,
             fontSize: 'var(--text-base)',
             letterSpacing: '0.14em',
-            color: 'var(--ua-gold)',
+            color: 'var(--faction-ua-card-accent)',
             textDecoration: 'none',
           }}
         >
@@ -259,7 +265,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
             fontSize: 'var(--text-xs)',
             letterSpacing: '0.22em',
             textTransform: 'uppercase',
-            color: 'var(--ua-muted)',
+            color: 'var(--faction-ua-card-muted)',
             marginBottom: 'var(--space-md)',
             display: 'flex',
             flexWrap: 'wrap',
@@ -268,10 +274,10 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
           }}
         >
           <span>{t('detail.ua.acquisitionGrade', { grade: praxis.task_level_required > 0 ? praxis.task_level_required : '—' })}</span>
-          <span style={{ color: 'var(--ua-line)' }}>·</span>
+          <span style={{ color: 'var(--faction-ua-rule)' }}>·</span>
           <span>{modeLabel(praxis.type, t)}</span>
-          <span style={{ color: 'var(--ua-line)' }}>·</span>
-          <span style={{ fontFamily: SERIF, fontSize: 'var(--text-md)', fontStyle: 'italic', letterSpacing: 0, textTransform: 'none', color: 'var(--ua-sub)' }}>
+          <span style={{ color: 'var(--faction-ua-rule)' }}>·</span>
+          <span style={{ fontFamily: SERIF, fontSize: 'var(--text-md)', fontStyle: 'italic', letterSpacing: 0, textTransform: 'none', color: 'var(--faction-ua-card-body)' }}>
             {t('detail.ua.returnedToSalon', { date: formatTimestamp(sealedDate) })}
           </span>
         </div>
@@ -284,7 +290,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
             fontWeight: 600,
             fontSize: 'var(--text-display)',
             lineHeight: 1.06,
-            color: 'var(--ua-ink)',
+            color: 'var(--faction-ua-card-text)',
             marginBottom: 'var(--space-lg)',
           }}
         >
@@ -302,7 +308,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
             gap: 'var(--space-lg)',
             paddingBottom: 'var(--space-xl)',
             marginBottom: 'var(--space-xl)',
-            borderBottom: '1px solid var(--ua-line-soft)',
+            borderBottom: '1px solid var(--faction-ua-hair)',
           }}
         >
           <Link to={`/characters/${praxis.created_by_id}`}>
@@ -325,7 +331,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
                 fontStyle: 'italic',
                 fontWeight: 500,
                 fontSize: 'var(--text-xl)',
-                color: 'var(--ua-ink)',
+                color: 'var(--faction-ua-card-text)',
                 textDecoration: 'none',
               }}
             />
@@ -334,7 +340,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
                 fontFamily: MONO,
                 fontSize: 'var(--text-xs)',
                 letterSpacing: '0.06em',
-                color: 'var(--ua-muted)',
+                color: 'var(--faction-ua-card-muted)',
               }}
             >
               {t('detail.ua.acquiringHand')}
@@ -349,7 +355,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
                 fontWeight: 700,
                 fontSize: 'var(--text-heading)',
                 lineHeight: 1,
-                color: 'var(--ua-orange)',
+                color: 'var(--faction-ua-card-accent)',
               }}
             >
               {praxis.task_point_value}
@@ -359,7 +365,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
                 fontFamily: REGALIA,
                 fontSize: 'var(--text-xs)',
                 letterSpacing: '0.1em',
-                color: 'var(--ua-muted)',
+                color: 'var(--faction-ua-card-muted)',
                 marginTop: 'var(--space-xs)',
               }}
             >
@@ -372,11 +378,11 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
         {praxis.body_text && (
           <div style={{ marginBottom: 'var(--space-xl)' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', margin: '0 0 var(--space-lg)' }}>
-              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
-              <span style={{ fontFamily: REGALIA, fontSize: 'var(--text-sm)', letterSpacing: '0.22em', color: 'var(--ua-gold)', whiteSpace: 'nowrap' }}>
+              <div style={{ height: 1, flex: 1, background: 'var(--faction-ua-hair)' }} />
+              <span style={{ fontFamily: REGALIA, fontSize: 'var(--text-sm)', letterSpacing: '0.22em', color: 'var(--faction-ua-card-accent)', whiteSpace: 'nowrap' }}>
                 {t('detail.ua.theProcess')}
               </span>
-              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
+              <div style={{ height: 1, flex: 1, background: 'var(--faction-ua-hair)' }} />
             </div>
             <MarkdownPreview
               source={praxis.body_text}
@@ -384,7 +390,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
               style={{
                 fontFamily: SERIF,
                 lineHeight: 1.85,
-                color: 'var(--ua-sub)',
+                color: 'var(--faction-ua-card-body)',
               }}
             />
           </div>
@@ -394,28 +400,30 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
         {praxis.media_items.length > 0 && (
           <div style={{ marginBottom: 'var(--space-xl)' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', margin: '0 0 var(--space-lg)' }}>
-              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
-              <span style={{ fontFamily: REGALIA, fontSize: 'var(--text-sm)', letterSpacing: '0.22em', color: 'var(--ua-gold)', whiteSpace: 'nowrap' }}>
+              <div style={{ height: 1, flex: 1, background: 'var(--faction-ua-hair)' }} />
+              <span style={{ fontFamily: REGALIA, fontSize: 'var(--text-sm)', letterSpacing: '0.22em', color: 'var(--faction-ua-card-accent)', whiteSpace: 'nowrap' }}>
                 {t('detail.ua.thePlate', { count: praxis.media_items.length })}
               </span>
-              <div style={{ height: 1, flex: 1, background: 'var(--ua-line-soft)' }} />
+              <div style={{ height: 1, flex: 1, background: 'var(--faction-ua-hair)' }} />
             </div>
-            {/* gilt frame: gold-leaf outer, gold inner mat, then the gallery */}
+            {/* Sheet frame: sand outer, a neutral inner mat, then the gallery.
+                Was a gilt double-frame; the gilt gradient died with the legacy
+                family (#853) and gold now belongs to WOW. */}
             <div
               style={{
                 padding: 'var(--space-sm)',
-                background: 'var(--ua-gilt)',
-                boxShadow: `0 10px 22px color-mix(in srgb, var(--ua-ink) 20%, transparent),
-                            inset 0 0 0 1px color-mix(in srgb, white 40%, transparent)`,
+                background: 'var(--faction-ua-panel)',
+                boxShadow: `0 10px 22px var(--color-overlay-medium),
+                            inset 0 0 0 1px var(--faction-ua-hair)`,
               }}
             >
               <div
                 style={{
                   padding: 'var(--space-xs)',
-                  background: 'linear-gradient(135deg, var(--ua-gold), var(--ua-gold-pale))',
+                  background: 'var(--faction-ua-rule)',
                 }}
               >
-                <div style={{ background: 'var(--ua-paper)', padding: 'var(--space-sm)' }}>
+                <div style={{ background: 'var(--faction-ua-card-bg)', padding: 'var(--space-sm)' }}>
                   <MediaGallery media={praxis.media_items} layout="grid" />
                 </div>
               </div>
@@ -428,8 +436,8 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
 
         {/* ── The Patronage (cast your appraisal) ── */}
         <div style={{ marginBottom: 'var(--space-lg)' }}>
-          <div style={{ marginBottom: 'var(--space-lg)', paddingTop: 'var(--space-lg)', borderTop: '1px solid var(--ua-line-soft)' }}>
-            <span style={{ fontFamily: REGALIA, fontSize: 'var(--text-base)', letterSpacing: '0.2em', color: 'var(--ua-gold)' }}>
+          <div style={{ marginBottom: 'var(--space-lg)', paddingTop: 'var(--space-lg)', borderTop: '1px solid var(--faction-ua-hair)' }}>
+            <span style={{ fontFamily: REGALIA, fontSize: 'var(--text-base)', letterSpacing: '0.2em', color: 'var(--faction-ua-card-accent)' }}>
               {t('detail.ua.patronage')}
             </span>
           </div>

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
@@ -22,20 +22,26 @@ import { MobileStarVote } from './shared'
  * (full media); a Cormorant-italic finding headline, the account body, and a
  * thumb-sized appraisal caster follow. Renders the same invariant CONTENT +
  * behavior slots as every archetype (the shared praxisDetail module) — only the
- * dress changes. Grounds on `--faction-ua-*` / `--ua-*` tokens; always-light.
+ * dress changes.
+ *
+ * REPOINTED, NOT REBUILT (#853): the constants below keep their old salon names
+ * (GOLD, GILT, …) but no longer resolve to gold — the legacy `--ua-*` family was
+ * deleted and each one now points at the nearest `--faction-ua-*` primitive. The
+ * skin therefore also dims with the theme (#848 ended UA's always-light rule).
+ * A rebuild against the UA identity kit is a separate, future issue.
  */
 
 const PAPER = 'var(--faction-ua-card-bg)'
-const PAPER_WARM = 'var(--ua-paper-warm)'
-const WALL = 'var(--ua-wall)'
+const PAPER_WARM = 'var(--faction-ua-lift)'
+const WALL = 'var(--faction-ua-page)'
 const INK = 'var(--faction-ua-card-text)'
 const ACCENT = 'var(--faction-ua-card-accent)'
 const SUB = 'var(--faction-ua-card-muted)'
-const MUTED = 'var(--ua-muted)'
-const GOLD = 'var(--ua-gold)'
-const GOLD_PALE = 'var(--ua-gold-pale)'
-const LINE = 'var(--ua-line)'
-const GILT = 'var(--ua-gilt)'
+const MUTED = 'var(--faction-ua-card-muted)'
+const GOLD = 'var(--faction-ua-card-accent)'
+const GOLD_PALE = 'var(--faction-ua-panel)'
+const LINE = 'var(--faction-ua-rule)'
+const GILT = 'var(--faction-ua-panel)'
 const DISPLAY = 'var(--faction-ua-card-font)'
 const ENGRAVED = 'var(--font-faction-engraved)'
 const MONO = 'var(--font-body)'

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -113,13 +113,9 @@ const ARCHETYPE_PAIRS: Pair[] = [
   { what: "snide deep wall", surface: "--faction-snide-wall-deep", text: "--faction-snide-wall-text" },
   { what: "snide xerox paper, ink", surface: "--faction-snide-paper", text: "--faction-snide-ink" },
 
-  // UA — LEGACY gilt-salon family, awaiting deletion in #853. Still measured
-  // because ~20 components still paint with it; --ua-ink is "brown ink — all
-  // text". It has no dark values and is not getting any: it is going away.
-  { what: "ua sheet, ink", surface: "--ua-paper", text: "--ua-ink" },
-  { what: "ua sheet, secondary", surface: "--ua-paper", text: "--ua-sub" },
-  { what: "ua sheet, mono labels", surface: "--ua-paper", text: "--ua-muted" },
-  { what: "ua wall, ink", surface: "--ua-wall", text: "--ua-ink" },
+  // (The legacy UA gilt-salon family was measured here until #853 deleted it.
+  // Every surface that painted with it now reads the sun-bleached primitives
+  // below, which are measured in BOTH themes rather than light only.)
 
   // UA — the sun-bleached practice (#788, #848). UA is the first faction with
   // FOUR themed surfaces (page ground, card, inset panel, raised lift) rather

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -213,11 +213,10 @@ const BASELINE: Record<string, { ratio: number; issue: number }> = {
   "dark | ephemerists card accent": { ratio: 3.72, issue: 651 },
   // The same rubric vermilion, reached through its archetype-private primitive.
   "dark | ephemerists vellum, rubric": { ratio: 3.72, issue: 651 },
-  // UA mono metadata labels on the legacy gilt sheet. Both themes measure the
-  // same because the legacy family has no dark values; #853 deletes the family,
-  // which is what retires these two entries.
-  "light | ua sheet, mono labels": { ratio: 3.06, issue: 651 },
-  "dark | ua sheet, mono labels": { ratio: 3.06, issue: 651 },
+  // (UA mono metadata labels on the legacy gilt sheet measured 3.06:1 in both
+  // themes and were listed here until #853 deleted the legacy family, exactly
+  // as this entry predicted. The surfaces that used to paint that pair now read
+  // --faction-ua-card-muted, which clears AA on every UA surface.)
 };
 
 function key(theme: Theme, pair: Pair): string {


### PR DESCRIPTION
Closes #853

The last step of the UA identity chain (#788). The fourteen legacy gilt-salon
colour tokens are gone from `index.css`, and the four files that still read them
have been repointed at the `--faction-ua-*` namespace.

**Deleted, not migrated.** A rename would have preserved exactly the thing that
made this a problem: a private second palette read as bare `var()` strings
rather than through `factionCssVar()`, so nothing type-checks it and a missed
reference renders as an unstyled element instead of failing the build. UA's gold
is not re-homed — it went to Warriors of Whimsy in #838.

## Three commits, in the order the issue demanded

1. **Repoint every remaining reader.** No declaration touched, so a missed
   reference would have shown up as a diff rather than as a silent regression.
2. **Delete the declarations**, plus the doc sweep.
3. **Retire two AA-debt baseline entries** the deletion pays off (see below).

## Repointed WITHOUT restyling — cosmetically unchanged by intent

These four keep their current layout, ornament and language. They simply stop
painting with tokens that no longer exist. A real rebuild against the UA
identity kit is a **separate, future issue** for each:

| File | Notes |
|---|---|
| `frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx` | **54 refs — the heaviest remaining reader, and owned by no issue in the chain.** It is neither the praxis *card* (#857) nor the *task* detail page (#851); it fell through the gap between them. Still says "salon", "acquisition", "appraisal". |
| `frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx` | Deliberately deferred by #852. Its constants keep their old names (`GOLD`, `GILT`, …) but no longer resolve to gold. |
| `frontend/src/components/vote/UaVote.tsx` | Comment only — reworded off the dead token name. |
| `frontend/src/components/cards/UaSigil.tsx` | Comment only — same. |

Mapping used: `paper`→`card-bg`, `paper-warm`→`lift`, `wall`→`page`,
`ink`→`card-text`, `sub`→`card-body`, `muted`→`card-muted`, `line`→`rule`,
`line-soft`→`hair`, `orange`/`gold`→`card-accent`, `gold-pale`→`panel`.

**Two places had no like-for-like heir**, because gold left the faction — these
are the only visual changes in the diff:
- the evidence plate's **gilt double-frame** becomes a sand/neutral mat
  (`--faction-ua-panel` outer, `--faction-ua-rule` inner);
- the ink-tinted drop shadows (`color-mix(… --ua-ink 16% …)`) become
  `--color-overlay-medium`. The old mix would have **inverted** in dark, painting
  a pale glow under the sheet.

Both praxis-detail files also stop claiming UA is always-light — #848 ended that,
and every `--faction-ua-*` token carries a `[data-theme="dark"]` value. They now
follow the theme through the cascade, with no JS branch.

## Kept on purpose

`grep -- "--ua-"` over-matches. `--ua-grow-delay`, `--ua-spin-dur`,
`--ua-spin-dir` and `--ua-twist-dur` are **animation-local** custom properties on
the mandala keyframes, set inline by `UaMandala` and `UaVote`. They are timing,
not palette, and #849 made them more load-bearing, not less. The tombstone
comment in `index.css` says so explicitly, so the next sweep does not eat them.

## Guards widened, not dropped

`factionAvatar` and `factionSigil` each asserted against **one** token name
(`var(--ua-gold)`, `var(--ua-orange)`). Since those names are now deleted, a
literal assertion would be trivially true forever. Both now assert against the
whole family — `not.toMatch(/var\(--ua-[a-z]/)` — which is a real guard again.
(This is the shape #879 wants to generalise into `factionTokensDeclared`.)

## The contrast ledger gets shorter

`factionContrast`'s BASELINE carried `ua sheet, mono labels` at 3.06:1 in **both**
themes, with a note saying #853's deletion is what retires it. It does. Net
effect: this chain closes two entries off the AA debt list rather than adding
any.

`WORLD_ZERO_STYLE.md` §4 also still listed UA's headline face as **IM Fell
English**; #848 replaced it with Cormorant Garamond via `--font-faction-serif`.
Fixed, with EB Garamond named as the secondary.

## Verification

- `grep -rE -- "--ua-(orange|gold|gilt|ink|sub|muted|paper|wall|line)" frontend/src` → **no hits**
- `tsc --noEmit` → clean (only the known `node:fs`/`node:url` stale-junction false alarms from PR #675)
- `vitest` → **1233 passed / 109 files**, zero failures
- `eslint .` → clean
- `vite build` → clean

## ⚠️ No visual QA was done

I cannot render this branch — no screenshots, no dev stack. Everything above is
grep, type-check, test and lint. The palette shift is a *token* argument, not a
*pixel* one.

### What to eyeball

1. **Praxis detail page, UA task, light AND dark.** The 54-reference file. Dark
   is genuinely new behaviour here — it has never dimmed before.
2. **The evidence plate** on a praxis with media. This is where the gilt frame
   used to be; it is now sand-on-neutral and will read noticeably flatter.
3. **Mobile praxis detail, UA.** Same two questions, phone-shaped. Note its
   inner mat is still a *gradient* (`linear-gradient(135deg, accent, panel)`) —
   sienna into sand rather than gold into pale gold.
4. **Both `--faction-ua-panel` frames in dark.** `panel` is `#2d261f` there;
   check the plate frame still separates from the card behind it.
5. **The UA mandala, anywhere it spins** (vote widget, page backdrop, join card,
   faction hero). Confirms the four surviving animation properties really were
   untouched.
6. **The `✦` glyphs and rank numerals** in "The Standing" ledger — they moved
   from gold to `--faction-ua-card-accent` and are now the same hue as the
   surrounding accent text, which they were not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)