### PR TITLE
fix(coven): correct docstrings still describing Coven files as Warriors of Whimsy

### DIFF
--- a/frontend/src/components/avatar/CovenAvatar.tsx
+++ b/frontend/src/components/avatar/CovenAvatar.tsx
@@ -13,7 +13,7 @@ function MoonGlyph({ size, color }: { size: number; color: string }) {
 }
 
 /**
- * Warriors of Whimsy avatar — the standard circle with a pink "coven" moon membership
+ * Cozy Coven avatar — the standard circle with a pink "coven" moon membership
  * badge clipped to the lower-right.
  */
 export default function CovenAvatar({ character, size }: FactionAvatarProps) {

--- a/frontend/src/components/backdrop/CovenBackdrop.tsx
+++ b/frontend/src/components/backdrop/CovenBackdrop.tsx
@@ -1,5 +1,5 @@
 /**
- * Warriors of Whimsy full-page backdrop — a lo-fi pastel "desktop": soft pink field with a
+ * Cozy Coven full-page backdrop — a lo-fi pastel "desktop": soft pink field with a
  * dotted grid and a gentle corner glow. Theme-aware via the `.coven-backdrop`
  * rule in index.css. Fixed behind page content at z-index 0.
  */

--- a/frontend/src/components/cards/CovenFactionHero.tsx
+++ b/frontend/src/components/cards/CovenFactionHero.tsx
@@ -3,7 +3,7 @@ import type { FactionHeroProps } from "../../pages/FactionDetail";
 import i18n from "../../i18n";
 
 /**
- * Warriors of Whimsy faction-page hero — whimsy.exe pinned to a cork memo board.
+ * Cozy Coven faction-page hero — whimsy.exe pinned to a cork memo board.
  * A pastel "app window" charm, a Caveat-script wordmark + motto, the blurb, and —
  * per the faction-page standardization — the three counts as taped sticker charms
  * in a SIDE column (never a full-width band). Two pushpins tack the banner down.
@@ -11,8 +11,8 @@ import i18n from "../../i18n";
  *
  * Theme-aware through the cascade: every colour resolves to a --faction-coven-*
  * token (which already carries light + dark values), so the board never mutates
- * the global theme. The script face is the WoW card-font token (Caveat); body
- * copy uses --font-body, matching CovenTaskCard / the WoW PraxisCard branch.
+ * the global theme. The script face is the Coven card-font token (Caveat); body
+ * copy uses --font-body, matching CovenTaskCard / the Coven PraxisCard branch.
  *
  * The page passes raw counts; the faction labels them in its own whimsy voice.
  * Motto is a faction constant (not a backend field).
@@ -34,12 +34,12 @@ const DOT = "var(--faction-coven-dot)";
 const SCRIPT = "var(--faction-coven-card-font)";
 const BODY = "var(--font-body)";
 
-// The board's board-brown shadow has no dedicated token; the WoW atoms use a raw
+// The board's board-brown shadow has no dedicated token; the Coven atoms use a raw
 // warm-brown rgba for their pinned-paper drop shadows. Reuse the same value.
 // ponytail: no --faction-coven-board-shadow token exists; matching the atoms' rgba.
 const BOARD_SHADOW = "rgba(80,50,30,0.3)";
 
-/** Tiny four-point sparkle — same glyph the WoW task/window chrome uses. */
+/** Tiny four-point sparkle — same glyph the Coven task/window chrome uses. */
 function Sparkle({ size = 12, color = "currentColor" }: { size?: number; color?: string }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block" }}>

--- a/frontend/src/components/cards/CovenSigil.tsx
+++ b/frontend/src/components/cards/CovenSigil.tsx
@@ -1,5 +1,5 @@
 /**
- * CovenSigil — the Warriors of Whimsy four-point sparkle, the faction's only mark.
+ * CovenSigil — the Cozy Coven four-point sparkle, the faction's only mark.
  *
  * The single canonical COVEN emblem, drawn once and reused everywhere the sparkle
  * appears (faction-select tile, the wow.exe title bar, mobile praxis card).

--- a/frontend/src/components/cards/CovenTaskCard.tsx
+++ b/frontend/src/components/cards/CovenTaskCard.tsx
@@ -4,7 +4,7 @@ import i18n from "../../i18n";
 import LevelGem from "../ui/LevelGem";
 
 /**
- * Warriors of Whimsy — wow.exe.
+ * Cozy Coven — wow.exe.
  * Lo-fi computer-witch window: pastel title bar with window dots, a faint
  * dotted-grid body, and an inner "notepad" panel holding the task in the
  * Caveat headline font. Visuals only — same prop contract as the other cards.

--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -7,7 +7,7 @@ import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
 import { CommentFlagControl } from '../FlagControl'
 
 /**
- * Warriors of Whimsy — `{handle}.exe` (ADR-0018). Reuses the task-card window
+ * Cozy Coven — `{handle}.exe` (ADR-0018). Reuses the task-card window
  * chrome verbatim (--faction-coven-win-border / title gradient / dotted body),
  * retitled to the author's handle. Handwritten Caveat body.
  */

--- a/frontend/src/components/duel/CovenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenDuelSealConfirm.tsx
@@ -1,5 +1,5 @@
 /**
- * Warriors of Whimsy DESKTOP duel seal-confirm (#720) — design panel 2b.
+ * Cozy Coven DESKTOP duel seal-confirm (#720) — design panel 2b.
  *
  * The Default dialog's content, re-hung inside a centred `wow.exe` window:
  * traffic-light title bar, dotted board, notepad scrap for the stakes and the

--- a/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
@@ -1,5 +1,5 @@
 /**
- * Warriors of Whimsy MOBILE duel seal-confirm (#720) — design panel 1b.
+ * Cozy Coven MOBILE duel seal-confirm (#720) — design panel 1b.
  *
  * The same content as the desktop window (2b is explicitly "the mobile sheet laid
  * out for the wider frame"), rebuilt as a bottom sheet: full-bleed on the page

--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -3,11 +3,11 @@ import type { ReactNode } from 'react'
 import i18n from '../../i18n'
 
 /**
- * Warriors of Whimsy feed frame — the neutral feed card dressed as a tiny
+ * Cozy Coven feed frame — the neutral feed card dressed as a tiny
  * "whimsy.exe" desktop window. A pink title bar (traffic-light dots + a script
  * window name + a sparkle charm) sits above a notepad/paper body that holds the
  * untouched card `{children}`. Frame-level chrome only: this is a thin wrapper,
- * not a reimplementation of the card. Flips with the theme via the WoW tokens.
+ * not a reimplementation of the card. Flips with the theme via the Coven tokens.
  */
 
 const WIN_BORDER = 'var(--faction-coven-win-border)'
@@ -19,7 +19,7 @@ const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
 const SCRIPT = 'var(--faction-coven-card-font)'
 const PINK = 'var(--faction-coven)'
 
-/** The four-point sparkle charm — WoW's signature window flourish. */
+/** The four-point sparkle charm — Coven's signature window flourish. */
 function Sparkle({ size }: { size: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
@@ -1,5 +1,5 @@
 /**
- * CovenProfileBody — Warriors of Whimsy scrapbook player-profile skin (#460).
+ * CovenProfileBody — Cozy Coven scrapbook player-profile skin (#460).
  * Ported from docs/design/profile/templates/Warriors of Whimsy Profile.dc.html:
  * a cork-board mat with push-pin dots, slight tilts, washi-tape strips, and an
  * ".exe window" progression panel. COVEN follows the global light/dark cascade —

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -10,20 +10,20 @@ import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
- * Warriors of Whimsy faction-body — the whimsy.exe cork-memo-board skin of the
+ * Cozy Coven faction-body — the whimsy.exe cork-memo-board skin of the
  * standardized six-section spine (② About, ③ join.exe, ④ Tasks, ⑤ Praxis,
  * ⑥ Members). Section ① (hero + side stat charms) is CovenFactionHero, above.
  *
  * Same shape as EverymenFactionBody / UaFactionBody — Tasks/Praxis reuse the
- * app-wide per-faction cards (TaskCard / PraxisCard already dispatch to the WoW
+ * app-wide per-faction cards (TaskCard / PraxisCard already dispatch to the Coven
  * atoms) so this file only owns the board chrome the design adds around them: the
  * two-column layout, the taped index cards, the pinned join.exe window, the
  * Witch-of-the-week polaroid + coven roster, and the FDL laurel on the single
  * top-scoring praxis.
  *
  * Every colour resolves to a --faction-coven-* token (dark-mode-aware via the
- * cascade). The script face is the WoW card-font token (Caveat); body copy uses
- * --font-body, matching CovenTaskCard and the WoW PraxisCard branch.
+ * cascade). The script face is the Coven card-font token (Caveat); body copy uses
+ * --font-body, matching CovenTaskCard and the Coven PraxisCard branch.
  */
 
 const PINK = "var(--faction-coven)";
@@ -45,7 +45,7 @@ const SCRIPT = "var(--faction-coven-card-font)";
 const BODY = "var(--font-body)";
 
 // The board's warm-brown drop shadow + the index card's ruling have no dedicated
-// tokens; the WoW atoms hardcode the same warm rgba pair for their pinned paper.
+// tokens; the Coven atoms hardcode the same warm rgba pair for their pinned paper.
 // Reuse them so this skin matches the atoms exactly.
 // ponytail: no --faction-coven-board-shadow / -rule token exists yet.
 const BOARD_SHADOW = "rgba(80,50,30,0.28)";
@@ -53,7 +53,7 @@ const PIN_SHADOW = "rgba(80,50,30,0.4)";
 // Faint hairline for a card edge — a muted mix of the notepad border.
 const HAIRLINE = "color-mix(in srgb, var(--faction-coven-notepad-border) 55%, transparent)";
 
-/** Tiny four-point sparkle — the WoW chrome's signature glyph. */
+/** Tiny four-point sparkle — the Coven chrome's signature glyph. */
 function Sparkle({ size = 12, color = "currentColor" }: { size?: number; color?: string }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flexShrink: 0 }}>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
@@ -8,7 +8,7 @@ import type { CharacterOut } from '../../../api/auth'
 import type { FactionDetailState } from '../useFactionDetail'
 
 /**
- * Warriors of Whimsy MOBILE faction page (#531) — the coven, phone shaped. The
+ * Cozy Coven MOBILE faction page (#531) — the coven, phone shaped. The
  * same single-column slots as the Default mobile faction page (a hero with real
  * member/task counts, top members, recent praxis, and the invite-gated Join model
  * via `state.membership`, ADR-0019) — only the dress changes: a pink scrapbook

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -6,7 +6,7 @@ import { mediaUrl } from '../../../utils/media'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
- * Warriors of Whimsy MOBILE FieldDesk home (#500) — the scrapbook window idiom
+ * Cozy Coven MOBILE FieldDesk home (#500) — the scrapbook window idiom
  * on a phone: the carried life and its in-progress quests each become a little
  * pink "window" (traffic-light dots + sparkle-titled bar, a dotted board and an
  * inner notepad), taped to a rose board. Same content slots as the Default

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -1,5 +1,5 @@
 /**
- * Warriors of Whimsy praxis-read archetype — the sealed praxis rendered as a
+ * Cozy Coven praxis-read archetype — the sealed praxis rendered as a
  * "praxis.exe" desktop window: pink computer-witch chrome with a traffic-light
  * title bar, a dotted desktop body, Caveat-script "finding" headline, sparkle
  * charms, dotted-running-rule section dividers, and a window-framed evidence
@@ -7,7 +7,7 @@
  * Praxis.html / whimsy-exe.jsx); wired to the real {@link PraxisDetailState}.
  *
  * Invariant behavior slots (admin bar, banners, owner actions, flag) come from
- * the shared module — this archetype owns only presentation. WoW flips with the
+ * the shared module — this archetype owns only presentation. Coven flips with the
  * theme normally, so every color reads from --faction-coven* tokens (light + dark
  * already defined in index.css). No document-theme mutation, no hardcoded hex.
  * The author byline themes to the AUTHOR's faction, not the task's.

--- a/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
@@ -1,5 +1,5 @@
 /**
- * Warriors of Whimsy DESKTOP duel rail (#720) — the duel context as a second
+ * Cozy Coven DESKTOP duel rail (#720) — the duel context as a second
  * `wow.exe` window docked above the praxis, matching the design's panels 2b/2c.
  *
  * Pure frame. Every slot arrives pre-rendered from `DuelCrossLink`: the

--- a/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
@@ -1,5 +1,5 @@
 /**
- * Warriors of Whimsy MOBILE duel rail (#720) — panel 1c of the design.
+ * Cozy Coven MOBILE duel rail (#720) — panel 1c of the design.
  *
  * The desktop window, thumbed down: the title bar loses its side-by-side tally
  * (a score pair and a script headline on one phone-width row wrap into mush) and

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
@@ -1,5 +1,5 @@
 /**
- * Warriors of Whimsy MOBILE praxis-detail skin (#499) — the praxis.exe window on
+ * Cozy Coven MOBILE praxis-detail skin (#499) — the praxis.exe window on
  * a phone: a pink computer-witch window (traffic-light title bar, dotted board,
  * inner notepad) holds the full media, then a Caveat "finding" headline, the
  * account body, and a big thumb-sized star caster. Single-column; ported from

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -9,7 +9,7 @@ import type { PraxisCardOut } from "../../../api/praxis";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
- * Warriors of Whimsy task-detail archetype — the job rendered as a
+ * Cozy Coven task-detail archetype — the job rendered as a
  * "whimsy.exe" desktop window: a pink computer-witch chrome with a
  * traffic-light title bar, a dotted desktop body, Caveat-script headings,
  * sparkle charms, "spells cast" completions (the most-loved one wears a

--- a/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
@@ -6,7 +6,7 @@ import { MobileStickyBar, MobileStickyCaption } from './shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
- * Warriors of Whimsy MOBILE task-detail skin (#531) — the quest.exe window on a
+ * Cozy Coven MOBILE task-detail skin (#531) — the quest.exe window on a
  * phone. A pink scrapbook window hero (traffic-light title bar, dotted board,
  * inner notepad) carries the Caveat title + sparks/level plates, then the "what
  * we're asking" brief, the love-so-far aggregate, the spells cast (completions),

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/CovenMobileTaskCard.tsx
@@ -6,7 +6,7 @@ import { factionCssVar, factionName } from '../../../../utils/factions'
 import { MobileTaskDescription } from './shared'
 
 /**
- * Warriors of Whimsy MOBILE task card (#531/#565) — a pink scrapbook "quest"
+ * Cozy Coven MOBILE task card (#531/#565) — a pink scrapbook "quest"
  * sticker-card: dotted board, inner notepad, sparkle accents, Caveat title.
  * Reads `task.primary_faction_slug` for its own faction tint. Grounds on the
  * `--faction-coven-*` window tokens; always-light. Presentation-only.


### PR DESCRIPTION
Closes #884

## What changed

20 `Coven*` files carried header docstrings dating from before #784 split Cozy Coven off Warriors of Whimsy — describing the file's own identity as "Warriors of Whimsy," or attributing shared atoms/tokens/chrome to "WoW" when they're now Coven's own (label lag ADR-0050 exists to stop):

- Opening identity lines ("Warriors of Whimsy avatar/backdrop/hero/…") corrected to "Cozy Coven."
- Self-referential "the WoW atoms / WoW chrome / WoW card-font token / WoW PraxisCard branch" comments corrected to "Coven," since no live `WowFactionHero`/`WowFactionBody`/`WowFeedFrame`/`WowAvatar` component exists to be a legitimate cross-faction comparison — only vendored `.design-sync/previews/` design source and a handful of live `Wow*` files in unrelated domains (praxisCard, vote, editPraxis).

## Deliberately left untouched

Per the issue's trap warning and comments-only scope:
- The literal `wow.exe` window-caption string — intentional pre-#784 chrome pinned by `dispatch.test.tsx`.
- `wow.*` i18n key namespace and `wow-treatment` Field Kit section references — real, still-current key/section names, not slug claims.
- Vendored design-source filenames/paths (`Warriors of Whimsy Praxis.html`, `Warriors of Whimsy Profile.dc.html`, `WhimsyTaskDetail.tsx`, `the WoW design kit`) — genuine provenance, not identity claims.
- `CovenProfileBody.tsx`'s `playerEyebrow: 'Player · Warriors of Whimsy'` — this is a **rendered** string, not a docstring, so it's out of scope for a comments-only issue (flagging here for visibility; a real UI bug, but a different fix).

## Test results

Comment-only diff — verified via `git diff` that every changed line is a comment line. `frontend`: `npx vitest run` → **1233 passed** across **109 test files**, including the `dispatch.test.tsx` suites that pin the `wow.exe` caption.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QZTSCzhkR4zUeMVRh5K8ik)_