### PR TITLE
fix(badge): the Duelist badge survives era close (#748)

### DIFF
--- a/backend/services/badge.py
+++ b/backend/services/badge.py
@@ -23,27 +23,40 @@ from schemas.character import BadgeOut
 from services.duel_outcome import duel_winner
 from services.vote_tally import get_tally, tally_votes
 
-# A duel only feeds the duelist badge while it is still live. `resolved` duels
-# are excluded on purpose (#748): their outcome is a frozen, *past-era* fact and
-# belongs to the deferred "won a duel last era" badge (#823), not this one.
-LIVE_DUEL_STATUSES: tuple[DuelStatus, ...] = (DuelStatus.active, DuelStatus.settled)
+# Every duel status that can feed the duelist badge. `resolved` is included
+# (owner ruling on #748, 2026-07-21): the badge means "won *or* winning", not
+# "winning right now", so a win survives the era close #824 freezes it at.
+# #823 narrows to the last-era-only case.
+BADGE_DUEL_STATUSES: tuple[DuelStatus, ...] = (
+    DuelStatus.active,
+    DuelStatus.settled,
+    DuelStatus.resolved,
+)
 
 
 async def _duel_winning_character_ids(
     character_ids: set[int],
     session: AsyncSession,
 ) -> set[int]:
-    """Ids of the given characters that are winning at least one live duel (#748).
+    """Ids of the given characters that have won or are winning a duel (#748).
 
-    Two set-based queries regardless of page size: one for every live duel any
-    of these characters is a side of (joined to the challenger's praxis, which
-    is where the challenger's character id lives), then one
-    :func:`tally_votes` over both sides' praxis ids.
+    Two set-based queries regardless of page size: one for every badge-eligible
+    duel any of these characters is a side of (joined to the challenger's praxis,
+    which is where the challenger's character id lives), then one
+    :func:`tally_votes` over the *live* sides' praxis ids.
 
-    The winner of each duel comes from the one shared rule
-    (:func:`services.duel_outcome.duel_winner`, ADR-0052) — forfeit first, then
-    strictly-greater ``points_from_votes``, else a tie. Never infer a winner
-    from the points: a forfeit winner can hold the *lower* score.
+    Frozen and live split the same way :mod:`services.praxis_scoring` splits
+    them:
+
+    * ``resolved`` — read the frozen ``Duel.winner_character_id`` directly.
+      #824 froze it at era close on purpose; recomputing would re-open a settled
+      fact, and these duels need no tally row at all.
+    * ``active`` / ``settled`` — the winner comes from the one shared rule
+      (:func:`services.duel_outcome.duel_winner`, ADR-0052) over the live tally:
+      forfeit first, then strictly-greater ``points_from_votes``, else a tie.
+
+    Never infer a winner from the points: a forfeit winner can hold the *lower*
+    score, frozen or live.
     """
     if not character_ids:
         return set()
@@ -57,13 +70,15 @@ async def _duel_winning_character_ids(
                 Duel.challenger_praxis_id,
                 Duel.opponent_praxis_id,
                 Duel.forfeited_by_character_id,
+                Duel.status,
+                Duel.winner_character_id,
             )
             .join(
                 challenger_praxis,
                 challenger_praxis.id == Duel.challenger_praxis_id,
             )
             .where(
-                Duel.status.in_(LIVE_DUEL_STATUSES),
+                Duel.status.in_(BADGE_DUEL_STATUSES),
                 or_(
                     challenger_praxis.created_by_id.in_(character_ids),
                     Duel.opponent_character_id.in_(character_ids),
@@ -74,30 +89,37 @@ async def _duel_winning_character_ids(
     if not duel_rows:
         return set()
 
-    praxis_ids = {row.challenger_praxis_id for row in duel_rows}
+    # Only the live duels need a tally: a resolved duel's winner is already
+    # frozen on the row, so tallying its sides would be wasted work.
+    live_rows = [row for row in duel_rows if row.status != DuelStatus.resolved]
+    praxis_ids = {row.challenger_praxis_id for row in live_rows}
     praxis_ids.update(
         row.opponent_praxis_id
-        for row in duel_rows
+        for row in live_rows
         if row.opponent_praxis_id is not None
     )
     tallies = await tally_votes(list(praxis_ids), session)
 
     winners: set[int] = set()
     for row in duel_rows:
-        opponent_points = (
-            get_tally(tallies, row.opponent_praxis_id).points_from_votes
-            if row.opponent_praxis_id is not None
-            else 0
-        )
-        winner_character_id: Optional[int] = duel_winner(
-            challenger_character_id=row.challenger_character_id,
-            opponent_character_id=row.opponent_character_id,
-            challenger_points=get_tally(
-                tallies, row.challenger_praxis_id
-            ).points_from_votes,
-            opponent_points=opponent_points,
-            forfeited_by_character_id=row.forfeited_by_character_id,
-        )
+        if row.status == DuelStatus.resolved:
+            # Frozen fact (#824): trust the recorded winner, never the points.
+            winner_character_id: Optional[int] = row.winner_character_id
+        else:
+            opponent_points = (
+                get_tally(tallies, row.opponent_praxis_id).points_from_votes
+                if row.opponent_praxis_id is not None
+                else 0
+            )
+            winner_character_id = duel_winner(
+                challenger_character_id=row.challenger_character_id,
+                opponent_character_id=row.opponent_character_id,
+                challenger_points=get_tally(
+                    tallies, row.challenger_praxis_id
+                ).points_from_votes,
+                opponent_points=opponent_points,
+                forfeited_by_character_id=row.forfeited_by_character_id,
+            )
         if winner_character_id is not None and winner_character_id in character_ids:
             winners.add(winner_character_id)
     return winners

--- a/backend/tests/integration/test_duelist_badge.py
+++ b/backend/tests/integration/test_duelist_badge.py
@@ -1,9 +1,14 @@
-"""The duelist badge — winning a *live* duel (#748, ADR-0033, ADR-0011).
+"""The duelist badge — having won *or* being ahead in a duel (#748, ADR-0033, ADR-0011).
 
-The badge holds when a character is currently ahead on votes in a live duel, or
-holds a forfeit win. It is provisional by design (ADR-0011: mid-era the tally
-floats); a `resolved` duel is a frozen past-era fact and belongs to the deferred
-"won a duel last era" badge (#823), so it must NOT grant this one.
+The badge holds when a character is currently ahead on votes in a live duel,
+holds a forfeit win, or is the frozen winner of a `resolved` duel. Live wins are
+provisional by design (ADR-0011: mid-era the tally floats); the resolved case is
+the frozen one — owner ruling 2026-07-21 made the badge survive era close, so a
+win does not silently vanish when #824 resolves every live duel at reset.
+
+The resolved case reads `Duel.winner_character_id` and never recomputes: a
+forfeit winner can hold the *lower* frozen score, which is what
+`test_resolved_forfeit_winner_with_the_lower_score_keeps_the_badge` pins.
 
 The last test is the load-bearing one: the per-character duel fact must resolve
 in a fixed number of set-based queries, not one per character (ADR-0033's
@@ -214,10 +219,10 @@ async def test_forfeit_hands_the_badge_to_the_other_side(
 
 
 @pytest.mark.asyncio
-async def test_resolved_duel_does_not_grant_the_badge(
+async def test_resolved_duel_grants_the_badge_to_its_frozen_winner(
     db_session: AsyncSession, era: Era, faction_ua: Faction
 ):
-    """A frozen past-era win is #823's badge, not this one."""
+    """The badge survives era close: "won or winning" (owner ruling 2026-07-21)."""
     duel, challenger, opponent = await _make_duel(
         db_session,
         era,
@@ -230,7 +235,100 @@ async def test_resolved_duel_does_not_grant_the_badge(
     duel.winner_character_id = challenger.id
     await db_session.commit()
 
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_resolved_duel_frozen_to_the_opponent_leaves_the_loser_bare(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    duel, challenger, opponent = await _make_duel(
+        db_session,
+        era,
+        label="lost",
+        challenger_votes=0,
+        opponent_votes=5,
+        status=DuelStatus.active,
+    )
+    duel.status = DuelStatus.resolved
+    duel.winner_character_id = opponent.id
+    await db_session.commit()
+
     assert await _badge_keys(db_session, challenger) == []
+    assert await _badge_keys(db_session, opponent) == ["duelist"]
+
+
+@pytest.mark.asyncio
+async def test_resolved_duel_with_no_frozen_winner_grants_nothing(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """A tie / no-contest froze `winner_character_id` as NULL — nobody won."""
+    duel, challenger, opponent = await _make_duel(
+        db_session,
+        era,
+        label="draw",
+        challenger_votes=3,
+        opponent_votes=3,
+        status=DuelStatus.active,
+    )
+    duel.status = DuelStatus.resolved
+    duel.winner_character_id = None
+    await db_session.commit()
+
+    assert await _badge_keys(db_session, challenger) == []
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_resolved_forfeit_winner_with_the_lower_score_keeps_the_badge(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """The frozen field is authoritative — never inferred from the snapshot points.
+
+    The opponent forfeited while holding the *higher* tally, so #824 froze the
+    challenger as winner on the lower score. Comparing points would hand the
+    badge to the wrong side.
+    """
+    duel, challenger, opponent = await _make_duel(
+        db_session,
+        era,
+        label="ffpast",
+        challenger_votes=1,
+        opponent_votes=9,
+        status=DuelStatus.active,
+        forfeiter="opponent",
+    )
+    duel.status = DuelStatus.resolved
+    duel.winner_character_id = challenger.id
+    await db_session.commit()
+
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_resolved_duel_ignores_a_live_tally_that_disagrees(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """Recomputing at all is the bug: the frozen winner trails on live votes.
+
+    No forfeit is recorded, so `duel_winner` over the tally would name the
+    opponent. Only reading `Duel.winner_character_id` gets this right.
+    """
+    duel, challenger, opponent = await _make_duel(
+        db_session,
+        era,
+        label="drift",
+        challenger_votes=1,
+        opponent_votes=9,
+        status=DuelStatus.active,
+    )
+    duel.status = DuelStatus.resolved
+    duel.winner_character_id = challenger.id
+    await db_session.commit()
+
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
     assert await _badge_keys(db_session, opponent) == []
 
 
@@ -280,10 +378,12 @@ async def test_endpoint_surfaces_the_duelist_badge(
 async def test_batch_path_is_constant_query_count(
     db_connection, db_session: AsyncSession, era: Era, faction_ua: Faction
 ):
-    """A 6-character page costs the same number of queries as a 2-character one.
+    """An 8-character page costs the same number of queries as a 2-character one.
 
     Guards ADR-0033's amended rule: the per-character duel fact must fold into
-    set-based queries, never one query per character in the loop.
+    set-based queries, never one query per character in the loop. The large page
+    mixes live and `resolved` duels, so the frozen-vs-live split must not cost a
+    query either.
     """
     _, one_challenger, one_opponent = await _make_duel(
         db_session, era, label="b1", challenger_votes=5, opponent_votes=1
@@ -294,6 +394,12 @@ async def test_batch_path_is_constant_query_count(
     _, three_challenger, three_opponent = await _make_duel(
         db_session, era, label="b3", forfeiter="challenger"
     )
+    four_duel, four_challenger, four_opponent = await _make_duel(
+        db_session, era, label="b4", challenger_votes=2, opponent_votes=7
+    )
+    four_duel.status = DuelStatus.resolved
+    four_duel.winner_character_id = four_challenger.id
+    await db_session.commit()
 
     statements: list[str] = []
 
@@ -317,6 +423,8 @@ async def test_batch_path_is_constant_query_count(
                 two_opponent,
                 three_challenger,
                 three_opponent,
+                four_challenger,
+                four_opponent,
             ],
             db_session,
         )
@@ -333,3 +441,6 @@ async def test_batch_path_is_constant_query_count(
     assert large[two_challenger.id].is_duel_winner is False
     assert large[three_opponent.id].is_duel_winner is True
     assert large[three_challenger.id].is_duel_winner is False
+    # Frozen winner, despite trailing the live tally 2-7.
+    assert large[four_challenger.id].is_duel_winner is True
+    assert large[four_opponent.id].is_duel_winner is False


### PR DESCRIPTION
Implements the owner ruling of 2026-07-21 on #748: **the Duelist badge survives era close.** It means "won *or* winning", not "winning right now".

As shipped in PR #871, `LIVE_DUEL_STATUSES = (active, settled)` excluded `resolved`. Since #824 (PR #865) flips every live duel to `resolved` at era reset, a forfeit win — which #748 calls "sticky and durable" — silently vanished the moment an era turned. That cliff is now closed.

## The change — `backend/services/badge.py`

- `LIVE_DUEL_STATUSES` → **`BADGE_DUEL_STATUSES`**, now `(active, settled, resolved)`. The old name was no longer honest; docstring and comment updated with it. No other reference existed repo-wide.
- **Frozen vs. live split**, mirroring `services/praxis_scoring.py` (~line 189):
  - `resolved` → read the frozen `Duel.winner_character_id` **directly**. No recompute. #824 froze it deliberately and a forfeit winner can hold the *lower* snapshot score, so inferring from points is a known trap.
  - `active` / `settled` → unchanged, still `services.duel_outcome.duel_winner(...)` over the live tally.
- `Duel.status` and `Duel.winner_character_id` added to the `select(...)` column list.
- **Batch discipline preserved** (ADR-0033 amended rule — the Constellation roster is a list path): still **two set-based queries regardless of page size**. The tally pass now builds `praxis_ids` from *live* rows only, so resolved duels cost no tally rows at all rather than being tallied and then ignored.

Nothing else touched: no change to `badges.py`, the `BadgeContext` shape, the frontend glyph, `services/era.py`, or `duel_outcome.py`.

## Tests — `backend/tests/integration/test_duelist_badge.py`

`test_resolved_duel_does_not_grant_the_badge` asserted exactly the behaviour this ruling reverses; it is inverted. Added:

- resolved + frozen winner is this character → **present**
- resolved + frozen winner is the opponent → **absent** for the loser
- resolved + `winner_character_id IS NULL` (tie / no-contest) → **absent** for both
- resolved **forfeit where the winner holds the LOWER snapshot score** (1 vs 9, opponent forfeited) → still **present**
- resolved + frozen winner trails the live tally 1-9 with **no forfeit recorded** → still **present**. This is the strongest guard: `duel_winner` over that tally names the *opponent*, so it only passes if the frozen field is read rather than recomputed.

All existing live-duel cases pass unchanged. The batch guard now mixes a `resolved` duel into the large page, proving the frozen-vs-live split costs no extra query.

## Verification

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz748c_test \
  python -m pytest --cov=. --cov-fail-under=80 -q
```

**706 passed in 64.02s — total coverage 89.28%** (target 80%). Targeted file: `tests/integration/test_duelist_badge.py` — 13 passed.

No migration. No schema change — `Duel.winner_character_id` already exists (#824).

## Knock-on

Per the ruling, **#823 narrows**: "won a duel last era" is no longer "the historical case" but specifically the *last-era-only* case, i.e. filtering `resolved_at` against the previous era's boundaries rather than granting on any resolved win. This PR grants on **any** resolved win, in any era. Not changed here.

Still true from #871: `build_badge_contexts` (plural) has no production caller — the batch discipline is guarded by tests alone.

## What to eyeball

- **No visual QA was done.** I cannot screenshot and there is no dev stack running; everything here is verified by tests only. The frontend glyph is untouched and still falls back to `UnknownBadgeArt` (dashed medallion) until the separate `badgeArt.tsx` work lands.
- The **ruling itself is a player-visible semantics change**: characters who won duels in *past* eras will start showing the Duelist badge on the Constellation roster and their profile the moment this merges. Confirm that population looks right — it could be a lot of people at once.
- The badge is now **permanent** for any resolved win. There is no decay and no "last era only" filter; that is #823's job.
- A resolved duel with `winner_character_id IS NULL` grants nothing to either side. Worth confirming #824 actually writes NULL on ties rather than picking a side.
- Naming: `BADGE_DUEL_STATUSES` — say the word if you would rather it read `DUELIST_BADGE_STATUSES` or similar.

Closes #748
