### PR TITLE
copy(wow): adopt the design's tier ladder (#840 / #844 ruling)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -95,7 +95,7 @@ The two axes are independent, and #830 collapsed them: it read a mislabelled moc
 | Card | cream / gold / **plum** chronicle | **pink** marker sticker |
 | Widget | googly **balloons** | **moon phases** on a night plate |
 | Glyph | `✦` | `✨` |
-| Tier ladder | `a start … excellent · legendary` | `sweet · lovely · wonderful · magical · iconic` |
+| Tier ladder | `a start · quite solid · jolly good · splendid! · legendary!` | `sweet · lovely · wonderful · magical · iconic` |
 | Register | archaic — *"Cast thy Verdict"* | cozy-casual — *"how'd this land?"* |
 
 **On the hue.** Yellow is the palette's hard case (#651, #669, #677), for two reasons that pull in opposite directions. A yellow saturated enough to read as yellow needs **dark ink** on it, never white — hence `--faction-wow-on-fill` is ink in both themes. And WOW sits **adjacent to UA** in the spectrum, so the two are painted touching in the Leaderboard/DefaultPlayers stripe bars and Meadow's bloom; a goldenrod too near UA's burnt orange reads as a second brown at that size. The shipped light value resolves this by pushing hue rather than lightness — clear of orange, deep enough to stay legible.

--- a/docs/adr/0050-wow-and-coven-visual-identity.md
+++ b/docs/adr/0050-wow-and-coven-visual-identity.md
@@ -50,7 +50,7 @@ needed.
 | Card | cream / gold / plum chronicle | pink marker-sticker card, light **and** dark |
 | Widget | googly **balloons** | **moon phases** on a night plate |
 | Glyph | `✦` (the one place the retired `✦` survives) | `✨` |
-| Tier ladder | `…excellent · legendary` | `sweet · lovely · wonderful · magical · iconic` |
+| Tier ladder | `a start · quite solid · jolly good · splendid! · legendary!` | `sweet · lovely · wonderful · magical · iconic` |
 | Caption | `Cast thy Verdict` / `thou dubbed it legendary!` | `how'd this land?` / `magical · YAY!` |
 | Register | archaic — *"for the quest"*, *"Sealed by the Court"*, *"here, an illumination"* | cozy-casual — *"all done!"*, *"Drop a happy little photo"*, *"a crew of four"* |
 
@@ -118,18 +118,26 @@ Yes: the project whose every file says "Warriors of Whimsy" is the *Coven* kit.
 Subagents cannot reach `claude.ai` design URLs — the orchestrating session must
 read them and paste the findings into the dispatch prompt.
 
-## Open, as of the epic's close (#844)
+## Resolved after the epic's close (#844)
 
-**WOW's tier ladder is unresolved and the shipped one was kept pending an owner
-ruling.** Two readings disagree:
+**WOW's tier ladder — the design bundle wins (owner ruling, 2026-07-21).**
+At the epic's close two readings disagreed:
 
-- the design bundle draws `a start · quite solid · jolly good · splendid! ·
+- the design bundle drew `a start · quite solid · jolly good · splendid! ·
   legendary!`;
-- issue #840's body, the vendored `LABELS.md` and `WORLD_ZERO_STYLE.md` all say
-  `… excellent · legendary`.
+- issue #840's body, the vendored `LABELS.md` and `WORLD_ZERO_STYLE.md` all said
+  `… excellent · legendary`, and that is what shipped —
+  `a start · solid · good · excellent · legendary`, which is also the Everymen
+  ladder.
 
-`frontend/src/locales/en/votes.json` currently ships the second —
-`a start · solid · good · excellent · legendary` — which is also the Everymen
-ladder. Coven's (`sweet · lovely · wonderful · magical · iconic`) is not in
-dispute. This is recorded here rather than left to the deleted bundle precisely
-because it is *unresolved*; it must not vanish with the directory.
+Three sources against one, and the one won: the archaic register *is* WOW's
+chronicle voice, and #840's own sample voted string (`thou dubbed it
+legendary!`) carries the exclamation mark that only the bundle's ladder
+supplies. Duplicating the Everymen ladder gave WOW no voice of its own.
+
+`frontend/src/locales/en/votes.json` now ships the bundle's ladder, and the
+keys were renamed with the values (`solid` → `quite-solid`, `good` →
+`jolly-good`, `excellent` → `splendid`) so no key describes a value it no
+longer holds. `chrome.wow.picked` (`thou dubbed it {{label}}`) is unchanged —
+only the `{{label}}` values moved. Coven's
+(`sweet · lovely · wonderful · magical · iconic`) was never in dispute.

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -54,9 +54,9 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
   wow: {
     tiers: [
       { value: 1, label: i18n.t('votes:wow.a-start') },
-      { value: 2, label: i18n.t('votes:wow.solid') },
-      { value: 3, label: i18n.t('votes:wow.good') },
-      { value: 4, label: i18n.t('votes:wow.excellent') },
+      { value: 2, label: i18n.t('votes:wow.quite-solid') },
+      { value: 3, label: i18n.t('votes:wow.jolly-good') },
+      { value: 4, label: i18n.t('votes:wow.splendid') },
       { value: 5, label: i18n.t('votes:wow.legendary') },
     ],
   },

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -22,10 +22,10 @@
   },
   "wow": {
     "a-start": "a start",
-    "solid": "solid",
-    "good": "good",
-    "excellent": "excellent",
-    "legendary": "legendary"
+    "quite-solid": "quite solid",
+    "jolly-good": "jolly good",
+    "splendid": "splendid!",
+    "legendary": "legendary!"
   },
   "snide": {
     "meh": "meh",


### PR DESCRIPTION
## The ruling

ADR-0050 closed the praxis-card epic (#818) with one item explicitly left **open**:
WOW's tier ladder. The design bundle drew one ladder; issue #840's body, the
vendored `LABELS.md` and `WORLD_ZERO_STYLE.md` drew another, and the shipped
`votes.json` followed the latter pending an owner call.

**Owner ruling, 2026-07-21: the design bundle wins.**

| value | shipped | adopted |
|---|---|---|
| 1 | `a start` | `a start` (unchanged) |
| 2 | `solid` | **`quite solid`** |
| 3 | `good` | **`jolly good`** |
| 4 | `excellent` | **`splendid!`** |
| 5 | `legendary` | **`legendary!`** |

Tiers 4 and 5 gain exclamation marks deliberately — that is what tipped the
ruling, since #840's own sample voted string was `thou dubbed it legendary!`,
which the shipped ladder could never produce. The archaic register is WOW's
chronicle voice; the old ladder was a verbatim copy of the Everymen one, so WOW
had no voice of its own.

## Files touched

- `frontend/src/locales/en/votes.json` — the `wow` block: new values, and the
  three keys that no longer described their value were **renamed with them**
  (`solid` → `quite-solid`, `good` → `jolly-good`, `excellent` → `splendid`),
  following the existing kebab-case convention. `a-start` and `legendary` keep
  their names. This avoids the key/value drift #850 had to clean up.
- `frontend/src/components/vote/voteReframes.ts` — `wow.tiers` now references the
  renamed keys. Order and `value:` numbers unchanged.
- `docs/adr/0050-wow-and-coven-visual-identity.md` — pair table updated, and the
  `## Open, as of the epic's close (#844)` section retitled
  `## Resolved after the epic's close (#844)` and rewritten to record the
  resolution. The history of the conflict is kept, not deleted; it was the only
  open item, so no empty "Open" heading remains.
- `WORLD_ZERO_STYLE.md` — pair table row updated to the full ladder.

**Not touched, deliberately:**

- `frontend/src/components/ui/VoteStamps.tsx` — reads `voteStamps.*` from
  `common.json`, a different namespace, not WOW's ladder.
- `votes.json`'s `everymen` block, which still legitimately reads
  `fair · solid · good · excellent · legendary`.
- `chrome.wow.picked` (`thou dubbed it {{label}}`) — the template was already
  right; only the `{{label}}` values moved.
- Coven's ladder, tokens, `index.css`, any styling.

## Verification

- `npx vitest run` — **1233 passed / 109 files**. The catalog key-parity test is
  the guard here and is green; its one WOW assertion (`votes:wow.a-start` is
  `'a start'`) is still true and needed no change. Grepped the whole test file
  for the other ladder keys — there were none.
- `npx tsc --noEmit` — clean. (Only the known stale-junction
  `Cannot find module 'node:fs'/'node:url'` false alarm from PR #675.)
- `npx eslint src` — clean.
- `npx vite build` — built in 3.64s.
- `grep -rn "excellent" frontend/src` — remaining hits are Everymen's ladder and
  `VoteStamps.tsx`'s separate namespace, both correct.

## What to eyeball

- A WOW-skinned praxis card's vote widget: all five tier labels, checking that
  `quite solid` and `jolly good` don't overflow their slot — they are noticeably
  longer than `solid` / `good` and the widget was laid out for the short ones.
- The chronicle's voted-state line, `thou dubbed it splendid!` /
  `thou dubbed it legendary!` — the label now carries its own `!`, so confirm the
  sentence doesn't end up with a doubled or orphaned punctuation mark.
- The score-stamp / tier-4 and tier-5 states specifically, since those are the
  two that changed punctuation.
- Mobile WOW skins, where the vote row is narrowest.

**No visual QA was done.** This branch was verified by tests, `tsc`, `eslint` and
`vite build` only — there is no dev stack available here and the Browser pane
renderer cannot screenshot. Every item above is outstanding.

Settles the item left open by #818 / #840 / #844 (all already closed — no
`Closes` here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
