### PR TITLE
Praxis card chrome: one score, a portrait byline, a legible meta line, and the faction's own font (#888)

### DIFF
--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -96,6 +96,12 @@ class PraxisCardOut(BaseModel):
     moderation_status: ModerationStatus
     created_by_id: int
     created_by_display_name: str
+    # The author's portrait, for the card byline (#888). Relative media path or
+    # "" — an empty string is the ordinary case (no portrait uploaded) and the
+    # byline degrades to the shared monogram avatar, not a placeholder image.
+    # Deliberately card-only: ``PraxisOut`` gets it if the detail byline ever
+    # needs a face.
+    created_by_avatar_url: str = ""
     created_at: datetime
     updated_at: datetime
     submitted_at: Optional[datetime] = None

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -401,6 +401,12 @@ async def build_praxis_card_out(
     task_point_value = praxis.task.point_value if praxis.task else 0
     task_level_required = praxis.task.level_required if praxis.task else 0
     created_by_display_name = praxis.created_by.display_name if praxis.created_by else ""
+    # The author's portrait for the card byline (#888). ``created_by`` is already
+    # loaded on every path into this builder (it is what feeds the display name),
+    # so this costs no additional query.
+    created_by_avatar_url = (
+        praxis.created_by.avatar_url if praxis.created_by else None
+    ) or ""
 
     viewer_vote_info = viewer_votes.get(praxis.id) if viewer_votes else None
 
@@ -437,6 +443,7 @@ async def build_praxis_card_out(
         moderation_status=praxis.moderation_status,
         created_by_id=praxis.created_by_id,
         created_by_display_name=created_by_display_name,
+        created_by_avatar_url=created_by_avatar_url,
         created_at=praxis.created_at,
         updated_at=praxis.updated_at,
         submitted_at=praxis.submitted_at,

--- a/backend/tests/integration/test_praxis_card_byline.py
+++ b/backend/tests/integration/test_praxis_card_byline.py
@@ -1,0 +1,119 @@
+"""Integration tests for the praxis-card byline payload (#888).
+
+The card byline shows the author's portrait beside their name. ``PraxisCardOut``
+carries ``created_by_avatar_url`` for that; it is a plain string so an author
+with no portrait uploaded degrades to the shared monogram avatar rather than a
+null the frontend has to special-case.
+
+``PraxisOut`` (the detail payload) deliberately does NOT carry the field — the
+detail byline has no portrait — so this file also pins that asymmetry, since it
+is the kind of thing a later "make them symmetric" refactor would quietly undo.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from models.character import Character
+from models.era import Era
+from models.faction import Faction
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from services.praxis import build_praxis_card_out, build_praxis_out
+
+
+async def _make_solo_praxis(session: AsyncSession, author: Character) -> Praxis:
+    task = Task(
+        title="a task",
+        description="proof",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=author.id,
+        primary_faction_slug="ua",
+    )
+    session.add(task)
+    await session.flush()
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=author.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title="solo",
+        body_text="proof",
+    )
+    session.add(praxis)
+    await session.flush()
+    session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id))
+    await session.flush()
+    return praxis
+
+
+async def _load_card(session: AsyncSession, praxis_id: int):
+    result = await session.execute(
+        select(Praxis)
+        .where(Praxis.id == praxis_id)
+        .options(
+            selectinload(Praxis.task),
+            selectinload(Praxis.created_by),
+            selectinload(Praxis.members),
+            selectinload(Praxis.media_items),
+        )
+    )
+    return await build_praxis_card_out(result.scalar_one(), session)
+
+
+@pytest.mark.asyncio
+async def test_card_carries_the_authors_portrait(
+    db_session: AsyncSession, era: Era, faction_ua: Faction, character: Character
+):
+    character.avatar_url = "avatars/isolde.png"
+    praxis = await _make_solo_praxis(db_session, character)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert card.created_by_avatar_url == "avatars/isolde.png"
+    assert card.created_by_display_name == character.display_name
+
+
+@pytest.mark.asyncio
+async def test_portraitless_author_degrades_to_empty_string(
+    db_session: AsyncSession, era: Era, faction_ua: Faction, character: Character
+):
+    """No portrait is the ordinary case.
+
+    ``Character.avatar_url`` is NOT NULL and defaults to ``""``, so the empty
+    string is what a portraitless author actually stores — the card must carry
+    it through as "" rather than inventing a placeholder path.
+    """
+    character.avatar_url = ""
+    praxis = await _make_solo_praxis(db_session, character)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert card.created_by_avatar_url == ""
+
+
+@pytest.mark.asyncio
+async def test_detail_payload_is_deliberately_left_without_a_portrait(
+    db_session: AsyncSession, era: Era, faction_ua: Faction, character: Character
+):
+    """PraxisOut stays as it was (#888): only the CARD byline grew a face."""
+    character.avatar_url = "avatars/isolde.png"
+    praxis = await _make_solo_praxis(db_session, character)
+
+    result = await db_session.execute(
+        select(Praxis)
+        .where(Praxis.id == praxis.id)
+        .options(
+            selectinload(Praxis.task),
+            selectinload(Praxis.created_by),
+            selectinload(Praxis.members),
+            selectinload(Praxis.invites),
+            selectinload(Praxis.media_items),
+        )
+    )
+    detail = await build_praxis_out(result.scalar_one(), db_session)
+
+    assert not hasattr(detail, "created_by_avatar_url")

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -99,6 +99,12 @@ export interface PraxisCardOut {
   moderation_status: ModerationStatus
   created_by_id: number
   created_by_display_name: string
+  /**
+   * The author's portrait for the card byline (#888). `""` when they have none
+   * — the byline falls back to the shared monogram avatar. Optional so a stale
+   * cached payload degrades to the monogram rather than crashing the card.
+   */
+  created_by_avatar_url?: string
   created_at: string
   updated_at: string
   submitted_at: string | null

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * #888 — the shared praxis-card chrome: one score, a portrait byline, a legible
+ * meta line, and the faction's own typefaces.
+ *
+ * SSR-rendered in isolation with the real i18n catalog. No effects run here, so
+ * these pin markup and copy, not interaction.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import type { ReactElement } from 'react'
+import '../../../i18n'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { PraxisByline, PraxisStats, PraxisVoteFooter } from '../shared'
+import { MobileVoteFooter } from '../mobile/shared'
+
+function praxis(overrides: Partial<PraxisCardOut>): PraxisCardOut {
+  return {
+    id: 1,
+    created_by_id: 7,
+    created_by_display_name: 'Isolde',
+    created_by_faction_slug: 'ua',
+    created_by_avatar_url: '',
+    task_faction_slug: 'ua',
+    task_level_required: 0,
+    task_point_value: 5,
+    member_count: 1,
+    score: 12.5,
+    voter_count: 3,
+    ...overrides,
+  } as PraxisCardOut
+}
+
+const render = (node: ReactElement) =>
+  renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>)
+
+const text = (html: string) => html.replace(/<[^>]*>/g, '')
+
+describe('one score per card (#888, closes #663)', () => {
+  it('the byline no longer states the total', () => {
+    const body = text(render(<PraxisByline praxis={praxis({ score: 12.5 })} />))
+    expect(body).toContain('Isolde')
+    expect(body).not.toContain('12.5')
+  })
+
+  it('the desktop vote footer states no points and no vote count', () => {
+    const body = text(render(<PraxisVoteFooter praxis={praxis({})} />))
+    expect(body).not.toMatch(/\bpts\b/)
+    // No FIGURE of any kind: the tally line was "{points} pts · {count} votes",
+    // and both numbers are gone with it. (The footer's own "log in to vote"
+    // prompt survives — this is about the tally, not the control.)
+    expect(body).not.toMatch(/\d/)
+  })
+
+  it('the mobile vote footer states no points and no vote count', () => {
+    const body = text(render(<MobileVoteFooter praxis={praxis({})} />))
+    expect(body).not.toMatch(/\bpts\b/)
+    // No FIGURE of any kind: the tally line was "{points} pts · {count} votes",
+    // and both numbers are gone with it. (The footer's own "log in to vote"
+    // prompt survives — this is about the tally, not the control.)
+    expect(body).not.toMatch(/\d/)
+  })
+})
+
+describe('the byline portrait (#888)', () => {
+  it('renders the author portrait when they have one', () => {
+    const html = render(
+      <PraxisByline praxis={praxis({ created_by_avatar_url: 'avatars/isolde.png' })} />,
+    )
+    expect(html).toContain('avatars/isolde.png')
+  })
+
+  it('degrades to the shared monogram avatar when they have none', () => {
+    const html = render(<PraxisByline praxis={praxis({ created_by_avatar_url: '' })} />)
+    // No <img>, and the monogram follows the DISPLAY name, not the id.
+    expect(html).not.toContain('<img')
+    expect(text(html)).toContain('I')
+  })
+
+  it('survives a payload with no avatar field at all', () => {
+    const stale = praxis({})
+    delete (stale as Partial<PraxisCardOut>).created_by_avatar_url
+    expect(() => render(<PraxisByline praxis={stale} />)).not.toThrow()
+  })
+})
+
+describe('the meta line (#888)', () => {
+  it('shows the level on a level-0 task, so the segment count never varies', () => {
+    const zero = text(render(<PraxisStats praxis={praxis({ task_level_required: 0 })} />))
+    const five = text(render(<PraxisStats praxis={praxis({ task_level_required: 5 })} />))
+    expect(zero).toContain('L0')
+    expect(five).toContain('L5')
+    // The separator count is the shape being pinned: a ragged meta line across a
+    // wall of cards was the bug, not the missing level per se.
+    const separators = (html: string) => (html.match(/·/g) ?? []).length
+    expect(separators(zero)).toBe(separators(five))
+  })
+
+  it('sits at the top of the label tier, not its 8px floor', () => {
+    const html = render(<PraxisStats praxis={praxis({})} />)
+    expect(html).toContain('var(--text-xl)')
+    expect(html).not.toContain('var(--text-xs)')
+  })
+})
+
+describe('the faction font pair (#888)', () => {
+  it('threads the display face to the author name and the body face beside it', () => {
+    const html = render(
+      <PraxisByline
+        praxis={praxis({ created_by_faction_slug: 'snide' })}
+        fonts={{ display: 'var(--faction-snide-card-font)', body: 'var(--faction-snide-font-type)' }}
+      />,
+    )
+    expect(html).toContain('var(--faction-snide-card-font)')
+    expect(html).toContain('var(--faction-snide-font-type)')
+  })
+
+  it('leaves a slot on its font-* class when an archetype has no opinion', () => {
+    const html = render(<PraxisStats praxis={praxis({})} />)
+    expect(html).toContain('font-body')
+    expect(html).not.toContain('font-family')
+  })
+})

--- a/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
@@ -55,6 +55,13 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           color: factionCssVar("coven", "card-text"),
         }}
         showCrown={showCrown}
+        // Coven answers both questions with Caveat (#888). The sticker's voice
+        // IS the handwriting — the pair does not force a second face on a
+        // faction that only has one, it just stops asking `font-body` instead.
+        fonts={{
+          display: "var(--faction-coven-card-font)",
+          body: "var(--faction-coven-card-font)",
+        }}
         eyebrow={
           <div
             style={{

--- a/frontend/src/components/praxisCard/desktop/DefaultPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/DefaultPraxisCard.tsx
@@ -43,6 +43,12 @@ export function DefaultPraxisCard({ praxis, adminProps, showCrown }: ArchetypePr
         muted="var(--faction-default-card-muted)"
         paper="var(--faction-default-card-bg)"
         showCrown={showCrown}
+        // Bebas Neue carries the sheet's identity; Courier Prime reads the
+        // proof. The quiet sheet keeps the house body face on purpose (#888).
+        fonts={{
+          display: "var(--faction-default-card-font)",
+          body: "var(--font-body)",
+        }}
         titleStyle={{
           fontFamily: "var(--faction-default-card-font)",
           letterSpacing: "0.02em",

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -51,6 +51,13 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
         paper="var(--eph-vellum)"
         titleStyle={{ fontFamily: "var(--eph-display)", color: "var(--eph-vellum-text)" }}
         showCrown={showCrown}
+        // Cinzel for the rubric, EB Garamond for the entry — the codex pair,
+        // named in the --faction-* family rather than the legacy --eph-* one
+        // (#888). Same values either way; one namespace to ask.
+        fonts={{
+          display: "var(--faction-ephemerists-card-font)",
+          body: "var(--faction-ephemerists-body-font)",
+        }}
         eyebrow={
           <div
             className="eyebrow"

--- a/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
@@ -99,6 +99,13 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
           muted={factionCssVar("everymen", "card-muted")}
           paper={factionCssVar("everymen", "card-bg")}
           showCrown={showCrown}
+          // Bebas Neue is Everymen's declared card font and, until #888, reached
+          // task and faction cards but never a praxis card. The broadsheet's own
+          // Special Elite stays on the reading matter.
+          fonts={{
+            display: "var(--faction-everymen-card-font)",
+            body: "var(--font-faction-typewriter)",
+          }}
         />
       </div>
     </div>

--- a/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
@@ -143,6 +143,13 @@ export function SingularityPraxisCard({ praxis, adminProps, showCrown }: Archety
           muted="var(--faction-singularity-phosphor-dim)"
           paper="var(--faction-singularity-card-bg)"
           showCrown={showCrown}
+          // A terminal has one face by definition, so Singularity answers both
+          // questions with Share Tech Mono — via its own card token, not the
+          // raw family (#888).
+          fonts={{
+            display: "var(--faction-singularity-card-font)",
+            body: "var(--faction-singularity-card-font)",
+          }}
           titleStyle={{
             fontFamily: "var(--font-faction-terminal)",
             textTransform: "uppercase",

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -50,6 +50,14 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
         muted="var(--faction-snide-card-muted)"
         paper="var(--faction-snide-card-bg)"
         showCrown={showCrown}
+        // The split earning its keep (#888): Permanent Marker is S.N.I.D.E.'s
+        // declared card font and it finally reaches the card — but only where
+        // identity belongs. A two-line excerpt set in it is unreadable, so the
+        // body stays on the slab's Special Elite.
+        fonts={{
+          display: "var(--faction-snide-card-font)",
+          body: "var(--faction-snide-font-type)",
+        }}
         titleStyle={{
           fontFamily: "var(--faction-snide-font-impact)",
           textTransform: "uppercase",

--- a/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
@@ -78,6 +78,12 @@ export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
             letterSpacing: "-0.01em",
           }}
           showCrown={showCrown}
+          // Cormorant engraves, EB Garamond reads — the same pair the UA mobile
+          // card already carried (#888).
+          fonts={{
+            display: "var(--faction-ua-card-font)",
+            body: "var(--faction-ua-body-font)",
+          }}
           eyebrow={
             /*
              * The running head sits INSIDE the text column, above the title, so

--- a/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
@@ -72,6 +72,12 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
             color: "var(--faction-wow-card-text)",
           }}
           showCrown={showCrown}
+          // MedievalSharp illuminates, Lora reads — the chronicle's own pair,
+          // matching the WOW mobile card (#888).
+          fonts={{
+            display: "var(--faction-wow-card-font)",
+            body: "var(--faction-wow-body-font)",
+          }}
           eyebrow={
             <div
               className="eyebrow"

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -12,6 +12,7 @@ import {
   PraxisMediaGallery,
   PraxisVoteFooter,
   type AdminProps,
+  type PraxisCardFonts,
 } from "../shared";
 import ScoreStamp from "../scoreStamp/ScoreStamp";
 
@@ -83,6 +84,7 @@ export function PraxisBody({
   mediaEmptyLabel,
   mediaEmptyStyle,
   footnote,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   tint: string;
@@ -122,6 +124,18 @@ export function PraxisBody({
    * `PraxisStats` already carries the level/crew/date facts.
    */
   footnote?: ReactNode;
+  /**
+   * The archetype's two typefaces (#888) — display for identity (title, author
+   * name, mode chip), body for reading (task line, excerpt, meta line). Before
+   * this, `../shared` declared no `fontFamily` at all, so every faction's card
+   * body was Courier Prime however loudly its frame declared otherwise.
+   *
+   * Each archetype passes its OWN pair. The slots deliberately do not resolve
+   * `--faction-{slug}-card-font` themselves: that would be a second dispatch
+   * mechanism, and it collapses the display/body split that keeps a Permanent
+   * Marker faction's excerpt readable.
+   */
+  fonts?: PraxisCardFonts;
 }) {
   return (
     <>
@@ -135,9 +149,14 @@ export function PraxisBody({
       >
         <div style={{ flex: 1, minWidth: 0 }}>
           {eyebrow}
-          <PraxisTitle praxis={praxis} style={titleStyle} />
-          <PraxisTaskLink praxis={praxis} style={{ color: muted }} lead={taskLead} />
-          <PraxisExcerpt praxis={praxis} style={{ color: muted }} />
+          <PraxisTitle praxis={praxis} style={titleStyle} fonts={fonts} />
+          <PraxisTaskLink
+            praxis={praxis}
+            style={{ color: muted }}
+            lead={taskLead}
+            fonts={fonts}
+          />
+          <PraxisExcerpt praxis={praxis} style={{ color: muted }} fonts={fonts} />
         </div>
         {/*
          * The conditional score stamp (ADR-0047) on EVERY faction (#821), now a
@@ -149,8 +168,12 @@ export function PraxisBody({
          */}
         <ScoreStamp praxis={praxis} showCrown={showCrown} />
       </div>
-      <PraxisStats praxis={praxis} style={{ color: muted, marginTop: "var(--space-sm)" }} />
-      <PraxisModeChip praxis={praxis} />
+      <PraxisStats
+        praxis={praxis}
+        style={{ color: muted, marginTop: "var(--space-sm)" }}
+        fonts={fonts}
+      />
+      <PraxisModeChip praxis={praxis} fonts={fonts} />
       <PraxisRoster praxis={praxis} accent={tint} paper={paper} />
       {/* Every card shows the media slot — a drop target when empty (#821). */}
       <PraxisMediaGallery
@@ -160,9 +183,10 @@ export function PraxisBody({
         showPlaceholder
         emptyLabel={mediaEmptyLabel}
         emptyStyle={mediaEmptyStyle}
+        fonts={fonts}
       />
       {footnote}
-      <PraxisByline praxis={praxis} style={{ color: muted }} />
+      <PraxisByline praxis={praxis} style={{ color: muted }} fonts={fonts} />
       <PraxisVotedByMarker praxis={praxis} style={{ color: muted }} />
       {voteRule}
       <PraxisVoteFooter praxis={praxis} />

--- a/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/DefaultMobilePraxisCard.tsx
@@ -23,7 +23,10 @@ export default function DefaultMobilePraxisCard({ praxis }: { praxis: PraxisCard
     accent: 'var(--faction-default-card-accent)',
     paper: 'var(--faction-default-card-bg)',
     displayFont: 'var(--faction-default-card-font)',
-    bodyFont: "'Courier Prime', monospace",
+    // The house body face, by its token (#888). A font STRING passes the style
+    // ratchet — it is not a size or a hex — while being exactly the laundering
+    // the ratchet exists to catch.
+    bodyFont: 'var(--font-body)',
   }
   return (
     <div

--- a/frontend/src/components/praxisCard/mobile/EphemeristsMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/EphemeristsMobilePraxisCard.tsx
@@ -16,8 +16,10 @@ export default function EphemeristsMobilePraxisCard({ praxis }: { praxis: Praxis
     muted: 'var(--eph-muted)',
     accent: 'var(--eph-rubric)',
     paper: 'var(--eph-vellum)',
-    displayFont: 'var(--eph-display)',
-    bodyFont: 'var(--eph-serif)',
+    // Same faces, asked for in the --faction-* family the other seven cards use
+    // (#888). --eph-* stays the declaration site; this is the seam's namespace.
+    displayFont: 'var(--faction-ephemerists-card-font)',
+    bodyFont: 'var(--faction-ephemerists-body-font)',
   }
   return (
     <div

--- a/frontend/src/components/praxisCard/mobile/EverymenMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/EverymenMobilePraxisCard.tsx
@@ -14,8 +14,12 @@ export default function EverymenMobilePraxisCard({ praxis }: { praxis: PraxisCar
     muted: factionCssVar('everymen', 'card-muted'),
     accent: factionCssVar('everymen', 'card-accent'),
     paper: factionCssVar('everymen', 'card-bg'),
-    displayFont: "'Special Elite', serif",
-    bodyFont: "'Special Elite', serif",
+    // Special Elite by its token (#888). The DESKTOP card lifts its display
+    // face to Bebas Neue, Everymen's declared card font; the mobile broadsheet
+    // is left on one typewriter face, since that is what it renders today and
+    // this pass is tokenization, not a mobile restyle.
+    displayFont: 'var(--font-faction-typewriter)',
+    bodyFont: 'var(--font-faction-typewriter)',
   }
   return (
     <div

--- a/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
@@ -15,8 +15,8 @@ export default function SingularityMobilePraxisCard({ praxis }: { praxis: Praxis
     muted: 'var(--faction-singularity-card-muted)',
     accent: 'var(--faction-singularity-card-accent)',
     paper: 'var(--faction-singularity-card-bg)',
-    displayFont: "'Share Tech Mono', monospace",
-    bodyFont: "'Share Tech Mono', monospace",
+    displayFont: 'var(--faction-singularity-card-font)',
+    bodyFont: 'var(--faction-singularity-card-font)',
   }
   return (
     <div
@@ -44,7 +44,7 @@ export default function SingularityMobilePraxisCard({ praxis }: { praxis: Praxis
         <div
           style={{
             marginBottom: 'var(--space-md)',
-            fontFamily: "'Share Tech Mono', monospace",
+            fontFamily: 'var(--faction-singularity-card-font)',
             fontSize: 'var(--text-sm)',
             letterSpacing: '0.15em',
             textTransform: 'uppercase',

--- a/frontend/src/components/praxisCard/mobile/shared.tsx
+++ b/frontend/src/components/praxisCard/mobile/shared.tsx
@@ -474,14 +474,18 @@ export function MobileVotedByMarker({
   )
 }
 
+/**
+ * Slot: the vote footer. Passes NO `points`/`totalVotes` (#888, closing #663) —
+ * `VoteShell`'s `points != null` guard then hides the "N pts · M votes" tally,
+ * leaving the score stamp as the card's only statement of the total. Same
+ * deletion as the desktop footer; `VoteShell` itself is untouched.
+ */
 export function MobileVoteFooter({ praxis }: { praxis: PraxisCardOut }) {
   return (
     <VoteUI
       factionSlug={praxis.task_faction_slug}
       praxisId={praxis.id}
       currentValue={praxis.viewer_vote ?? undefined}
-      points={praxis.score}
-      totalVotes={praxis.voter_count}
     />
   )
 }

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -1,9 +1,11 @@
 import type { CSSProperties, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import type { CharacterOut } from "../../api/auth";
 import type { PraxisCardOut } from "../../api/praxis";
 import { factionName } from "../../utils/factions";
 import { mediaUrl } from "../../utils/media";
+import FactionAvatar from "../avatar/FactionAvatar";
 import VoteUI from "../vote/VoteUI";
 
 /**
@@ -27,6 +29,28 @@ import VoteUI from "../vote/VoteUI";
  */
 export const ROSTER_NAME_CAP = 7
 
+/**
+ * The two faces a desktop praxis card writes in (#888) — the same split the
+ * mobile slots have carried since #573 as `MobileSlotTheme.displayFont` /
+ * `bodyFont`. Ported here because desktop never got the seam: `shared.tsx` had
+ * no `fontFamily` at all, so every faction's card read in Courier Prime no
+ * matter what its own frame declared.
+ *
+ * It is a PAIR on purpose, not one resolved `--faction-{slug}-card-font`. A
+ * single font collapses the split, and several card fonts are display faces
+ * that stop being readable at paragraph length — S.N.I.D.E.'s is Permanent
+ * Marker, which is a fine byline and an unreadable two-line excerpt.
+ *
+ * Both values are optional: a slot given nothing keeps its `font-*` class, so
+ * an archetype that has no opinion is unchanged.
+ */
+export interface PraxisCardFonts {
+  /** The identity face — author name, title, mode chip. */
+  display?: string;
+  /** The reading face — task line, excerpt, meta line. */
+  body?: string;
+}
+
 export function rosterNames(
   members: { display_name?: string | null }[],
   cap = ROSTER_NAME_CAP,
@@ -42,15 +66,21 @@ export function rosterNames(
 export function PraxisTitle({
   praxis,
   style,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   style?: CSSProperties;
+  fonts?: PraxisCardFonts;
 }) {
   return (
     <Link to={`/praxes/${praxis.id}`}>
       <h3
         className="content-title font-display font-semibold leading-tight hover:underline"
-        style={{ marginBottom: "var(--space-sm)", ...style }}
+        style={{
+          marginBottom: "var(--space-sm)",
+          fontFamily: fonts?.display,
+          ...style,
+        }}
       >
         {praxis.title}
       </h3>
@@ -63,9 +93,11 @@ export function PraxisTaskLink({
   praxis,
   style,
   lead,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   style?: CSSProperties;
+  fonts?: PraxisCardFonts;
   /**
    * An optional un-linked run-in before the task title (#840). Some factions
    * write this line as a sentence rather than a bare reference — WOW's chronicle
@@ -79,14 +111,17 @@ export function PraxisTaskLink({
       <Link
         to={`/tasks/${praxis.task_id}`}
         className="font-body hover:underline"
-        style={{ fontSize: "var(--text-content)", ...style }}
+        style={{ fontSize: "var(--text-content)", fontFamily: fonts?.body, ...style }}
       >
         {praxis.task_title}
       </Link>
     );
   }
   return (
-    <span className="font-body" style={{ fontSize: "var(--text-content)", ...style }}>
+    <span
+      className="font-body"
+      style={{ fontSize: "var(--text-content)", fontFamily: fonts?.body, ...style }}
+    >
       <span style={{ marginRight: "var(--space-xs)" }}>{lead}</span>
       <Link to={`/tasks/${praxis.task_id}`} className="hover:underline" style={{ color: "inherit" }}>
         {praxis.task_title}
@@ -95,13 +130,57 @@ export function PraxisTaskLink({
   );
 }
 
-/** Slot: the author + score footer row (dashed rule on top). */
+/**
+ * The praxis author as the shared avatar surface wants them (#888).
+ *
+ * `FactionAvatar` reads only username / avatar_url / faction_slug off a
+ * `CharacterOut`; a card payload carries those three under different names, so
+ * pad the rest. Mirrors `comments/shared.tsx`'s `authorToCharacter` — reusing
+ * the one avatar convention (portrait, else monogram, else spectrum ring) is
+ * the point, so the card never grows a placeholder of its own.
+ *
+ * `display_name` stands in for `username` deliberately: it is what the byline
+ * shows, so it is what the monogram initial and the img alt should follow.
+ */
+function authorAsCharacter(praxis: PraxisCardOut): CharacterOut {
+  const name = praxis.created_by_display_name || `#${praxis.created_by_id}`;
+  return {
+    id: praxis.created_by_id,
+    username: name,
+    display_name: name,
+    avatar_url: praxis.created_by_avatar_url || null,
+    faction_slug: praxis.created_by_faction_slug ?? null,
+    bio: null,
+    location: null,
+    level: 0,
+    score: 0,
+    all_time_score: 0,
+    status: "active",
+    created_at: "",
+  };
+}
+
+/** The byline portrait's diameter. Not a spacing value — a drawn disc. */
+// eslint-disable-next-line local/no-raw-style-values -- ornament: the portrait disc's drawn diameter (§4a), passed as a number to FactionAvatar's size API.
+const BYLINE_PORTRAIT_SIZE = 28;
+
+/**
+ * Slot: the author byline (dashed rule on top) — name, portrait, faction tag.
+ *
+ * The praxis TOTAL used to sit at the right of this row. It is gone (#888,
+ * closing #663): the score stamp is the card's sole owner of that number, and
+ * a card that states its total twice invites the reader to check whether the
+ * two agree. The portrait takes the name's right-hand side; the author's
+ * faction tag takes the far edge the score vacated.
+ */
 export function PraxisByline({
   praxis,
   style,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   style?: CSSProperties;
+  fonts?: PraxisCardFonts;
 }) {
   // The author's own member faction, shown only when it differs from the task
   // faction (the frame already carries the task faction's voice). Resolved via
@@ -112,32 +191,42 @@ export function PraxisByline({
     <div
       className="flex justify-between items-center font-body"
       style={{
-        fontSize: "var(--text-xs)",
+        // Byline chrome sits at the TOP of the label tier (14px), not its floor
+        // (8px). The name itself overrides up to the content tier below.
+        fontSize: "var(--text-xl)",
         marginTop: "var(--space-sm)",
         paddingTop: "var(--space-sm)",
         borderTop: "1px dashed rgba(128,128,128,0.3)",
+        gap: "var(--space-sm)",
         ...style,
       }}
     >
-      <span className="flex items-baseline" style={{ gap: "var(--space-xs)", minWidth: 0 }}>
+      <span className="flex items-center" style={{ gap: "var(--space-sm)", minWidth: 0 }}>
         <Link
           to={`/characters/${praxis.created_by_id}`}
-          className="hover:underline"
+          // A person's name is readable text, not scanned chrome: content tier
+          // (18px). It ties the task link's size, and separates from it by
+          // weight and by the faction's own display face instead.
+          className="content-text font-semibold hover:underline"
+          style={{
+            fontFamily: fonts?.display,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
         >
           {praxis.created_by_display_name || `#${praxis.created_by_id}`}
         </Link>
-        {showFaction && (
-          <span style={{ opacity: 0.7, whiteSpace: "nowrap" }}>
-            {`· ${factionName(authorFaction)}`}
-          </span>
-        )}
+        <FactionAvatar
+          character={authorAsCharacter(praxis)}
+          size={BYLINE_PORTRAIT_SIZE}
+        />
       </span>
-      {praxis.score !== null && (
+      {showFaction && (
         <span
-          className="font-display font-bold"
-          style={{ fontSize: "var(--text-content)", color: "inherit" }}
+          style={{ fontFamily: fonts?.body, opacity: 0.7, whiteSpace: "nowrap" }}
         >
-          {praxis.score.toFixed(1)}
+          {factionName(authorFaction)}
         </span>
       )}
     </div>
@@ -166,13 +255,22 @@ export function PraxisVotedByMarker({
   );
 }
 
-/** Slot: base points + collaboration mode — a compact stat line. */
+/**
+ * Slot: level + base points + collaboration mode + date — the meta line.
+ *
+ * FOUR segments, always, in that order (#888). The level used to be conditional
+ * on `task_level_required > 0`, so a level-0 task dropped it and the separator
+ * count changed card to card — a ragged line across a wall of cards. `L0` is a
+ * real answer to "what does this need?", so it renders.
+ */
 export function PraxisStats({
   praxis,
   style,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   style?: CSSProperties;
+  fonts?: PraxisCardFonts;
 }) {
   const { t } = useTranslation("praxis");
   const collaborators = praxis.member_count - 1;
@@ -182,14 +280,12 @@ export function PraxisStats({
   return (
     <div
       className="flex items-center gap-2 font-body"
-      style={{ fontSize: "var(--text-xs)", ...style }}
+      style={{ fontSize: "var(--text-xl)", fontFamily: fonts?.body, ...style }}
     >
-      {praxis.task_level_required > 0 && (
-        <>
-          <span style={{ fontWeight: 600, opacity: 0.75 }}>{t("card.level", { level: praxis.task_level_required })}</span>
-          <span aria-hidden>·</span>
-        </>
-      )}
+      <span style={{ fontWeight: 600, opacity: 0.75 }}>
+        {t("card.level", { level: praxis.task_level_required })}
+      </span>
+      <span aria-hidden>·</span>
       <span style={{ fontWeight: 700 }}>{t("card.points", { points: praxis.task_point_value })}</span>
       <span aria-hidden>·</span>
       <span>{collaborators > 0 ? t("card.crew", { count: collaborators }) : t("card.solo")}</span>
@@ -207,15 +303,18 @@ export function PraxisStats({
 export function PraxisExcerpt({
   praxis,
   style,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   style?: CSSProperties;
+  fonts?: PraxisCardFonts;
 }) {
   if (!praxis.body_text) return null;
   return (
     <p
       className="card-description font-body"
       style={{
+        fontFamily: fonts?.body,
         marginTop: "var(--space-sm)",
         marginBottom: "0",
         lineHeight: 1.5,
@@ -321,9 +420,11 @@ export function PraxisRoster({
 export function PraxisModeChip({
   praxis,
   style,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   style?: CSSProperties;
+  fonts?: PraxisCardFonts;
 }) {
   const { t } = useTranslation("common");
   const isDuel = praxis.type === "duel";
@@ -331,7 +432,11 @@ export function PraxisModeChip({
   const isPending = praxis.submit_proposed_at != null;
   if (!isDuel && !isCollab && !isPending) return null;
   const chip: CSSProperties = {
-    fontSize: "var(--text-xs)",
+    // A chip is a LABEL, not running text: it keeps the label tier (#888 leaves
+    // `.eyebrow`/`--text-sm` alone by design), but at the 9px step rather than
+    // the 8px floor the meta line just left.
+    fontSize: "var(--text-sm)",
+    fontFamily: fonts?.display,
     letterSpacing: "0.14em",
     textTransform: "uppercase",
     padding: "var(--space-xs) var(--space-sm)",
@@ -391,10 +496,12 @@ export function PraxisMediaGallery({
   showPlaceholder,
   emptyLabel,
   emptyStyle,
+  fonts,
 }: {
   praxis: PraxisCardOut;
   accent: string;
   paper?: string;
+  fonts?: PraxisCardFonts;
   /**
    * When set, an empty gallery renders a neutral dashed drop-target placeholder
    * (the mock's "media slot") instead of nothing. Opt-in so it stays off the
@@ -425,7 +532,9 @@ export function PraxisMediaGallery({
           border: `1px dashed color-mix(in srgb, ${accent} 45%, transparent)`,
           background: `color-mix(in srgb, ${accent} 4%, transparent)`,
           color: accent,
-          fontSize: "var(--text-xs)",
+          // Label tier, at the eyebrow step rather than the 8px floor (#888).
+          fontSize: "var(--text-sm)",
+          fontFamily: fonts?.body,
           letterSpacing: "0.14em",
           textTransform: "uppercase",
           opacity: 0.7,
@@ -472,7 +581,9 @@ export function PraxisMediaGallery({
                 </span>
                 <span
                   style={{
-                    fontSize: "var(--text-xs)",
+                    // Label tier, eyebrow step rather than the 8px floor (#888).
+                    fontSize: "var(--text-sm)",
+                    fontFamily: fonts?.body,
                     letterSpacing: "0.1em",
                     textTransform: "uppercase",
                   }}
@@ -506,8 +617,13 @@ export function PraxisMediaGallery({
 /**
  * Slot: the vote footer — the real per-faction VoteUI, keyed by the task
  * faction. Pre-highlights the viewer's own cast (`viewer_vote`); casting is
- * self-managed by VoteUI's own useVote path (no external handler). An additive
- * footer — it never replaces the score-hero stamp.
+ * self-managed by VoteUI's own useVote path (no external handler).
+ *
+ * It passes NO `points`/`totalVotes` (#888, closing #663). `VoteShell`'s
+ * existing `points != null` guard then drops the whole "N pts · M votes" tally
+ * line, leaving the star control alone. That is the entire mechanism: the guard
+ * is not re-cut here, and the praxis DETAIL page — a different caller that does
+ * pass them — keeps its tally.
  */
 export function PraxisVoteFooter({
   praxis,
@@ -522,8 +638,6 @@ export function PraxisVoteFooter({
         factionSlug={praxis.task_faction_slug}
         praxisId={praxis.id}
         currentValue={praxis.viewer_vote ?? undefined}
-        points={praxis.score}
-        totalVotes={praxis.voter_count}
       />
     </div>
   );

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -160,8 +160,12 @@ function authorAsCharacter(praxis: PraxisCardOut): CharacterOut {
   };
 }
 
-/** The byline portrait's diameter. Not a spacing value — a drawn disc. */
-// eslint-disable-next-line local/no-raw-style-values -- ornament: the portrait disc's drawn diameter (§4a), passed as a number to FactionAvatar's size API.
+/**
+ * The byline portrait's diameter. An argument to `FactionAvatar`'s own size API
+ * (which takes `'sm' | 'md' | px`), not a style value — it sits between the two
+ * named steps because the byline wants a face bigger than the roster's 24 and
+ * smaller than a profile's 32.
+ */
 const BYLINE_PORTRAIT_SIZE = 28;
 
 /**

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -147,6 +147,12 @@
   --faction-coven-card-font: var(--font-faction-script);
   --faction-snide-card-font: var(--font-faction-marker);
   --faction-ephemerists-card-font: var(--eph-display);
+  /* The codex's READING face — the other half of the Ephemerists pair (#888).
+     `--eph-serif` already held this value; naming it in the --faction-* family
+     is what lets the praxis-card font seam ask every faction the same two
+     questions (display face, body face) instead of one faction answering from
+     a legacy namespace. Same shape as --faction-ua-body-font / -wow-body-font. */
+  --faction-ephemerists-body-font: var(--eph-serif);
   --faction-singularity-card-font: var(--font-faction-terminal);
 
   /* ── WARRIORS OF WHIMSY · yellow SPINE, cream/gold/plum SKIN (#812, #838) ──


### PR DESCRIPTION
Four fixes to the shared praxis-card chrome. They travel together because they all land in `components/praxisCard/shared.tsx`.

Closes #888
Closes #663

Based on `43200d6f`, after #881 (PR #902, ADR-0053) deleted `PraxisScoreHero`.

---

## 1. One score per card

Pure deletion. The byline's copy of the total is gone, and neither vote footer passes `points`/`totalVotes` any more — so `VoteShell`'s existing `points != null` guard drops the whole "N pts · M votes" tally line on its own.

**`VoteShell` is unmodified**, as the issue requires: every other `points=` caller is a vote widget passing through, and the praxis detail page still shows its tally. `praxis.score` now has no reader anywhere in `praxisCard/` outside `scoreStamp/`; `voter_count` has none at all. The stamp is the sole owner. Resolves #663, whose stalling constraint was exactly that guard.

## 2. Portrait + real name in the byline

Backend: `PraxisCardOut` gains `created_by_avatar_url: str = ""`, populated from `praxis.created_by.avatar_url` in `build_praxis_card_out`. `created_by` is already loaded on every path into that builder (it is what feeds the display name), so **no new query**. `PraxisOut` deliberately untouched.

Frontend: the portrait is the existing `FactionAvatar` surface — portrait, else monogram, else spectrum ring — adapted with the same `authorToCharacter` pad `comments/shared.tsx` already uses. No card-local placeholder was invented. `display_name` stands in for `username` so the monogram initial and the img `alt` follow the name the byline actually shows.

`Character.avatar_url` turned out to be **NOT NULL with a `""` default**, so "no portrait" is the empty string, never `None` — the schema default and the test both reflect that rather than the null I first assumed.

## 3. Legible meta line

- The level segment is now unconditional, so a level-0 task reads `L0` and every card has the same four segments. The test pins the **separator count** at L0 vs L5, since ragged separators were the actual complaint.
- Author name → `.content-text` (18px), separated from the same-sized task link by weight and by the faction's display face.
- Meta line → `var(--text-xl)` (14px), from its 8px floor.
- Title (24px) and task link (18px) unchanged.

## 4. The faction's own typefaces

`praxisCard/shared.tsx` declared **zero** `fontFamily`, and its seven `font-body` classes overrode whatever the frame set — so every desktop praxis card rendered in Courier Prime however loudly its archetype declared otherwise. Snide's Permanent Marker and Everymen's Bebas Neue reached task and faction cards but never a praxis card.

Ports the seam mobile has carried since #573: a `PraxisCardFonts` **pair** (`display` / `body`) that each archetype passes for itself. The slots do **not** resolve `--faction-{slug}-card-font` — that would be a second dispatch mechanism, and it collapses the split. Snide is the case that proves it: Permanent Marker finally reaches the card as the identity face, while the two-line excerpt stays on the slab's Special Elite. Both fields are optional, so a slot given nothing keeps its `font-*` class.

Albescent needs no pair — it wraps `DefaultPraxisCard` and inherits.

---

## Corrections to the issue

The issue's line numbers are all stale (it predates #881 and the #839 desktop split — the archetypes now live in `desktop/*PraxisCard.tsx`, not `PraxisCard.tsx`). More substantively, **its part-4 font list is half wrong**:

| file | issue says | actual |
|---|---|---|
| `UaMobilePraxisCard` | `'Marcellus SC', serif`, mint a token | **already fixed** by the UA redesign wave — no token minted, none needed |
| `CovenMobilePraxisCard` | reaches past to `--font-faction-script` | **already fixed** |
| `DefaultMobilePraxisCard` | Courier Prime | still live → `var(--font-body)` |
| `SingularityMobilePraxisCard` | Share Tech Mono | still live, **three** places → `var(--faction-singularity-card-font)` |
| `EverymenMobilePraxisCard` | *not mentioned* | **`'Special Elite', serif`**, two places — same laundering, fixed |
| `EphemeristsMobilePraxisCard` | *not mentioned* | `--eph-*`, a legacy namespace — see below |

## Judgement calls worth a look

1. **Ephemerists namespace.** Its slots used `--eph-display` / `--eph-serif`. Those are declared, so this was consistency, not a bug. I repointed both desktop and mobile to the `--faction-*` family, which needed one new token, `--faction-ephemerists-body-font: var(--eph-serif)` — same value, same shape as `--faction-ua-body-font`. `--eph-*` stays the declaration site. The #892 guard covers it.
2. **Byline layout.** The issue says the portrait goes "immediately to its right" *and* "where the deleted score used to sit", which are two different places. I took the explicit one: name, then portrait. The author's faction tag takes the far edge the score vacated.
3. **8px on the card.** The issue rules `.eyebrow` (9px) out of scope but also says "no text below 14px" and "the illegibility is specific to `--text-xs` (8px) on this card". Those pull apart. I bumped the three remaining 8px label-tier spots on the card (mode chip, media empty label, media type label) to `--text-sm` — the blessed eyebrow step — so nothing on the card sits at the 8px floor, without re-tiering anything or touching another surface. The `aria-hidden` roster monogram keeps its size, being a glyph fitted to a 24px disc. **Revert this if you'd rather the label tier stayed frozen.**
4. **Mobile Everymen** was tokenized to `--font-faction-typewriter` (preserving what it renders today) rather than lifted to its declared Bebas Neue card font, which the desktop card now uses for display. This pass was tokenization; a mobile restyle wasn't asked for. The two form factors now differ on Everymen's display face.

## Verification

`pytest` 716 passed · `vitest` 1256 passed (110 files) · `tsc --noEmit` clean · `eslint src` clean · `vite build` succeeds. Backend ran against a dedicated `wz888_test`.

**Visual QA is outstanding** — no screenshots were taken and no dev stack was run. Everything below is unverified visually.

## What to eyeball

- **S.N.I.D.E. · solo praxis with a 2-line body.** The whole reason display and body are separate: the author name should be Permanent Marker, the excerpt Special Elite. If the excerpt is in marker, the pair is wired backwards.
- **Everymen · desktop vs mobile, side by side.** Desktop display is now Bebas Neue, mobile is still Special Elite (call 4 above). Decide whether that divergence stands.
- **Coven and Singularity · any card with a long excerpt.** Both answer display and body with one face (Caveat, Share Tech Mono). Check an 18px Caveat excerpt is actually readable.
- **Any faction · level-0 task.** The meta line should read `L0 · 5 pts · solo · <date>` — four segments, matching a level-5 card beside it.
- **Any faction · author with no uploaded portrait.** Should be the monogram/spectrum-ring avatar at 28px, not a broken image; the initial should follow the display name.
- **Unaffiliated (`na`) and Albescent · author whose faction differs from the task faction.** Exercises the faction tag at the far right of the byline, in the slot the score vacated, plus Albescent's inherited Default fonts under the drift.
- **Any faction · a card the viewer has voted on.** The star row should still pre-highlight, with no "N pts · M votes" line under it.
- **Praxis detail page · same praxis.** Its tally must still be there — that is the check that `VoteShell` was left alone.
- **Ephemerists · dark mode.** Confirms the new `--faction-ephemerists-body-font` resolves through the `[data-theme="dark"]` cascade the same as `--eph-serif` did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
