### PR TITLE
fix(mobile): the mobile logged-out vote gate speaks its faction's voice

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -13,6 +13,7 @@ import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
 import '../../../i18n'
+import i18n from '../../../i18n'
 import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut } from '../../../api/praxis'
@@ -153,6 +154,57 @@ describe('mobile praxis-read earned-points breakdown', () => {
       expect(text, 'multiplier value').toContain('1.1')
       expect(text, 'multiplier operator').toContain('×')
       expect(text, 'vote points').toContain('14')
+    })
+  }
+})
+
+// ─── Logged-out vote gate voice (#864) ───────────────────────────────────────
+// The mobile caster does NOT go through VoteUI, so nothing published the task
+// faction to the shared gate chrome and every mobile gate spoke the
+// unaffiliated spectrum while desktop spoke its faction's. Each archetype now
+// publishes its own slug on VoteFactionContext. `state()` leaves `user` null, so
+// MobileStarVote renders the gate rather than the caster.
+
+/**
+ * The gate's own style attribute — isolated by the copy that follows the tag, so
+ * a faction token used ELSEWHERE in the skin (its accent is all over the page)
+ * can't satisfy the assertion. Singularity's caret prefix sits between the two.
+ */
+function gateStyle(html: string): string {
+  const copy = i18n.t('votes:chrome.loginGate')
+  const match = html.match(
+    new RegExp(`<p[^>]*class="eyebrow"[^>]*style="([^"]*)"[^>]*>[^<]*${copy}`),
+  )
+  expect(match, 'logged-out gate is rendered').not.toBeNull()
+  return match![1]
+}
+
+/** A gate wearing the spectrum is the bug this describes — the default voice. */
+const SPECTRUM = '--faction-default-rainbow'
+
+describe('mobile praxis-read logged-out vote gate', () => {
+  for (const [slug, Archetype] of Object.entries(surfaceMap('mobilePraxisDetail'))) {
+    it(`${slug} speaks in its own voice, not the unaffiliated default`, () => {
+      const style = gateStyle(render(<Archetype state={state()} />).html)
+      expect(style, 'faction accent').toContain(`--faction-${slug}-card-accent`)
+      expect(style, 'default spectrum').not.toContain(SPECTRUM)
+    })
+  }
+
+  it('gives wow the chronicle voice through the default archetype', () => {
+    // wow has no mobile archetype of its own, so the default skin has to carry
+    // the slug through — a constant would have silently unthemed it.
+    const style = gateStyle(render(<DefaultMobilePraxisDetail state={state()} />).html)
+    expect(style, 'faction accent').toContain('--faction-wow-card-accent')
+    expect(style, 'default spectrum').not.toContain(SPECTRUM)
+  })
+
+  for (const slug of ['na', 'albescent']) {
+    it(`keeps ${slug} on the unaffiliated spectrum`, () => {
+      const unaffiliated = state()
+      unaffiliated.praxis = { ...PRAXIS, task_faction_slug: slug }
+      const style = gateStyle(render(<DefaultMobilePraxisDetail state={unaffiliated} />).html)
+      expect(style, 'default spectrum').toContain(SPECTRUM)
     })
   }
 })

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
@@ -25,6 +25,7 @@ import {
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
+import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import { MobileStarVote } from './shared'
 
 const PINK = 'var(--faction-coven)'
@@ -200,11 +201,13 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={PINK} font={SCRIPT} />
         </div>
-        <MobileStarVote
-          praxisId={praxis.id}
-          accent={PINK}
-          accentFont={SCRIPT}
-        />
+        <VoteFactionContext.Provider value="coven">
+          <MobileStarVote
+            praxisId={praxis.id}
+            accent={PINK}
+            accentFont={SCRIPT}
+          />
+        </VoteFactionContext.Provider>
       </Window>
 
       {/* Flag + voter breakdown (invariant) */}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
@@ -25,6 +25,7 @@ import {
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
+import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import { MobileStarVote } from './shared'
 
 export default function DefaultPraxisDetail({ state }: { state: PraxisDetailState }) {
@@ -135,10 +136,16 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={accent} />
         </div>
-        <MobileStarVote
-          praxisId={praxis.id}
-          accent={accent}
-        />
+        {/* The default skin serves every faction without a mobile archetype of
+            its own, so the gate's voice comes from the praxis, not a constant:
+            `wow` lands here and must still speak in the chronicle plum, while
+            `na`/`albescent` fall through to the spectrum (ADR-0039). */}
+        <VoteFactionContext.Provider value={praxis.task_faction_slug}>
+          <MobileStarVote
+            praxisId={praxis.id}
+            accent={accent}
+          />
+        </VoteFactionContext.Provider>
       </div>
 
       {/* Flag + voter breakdown (invariant) */}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/EphemeristsPraxisDetail.tsx
@@ -15,6 +15,7 @@ import {
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
+import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import { MobileStarVote } from './shared'
 
 /**
@@ -137,11 +138,13 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={RUBRIC} font={DISPLAY} />
         </div>
-        <MobileStarVote
-          praxisId={praxis.id}
-          accent={RUBRIC}
-          accentFont={DISPLAY}
-        />
+        <VoteFactionContext.Provider value="ephemerists">
+          <MobileStarVote
+            praxisId={praxis.id}
+            accent={RUBRIC}
+            accentFont={DISPLAY}
+          />
+        </VoteFactionContext.Provider>
       </Leaf>
 
       {/* Flag + voter breakdown (invariant) */}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
@@ -14,6 +14,7 @@ import {
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
+import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import { MobileStarVote } from './shared'
 
 /**
@@ -133,11 +134,13 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={RED} font={ACCENT_FONT} />
         </div>
-        <MobileStarVote
-          praxisId={praxis.id}
-          accent={RED}
-          accentFont={ACCENT_FONT}
-        />
+        <VoteFactionContext.Provider value="everymen">
+          <MobileStarVote
+            praxisId={praxis.id}
+            accent={RED}
+            accentFont={ACCENT_FONT}
+          />
+        </VoteFactionContext.Provider>
       </Plate>
 
       {/* Flag + voter breakdown (invariant) */}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/SingularityPraxisDetail.tsx
@@ -14,6 +14,7 @@ import {
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
+import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import { MobileStarVote } from './shared'
 
 /**
@@ -142,11 +143,13 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={PHOSPHOR} font={FONT} />
         </div>
-        <MobileStarVote
-          praxisId={praxis.id}
-          accent={PHOSPHOR}
-          accentFont={FONT}
-        />
+        <VoteFactionContext.Provider value="singularity">
+          <MobileStarVote
+            praxisId={praxis.id}
+            accent={PHOSPHOR}
+            accentFont={FONT}
+          />
+        </VoteFactionContext.Provider>
       </Panel>
 
       {/* Flag + voter breakdown (invariant) */}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/SnidePraxisDetail.tsx
@@ -14,6 +14,7 @@ import {
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
+import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import { MobileStarVote } from './shared'
 
 /**
@@ -140,11 +141,13 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={ACID} font={IMPACT} />
         </div>
-        <MobileStarVote
-          praxisId={praxis.id}
-          accent={ACID}
-          accentFont={IMPACT}
-        />
+        <VoteFactionContext.Provider value="snide">
+          <MobileStarVote
+            praxisId={praxis.id}
+            accent={ACID}
+            accentFont={IMPACT}
+          />
+        </VoteFactionContext.Provider>
       </Plate>
 
       {/* Flag + voter breakdown (invariant) */}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
@@ -14,6 +14,7 @@ import {
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
+import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import { MobileStarVote } from './shared'
 
 /**
@@ -149,11 +150,13 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
         <div style={{ marginBottom: 'var(--space-md)' }}>
           <PraxisScoreBreakdown state={state} align="center" accent={ACCENT} font={DISPLAY} />
         </div>
-        <MobileStarVote
-          praxisId={praxis.id}
-          accent={ACCENT}
-          accentFont={DISPLAY}
-        />
+        <VoteFactionContext.Provider value="ua">
+          <MobileStarVote
+            praxisId={praxis.id}
+            accent={ACCENT}
+            accentFont={DISPLAY}
+          />
+        </VoteFactionContext.Provider>
       </Plate>
 
       {/* Flag + voter breakdown (invariant) */}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
@@ -8,6 +8,15 @@
  * (48px star buttons) for the feed-detail surface. Logged-out viewers get the
  * shared VoteLoginGate; the points/vote tally reuses the shared VoteSummary
  * (#375: a running tally, never an average).
+ *
+ * The mobile path does not go through {@link VoteUI}, so nothing publishes the
+ * task faction to that shared chrome here — which left every mobile gate
+ * speaking the unaffiliated spectrum voice while desktop spoke its faction's
+ * (#864). Each mobile archetype therefore wraps its caster in
+ * `VoteFactionContext.Provider` with its own slug (the default skin passes
+ * `praxis.task_faction_slug`, since it serves whichever factions have no mobile
+ * archetype). A NEW mobile praxis-detail archetype must do the same, or its gate
+ * silently falls back to the spectrum.
  */
 import { useTranslation } from 'react-i18next'
 import { useVote } from '../../../components/vote/useVote'


### PR DESCRIPTION
Closes #864

`MobileStarVote` renders the logged-out vote gate but does not go through `VoteUI`, so nothing published the task faction to the shared gate chrome: every faction's **mobile** praxis-detail gate fell through to the unaffiliated spectrum voice while desktop got its own eyebrow treatment.

## What changed

Routed through the existing `VoteFactionContext` (the seam #855 added) rather than threading a `factionSlug` prop — each of the seven mobile praxis-detail archetypes now wraps its caster in `VoteFactionContext.Provider`. `VoteLoginGate` already reads that context, so `shared.tsx` needed only a docstring.

**Which single point, and why not a smaller one.** The smallest possible diff would have been one provider in the `PraxisDetail` dispatcher (it holds `task_faction_slug` for both form factors). I chose the per-archetype provider instead because it is the only version that is *testable* in this harness and the only one that survives reuse: the archetype becomes self-sufficient — its gate speaks correctly no matter who renders it — and `useFormFactor` returns `'desktop'` under `renderToStaticMarkup`, so a dispatcher-level provider could not be exercised by any test at all. `MobileStarVote` cannot derive the slug itself: it receives only `praxisId`.

The six faction skins pass a constant slug. `DefaultPraxisDetail` passes `praxis.task_faction_slug`, because it serves every faction with no mobile archetype — notably **`wow`**, which must still speak the chronicle plum; a constant there would have silently unthemed it. `na`/`albescent` keep falling through to the spectrum (ADR-0039).

Out of scope and untouched, per #855: the gate copy, the casing table, `votes.chrome.loginGate`, `GateTreatment`.

## Verification

- `tsc --noEmit`: no errors in changed files (the only output is the pre-existing `node:fs`/`node:path`/`node:url` + `TS7006` noise in `fontsLoaded.test.ts` / `factionTokensDeclared.test.ts`, the known stale-junction false alarm from PR #675).
- `vite build`: clean. `eslint src/pages/praxisDetail src/components/vote`: clean.
- `vitest run`: 1242 passed / 109 files. New cases in `mobileArchetypeSlots.test.tsx` walk `surfaceMap('mobilePraxisDetail')` logged out and assert the **gate's own style attribute** (isolated by the copy that follows the tag, so a faction accent used elsewhere on the page can't satisfy it) carries `--faction-<slug>-card-accent` and not `--faction-default-rainbow`. Confirmed the guard bites: reverting the Snide + Default archetypes fails exactly those two cases.
- **Visual QA is outstanding** — no screenshots and no dev stack in this environment; every claim above is from tests, tsc, eslint and the build.

## What to eyeball

Log out, narrow to a phone viewport (<768px), open a praxis detail page and check the one line where the star caster would be:

- **S.N.I.D.E.** praxis — heavy acid-green sans, wide tracking, on the ransom plate.
- **Singularity** praxis — lowercase phosphor with the `>` caret prefix and its glow, inside the readout panel.
- **UA** praxis — gilt UA body face, wide tracking.
- **Everymen** praxis — union red, condensed.
- **Ephemerists** praxis — rubric red on the vellum leaf.
- **Coven** praxis — marker pink, sentence case (not the plum — ADR-0050 labels WOW/Coven backwards).
- **WOW** praxis (renders the *default* mobile skin) — chronicle plum, sentence case.
- **Unaffiliated (`na`) and Albescent** praxis (default skin) — should still be the rainbow spectrum gradient, unchanged.

Worth a glance in dark mode too, and worth confirming the logged-*in* mobile caster is untouched (same five 48px stars, same tally).
